### PR TITLE
webadmin: alarms -- fix behavior of display table header checkboxes

### DIFF
--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/alarms/AlarmsPage.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/alarms/AlarmsPage.java
@@ -85,6 +85,7 @@ public class AlarmsPage extends BasePage implements AuthenticatedWebPage {
 
     private static final long serialVersionUID = 993708875580341999L;
     private Button refreshButton;
+    private DisplayPanel displayPanel;
 
     public AlarmsPage() {
         refreshButton = new Button("refresh") {
@@ -93,13 +94,17 @@ public class AlarmsPage extends BasePage implements AuthenticatedWebPage {
             @Override
             public void onSubmit() {
                 getWebadminApplication().getAlarmDisplayService().refresh();
+                if (displayPanel != null) {
+                    displayPanel.clearHeaders();
+                }
             }
         };
 
         Form<?> form = new Form<Void>("form");
         form.add(new QueryPanel("filterPanel", this));
         if(getWebadminApplication().getAlarmDisplayService().isConnected()) {
-            form.add(new DisplayPanel("displayPanel", this));
+            displayPanel = new DisplayPanel("displayPanel", this);
+            form.add(displayPanel);
         } else {
             form.add(new ErrorPanel("displayPanel"));
         }
@@ -117,6 +122,7 @@ public class AlarmsPage extends BasePage implements AuthenticatedWebPage {
                 getWebadminApplication().getAlarmDisplayService().refresh();
             }
         });
+
         add(form);
     }
 

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/alarms/CheckPanel.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/alarms/CheckPanel.java
@@ -81,12 +81,17 @@ import java.util.UUID;
  * @author arossi
  */
 public final class CheckPanel extends Panel {
+    private static final long serialVersionUID = 4172391497442451620L;
+
+    private final CheckBox checkBox;
+
     public static abstract class CheckBoxColumn<T> extends AbstractColumn<T> {
         private static final long serialVersionUID = 8433056726333659452L;
 
         private final String uuid
             = UUID.randomUUID().toString().replace("-", "");
         private final String headerLabel;
+        private CheckPanel headerPanel;
 
         public CheckBoxColumn(String headerLabel, IModel<String> displayModel) {
             super(displayModel);
@@ -115,9 +120,9 @@ public final class CheckPanel extends Panel {
 
         @Override
         public Component getHeader(String componentId) {
-            CheckPanel panel = new CheckPanel(componentId, headerLabel,
+            headerPanel = new CheckPanel(componentId, headerLabel,
                             new Model<Boolean>(), uuid);
-            panel.get("check").add(new Behavior() {
+            headerPanel.get("check").add(new Behavior() {
                 private static final long serialVersionUID = -4210875030052297922L;
 
                 @Override
@@ -125,26 +130,30 @@ public final class CheckPanel extends Panel {
                     tag.put("onclick", js);
                 }
             });
-            return panel;
+
+            return headerPanel;
+        }
+
+        public void clearHeader() {
+           if (headerPanel !=null) {
+               headerPanel.checkBox.setModelObject(false);
+           }
         }
     }
-
-    private static final long serialVersionUID = 4172391497442451620L;
 
     public CheckPanel(String id, String label, IModel<Boolean> checkModel,
                     String uuid) {
         super(id);
         add(new Label("label", label));
-        add(newCheckBox("check", checkModel, uuid));
+        checkBox = newCheckBox("check", checkModel, uuid);
+        add(checkBox);
     }
 
     public CheckPanel(String id, IModel<Boolean> checkModel, String uuid) {
-        super(id);
         /*
          * label is in the mark-up so it needs to be added here
          */
-        add(new Label("label", ""));
-        add(newCheckBox("check", checkModel, uuid));
+        this(id, "", checkModel, uuid);
     }
 
     protected CheckBox newCheckBox(String id, IModel<Boolean> checkModel,

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/alarms/DisplayPanel.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/alarms/DisplayPanel.java
@@ -93,6 +93,9 @@ public class DisplayPanel extends Panel {
 
     private static final long serialVersionUID = -4499489059537621331L;
 
+    private CheckBoxColumn<LogEntry> delete;
+    private CheckBoxColumn<LogEntry> close;
+
     public DisplayPanel(String id, final AlarmsPage parent) {
         super(id);
         List<IColumn<LogEntry>> columns
@@ -125,6 +128,11 @@ public class DisplayPanel extends Panel {
         add(table);
     }
 
+    public void clearHeaders() {
+        delete.clearHeader();
+        close.clearHeader();
+    }
+
     private void addAttributeColumns(List<IColumn<LogEntry>> columns) {
         columns.add(new PropertyColumn<LogEntry>(Model.of("First"), "first",
                         "formattedDateOfFirstArrival"));
@@ -148,7 +156,7 @@ public class DisplayPanel extends Panel {
 
     private void addCloseColumn(List<IColumn<LogEntry>> columns,
                     final AlarmTableProvider provider) {
-        columns.add(new CheckBoxColumn<LogEntry>("Close", Model.of("Close")) {
+        close = new CheckBoxColumn<LogEntry>("Close", Model.of("Close")) {
             private static final long serialVersionUID = -7237325512597811741L;
 
             @Override
@@ -182,12 +190,14 @@ public class DisplayPanel extends Panel {
                     }
                 };
             }
-        });
+        };
+
+        columns.add(close);
     }
 
     private void addDeleteColumn(List<IColumn<LogEntry>> columns,
                     final AlarmTableProvider provider) {
-        columns.add(new CheckBoxColumn<LogEntry>("Delete", Model.of("Delete")) {
+        delete = new CheckBoxColumn<LogEntry>("Delete", Model.of("Delete")) {
             private static final long serialVersionUID = -7237325512597811741L;
 
             @Override
@@ -217,7 +227,9 @@ public class DisplayPanel extends Panel {
                     }
                 };
             }
-        });
+        };
+
+        columns.add(delete);
     }
 
     private void addNotesColumn(List<IColumn<LogEntry>> columns,


### PR DESCRIPTION
module: webadmin

The header checkboxes on the alarm display table have a custom jquery/javascript executable which allows them to set or unset all the visible checkboxes in the given table column.  However, when refresh is activated, the checkboxes remain checked, which is annoying.

This patch implements a clearHeader method which programmatically clears the header checkboxes after refresh.

Target: master
Committed: master@a4b3421d462ed55dfff53c31903c3d5279686efe
Acked-by: Dmitry
Patch: http://rb.dcache.org/r/5552/
Require-notes: yes
Require-book: no
Request: 2.6
