### PR TITLE
billing: add flag to turn plotting on/off; fix SQL for migration scripts

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/html/HttpBillingHistoryEngine.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/html/HttpBillingHistoryEngine.java
@@ -12,59 +12,56 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Servlet stand-in {@link org.dcache.services.httpd.HttpServiceCell}. <br><br>
+ * Servlet stand-in {@link org.dcache.services.httpd.HttpServiceCell}. <br>
+ * <br>
  * Constructs dynamic html page with table of plots.
  *
  * @see BillingHistory
  * @author arossi
  */
 public final class HttpBillingHistoryEngine extends BillingHistory implements
-HttpResponseEngine {
+                HttpResponseEngine {
 
     private static final Logger _log = LoggerFactory.getLogger(HttpBillingHistoryEngine.class);
     private static final String fileSep = System.getProperty("file.separator");
-
     private static final String THUMBNAIL_W = "120";
     private static final String THUMBNAIL_H = "60";
+    private static final String GENERATE_PLOTS = "generatePlots";
 
     private CellNucleus nucleus;
-    private final Thread _billingHistory;
+    private final boolean generatePlots;
+    private Thread _billingHistory;
 
-    /**
-     * @param nucleus
-     * @param args
-     */
     public HttpBillingHistoryEngine(CellNucleus nucleus, String[] args) {
         super(new Args(args));
         this.nucleus = nucleus;
-        _billingHistory = nucleus.newThread(this, "billing-history");
+        generatePlots = Boolean.valueOf(getArgs().getOpt(GENERATE_PLOTS));
+        if (generatePlots) {
+            _billingHistory = nucleus.newThread(this, "billing-history");
+        }
     }
 
     @Override
-    public void startup()
-    {
-        _billingHistory.start();
+    public void startup() {
+        if (generatePlots) {
+            _billingHistory.start();
+        }
     }
 
-
     @Override
-    public void shutdown()
-    {
-        setRunning(false);
-        _billingHistory.interrupt();
-        try {
-            _billingHistory.join();
-        } catch (InterruptedException e) {
-            _log.warn("Interrupted while waiting for BillingHistory thread to terminate");
+    public void shutdown() {
+        if (generatePlots) {
+            setRunning(false);
+            _billingHistory.interrupt();
+            try {
+                _billingHistory.join();
+            } catch (InterruptedException e) {
+                _log.warn("Interrupted while waiting for BillingHistory thread to terminate");
+            }
         }
         close();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see dmg.util.HttpResponseEngine#queryUrl(dmg.util.HttpRequest)
-     */
     @Override
     public void queryUrl(HttpRequest request) throws HttpException {
         request.printHttpHeader(0);
@@ -72,46 +69,52 @@ HttpResponseEngine {
                         this.nucleus.getDomainContext()));
     }
 
-    /**
-     * Constructs the html page.
-     *
-     * @param contents
-     */
     public void emit(HTMLWriter contents) {
         contents.addHeader("/styles/common.css", "Billing History Plots");
-        contents.println("<table align='center'>");
-        contents.println("<tr>");
-        contents.println("<th>Plot Type</th>");
-        contents.println("<th>24-Hour</th>");
-        contents.println("<th>Weekly</th>");
-        contents.println("<th>Monthly</th>");
-        contents.println("<th>Yearly</th>");
-        contents.println("</tr>");
-        for (int t = 0; t < BillingHistory.TYPE.length; t++) {
-            printRow(contents, BillingHistory.TITLE[t], BillingHistory.TYPE[t]);
+        if (!generatePlots) {
+            printWarning(contents);
+        } else {
+            contents.println("<table align='center'>");
+            contents.println("<tr>");
+            contents.println("<th>Plot Type</th>");
+            contents.println("<th>24-Hour</th>");
+            contents.println("<th>Weekly</th>");
+            contents.println("<th>Monthly</th>");
+            contents.println("<th>Yearly</th>");
+            contents.println("</tr>");
+            for (int t = 0; t < BillingHistory.TYPE.length; t++) {
+                printRow(contents, BillingHistory.TITLE[t],
+                                BillingHistory.TYPE[t]);
+            }
+            contents.println("</table>");
         }
-        contents.println("</table>");
         contents.addFooter(this.getClass().getName());
         contents.flush();
     }
 
     /**
+     * Generates warning message that plots are turned off.
+     */
+    private void printWarning(HTMLWriter contents) {
+        contents.println("<table align='center'>");
+        contents.println("<tr><td>");
+        contents.println("<h2>Billing Plots Have been Disabled</h2>");
+        contents.println("</td></tr>");
+        contents.println("</table>");
+    }
+
+    /**
      * Generates row in the table containing link to the image file for plot.
-     *
-     * @param contents
-     * @param title
-     * @param type
      */
     private void printRow(HTMLWriter contents, String title, String type) {
         contents.println("<tr>");
         contents.println("<td align='right'><i>" + title + "</i></td>");
-        String prefix =  subDir + fileSep + type;
+        String prefix = subDir + fileSep + type;
         for (String tag : BillingHistory.EXT) {
             String file = prefix + tag + imgExt;
             contents.println("<td><a href='" + file + "'> <img src='" + file
                             + "' width=" + THUMBNAIL_W + " height="
-                            + THUMBNAIL_H
-                            + "> </a></td>");
+                            + THUMBNAIL_H + "> </a></td>");
         }
         contents.println("</tr>");
     }

--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -30,6 +30,11 @@ httpd.static-content.index=${httpd.static-content.dir}/index.html
 httpd.static-content.plots=/var/lib/dcache/plots
 httpd.static-content.plots.subdir=/plots
 
+#  ---- If this is set, the daemon for billing plot generation is turned on
+#       Non-service-specific name is retained for legacy reasons
+#
+(one-of?true|false)generatePlots=true
+
 #
 #   Document which TCP ports are opened
 #

--- a/skel/share/migration/migrate_from_messageinfo.sql
+++ b/skel/share/migration/migrate_from_messageinfo.sql
@@ -8,42 +8,41 @@
 --- hitinfo
 --------------------------------------------------------------------------------
 
-INSERT into billinginfo_rd_daily (transferred, size, count, date) SELECT SUM(transfersize),\
- SUM(fullsize), COUNT(datestamp), (DATE(datestamp)) from billinginfo \
-where isnew ='f' group by DATE(datestamp) ;
+INSERT into billinginfo_rd_daily (transferred, size, count, date) SELECT SUM(transfersize),
+ SUM(fullsize), COUNT(datestamp), (DATE(datestamp)) from billinginfo
+ where isnew ='f' group by DATE(datestamp) ;
 
-INSERT into billinginfo_wr_daily (transferred, size, count, date) SELECT SUM(transfersize),\
- SUM(fullsize), COUNT(datestamp), (DATE(datestamp)) from billinginfo \
-where isnew ='t' group by DATE(datestamp) ;
+INSERT into billinginfo_wr_daily (transferred, size, count, date) SELECT SUM(transfersize),
+ SUM(fullsize), COUNT(datestamp), (DATE(datestamp)) from billinginfo
+ where isnew ='t' group by DATE(datestamp) ;
 
-INSERT into storageinfo_rd_daily (size, count, date) SELECT SUM(fullsize), COUNT(datestamp),\
- (DATE(datestamp)) from storageinfo \
-where action ='restore' group by DATE(datestamp) ;
+INSERT into storageinfo_rd_daily (size, count, date) SELECT SUM(fullsize), COUNT(datestamp),
+ (DATE(datestamp)) from storageinfo
+ where action ='restore' group by DATE(datestamp) ;
 
-INSERT into storageinfo_wr_daily (size, count, date) SELECT SUM(fullsize), COUNT(datestamp),\
- (DATE(datestamp)) from storageinfo \
-where action ='store' group by DATE(datestamp) ;
+INSERT into storageinfo_wr_daily (size, count, date) SELECT SUM(fullsize), COUNT(datestamp),
+ (DATE(datestamp)) from storageinfo
+ where action ='store' group by DATE(datestamp) ;
 
-INSERT into billinginfo_tm_daily (maximum, minimum, totaltime, count, date) \
-SELECT MAX(connectiontime), MIN(connectiontime), SUM(connectiontime), \
-COUNT(datestamp), (DATE(datestamp)) \
-from billinginfo group by DATE(datestamp) ;
+INSERT into billinginfo_tm_daily (maximum, minimum, totaltime, count, date)
+ SELECT MAX(connectiontime), MIN(connectiontime), SUM(connectiontime),
+ COUNT(datestamp), (DATE(datestamp))
+ from billinginfo group by DATE(datestamp) ;
 
-INSERT into costinfo_daily (totalcost, count, date) SELECT SUM(cost), COUNT(datestamp), \
-(DATE(datestamp)) from costinfo group by DATE(datestamp) ;
+INSERT into costinfo_daily (totalcost, count, date) SELECT SUM(cost), COUNT(datestamp),
+ (DATE(datestamp)) from costinfo group by DATE(datestamp) ;
 
-CREATE TEMPORARY TABLE temp_hitinfo_daily (cached biginit, ncached bigint, total bigint, \
-date timestamp);
+CREATE TEMPORARY TABLE temp_hitinfo_daily (cached bigint, ncached bigint, total bigint, date timestamp);
 
-INSERT into temp_hitinfo_daily (cached, ncached, total, date) \
-SELECT COUNT(filecached), 0, COUNT(filecached), DATE(datestamp) from hitinfo \
-where filecached = true group by DATE(datestamp);
+INSERT into temp_hitinfo_daily (cached, ncached, total, date)
+ SELECT COUNT(filecached), 0, COUNT(filecached), DATE(datestamp) from hitinfo
+ where filecached = true group by DATE(datestamp);
 
-INSERT into temp_hitinfo_daily (cached, ncached, total, date) \
-SELECT 0, COUNT(filecached), COUNT(filecached), DATE(datestamp) from hitinfo \
-where filecached = false group by DATE(datestamp);
+INSERT into temp_hitinfo_daily (cached, ncached, total, date)
+ SELECT 0, COUNT(filecached), COUNT(filecached), DATE(datestamp) from hitinfo
+ where filecached = false group by DATE(datestamp);
 
-INSERT into hitinfo_daily (cached, notcached, count, date) \
-SELECT SUM(cached), SUM(ncached), SUM(total), date from temp_hitinfo_daily group by date;
+INSERT into hitinfo_daily (cached, notcached, count, date)
+ SELECT SUM(cached), SUM(ncached), SUM(total), date from temp_hitinfo_daily group by date;
 
 DROP TABLE temp_hitinfo_daily;

--- a/skel/share/migration/migrate_from_preexistent.sql
+++ b/skel/share/migration/migrate_from_preexistent.sql
@@ -11,23 +11,23 @@
 --- hits_daily
 --------------------------------------------------------------------------------
 
-INSERT into billinginfo_rd_daily (transferred, size, count, date) \
-SELECT transfersize, fullsize, count data from dc_rd_daily ;
+INSERT into billinginfo_rd_daily (transferred, size, count, date)
+ SELECT transfersize, fullsize, count, date from dc_rd_daily ;
 
-INSERT into billinginfo_wr_daily (transferred, size, count, date) \
-SELECT transfersize, fullsize, count data from dc_wr_daily ;
+INSERT into billinginfo_wr_daily (transferred, size, count, date)
+ SELECT transfersize, fullsize, count, date from dc_wr_daily ;
 
-INSERT into storageinfo_rd_daily (size, count, date) \
-SELECT fullsize, count data from en_rd_daily ;
+INSERT into storageinfo_rd_daily (size, count, date)
+ SELECT fullsize, count, date from en_rd_daily ;
 
-INSERT into storageinfo_wr_daily (size, count, date) \
-SELECT fullsize, count data from en_wr_daily ;
+INSERT into storageinfo_wr_daily (size, count, date)
+ SELECT fullsize, count, date from en_wr_daily ;
 
-INSERT into billinginfo_tm_daily (maximum, minimum, totaltime, count, date) \
-SELECT max, min, avg*count, count, date from dc_tm_daily;
+INSERT into billinginfo_tm_daily (maximum, minimum, totaltime, count, date)
+ SELECT max, min, avg*count, count, date from dc_tm_daily;
 
-INSERT into costinfo_daily (totalcost, count, date) \
-SELECT mean*count, count, date from cost_daily;
+INSERT into costinfo_daily (totalcost, count, date)
+ SELECT mean*count, count, date from cost_daily;
 
-INSERT into temp_hitinfo_daily (cached, ncached, total, date) \
-SELECT cached, notcached, count, date from hits_daily;
+INSERT into hitinfo_daily (cached, notcached, count, date)
+ SELECT cached, notcached, count, date from hits_daily;

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -122,6 +122,7 @@ define context billingHistory-db-yes.exe endDefine
    set alias billingHistory class org.dcache.services.billing.html.HttpBillingHistoryEngine "billingHistory \
      -plotsDir=${httpd.static-content.plots} \
      -subDir=${httpd.static-content.plots.subdir} \
+     -generatePlots=${generatePlots} \
      -plotsProperties=${billingPlotPropertiesFile} \
      -plotsTimeout=30 \
      -exportType=png \


### PR DESCRIPTION
module: dcache services billing

When running the liquibase changesets on the billing database from 1.9.12+, there may be interference from the plotting thread which runs in a separate thread and already begins to execute queries on non-existent views.  This might actually cause the creation of the additional triggers to hang inside of the liquibase thread.

This version of billing never added the ability to turn plot generation on or off.  We add that capability here, and recommend that plots be turned off when running the upgraded dCache for the first time.

It also came to my attention that a patch fixing some typos in the migration scripts provided in shared/migration was never merged to this branch, so I have included those fixes as well (see http://rb.dcache.org/r/4389, trunk@17253).

Target: 2.2
Patch: http://rb.dcache.org/r/5500/
Merge-req: http://rt.dcache.org/Ticket/Display.html?id=7784
Require-book: no
Require-notes: yes
Acked-by: Tigran

RELEASE NOTES:  Adds ability, via the "generatePlots" property (found in later versions), to turn plotting off or on (on by default).  This is recommended when running the first time, since the plotting thread may interfere with the liquibase migration.  The sql migration scripts (in shared/migration) also had a some typographical problems which have been corrected.

Tested on testbed.
