### PR TITLE
use a more secure default for webadminAdminGid

### DIFF
--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -78,7 +78,7 @@ webadminDCacheInstanceName=${host.name}
 #
 #   When a user has this GID he can become an Admin for webadmininterface
 #
-webadminAdminGid=1000
+webadminAdminGid=0
 
 #
 #   timeout value in ms for the cell gathering data from dCache for webadmin


### PR DESCRIPTION
Haveing a default value of 1000 for webadminAdminGid seems a tiny bit insecure
to me. 1000 is in no way a special GID and might be already used for any group
even such that gPlazma may map to (actually we at LMU had a test user mapped
to 1000:1000 for a while).
0 (root) seems to be the only appropriate choice and aligns quite well to the
default of admin.ssh2.gid.
I'm not sure whether the choice of 1000 was made deliberately, but it seems
at least Gerd agrees that 0 would be better. So pick it if you like or not :).
The change should be noted in the release notes, as it may "break" the setup
of sites that actually used 1000.
- Changed the default value of webadminAdminGid to "0" (for the gid of root).
  
  Require-notes: yes
  Require-book: no

Signed-off-by: Christoph Anton Mitterer mail@christoph.anton.mitterer.name
