### PR TITLE
use example.org in some more places

### DIFF
--- a/skel/etc/dcachesrm-gplazma.policy
+++ b/skel/etc/dcachesrm-gplazma.policy
@@ -78,7 +78,7 @@ vomsValidation="false"
 
 # SAZ Settings
 saz-client="OFF"
-SAZ_SERVER_HOST="saz-server.oursite.edu"
+SAZ_SERVER_HOST="saz-server.example.org"
 SAZ_SERVER_PORT="8888"
 
 # #################################################################################

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -233,10 +233,10 @@ gplazma.argus.endpoint=https://localhost:8154/authz
 gplazma.kpwd.file=${kpwdFile}
 
 #  ---- NIS server host
-gplazma.nis.server=nisserv.domain.com
+gplazma.nis.server=nisserv.example.org
 
 #  ---- NIS domain name
-gplazma.nis.domain=domain.com
+gplazma.nis.domain=example.org
 
 #  ---- JAAS application name
 #
@@ -258,7 +258,7 @@ gplazma.xacml.ca=${grid.ca.path}
 #
 
 # LDAP server host
-gplazma.ldap.server = ldap.example.com
+gplazma.ldap.server = ldap.example.org
 # LDAP server port number
 gplazma.ldap.port = 389
 

--- a/skel/share/examples/gplazma/dcache.kpwd
+++ b/skel/share/examples/gplazma/dcache.kpwd
@@ -33,9 +33,9 @@
 
 version 2.1
 
-mapping "/O=Grid/O=Globus/OU=domain.org/CN=EXP Production" local-account
+mapping "/O=Grid/O=Globus/OU=example.org/CN=EXP Production" local-account
 # the following are the user auth records
 login local-account read-write uid gid / / /
- /O=Grid/O=Globus/OU=domain.org/CN=EXP Production
+ /O=Grid/O=Globus/OU=example.org/CN=EXP Production
 
 # the following are the user auth records


### PR DESCRIPTION
example.org is already used in most places as default domain name.
- Use example.org instead of real (not reserved) domain names in some more
  places.

Using example.org is already much better than using real domain names as it was
done in the past, but still it has some negative effects.
If a dCache instance really uses them, the example.org server will get
“attacked”.
Or it could be even a security problem, when someone manages to actually run a
services on example.org, which dCache tries to use then (and potentially
trusts).

The best way IMHO would be to mark all options where an example value is given
with some flag, that they _must_ be overridden.
Another alternative, that should work in practise is using a domain like
“example.invalid” as this should already be sorted out by the local nameservers.
And ”invalid” is a specially reserved (top level) domain.

Signed-off-by: Christoph Anton Mitterer mail@christoph.anton.mitterer.name
