### PR TITLE
Fix dCache FTP and SRM to be standards-compliant by default

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -481,6 +481,45 @@ kpwdFile=${dcache.paths.etc}/dcache.kpwd
 #
 #srmImplicitSpaceManagerEnabled=yes
 
+
+#  ---- How to handle an upload when the file already exists
+#
+#   The following property affects both the FTP family of doors and
+#   the SRM.  For WebDAV and dcap see the webdav.overwrite and
+#   truncate properties respectively.  For xrootd, the policy is
+#   controlled by the client.
+#
+#   For the FTP door, the overwriteEnabled property controls how to
+#   respond when a client attempts to upload data to a file that
+#   already exists.  If set to 'false' then such attempts will always
+#   fail.  If set to 'true' then the upload will succeed if the user
+#   has sufficient permissions to delete the existing data.
+#
+#   Note that RFC 959 states:
+#
+#       STORE (STOR)
+#
+#       [...] If the file specified in the pathname exists at the
+#       server site, then its contents shall be replaced by the data
+#       being transferred.
+#
+#   By setting overwriteEnabled to 'false', FTP doors will not be
+#   standards-compliant and some clients may fail to operate
+#   correctly.
+#
+#   When an SRM client initiates uploading of data, the request
+#   specifies a policy for how to handle any existing files.  There
+#   are three polices: overwrite any existing data, don't overwrite
+#   (so fail that file), use the system default policy.  The system
+#   default policy is controlled by the srmOverwriteByDefault
+#   property.  The overwriteEnabled property controls whether any
+#   overwriting of data is allowed, irrespective of the
+#   client-supplied policy and the value of srmOverwriteByDefault.
+#
+#   By setting overwriteEnabled to 'false', the SRM will not be
+#   standards-compliant and some clients may fail to operate
+#   correctly.
+#
 (one-of?true|false)overwriteEnabled=false
 
 #  -----------------------------------------------------------------------


### PR DESCRIPTION
The overwriteEnabled property affects FTP and SRM doors.  The default
is currently 'false', which prevents overwriting of data if the file
already exists.

RFC 959 is quite clear:

```
     STORE (STOR)

        This command causes the server-DTP to accept the data
        transferred via the data connection and to store the data as
        a file at the server site.  If the file specified in the
        pathname exists at the server site, then its contents shall
        be replaced by the data being transferred.  A new file is
        created at the server site if the file specified in the
        pathname does not already exist.
```

Therefore, by setting overwriteEnabled to 'false', dCache is not
RFC-959 compliant.  This is our default behaviour.

Similarly, SRM protocol is also quite clear how storage elements are
expected to behave.  Setting overwriteEnabled=false breaks that
expected behaviour.

Moreover, there is no additional security from setting
overwriteEnabled=false.  The client can simply delete the data and
upload afresh.

The net result is that dCache is, by default, not standards compliant
for no direct benefit.

For the 2.2 branch, we maintain the existing default value, but
include the warning text.

FOR RELEASE NOTES:

This patch adds an explanation of the overwriteEnabled configuration option.
This controls dCache's behaviour when user attempts to overwrite an existing
file via FTP or SRM.

The default behaviour is not standards-complaint.  This patch does NOT
alter this behaviour.  Sites are invited to review their configuration.

Target: master
Request: 2.6
Request: 2.2
Patch: http://rb.dcache.org/r/5544/
Acked-by: Dmitry Litvintsev
Acked-by: Tigran Mkrtchyan
Acked-by: Gerd Behrmann
Requires-notes: yes
Requires-book: no
