### PR TITLE
don't use /opt/ paths in dcachesrm-gplazma.policy

### DIFF
--- a/skel/etc/dcachesrm-gplazma.policy
+++ b/skel/etc/dcachesrm-gplazma.policy
@@ -55,7 +55,7 @@ gplazmalite-vorole-mapping-priority="2"
 #  An example dcache.kpwd is located in the share/examples/gplazma directory.
 #  Copy this file into ${dcache.paths.etc} directory and modify the file's
 #  content as appropriate.
-kpwdPath="/opt/d-cache/etc/dcache.kpwd"
+kpwdPath="/etc/dcache/dcache.kpwd"
 
 # grid-mapfile
 gridMapFilePath="/etc/grid-security/grid-mapfile"


### PR DESCRIPTION
There's still a place in the template file, where /opt is used, namely the
default for the kpwdPath property.
- Change the default value for the kpwdPath to "/etc/dcache/dcache.kpwd".

Actually I'd personally suggest introducing a new subdirectory like
/etc/dcache/access_control/
where access control related files should go into. This may include things like
grid-vorolemap, grid-mapfile, storage-authzdb or dcache.kpwd.
/etc/grid-security doesn't seem the right place for them, as they are not
necessarily grid-related.
But that could be done in another patch.

Signed-off-by: Christoph Anton Mitterer mail@christoph.anton.mitterer.name
