### PR TITLE
dcache: alarms fix four small bugs

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/commandline/SendAlarm.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/commandline/SendAlarm.java
@@ -204,7 +204,7 @@ public class SendAlarm {
             sourceHost = arg;
 
             arg = uri.getPath();
-            if (arg == null) {
+            if (arg == null || arg.isEmpty()) {
                 arg = DEFAULT_SOURCE_PATH;
             }
 

--- a/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
@@ -131,6 +131,12 @@ public class DataNucleusLogEntryStore implements ILogEntryDAO {
                 LogEntry original = dup.iterator().next();
                 original.setLastUpdate(entry.getLastUpdate());
                 original.setReceived(original.getReceived() + 1);
+		/*
+                 * this needs to be done or else newly arriving instances
+                 * will not be tracked if this type has been closed
+                 * previously
+                 */
+                original.setClosed(false);
                 /*
                  * original is not detached so it will be updated on commit
                  */

--- a/modules/dcache/src/main/java/org/dcache/alarms/logback/AlarmDefinition.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/logback/AlarmDefinition.java
@@ -569,7 +569,7 @@ public class AlarmDefinition {
             alarmType.addContent(new Element(LOGGER_TAG)
             .setText(logger));
         }
-        if (matchException != null && !matchException) {
+        if (matchException != null && matchException) {
             alarmType.addContent(new Element(MATCH_EXCEPTION_TAG)
             .setText(matchException.toString()));
         }

--- a/skel/var/alarms/logback-server.xml
+++ b/skel/var/alarms/logback-server.xml
@@ -37,28 +37,6 @@
         </encoder>
     </appender>
 
-    <!-- stores all received events; adds alarm metadata on the basis of either
-         a marker or a match with one of the alarmType definitions provided;
-         delegates all received events to other appenders, possibly with using a
-         cloned event with an added alarm marker if it is an alarm and was not
-         originally sent with one.
-         for further information, see the dCache Book -->
-    <appender name="STORE" class="org.dcache.alarms.logback.LogEntryAppender">
-        <storePath>${alarms.store.path}</storePath>
-        <url>${alarms.store.db.url}</url>
-        <user>${alarms.store.db.user}</user>
-        <pass>${alarms.store.db.pass}</pass>
-        <driver>${alarms.store.db.driver}</driver>
-        <propertiesPath>${alarms.store.db.properties}</propertiesPath>
-        <definitionsPath>${alarms.definitions.path}</definitionsPath>
-        <!-- it would be normal to comment this out if you are using an RDBMS
-             and not running periodic deletes -->
-        <appender-ref ref="HISTORY"/>
-        <!-- uncomment this in order to receive alarm mails;
-             see below for how to set mail appender -->
-        <!-- <appender-ref ref="ALARM_MAIL"/> -->
-    </appender>
-
     <!--
         if you wish alarms to be sent as email, you will need to provide host,
         to and from information below (note the possibility of multiple 'to's),
@@ -80,6 +58,28 @@
             <!-- send just one log entry per email -->
             <bufferSize>1</bufferSize>
         </cyclicBufferTracker>
+    </appender>
+
+    <!-- stores all received events; adds alarm metadata on the basis of either
+         a marker or a match with one of the alarmType definitions provided;
+         delegates all received events to other appenders, possibly with using a
+         cloned event with an added alarm marker if it is an alarm and was not
+         originally sent with one.
+         for further information, see the dCache Book -->
+    <appender name="STORE" class="org.dcache.alarms.logback.LogEntryAppender">
+        <storePath>${alarms.store.path}</storePath>
+        <url>${alarms.store.db.url}</url>
+        <user>${alarms.store.db.user}</user>
+        <pass>${alarms.store.db.pass}</pass>
+        <driver>${alarms.store.db.driver}</driver>
+        <propertiesPath>${alarms.store.db.properties}</propertiesPath>
+        <definitionsPath>${alarms.definitions.path}</definitionsPath>
+        <!-- it would be normal to comment this out if you are using an RDBMS
+             and not running periodic deletes -->
+        <appender-ref ref="HISTORY"/>
+        <!-- uncomment this in order to receive alarm mails;
+             see below for how to set mail appender -->
+        <!-- <appender-ref ref="ALARM_MAIL"/> -->
     </appender>
 
      <logger name="ch.qos.logback" additivity="false">


### PR DESCRIPTION
module dcache alarms

Four small bugs:
1.  alarm send:  if -s does not provide a path, the subsequent string operation throws array out of bounds.
2.  alarm definition toXML is not emitting the matchException node when the value is true rather than false (the default)
3.  the server logback file defines the MAIL appender reference after it uses it, which is not allowed.
4.  If an alarm has an id which permits duplicates, and the admin closes the alarm, but thereafter another of its type arrives, that alarm currently will not be visible unless show closed is selected.  The fix is to force the closed flag to false on duplicate arrival.

Target: master
Committed: ce8d000e6a87d3abab649deded7494a34b34d572
Patch:  http://rb.dcache.org/r/5602
Require-notes: yes
Require-book: no
Request: 2.6
Acked-by: Tigran

RELEASE NOTES:

Fixes four small bugs.
1.  dcache alarm send:  if -s does not provide a path (e.g., "src://otfrid" rather than "src://otfrid/"), the subsequent string o$
2.  dcache alarm add \* modify fail to record matchException = true because of a logic error in the XML emitter.
3.  the server logback file defined the MAIL appender reference after it uses it, which is not allowed.
4.  If an alarm has an id which permits duplicates, and the admin closes the alarm, but thereafter another of its type arrives, that alarm currently will not be visible unless show closed is selected.  The fix is to force the closed flag to false on duplicate arrival.
