### PR TITLE
webdav: Fix interpretation of client cert properties

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -276,9 +276,9 @@
 	  <property name="caCertificatePath" value="${grid.ca.path}"/>
 	  <property name="autoFlush" value="true"/>
 	  <property name="encrypt" value="true"/>
-	  <property name="requireClientAuth" value="${webdavWantClientAuth}"/>
-	  <property name="acceptNoClientCerts"
-		    value="#{ '${webdavNeedClientAuth}' == 'false' }"/>
+      <property name="requireClientAuth" value="${webdavNeedClientAuth}"/>
+      <property name="acceptNoClientCerts"
+                 value="#{ '${webdavWantClientAuth}' == 'false' }"/>
 	  <property name="gssMode" value="SSL"/>
 	  <property name="millisecBetweenHostCertRefresh"
 		    value="#{ ${hostCertificateRefreshPeriod} * 1000 }"/>


### PR DESCRIPTION
Addresses a problem that causes the interpretation of the
webdavWantClientAuth and webdavNeedClientAuth properties to
be reversed.

JGlobus 2 seems to have a different interpretation of these
flags. The relevant JGlobus code is:

```
 if (this.requireClientAuth.booleanValue() == Boolean.TRUE) {
         this.sslEngine.setNeedClientAuth(this.requireClientAuth.booleanValue());
 } else
         this.sslEngine.setWantClientAuth(!this.acceptNoClientCerts.booleanValue());
```

Target: trunk
Request: 2.6
Request: 2.2-sha2
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5615/
(cherry picked from commit c914cdcb1fa4d476a8eaeb7abc103251c065170b)
