### PR TITLE
wevdav,xrootd,nfs: Fix blocking reverse DNS lookup

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -511,7 +511,7 @@ public class Transfer implements Comparable<Transfer>
                                _poolName,
                                _status,
                                _startedAt,
-                               _clientAddress.getAddress().getHostName());
+                               _clientAddress.getHostString());
     }
 
     /**


### PR DESCRIPTION
Addresses an issue in these doors that could cause the door to
become unresponsive.

Our monitoring services periodically poll our doors to get a list
of active transfers. The door did a reverse DNS lookup on the client
IP and this lookup could block the door.

Target: trunk
Request: 2.6
Request: 2.5
Request: 2.2
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5546/
(cherry picked from commit cf364eecc3a2b69e321ad41246c238900fbdf902)
