### PR TITLE
srm: Make login broker of SRM configurable and clean up properties

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
@@ -48,8 +48,8 @@
 
   <bean id="login-broker-stub" class="org.dcache.cells.CellStub">
     <description>Login broker communication stub</description>
-    <property name="destination" value="LoginBroker"/>
-    <property name="timeout" value="#{ ${srmPnfsTimeout} * 1000 }"/>
+    <property name="destination" value="${srm.lookup.loginbroker}"/>
+    <property name="timeout" value="#{ ${srm.lookup.timeout} * 1000 }"/>
   </bean>
 
   <bean id="pnfs-stub" class="org.dcache.cells.CellStub">
@@ -80,15 +80,15 @@
         <description>Thread pool for scheduled activities</description>
       </bean>
     </property>
-    <property name="updateTime" value="${loginBrokerUpdateTime}"/>
-    <property name="updateThreshold" value="${loginBrokerUpdateThreshold}"/>
+    <property name="updateTime" value="${srm.loginbroker.period}"/>
+    <property name="updateThreshold" value="${srm.loginbroker.threshold}"/>
     <property name="protocolEngine" value="diskCacheV111.srm.dcache.Storage"/>
-    <property name="protocolVersion" value="${protocolVersion}"/>
-    <property name="protocolFamily" value="${protocolFamily}"/>
+    <property name="protocolVersion" value="${srm.loginbroker.version}"/>
+    <property name="protocolFamily" value="${srm.loginbroker.family}"/>
     <property name="port" value="${srmPort}"/>
     <property name="loginBroker">
       <bean class="dmg.cells.nucleus.CellPath">
-        <constructor-arg value="${srmLoginBroker}"/>
+        <constructor-arg value="${srm.loginbroker}"/>
       </bean>
     </property>
   </bean>
@@ -119,9 +119,9 @@
     <property name="isSpaceManagerEnabled"
               value="${spaceManagerEnabled}"/>
     <property name="loginBrokerUpdatePeriod"
-              value="${srmLoginBrokerUpdatePeriod}"/>
+              value="${srm.lookup.period}"/>
     <property name="numberOfDoorsInRandomSelection"
-              value="${srmNumberOfDoorsInRandomSelection}"/>
+              value="${srm.lookup.population-size}"/>
     <property name="useCustomGetHostByAddress"
               value="${srmCustomGetHostByAddr}"/>
     <property name="ignoreClientProtocolOrder"

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -369,7 +369,6 @@ dir/cell.name=dirLookupPool
 
 pnfsmanager=PnfsManager
 poolmanager=PoolManager
-loginBroker=LoginBroker
 
 #  -----------------------------------------------------------------------
 #          Login broker
@@ -380,6 +379,12 @@ loginBroker=LoginBroker
 #   all doors other than the SRM door register with a single central
 #   login broker.
 #
+
+#  ----- Cell address non-SRM doors register with
+#
+# Doors other than the SRM register with this address, and the SRM
+# looks up doors at this address.
+loginBroker=LoginBroker
 
 #  ---- How often a door register with its login brokers
 #

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -441,16 +441,46 @@ srmSizeOfSingleRemoveBatch=100
 #
 srmUserCredentialsDirectory=@srmUserCredentialsDirectory@
 
-# ---- Login broker timeout in millis
+# ---- Login broker the SRM will ask to locate doors
+srm.lookup.loginbroker=${loginBroker}
+
+# ---- Login broker cache life time in milliseconds
 srmLoginBrokerUpdatePeriod=3000
+srm.lookup.period=${srmLoginBrokerUpdatePeriod}
+
+# ---- Login broker lookup timeout after which a request is retried (seconds)
+srm.lookup.timeout=${srmPnfsTimeout}
 
 # ---- Number of doors in random door selection
 #
-# SRM will order doors according to their load and select sertain
+# SRM will order doors according to their load and select certain
 # number of the least loaded and then randomly choose which one to
 # use.
 #
 srmNumberOfDoorsInRandomSelection=5
+srm.lookup.population-size=${srmNumberOfDoorsInRandomSelection}
+
+#  ---- Cell address of login broker the SRM registers with
+srm.loginbroker=srm-LoginBroker
+
+#  ---- How often the SRM registers with the loginbroker (seconds)
+srm.loginbroker.period=${loginBrokerUpdateTime}
+
+#  ---- Threshold for load changes in SRM to trigger loginbroker registration
+#
+#   The registration with a login broker contains information about
+#   the current load of SRM. If the load changes rapidly, then a
+#   door may updates its registration before the next scheduled update
+#   time. This parameter specifies the fraction of the load that
+#   triggers a reregistration.
+#
+srm.loginbroker.threshold=${loginBrokerUpdateThreshold}
+
+#  ---- Protocol version registered in login broker
+srm.loginbroker.version=1.1.1
+
+#  ---- Protocol family registered in login broker
+srm.loginbroker.family=SRM
 
 # ---- Days before old transfers are removed from the database
 #

--- a/skel/share/services/srm.batch
+++ b/skel/share/services/srm.batch
@@ -118,11 +118,18 @@ check -strong srmUserCredentialsDirectory
 check -strong pnfsmanager
 check -strong poolmanager
 
-check -strong srmLoginBrokerUpdatePeriod
+check -strong srm.loginbroker
+check -strong srm.loginbroker.period
+check -strong srm.loginbroker.threshold
+check -strong srm.loginbroker.version
+check -strong srm.loginbroker.family
+
+check -strong srm.lookup.loginbroker
+check -strong srm.lookup.period
+check -strong srm.lookup.timeout
+check -strong srm.lookup.population-size
 
 check -strong srmPoolManagerTimeout
-
-check -strong srmNumberOfDoorsInRandomSelection
 
 check -strong srmKeepRequestHistoryPeriod
 
@@ -140,8 +147,6 @@ check -strong srmCleanPendingRequestsOnRestart
 check -strong srmClientDNSLookup
 
 check -strong srmGracefulShutdown
-check -strong loginBrokerUpdateTime
-check -strong loginBrokerUpdateThreshold
 
 check -strong srmCustomGetHostByAddr
 check -strong srmIgnoreClientProtocolOrder
@@ -287,11 +292,15 @@ create org.dcache.cells.UniversalSpringCell ${cell.name} \
         -srmJdbcExecutionThreadNum=${srmJdbcExecutionThreadNum} \
         -srmMaxNumberOfJdbcTasksInQueue=${srmMaxNumberOfJdbcTasksInQueue} \
         -srmAuthzCacheLifetime=${srmAuthzCacheLifetime} \
-        -srmLoginBroker=srm-LoginBroker \
-        -protocolFamily=SRM \
-        -protocolVersion=1.1.1 \
-        -srmLoginBrokerUpdatePeriod=${srmLoginBrokerUpdatePeriod} \
-        -srmNumberOfDoorsInRandomSelection=${srmNumberOfDoorsInRandomSelection} \
+        -srm.loginbroker=${srm.loginbroker} \
+        -srm.loginbroker.period=${srm.loginbroker.period} \
+        -srm.loginbroker.threshold=${srm.loginbroker.threshold} \
+        -srm.loginbroker.version=${srm.loginbroker.version} \
+        -srm.loginbroker.family=${srm.loginbroker.family} \
+        -srm.lookup.loginbroker=${srm.lookup.loginbroker} \
+        -srm.lookup.timeout=${srm.lookup.timeout} \
+        -srm.lookup.period=${srm.lookup.period} \
+        -srm.lookup.population-size=${srm.lookup.population-size} \
         -overwriteEnabled=${overwriteEnabled} \
         -srmOverwriteByDefault=${srmOverwriteByDefault} \
         -srmCustomGetHostByAddr=${srmCustomGetHostByAddr} \
@@ -333,8 +342,6 @@ create org.dcache.cells.UniversalSpringCell ${cell.name} \
         -srmClientTransport=${srmClientTransport} \
         -srmGracefulShutdown=\"${srmGracefulShutdown}\" \
         -srmPinOnlineFiles=\"${srmPinOnlineFiles}\" \
-        -loginBrokerUpdateTime=\"${loginBrokerUpdateTime}\" \
-        -loginBrokerUpdateThreshold=\"${loginBrokerUpdateThreshold}\" \
         -dcache.paths.share=\"${dcache.paths.share}\" \
         -qosPluginClass=\"${qosPluginClass}\" \
         -qosConfigFile=\"${qosConfigFile}\" \


### PR DESCRIPTION
The patch allows the login brokers used by the SRM to be configurable.
Since the SRM uses two login brokers, one for lookup and one for
registration, I have renamed all related properties such that those
related to door lookup begin with srm.lookup. and those for login
broker registration begin with srm.loginbroker.

When merging into stable branches, the old properties will not be marked
deprecated.

Deprecated by this patch:

srmLoginBrokerUpdatePeriod
srmNumberOfDoorsInRandomSelection

Introduced by this patch:

srm.lookup.loginbroker
srm.lookup.timeout
srm.lookup.population-size
srm.loginbroker
srm.loginbroker.period
srm.loginbroker.threshold
srm.loginbroker.family
srm.loginbroker.version

Target: trunk
Request: 2.6
Request: 2.2
Require-book: yes
Require-notes: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5604/
