### PR TITLE
dcache: billing -- fix error in liquibase varchar changeset

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.4.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.4.xml
@@ -20,4 +20,82 @@
         <dropTable tableName="costinfo_daily"/>
         <dropTable tableName="costinfo"/>
     </changeSet>
+    <!-- VARCHAR ADJUSTMENTS, AGAIN.  The original changeset was discovered to have an off-by-one error in it -->
+    <changeSet author="arossi" id="5.1.0" context="billing" failOnError="false">
+        <sql splitStatements="false">
+            INSERT INTO billinginfo (errormessage)
+            VALUES ('000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006');
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.1" context="billing">
+        <!-- If the insert (5.1.0) worked, the database was probably already initialized with VARCHAR unlimited;
+             so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from billinginfo where errormessage = '000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006'</sqlCheck>
+        </preConditions>
+        <sql splitStatements="false">
+            DELETE FROM billinginfo
+            WHERE errormessage = '000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006';
+        </sql>
+        <modifyDataType tableName="billinginfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
+        <modifyDataType tableName="billinginfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
+    </changeSet>
+    <changeSet author="arossi" id="5.1.2" context="billing" failOnError="false">
+        <sql splitStatements="false">
+            INSERT INTO doorinfo (errormessage)
+            VALUES ('000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006');
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.3" context="billing">
+        <!-- If the insert (5.1.2) worked, the database was probably already initialized with VARCHAR unlimited;
+             so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from doorinfo where errormessage = '000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006'</sqlCheck>
+        </preConditions>
+        <sql splitStatements="false">
+            DELETE FROM doorinfo
+            WHERE errormessage = '000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006';
+        </sql>
+        <modifyDataType tableName="doorinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
+        <modifyDataType tableName="doorinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
+        <modifyDataType tableName="doorinfo" columnName="path" newDataType="VARCHAR(8000)" />
+    </changeSet>
+    <changeSet author="arossi" id="5.1.4" context="billing" failOnError="false">
+        <sql splitStatements="false">
+            INSERT INTO storageinfo (errormessage)
+            VALUES ('000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006');
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.5" context="billing">
+        <!-- If the insert (5.1.4) worked, the database was probably already initialized with VARCHAR unlimited;
+             so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from storageinfo where errormessage = '000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006'</sqlCheck>
+        </preConditions>
+        <sql splitStatements="false">
+            DELETE FROM storageinfo
+            WHERE errormessage = '000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006';
+        </sql>
+        <modifyDataType tableName="storageinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
+        <modifyDataType tableName="storageinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
+    </changeSet>
+    <changeSet author="arossi" id="5.1.6" context="billing" failOnError="false">
+        <sql splitStatements="false">
+            INSERT INTO hitinfo (errormessage)
+            VALUES ('000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006');
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.7" context="billing">
+        <!-- If the insert (5.1.6) worked, the database was probably already initialized with VARCHAR unlimited;
+             so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from hitinfo where errormessage = '000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006'</sqlCheck>
+        </preConditions>
+        <sql splitStatements="false">
+            DELETE FROM hitinfo
+            WHERE errormessage = '000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006000000000700000000080000000009000000000C000000000100000000020000000003000000000400000000050000000006';
+        </sql>
+        <modifyDataType tableName="hitinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
+        <modifyDataType tableName="hitinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
module: dcache

The liquibase changeset 4.1.7 was discovered to contain an off-by-one error in the string used to test the condition for changing the varchar length in the billing tables (the actual length of the string was 256, not 257). As a result, 4.1.7. 4.1.8 and 4.1.9 never will run, and all billing installations created by liquibase (which hardcodes the default to 256) remained as such.

The reason for the requested change was that the path and errormessage attributes of certain tables can well exceed 256.

The new changesets correct the error.

Target: master
Committed: master@db5ddfd6566edcbffa0829f16314bc9c2f0a3da8
Patch: http://rb.dcache.org/r/5555
Require-book: no
Require-notes: yes
Request: 2.2
Request: 2.6
Acked-by: Dmitry

RELEASE NOTES:  Fix string lengths in billing databse tables. Tables created automatically contained character columns limited to 256 which is too restrictive for path and errormessage columns in billinginfo, doorinfo and storageinfo tables. Additionaly, the length of pnfsid string was limited to 36.  
A previous patch designed to address this issue failed to so.

TESTING:

see patch http://rb.dcache.org/r/5555 for master
