### PR TITLE
dcache: billing -- fix error in liquibase varchar changeset

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
@@ -628,18 +628,18 @@
 			f_update_costinfo_daily();
 		</sql>
 	</changeSet>
-    <!-- VARCHAR ADJUSTMENTS -->
-    <changeSet author="arossi" id="4.1.7" context="billing" failOnError="false">
+    <!-- VARCHAR ADJUSTMENTS (previous changeset has bug and has never run; this one corrects it)-->
+    <changeSet author="arossi" id="4.1.7.1" context="billing" failOnError="false">
         <sql splitStatements="false">
-            INSERT INTO costinfo (errormessage)
-            VALUES ('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX');
+            INSERT INTO costinfo (pnsfid, errormessage)
+            VALUES('-1', '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789');
         </sql>
     </changeSet>
-    <changeSet author="arossi" id="4.1.8" context="billing">
-        <!-- If the insert (4.1.7) worked, the database was probably already initialized with VARCHAR unlimited;
+    <changeSet author="arossi" id="4.1.8.1" context="billing">
+        <!-- If the insert (4.1.7.1) worked, the database was probably already initialized with VARCHAR unlimited;
              so this check runs the changeset only if select turns 0, i.e., no insert occurred -->
         <preConditions onError="CONTINUE" onFail="MARK_RAN">
-            <sqlCheck expectedResult="0">select count(*) from costinfo where errormessage = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX'</sqlCheck>
+            <sqlCheck expectedResult="0">select count(*) from costinfo where pnfsid='-1'</sqlCheck>
         </preConditions>
         <modifyDataType tableName="doorinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
         <modifyDataType tableName="doorinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
@@ -653,13 +653,12 @@
         <modifyDataType tableName="hitinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
         <modifyDataType tableName="hitinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
     </changeSet>
-    <changeSet author="arossi" id="4.1.9" context="billing">
+    <changeSet author="arossi" id="4.1.9.1" context="billing">
         <preConditions onError="CONTINUE" onFail="MARK_RAN">
-            <sqlCheck expectedResult="1">select count(*) from costinfo where errormessage = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX'</sqlCheck>
+            <sqlCheck expectedResult="1">select count(*) from costinfo where pnfsid='-1'</sqlCheck>
         </preConditions>
         <sql splitStatements="false">
-            DELETE FROM costinfo
-            WHERE errormessage = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX';
+            DELETE FROM costinfo WHERE pnfsid='-1';
         </sql>
-     </changeSet>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
version of http://rb.dcache.org/r/5555 for dCache 2.2

module: dcache

The liquibase changeset 4.1.7 was discovered to contain an off-by-one error in the string used to test the condition for changing the varchar length in the billing tables (the actual length of the string was 256, not 257). As a result, 4.1.7. 4.1.8 and 4.1.9 never will run, and all billing installations created by liquibase (which hardcodes the default to 256) remained as such.

The reason for the requested change was that the path and errormessage attributes of certain tables can well exceed 256.

The new changesets correct the error.

Target: 2.2
Patch: http://rb.dcache.org/r/5559
Require-book: no
Require-notes: yes
Acked-by: Dmitry

RELEASE NOTES:  Fix string lengths in billing databse tables. Tables created automatically contained character columns limited to 256 which is too restrictive for path and errormessage columns in billinginfo, doorinfo and storageinfo tables. Additionaly, the length of pnfsid string was limited to 36.
A previous patch designed to address this issue failed to so.]
