### PR TITLE
pnfsmanager: Fix permission check on root directory

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/namespace/ACLPermissionHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/namespace/ACLPermissionHandler.java
@@ -99,6 +99,10 @@ public class ACLPermissionHandler implements PermissionHandler
                                    FileAttributes parentAttr,
                                    FileAttributes childAttr)
     {
+        if (parentAttr == null) {
+            return ACCESS_DENIED;
+        }
+
         Permission permissionParent = getPermission(subject, parentAttr);
         Permission permissionChild = getPermission(subject, childAttr);
         return AccessType.valueOf(AclNFSv4Matcher.isAllowed(permissionParent,


### PR DESCRIPTION
Addresses an issue in which listing the root directory through
FTP fails with a null pointer exception.

The problem has previously been fixed on master, however the
merge to 2.2 was incomplete due to code difference between
the two branches.

Target: 2.2
Request: 2.2
Require-book: no
Require-notes: yes
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7757
Patch: http://rb.dcache.org/r/5488/
Acked-by: Tigran Mkrtchyn tigran.mkrtchyan@desy.de
