### PR TITLE
(2.2) dcache: minimal backport to enable remote logging from 2.2 domains

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/IAlarms.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/IAlarms.java
@@ -1,0 +1,108 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.alarms;
+
+/**
+ * Convenience interface for properties in common between the wire object and
+ * the storage object for Alarm processing.
+ *
+ * @author arossi
+ */
+public interface IAlarms {
+    /*
+     * Shared alarm property/field names
+     */
+    final String KEY_TAG = "key";
+    final String TIMESTAMP_TAG = "timestamp";
+    final String TYPE_TAG = "type";
+    final String SEVERITY_TAG = "severity";
+    final String HOST_TAG = "host";
+    final String DOMAIN_TAG = "domain";
+    final String SERVICE_TAG = "service";
+    final String MESSAGE_TAG = "message";
+    final String GROUP_TAG = "group";
+
+    /*
+     * The base marker; all specific alarm types carry an additional
+     * embedded Marker.
+     */
+    final String ALARM_MARKER = "ALARM";
+
+    /*
+     * Placeholder for host name which cannot be resolved.
+     */
+    final String UNKNOWN_HOST = "<unknown host>";
+
+    /*
+     * Placeholder for host name which cannot be resolved.
+     */
+    final String UNKNOWN_SERVICE = "<unknown service>";
+
+    /*
+     * Placeholder for host name which cannot be resolved.
+     */
+    final String UNKNOWN_DOMAIN = "<unknown domain>";
+
+    /*
+     * These are defined elsewhere for use in the MDC.
+     */
+    final String CELL = "cells.cell";
+    final String DOMAIN = "cells.domain";
+}

--- a/modules/dcache/src/main/java/org/dcache/alarms/logback/RemoteMDCFilter.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/logback/RemoteMDCFilter.java
@@ -1,0 +1,108 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.alarms.logback;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import org.dcache.alarms.IAlarms;
+
+/**
+ * This filter can be added to the appender responsible for sending logging
+ * messages. It will accept all events but adds "host", "domain" and "service"
+ * to the MDC.  These need to be kept distinct from cell.cell and
+ * cell.domain because the latter can get clobbered on the receiving end
+ * if the messages are processed by a remote server running inside dCache
+ * as a cell.<br>
+ * <br>
+ * Note that there is no level requirement here.
+ *
+ * @author arossi
+ */
+public class RemoteMDCFilter extends Filter<ILoggingEvent> {
+
+    private static String host;
+
+    static {
+        try {
+            host = InetAddress.getLocalHost().getCanonicalHostName();
+        } catch (UnknownHostException e) {
+            host = IAlarms.UNKNOWN_HOST;
+        }
+    }
+
+    public static String getHost() {
+        return host;
+    }
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        Map<String,String> mdc = event.getMDCPropertyMap();
+        mdc.put(IAlarms.HOST_TAG, host);
+        mdc.put(IAlarms.SERVICE_TAG, mdc.get(IAlarms.CELL));
+        mdc.put(IAlarms.DOMAIN_TAG, mdc.get(IAlarms.DOMAIN));
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/skel/etc/logback.xml
+++ b/skel/etc/logback.xml
@@ -103,9 +103,22 @@
     </encoder>
   </appender-->
 
+   <!-- sends error/warn to a remote logback server -->
+  <appender name="remote" class="ch.qos.logback.classic.net.SocketAppender">
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+          <level>${alarms.remote-logging.level}</level>
+      </filter>
+      <!-- adds a few properties to MDC -->
+      <filter class="org.dcache.alarms.logback.RemoteMDCFilter"/>
+      <remoteHost>${alarms.server.host}</remoteHost>
+      <port>${alarms.server.port}</port>
+      <reconnectionDelay>10000</reconnectionDelay>
+  </appender>
+
   <root>
     <appender-ref ref="stdout"/>
     <appender-ref ref="pinboard"/>
+    <appender-ref ref="remote"/>
   </root>
 
   <logger name="events" additivity="false">
@@ -128,6 +141,7 @@
     <appender-ref ref="pinboard"/>
     <appender-ref ref="traceFile"/>
     <appender-ref ref="events"/>
+    <appender-ref ref="remote"/>
   </logger>
 
   <turboFilter class="dmg.util.logback.CellThresholdFilter">
@@ -175,6 +189,12 @@
 
     <threshold>
       <appender>stdout</appender>
+      <logger>root</logger>
+      <level>warn</level>
+    </threshold>
+
+    <threshold>
+      <appender>remote</appender>
       <logger>root</logger>
       <level>warn</level>
     </threshold>

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -1,0 +1,22 @@
+#  -----------------------------------------------------------------------
+#     Default values for alarms.
+#
+#     This file has been only partly back-ported to enable sending
+#     log events to a remote logback server such as the one used for alarms
+#     in dcache 2.6+; this way pool error messages will arrive
+#     at any such alarm service without having to update the pool nodes
+#     to a version > 2.2.
+#  -----------------------------------------------------------------------
+#
+#  ---- Level of events to send via the socket appender to the remote server
+#
+(one-of?off|error|warn)alarms.remote-logging.level=off
+
+#  ---- Host on which the alarm server will run
+#       relative to this dCache installation
+#
+alarms.server.host=localhost
+
+#  ---- Port on which the alarm server will listen
+#
+alarms.server.port=60001


### PR DESCRIPTION
dcache: alarms

For mixed installations where the head and door nodes may be running later versions but pool nodes are not updated from 2.2, it would still be nice for a potential alarm server to receive error or warn events from the pools.

This patch provides a minimal backport of alarm sending (actually, log event sending) capabilities.
- IAlarms interface for certain constants that are used
- An appender implementation which adds some properties to the MDC before sending the event
- an alarms.properties default with only the properties used to configure the appender
- the necessary xml for the remote appender in logback.xml

Note that this preserves the 2.6 semantics (e.g., the error/warn limitation and the property naming), not the more generalized configuration added to 2.7+.

Target: 2.2
Patch: http://rb.dcache.org/r/5564
Require-notes: yes
Require-book: yes
Acked-by: Tigran

RELEASE NOTES:
BOOK:

Version 2.2 does not contain the full alarm service capabilities (server, store and webpage); however, this patch allows all 2.2 domains to communicate with a potential alarm server by enabling the sending of log events (at the ERROR or WARN levels) to a remote server.  The following properties determine the server endpoint and the level of log events sent:

(one-of?off|error|warn)alarms.remote-logging.level=off

alarms.server.host=localhost

alarms.server.port=60001

The default for 2.2 has been set to "off", unlike later versions, where it is set to warn.
