### PR TITLE
webadmin: make srmSpaceManagerEnabled aware; enable real backoff on coll...

### DIFF
--- a/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/communication/collectors/Collector.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/communication/collectors/Collector.java
@@ -32,6 +32,7 @@ public abstract class Collector implements Runnable,
     protected CellStub _cellStub;
     protected Long sleepInterval;
 
+    private boolean enabled = true;
     private IBackoffAlgorithmFactory factory;
     private BackoffController controller;
 
@@ -47,11 +48,16 @@ public abstract class Collector implements Runnable,
         controller = new BackoffControllerBuilder().using(factory).build();
     }
 
+    public synchronized boolean isEnabled() {
+        return enabled;
+    }
+
     @Override
     public void run() {
         Status status = Status.SUCCESS;
-        while (true) {
+        while (isEnabled()) {
             try {
+                logger.debug("collector {} calling controller.call", this);
                 status = controller.call(this);
             } catch (InterruptedException t) {
                 break;
@@ -93,5 +99,9 @@ public abstract class Collector implements Runnable,
 
     public void setSleepInterval(Long sleepInterval) {
         this.sleepInterval = sleepInterval;
+    }
+
+    protected synchronized void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 }

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/communication/collectors/PoolMonitorCollector.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/communication/collectors/PoolMonitorCollector.java
@@ -23,29 +23,26 @@ public class PoolMonitorCollector extends Collector {
     private boolean plottingEnabled;
     private RrdPoolInfoAgent rrdAgent;
 
-    private void collectPoolSelectionUnit() throws InterruptedException {
-        try {
-            _log.debug("Retrieving Pool Monitor");
-            PoolManagerGetPoolMonitor reply
-                = _cellStub.sendAndWait(new PoolManagerGetPoolMonitor());
-            PoolMonitor monitor = reply.getPoolMonitor();
-            _pageCache.put(ContextPaths.POOLMONITOR, monitor);
-            if (plottingEnabled) {
-                rrdAgent.notify(monitor);
-            }
-            _log.debug("Pool Monitor retrieved successfully");
-        } catch (CacheException ex) {
-            _log.debug("Could not retrieve Pool Monitor ", ex);
-            _pageCache.remove(ContextPaths.POOLMONITOR);
+    private void collectPoolSelectionUnit() throws CacheException,
+                    InterruptedException {
+        _log.debug("Retrieving Pool Monitor");
+        PoolManagerGetPoolMonitor reply
+            = _cellStub.sendAndWait(new PoolManagerGetPoolMonitor());
+        PoolMonitor monitor = reply.getPoolMonitor();
+        _pageCache.put(ContextPaths.POOLMONITOR, monitor);
+        if (plottingEnabled) {
+            rrdAgent.notify(monitor);
         }
+        _log.debug("Pool Monitor retrieved successfully");
     }
 
     @Override
     public Status call() throws Exception {
         try {
             collectPoolSelectionUnit();
-        } catch (RuntimeException e) {
-            _log.error(e.toString(), e);
+        } catch (CacheException ex) {
+            _log.debug("Could not retrieve Pool Monitor ", ex);
+            _pageCache.remove(ContextPaths.POOLMONITOR);
             return Status.FAILURE;
         }
         return Status.SUCCESS;

--- a/modules/webadmin/src/main/webapp/WEB-INF/WebAdminInterface.xml
+++ b/modules/webadmin/src/main/webapp/WEB-INF/WebAdminInterface.xml
@@ -13,6 +13,7 @@
     <jee:jndi-lookup id="loginBrokerName" jndi-name="java:comp/env/loginBrokerName"/>
     <jee:jndi-lookup id="pnfsManagerName" jndi-name="java:comp/env/pnfsManagerName"/>
     <jee:jndi-lookup id="poolManagerName" jndi-name="java:comp/env/poolManagerName"/>
+    <jee:jndi-lookup id="srmSpaceManagerEnabled" jndi-name="java:comp/env/srmSpaceManagerEnabled"/>
     <jee:jndi-lookup id="collectorTimeout" jndi-name="java:comp/env/collectorTimeout"/>
     <jee:jndi-lookup id="transfersCollectorUpdate" jndi-name="java:comp/env/transfersCollectorUpdate"/>
     <jee:jndi-lookup id="billingToDb" jndi-name="java:comp/env/billingToDb"/>
@@ -96,6 +97,14 @@
         <property name="quitAtMaxDelay" value="false"/>
     </bean>
 
+    <bean id="ExponentialBackoff" class="org.dcache.util.backoff.ExponentialBackoffAlgorithmFactory">
+        <property name="maxDelay" value="1"/>
+        <property name="maxUnit" value="HOURS"/>
+        <property name="minDelay" value="10"/>
+        <property name="minUnit" value="SECONDS"/>
+        <property name="quitAtMaxDelay" value="false"/>
+    </bean>
+
     <bean id="TransfersConstantBackoff" class="org.dcache.util.backoff.ExponentialBackoffAlgorithmFactory">
         <property name="maxDelay" ref="transfersCollectorUpdate"/>
         <property name="maxUnit" value="SECONDS"/>
@@ -160,16 +169,17 @@
                     <property name="cellStub" ref="PoolMonitorCollectorCellStub"/>
                     <property name="name" value="PoolMonitor Collector"/>
                     <property name="sleepInterval" value="10000"/>
-                    <property name="algorithmFactory" ref="FastConstantBackoff"/>
+                    <property name="algorithmFactory" ref="ExponentialBackoff"/>
                     <property name="plottingEnabled" ref="pqpEnabled"/>
                     <property name="rrdAgent" ref="RrdPoolInfoAgent"/>
                 </bean>
                 <bean id="SpaceTokenCollector" class="org.dcache.webadmin.model.dataaccess.communication.collectors.SpaceTokenCollector"
                     init-method="initialize">
+                    <property name="spaceManagerEnabled" ref="srmSpaceManagerEnabled"/>
                     <property name="cellStub" ref="SpaceTokenCollectorCellStub"/>
                     <property name="name" value="SpaceToken Collector"/>
                     <property name="sleepInterval" value="10000"/>
-                    <property name="algorithmFactory" ref="FastConstantBackoff"/>
+                    <property name="algorithmFactory" ref="ExponentialBackoff"/>
                 </bean>
                 <bean id="RestoreHandlerCollector" class="org.dcache.webadmin.model.dataaccess.communication.collectors.RestoreHandlerCollector"
                     init-method="initialize">
@@ -177,7 +187,7 @@
                     <property name="name" value="RestoreHandler Collector"/>
                     <property name="poolManagerName" ref="poolManagerName"/>
                     <property name="sleepInterval" value="10000"/>
-                    <property name="algorithmFactory" ref="FastConstantBackoff"/>
+                    <property name="algorithmFactory" ref="ExponentialBackoff"/>
                 </bean>
             </list>
         </constructor-arg>

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -50,6 +50,7 @@ define context webadmin.exe endDefine
      -loginBrokerName=${loginBroker} \
      -pnfsManagerName=${pnfsmanager} \
      -poolManagerName=${poolmanager} \
+     -srmSpaceManagerEnabled=${srmSpaceManagerEnabled} \
      -collectorTimeout=${collectorTimeout} \
      -transfersCollectorUpdate=${transfersCollectorUpdate} \
      -tempUnpackDir=${webadminWarunpackdir} \


### PR DESCRIPTION
...ectors

module: webadmin

In order to populate the webadmin pages, data collector daemons are run which contact various services such as the PoolManager or the SpaceManager.  While it would be uncommon to run dCache with most of these services, it is not uncommon for the SpaceManager not to be there.  In this case, we would like to avoid running this collector; and in general, we would also like to backoff from pinging services which may be temporarily offline.

Some time ago, a backoff algorithm factory was added to use precisely for this reason.  However, the original constant recurrent message send/wait was for the moment maintained.

This patch does the following:
- it passes through knowledge of the srmSpaceManagerEnabled property.  It is assumed here that the local dcache.conf file will reflect the actual setting, whereever the SpaceManager may be configured to run;
- it slightly restructures several of the collectors so that backoff will occur at the correct place in the looping logic;
- it creates and adds an exponential backoff algorithm to be used by the collectors most susceptible to not finding their single endpoints (PoolMonitor, RestoreHandler, SpaceToken).

Target: master
Committed: master@92687f8010e0dfa60412aaef316e5aff80411769
Patch: http://rb.dcache.org/r/5571/
Require-notes: no
Require-book: no
Request: 2.6
Acked-by: Tigran

Redeployed.
1.  With default, the SpaceToken collector does not run (srmSpaceManagerEnabled=no)
2.  Setting srmSpaceManagerEnabled=yes, but with no actual space manager running, observed the correct backoff behavior
3.  Adding space manager and starting the domain allowed the collector to connect on its subsequent iteration.
