### PR TITLE
Ban all Diffie-Hellman ciphers in Java 1.7.0_6 and higher

### DIFF
--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GsiFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GsiFtpDoorV1.java
@@ -58,6 +58,12 @@ public class GsiFtpDoorV1 extends GssFtpDoorV1
     )
     protected String service_trusted_certs;
 
+    @Option(
+            name="gridftp.security.ciphers",
+            required=true
+    )
+    protected String cipherFlags;
+
     private String _user;
 
     /** Creates a new instance of GsiFtpDoorV1 */
@@ -118,7 +124,7 @@ public class GsiFtpDoorV1 extends GssFtpDoorV1
                                (ExtendedGSSContext)manager.createContext(cred);
 
         context.setOption(GSSConstants.GSS_MODE, GSIConstants.MODE_GSI);
-        context.setBannedCiphers(Crypto.BANNED_CIPHERS);
+        context.setBannedCiphers(Crypto.getBannedCipherSuitesFromConfigurationValue(cipherFlags));
 
         return context;
     }

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -201,7 +201,12 @@
       </property>
   </bean>
 
-  <beans profile="connector-http">
+    <bean id="banned-ciphers" class="org.dcache.util.Crypto"
+          factory-method="getBannedCipherSuitesFromConfigurationValue">
+        <constructor-arg value="${webdav.security.ciphers}"/>
+    </bean>
+
+    <beans profile="connector-http">
       <bean id="protocol-family" class="java.lang.String">
           <description>http</description>
 	  <constructor-arg type="String" value="http"/>
@@ -248,7 +253,6 @@
   </beans>
 
 
-
   <beans profile="connector-https">
       <bean id="https-connector"
 	    class="org.eclipse.jetty.server.ssl.SslSelectChannelConnector">
@@ -263,9 +267,7 @@
 	  <property name="trustPassword" value="${webdavTrustStorePassword}"/>
 	  <property name="wantClientAuth" value="${webdavWantClientAuth}"/>
 	  <property name="needClientAuth" value="${webdavNeedClientAuth}"/>
-          <property name="excludeCipherSuites">
-              <util:constant static-field="org.dcache.util.Crypto.BANNED_CIPHERS"/>
-	  </property>
+      <property name="excludeCipherSuites" ref="banned-ciphers"/>
       </bean>
   </beans>
 
@@ -290,6 +292,7 @@
 		    value="#{ ${hostCertificateRefreshPeriod} * 1000 }"/>
 	  <property name="millisecBetweenTrustAnchorRefresh"
 		    value="#{ ${trustAnchorRefreshPeriod} * 1000 }"/>
+      <property name="excludeCipherSuites" ref="banned-ciphers"/>
       </bean>
   </beans>
 

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
@@ -89,6 +89,10 @@ public class HttpServiceCell extends AbstractCell implements EnvironmentAware {
             description = "Password for accessing trusted CA certs")
     protected String trustPassword;
 
+    @Option(name = "httpd.security.ciphers",
+            description = "Cipher flags")
+    protected String cipherFlags;
+
     private Server server;
     private String defaultWebappsXml;
     private volatile Map<String, Object> environment = Collections.emptyMap();
@@ -251,7 +255,7 @@ public class HttpServiceCell extends AbstractCell implements EnvironmentAware {
         final SslSelectChannelConnector connector = new SslSelectChannelConnector();
         connector.setPort(httpsPort);
         connector.setHost(IPV4_INETADDR_ANY);
-        connector.setExcludeCipherSuites(Crypto.BANNED_CIPHERS);
+        connector.setExcludeCipherSuites(Crypto.getBannedCipherSuitesFromConfigurationValue(cipherFlags));
         final SslContextFactory factory = connector.getSslContextFactory();
         factory.setKeyStorePath(keystore);
         factory.setKeyStoreType(keystoreType);

--- a/modules/dcache/src/main/java/org/dcache/util/JettyGSIConnector.java
+++ b/modules/dcache/src/main/java/org/dcache/util/JettyGSIConnector.java
@@ -36,6 +36,7 @@ import dmg.cells.nucleus.CDC;
 
 import org.dcache.commons.util.NDC;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.dcache.util.Files.checkDirectory;
 import static org.dcache.util.Files.checkFile;
 import static org.globus.axis.gsi.GSIConstants.*;
@@ -92,6 +93,7 @@ public class JettyGSIConnector
     private volatile boolean _rejectLimitedProxy = false;
     private volatile Integer _mode = GSIConstants.MODE_SSL;
     private volatile int _handshakeTimeout = 0; // 0 means use maxIdleTime
+    private String[] _excludedCipherSuites = {};
 
     /**
      * Assing default values to the certificate refresh intervals
@@ -289,6 +291,11 @@ public class JettyGSIConnector
         _handshakeTimeout = msec;
     }
 
+    public void setExcludeCipherSuites(String[] cipherSuites)
+    {
+        _excludedCipherSuites = checkNotNull(cipherSuites);
+    }
+
     protected ExtendedGSSContext createGSSContext()
         throws GSSException
     {
@@ -309,7 +316,7 @@ public class JettyGSIConnector
         //                       _trustedCerts);
         // }
 
-        context.setBannedCiphers(Crypto.BANNED_CIPHERS);
+        context.setBannedCiphers(_excludedCipherSuites);
         context.requestConf(_encrypt);
         return context;
     }

--- a/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
@@ -384,6 +384,10 @@
     <property name="maxQueued" value="${srmJettyThreadsMaxQueued}"/>
   </bean>
 
+  <bean id="banned-ciphers" class="org.dcache.util.Crypto"
+        factory-method="getBannedCipherSuitesFromConfigurationValue">
+      <constructor-arg value="${srm.security.ciphers}"/>
+  </bean>
 
   <bean id="server" class="org.eclipse.jetty.server.Server"
         init-method="start" destroy-method="stop">
@@ -461,6 +465,7 @@
         <property name="handshakeTimeout" value="10000" />
         <property name="millisecBetweenHostCertRefresh" value="#{ ${hostCertificateRefreshPeriod} * 1000 }" />
         <property name="millisecBetweenTrustAnchorRefresh" value="#{ ${trustAnchorRefreshPeriod} * 1000 }" />
+        <property name="excludeCipherSuites" ref="banned-ciphers"/>
     </bean>
 
     <bean id="ssl-connector"
@@ -486,6 +491,7 @@
         <property name="handshakeTimeout" value="10000" />
         <property name="millisecBetweenHostCertRefresh" value="#{ ${hostCertificateRefreshPeriod} * 1000 }" />
         <property name="millisecBetweenTrustAnchorRefresh" value="#{ ${trustAnchorRefreshPeriod} * 1000 }" />
+        <property name="excludeCipherSuites" ref="banned-ciphers"/>
     </bean>
 
 </beans>

--- a/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
+++ b/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
@@ -42,14 +42,15 @@ import static org.dcache.util.Files.checkFile;
 
 class GsiTunnel extends GssTunnel  {
 
-    private final static Logger _log = LoggerFactory.getLogger(GsiTunnel.class);
+    private static final Logger _log = LoggerFactory.getLogger(GsiTunnel.class);
 
     private ExtendedGSSContext _e_context;
 
-    private final static String SERVICE_KEY = "service_key";
-    private final static String SERVICE_CERT = "service_cert";
-    private final static String SERVICE_TRUSTED_CERTS = "service_trusted_certs";
-    private final static String SERVICE_VOMS_DIR = "service_voms_dir";
+    private static final String SERVICE_KEY = "service_key";
+    private static final String SERVICE_CERT = "service_cert";
+    private static final String SERVICE_TRUSTED_CERTS = "service_trusted_certs";
+    private static final String SERVICE_VOMS_DIR = "service_voms_dir";
+    private static final String CIPHER_FLAGS = "ciphers";
 
     private final Args _arguments;
     private PKIVerifier _pkiVerifier;
@@ -70,6 +71,7 @@ class GsiTunnel extends GssTunnel  {
             String service_cert = _arguments.getOption(SERVICE_CERT);
             String service_trusted_certs = _arguments.getOption(SERVICE_TRUSTED_CERTS);
             String service_voms_dir = _arguments.getOption(SERVICE_VOMS_DIR);
+
             /* Unfortunately, we can't rely on GlobusCredential to provide
              * meaningful error messages so we catch some obvious problems
              * early.
@@ -99,7 +101,8 @@ class GsiTunnel extends GssTunnel  {
             GSSManager manager = ExtendedGSSManager.getInstance();
             _e_context = (ExtendedGSSContext) manager.createContext(cred);
             _e_context.setOption(GSSConstants.GSS_MODE, GSIConstants.MODE_GSI);
-            _e_context.setBannedCiphers(Crypto.BANNED_CIPHERS);
+            _e_context.setBannedCiphers(
+                    Crypto.getBannedCipherSuitesFromConfigurationValue(_arguments.getOption(CIPHER_FLAGS)));
             _context = _e_context;
             // do not use channel binding with GSIGSS
             super.useChannelBinding(false);

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -649,6 +649,27 @@ sshPort=22124
 #
 listen=
 
+#   Comma separated list of flags related to ciphers
+#
+#   DISABLE_BROKEN_DH
+#
+#   Diffie-Hellman is broken in Java 1.7u6 and forward. If  DISABLE_BROKEN_DH is
+#   included, dCache will disable all cipher families involving Diffie-Hellman on
+#   those versions of Java. Depending on the client, this may result in less
+#   secure SSL/TLS/GSI connections.
+#
+#   The symptoms of running with broken Diffie-Hellman enabled is that approximately
+#   0.4% of all connections will fail during handshake.
+#
+#   DISABLE_EC
+#
+#   Elliptic Curve ciphers are broken in Java 1.7 on Linux. The problem is that the
+#   JRE successfully negotiates the use of cipher variants not supported by libnss3.
+#   If this option is specified, dCache will disable all cipher families involving
+#   Elliptic Curve ciphers.
+#
+dcache.security.ciphers=DISABLE_EC,DISABLE_BROKEN_DH
+
 #  -----------------------------------------------------------------------
 #          Database Configuration
 #  -----------------------------------------------------------------------

--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -70,6 +70,10 @@ kerberosdcap/kerberos.service-principle-name=host/${host.fqdn}@${kerberos.realm}
 # read-only access
 #
 (one-of?true|false)dcapReadOnly=false
+
+#  Security related properties
+gsidcap.security.ciphers=${dcache.security.ciphers}
+
 #
 #   Document which TCP ports are opened
 #

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -173,6 +173,8 @@ ftp.read-only=false
 #
 ftp/ftp.read-only=true
 
+#  Security related properties
+gridftp.security.ciphers=${dcache.security.ciphers}
 
 #
 #   Document which TCP ports are opened

--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -92,6 +92,9 @@ collectorTimeout=5000
 #
 transfersCollectorUpdate=60000
 
+#  Security related properties
+httpd.security.ciphers=${dcache.security.ciphers}
+
 #
 #   --- For Alarms
 #

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -593,6 +593,8 @@ qosConfigFile=
 (one-of?true|false)srmImplicitSpaceManagerEnabled=true
 (one-of?true|false)srmSpaceReservationStrict=true
 
+#  Security related properties
+srm.security.ciphers=${dcache.security.ciphers}
 
 #
 #   Document which TCP ports are opened

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -307,6 +307,9 @@ webdav.templates.html=file:${dcache.paths.share}/webdav/templates/html.stg
 #
 (one-of?true|false)webdavChrootToUserRoot=false
 
+#  Security related properties
+webdav.security.ciphers=${dcache.security.ciphers}
+
 #  ---- Artwork elements
 #
 #  These properties are obsolete. Modify the template to customize the

--- a/skel/share/services/gridftp.batch
+++ b/skel/share/services/gridftp.batch
@@ -29,6 +29,7 @@ check -strong ftp.read-only
 check -strong grid.hostcert.key
 check -strong grid.hostcert.cert
 check -strong grid.ca.path
+check gridftp.security.ciphers
 check FtpTLogDir
 check listen
 
@@ -93,5 +94,6 @@ create dmg.cells.services.login.LoginManager ${cell.name} \
              -service-key=${grid.hostcert.key} \
              -service-cert=${grid.hostcert.cert} \
              -service-trusted-certs=${grid.ca.path} \
+             -gridftp.security.ciphers=\"${gridftp.security.ciphers}\" \
 "
 

--- a/skel/share/services/gsidcap.batch
+++ b/skel/share/services/gsidcap.batch
@@ -16,6 +16,7 @@ check -strong dcapReadOnly
 check -strong dcapAnonymousAccessLevel
 check gsidcapIoQueue
 check listen
+check gsidcap.security.ciphers
 
 #
 #  ----  Usage of Srm Space Manager
@@ -55,7 +56,7 @@ create dmg.cells.services.login.LoginManager ${cell.name} \
               -stageConfigurationFilePath=${stageConfigurationFilePath} \
               -io-queue=${gsidcapIoQueue} \
               -io-queue-overwrite=${gsidcapIoQueueOverwrite} \
-              -socketfactory=\"javatunnel.TunnelServerSocketCreator,javatunnel.GsiTunnel,-service_key='${grid.hostcert.key}' -service_cert='${grid.hostcert.cert}' -service_trusted_certs='${grid.ca.path}' -service_voms_dir='${grid.path}/vomsdir'\" \
+              -socketfactory=\"javatunnel.TunnelServerSocketCreator,javatunnel.GsiTunnel,-service_key='${grid.hostcert.key}' -service_cert='${grid.hostcert.cert}' -service_trusted_certs='${grid.ca.path}' -service_voms_dir='${grid.path}/vomsdir' -ciphers='${gsidcap.security.ciphers}'\" \
               -read-only=${dcapReadOnly} \
               -anonymous-access=${dcapAnonymousAccessLevel} \
               "

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -18,6 +18,8 @@ check -strong httpd.static-content.styles
 check -strong httpd.static-content.index
 check -strong httpd.static-content.plots
 
+check httpd.security.ciphers
+
 # Default content for httpd service.
 #
 # Can be redefined in etc/httpd.conf or additional content can
@@ -211,6 +213,7 @@ create org.dcache.services.httpd.HttpServiceCell ${cell.name} \
        "-authenticated=${authenticated}  \
         -httpPort=${port}  \
         -httpsPort=${httpsPort}  \
+        -httpd.security.ciphers=\"${httpd.security.ciphers}\" \
         -keystore=${keyStore}  \
         -keystoreType=PKCS12  \
         -keystorePassword=${keyStorePassword}  \

--- a/skel/share/services/srm.batch
+++ b/skel/share/services/srm.batch
@@ -164,6 +164,8 @@ check -strong grid.hostcert.key
 check -strong grid.hostcert.cert
 check -strong grid.ca.path
 
+check srm.security.ciphers
+
 
 # The 'spaceManagerEnabled' environment variable is a sanitised
 # version of 'srmSpaceManagerEnabled'.  It is always set and is either
@@ -348,4 +350,5 @@ create org.dcache.cells.UniversalSpringCell ${cell.name} \
         -service-trusted-certs=${grid.ca.path} \
         -gplazma=${gplazma} \
         -spaceManagerEnabled=${spaceManagerEnabled} \
+        -srm.security.ciphers=\"${srm.security.ciphers}\" \
 "

--- a/skel/share/services/webdav.batch
+++ b/skel/share/services/webdav.batch
@@ -46,6 +46,8 @@ check webdavInternalAddress
 check webdavIoQueue
 check loginBroker
 
+check webdav.security.ciphers
+
 define env verify-http.exe enddefine
 enddefine
 
@@ -153,4 +155,6 @@ create org.dcache.cells.UniversalSpringCell ${cell.name} \
     -grid.hostcert.cert=${grid.hostcert.cert} \
     -grid.hostcert.key=${grid.hostcert.key} \
     -grid.ca.path=${grid.ca.path} \
-    -export -cellClass=WebDAVDoor"
+    -export -cellClass=WebDAVDoor \
+    -webdav.security.ciphers=\"${webdav.security.ciphers}\" \
+    "


### PR DESCRIPTION
Addresses an issue in SSL/TLS/GSI sessions that approximately one
out of 256 connections fail with an 'invalid padding' error. This
affects gridftp, webdav with https, httpd with https, SRM and gsidcap.
It should be noted that this significantly reduces the number of
available ciphers.

It appears that Diffie-Hellman is broken in Java 1.7.0_6 and higher. This
patch bans those ciphers if a broken version of Java is used.

The patch adds new configuration properties for configuring whether
certain cipher families are banned:

dcache.security.ciphers
webdav.security.ciphers
httpd.security.ciphers
gsidcap.security.ciphers
srm.security.ciphers
gridftp.security.ciphers

The latter are defined in terms of the first. The property names follow
the schema agreed upon at the 2013 developers workshop. The patch
introduces a new configuration property group called security. It is
intended for general security related properties like authentication,
authorization, cryptography, etc.

Target: trunk
Request: 2.6
Request: 2.2-sha2
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@gnal.gov
Patch: http://rb.dcache.org/r/5616/
(cherry picked from commit 4cc7e3e6395388a7f98ad028b6c613cec8891c4f)
