### PR TITLE
Minor bug fix upgrades for third party dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.slf4j>1.7.2</version.slf4j>
+        <version.slf4j>1.7.5</version.slf4j>
         <version.milton>2.3.0.6</version.milton>
-        <version.spring>3.2.0.RELEASE</version.spring>
-        <version.aspectj>1.7.1</version.aspectj>
+        <version.spring>3.2.2.RELEASE</version.spring>
+        <version.aspectj>1.7.2</version.aspectj>
         <version.smc>6.1.0</version.smc>
         <version.xerces>2.9.1</version.xerces>
         <version.jetty>7.6.10.v20130312</version.jetty>
-        <version.wicket>1.5.9</version.wicket>
+        <version.wicket>1.5.10</version.wicket>
         <version.xrootd4j>1.2.0</version.xrootd4j>
         <version.jglobus>2.0.5-dcache-rc4</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.0.9</version>
+                <version>1.0.12</version>
             </dependency>
             <dependency>
                 <groupId>jline</groupId>
@@ -286,7 +286,7 @@
             <dependency>
                 <groupId>com.sleepycat</groupId>
                 <artifactId>je</artifactId>
-                <version>5.0.58</version>
+                <version>5.0.73</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.mq</groupId>
@@ -517,7 +517,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.3.170</version>
+                <version>1.3.171</version>
             </dependency>
 
             <dependency>
@@ -797,6 +797,7 @@
                     <version>3.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>2.6</version>
                 </plugin>
@@ -806,6 +807,7 @@
                     <version>2.6</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>2.4</version>
                     <configuration>
@@ -813,10 +815,12 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
                     <version>2.3</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>2.5</version>
                 </plugin>
@@ -883,10 +887,12 @@
                     </dependencies>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.7</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.13</version>
                 </plugin>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -122,7 +122,7 @@
     -DwantLog4jSetup=n \
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath=${dcache.java.oom.file} \
-    -javaagent:${dcache.paths.classes}/spring-instrument-3.2.0.RELEASE.jar \
+    -javaagent:${dcache.paths.classes}/spring-instrument-3.2.2.RELEASE.jar \
     ${dcache.java.options.extra}
 
 # Whether to cache the compiled configuration files. If disabled most dCache


### PR DESCRIPTION
Addresses the issue that several third party libraries used by dCache
have bug fix releases newer than the version we use.

I would have liked to get these committed before 2.6.0 got released,
but didn't have the time to do it.

Target: master
Request: 2.6
Require-book: no
Require-notes: yes
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5549/
(cherry picked from commit e9e94ce5da598f9d5d6a57ee551504fcfcce44e7)
