### PR TITLE
fixed RPM bash completion for dcache

### DIFF
--- a/pkgs/rpm/dcache.bash-completion
+++ b/pkgs/rpm/dcache.bash-completion
@@ -44,5 +44,4 @@ _dcache ()
   return 0
 }
 
-complete -F _dcache /opt/d-cache/bin/dcache
-
+complete -F _dcache dcache


### PR DESCRIPTION
The bash completion file for the RPM was broken, even if it was not using the
old /opt layout.
- Removed the path to the binary to be completed.

Require-notes: no
Require-book: no

Signed-off-by: Christoph Anton Mitterer mail@christoph.anton.mitterer.name
