### PR TITLE
dcache: fix DoorRequestInfoMessage so that owner is DN if there is publi...

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
@@ -1,14 +1,25 @@
 // $Id: DoorRequestInfoMessage.java,v 1.8 2006-04-11 09:47:53 tigran Exp $
 package diskCacheV111.vehicles;
 
-import javax.security.auth.Subject;
-import org.dcache.auth.Subjects;
 import org.antlr.stringtemplate.StringTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+
+import java.security.cert.X509Certificate;
+
+import org.dcache.auth.Subjects;
+import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.util.CertificateUtils;
 
 public class DoorRequestInfoMessage extends PnfsFileInfoMessage
 {
+    private static final Logger _logger
+        = LoggerFactory.getLogger(DoorRequestInfoMessage.class);
     private long _transactionTime = 0;
     private String _client = "unknown";
+    private String _owner;
 
     private static final long serialVersionUID = 2469895982145157834L;
 
@@ -44,12 +55,11 @@ public class DoorRequestInfoMessage extends PnfsFileInfoMessage
 
     public String getOwner()
     {
-        Subject subject = getSubject();
-        String owner = Subjects.getDn(subject);
-        if (owner == null) {
-            owner = Subjects.getUserName(subject);
-        }
-        return owner;
+        return _owner;
+    }
+
+    public void setOwner(String owner) {
+        _owner = owner;
     }
 
     public int getGid()
@@ -70,6 +80,14 @@ public class DoorRequestInfoMessage extends PnfsFileInfoMessage
     }
 
     @Override
+    public void setSubject(Subject subject) {
+        super.setSubject(subject);
+        if (_owner == null) {
+	     setOwner(getOwner(subject));
+        }
+    }
+
+    @Override
     public void fillTemplate(StringTemplate template)
     {
         super.fillTemplate(template);
@@ -78,5 +96,31 @@ public class DoorRequestInfoMessage extends PnfsFileInfoMessage
         template.setAttribute("gid", getGid());
         template.setAttribute("owner", getOwner());
         template.setAttribute("client", getClient());
+    }
+
+    private static String getOwner(Subject subject) {
+        String owner = Subjects.getDn(subject);
+        if (owner == null) {
+            owner = findDnFromCredential(subject);
+        }
+        if (owner == null) {
+            owner = Subjects.getUserName(subject);
+        }
+        return owner;
+    }
+
+    private static String findDnFromCredential(Subject subject) {
+        for (Object credential: subject.getPublicCredentials()) {
+            if (credential instanceof X509Certificate[]) {
+                X509Certificate[] chain = (X509Certificate[]) credential;
+                try {
+                    return CertificateUtils.getSubjectFromX509Chain(chain, false);
+                } catch (AuthenticationException t) {
+                    _logger.error("There was a problem in extracting the DN from a certificate chain in {}",
+                                  subject);
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
...c credential

With gPlazma 2, the XACML plugin no longer has an ad hoc data structure (like KPWD) from which the DN of the user can be derived on the door message, because the authorized principals include only UserName, UID and GID principals.  However, our CMS Tier1 users say they require this database field to reflect the DN, and not the role name which ends up appearing there.

This fix is simple: the best effort to find a DN and make the "owner" field carry it now includes a search of the certificate chain.

Target: 2.2
Patch: http://rb.dcache.org/r/5536
Require-book: no
Require-notes: yes
Acked-by: Dmitry
