### PR TITLE
all: Avoid error when hostkey is not readable to user

### DIFF
--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -267,7 +267,7 @@ checkForNonMigratedDcache()
 #  key through a 'openssl rsa' command that only alters the format.
 checkForPkcs8HostKey()
 {
-    if [ -f $(getProperty grid.hostcert.key) ] && \
+    if [ -r $(getProperty grid.hostcert.key) ] && \
        grep "BEGIN PRIVATE KEY" $(getProperty grid.hostcert.key) >/dev/null; then
 
         printp "The file $(getProperty grid.hostcert.key) is in PKCS#8        \


### PR DESCRIPTION
Was previously merged in ad4a20942d1cb61cb77b981961ef2d4086233fd9 however the fix was subsequently lost in 4c5f7f538c027e1c226f70f54ca6f4fbed0f8e80.
