### PR TITLE
pool: Resolve 'no such provider: BC' error in SRM 3rd party copy

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/transferManager/RemoteGsiftpTransferProtocolInfo.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/transferManager/RemoteGsiftpTransferProtocolInfo.java
@@ -1,24 +1,24 @@
 package diskCacheV111.vehicles.transferManager;
 
 import com.google.common.base.Throwables;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.globus.gsi.GlobusCredential;
+import org.globus.gsi.gssapi.GlobusGSSCredentialImpl;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.security.cert.CertificateException;
-import java.util.Collections;
-
-import org.globus.gsi.GlobusCredential;
-import org.globus.gsi.gssapi.GlobusGSSCredentialImpl;
-import org.ietf.jgss.GSSCredential;
-import org.ietf.jgss.GSSException;
 
 import diskCacheV111.vehicles.IpProtocolInfo;
 
@@ -51,6 +51,12 @@ public class RemoteGsiftpTransferProtocolInfo implements IpProtocolInfo
 
     private PrivateKey key;
     private X509Certificate[] certChain;
+
+    static
+    {
+        // The getCredential method relies on the BC provider
+        Security.addProvider(new BouncyCastleProvider());
+    }
 
     public RemoteGsiftpTransferProtocolInfo(String protocol,
                                             int major,


### PR DESCRIPTION
Addresses an issue in which third party srm copy transfers failed
with a "no such provider: BC" error in pools. The problem is a
regression introduced in dCache 2.2.9.

JGlobus and other code on-demand loads the bouncy castle provider
automatically. If the pool is loaded together with such
components, the error does not occur. However on its own, there
may be no code that loads bouncy castle and thus the third party
copy fails.

Target: 2.2
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5499/
