### PR TITLE
SRM: don't talk to SpaceManager when disabled

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -228,6 +228,8 @@ public final class Storage
     private final static String INFINITY = "infinity";
 
     private static boolean kludgeDomainMainWasRun = false;
+    private static final String SPACEMANAGER_DISABLED_MESSAGE =
+            "space reservation is disabled";
 
     /* these are the  protocols
      * that are not sutable for either put or get */
@@ -277,6 +279,7 @@ public final class Storage
     private DirectoryListSource _listSource;
 
     private boolean _isOnlinePinningEnabled = true;
+    private boolean _isSpaceManagerEnabled;
 
     // public static SRM getSRMInstance(String xmlConfigPath)
     public static SRM getSRMInstance(final String[] dCacheParams,
@@ -351,6 +354,11 @@ public final class Storage
     }
 
     @Required
+    public void setIsSpaceManagerEnabled(boolean isEnabled)
+    {
+        _isSpaceManagerEnabled = isEnabled;
+    }
+
     public void setSpaceManagerStub(CellStub spaceManagerStub)
     {
         _spaceManagerStub = spaceManagerStub;
@@ -1671,22 +1679,24 @@ public final class Storage
 
             /* Determine space tokens.
              */
-            try {
-                GetFileSpaceTokensMessage msg =
-                    new GetFileSpaceTokensMessage(attributes.getPnfsId());
-                msg = _spaceManagerStub.sendAndWait(msg);
+            if(_isSpaceManagerEnabled) {
+                try {
+                    GetFileSpaceTokensMessage msg =
+                        new GetFileSpaceTokensMessage(attributes.getPnfsId());
+                    msg = _spaceManagerStub.sendAndWait(msg);
 
-                if (msg.getSpaceTokens() != null) {
-                    fmd.spaceTokens = new long[msg.getSpaceTokens().length];
-                    System.arraycopy(msg.getSpaceTokens(), 0,
-                                     fmd.spaceTokens, 0,
-                                     msg.getSpaceTokens().length);
+                    if (msg.getSpaceTokens() != null) {
+                        fmd.spaceTokens = new long[msg.getSpaceTokens().length];
+                        System.arraycopy(msg.getSpaceTokens(), 0,
+                                         fmd.spaceTokens, 0,
+                                         msg.getSpaceTokens().length);
+                    }
+                } catch (TimeoutCacheException e) {
+                    /* SpaceManager is optional, so we don't clasify this
+                     * as an error.
+                     */
+                    _log.info(e.getMessage());
                 }
-            } catch (TimeoutCacheException e) {
-                /* SpaceManager is optional, so we don't clasify this
-                 * as an error.
-                 */
-                _log.info(e.getMessage());
             }
 
             return fmd;
@@ -2687,7 +2697,10 @@ public final class Storage
             DcacheFileMetaData fmd = super.toFmd(dir, entry);
             if (!fmd.isDirectory) {
                 lookupLocality(entry.getFileAttributes(), fmd);
-                lookupTokens(entry.getFileAttributes(), fmd);
+
+                if (_isSpaceManagerEnabled) {
+                    lookupTokens(entry.getFileAttributes(), fmd);
+                }
             }
             return fmd;
         }
@@ -2753,17 +2766,14 @@ public final class Storage
             String accessLatency,
             String description,
             SrmReserveSpaceCallbacks callbacks) {
-        AuthorizationRecord duser = (AuthorizationRecord) user;
 
-        SrmReserveSpaceCompanion.reserveSpace(
-                duser,
-                sizeInBytes,
-                spaceReservationLifetime,
-                retentionPolicy,
-                accessLatency,
-                description,
-                callbacks,
-                _spaceManagerStub);
+        if (_isSpaceManagerEnabled) {
+            SrmReserveSpaceCompanion.reserveSpace((AuthorizationRecord) user,
+                    sizeInBytes, spaceReservationLifetime, retentionPolicy,
+                    accessLatency, description, callbacks, _spaceManagerStub);
+        } else {
+            callbacks.ReserveSpaceFailed(SPACEMANAGER_DISABLED_MESSAGE);
+        }
     }
 
     @Override
@@ -2771,20 +2781,18 @@ public final class Storage
             String spaceToken,
             Long releaseSizeInBytes, // everything is null
             SrmReleaseSpaceCallbacks callbacks) {
-        long longSpaceToken;
-        try {
-            longSpaceToken = Long.parseLong(spaceToken);
-        } catch(Exception e){
-            callbacks.ReleaseSpaceFailed("invalid space token="+spaceToken);
-            return;
-        }
+        if (_isSpaceManagerEnabled) {
+            try {
+                long token = Long.parseLong(spaceToken);
 
-        AuthorizationRecord duser = (AuthorizationRecord) user;
-        SrmReleaseSpaceCompanion.releaseSpace(duser,
-                longSpaceToken,
-                releaseSizeInBytes,
-                callbacks,
-                _spaceManagerStub);
+                SrmReleaseSpaceCompanion.releaseSpace((AuthorizationRecord) user,
+                    token, releaseSizeInBytes, callbacks, _spaceManagerStub);
+            } catch(NumberFormatException e){
+                callbacks.ReleaseSpaceFailed("invalid space token="+spaceToken);
+            }
+        } else {
+            callbacks.ReleaseSpaceFailed(SPACEMANAGER_DISABLED_MESSAGE);
+        }
     }
 
     @Override
@@ -2796,22 +2804,19 @@ public final class Storage
                                         boolean overwrite,
                                         SrmUseSpaceCallbacks callbacks)
     {
-        try {
-            long longSpaceToken = Long.parseLong(spaceToken);
-            AuthorizationRecord duser = (AuthorizationRecord) user;
-            FsPath fsPath = getPath(surl);
-            SrmMarkSpaceAsBeingUsedCompanion.markSpace(duser,
-                                                       longSpaceToken,
-                                                       fsPath.toString(),
-                                                       sizeInBytes,
-                                                       useLifetime,
-                                                       overwrite,
-                                                       callbacks,
-                                                       _spaceManagerStub);
-        } catch (SRMInvalidPathException e) {
-            callbacks.SrmUseSpaceFailed("Invalid path: " + e.getMessage());
-        } catch (NumberFormatException e){
-            callbacks.SrmUseSpaceFailed("invalid space token=" + spaceToken);
+        if (_isSpaceManagerEnabled) {
+            try {
+                SrmMarkSpaceAsBeingUsedCompanion.markSpace((AuthorizationRecord) user,
+                        Long.parseLong(spaceToken), getPath(surl).toString(),
+                        sizeInBytes, useLifetime, overwrite, callbacks,
+                        _spaceManagerStub);
+            } catch (SRMInvalidPathException e) {
+                callbacks.SrmUseSpaceFailed("Invalid path: " + e.getMessage());
+            } catch (NumberFormatException ignored){
+                callbacks.SrmUseSpaceFailed("invalid space token=" + spaceToken);
+            }
+        } else {
+            callbacks.SrmUseSpaceFailed(SPACEMANAGER_DISABLED_MESSAGE);
         }
     }
 
@@ -2821,19 +2826,25 @@ public final class Storage
                                           URI surl,
                                           SrmCancelUseOfSpaceCallbacks callbacks)
     {
-        try {
-            long longSpaceToken = Long.parseLong(spaceToken);
-            AuthorizationRecord duser = (AuthorizationRecord) user;
-            FsPath fsPath = getPath(surl);
-            SrmUnmarkSpaceAsBeingUsedCompanion.unmarkSpace(duser,
-                                                           longSpaceToken,
-                                                           fsPath.toString(),
-                                                           callbacks,
-                                                           _spaceManagerStub);
-        } catch (SRMInvalidPathException e) {
-            callbacks.CancelUseOfSpaceFailed("Invalid path: " + e.getMessage());
-        } catch (NumberFormatException e){
-            callbacks.CancelUseOfSpaceFailed("invalid space token="+spaceToken);
+        if (_isSpaceManagerEnabled) {
+            try {
+                SrmUnmarkSpaceAsBeingUsedCompanion.unmarkSpace((AuthorizationRecord) user,
+                        Long.parseLong(spaceToken), getPath(surl).toString(),
+                        callbacks, _spaceManagerStub);
+            } catch (SRMInvalidPathException e) {
+                callbacks.CancelUseOfSpaceFailed("Invalid path: " + e.getMessage());
+            } catch (NumberFormatException ignored){
+                callbacks.CancelUseOfSpaceFailed("invalid space token="+spaceToken);
+            }
+        } else {
+            callbacks.CancelUseOfSpaceFailed(SPACEMANAGER_DISABLED_MESSAGE);
+        }
+    }
+
+    private void guardSpaceManagerEnabled() throws SRMException
+    {
+        if (!_isSpaceManagerEnabled) {
+            throw new SRMException(SPACEMANAGER_DISABLED_MESSAGE);
         }
     }
 
@@ -2849,6 +2860,7 @@ public final class Storage
         throws SRMException
     {
         _log.debug("srmGetSpaceMetaData");
+        guardSpaceManagerEnabled();
         if(spaceTokens == null) {
             throw new SRMException("null array of space tokens");
         }
@@ -2957,8 +2969,9 @@ public final class Storage
     public String[] srmGetSpaceTokens(SRMUser user, String description)
         throws SRMException
     {
-        AuthorizationRecord duser = (AuthorizationRecord) user;
         _log.debug("srmGetSpaceTokens ("+description+")");
+        guardSpaceManagerEnabled();
+        AuthorizationRecord duser = (AuthorizationRecord) user;
         GetSpaceTokens getTokens =
             new GetSpaceTokens(duser,
                                description);
@@ -3078,6 +3091,7 @@ public final class Storage
                                              long newReservationLifetime)
         throws SRMException
     {
+        guardSpaceManagerEnabled();
         try {
             long longSpaceToken = Long.parseLong(spaceToken);
             ExtendLifetime extendLifetime =

--- a/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
@@ -116,6 +116,8 @@
     <property name="transferManagerStub" ref="transfer-manager-stub"/>
     <property name="copyManagerStub" ref="copy-manager-stub"/>
     <property name="pinManagerStub" ref="pin-manager-stub"/>
+    <property name="isSpaceManagerEnabled"
+              value="${spaceManagerEnabled}"/>
     <property name="loginBrokerUpdatePeriod"
               value="${srmLoginBrokerUpdatePeriod}"/>
     <property name="numberOfDoorsInRandomSelection"

--- a/skel/share/services/srm.batch
+++ b/skel/share/services/srm.batch
@@ -161,21 +161,33 @@ check -strong grid.hostcert.cert
 check -strong grid.ca.path
 
 
+# The 'spaceManagerEnabled' environment variable is a sanitised
+# version of 'srmSpaceManagerEnabled'.  It is always set and is either
+# 'true' or 'false'.
+
+onerror continue
+define env srmSpaceManagerOn.exe endExe
+  set env spaceManagerEnabled true
+endExe
+
 #
 # Force space manager related settings to off if space manager is
 # disabled.
 #
-
-onerror continue
 define env srmSpaceManagerOff.exe endExe
   set env srmImplicitSpaceManagerEnabled false
-  set env srmSpaceReservation false
   set env srmSpaceReservationStrict false
+  set env spaceManagerEnabled false
 endExe
 
 eval ${srmSpaceManagerEnabled} true == ${srmSpaceManagerEnabled} on == || ${srmSpaceManagerEnabled} yes == || ${srmSpaceManagerEnabled} enabled == ||
-exec env srmSpaceManagerOff.exe -ifnotok
+set env srmSpaceManagerIsOn ${rc}
+exec env srmSpaceManagerOn.exe -ifok=srmSpaceManagerIsOn
+exec env srmSpaceManagerOff.exe -ifnotok=srmSpaceManagerIsOn
 onerror shutdown
+
+
+
 
 exec file:${dcache.paths.share}/cells/threadmanager.fragment
 exec file:${dcache.paths.share}/cells/embedded-gPlazma.fragment
@@ -329,4 +341,5 @@ create org.dcache.cells.UniversalSpringCell ${cell.name} \
         -service-key=${grid.hostcert.key} \
         -service-cert=${grid.hostcert.cert} \
         -service-trusted-certs=${grid.ca.path} \
+        -spaceManagerEnabled=${spaceManagerEnabled} \
 "


### PR DESCRIPTION
A recent patch (committed master@2ba5c9 and 2.2@d069ff) fixed an NPE.
The submitter mentioned concerns that this would "break something",
which turned out to be correct.  After the patch, SRM verbose ls
(and space-related operations) no longer function correctly if
space-manager is disabled.  This is because SRM verbose-ls always
sends a request to space-manager and, after the patch, space-manager
gives an error-response when running but configured to be disabled.

This patch alters the SRM so that if configuration shows that
space-manager is disabled then no communication with space-manager
is attempted.  SRM verbose ls will list all files are in no
space-reservations and the space-related operations will fail with
a friendly error message.

A side-effect of this patch is that the 'spacemanager' service is
no longer needed when space-manager is disabled.

Target: master
Request: 2.6
Request: 2.2
Patch: http://rb.dcache.org/r/5526/
Acked-by: Gerd Behrmann
