### PR TITLE
improved documentation for atime.gap

### DIFF
--- a/skel/share/defaults/pnfsmanager.properties
+++ b/skel/share/defaults/pnfsmanager.properties
@@ -204,14 +204,22 @@ pnfsmanager/db.schema.changelog=${chimera.db.schema.changelog}
 
 
 #
-#  --- define time precision for atime updates on read.
+#  --- Last Access Time (atime) updates for files
 #
-#  File's last access time (atime) update precision in seconds.
+#  This integer value controls whether and when dCache updates the last access
+#  time of files on reading them.
 #
-#  For performance reasons dCache can refrain from updating files access time on read.
-#  This behavior is controlled by atime.gap parameter is set to a positive number.
-#  If a difference between a file's current atime value and new one is smaller than gap,
-#  then the file's atime will not be updated.
+#  Values <  0: atimes are never updated.
+#  Values >= 0: The maximum absolute(!) difference (in seconds) between a file's
+#               "new" atime and its curently stored one, where the atime is not
+#               yet updated.
+#               For example, when using a value of "4" and the old atime is (in
+#               POSIX time) "1000000000", then atimes up to including
+#               "1000000004" (but also down to "999999996") are not written;
+#               "1000000005" or later (respectively "999999995" or earlier)
+#               would be saved.
+#
+#  Updating the atimes less often (or not at all) may have performance benefits.
 #
 pnfsmanager/atime.gap=-1
 


### PR DESCRIPTION
The old documentation for atime.gap seemed to be not very exact and a bit
misleading, especially it lacked information about absolute differences being
used.
- Rewrote the documentation for atime.gap based on the code in modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
  including an example for how it works.
