### PR TITLE
Ban elliptic-curve ciphers to prevent unsupported ciphers from being sel...

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/Crypto.java
+++ b/modules/common/src/main/java/org/dcache/util/Crypto.java
@@ -1,0 +1,99 @@
+package org.dcache.util;
+
+/**
+ *  Various useful cryptographic utility method
+ */
+public class Crypto
+{
+    /* The following is a list of cipher suites that are problematic
+     * with currently suported versions of Java.
+     *
+     * The problem is described here:
+     *
+     *     https://bugs.launchpad.net/ubuntu/+source/openjdk-6/+bug/1006776
+     *
+     * Note that, despite the comment in the ticket, the problem is
+     * also present for OpenJDK v7.
+     *
+     * During the SSL/TLS handshake, the client will send a list of
+     * supported ciphers.  The server will choose one, based on the
+     * client-supplied list and the ciphers it supports.
+     *
+     * The problem is that libnss3 supports only 3 EC (elliptic curve)
+     * ciphers, but the Java security provider that wraps libnss3
+     * believes it supports all elliptic curve ciphers.  If the
+     * client's list of supported ciphers includes those based on EC
+     * then the Java server may choose an EC cipher.  This SSL
+     * negotiation will then fail with the 'CKR_DOMAIN_PARAMS_INVALID'
+     * error.  For example, JGlobus will log the following:
+     *
+     *    19 Apr 2013 17:40:43 (SRM-zitpcx6184) []
+     *    org.globus.common.Chained IOException: Authentication failed
+     *    [Caused by: Failure unspecified at GSS-API level [Caused by:
+     *    Failure unspecified at GSS-API level [Caused by:
+     *    sun.security.pkcs11.wrapper.PKCS11Exception:
+     *    CKR_DOMAIN_PARAMS_INVALID]]]
+     *
+     * Clients that do not support EC-based ciphers are not affected
+     * by this bug; for example, OpenSSL prior to v1.0.0 (or there
+     * abouts) and most Java-based clients.
+     *
+     * Some clients provide control of the cipher selection.  For
+     * example, the OpenSSL sample client ('s_client') provides the
+     * -cipher option.  This may be used to omit all eliptic curve
+     * ciphers as a client-side work-around.  For example, the
+     * following command may be used to connect to the localhost's
+     * HTTPS SRM endpoint while excluding any EC-based cipher:
+     *
+     *     openssl s_client -connect localhost:8445 -cipher 'DEFAULT:!ECDH'
+     *
+     * It is also possible to disable support on the server by editing
+     * the 'java.security' file to remove the security provider that
+     * is supplying the (broken) eliptic curve support.  This is
+     * controlled by the file 'java.security', which is located in a
+     * distribution-specific directory.  For Debian, the file is in
+     * the /etc/java-7-openjdk/security directory and for RHEL, it's
+     * in the /usr/java/<version>/jre/lib/security directory.
+     *
+     * As we can't control all clients and the instructions for how to
+     * disable the EC ciphers is fiddly, we have a server-side
+     * work-around: dCache components (typically doors) can remove
+     * these ciphers from the list of supported ciphers, preventing
+     * them from being chosen during the SSL/TLS negotiation.
+     *
+     * The following list was generated from OpenJDK source code using
+     * the command:
+     */
+
+    //    sed -n '/add.*TLS_ECDHE/s/.*add(\([^,]*\).*/        \1,/p'
+    //    sun/security/ssl/CipherSuite.java | sort
+
+    public static final String[] BANNED_CIPHERS = {
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+        "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+        "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDHE_ECDSA_WITH_NULL_SHA",
+        "TLS_ECDHE_RSA_WITH_NULL_SHA",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_PSK_WITH_RC4_128_SHA",
+        "TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA",
+        "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_PSK_WITH_NULL_SHA",
+        "TLS_ECDHE_PSK_WITH_NULL_SHA256",
+        "TLS_ECDHE_PSK_WITH_NULL_SHA384"};
+}

--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GsiFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GsiFtpDoorV1.java
@@ -39,6 +39,9 @@ import diskCacheV111.util.PermissionDeniedCacheException;
 import java.security.cert.X509Certificate;
 import javax.security.auth.Subject;
 import java.io.IOException;
+
+import org.dcache.util.Crypto;
+
 /**
  *
  * @author  timur
@@ -129,6 +132,8 @@ public class GsiFtpDoorV1 extends GssFtpDoorV1
                                (ExtendedGSSContext)manager.createContext(cred);
 
         context.setOption(GSSConstants.GSS_MODE, GSIConstants.MODE_GSI);
+        context.setBannedCiphers(Crypto.BANNED_CIPHERS);
+
         return context;
     }
 

--- a/modules/dcache/src/main/java/org/dcache/util/JettyGSIConnector.java
+++ b/modules/dcache/src/main/java/org/dcache/util/JettyGSIConnector.java
@@ -309,6 +309,7 @@ public class JettyGSIConnector
         //                       _trustedCerts);
         // }
 
+        context.setBannedCiphers(Crypto.BANNED_CIPHERS);
         context.requestConf(_encrypt);
         return context;
     }

--- a/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
+++ b/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
@@ -28,6 +28,8 @@ import org.globus.gsi.jaas.GlobusPrincipal;
 import org.gridforum.jgss.ExtendedGSSContext;
 import org.gridforum.jgss.ExtendedGSSManager;
 
+import org.dcache.util.Crypto;
+
 import static org.dcache.util.Files.checkFile;
 import static org.dcache.util.Files.checkDirectory;
 
@@ -74,7 +76,7 @@ class GsiTunnel extends GssTunnel  {
             _e_context = (ExtendedGSSContext) manager.createContext(cred);
             _e_context.setOption(GSSConstants.GSS_MODE, GSIConstants.MODE_GSI);
             _e_context.setOption(GSSConstants.TRUSTED_CERTIFICATES, trusted_certs);
-
+            _e_context.setBannedCiphers(Crypto.BANNED_CIPHERS);
             _context = _e_context;
             // do not use channel binding with GSIGSS
             super.useChannelBinding(false);


### PR DESCRIPTION
...ected

Elliptic-Curve (EC) based ciphers offer advantages over RSA- and
DSA-based ciphers and are being introduced, albeit slowly.  OpenJDK (6 &
7) use external libraries, such as libnss3, to provide support for
various cipher-suites, including support for EC ciphers.  The libnss3
library provide only partial support for all of the EC-based ciphers.

Unfortuantely, the generic front-end believes all ciphers are supported.
So, if during an SSL/TLS negotiation, the client requests an EC cipher
that libnss3 doesn't support, the SSLEngine may choose that cipher.  The
result is an exception being thrown with the cryptic
'CKR_DOMAIN_PARAMS_INVALID' message.

Rather than trying to deploy work-arounds in the client or trying to
document how to disable EC-support in the server using JVM-related
configuration, this patch bans the EC ciphers programatically.

Patch: http://rb.dcache.org/r/5527/
Acked-by: Gerd Behrmann
Target: master
Request: 2.6
(cherry picked from commit 137e1365954713879e87be014e19f5044fabb13d)

Conflicts:
    modules/dcache-ftp/src/main/java/diskCacheV111/doors/GsiFtpDoorV1.java
    modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
