### PR TITLE
dcache: fix billing liquibase add plpgsql changeset

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
@@ -367,10 +367,16 @@
 			<column name="date"/>
 		</createIndex>
 	</changeSet>
-	<changeSet id="4.0" author="arossi" context="billing">
-		<preConditions onError="WARN" onFail="WARN">
-			<sqlCheck expectedResult="CREATE LANGUAGE">CREATE LANGUAGE plpgsql</sqlCheck>
-		</preConditions>
+    <changeSet id="4.0.0" author="arossi" context="billing">
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from pg_catalog.pg_language where lanname='plpgsql'</sqlCheck>
+        </preConditions>
+        <comment>create plpgsql</comment>
+        <sql splitStatements="false">
+            CREATE LANGUAGE plpgsql;
+        </sql>
+    </changeSet>
+	<changeSet id="4.0.1" author="arossi" context="billing">
 		<comment>trigger functions</comment>
 		<sql splitStatements="false">CREATE OR REPLACE FUNCTION f_update_billinginfo_rd_daily() RETURNS TRIGGER
 			AS $$


### PR DESCRIPTION
module: dcache

Prior to version 8.4, postgres did not automatically contain support for plpgsql, and the language had to be explicitly added to the database.

The liquibase changeset was written to use an sqlCheck which was intended to execute the sql statement and ignore the warning that the language was already present.  For 8.4+ this worked fine, but on an actual 8.3 installation, the sql would not execute because sqlCheck required a return value and was getting none (what is shown in the interpreter after the statement is executed evidently is not a return value).  Hence the changeset fails entirely there.  Another disadvantage of this was the fact that the successful completion (where the warning is skipped) looked like an error and was confusing (see the ticket reported below).

Our approach here is to modify the original changeset by substituting for it two new ones with new ids which will behave correctly.  The absence of the old changeset from the changelog does not cause problems -- the entry for just continues to occupy a dead row in the databasechangelog table.

Target: master
Patch: http://rb.dcache.org/r/5572
Require-notes: no
Require-book: no
Request: 2.6
Request: 2.2
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7809
Acked-by: Tigran

Ran the new changeset successfully over a previous installation without errors or warnings.
