### PR TITLE
ftp: Remove duplicate session ID in NDC

### DIFF
--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/AbstractFtpDoorV1.java
@@ -159,7 +159,6 @@ import org.dcache.auth.attributes.RootDirectory;
 import org.dcache.cells.AbstractCell;
 import org.dcache.cells.CellStub;
 import org.dcache.cells.Option;
-import org.dcache.commons.util.NDC;
 import org.dcache.namespace.ACLPermissionHandler;
 import org.dcache.namespace.ChainedPermissionHandler;
 import org.dcache.namespace.FileAttribute;
@@ -1435,7 +1434,6 @@ public abstract class AbstractFtpDoorV1
     @Override
     public void run()
     {
-        NDC.push(CDC.getSession());
         try {
             try {
                 /* Notice that we do not close the input stream, as
@@ -1490,8 +1488,6 @@ public abstract class AbstractFtpDoorV1
              * called (although from a different thread).
              */
             kill();
-
-            NDC.clear();
         }
     }
 


### PR DESCRIPTION
Addresses the issue that the session ID is stored twice in the diagnostic
context of log messages generated by the FTP door.

The NDC is already initialized with the session ID in Tranfer#initSession.

Target: trunk
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/5610/
(cherry picked from commit 6cfd0b63c8671a53592ba007583f1a09dae4e0a2)
