### PR TITLE
switched another real domainname to example.org

### DIFF
--- a/skel/share/defaults/missingfiles-semsg.properties
+++ b/skel/share/defaults/missingfiles-semsg.properties
@@ -12,7 +12,7 @@
 #
 #   The hostname of the message broker
 #
-missing-files.plugins.semsg.broker.host = dev.msg.example.org
+missing-files.plugins.semsg.broker.host = semsg-broker.example.org
 #
 #   The TCP port number on which the message broken is listening.
 #


### PR DESCRIPTION
- Changed the default value of missing-files.plugins.semsg.broker.host to a
  reserved domain name.

Signed-off-by: Christoph Anton Mitterer mail@christoph.anton.mitterer.name
