### PR TITLE
pool: Make access time update non-blocking

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -99,6 +99,7 @@ import org.dcache.pool.repository.v5.CacheRepositoryV5;
 import org.dcache.util.IoPriority;
 import org.dcache.util.Version;
 import org.dcache.vehicles.FileAttributes;
+import org.dcache.vehicles.PnfsSetFileAttributes;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -516,14 +517,9 @@ public class PoolV4
 
         @Override
         public void accessTimeChanged(EntryChangeEvent event) {
-            PnfsId id = event.getPnfsId();
-            try {
-                FileAttributes fileAttributes = new FileAttributes();
-                fileAttributes.setAccessTime(System.currentTimeMillis());
-                _pnfs.setFileAttributes(id, fileAttributes);
-            } catch (CacheException e) {
-                _log.warn("Failed to update ATime: {}", e.getMessage());
-            }
+            FileAttributes fileAttributes = new FileAttributes();
+            fileAttributes.setAccessTime(System.currentTimeMillis());
+            _pnfs.notify(new PnfsSetFileAttributes(event.getPnfsId(), fileAttributes));
         }
     }
 


### PR DESCRIPTION
Addresses a performance issue when reading files from a pool.

Patch http://rb.dcache.org/r/4568/ modified the pool to let access
time be updated whenever a file is read. The update is however blocking,
which means that the notification thread in the pool is blocked until
a reply from PnfsManager is received. Given that we do not use the
reply for anything, we can just as well turn the access time update
into a non-blocking notification.

Target: trunk
Request: 2.6
Require-notes: no
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5472/
