### PR TITLE
ftp: Log CertPath in case CertPath validation fails

### DIFF
--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GssFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GssFtpDoorV1.java
@@ -1,5 +1,6 @@
 package diskCacheV111.doors;
 
+import com.google.common.base.Throwables;
 import org.ietf.jgss.ChannelBinding;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSException;
@@ -9,12 +10,16 @@ import org.ietf.jgss.MessageProp;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
+import java.security.cert.CertPathValidatorException;
 
 import diskCacheV111.util.Base64;
 
 import dmg.util.Args;
 import dmg.util.CommandExitException;
 import dmg.util.StreamEngine;
+
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.getFirst;
 
 public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
 {
@@ -108,9 +113,19 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
             //debug("GssFtpDoorV1::ac_adat: Token created");
             _gssIdentity = _serviceContext.getSrcName();
             //debug("GssFtpDoorV1::ac_adat: User principal: " + UserPrincipal);
-        } catch( Exception e ) {
-            _logger.error("GssFtpDoorV1::ac_adat: got service context exception", e);
-            reply("535 Authentication failed: " + e);
+        } catch (InterruptedException e) {
+            reply("421 Service unavailable");
+            return;
+        } catch (GSSException e) {
+            CertPathValidatorException cpve =
+                    getFirst(filter(Throwables.getCausalChain(e), CertPathValidatorException.class), null);
+            if (cpve != null && cpve.getCertPath() != null && _logger.isDebugEnabled()) {
+                _logger.error("Authentication failed: {} in #{} of {}",
+                        e.getMessage(), cpve.getIndex() + 1, cpve.getCertPath());
+            } else {
+                _logger.error("Authentication failed: {}", e.getMessage());
+            }
+            reply("535 Authentication failed: " + e.getMessage());
             return;
         } finally {
             disableInterrupt();


### PR DESCRIPTION
Addresses the issue that if authentication fails with a certificate
chain validation error, the error message contains absolutely no
information about the certificate that triggered the failure.

Requires https://github.com/gbehrmann/JGlobus/tree/feature/certpathvalidationexception_includes_certpath

Target: trunk
Request: 2.6
Request: 2.5
Request: 2.2-sha2
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5543/
(cherry picked from commit ae2c685b6e98bacd2db15aa3ec18ca1e4bbb9e45)
