### PR TITLE
pool: Don't claim a restore was successfull when it failed

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/HsmStorageHandler2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/HsmStorageHandler2.java
@@ -577,6 +577,7 @@ public class HsmStorageHandler2
                     Thread.interrupted();
                 }
                 _handle.commit(null);
+                _log.info("File successfully restored from tape");
             } catch (CacheException e) {
                 _log.error(e.toString());
                 returnCode = 1;
@@ -620,8 +621,6 @@ public class HsmStorageHandler2
                 }
                 _infoMsg.setTransferTime(System.currentTimeMillis() - _timestamp);
                 sendBillingInfo();
-
-                _log.info("File successfully restored from tape");
             }
         }
 


### PR DESCRIPTION
Addresses the issue that the pool logs "File successfully
restored from tape" no matter whether the restore was
successful or not.

Target: trunk
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5485/
