### PR TITLE
gplazma: Simplify mapping plugin interface

### DIFF
--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/AuthzDbPlugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/AuthzDbPlugin.java
@@ -83,7 +83,7 @@ public class AuthzDbPlugin
 
     /**
      * package visible constructor for testing purposes
-     * @param authzMapCache map of usernames to user information (e.q. uid/gid)
+     * @param map map of usernames to user information (e.q. uid/gid)
      */
     AuthzDbPlugin(SourceBackedPredicateMap<String,UserAuthzInformation> map,
                   ImmutableList<PrincipalType> uidOrder,
@@ -157,8 +157,7 @@ public class AuthzDbPlugin
     }
 
     @Override
-    public void map(Set<Principal> principals,
-                    Set<Principal> authorizedPrincipals)
+    public void map(Set<Principal> principals)
         throws AuthenticationException
     {
         /* Classify input principals.
@@ -220,9 +219,9 @@ public class AuthzDbPlugin
          */
         UserAuthzInformation user =
             getEntity(_uidOrder, loginUid, null, loginName, userName, primaryGroup);
-        authorizedPrincipals.add(new UidPrincipal(user.getUid()));
+        principals.add(new UidPrincipal(user.getUid()));
         if (user.getUsername() != null) {
-            authorizedPrincipals.add(new UserNamePrincipal(user.getUsername()));
+            principals.add(new UserNamePrincipal(user.getUsername()));
         }
 
         /* Pick a GID to authorize.
@@ -230,13 +229,13 @@ public class AuthzDbPlugin
         UserAuthzInformation group =
             getEntity(_gidOrder, null, loginGid, loginName, userName, primaryGroup);
         long primaryGid = group.getGids()[0];
-        authorizedPrincipals.add(new GidPrincipal(primaryGid, true));
+        principals.add(new GidPrincipal(primaryGid, true));
 
         /* Add remaining gids.
          */
         for (long gid: gids) {
             if (gid != primaryGid) {
-                authorizedPrincipals.add(new GidPrincipal(gid, false));
+                principals.add(new GidPrincipal(gid, false));
             }
         }
     }

--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/GridMapFilePlugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/GridMapFilePlugin.java
@@ -69,8 +69,7 @@ public class GridMapFilePlugin
     }
 
     @Override
-    public void map(Set<Principal> principals,
-                    Set<Principal> authorizedPrincipals)
+    public void map(Set<Principal> principals)
         throws AuthenticationException
     {
         if (any(principals, instanceOf(UserNamePrincipal.class))) {
@@ -82,8 +81,6 @@ public class GridMapFilePlugin
         Map.Entry<Principal,String> entry = getMappingFor(principals);
         checkAuthentication(entry != null, "no mapping");
 
-        Principal principal = new UserNamePrincipal(entry.getValue());
-        principals.add(principal);
-        authorizedPrincipals.add(entry.getKey());
+        principals.add(new UserNamePrincipal(entry.getValue()));
     }
 }

--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/VoRoleMapPlugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/VoRoleMapPlugin.java
@@ -50,7 +50,7 @@ public class VoRoleMapPlugin implements GPlazmaMappingPlugin
 
     /**
      * package visible constructor for testing purposes
-     * @param voMapCache map of dnfqans to usernames
+     * @param map map of dnfqans to usernames
      */
     VoRoleMapPlugin(SourceBackedPredicateMap<NameRolePair,String> map)
     {
@@ -70,8 +70,7 @@ public class VoRoleMapPlugin implements GPlazmaMappingPlugin
     private boolean addMappingFor(FQAN fqan,
                                   GlobusPrincipal globusPrincipal,
                                   boolean isPrimary,
-                                  Set<Principal> principals,
-                                  Set<Principal> authorizedPrincipals)
+                                  Set<Principal> principals)
     {
         String dn = globusPrincipal.getName();
         List<String> names =
@@ -82,15 +81,13 @@ public class VoRoleMapPlugin implements GPlazmaMappingPlugin
 
         String name = names.get(0);
         principals.add(new GroupNamePrincipal(name, isPrimary));
-        authorizedPrincipals.add(new FQANPrincipal(fqan, isPrimary));
-        authorizedPrincipals.add(globusPrincipal);
+        principals.add(new FQANPrincipal(fqan, isPrimary));
         _log.info("VOMS authorization successful for user with DN: {} and FQAN: {} for user name: {}.", dn, fqan, name);
         return true;
     }
 
     @Override
-    public void map(Set<Principal> principals,
-                    Set<Principal> authorizedPrincipals)
+    public void map(Set<Principal> principals)
         throws AuthenticationException
     {
         List<FQANPrincipal> fqanPrincipals =
@@ -98,7 +95,7 @@ public class VoRoleMapPlugin implements GPlazmaMappingPlugin
         List<GlobusPrincipal> globusPrincipals =
             Lists.newArrayList(filter(principals, GlobusPrincipal.class));
 
-        boolean hasPrimary = containsPrimaryGroupName(authorizedPrincipals);
+        boolean hasPrimary = containsPrimaryGroupName(principals);
         boolean authorized = false;
 
         for (FQANPrincipal fqanPrincipal: fqanPrincipals) {
@@ -107,8 +104,7 @@ public class VoRoleMapPlugin implements GPlazmaMappingPlugin
             FQAN fqan = fqanPrincipal.getFqan();
             do {
                 for (GlobusPrincipal globusPrincipal: globusPrincipals) {
-                    if (addMappingFor(fqan, globusPrincipal, isPrimary,
-                                      principals, authorizedPrincipals)) {
+                    if (addMappingFor(fqan, globusPrincipal, isPrimary, principals)) {
                         authorized = true;
                         found = true;
                         hasPrimary |= isPrimary;

--- a/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/plugins/AuthzDbPluginTest.java
+++ b/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/plugins/AuthzDbPluginTest.java
@@ -42,20 +42,17 @@ public class AuthzDbPluginTest
             new SourceBackedPredicateMap<>(new MemoryLineSource(Resources.readLines(TEST_FIXTURE, Charset.defaultCharset())), new AuthzMapLineParser());
     }
 
-    public void check(Set<? extends Principal> principals,
-                      Set<? extends Principal> expectedAuthorizedPrincipals)
+    public void check(Set<? extends Principal> input,
+                      Set<? extends Principal> output)
         throws AuthenticationException
     {
         AuthzDbPlugin plugin =
             new AuthzDbPlugin(testFixture,
                               ImmutableList.of(UID,LOGIN,USER,GROUP),
                               ImmutableList.of(GID,LOGIN,GROUP,USER));
-        Set<Principal> sourcePrincipals = Sets.newHashSet(principals);
-        Set<Principal> expectedPrincipals = Sets.newHashSet(principals);
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        plugin.map(sourcePrincipals, authorizedPrincipals);
-        assertEquals(expectedPrincipals, sourcePrincipals);
-        assertEquals(expectedAuthorizedPrincipals, authorizedPrincipals);
+        Set<Principal> principals = Sets.newHashSet(input);
+        plugin.map(principals);
+        assertEquals(output, principals);
     }
 
     @Test
@@ -86,7 +83,8 @@ public class AuthzDbPluginTest
         check(ImmutableSet.of(new GroupNamePrincipal("behrmann", true)),
               ImmutableSet.of(new UidPrincipal(1000),
                               new GidPrincipal(1000, true),
-                              new UserNamePrincipal("behrmann")));
+                              new UserNamePrincipal("behrmann"),
+                              new GroupNamePrincipal("behrmann", true)));
     }
 
     @Test(expected=AuthenticationException.class)
@@ -106,7 +104,9 @@ public class AuthzDbPluginTest
               ImmutableSet.of(new UidPrincipal(1002),
                               new GidPrincipal(1001, false),
                               new GidPrincipal(1002, true),
-                              new UserNamePrincipal("atlas-prod")));
+                              new UserNamePrincipal("atlas-prod"),
+                              new GroupNamePrincipal("atlas-user", false),
+                              new GroupNamePrincipal("atlas-prod", true)));
     }
 
     @Test
@@ -118,7 +118,10 @@ public class AuthzDbPluginTest
                               new LoginUidPrincipal(1001)),
               ImmutableSet.of(new UidPrincipal(1001),
                               new GidPrincipal(1001, false),
-                              new GidPrincipal(1002, true)));
+                              new GidPrincipal(1002, true),
+                              new GroupNamePrincipal("atlas-user", false),
+                              new GroupNamePrincipal("atlas-prod", true),
+                              new LoginUidPrincipal(1001)));
     }
 
     @Test
@@ -131,6 +134,9 @@ public class AuthzDbPluginTest
               ImmutableSet.of(new UidPrincipal(1002),
                               new GidPrincipal(1001, true),
                               new GidPrincipal(1002, false),
+                              new LoginGidPrincipal(1001),
+                              new GroupNamePrincipal("atlas-user", false),
+                              new GroupNamePrincipal("atlas-prod", true),
                               new UserNamePrincipal("atlas-prod")));
     }
 
@@ -153,7 +159,8 @@ public class AuthzDbPluginTest
               ImmutableSet.of(new UidPrincipal(1000),
                               new GidPrincipal(1000, false),
                               new GidPrincipal(1001, true),
-                              new UserNamePrincipal("behrmann")));
+                              new UserNamePrincipal("behrmann"),
+                              new GroupNamePrincipal("atlas-user", true)));
     }
 
     @Test
@@ -165,7 +172,8 @@ public class AuthzDbPluginTest
               ImmutableSet.of(new UidPrincipal(1000),
                               new GidPrincipal(1000, true),
                               new GidPrincipal(1001, false),
-                              new UserNamePrincipal("behrmann")));
+                              new UserNamePrincipal("behrmann"),
+                              new GroupNamePrincipal("atlas-user", false)));
     }
 
     @Test
@@ -180,7 +188,12 @@ public class AuthzDbPluginTest
               ImmutableSet.of(new UidPrincipal(1001),
                               new GidPrincipal(1000, false),
                               new GidPrincipal(1001, true),
-                              new GidPrincipal(1002, false)));
+                              new GidPrincipal(1002, false),
+                              new UserNamePrincipal("behrmann"),
+                              new GroupNamePrincipal("atlas-user", false),
+                              new GroupNamePrincipal("atlas-prod", true),
+                              new LoginUidPrincipal(1001),
+                              new LoginGidPrincipal(1001)));
     }
 
     @Test
@@ -193,7 +206,9 @@ public class AuthzDbPluginTest
               ImmutableSet.of(new UidPrincipal(1000),
                               new GidPrincipal(1000, true),
                               new GidPrincipal(1002, false),
-                              new UserNamePrincipal("behrmann")));
+                              new UserNamePrincipal("behrmann"),
+                              new GroupNamePrincipal("atlas-prod", true),
+                              new LoginNamePrincipal("behrmann")));
     }
 
     @Test(expected=AuthenticationException.class)

--- a/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/plugins/VoRoleMapPluginTest.java
+++ b/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/plugins/VoRoleMapPluginTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 
 import java.security.Principal;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -30,14 +29,13 @@ public class VoRoleMapPluginTest
     private LineSource _source;
     private VoRoleMapFileMaker _content;
     private Set<Principal> _principals;
-    private Set<Principal> _authorizedPrincipals;
 
     @Test(expected=NullPointerException.class)
     public void shouldThrowNPEWhenGivenNullArgs() throws AuthenticationException
     {
         givenVoRoleMapFile().thatIsEmpty();
 
-        whenMapPluginCalledWith(null, null);
+        whenMapPluginCalledWith((Set<Principal>) null);
     }
 
 
@@ -56,9 +54,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, hasPrimaryFqan("/acme"));
         assertThat(_principals, hasPrimaryGroupName("acme01"));
         assertThat(_principals, not(hasGroupName("acme01")));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme"));
     }
 
 
@@ -77,9 +72,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, hasPrimaryFqan("/acme"));
         assertThat(_principals, hasPrimaryGroupName("acme01"));
         assertThat(_principals, not(hasGroupName("acme01")));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme"));
     }
 
 
@@ -102,9 +94,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, hasPrimaryFqan("/acme"));
         assertThat(_principals, hasPrimaryGroupName("acme01"));
         assertThat(_principals, not(hasGroupName("acme01")));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme"));
     }
 
 
@@ -124,9 +113,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, hasPrimaryFqan("/acme/Role=genius"));
         assertThat(_principals, hasFqan("/acme"));
         assertThat(_principals, hasGroupName("acme01")); // FIXME should be primaryGroupName?
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasFqan("/acme"));
     }
 
 
@@ -177,9 +163,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, not(hasGroupName("acme01")));
         assertThat(_principals, not(hasPrimaryGroupName("acme02")));
         assertThat(_principals, not(hasGroupName("acme02")));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme"));
     }
 
 
@@ -201,9 +184,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, not(hasGroupName("acme01")));
         assertThat(_principals, not(hasPrimaryGroupName("acme02")));
         assertThat(_principals, not(hasGroupName("acme02")));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme"));
     }
 
 
@@ -227,10 +207,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, not(hasGroupName("genius01")));
         assertThat(_principals, not(hasPrimaryGroupName("acme01")));
         assertThat(_principals, hasGroupName("acme01"));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme/Role=genius"));
-        assertThat(_authorizedPrincipals, hasFqan("/acme"));
     }
 
 
@@ -254,10 +230,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, not(hasGroupName("acme01")));
         assertThat(_principals, not(hasPrimaryGroupName("genius01")));
         assertThat(_principals, hasGroupName("genius01"));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme"));
-        assertThat(_authorizedPrincipals, hasFqan("/acme/Role=genius"));
     }
 
 
@@ -275,9 +247,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, hasPrimaryFqan("/acme"));
         assertThat(_principals, hasPrimaryGroupName("acme01"));
         assertThat(_principals, not(hasGroupName("acme01")));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme"));
     }
 
 
@@ -294,9 +263,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, hasDn("/O=ACME/CN=Wile E Coyote"));
         assertThat(_principals, hasPrimaryFqan("/acme"));
         assertThat(_principals, hasPrimaryGroupName("acme01"));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme"));
     }
 
 
@@ -315,10 +281,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, hasPrimaryFqan("/acme/Role=genius"));
         assertThat(_principals, hasFqan("/acme"));
         assertThat(_principals, hasGroupName("acme01")); // FIXME should be primaryGroupName
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasFqan("/acme"));
-        assertThat(_authorizedPrincipals, not(hasPrimaryFqan("/acme/Role=genius")));
     }
 
 
@@ -342,10 +304,6 @@ public class VoRoleMapPluginTest
         assertThat(_principals, not(hasGroupName("acme01")));
         assertThat(_principals, not(hasPrimaryGroupName("genius01")));
         assertThat(_principals, hasGroupName("genius01"));
-
-        assertThat(_authorizedPrincipals, hasDn("/O=ACME/CN=Wile E Coyote"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/acme"));
-        assertThat(_authorizedPrincipals, hasFqan("/acme/Role=genius"));
     }
 
     @Test
@@ -360,8 +318,8 @@ public class VoRoleMapPluginTest
                 .withFqan("/cms"));
 
         assertThat(_principals, hasPrimaryGroupName("cms001"));
-        assertThat(_authorizedPrincipals, hasDn("/DC=es/DC=irisgrid/O=ciemat/CN=antonio-delgado-peris"));
-        assertThat(_authorizedPrincipals, hasPrimaryFqan("/cms"));
+        assertThat(_principals, hasDn("/DC=es/DC=irisgrid/O=ciemat/CN=antonio-delgado-peris"));
+        assertThat(_principals, hasPrimaryFqan("/cms"));
     }
 
 
@@ -410,14 +368,12 @@ public class VoRoleMapPluginTest
             throws AuthenticationException
     {
         Set<Principal> principals = Sets.newHashSet(maker.build());
-        whenMapPluginCalledWith(principals, new HashSet<Principal>());
+        whenMapPluginCalledWith(principals);
     }
 
-    private void whenMapPluginCalledWith(Set<Principal> principals,
-            Set<Principal> authorizedPrincipals) throws AuthenticationException
+    private void whenMapPluginCalledWith(Set<Principal> principals) throws AuthenticationException
     {
         _principals = principals;
-        _authorizedPrincipals = authorizedPrincipals;
 
         VOMapLineParser parser = new VOMapLineParser();
 
@@ -426,7 +382,7 @@ public class VoRoleMapPluginTest
                 parser);
 
         GPlazmaMappingPlugin plugin = new VoRoleMapPlugin(map);
-        plugin.map(_principals, _authorizedPrincipals);
+        plugin.map(_principals);
     }
 
     private VoRoleMapFileMaker givenVoRoleMapFile()

--- a/modules/gplazma2-jaas/src/main/java/org/dcache/gplazma/plugins/MutatorPlugin.java
+++ b/modules/gplazma2-jaas/src/main/java/org/dcache/gplazma/plugins/MutatorPlugin.java
@@ -1,16 +1,19 @@
 package org.dcache.gplazma.plugins;
 
+import org.globus.gsi.jaas.GlobusPrincipal;
+
+import javax.security.auth.kerberos.KerberosPrincipal;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.Principal;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-import javax.security.auth.kerberos.KerberosPrincipal;
+
 import org.dcache.auth.FQANPrincipal;
 import org.dcache.auth.LoginNamePrincipal;
 import org.dcache.auth.UserNamePrincipal;
-import org.globus.gsi.jaas.GlobusPrincipal;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.instanceOf;
@@ -46,7 +49,7 @@ public class MutatorPlugin implements GPlazmaMappingPlugin {
     }
 
     @Override
-    public void map(Set<Principal> principals, Set<Principal> authorizedPrincipals) {
+    public void map(Set<Principal> principals) {
         Set<Principal> mutated = new HashSet<>();
         for (Principal p : filter(principals, instanceOf(inPrincipal))) {
             try {

--- a/modules/gplazma2-jaas/src/test/java/org/dcache/gplazma/plugins/MutatorPluginTest.java
+++ b/modules/gplazma2-jaas/src/test/java/org/dcache/gplazma/plugins/MutatorPluginTest.java
@@ -1,17 +1,17 @@
 package org.dcache.gplazma.plugins;
 
 import com.google.common.collect.Sets;
-import java.security.Principal;
-import java.util.NoSuchElementException;
-import java.util.Properties;
-import java.util.Set;
-import org.dcache.auth.LoginNamePrincipal;
-import org.dcache.auth.UserNamePrincipal;
 import org.junit.Test;
 
-import static com.google.common.collect.Iterables.find;
+import java.security.Principal;
+import java.util.Properties;
+import java.util.Set;
+
+import org.dcache.auth.LoginNamePrincipal;
+import org.dcache.auth.UserNamePrincipal;
+
 import static com.google.common.base.Predicates.instanceOf;
-import static org.junit.Assert.*;
+import static com.google.common.collect.Iterables.find;
 
 public class MutatorPluginTest {
 
@@ -56,46 +56,11 @@ public class MutatorPluginTest {
         prop.setProperty(MutatorPlugin.OUT_OPTION, "username");
 
         MutatorPlugin mutator = new MutatorPlugin(prop);
-        Set<Principal> in = Sets.newHashSet((Principal) new LoginNamePrincipal("myname"));
-        Set<Principal> out = Sets.newHashSet();
+        Set<Principal> principals = Sets.newHashSet((Principal) new LoginNamePrincipal("myname"));
 
-        mutator.map(in, out);
+        mutator.map(principals);
 
         // will throw exception if no  match
-        find(in, instanceOf(UserNamePrincipal.class));
-    }
-
-    @Test(expected = NoSuchElementException.class)
-    public void testNoOriginalPrincipalLeak() throws Exception {
-        Properties prop = new Properties();
-
-        prop.setProperty(MutatorPlugin.IN_OPTION, "org.dcache.auth.LoginNamePrincipal");
-        prop.setProperty(MutatorPlugin.OUT_OPTION, "username");
-
-        MutatorPlugin mutator = new MutatorPlugin(prop);
-        Set<Principal> in = Sets.newHashSet((Principal) new LoginNamePrincipal("myname"));
-        Set<Principal> out = Sets.newHashSet();
-
-        mutator.map(in, out);
-
-        // sould throw exception
-        find(out, instanceOf(LoginNamePrincipal.class));
-    }
-
-    @Test(expected = NoSuchElementException.class)
-    public void testNoProducedPrincipalLeak() throws Exception {
-        Properties prop = new Properties();
-
-        prop.setProperty(MutatorPlugin.IN_OPTION, "org.dcache.auth.LoginNamePrincipal");
-        prop.setProperty(MutatorPlugin.OUT_OPTION, "username");
-
-        MutatorPlugin mutator = new MutatorPlugin(prop);
-        Set<Principal> in = Sets.newHashSet((Principal) new LoginNamePrincipal("myname"));
-        Set<Principal> out = Sets.newHashSet();
-
-        mutator.map(in, out);
-
-        // sould throw exception
-        find(out, instanceOf(UserNamePrincipal.class));
+        find(principals, instanceOf(UserNamePrincipal.class));
     }
 }

--- a/modules/gplazma2-kpwd/src/main/java/org/dcache/auth/gplazma/KpwdPlugin.java
+++ b/modules/gplazma2-kpwd/src/main/java/org/dcache/auth/gplazma/KpwdPlugin.java
@@ -196,8 +196,7 @@ public class KpwdPlugin
      * Authorizes user name, DN, Kerberos principal, UID and GID.
      */
     @Override
-    public void map(Set<Principal> principals,
-                    Set<Principal> authorizedPrincipals)
+    public void map(Set<Principal> principals)
         throws AuthenticationException
     {
         KpwdPrincipal kpwd =
@@ -254,20 +253,9 @@ public class KpwdPlugin
 
             authRecord.DN = principal.getName();
             kpwd = new KpwdPrincipal(authRecord);
-
-            if (!(principal instanceof UserNamePrincipal)) {
-                /*
-                 * besides GlobusPrincipal, KerberosPrincipal, LoginNamePrincipal
-                 * kpwd file can contain UserNamePrincipal that can be mapped to
-                 * another UserNamePrincipal. To avoid issue with multiple usernames
-                 * we skip adding principal if it is UserNamePrincipal
-                 *
-                 */
-                authorizedPrincipals.add(principal);
-            }
         }
 
-        authorizedPrincipals.add(kpwd);
+        principals.add(kpwd);
 
         /* We explicitly check whether the user record is banned and
          * don't authorize the remaining principals. We do however
@@ -276,9 +264,9 @@ public class KpwdPlugin
          */
         checkAuthentication(!kpwd.isDisabled(), "account disabled");
 
-        authorizedPrincipals.add(new UserNamePrincipal(kpwd.getName()));
-        authorizedPrincipals.add(new UidPrincipal(kpwd.getUid()));
-        authorizedPrincipals.add(new GidPrincipal(kpwd.getGid(), true));
+        principals.add(new UserNamePrincipal(kpwd.getName()));
+        principals.add(new UidPrincipal(kpwd.getUid()));
+        principals.add(new GidPrincipal(kpwd.getGid(), true));
     }
 
     private static String errorMessage(Principal principal1,

--- a/modules/gplazma2-kpwd/src/test/java/org/dcache/auth/gplazma/KpwdPluginTest.java
+++ b/modules/gplazma2-kpwd/src/test/java/org/dcache/auth/gplazma/KpwdPluginTest.java
@@ -52,51 +52,44 @@ public class KpwdPluginTest
     }
 
     public void check(Set<?> credentials,
-                      Set<? extends Principal> principals,
-                      Set<? extends Principal> expectedAuthorizedPrincipals,
+                      Set<? extends Principal> input,
+                      Set<? extends Principal> output,
                       Set<?> expectedAttributes)
         throws AuthenticationException
     {
         KpwdPlugin plugin = new KpwdPlugin(testFixture);
         Set<Object> privateCredentials = Sets.newHashSet(credentials);
-        Set<Principal> identifiedPrincipals = Sets.newHashSet(principals);
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
+        Set<Principal> principals = Sets.newHashSet(input);
         Set<Object> attributes = Sets.newHashSet();
 
-        plugin.authenticate(Sets.newHashSet(), privateCredentials,
-                            identifiedPrincipals);
+        plugin.authenticate(Sets.newHashSet(), privateCredentials, principals);
 
-        plugin.map(identifiedPrincipals, authorizedPrincipals);
-        assertTrue("expected: " + expectedAuthorizedPrincipals
-                   + " was: " + authorizedPrincipals,
-                   authorizedPrincipals.containsAll(expectedAuthorizedPrincipals));
+        plugin.map(principals);
+        assertTrue("expected: " + output + " was: " + principals,
+                   principals.containsAll(output));
 
-        plugin.account(authorizedPrincipals);
+        plugin.account(principals);
 
-        plugin.session(authorizedPrincipals, attributes);
+        plugin.session(principals, attributes);
         assertEquals(expectedAttributes, attributes);
     }
 
-    public void check(Set<? extends Principal> principals,
-                      Set<? extends Principal> expectedAuthorizedPrincipals,
+    public void check(Set<? extends Principal> input,
+                      Set<? extends Principal> output,
                       Set<?> expectedAttributes)
         throws AuthenticationException
     {
         KpwdPlugin plugin = new KpwdPlugin(testFixture);
-        Set<Principal> identifiedPrincipals = Sets.newHashSet(principals);
-        Set<Principal> expectedPrincipals = Sets.newHashSet(principals);
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
+        Set<Principal> principals = Sets.newHashSet(input);
         Set<Object> attributes = Sets.newHashSet();
 
-        plugin.map(identifiedPrincipals, authorizedPrincipals);
-        assertEquals(expectedPrincipals, identifiedPrincipals);
-        assertTrue("expected: " + expectedAuthorizedPrincipals
-                   + " was: " + authorizedPrincipals,
-                   authorizedPrincipals.containsAll(expectedAuthorizedPrincipals));
+        plugin.map(principals);
+        assertTrue("expected: " + output + " was: " + principals,
+                   principals.containsAll(output));
 
-        plugin.account(authorizedPrincipals);
+        plugin.account(principals);
 
-        plugin.session(authorizedPrincipals, attributes);
+        plugin.session(principals, attributes);
         assertEquals(expectedAttributes, attributes);
     }
 

--- a/modules/gplazma2-krb5/src/main/java/org/dcache/gplazma/plugins/Krb5.java
+++ b/modules/gplazma2-krb5/src/main/java/org/dcache/gplazma/plugins/Krb5.java
@@ -33,7 +33,7 @@ public class Krb5 implements GPlazmaMappingPlugin
     }
 
     @Override
-    public void map(Set<Principal> principals, Set<Principal> authorizedPrincipals) throws AuthenticationException {
+    public void map(Set<Principal> principals) throws AuthenticationException {
         Set<Principal> kerberosPrincipals = new HashSet<>();
         for (Principal principal : principals) {
             if (principal instanceof KerberosPrincipal) {

--- a/modules/gplazma2-nis/src/main/java/org/dcache/gplazma/plugins/Nis.java
+++ b/modules/gplazma2-nis/src/main/java/org/dcache/gplazma/plugins/Nis.java
@@ -78,8 +78,6 @@ public class Nis implements GPlazmaIdentityPlugin, GPlazmaSessionPlugin, GPlazma
 
     /**
      * Create a NIS identity plugin.
-     * @param args an array of {@link String} where first element is the NIS
-     * server name and second is the NIS domain name.
      * @throws NamingException
      */
     public Nis(Properties properties) throws NamingException {
@@ -96,20 +94,19 @@ public class Nis implements GPlazmaIdentityPlugin, GPlazmaSessionPlugin, GPlazma
     }
 
     @Override
-    public void map(Set<Principal> principals, Set<Principal> authorizedPrincipals) throws AuthenticationException {
+    public void map(Set<Principal> principals) throws AuthenticationException {
         Principal principal =
                 find(principals, instanceOf(UserNamePrincipal.class), null);
         if (principal != null) {
             try {
                 Attributes userAttr = _ctx.getAttributes(NISMAP_PASSWORD_BY_NAME + "/" + principal.getName());
-                authorizedPrincipals.add(principal);
-                authorizedPrincipals.add(new UidPrincipal((String) userAttr.get(UID_NUMBER_ATTRIBUTE).get()));
-                authorizedPrincipals.add(new GidPrincipal((String) userAttr.get(GID_NUMBER_ATTRIBUTE).get(), true));
+                principals.add(new UidPrincipal((String) userAttr.get(UID_NUMBER_ATTRIBUTE).get()));
+                principals.add(new GidPrincipal((String) userAttr.get(GID_NUMBER_ATTRIBUTE).get(), true));
                 NamingEnumeration<SearchResult> groupResult =_ctx.search(NISMAP_GROUP_BY_NAME,
                         new BasicAttributes(MEMBER_UID_ATTRIBUTE, principal.getName()));
                 while (groupResult.hasMore()) {
                     SearchResult result = groupResult.next();
-                    authorizedPrincipals.add(
+                    principals.add(
                             new GidPrincipal((String) result.getAttributes().get(GID_NUMBER_ATTRIBUTE).get(), false));
                 }
             } catch (NamingException e) {

--- a/modules/gplazma2-nsswitch/src/main/java/org/dcache/gplazma/plugins/Nsswitch.java
+++ b/modules/gplazma2-nsswitch/src/main/java/org/dcache/gplazma/plugins/Nsswitch.java
@@ -42,7 +42,7 @@ public class Nsswitch implements GPlazmaMappingPlugin, GPlazmaIdentityPlugin, GP
     private final LibC _libc;
 
     /**
-     * Create an instance of {@link Nss} gplazma plugin.
+     * Create an instance of {@link Nsswitch} gplazma plugin.
      *
      * @param properties
      * @throws UnsatisfiedLinkError if unable to load system libraries.
@@ -51,22 +51,29 @@ public class Nsswitch implements GPlazmaMappingPlugin, GPlazmaIdentityPlugin, GP
         _libc = (LibC) Native.loadLibrary("c", LibC.class);
     }
 
-    @Override
-    public void map(Set<Principal> principals, Set<Principal> authorizedPrincipals) throws AuthenticationException {
+    private __password findPasswordRecord(Set<Principal> principals) {
         for (UserNamePrincipal principal: filter(principals, UserNamePrincipal.class)) {
             __password p = _libc.getpwnam(principal.getName());
             if (p != null) {
-                authorizedPrincipals.add(principal);
-                authorizedPrincipals.add(new UidPrincipal(p.uid));
-                authorizedPrincipals.add(new GidPrincipal(p.gid, true));
-                int[] gids = groupsOf(p);
-                for (int id : gids) {
-                    authorizedPrincipals.add(new GidPrincipal(id, false));
-                }
-                return;
+                return p;
             }
         }
-        throw new AuthenticationException("no mapping");
+        return null;
+    }
+
+    @Override
+    public void map(Set<Principal> principals) throws AuthenticationException {
+        __password p = findPasswordRecord(principals);
+        if (p != null) {
+            principals.add(new UidPrincipal(p.uid));
+            principals.add(new GidPrincipal(p.gid, true));
+            int[] gids = groupsOf(p);
+            for (int id : gids) {
+                principals.add(new GidPrincipal(id, false));
+            }
+        } else {
+            throw new AuthenticationException("no mapping");
+        }
     }
 
     /**

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/CombinedLoginMonitor.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/CombinedLoginMonitor.java
@@ -76,22 +76,19 @@ public class CombinedLoginMonitor implements LoginMonitor
 
     @Override
     public void mapPluginBegins(String name, ConfigurationItemControl control,
-            Set<Principal> principals, Set<Principal> authorizedPrincipals)
+            Set<Principal> principals)
     {
         for(LoginMonitor monitor : _inner) {
-            monitor.mapPluginBegins(name, control, principals,
-                    authorizedPrincipals);
+            monitor.mapPluginBegins(name, control, principals);
         }
     }
 
     @Override
     public void mapPluginEnds(String name, ConfigurationItemControl control,
-            Result result, String error, Set<Principal> principals,
-            Set<Principal> authorizedPrincipals)
+            Result result, String error, Set<Principal> principals)
     {
         for(LoginMonitor monitor : _inner) {
-            monitor.mapPluginEnds(name, control, result, error, principals,
-                    authorizedPrincipals);
+            monitor.mapPluginEnds(name, control, result, error, principals);
         }
     }
 

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/IgnoringLoginMonitor.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/IgnoringLoginMonitor.java
@@ -47,15 +47,14 @@ public class IgnoringLoginMonitor implements LoginMonitor
 
     @Override
     public void mapPluginBegins(String name, ConfigurationItemControl control,
-            Set<Principal> principals, Set<Principal> authorizedPrincipals)
+            Set<Principal> principals)
     {
         // ignored
     }
 
     @Override
     public void mapPluginEnds(String name, ConfigurationItemControl control,
-            Result result, String error, Set<Principal> principals,
-            Set<Principal> authorizedPrincipals)
+            Result result, String error, Set<Principal> principals)
     {
         // ignored
     }

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoggingLoginMonitor.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoggingLoginMonitor.java
@@ -43,10 +43,9 @@ public class LoggingLoginMonitor extends IgnoringLoginMonitor
 
     @Override
     public void mapPluginBegins(String name, ConfigurationItemControl control,
-            Set<Principal> principals, Set<Principal> authorizedPrincipals)
+            Set<Principal> principals)
     {
-        _log.debug("calling (principals: {}, authPrincipals: {})", principals,
-                authorizedPrincipals);
+        _log.debug("calling (principals: {})", principals);
     }
 
     @Override
@@ -73,7 +72,7 @@ public class LoggingLoginMonitor extends IgnoringLoginMonitor
             ConfigurationItemControl control, Set<Principal> principals,
             Set<Object> attributes)
     {
-        _log.debug("calling (pricipals: {}, attrib: {})", principals,
+        _log.debug("calling (principals: {}, attributes: {})", principals,
                 attributes);
 
     }

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginMonitor.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginMonitor.java
@@ -51,11 +51,10 @@ public interface LoginMonitor
     public void mapBegins(Set<Principal> principals);
 
     public void mapPluginBegins(String name, ConfigurationItemControl control,
-            Set<Principal> principals, Set<Principal> authorizedPrincipals);
+            Set<Principal> principals);
 
     public void mapPluginEnds(String name, ConfigurationItemControl control,
-            Result result, String error, Set<Principal> principals,
-            Set<Principal> authorizedPrincipals);
+            Result result, String error, Set<Principal> principals);
 
     public void mapEnds(Set<Principal> principals, Result result);
 

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResult.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResult.java
@@ -1,5 +1,7 @@
 package org.dcache.gplazma.monitor;
 
+import com.google.common.collect.Sets;
+
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -260,10 +262,10 @@ public class LoginResult
         private final Set<T> _before;
         private final Set<T> _after;
 
-        SetDiff(Set<T> before, Set<T> after)
+        SetDiff(Iterable<T> before, Iterable<T> after)
         {
-            _before = new HashSet<>(before);
-            _after = new HashSet<>(after);
+            _before = Sets.newHashSet(before);
+            _after = Sets.newHashSet(after);
         }
 
         public Set<T> getBefore()
@@ -397,32 +399,21 @@ public class LoginResult
      */
     public static class MapPluginResult extends PAMPluginResult
     {
-        private SetDiff<Principal> _identified;
-        private SetDiff<Principal> _authorized;
+        private SetDiff<Principal> _principals;
 
         MapPluginResult(String name, ConfigurationItemControl control)
         {
             super(name, control);
         }
 
-        public void setIdentified(Set<Principal> before, Set<Principal> after)
+        public void setPrincipals(Iterable<Principal> before, Iterable<Principal> after)
         {
-            _identified = new SetDiff<>(before, after);
+            _principals = new SetDiff<>(before, after);
         }
 
-        public void setAuthorized(Set<Principal> before, Set<Principal> after)
+        public SetDiff<Principal> getPrincipals()
         {
-            _authorized = new SetDiff<>(before, after);
-        }
-
-        public SetDiff<Principal> getIdentified()
-        {
-            return _identified;
-        }
-
-        public SetDiff<Principal> getAuthorized()
-        {
-            return _authorized;
+            return _principals;
         }
     }
 

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
@@ -746,8 +746,7 @@ public class LoginResultPrinter
     private void printPluginBehaviour(MapPluginResult plugin, boolean isLast)
     {
         String prefix = isLast ? " |        " : " |   |    ";
-        printPrincipalsDiff(prefix, plugin.getIdentified());
-        printPrincipalsDiff(prefix, plugin.getAuthorized());
+        printPrincipalsDiff(prefix, plugin.getPrincipals());
     }
 
     private void printPluginBehaviour(AccountPluginResult plugin, boolean isLast)

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/RecordingLoginMonitor.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/RecordingLoginMonitor.java
@@ -27,8 +27,7 @@ public class RecordingLoginMonitor implements LoginMonitor
      * or plug
      */
     private Set<Principal> _atPhaseStartPrincipals;
-    private Set<Principal> _identifiedPrincipals;
-    private Set<Principal> _authorizedPrincipals;
+    private Set<Principal> _principals;
     private Set<Object> _publicCredentials;
     private Set<Object> _privateCredentials;
 
@@ -49,7 +48,7 @@ public class RecordingLoginMonitor implements LoginMonitor
     {
         AuthPhaseResult auth = _result.getAuthPhase();
         auth.addPluginResult(new AuthPluginResult(name, control));
-        _identifiedPrincipals = new HashSet<>(principals);
+        _principals = new HashSet<>(principals);
         _publicCredentials = new HashSet<>(publicCredentials);
         _privateCredentials = new HashSet<>(privateCredentials);
     }
@@ -61,7 +60,7 @@ public class RecordingLoginMonitor implements LoginMonitor
     {
         AuthPhaseResult auth = _result.getAuthPhase();
         AuthPluginResult plugin = auth.getLastPlugin();
-        plugin.setIdentified(_identifiedPrincipals, principals);
+        plugin.setIdentified(_principals, principals);
         plugin.setPublicCredentials(_publicCredentials, publicCredentials);
         plugin.setPrivateCredentials(_privateCredentials, privateCredentials);
         plugin.setResult(result);
@@ -86,24 +85,21 @@ public class RecordingLoginMonitor implements LoginMonitor
 
     @Override
     public void mapPluginBegins(String name, ConfigurationItemControl control,
-            Set<Principal> principals, Set<Principal> authorizedPrincipals)
+            Set<Principal> principals)
     {
         MapPhaseResult map = _result.getMapPhase();
         map.addPluginResult(new MapPluginResult(name, control));
-        _identifiedPrincipals = new HashSet<>(principals);
-        _authorizedPrincipals = new HashSet<>(authorizedPrincipals);
+        _principals = new HashSet<>(principals);
     }
 
     @Override
     public void mapPluginEnds(String name, ConfigurationItemControl control,
-            Result result, String error, Set<Principal> principals,
-            Set<Principal> authorizedPrincipals)
+            Result result, String error, Set<Principal> principals)
     {
         MapPhaseResult map = _result.getMapPhase();
         MapPluginResult plugin = map.getLastPlugin();
         plugin.setResult(result);
-        plugin.setIdentified(_identifiedPrincipals, principals);
-        plugin.setAuthorized(_authorizedPrincipals, authorizedPrincipals);
+        plugin.setPrincipals(_principals, principals);
         if(result == Result.FAIL) {
             plugin.setError(error);
         }
@@ -129,7 +125,7 @@ public class RecordingLoginMonitor implements LoginMonitor
     {
         AccountPhaseResult account = _result.getAccountPhase();
         account.addPluginResult(new AccountPluginResult(name, control));
-        _authorizedPrincipals = new HashSet<>(principals);
+        _principals = new HashSet<>(principals);
     }
 
     @Override
@@ -139,7 +135,7 @@ public class RecordingLoginMonitor implements LoginMonitor
     {
         AccountPhaseResult account = _result.getAccountPhase();
         AccountPluginResult plugin = account.getLastPlugin();
-        plugin.setAuthorized(_authorizedPrincipals, principals);
+        plugin.setAuthorized(_principals, principals);
         plugin.setResult(result);
         if(result == Result.FAIL) {
             plugin.setError(error);
@@ -167,7 +163,7 @@ public class RecordingLoginMonitor implements LoginMonitor
     {
         SessionPhaseResult session = _result.getSessionPhase();
         session.addPluginResult(new SessionPluginResult(name, control));
-        _authorizedPrincipals = new HashSet<>(principals);
+        _principals = new HashSet<>(principals);
     }
 
     @Override
@@ -177,7 +173,7 @@ public class RecordingLoginMonitor implements LoginMonitor
     {
         SessionPhaseResult session = _result.getSessionPhase();
         SessionPluginResult plugin = session.getLastPlugin();
-        plugin.setAuthorized(_authorizedPrincipals, principals);
+        plugin.setAuthorized(_principals, principals);
         plugin.setAttributes(attributes);
         plugin.setResult(result);
         if(result == Result.FAIL) {

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/plugins/GPlazmaMappingPlugin.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/plugins/GPlazmaMappingPlugin.java
@@ -15,7 +15,6 @@ import org.dcache.gplazma.AuthenticationException;
  */
 public interface GPlazmaMappingPlugin extends GPlazmaPlugin
 {
-    public void map(Set<Principal> principals,
-                    Set<Principal> authorizedPrincipals)
+    public void map(Set<Principal> principals)
         throws AuthenticationException;
 }

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultMappingStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultMappingStrategy.java
@@ -33,8 +33,8 @@ public class DefaultMappingStrategy implements MappingStrategy
     }
 
     /**
-     * Devegates execution of the
-     * {@link GPlazmaMappingPlugin#map(SessionID, Set<Principal>, Set<Principal>) GPlazmaMappingPlugin.map}
+     * Delegates execution of the
+     * {@link GPlazmaMappingPlugin#map(Set<Principal>) GPlazmaMappingPlugin.map}
      * methods of the plugins supplied by
      * {@link GPlazmaStrategy#setPlugins(List<GPlazmaPluginElement<T>>) GPlazmaStrategy.setPlugins}
      *  to
@@ -42,17 +42,15 @@ public class DefaultMappingStrategy implements MappingStrategy
      * by providing anonymous implementation of the
      * {@link PluginCaller#call(GPlazmaPlugin) PluginCaller}
      * interface.
-     * @param sessionID
+     * @param monitor
      * @param principals
-     * @param authorizedPrincipals
      * @throws AuthenticationException
      * @see PAMStyleStrategy
      * @see PluginCaller
      */
     @Override
     public synchronized void map(final LoginMonitor monitor,
-            final Set<Principal> principals,
-            final Set<Principal> authorizedPrincipals)
+            final Set<Principal> principals)
             throws AuthenticationException
     {
         pamStyleMappingStrategy.callPlugins( new PluginCaller<GPlazmaMappingPlugin>()
@@ -61,22 +59,21 @@ public class DefaultMappingStrategy implements MappingStrategy
             public void call(GPlazmaPluginElement<GPlazmaMappingPlugin> pe)
                     throws AuthenticationException
             {
-                monitor.mapPluginBegins(pe.getName(), pe.getControl(),
-                        principals, authorizedPrincipals);
+                monitor.mapPluginBegins(pe.getName(), pe.getControl(), principals);
 
                 GPlazmaMappingPlugin plugin = pe.getPlugin();
 
                 Result result = Result.FAIL;
                 String error = null;
                 try {
-                    plugin.map(principals, authorizedPrincipals);
+                    plugin.map(principals);
                     result = Result.SUCCESS;
                 } catch(AuthenticationException e) {
                     error = e.getMessage();
                     throw e;
                 } finally {
                     monitor.mapPluginEnds(pe.getName(), pe.getControl(), result,
-                            error, principals, authorizedPrincipals);
+                            error, principals);
                 }
             }
         });

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/MappingStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/MappingStrategy.java
@@ -15,7 +15,6 @@ import org.dcache.gplazma.plugins.GPlazmaMappingPlugin;
 public interface MappingStrategy
                  extends GPlazmaStrategy<GPlazmaMappingPlugin> {
 
-    public void map(LoginMonitor monitor, Set<Principal> principals,
-                    Set<Principal> authorizedPrincipals)
+    public void map(LoginMonitor monitor, Set<Principal> principals)
                 throws AuthenticationException;
 }

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/AlwaysFailPlugin.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/AlwaysFailPlugin.java
@@ -35,7 +35,7 @@ public class AlwaysFailPlugin implements
     }
 
     @Override
-    public void map(Set<Principal> principals, Set<Principal> authorizedPrincipals) throws AuthenticationException {
+    public void map(Set<Principal> principals) throws AuthenticationException {
         throw new AuthenticationException(FAIL_MSG);
     }
 

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/GPlazmaTests.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/GPlazmaTests.java
@@ -305,24 +305,16 @@ public class GPlazmaTests {
    }
 
     /**
-     * Configuration is same as in testLogin, but without mapping
-     * should fail in the check of presence authorized principals
+     * Configuration is same as in testLogin, but without mapping.
      * @throws AuthenticationException
      */
-    @Test (expected=AuthenticationException.class)
+    @Test
     public void testLoginWithoutMapping() throws AuthenticationException {
-        //configuration
-        Configuration config = newConfiguration (
-            AUTH_CONFIG_ITEM,
-            ACCOUNT_CONFIG_ITEM,
-            SESSION_CONFIG_ITEM);
-
-        assertFalse(CheckUIDAccountPlugin.isCalled());
-
-        // do the work here
-        LoginReply result = new GPlazma(newLoadStrategy(config), EMPTY_PROPERTIES).login(_inputSubject);
-
-        Assert.assertNotNull(result);
+        Configuration config = newConfiguration(
+                AUTH_CONFIG_ITEM,
+                ACCOUNT_CONFIG_ITEM,
+                SESSION_CONFIG_ITEM);
+        runLoginAssertions(config);
    }
     /**
      * Configuration is same as in testLogin, but without authentication

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/IdentityMappingPlugin.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/IdentityMappingPlugin.java
@@ -13,9 +13,6 @@ public class IdentityMappingPlugin implements GPlazmaMappingPlugin {
     }
 
     @Override
-    public void map(Set<Principal> principals, Set<Principal> authorizedPrincipals) throws AuthenticationException {
-        for (Principal p : principals) {
-            authorizedPrincipals.add(p);
-        }
+    public void map(Set<Principal> principals) throws AuthenticationException {
     }
 }

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/monitor/LoginResultPrinterTest.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/monitor/LoginResultPrinterTest.java
@@ -29,6 +29,7 @@ import org.dcache.gplazma.monitor.LoginResult.MapPluginResult;
 import org.dcache.gplazma.monitor.LoginResult.SessionPhaseResult;
 import org.dcache.gplazma.monitor.LoginResult.SessionPluginResult;
 
+import static com.google.common.collect.Iterables.concat;
 import static org.dcache.gplazma.configuration.ConfigurationItemControl.*;
 import static org.dcache.gplazma.monitor.LoginMonitor.Result.FAIL;
 import static org.dcache.gplazma.monitor.LoginMonitor.Result.SUCCESS;
@@ -106,14 +107,12 @@ public class LoginResultPrinterTest
 
         givenMapPhaseRuns(
                 mapPlugin("kerberos", OPTIONAL, FAIL,
-                        "no kerberos principal found", identified, identified,
-                        NO_PRINCIPALS, NO_PRINCIPALS),
+                        "no kerberos principal found", identified, identified),
                 mapPlugin("vorolemap", OPTIONAL, SUCCESS, null, identified,
-                        identified, NO_PRINCIPALS, principals(NAME_ATLAS_PROD)),
-                mapPlugin("authzdb", SUFFICIENT, SUCCESS, null, identified,
-                        identified, principals(NAME_ATLAS_PROD),
-                        principals(NAME_ATLAS_PROD, UID, GID_ATLAS_PROD))
-                );
+                        concat(identified, principals(NAME_ATLAS_PROD))),
+                mapPlugin("authzdb", SUFFICIENT, SUCCESS, null,
+                        concat(identified, principals(NAME_ATLAS_PROD)),
+                        concat(identified, principals(NAME_ATLAS_PROD, UID, GID_ATLAS_PROD))));
 
         givenAccountPhaseWith(SUCCESS, authorized, authorized);
 
@@ -212,13 +211,11 @@ public class LoginResultPrinterTest
     }
 
     MapPluginResult mapPlugin(String name, ConfigurationItemControl control,
-            Result result, String error, Set<Principal> identifiedBefore,
-            Set<Principal> identifiedAfter, Set<Principal> authorizedBefore,
-            Set<Principal> authorizedAfter)
+            Result result, String error, Iterable<Principal> principalsBefore,
+            Iterable<Principal> principalsAfter)
     {
         MapPluginResult plugin = new MapPluginResult(name, control);
-        plugin.setIdentified(identifiedBefore, identifiedAfter);
-        plugin.setAuthorized(authorizedBefore, authorizedAfter);
+        plugin.setPrincipals(principalsBefore, principalsAfter);
         plugin.setResult(result);
         if(result == Result.FAIL) {
             plugin.setError(error);

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/MappingStrategyMapTests.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/MappingStrategyMapTests.java
@@ -129,8 +129,7 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(emptyList);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     /**
@@ -146,8 +145,7 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(oneDoNothingPlugins);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     @Test (expected=AuthenticationException.class)
@@ -158,8 +156,7 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(failedPlugins);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     @Test
@@ -170,8 +167,7 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(successRequiredPlugins);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     @Test
@@ -182,8 +178,7 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(successRequisitePlugins);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     @Test
@@ -195,7 +190,6 @@ public class MappingStrategyMapTests
         strategy.setPlugins(successOptionalPlugins);
         Set<Principal> principals = Sets.newHashSet();
         Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
     }
 
     @Test
@@ -206,8 +200,7 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(successSufficientPlugins);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     /**
@@ -223,8 +216,7 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(sufficientPluginFollowedByFailedArray);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     /**
@@ -240,8 +232,7 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(testOptionalFailingPlugins);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     /**
@@ -258,8 +249,7 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(testRequesitePlugins1);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     /**
@@ -276,15 +266,13 @@ public class MappingStrategyMapTests
         assertNotNull(strategy);
         strategy.setPlugins(testRequesitePlugins2);
         Set<Principal> principals = Sets.newHashSet();
-        Set<Principal> authorizedPrincipals = Sets.newHashSet();
-        strategy.map(IGNORING_LOGIN_MONITOR, principals, authorizedPrincipals);
+        strategy.map(IGNORING_LOGIN_MONITOR, principals);
     }
 
     private static final class DoNotingStrategy implements GPlazmaMappingPlugin
     {
         @Override
-        public void map(Set<Principal> principals,
-                Set<Principal> authorizedPrincipals)
+        public void map(Set<Principal> principals)
                 throws AuthenticationException
         {
         }
@@ -294,16 +282,15 @@ public class MappingStrategyMapTests
             implements GPlazmaMappingPlugin
     {
         @Override
-        public void map(Set<Principal> principals,
-                Set<Principal> authorizedPrincipals)
+        public void map(Set<Principal> principals)
                 throws AuthenticationException
         {
             UidPrincipal uid = new UidPrincipal(1L);
             GidPrincipal gid = new GidPrincipal(1L, true);
             UserNamePrincipal userName = new UserNamePrincipal("user");
-            authorizedPrincipals.add(uid);
-            authorizedPrincipals.add(gid);
-            authorizedPrincipals.add(userName);
+            principals.add(uid);
+            principals.add(gid);
+            principals.add(userName);
         }
     }
 
@@ -311,8 +298,7 @@ public class MappingStrategyMapTests
             implements GPlazmaMappingPlugin
     {
         @Override
-        public void map(Set<Principal> principals,
-                Set<Principal> authorizedPrincipals)
+        public void map(Set<Principal> principals)
                 throws AuthenticationException
         {
             throw new AuthenticationException("I always fail");
@@ -323,8 +309,7 @@ public class MappingStrategyMapTests
             implements GPlazmaMappingPlugin
     {
         @Override
-        public void map(Set<Principal> principals,
-                Set<Principal> authorizedPrincipals)
+        public void map(Set<Principal> principal)
                 throws AuthenticationException
         {
             throw new TestAuthenticationException("I always fail too");
@@ -335,8 +320,7 @@ public class MappingStrategyMapTests
             implements GPlazmaMappingPlugin
     {
         @Override
-        public void map(Set<Principal> principals,
-                Set<Principal> authorizedPrincipals)
+        public void map(Set<Principal> principals)
                 throws AuthenticationException
         {
             throw new RuntimeException("That is what I call an exception");


### PR DESCRIPTION
Addresses an issue with the interface of gPlazma mapping plugins.
Third party mapping plugins will have to be updated.

The old interface distinguished between identified principals and
authorized principals. The idea was that only principals that had
somehow been recognized by a mapping plugin would be considered
authorized and returned to dCache. This approach howeve has several
problems:
- Complexity
- Redundancy; a principal by definition is an assertion that the
  principal belongs to the user (although the level of trust can
  be given a principal strongly depends on its type, eg a DN is
  stronger that a user name, and a user name is stronger than an
  unchecked login name). More over, a principal in it self doesn't
  give access to any additional resources: A second authorization
  step is always done by dCache, authorizing a particular principal
  to do something.
- Limiting, as it was impossible to just "pass through" a principal
  already generated and confirmed by the door. Some doors can do
  their own authentication and there is no reason why one should
  absolutely have to configure a mapping plugin just for the i
  principal to be passed through.
- Inability of authentication plugins to generate principals that
  are passed through to dCache without further mapping. For instance,
  the XACML plugin takes DN and FQAN extracted from the cert chain
  and does a lookup through XACML to generate a user name. A
  subsequent mapping plugin maps the user name to UID/GID, but the
  DN and FQAN is lost as it is not mapped. Yet both DN and FQAN are
  used by other components in dCache for authorization steps.

This patch addresses the problem by changing the mapping plugin
interface. It now takes a single set of principals which it can
add principals to (and possible remove from). Tests are updated
to reflect the changed semantics.

Merge for 2.6 is requested because the patch is a prerequisite to
resolve the XACML problem mentioned above.

Target: master
Request: 2.6
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5545/
(cherry picked from commit b5a977e0463a6084401eaa0aeca1a8b6ba938bdf)
