### PR TITLE
common: backoff fix error in precondition check

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/backoff/ExponentialBackoffAlgorithmFactory.java
+++ b/modules/common/src/main/java/org/dcache/util/backoff/ExponentialBackoffAlgorithmFactory.java
@@ -153,12 +153,12 @@ public class ExponentialBackoffAlgorithmFactory implements
     private boolean quitAtMaxDelay = false;
 
     @Override
-    public IBackoffAlgorithm getAlgorithm() throws IllegalArgumentException {
+    public IBackoffAlgorithm getAlgorithm() {
         ExponentialBackoffAlgorithm algorithm = new ExponentialBackoffAlgorithm();
         algorithm.minDelayInMillis = minUnit.toMillis(minDelay);
         if (maxDelay != null) {
-            checkArgument(maxDelay >= minDelay);
             algorithm.maxDelayInMillis = maxUnit.toMillis(maxDelay);
+            checkArgument(algorithm.maxDelayInMillis  >= algorithm.minDelayInMillis);
         }
 
         return algorithm;

--- a/modules/common/src/main/java/org/dcache/util/backoff/IBackoffAlgorithmFactory.java
+++ b/modules/common/src/main/java/org/dcache/util/backoff/IBackoffAlgorithmFactory.java
@@ -73,5 +73,5 @@ public interface IBackoffAlgorithmFactory {
      *
      * @return a valid, initialized algorithm
      */
-    IBackoffAlgorithm getAlgorithm() throws IllegalArgumentException;
+    IBackoffAlgorithm getAlgorithm();
 }


### PR DESCRIPTION
module: common

The ExponentialBackoffAlgorithmFactory checks to make sure that max >= min.  However, the precondition is actually checking two values which may not have the same time unit.

This patch fixes the precondition check to use the delays converted to milliseconds.

Target: master
Acked-by: Tigran
Patch: http://rb.dcache.org/r/5568
Require-notes: no
Require-book: no
Request: 2.6
Committed: master@15848f5de6a5b120892758375f1cc27b05d51c91
