### PR TITLE
skel: fix billing database properties to work with dcache database comma...

### DIFF
--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -233,7 +233,7 @@ billing.format.StorageInfoMessage=$date$ [$cellType$:$cellName$:$type$] [$pnfsid
 #       createdb -O srmdcache -U postgres billing
 #       createlang -U srmdcache plpgsql billing
 #
-billingToDb=no
+(one-of?yes|no)billingToDb=no
 
 # ---- Use DAO access layer to persistence
 #
@@ -294,9 +294,17 @@ billingDbName=billing
 billingPlotPropertiesFile=
 
 #
+#  To enable conditional presence of database for the dcache database commands
+#
+(immutable)billing-db-name-when-yes=${billingDbName}
+(immutable)billing-db-name-when-no=
+(immutable)billing-db-scheme-changelog-when-yes=${billingChangelog}
+(immutable)billing-db-scheme-changelog-when-no=
+
+#
 # Database related settings reserved for internal use.
 #
-(immutable)billing/db.name=${billingDbName}
+(immutable)billing/db.name=${billing-db-name-when-${billingToDb}}
 billing/db.user=${billingDbUser}
 (immutable)billing/db.host=${billingDbHost}
 billing/db.password=${billingDbPass}
@@ -304,4 +312,4 @@ billing/db.password.file=${billingDbPgPassFileName}
 billing/db.driver=${billingDbDriver}
 billing/db.url=${billingDbUrl}
 billing/db.schema.auto=${updateBillingDb}
-billing/db.schema.changelog=${billingChangelog}
+billing/db.schema.changelog=${billing-db-scheme-changelog-when-${billingToDb}}


### PR DESCRIPTION
...nds

module: skel, defaults

While conditional initialization of the billing database works when the cell is created (via Spring), the database commands currently do not handle correctly the case where there is no billing database and billingToDb=no. In particular, database ls lists the billing database regardless, and database update fails because it tries to run the liquibase changelog on a non-existent database.

To fix this, we have added conditional immutable properties in the style of several other default properties files.

Target: master
Committed: master@02dacf3
Patch: http://rb.dcache.org/r/5563
Require-book: no
Require-notes: yes
Request: 2.6
Request: 2.2
Bug: http://rt.dcache.org/Ticket/Display.html?id=7809
Acked-by: Paul

RELEASE NOTES: Fixes a bug in the dcache database commands where update could not run if the billing database does not exist. dcache database ls now correctly lists or does not list the billing database, depending on the billingToDb property, and dcache database update will ignore billing if billingToDb=no.
