### PR TITLE
skel: httpd.properties mark plots subdir as obsolete

### DIFF
--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -137,6 +137,7 @@ webadmin.alarm.cleaner.delete-threshold=336
 #  ---- Obsolete and forbidden properties
 #
 (obsolete)httpdEnablePoolCollector=PoolCollector is now always enabled
+(obsolete)httpd.static-content.plots.subdir=No longer used
 (forbidden)images=use httpd.static-content.images instead
 (forbidden)styles=use httpd.static-content.styles instead
 (forbidden)webadminAuthenticated = use authenticated instead


### PR DESCRIPTION
module: skel

The httpd.static-content.plots.subdir has not been used since 2.3.

Target: master
Committed: master@d2fe542f0a4bd9218b7008ffe5890e6ba7818fde
Acked-by: Tigran
Patch: http://rb.dcache.org/r/5557
Require-notes: no
Require-book: no
Request: 2.6
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7815
