### PR TITLE
ftp: Log CertPath in case CertPath validation fails

### DIFF
--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GssFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GssFtpDoorV1.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.security.cert.CertPathValidatorException;
 import javax.security.auth.Subject;
 
 //jgss
@@ -28,6 +29,11 @@ import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.ChannelBinding;
 import org.ietf.jgss.GSSName;
 import org.ietf.jgss.MessageProp;
+
+import com.google.common.base.Throwables;
+
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.getFirst;
 
 public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
 {
@@ -120,9 +126,19 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
             //debug("GssFtpDoorV1::ac_adat: Token created");
             _gssIdentity = _serviceContext.getSrcName();
             //debug("GssFtpDoorV1::ac_adat: User principal: " + UserPrincipal);
-        } catch( Exception e ) {
-            _logger.error("GssFtpDoorV1::ac_adat: got service context exception", e);
-            reply("535 Authentication failed: " + e);
+        } catch (InterruptedException e) {
+            reply("421 Service unavailable");
+            return;
+        } catch (GSSException e) {
+            CertPathValidatorException cpve =
+                    getFirst(filter(Throwables.getCausalChain(e), CertPathValidatorException.class), null);
+            if (cpve != null && cpve.getCertPath() != null && _logger.isDebugEnabled()) {
+                _logger.error("Authentication failed: {} in #{} of {}",
+                        new Object[] { e.getMessage(), cpve.getIndex() + 1, cpve.getCertPath() });
+            } else {
+                _logger.error("Authentication failed: {}", e.getMessage());
+            }
+            reply("535 Authentication failed: " + e.getMessage());
             return;
         } finally {
             disableInterrupt();


### PR DESCRIPTION
Addresses the issue that if authentication fails with a certificate
chain validation error, the error message contains absolutely no
information about the certificate that triggered the failure.

Requires https://github.com/gbehrmann/JGlobus/tree/feature/certpathvalidationexception_includes_certpath

Target: trunk
Request: 2.6
Request: 2.5
Request: 2.2-sha2
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5543/
(cherry picked from commit ae2c685b6e98bacd2db15aa3ec18ca1e4bbb9e45)
(cherry picked from commit c4f2e7fdadc9e90fb8056ca49902dc1ab02f0552)
