### PR TITLE
webdav: switch hard-coded JGlobus paths to those configured

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -271,12 +271,9 @@
 
 	  <property name="port" value="${webdavPort}"/>
 	  <property name="host" value="${webdavAddress}"/>
-	  <property name="hostCertificatePath"
-		    value="/etc/grid-security/hostcert.pem"/>
-	  <property name="hostKeyPath"
-		    value="/etc/grid-security/hostkey.pem"/>
-	  <property name="caCertificatePath"
-		    value="/etc/grid-security/certificates"/>
+	  <property name="hostCertificatePath" value="${grid.hostcert.cert}"/>
+	  <property name="hostKeyPath" value="${grid.hostcert.key}"/>
+	  <property name="caCertificatePath" value="${grid.ca.path}"/>
 	  <property name="autoFlush" value="true"/>
 	  <property name="encrypt" value="true"/>
 	  <property name="requireClientAuth" value="${webdavWantClientAuth}"/>

--- a/skel/share/services/webdav.batch
+++ b/skel/share/services/webdav.batch
@@ -68,6 +68,9 @@ enddefine
 define env verify-https-jglobus.exe enddefine
   check -strong trustAnchorRefreshPeriod
   check -strong hostCertificateRefreshPeriod
+  check -strong grid.hostcert.cert
+  check -strong grid.hostcert.key
+  check -strong grid.ca.path
 enddefine
 
 define env failMissingKeyStore.exe enddefine
@@ -147,4 +150,7 @@ create org.dcache.cells.UniversalSpringCell ${cell.name} \
     -webdav.overwrite=${webdav.overwrite} \
     -missing-files.timeout=${missing-files.timeout} \
     -missing-files.name=${missing-files.name} \
+    -grid.hostcert.cert=${grid.hostcert.cert} \
+    -grid.hostcert.key=${grid.hostcert.key} \
+    -grid.ca.path=${grid.ca.path} \
     -export -cellClass=WebDAVDoor"


### PR DESCRIPTION
The WebDAV door may use either Jetty's built-in SSL support or
support coming from JGlobus.  If the latter is chosen then
various paths are hard-coded.

This does not respect a site's configuration and, as a specific
example, results in the system-test failing.

This patch switches the JGlobus WebDAV SSL connector to use
the configured path.

Patch: http://rb.dcache.org/r/5575/
Acked-by: Gerd Behrmann
Target: master
Request: 2.6
