### PR TITLE
gplazma-xacml: turn down noise level

### DIFF
--- a/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
+++ b/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
@@ -209,7 +209,7 @@ public final class XACMLPlugin implements GPlazmaAuthenticationPlugin {
             LocalId localId = xacmlClient.mapCredentials(_mappingServiceURL);
             Preconditions.checkArgument(localId != null, DENIED_MESSAGE + key);
 
-            logger.info("mapping service {} returned localId {} for {} ", _mappingServiceURL, localId, key);
+            logger.debug("mapping service {} returned localId {} for {} ", _mappingServiceURL, localId, key);
             return localId;
         }
     }
@@ -585,7 +585,7 @@ public final class XACMLPlugin implements GPlazmaAuthenticationPlugin {
                                 extensions);
             }
         }
-        logger.warn("no XACML mappings found for {}, {}", login, extensionSet);
+        logger.debug("no XACML mappings found for {}, {}", login, extensionSet);
         return null;
     }
 


### PR DESCRIPTION
module: gplazma-xacml

It is unnecessary to log the lack of xacml mapping at the warn level.  This will clutter the log.

Changed to debug.

Target: master
Committed: master@e4791a1cad3220b80732f40910761e5b0696d6e3
Acked-by: Paul
Patch: http://rb.dcache.org/r/5560
Require-notes: no
Require-book: no
Request: 2.6
