### PR TITLE
pool: Improve resilience against broken SI files

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/DiskErrorCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/DiskErrorCacheException.java
@@ -23,7 +23,7 @@ public class DiskErrorCacheException extends CacheException
         super(CacheException.ERROR_IO_DISK, msg);
     }
 
-    public DiskErrorCacheException(String message, Exception cause)
+    public DiskErrorCacheException(String message, Throwable cause)
     {
         super(CacheException.ERROR_IO_DISK, message, cause);
     }

--- a/modules/dcache/src/main/java/diskCacheV111/util/FileCorruptedCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/FileCorruptedCacheException.java
@@ -46,7 +46,7 @@ public class FileCorruptedCacheException extends CacheException
         _actualSize = Optional.absent();
     }
 
-    public FileCorruptedCacheException(String message, Exception cause)
+    public FileCorruptedCacheException(String message, Throwable cause)
     {
         super(FILE_CORRUPTED, message, cause);
         _expectedChecksums = Optional.absent();

--- a/modules/dcache/src/main/java/diskCacheV111/util/FileExistsCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/FileExistsCacheException.java
@@ -7,4 +7,9 @@ public class FileExistsCacheException extends CacheException {
      public FileExistsCacheException( String msg ){
         super( CacheException.FILE_EXISTS , msg ) ;
      }
+
+    public FileExistsCacheException(String msg, Throwable cause)
+    {
+        super(CacheException.FILE_EXISTS, msg, cause);
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/FileNotFoundCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/FileNotFoundCacheException.java
@@ -8,7 +8,7 @@ public class FileNotFoundCacheException extends CacheException {
         super( 10001 , msg ) ;
     }
 
-    public FileNotFoundCacheException( String msg, Exception cause){
+    public FileNotFoundCacheException( String msg, Throwable cause){
         super( 10001 , msg, cause ) ;
     }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/FileNotOnlineCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/FileNotOnlineCacheException.java
@@ -13,4 +13,9 @@ public class FileNotOnlineCacheException extends CacheException {
     public FileNotOnlineCacheException( String msg ){
         super( CacheException.FILE_NOT_ONLINE , msg ) ;
      }
+
+    public FileNotOnlineCacheException(String msg, Throwable cause)
+    {
+        super(CacheException.FILE_NOT_ONLINE, msg, cause);
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/LockedCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/LockedCacheException.java
@@ -8,4 +8,9 @@ public class LockedCacheException extends CacheException
     {
         super(CacheException.LOCKED, msg);
     }
+
+    public LockedCacheException(String msg, Throwable cause)
+    {
+        super(CacheException.LOCKED, msg, cause);
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/MissingResourceCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/MissingResourceCacheException.java
@@ -12,4 +12,9 @@ public class MissingResourceCacheException extends CacheException {
 	public MissingResourceCacheException(String msg) {
 		super(CacheException.RESOURCE, msg);
 	}
+
+    public MissingResourceCacheException(String msg, Throwable cause)
+    {
+        super(CacheException.RESOURCE, msg, cause);
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/NotDirCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/NotDirCacheException.java
@@ -7,4 +7,9 @@ public class NotDirCacheException extends CacheException {
      public NotDirCacheException( String msg ){
         super( CacheException.NOT_DIR , msg ) ;
      }
+
+    public NotDirCacheException(String msg, Throwable cause)
+    {
+        super(CacheException.NOT_DIR, msg, cause);
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/NotFileCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/NotFileCacheException.java
@@ -8,4 +8,8 @@ public class NotFileCacheException extends CacheException {
 		super(CacheException.NOT_FILE, msg);
 	}
 
+    public NotFileCacheException(String msg, Throwable cause)
+    {
+        super(CacheException.NOT_FILE, msg, cause);
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/NotInTrashCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/NotInTrashCacheException.java
@@ -8,4 +8,9 @@ public class NotInTrashCacheException extends CacheException
     {
         super(CacheException.NOT_IN_TRASH, msg);
     }
+
+    public NotInTrashCacheException(String msg, Throwable cause)
+    {
+        super(CacheException.NOT_IN_TRASH, msg, cause);
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/OutOfDateCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/OutOfDateCacheException.java
@@ -8,4 +8,9 @@ public class OutOfDateCacheException extends CacheException
     {
         super(OUT_OF_DATE, msg);
     }
+
+    public OutOfDateCacheException(String msg, Throwable cause)
+    {
+        super(OUT_OF_DATE, msg, cause);
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/PermissionDeniedCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/PermissionDeniedCacheException.java
@@ -8,4 +8,9 @@ public class PermissionDeniedCacheException extends CacheException
     {
         super(CacheException.PERMISSION_DENIED, msg);
     }
+
+    public PermissionDeniedCacheException(String msg, Throwable cause)
+    {
+        super(CacheException.PERMISSION_DENIED, msg, cause);
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -439,9 +439,14 @@ public class PoolV4
                     _repository.load();
                     enablePool();
                     _flushingThread.start();
+                } catch (RuntimeException e) {
+                    _log.error("Repository reported a problem. Please report this to support@dcache.org.", e);
+                    _log.warn("Pool not enabled {}", _poolName);
+                    disablePool(PoolV2Mode.DISABLED_DEAD | PoolV2Mode.DISABLED_STRICT,
+                            666, "Init failed: " + e.getMessage());
                 } catch (Throwable e) {
-                    _log.error("Repository reported a problem : " + e.getMessage());
-                    _log.warn("Pool not enabled " + _poolName);
+                    _log.error("Repository reported a problem: " + e.getMessage());
+                    _log.warn("Pool not enabled {}", _poolName);
                     disablePool(PoolV2Mode.DISABLED_DEAD | PoolV2Mode.DISABLED_STRICT,
                                 666, "Init failed: " + e.getMessage());
                 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/CacheRepositoryEntryImpl.java
@@ -1,17 +1,16 @@
 package org.dcache.pool.repository.meta.file;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedInputStream;
-import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.OptionalDataException;
-import java.io.StreamCorruptedException;
 import java.util.List;
 
 import diskCacheV111.util.CacheException;
@@ -29,6 +28,7 @@ import org.dcache.vehicles.FileAttributes;
 
 public class CacheRepositoryEntryImpl implements MetaDataRecord
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheRepositoryEntryImpl.class);
     private final CacheRepositoryEntryState _state;
     private final PnfsId _pnfsId;
     private int _linkCount;
@@ -266,16 +266,8 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
             try (ObjectInputStream in = new ObjectInputStream(new BufferedInputStream(new FileInputStream(objIn)))) {
                 return (StorageInfo) in.readObject();
             }
-        } catch (ClassNotFoundException cnf) {
-
-        } catch (InvalidClassException ife) {
-            // valid exception if siFIle is broken
-        } catch( StreamCorruptedException sce ) {
-            // valid exception if siFIle is broken
-        } catch (OptionalDataException ode) {
-            // valid exception if siFIle is broken
-        } catch (EOFException eof){
-            // object file size mismatch
+        } catch (Throwable t) {
+            LOGGER.debug("Failed to read {}: {}", objIn.getPath(), t.toString());
         }
         return null;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
@@ -106,8 +106,8 @@ public class FileMetaDataRepository
             return
                 new CacheRepositoryEntryImpl(id, controlFile, dataFile, siFile);
         } catch (IOException e) {
-            throw new RepositoryException("Failed to create new entry: "
-                                          + e.getMessage());
+            throw new RepositoryException(
+                    "Failed to create new entry " + id + ": " + e.getMessage(), e);
         }
     }
 
@@ -115,8 +115,8 @@ public class FileMetaDataRepository
     public MetaDataRecord create(MetaDataRecord entry)
         throws DuplicateEntryException, CacheException
     {
+        PnfsId id = entry.getPnfsId();
         try {
-            PnfsId id = entry.getPnfsId();
             File controlFile = new File(_metadir, id.toString());
             File siFile = new File(_metadir, "SI-" + id.toString());
             File dataFile = _fileStore.get(id);
@@ -137,8 +137,8 @@ public class FileMetaDataRepository
 
             return new CacheRepositoryEntryImpl(id, controlFile, dataFile, siFile, entry);
         } catch (IOException e) {
-            throw new RepositoryException("Failed to create new entry: "
-                                          + e.getMessage());
+            throw new RepositoryException(
+                    "Failed to create new entry " + id + ": " + e.getMessage(), e);
         }
     }
 
@@ -155,7 +155,10 @@ public class FileMetaDataRepository
                 return new CacheRepositoryEntryImpl(id, controlFile, dataFile, siFile);
             }
         } catch (IOException e) {
-            throw new DiskErrorCacheException("Failed to read meta data for " + id);
+            throw new DiskErrorCacheException(
+                    "Failed to read meta data for " + id + ": " + e.getMessage(), e);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Failed to read meta data for " + id, e);
         }
         return null;
     }
@@ -184,7 +187,7 @@ public class FileMetaDataRepository
 
             return true;
 	} catch (IOException e) {
-            _log.error("Failed to touch " + tmp + ": " + e.getMessage());
+            _log.error("Failed to touch " + tmp + ": " + e.getMessage(), e);
             return false;
 	}
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v3/RepositoryException.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v3/RepositoryException.java
@@ -2,19 +2,23 @@ package org.dcache.pool.repository.v3;
 
 import diskCacheV111.util.CacheException;
 
-public class RepositoryException extends CacheException {
+public class RepositoryException extends CacheException
+{
+    private static final long serialVersionUID = -3613396690222652485L;
 
-	public RepositoryException(int rc, String msg) {
-		super(rc, msg);
-	}
+    public RepositoryException(int rc, String msg, Throwable cause) {
+        super(rc, msg, cause);
+    }
 
-	public RepositoryException(String msg) {
-		super(msg);
-	}
+    public RepositoryException(int rc, String msg) {
+        super(rc, msg);
+    }
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = -3613396690222652485L;
+    public RepositoryException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
 
+    public RepositoryException(String msg) {
+        super(msg);
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -944,10 +944,8 @@ public class CacheRepositoryV5
                 return _store.get(id);
             } catch (CacheException e) {
                 if (e.getRc() != CacheException.TIMEOUT) {
-                    String s =
-                        String.format("Failed to read meta data record [%s]: %s",
-                                      id, e.getMessage());
-                    throw CacheExceptionFactory.exceptionOf(e.getRc(), s);
+                    throw CacheExceptionFactory.exceptionOf(e.getRc(),
+                            "Failed to read meta data for " + id + ": " + e.getMessage(), e);
                 }
             }
             Thread.sleep(1000);

--- a/modules/dcache/src/main/java/org/dcache/util/CacheExceptionFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/util/CacheExceptionFactory.java
@@ -34,39 +34,41 @@ public class CacheExceptionFactory {
     }
 
     public static CacheException exceptionOf(int errorCode, String message) {
+        return exceptionOf(errorCode, message, null);
+    }
 
+    public static CacheException exceptionOf(int errorCode, String message, Throwable cause) {
         switch (errorCode) {
-
             case ERROR_IO_DISK:
-                return new DiskErrorCacheException(message);
+                return new DiskErrorCacheException(message, cause);
             case FILE_NOT_FOUND:
-                return new FileNotFoundCacheException(message);
+                return new FileNotFoundCacheException(message, cause);
             case FILE_NOT_ONLINE:
-                return new FileNotOnlineCacheException(message);
+                return new FileNotOnlineCacheException(message, cause);
             case FILE_NOT_IN_REPOSITORY:
-                return new FileNotInCacheException(message);
+                return new FileNotInCacheException(message, cause);
             case FILE_EXISTS:
-                return new FileExistsCacheException(message);
+                return new FileExistsCacheException(message, cause);
             case NOT_DIR:
-                return new NotDirCacheException(message);
+                return new NotDirCacheException(message, cause);
             case NOT_FILE:
-                return new NotFileCacheException(message);
+                return new NotFileCacheException(message, cause);
             case RESOURCE:
-                return new MissingResourceCacheException(message);
+                return new MissingResourceCacheException(message, cause);
             case PERMISSION_DENIED:
-                return new PermissionDeniedCacheException(message);
+                return new PermissionDeniedCacheException(message, cause);
             case LOCKED:
-                return new LockedCacheException(message);
+                return new LockedCacheException(message, cause);
             case NOT_IN_TRASH:
-                return new NotInTrashCacheException(message);
+                return new NotInTrashCacheException(message, cause);
             case TIMEOUT:
-                return new TimeoutCacheException(message);
+                return new TimeoutCacheException(message, cause);
             case OUT_OF_DATE:
-                return new OutOfDateCacheException(message);
+                return new OutOfDateCacheException(message, cause);
             case FILE_IN_CACHE:
-                return new FileInCacheException(message);
+                return new FileInCacheException(message, cause);
             case FILE_CORRUPTED:
-                return new FileCorruptedCacheException(message);
+                return new FileCorruptedCacheException(message, cause);
             /*
              * these do not have exception classes
              */
@@ -80,7 +82,7 @@ public class CacheExceptionFactory {
             case FILE_NOT_STORED:
             case POOL_DISABLED:
             default:
-                return new CacheException(errorCode, message);
+                return new CacheException(errorCode, message, cause);
         }
     }
 


### PR DESCRIPTION
Addresses an issue in which corrupt SI files could cause pool
startup to fail. Eg. NPE or OOM during deserialization would
cause the pool to fail and it would not even log the file
triggering the problem. Such exceptions would typically be
caused by corrupt length fields or similar invalid data in
the SI file.

Also improved the exception chaining and logging in this part
of the pool.

The problem was reported on the user-forum list.

Target: trunk
Request: 2.6
Request: 2.2
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5609/
(cherry picked from commit 4db9462382dfcd15511a56ad7d596d6aa4b2ad2e)
