### PR TITLE
GLUE2: add GLUE2EndpointImplementation information

### DIFF
--- a/skel/share/info-provider/glue-2.0-defn.xml
+++ b/skel/share/info-provider/glue-2.0-defn.xml
@@ -441,6 +441,13 @@
               </map>
             </attr>
 
+	    <attr name="GLUE2EndpointImplementationName">dCache</attr>
+	    <attr name="GLUE2EndpointImplementationVersion">
+              <map name="cell-version-to-dcache-version">
+		<lookup path="/d:dCache/d:domains/d:domain[@name=current()/d:metric[@name='domain']]/d:cells/d:cell[@name=current()/d:metric[@name='cell']]/d:version/d:metric[@name='release']"/>
+	      </map>
+	    </attr>
+
             <choose>
               <optionally>
                 <when test="SRM">


### PR DESCRIPTION
The EGI GLUE2 profile requires us to publish the implementation name
and version for all published endpoints, which we currently don't
do.

This patch adds this information.

Target: master
Request: 2.6
Request: 2.2
Patch: http://rb.dcache.org/r/5591/
Acked-by: Gerd Behrmann
