### PR TITLE
improved documentation for ftp.read-only

### DIFF
--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -160,16 +160,18 @@ FtpTLogDir=
 (one-of?true|false)ftp.proxy.on-active=false
 
 
-#  ---- Whether FTP door allows users to modify content
+#  ---- Whether an FTP (plain, gss or gsi) allows non-read accesses
 #
-#
-#   The ftp.read-only property controls whether an FTP door will allow
-#   users to upload files, delete files or otherwise modify dCache's
-#   contents.
+#   This controls, wheter an FTP door of any type (plain, gss or gsi) allows
+#   non-read (i.e. write, delete, rename, etc.) accesses (when set to false)
+#   or not (when set to true).
+#   It may be limited to a given type (plain, gss or gsi) of FTP door by
+#   specifying the scope, with "ftp/", "kerberosftp/" or "gridftp/"
+#   respectively.
 #
 ftp.read-only=false
 #
-#   By default, the 'ftp' service (aka WeakFTP) is read-only.
+#   By default, plain FTP doors (the "ftp" service) is read-only.
 #
 ftp/ftp.read-only=true
 


### PR DESCRIPTION
- Made it more clear, that the option itself applies to any kind of FTP door.
- Explained how the scoping to a specific type of FTP door works.

Require-notes: no
Require-book: no

Signed-off-by: Christoph Anton Mitterer mail@christoph.anton.mitterer.name
