### PR TITLE
dcache: billing -- fix error in liquibase varchar changeset

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
@@ -628,38 +628,4 @@
 			f_update_costinfo_daily();
 		</sql>
 	</changeSet>
-    <!-- VARCHAR ADJUSTMENTS -->
-    <changeSet author="arossi" id="4.1.7" context="billing" failOnError="false">
-        <sql splitStatements="false">
-            INSERT INTO costinfo (errormessage)
-            VALUES ('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX');
-        </sql>
-    </changeSet>
-    <changeSet author="arossi" id="4.1.8" context="billing">
-        <!-- If the insert (4.1.7) worked, the database was probably already initialized with VARCHAR unlimited;
-             so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
-        <preConditions onError="CONTINUE" onFail="MARK_RAN">
-            <sqlCheck expectedResult="0">select count(*) from costinfo where errormessage = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX'</sqlCheck>
-        </preConditions>
-        <modifyDataType tableName="doorinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
-        <modifyDataType tableName="doorinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
-        <modifyDataType tableName="doorinfo" columnName="path" newDataType="VARCHAR(8000)" />
-        <modifyDataType tableName="storageinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
-        <modifyDataType tableName="storageinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
-        <modifyDataType tableName="costinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
-        <modifyDataType tableName="costinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
-        <modifyDataType tableName="billinginfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
-        <modifyDataType tableName="billinginfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
-        <modifyDataType tableName="hitinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
-        <modifyDataType tableName="hitinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
-    </changeSet>
-    <changeSet author="arossi" id="4.1.9" context="billing">
-        <preConditions onError="CONTINUE" onFail="MARK_RAN">
-            <sqlCheck expectedResult="1">select count(*) from costinfo where errormessage = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX'</sqlCheck>
-        </preConditions>
-        <sql splitStatements="false">
-            DELETE FROM costinfo
-            WHERE errormessage = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX';
-        </sql>
-     </changeSet>
 </databaseChangeLog>

--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.4.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.4.xml
@@ -20,4 +20,99 @@
         <dropTable tableName="costinfo_daily"/>
         <dropTable tableName="costinfo"/>
     </changeSet>
+    <!-- VARCHAR ADJUSTMENTS, AGAIN.  The original changeset was discovered to have an off-by-one error in it
+         4.1.7, 4.1.8 and 4.1.9 have been deleted -->
+    <changeSet author="arossi" id="5.1.0.0" context="billing" failOnError="false">
+        <sql splitStatements="false">
+            INSERT INTO billinginfo (pnfsid, errormessage)
+            VALUES ('-1', '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789');
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.0.1" context="billing">
+        <!-- If the insert (5.1.0) worked, the database was probably already initialized with VARCHAR unlimited;
+             so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from billinginfo where pnfsid='-1'</sqlCheck>
+        </preConditions>
+        <modifyDataType tableName="billinginfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
+        <modifyDataType tableName="billinginfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
+    </changeSet>
+    <changeSet author="arossi" id="5.1.0.2" context="billing">
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">select count(*) from billinginfo where pnfsid='-1'</sqlCheck>
+        </preConditions>
+        <sql splitStatements="false">
+            DELETE FROM billinginfo WHERE pnfsid='-1';
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.1.0" context="billing" failOnError="false">
+        <sql splitStatements="false">
+            INSERT INTO doorinfo (pnfsid, errormessage)
+            VALUES ('-1', '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789');
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.1.1" context="billing">
+        <!-- If the insert (5.1.2) worked, the database was probably already initialized with VARCHAR unlimited;
+             so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from doorinfo where pnfsid='-1'</sqlCheck>
+        </preConditions>
+        <modifyDataType tableName="doorinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
+        <modifyDataType tableName="doorinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
+        <modifyDataType tableName="doorinfo" columnName="path" newDataType="VARCHAR(8000)" />
+    </changeSet>
+    <changeSet author="arossi" id="5.1.1.2" context="billing">
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">select count(*) from doorinfo where pnfsid='-1'</sqlCheck>
+        </preConditions>
+        <sql splitStatements="false">
+            DELETE FROM doorinfo WHERE pnfsid='-1';
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.2.0" context="billing" failOnError="false">
+        <sql splitStatements="false">
+            INSERT INTO storageinfo (pnfsid, errormessage)
+            VALUES ('-1', '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789');
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.2.1" context="billing">
+        <!-- If the insert (5.1.4) worked, the database was probably already initialized with VARCHAR unlimited;
+             so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from storageinfo where pnfsid='-1'</sqlCheck>
+        </preConditions>
+        <modifyDataType tableName="storageinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
+        <modifyDataType tableName="storageinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
+    </changeSet>
+    <changeSet author="arossi" id="5.1.2.2" context="billing">
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">select count(*) from storageinfo where pnfsid='-1'</sqlCheck>
+        </preConditions>
+        <sql splitStatements="false">
+            DELETE FROM storageinfo WHERE pnfsid='-1';
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.3.0" context="billing" failOnError="false">
+        <sql splitStatements="false">
+            INSERT INTO hitinfo (pnfsid, errormessage)
+            VALUES ('-1', '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789');
+        </sql>
+    </changeSet>
+    <changeSet author="arossi" id="5.1.3.1" context="billing">
+        <!-- If the insert (5.1.6) worked, the database was probably already initialized with VARCHAR unlimited;
+             so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from hitinfo where pnfsid='-1'</sqlCheck>
+        </preConditions>
+        <modifyDataType tableName="hitinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
+        <modifyDataType tableName="hitinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
+    </changeSet>
+    <changeSet author="arossi" id="5.1.3.2" context="billing">
+        <preConditions onError="CONTINUE" onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">select count(*) from hitinfo where pnfsid='-1'</sqlCheck>
+        </preConditions>
+        <sql splitStatements="false">
+            DELETE FROM hitinfo WHERE pnfsid='-1';
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
module: dcache

The liquibase changeset 4.1.7 was discovered to contain an off-by-one error in the string used to test the condition for changing the varchar length in the billing tables (the actual length of the string was 256, not 257). As a result, 4.1.7. 4.1.8 and 4.1.9 never will run, and all billing installations created by liquibase (which hardcodes the default to 256) remained as such.

The reason for the requested change was that the path and errormessage attributes of certain tables can well exceed 256.

The new changesets correct the error.

Target: master
Committed: master@9e5b5f5077d152dc2ab5b3990b21989790a54aa9
Patch: http://rb.dcache.org/r/5555
Require-book: no
Require-notes: yes
Request: 2.6
Acked-by: Dmitry

Testing done:  Ran new changesets on new and previous installations, observing correct attribute lengths on table afterwards.

RELEASE NOTES:  Fixes string lengths in billing databse tables. Tables created automatically contained character columns limited to 256 which is too restrictive for path and errormessage columns in billinginfo, doorinfo and storageinfo tables. Additionaly, the length of pnfsid string was limited to 36.
A previous patch designed to address this issue failed to so.
