### PR TITLE
system-test: avoid awkward cell.name values

### DIFF
--- a/modules/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/modules/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -98,7 +98,7 @@ port=1094
 xrootdAllowedWritePaths=/
 
 [dCacheDomain/xrootd]
-cell.name=Xrootd/gsi-${host.name}
+cell.name=Xrootd-gsi-${host.name}
 port=1095
 xrootd/xrootdPlugins=gplazma:gsi
 xrootdAllowedWritePaths=/
@@ -111,7 +111,7 @@ webdavBasicAuthentication=true
 webdavProtocol=http
 
 [dCacheDomain/webdav]
-cell.name=WebDAV/S-${host.name}
+cell.name=WebDAV-S-${host.name}
 port=2881
 webdavAnonymousAccess=READONLY
 webdavBasicAuthentication=true


### PR DESCRIPTION
A few of the system-test cell.name values includes a forward
slash character, which the cells shell interprets as an
attempt to switch to the alternative addressing mode.

This patch updates these cells to use the neutral '-' character
instead.

Patch: http://rb.dcache.org/r/5585/
Acked-by: Gerd Behrmann
Target: master
Request: 2.6
