### PR TITLE
dcache: alarm command line, fix minor bug

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/commandline/AlarmDefinitionManager.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/commandline/AlarmDefinitionManager.java
@@ -180,7 +180,14 @@ public class AlarmDefinitionManager {
 
     static void printError(Throwable t) {
         if (t != null) {
-            System.err.println(t.getMessage());
+            if (t instanceof NullPointerException) {
+                /*
+                 * a bug, shouldn't happen
+                 */
+                t.printStackTrace();
+            } else {
+                System.err.println(t.getMessage());
+            }
             t = t.getCause();
         }
         while (t != null) {
@@ -205,7 +212,9 @@ public class AlarmDefinitionManager {
 
             try {
                 definition.validate();
+
                 Element alarmType = definition.toElement();
+                printDefinition(alarmType, outputter);
 
                 if (proceedWith("Add/Update definition", reader)) {
                     update(alarmType, outputter, rootNode, xmlFile);
@@ -357,7 +366,9 @@ public class AlarmDefinitionManager {
 
         while (true) {
             try {
-                String input = getInput("hit return to skip", reader);
+                String input = getInput("hit return to skip, "
+                                + AlarmDefinition.RM
+                                + " to remove value", reader);
                 if (input == null) {
                     return;
                 }


### PR DESCRIPTION
module: dcache, alarm command line interpreter

This patch does the following:
1.  Fixes bug in add and modify whereby includeInKey was not getting updated.  It also adds "group" to the help message for the attribute (missing previously).
2.  Prints out the full definition for confirmation/review before commit in both add and modify.
3.  Allows the elimination of an attribute (XML element) via the '-' character.

Target: master
Committed: master@8b658b3caa423ecdbcbb593473e002cebe068686
Patch: http://rb.dcache.org/r/5573/
Require-notes: yes
Require-book: no
Request: 2.6
Acked-by: Tigran

Testing: Tried out various options using add, remove and modify for illegal alteration by deletion of required elements; modified includeInKey, and tried to set group (with number and without, which is an error).

RELEASE NOTES:

For those who have tried out the dcache alarm definition commands, they may have noticed that "includeInKey" could not be modified once it was defined.  This bug has been fixed.  There is also a new feature allowing the deletion of a definition element using the '-' character.  The full xml for the definition is now also displayed before asking for confirmation to write.
