### PR TITLE
Various improvements to short-lived Java invocations

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/cli/FsFactory.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/cli/FsFactory.java
@@ -45,12 +45,15 @@ public class FsFactory {
         ds.setPassword(dbPass);
         ds.setIdleConnectionTestPeriodInMinutes(60);
         ds.setIdleMaxAgeInMinutes(240);
-        ds.setMaxConnectionsPerPartition(30);
-        ds.setMaxConnectionsPerPartition(10);
-        ds.setPartitionCount(3);
-        ds.setAcquireIncrement(5);
+        ds.setMaxConnectionsPerPartition(2); //mkdir needs two connections (!)
+        ds.setMinConnectionsPerPartition(1);
+        ds.setPartitionCount(1);
+        ds.setAcquireIncrement(1);
         ds.setStatementsCacheSize(100);
-        ds.setReleaseHelperThreads(3);
+        ds.setReleaseHelperThreads(0);
+        ds.setDisableConnectionTracking(true);
+        ds.setDisableJMX(true);
+        ds.setStatisticsEnabled(false);
 
         return new JdbcFs(ds, dbDialect);
     }

--- a/skel/bin/chimera-cli
+++ b/skel/bin/chimera-cli
@@ -84,8 +84,11 @@ lib="$(getProperty dcache.paths.share.lib)"
 
 dbpass=$(getProperty chimera.db.password)
 
-CLASSPATH="$(printClassPath)" \
-    ${JAVA} $(getProperty dcache.java.options) \
+classpath=$(printLimitedClassPath chimera bonecp \
+    guava slf4j-api dcache-common logback-classic \
+    logback-core logback-console-config)
+
+quickJava -Xbootclasspath/a:$classpath \
     -Dlog=${DCACHE_LOG:-warn} \
     ${class}  $(getProperty chimera.db.driver) \
     $(getProperty chimera.db.url) \
@@ -93,3 +96,4 @@ CLASSPATH="$(printClassPath)" \
     $(getProperty chimera.db.user) \
     ${dbpass:-""} \
     "$@"
+

--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -210,7 +210,7 @@ dumpHeap() # $1=force, $2=live, $3=file, $4=pid, $5=error
 # display dCache package version
 showVersion()
 {
-    "$JAVA" -cp "$(getProperty dcache.paths.classpath)" org.dcache.util.Version
+    CLASSPATH="$(getProperty dcache.paths.classpath)" quickJava org.dcache.util.Version
 }
 
 #  print either the user a PID is running as (if $1 is non-empty)
@@ -330,7 +330,7 @@ poolConvertMeta() # $1 = domain, $2 = cell, $3 = type
         fail 2 "Cannot convert pool '$name', as it is already of type $src."
     fi
 
-    CLASSPATH="$classpath" "$JAVA" org.dcache.pool.repository.MetaDataStoreCopyTool "$path" "$src" "$3"
+    CLASSPATH="$classpath" quickJava org.dcache.pool.repository.MetaDataStoreCopyTool "$path" "$src" "$3"
 
     printp ""\
            "The pool meta data database of '$name' was converted from
@@ -347,7 +347,7 @@ poolDumpYaml() # $1 = domain, $2 = cell
     classpath=$(getProperty dcache.paths.classpath "$1" "$2")
     path=$(getProperty path "$1" "$2")
     type=$(getProperty metaDataRepository "$1" "$2")
-    CLASSPATH="$classpath" "$JAVA" org.dcache.pool.repository.MetaDataStoreYamlTool "$path" "$type"
+    CLASSPATH="$classpath" quickJava org.dcache.pool.repository.MetaDataStoreYamlTool "$path" "$type"
 }
 
 if [ $# -eq 0 ]; then
@@ -777,7 +777,7 @@ case "$1" in
         checkForPkcs8HostKey
 
         if [ $# -eq 0 ]; then
-            CLASSPATH="$(getProperty dcache.paths.classpath)" "$JAVA" org.dcache.auth.KAuthFile
+            CLASSPATH="$(getProperty dcache.paths.classpath)" quickJava org.dcache.auth.KAuthFile
         else
             command="$1"
             shift
@@ -787,7 +787,7 @@ case "$1" in
                 touch "$kpwdFile"
             fi
 
-            CLASSPATH="$(getProperty dcache.paths.classpath)" "$JAVA" org.dcache.auth.KAuthFile "$command" "$(getProperty kpwdFile)" "$@"
+            CLASSPATH="$(getProperty dcache.paths.classpath)" quickJava org.dcache.auth.KAuthFile "$command" "$(getProperty kpwdFile)" "$@"
         fi
         ;;
 

--- a/skel/sbin/dcache-pool-meta-preupgrade
+++ b/skel/sbin/dcache-pool-meta-preupgrade
@@ -11,7 +11,7 @@ for domain in $(getProperty dcache.domains); do
         if [ "$service" = "pool" -a $(getProperty metaDataRepository "$domain" "$cell") = "org.dcache.pool.repository.meta.db.BerkeleyDBMetaDataRepository" ]; then
             path=$(getProperty path "$domain" "$cell")
             echo "Preparing $path for upgrade"
-            $JAVA -jar $(getProperty dcache.paths.share)/misc/je-4.1.21.jar DbPreUpgrade_4_1 -h "$path"
+            quickJava -jar $(getProperty dcache.paths.share)/misc/je-4.1.21.jar DbPreUpgrade_4_1 -h "$path"
         fi
     done
 done

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -92,17 +92,48 @@
 (not-for-services)dcache.java.library.path=${dcache.paths.lib}
 
 
-# Property to allow a site to add any extra, site-specific Java VM options.
+#  ---- Java VM options
+#
+#  Properties that control the options to the Java VM instances.
+#
+#  There are two kinds of Java virtual machine instances: short-lived
+#  and long-lived.
+#
+#  The short-lived invocations are expected to run as quickly as
+#  possible and generally complete within a few seconds.
+#
+#  The long-lived invocations are the dCache domains.  These will have
+#  the same duration as a dCache domain; i.e., many months or years.
+#
+#  dCache uses different Java options to hint to the JVM that the
+#  different invocations have different expected lifetimes; for
+#  example, short-lived invocations should favour startup speed over
+#  long-term optimisation.
+#
+#  The JVM options used are dcache.java.options and
+#  dcache.java.options.short-lived, both of which include
+#  dcache.java.options.common.  In general, these three properties
+#  should not be directly reconfigured, but site customisation should
+#  be achieved through other properties.  In particular, additional
+#  java command-line arguments may be added by configuring either the
+#  dcache.java.options.extra or dcache.java.options.short-lived.extra
+#  property (or both).
+
+#  This property allows site-specific extra options that are used only
+#  for long-lived JVM instances.
+#
 (not-for-services)dcache.java.options.extra=
 
-# Java VM options
+#  This property allows site-specific extra options that are used only
+#  for short-lived JVM instances.
 #
-# You should not modify this property.  Instead, use the appropriate
-# properties to alter specific behaviour, or use dcache.java.options.extra
-# to add any site-specific Java VM options.
+(not-for-services)dcache.java.options.short-lived.extra=
+
+#  This property provides Java command-line arguments for long-lived
+#  JVM instances.  Sites should not modify this property, but use the
+#  dcache.java.options.extra property to add any site-specific
+#  arguments.
 #
-# Notes:
-#   - wantLog4jSetup is used by eu.emi:trustmanager
 (not-for-services)dcache.java.options=\
     -server \
     -Xmx${dcache.java.memory.heap} \
@@ -118,12 +149,41 @@
     -Djava.security.krb5.kdc=${kerberos.key-distribution-center-list} \
     -Djavax.security.auth.useSubjectCredsOnly=false \
     -Djava.security.auth.login.config=${kerberos.jaas.config} \
-    -Djava.awt.headless=true \
-    -DwantLog4jSetup=n \
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath=${dcache.java.oom.file} \
     -javaagent:${dcache.paths.classes}/spring-instrument-3.2.2.RELEASE.jar \
+    ${dcache.java.options.common} \
     ${dcache.java.options.extra}
+
+
+#  This property provides Java command-line arguments for short-lived
+#  JVM instances.  Sites should not modify this property, but
+#  configure the dcache.java.options.short-lived.extra property to add
+#  any site-specific arguments.
+#
+(not-for-services)dcache.java.options.short-lived=\
+    -client \
+    -XX:+TieredCompilation \
+    -XX:TieredStopAtLevel=0 \
+    ${dcache.java.options.common} \
+    ${dcache.java.options.short-lived.extra}
+
+
+#  This property provides Java command-line arguments for both
+#  short-lived and long-lived JVM instances.  In general, sites should
+#  not modify this property, but modify either the
+#  dcache.java.options.extra property, the
+#  dcache.java.options.short-lived.extra property or both properties
+#  to add any site-specific arguments.
+#
+#  Notes:
+#     - wantLog4jSetup is used by eu.emi:trustmanager
+#
+(not-for-services)dcache.java.options.common=\
+    -Djava.awt.headless=true \
+    -DwantLog4jSetup=n
+
+
 
 # Whether to cache the compiled configuration files. If disabled most dCache
 # scripts will invoke the dCache boot loader to compile the configuration files.

--- a/skel/share/lib/alarm.sh
+++ b/skel/share/lib/alarm.sh
@@ -9,7 +9,7 @@ send_alarm() # $@ = [-s=<source-uri>] [-l=<log level>] [-t=<alarm subtype>] mess
     host=$(getProperty alarms.server.host)
     port=$(getProperty alarms.server.port)
 
-    CLASSPATH="$(getProperty dcache.paths.classpath)" "$JAVA" org.dcache.alarms.commandline.SendAlarm -d="dst://${host}:${port}" "$@"
+    CLASSPATH="$(getProperty dcache.paths.classpath)" quickJava org.dcache.alarms.commandline.SendAlarm -d="dst://${host}:${port}" "$@"
 }
 
 ##
@@ -19,5 +19,5 @@ handle_alarm_definition() # $1 = [add, modify, remove]
 {
     local file
     file=$(getProperty alarms.definitions.path)
-    CLASSPATH="$(getProperty dcache.paths.classpath)" "$JAVA" org.dcache.alarms.commandline.AlarmDefinitionManager $1 ${file}
+    CLASSPATH="$(getProperty dcache.paths.classpath)" quickJava org.dcache.alarms.commandline.AlarmDefinitionManager $1 ${file}
 }

--- a/skel/share/lib/database.sh
+++ b/skel/share/lib/database.sh
@@ -28,5 +28,5 @@ liquibase() # $1 = domain, $2 = cell, $3+ = liquibase arguments
     changelog=$(getProperty db.schema.changelog "$1" "$2")
 
     shift 2
-    CLASSPATH="$classpath" "$JAVA" liquibase.integration.commandline.Main --driver="${driver}" --changeLogFile="${changelog}" --url="${url}" --username="${user}" --password="${password}" "$@"
+    CLASSPATH="$classpath" quickJava liquibase.integration.commandline.Main --driver="${driver}" --changeLogFile="${changelog}" --url="${url}" --username="${user}" --password="${password}" "$@"
 }

--- a/skel/share/lib/loadConfig.sh
+++ b/skel/share/lib/loadConfig.sh
@@ -45,9 +45,31 @@ findJava()
     return 1
 }
 
+isJavaVersionOk()
+{
+    version=$($JAVA -version 2>&1)
+    case $version in
+        *1.7*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 bootLoader()
 {
-    $JAVA -client -cp "${DCACHE_CLASSPATH}" "-Dlog=${DCACHE_LOG:-warn}" "-Ddcache.home=${DCACHE_HOME}" "-Ddcache.paths.defaults=${DCACHE_DEFAULTS}" org.dcache.boot.BootLoader "$@"
+    CLASSPATH="${DCACHE_CLASSPATH}" "$JAVA" -client -XX:+TieredCompilation \
+	-XX:TieredStopAtLevel=0  "-Dlog=${DCACHE_LOG:-warn}" \
+	"-Ddcache.home=${DCACHE_HOME}" \
+	"-Ddcache.paths.defaults=${DCACHE_DEFAULTS}" \
+	org.dcache.boot.BootLoader "$@"
+}
+
+quickJava()
+{
+    "$JAVA" $(getProperty dcache.java.options.short-lived) "$@"
 }
 
 isCacheValidForFiles()
@@ -78,7 +100,7 @@ loadConfig()
 }
 
 # Get java location
-if ! findJava || ! "$JAVA" -version 2>&1 | egrep -e 'version "1\.[7]' >/dev/null ; then
+if ! findJava || ! isJavaVersionOk; then
     echo "Could not find usable Java VM. Please set JAVA_HOME to the path to Java 7"
     echo "or newer."
     exit 1

--- a/skel/share/lib/services.sh
+++ b/skel/share/lib/services.sh
@@ -133,11 +133,44 @@ printJavaPid() # $1 = domain
 printClassPath() # $1 = domain
 {
     local classpath
+    local plugin_classpath
+
+    classpath="$(getProperty dcache.paths.classpath "$1")"
+
+    plugin_classpath="$(printPluginClassPath "$1")"
+    if [ -n "$plugin_classpath" ]; then
+	classpath="${plugin_classpath}:${classpath}"
+    fi
+
+    echo $classpath
+}
+
+# Print the classpath of a CLI.  The dCache jar files are limited to
+# those matching the supplied list.
+printLimitedClassPath() # $1..$n = list of jar files
+{
+    local classpath
+    local classes_path
+    local jar
+
+    classpath="$(printPluginClassPath)"
+
+    classes_path="$(getProperty dcache.paths.classes)"
+    for name in "$@"; do
+	jar="$(echo $classes_path/$name-*.jar)"
+	classpath="${classpath}:${jar}"
+    done
+
+    echo $classpath
+}
+
+# Prints the classpath to include plugins for a given domain
+printPluginClassPath() # $1 = domain
+{
     local plugins
     local plugin
     local jar
 
-    classpath="$(getProperty dcache.paths.classpath "$1")"
     plugins="$(getProperty dcache.paths.plugins "$1")"
     while [ -n "$plugins" ]; do
         # plugins is a colon separated path of directories
@@ -160,6 +193,8 @@ printClassPath() # $1 = domain
 
     echo $classpath
 }
+
+
 
 # Start domain. Use runDomain rather than calling this function
 # directly.

--- a/skel/share/lib/upgrade_space_manager_schema.sh
+++ b/skel/share/lib/upgrade_space_manager_schema.sh
@@ -6,5 +6,4 @@
 @DCACHE_LOAD_CONFIG@
 
 CLASSPATH="$(getProperty dcache.paths.classpath)" \
-    ${JAVA} $(getProperty dcache.java.options) \
-    diskCacheV111.services.space.Manager $*
+    quickJava diskCacheV111.services.space.Manager "$@"


### PR DESCRIPTION
This patch adds several features to improve responsiveness
for various short-lived java invocations and in particular
the chimera-cli command.

The '-client' option is used (sporadically) as a hint to
the JVM not to waste time optimising the byte-code as much
of the code won't be run multiple times.  This option only has
an effect on 32-bit JVMs.  This patch adds '-client' to the
places where it's missing and adds the '-XX:+TieredCompilation
-XX:TieredStopAtLevel=1' options that have the same effect for
64-bit JVMs.

For short-lived tasks, much of the time is spent processing
the classes.  By limiting the classpath to only the jar files
that are needed, less time is taken.  This patch adds support
for this and applies it to the chimera-cli command.

A considerable fraction of the time processing a class involves
verifying certain aspects of the byte-code.  If we trust the
Java compiler and the source of the code, we can choose to
side-step this verification by adding the classes to the
bootstrap-classpath.  This patch does this for the
chimera-cli command.

The chimera-cli creates a BoneCP database pool.  The current
options are not optimal.  This patch updates them.

The effect of these changes were tested by timing how long it
takes to run "chimera-cli ls /" 10 times (discarding output)
using the system-test deployment.  This is then repeated 5
times and the mean and std. deviation is calculated.

The initial time to run "chimera-cli ls /" on my laptop is
(2.99 +/- 0.03) s

Each of the improvements had the following improvements:

```
-client -XX:+TieredCompilat... (0.64 +/- 0.07) s
Limiting jars on classpath     (0.44 +/- 0.03) s
Using boot-classpath           (0.45 +/- 0.02) s
Updated BoneCP configuration   (0.07 +/- 0.02) s

Total improvement              (1.56 +/- 0.03) s
```

Time to run "chimera-cli ls /" with all improvements is
(1.43 +/- 0.01) s

Acked-by: Tigran Mkrtchyan
Acked-by: Gerd Behrmann
Patch: http://rb.dcache.org/r/5584/
Target: master
Request: 2.6
