### PR TITLE
broadcast: Fix expiration of dynamic subscribers

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/multicaster/BroadcastCell.java
+++ b/modules/cells/src/main/java/dmg/cells/services/multicaster/BroadcastCell.java
@@ -186,8 +186,7 @@ public class BroadcastCell extends CellAdapter {
 
             String tmp = args.getOpt("expires") ;
             if( tmp != null ) {
-                expires = Long.parseLong(tmp) * 1000L + System
-                        .currentTimeMillis();
+                expires = Long.parseLong(tmp) * 1000L;
             }
 
             tmp = args.getOpt("cancelonfailure") ;
@@ -365,7 +364,7 @@ public class BroadcastCell extends CellAdapter {
                     }
                     long  expires = reg.getExpires() ;
                     if( expires > 0 ) {
-                        entry.setExpires(expires);
+                        entry.setExpires(expires + System.currentTimeMillis());
                     }
                 }
             }else if( event instanceof BroadcastUnregisterMessage ){


### PR DESCRIPTION
Addresses the issue that HSM cleaner is broken as it newer
receives pool-up notifications.

BroadcastRegistrationTask supplies a relative timeout, but the
broadcast registration cell expects an absolute timeout.

Target: trunk
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5601/
(cherry picked from commit 6276fca8040315bcf38e9c77a60e3c87258027e1)
