### PR TITLE
mark billingDb to be forbidden

### DIFF
--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -381,3 +381,5 @@ billing/db.schema.changelog=${billingChangelog}
 #  The following properties are Obsolete or Forbidden.
 #
 (forbidden)billingDb=use billingLogsDir instead
+(obsolete)billingDbCommitRows=use billingMaxInsertsBeforeCommit instead
+(obsolete)billingDbCommitIntervalInMilliseconds=use billingMaxTimeBeforeCommitInSecs instead


### PR DESCRIPTION
It seems billingDb was used at least until 1.9.12 instead of the current
billingLogsDir but never marked as forbidden.
- Mark billingDb to be forbidden and replaced by billingLogsDir.

Signed-off-by: Christoph Anton Mitterer mail@christoph.anton.mitterer.name
