### PR TITLE
dcache: alarms package.jdo missing varchar length on text fields

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/alarms/dao/package.jdo
+++ b/modules/dcache/src/main/resources/org/dcache/alarms/dao/package.jdo
@@ -6,6 +6,12 @@
     <package name="org.dcache.alarms.dao">
         <class name="LogEntry" detachable="true" >
             <field name="key" primary-key="true"/>
+            <field name="info">
+                <column name="info" length="8000" jdbc-type="VARCHAR" />
+            </field>
+            <field name="notes">
+                <column name="notes" length="8000" jdbc-type="VARCHAR" />
+            </field>
         </class>
     </package>
 </jdo>


### PR DESCRIPTION
module: dcache, alarms

Non-fatal truncation to 256 chars of info and notes fields on the database log entry fields (from DataNucleus) corrected by this patch.

Target: master
Committed: master@7d7e188e69f87033934fe2bfd160e4421fbb8666
Patch: http://rb.dcache.org/r/5574
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Dmitry
Merge-req:

Testing Done: Reran with gPlazma warn message, now properly stored and displayed.

RELEASE NOTES:

The info and notes fields of the alarm/log entry for the alarm service were potentially getting truncated at 256.  This patch increases length to 8000, as in the billing tables.
