### PR TITLE
Add support for banning problematic ciphers for Jetty SSL connectors

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+                           http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-3.1.xsd">
 
   <bean id="properties"
 	class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
@@ -280,6 +283,9 @@
 	  <property name="trustPassword" value="${webdavTrustStorePassword}"/>
 	  <property name="wantClientAuth" value="${webdavWantClientAuth}"/>
 	  <property name="needClientAuth" value="${webdavNeedClientAuth}"/>
+          <property name="excludeCipherSuites">
+              <util:constant static-field="org.dcache.util.Crypto.BANNED_CIPHERS"/>
+	  </property>
       </bean>
   </beans>
 


### PR DESCRIPTION
An earlier patch added support for banning ciphers through the JGlobus
library.  The same problem exists for the connectors supplied with
Jetty, which are used in the WebDAV/HTTP door and the webadmin.

This patch adds support for banning problematic ciphers for
these services.

Target: master
Request: 2.6
Signed-off-by: Paul Millar paul.millar@desy.de
Acked-by: Gerd Behrmann behrmann@nordu.net
Patch: http://rb.dcache.org/r/5614/
Require-notes: yes
Require-book: no
(cherry picked from commit d22ef811e7a3bd8f15093ed1fc199eda6b18b025)

Conflicts:
    modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
