### PR TITLE
ftp: Log stack trace on authentication failure

### DIFF
--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GssFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GssFtpDoorV1.java
@@ -125,6 +125,7 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
             } else {
                 _logger.error("Authentication failed: {}", e.getMessage());
             }
+	    _logger.trace("Authentication failed", e);
             reply("535 Authentication failed: " + e.getMessage());
             return;
         } finally {


### PR DESCRIPTION
A recent patch removed logging of stack trace during GSI/Kerberos
authentication failure. Although it is correct not to log a stack
trace for such a failure (it is not a bug), having a stack trace
while debugging JGlobus 2 is convenient. This patch adds logging
of the stack trace at trace level.

Target: trunk
Request: 2.6
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5547/
(cherry picked from commit 1a8276673b18fa49f544037b23e76a0d1de61af0)
