### PR TITLE
webadmin: add range to alarm query api and panel

### DIFF
--- a/modules/webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardAlarmDisplayService.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardAlarmDisplayService.java
@@ -82,6 +82,8 @@ import org.dcache.webadmin.controller.util.AlarmTableProvider;
 import org.dcache.webadmin.model.dataaccess.DAOFactory;
 import org.dcache.webadmin.model.dataaccess.ILogEntryDAO;
 import org.dcache.webadmin.model.exceptions.DAOException;
+import org.dcache.webadmin.model.util.AlarmJDOUtils;
+import org.dcache.webadmin.model.util.AlarmJDOUtils.AlarmDAOFilter;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -136,20 +138,25 @@ public class StandardAlarmDisplayService implements IAlarmDisplayService {
         if (!isConnected()) {
             return;
         }
+
         update();
         delete();
+
         Date after = alarmTableProvider.getAfter();
         Date before = alarmTableProvider.getBefore();
-        String severity = alarmTableProvider.getSeverity();
+        String severityStr = alarmTableProvider.getSeverity();
+        Severity severity = severityStr == null ? null :
+            Severity.valueOf(severityStr);
         String type = alarmTableProvider.getType();
         Boolean alarm = alarmTableProvider.isAlarm();
+        Integer rangeStart = alarmTableProvider.getFrom();
+        Integer rangeEnd = alarmTableProvider.getTo();
+
         try {
-            Collection<LogEntry> refreshed
-                = access.get(after,
-                             before,
-                             severity == null ? null
-                                              : Severity.valueOf(severity), type,
-                             alarm);
+            AlarmDAOFilter filter
+                = AlarmJDOUtils.getFilter(after, before, severity, type,
+                                          alarm, rangeStart, rangeEnd);
+            Collection<LogEntry> refreshed = access.get(filter);
             alarmTableProvider.setEntries(refreshed);
         } catch (DAOException e) {
             logger.error(e.getMessage(), e);

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/controller/util/AlarmTableProvider.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/controller/util/AlarmTableProvider.java
@@ -98,6 +98,8 @@ public class AlarmTableProvider extends
     private String severity = Severity.MODERATE.toString();
     private String type;
     private boolean showClosed;
+    private Integer from;
+    private Integer to;
 
     public void addToDeleted(LogEntry toDelete) {
         synchronized (deleted) {
@@ -134,6 +136,10 @@ public class AlarmTableProvider extends
         return new Date(before.getTime());
     }
 
+    public Integer getFrom() {
+        return from;
+    }
+
     public String getSeverity() {
         return severity;
     }
@@ -145,6 +151,10 @@ public class AlarmTableProvider extends
             return "ALARMS";
         }
         return "WARNINGS";
+    }
+
+    public Integer getTo() {
+        return to;
     }
 
     public String getType() {
@@ -185,12 +195,20 @@ public class AlarmTableProvider extends
         }
     }
 
+    public void setFrom(Integer from) {
+        this.from = from;
+    }
+
     public void setSeverity(String severity) {
         this.severity = severity;
     }
 
     public void setShowClosed(boolean showClosed) {
         this.showClosed = showClosed;
+    }
+
+    public void setTo(Integer to) {
+        this.to = to;
     }
 
     public void setType(String type) {

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/ILogEntryDAO.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/ILogEntryDAO.java
@@ -60,11 +60,10 @@ documents or software obtained from this server.
 package org.dcache.webadmin.model.dataaccess;
 
 import java.util.Collection;
-import java.util.Date;
 
-import org.dcache.alarms.Severity;
 import org.dcache.alarms.dao.LogEntry;
 import org.dcache.webadmin.model.exceptions.DAOException;
+import org.dcache.webadmin.model.util.AlarmJDOUtils.AlarmDAOFilter;
 
 /**
  * API for the persistent storage to be used in connection with
@@ -76,25 +75,10 @@ import org.dcache.webadmin.model.exceptions.DAOException;
  */
 public interface ILogEntryDAO {
     /**
-     * It is assumed that any further filtering will be done in memory.<br>
-     * <br>
-     *
-     * @param after
-     *            closed lower bound (>=) of date range; may be
-     *            <code>null</code>.
-     * @param before
-     *            closed upper bound (<=) of date range; may be
-     *            <code>null</code>.
-     * @param severity
-     *            <code>null</code> will be treated as equivalent to
-     *            <code>Severity.MODERATE</code>.
-     * @param type
-     *            may be <code>null</code>.
-     * @param isAlarm
-     *            may be <code>null</code>.
+     * It is assumed that any filtering beyond what the DAO filter takes
+     * will be done in memory.
      */
-    Collection<LogEntry> get(Date after, Date before, Severity severity,
-                    String type, Boolean isAlarm) throws DAOException;
+    Collection<LogEntry> get(AlarmDAOFilter filter) throws DAOException;
 
     /**
      * @return number of entries removed

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/impl/DataNucleusAlarmStore.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/impl/DataNucleusAlarmStore.java
@@ -77,7 +77,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import org.dcache.alarms.Severity;
 import org.dcache.alarms.dao.LogEntry;
 import org.dcache.webadmin.model.dataaccess.ILogEntryDAO;
 import org.dcache.webadmin.model.exceptions.DAOException;
@@ -151,16 +150,13 @@ public class DataNucleusAlarmStore implements ILogEntryDAO, Runnable {
     }
 
     @Override
-    public Collection<LogEntry> get(Date after, Date before, Severity severity,
-                    String type, Boolean isAlarm) throws DAOException {
+    public Collection<LogEntry> get(AlarmDAOFilter filter) throws DAOException {
         PersistenceManager readManager = getManager();
         if (readManager == null) {
             return Collections.emptyList();
         }
 
         Transaction tx = readManager.currentTransaction();
-        AlarmDAOFilter filter
-            = AlarmJDOUtils.getFilter(after, before, severity, type, isAlarm);
 
         try {
             tx.begin();

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/alarms/QueryPanel.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/alarms/QueryPanel.java
@@ -60,8 +60,6 @@ documents or software obtained from this server.
 package org.dcache.webadmin.view.panels.alarms;
 
 import org.apache.wicket.extensions.ajax.markup.html.autocomplete.DefaultCssAutoCompleteTextField;
-
-import org.apache.wicket.extensions.ajax.markup.html.autocomplete.AutoCompleteTextField;
 import org.apache.wicket.extensions.markup.html.form.DateTextField;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortableDataProvider;
 import org.apache.wicket.extensions.yui.calendar.DatePicker;
@@ -104,6 +102,7 @@ public class QueryPanel extends Panel {
         addTypeAutoComplete(parent, provider);
         addExpressionFields(provider);
         addShowClosed(provider);
+        addRangeFields(provider);
         add(parent.getRefreshButton());
     }
 
@@ -144,6 +143,14 @@ public class QueryPanel extends Panel {
                 return true;
             }
         });
+    }
+
+    private void addRangeFields(SortableDataProvider<LogEntry> provider) {
+        IModel<Integer> from = new PropertyModel<>(provider, "from");
+        add(new TextField<Integer>("rangeFrom", from));
+
+        IModel<Integer> to = new PropertyModel<>(provider, "to");
+        add(new TextField<Integer>("rangeTo", to));
     }
 
     private void addSeverityChoice(SortableDataProvider<LogEntry> provider) {

--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
@@ -55,6 +55,14 @@
 					wicket:id="regex" type="checkbox" />
 				</td>
 			</tr>
+			<tr>
+                <td><b><wicket:message key="range" /> </b></td>
+                <td><b><wicket:message key="from" /></b>
+                    <input wicket:id="rangeFrom" type="text" style="width: 40px;"/>
+                    <b><wicket:message key="to" /></b>
+                    <input wicket:id="rangeTo" type="text" style="width: 40px;"/></td>
+                <td/>
+            </tr>
 		</table>
 	</wicket:panel>
 </body>

--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.properties
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.properties
@@ -11,4 +11,7 @@ showClosed=Show Closed
 all=All
 onlyAlarms=Only Alarms
 noAlarms=No Alarms
+range=Limit
+from=From
+to=Up To
 refreshButton=Refresh

--- a/modules/webadmin/src/test/java/org/dcache/webadmin/controller/impl/StandardAlarmDisplayServiceTest.java
+++ b/modules/webadmin/src/test/java/org/dcache/webadmin/controller/impl/StandardAlarmDisplayServiceTest.java
@@ -71,7 +71,6 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import org.dcache.alarms.Severity;
 import org.dcache.alarms.dao.LogEntry;
 import org.dcache.webadmin.controller.util.AlarmTableProvider;
 import org.dcache.webadmin.model.dataaccess.ILogEntryDAO;
@@ -127,7 +126,6 @@ public class StandardAlarmDisplayServiceTest {
         delete.clear();
         inOrder.verify(mocked).update(update);
         inOrder.verify(mocked).remove(delete);
-        inOrder.verify(mocked).get(null, null, Severity.MODERATE, null, true);
     }
 
     @Test

--- a/modules/webadmin/src/test/java/org/dcache/webadmin/model/util/AlarmJDOUtilsTest.java
+++ b/modules/webadmin/src/test/java/org/dcache/webadmin/model/util/AlarmJDOUtilsTest.java
@@ -155,7 +155,8 @@ public class AlarmJDOUtilsTest {
 
     private void givenFilterParametersAre(Date after, Date before,
                     Severity severity, String type) {
-        filter = AlarmJDOUtils.getFilter(after, before, severity, type, null);
+        filter = AlarmJDOUtils.getFilter(after, before, severity, type,
+                        null, null, null);
     }
 
     private void givenSizeOfLogEntryListIs(int size) {


### PR DESCRIPTION
module: webadmin

The webadmin alarm page is currently set to display a maximum of 100 entries before creating a new page.  However, there is no way at this time to limit the number of entries to be returned from the database.  This feature would of course be useful, especially when the service is set to store lower level log events.

This patch slightly modifies the underlying API for the query and adds two range fields to the filter object, which are then used to create the DataNucleus layer query.  The query panel now has an addition line where the user can optionally express a single range (0 to 10, 20 to 30, etc) of results to be displayed.

An implementation note.  I would have liked to make these text boxes spinners rather than simply typed for Integer.  However, the 1.5.9 implementation of wicketstuff-minis which provides a spinner behavior seems to be buggy (I could not get it to work).  There is a wicket-ui-jquery  library which also provides the spinner capability but it requires Wicket 6.0+.  I attempted to upgrade to 6.0 but encountered issues in the way that the new Wicket handles css's which was screwing up both table size and the javascript on some pages, so I left this aside.  I do think it a good idea eventually to move to 6.7, since we are somewhat lagging wrt Wicket development -- that is, if we are convinced that our wagon is hitched to Wicket on a long term basis.

Target: master
Committed: master@a43093ddecc4e79d7c42df288fb81d3bd5d3b066S
Patch: http://rb.dcache.org/r/5554
Acked-by: Dmitry
Require-notes: yes
Require-book: no
Request: 2.6
Merge-req:

RELEASE NOTES:

The webadmin alarms page now allows the user to express a single result range for the query (for instance, 0 to 100, 50 to 75, etc.).
