### PR TITLE
gplazma2-xacml: fix regression on network address sort

### DIFF
--- a/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
+++ b/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
@@ -29,6 +29,7 @@ import java.security.Principal;
 import java.security.cert.CRLException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -439,6 +440,8 @@ public final class XACMLPlugin implements GPlazmaAuthenticationPlugin {
         if (addressList.isEmpty()) {
             return;
         }
+
+        addressList = new ArrayList<>(addressList);
 
         Collections.sort(addressList, NetworkUtils.getExternalInternalSorter());
         _resourceDNSHostName = addressList.get(0).getCanonicalHostName();


### PR DESCRIPTION
module:  gplazma2-xacml

svn trunk@18137 altered NetworkUtils to use an immutable list for local addresses.  The XACML plugin needs to sort these according to external/internal.  This sort was failing and causing failure to load the plugin (undiscovered until now).

Patch copies the immutable list and then sorts.

Target: 2.6
Patch: http://rb.dcache.org/r/5539
Require-notes: no
Require-book: no
Acked-by: Paul
