### PR TITLE
Ban all Diffie-Hellman ciphers in Java 1.7.0_6 and higher

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/Crypto.java
+++ b/modules/common/src/main/java/org/dcache/util/Crypto.java
@@ -1,10 +1,21 @@
 package org.dcache.util;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+
 /**
  *  Various useful cryptographic utility method
  */
 public class Crypto
 {
+    public enum CipherFlag
+    {
+        DISABLE_BROKEN_DH,
+        DISABLE_EC
+    }
+
     /* The following is a list of cipher suites that are problematic
      * with currently suported versions of Java.
      *
@@ -64,36 +75,227 @@ public class Crypto
      * The following list was generated from OpenJDK source code using
      * the command:
      */
-
     //    sed -n '/add.*TLS_ECDHE/s/.*add(\([^,]*\).*/        \1,/p'
     //    sun/security/ssl/CipherSuite.java | sort
+    public static final String[] EC_CIPHERS = new String[] {
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+            "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+            "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_NULL_SHA",
+            "TLS_ECDHE_RSA_WITH_NULL_SHA",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_PSK_WITH_RC4_128_SHA",
+            "TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_PSK_WITH_NULL_SHA",
+            "TLS_ECDHE_PSK_WITH_NULL_SHA256",
+            "TLS_ECDHE_PSK_WITH_NULL_SHA384"
+    };
 
-    public static final String[] BANNED_CIPHERS = {
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
-        "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
-        "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
-        "TLS_ECDHE_ECDSA_WITH_NULL_SHA",
-        "TLS_ECDHE_RSA_WITH_NULL_SHA",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_PSK_WITH_RC4_128_SHA",
-        "TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA",
-        "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA",
-        "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDHE_PSK_WITH_NULL_SHA",
-        "TLS_ECDHE_PSK_WITH_NULL_SHA256",
-        "TLS_ECDHE_PSK_WITH_NULL_SHA384"};
+    /* The following is a list of cipher suites that are problematic
+     * with currently available Java versions from 1.7u6 and up.
+     *
+     * The problem is described here:
+     *
+     *     https://forums.oracle.com/forums/thread.jspa?messageID=10875177&tstart=0
+     *
+     * The problem seems to be caused by a bug in how leading zeros are interpreted
+     * in Diffie-Hellman ciphers.
+     *
+     * The following list was generated from OpenJDK source code using the command:
+     */
+    //           sed -n '/add.*DH/s/.*add(\([^,]*\).*/        \1,/p' ~/Downloads/CipherSuite.java | sort
+    //
+    public static final String[] DH_CIPHERS = new String[] {
+            "SSL_DHE_DSS_EXPORT1024_WITH_DES_CBC_SHA",
+            "SSL_DHE_DSS_EXPORT1024_WITH_RC4_56_SHA",
+            "SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA",
+            "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+            "SSL_DHE_DSS_WITH_DES_CBC_SHA",
+            "SSL_DHE_DSS_WITH_RC4_128_SHA",
+            "SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA",
+            "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+            "SSL_DHE_RSA_WITH_DES_CBC_SHA",
+            "SSL_DH_DSS_EXPORT_WITH_DES40_CBC_SHA",
+            "SSL_DH_DSS_WITH_3DES_EDE_CBC_SHA",
+            "SSL_DH_DSS_WITH_DES_CBC_SHA",
+            "SSL_DH_RSA_EXPORT_WITH_DES40_CBC_SHA",
+            "SSL_DH_RSA_WITH_3DES_EDE_CBC_SHA",
+            "SSL_DH_RSA_WITH_DES_CBC_SHA",
+            "SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA",
+            "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5",
+            "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA",
+            "SSL_DH_anon_WITH_DES_CBC_SHA",
+            "SSL_DH_anon_WITH_RC4_128_MD5",
+            "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+            "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+            "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
+            "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+            "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+            "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
+            "TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA",
+            "TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256",
+            "TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA",
+            "TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256",
+            "TLS_DHE_DSS_WITH_SEED_CBC_SHA",
+            "TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA",
+            "TLS_DHE_PSK_WITH_AES_128_CBC_SHA",
+            "TLS_DHE_PSK_WITH_AES_128_CBC_SHA256",
+            "TLS_DHE_PSK_WITH_AES_128_GCM_SHA256",
+            "TLS_DHE_PSK_WITH_AES_256_CBC_SHA",
+            "TLS_DHE_PSK_WITH_AES_256_CBC_SHA384",
+            "TLS_DHE_PSK_WITH_AES_256_GCM_SHA384",
+            "TLS_DHE_PSK_WITH_NULL_SHA",
+            "TLS_DHE_PSK_WITH_NULL_SHA256",
+            "TLS_DHE_PSK_WITH_NULL_SHA384",
+            "TLS_DHE_PSK_WITH_RC4_128_SHA",
+            "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA",
+            "TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256",
+            "TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA",
+            "TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256",
+            "TLS_DHE_RSA_WITH_SEED_CBC_SHA",
+            "TLS_DH_DSS_WITH_AES_128_CBC_SHA",
+            "TLS_DH_DSS_WITH_AES_128_CBC_SHA256",
+            "TLS_DH_DSS_WITH_AES_128_GCM_SHA256",
+            "TLS_DH_DSS_WITH_AES_256_CBC_SHA",
+            "TLS_DH_DSS_WITH_AES_256_CBC_SHA256",
+            "TLS_DH_DSS_WITH_AES_256_GCM_SHA384",
+            "TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA",
+            "TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA256",
+            "TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA",
+            "TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA256",
+            "TLS_DH_DSS_WITH_SEED_CBC_SHA",
+            "TLS_DH_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_DH_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_DH_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_DH_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_DH_RSA_WITH_AES_256_CBC_SHA256",
+            "TLS_DH_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA",
+            "TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA256",
+            "TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA",
+            "TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA256",
+            "TLS_DH_RSA_WITH_SEED_CBC_SHA",
+            "TLS_DH_anon_WITH_AES_128_CBC_SHA",
+            "TLS_DH_anon_WITH_AES_128_CBC_SHA256",
+            "TLS_DH_anon_WITH_AES_128_GCM_SHA256",
+            "TLS_DH_anon_WITH_AES_256_CBC_SHA",
+            "TLS_DH_anon_WITH_AES_256_CBC_SHA256",
+            "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
+            "TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA",
+            "TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256",
+            "TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA",
+            "TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256",
+            "TLS_DH_anon_WITH_SEED_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_NULL_SHA",
+            "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+            "TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_PSK_WITH_NULL_SHA",
+            "TLS_ECDHE_PSK_WITH_NULL_SHA256",
+            "TLS_ECDHE_PSK_WITH_NULL_SHA384",
+            "TLS_ECDHE_PSK_WITH_RC4_128_SHA",
+            "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_NULL_SHA",
+            "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+            "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDH_ECDSA_WITH_NULL_SHA",
+            "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
+            "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDH_RSA_WITH_NULL_SHA",
+            "TLS_ECDH_RSA_WITH_RC4_128_SHA",
+            "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDH_anon_WITH_AES_128_CBC_SHA",
+            "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
+            "TLS_ECDH_anon_WITH_NULL_SHA",
+            "TLS_ECDH_anon_WITH_RC4_128_SHA"
+    };
+
+    /**
+     * @throws IllegalArgumentException if the value could not be parsed
+     */
+    public static String[] getBannedCipherSuitesFromConfigurationValue(String value)
+    {
+        String[] values = value.split(",");
+        CipherFlag[] flags = new CipherFlag[values.length];
+        for (int i = 0; i < values.length; i++) {
+            flags[i] = CipherFlag.valueOf(values[i]);
+        }
+        return getBannedCipherSuites(flags);
+    }
+
+    public static String[] getBannedCipherSuites(CipherFlag[] flags)
+    {
+        String version = System.getProperty("java.version");
+        Set<String> banned = new HashSet<String>();
+        for (CipherFlag flag : flags) {
+            switch (flag) {
+            case DISABLE_BROKEN_DH:
+                if (version.startsWith("1.7.0_")) {
+                    try {
+                        int update = Integer.parseInt(version.substring(6));
+                        if (update > 5) {
+                            banned.addAll(asList(DH_CIPHERS));
+                        }
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+                break;
+            case DISABLE_EC:
+                banned.addAll(asList(EC_CIPHERS));
+                break;
+            }
+        }
+        return banned.toArray(new String[banned.size()]);
+    }
+
 }

--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GsiFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/GsiFtpDoorV1.java
@@ -66,6 +66,12 @@ public class GsiFtpDoorV1 extends GssFtpDoorV1
     )
     protected String service_trusted_certs;
 
+    @Option(
+            name="gridftp.security.ciphers",
+            required=true
+    )
+    protected String cipherFlags;
+
     private String _user;
 
     /** Creates a new instance of GsiFtpDoorV1 */
@@ -132,7 +138,7 @@ public class GsiFtpDoorV1 extends GssFtpDoorV1
                                (ExtendedGSSContext)manager.createContext(cred);
 
         context.setOption(GSSConstants.GSS_MODE, GSIConstants.MODE_GSI);
-        context.setBannedCiphers(Crypto.BANNED_CIPHERS);
+        context.setBannedCiphers(Crypto.getBannedCipherSuitesFromConfigurationValue(cipherFlags));
 
         return context;
     }

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -219,7 +219,10 @@
       </property>
   </bean>
 
-
+    <bean id="banned-ciphers" class="org.dcache.util.Crypto"
+          factory-method="getBannedCipherSuitesFromConfigurationValue">
+        <constructor-arg value="${webdav.security.ciphers}"/>
+    </bean>
 
   <beans profile="connector-http">
       <bean id="protocol-family" class="java.lang.String">
@@ -268,7 +271,6 @@
   </beans>
 
 
-
   <beans profile="connector-https">
       <bean id="https-connector"
 	    class="org.eclipse.jetty.server.ssl.SslSelectChannelConnector">
@@ -283,9 +285,7 @@
 	  <property name="trustPassword" value="${webdavTrustStorePassword}"/>
 	  <property name="wantClientAuth" value="${webdavWantClientAuth}"/>
 	  <property name="needClientAuth" value="${webdavNeedClientAuth}"/>
-          <property name="excludeCipherSuites">
-              <util:constant static-field="org.dcache.util.Crypto.BANNED_CIPHERS"/>
-	  </property>
+      <property name="excludeCipherSuites" ref="banned-ciphers"/>
       </bean>
   </beans>
 
@@ -313,6 +313,7 @@
 		    value="#{ ${hostCertificateRefreshPeriod} * 1000 }"/>
 	  <property name="millisecBetweenTrustAnchorRefresh"
 		    value="#{ ${trustAnchorRefreshPeriod} * 1000 }"/>
+      <property name="excludeCipherSuites" ref="banned-ciphers"/>
       </bean>
   </beans>
 

--- a/modules/dcache/src/main/java/org/dcache/util/JettyGSIConnector.java
+++ b/modules/dcache/src/main/java/org/dcache/util/JettyGSIConnector.java
@@ -35,10 +35,10 @@ import org.eclipse.jetty.server.bio.SocketConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.globus.axis.gsi.GSIConstants.*;
-
-import static org.dcache.util.Files.checkFile;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.dcache.util.Files.checkDirectory;
+import static org.dcache.util.Files.checkFile;
+import static org.globus.axis.gsi.GSIConstants.*;
 
 /**
  * GSI Socket Connector for Jetty.
@@ -92,6 +92,7 @@ public class JettyGSIConnector
     private volatile boolean _rejectLimitedProxy = false;
     private volatile Integer _mode = GSIConstants.MODE_SSL;
     private volatile int _handshakeTimeout = 0; // 0 means use maxIdleTime
+    private String[] _excludedCipherSuites = {};
 
     /**
      * Assing default values to the certificate refresh intervals
@@ -289,6 +290,11 @@ public class JettyGSIConnector
         _handshakeTimeout = msec;
     }
 
+    public void setExcludeCipherSuites(String[] cipherSuites)
+    {
+        _excludedCipherSuites = checkNotNull(cipherSuites);
+    }
+
     protected ExtendedGSSContext createGSSContext()
         throws GSSException
     {
@@ -309,7 +315,7 @@ public class JettyGSIConnector
         //                       _trustedCerts);
         // }
 
-        context.setBannedCiphers(Crypto.BANNED_CIPHERS);
+        context.setBannedCiphers(_excludedCipherSuites);
         context.requestConf(_encrypt);
         return context;
     }

--- a/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
@@ -352,6 +352,11 @@
     <constructor-arg value="true"/>
   </bean>
 
+  <bean id="banned-ciphers" class="org.dcache.util.Crypto"
+        factory-method="getBannedCipherSuitesFromConfigurationValue">
+      <constructor-arg value="${srm.security.ciphers}"/>
+  </bean>
+
   <bean id="server" class="org.eclipse.jetty.server.Server"
         init-method="start" destroy-method="stop">
     <description>Jetty server hosting the SRM web application</description>
@@ -467,6 +472,7 @@
       <property name="handshakeTimeout" value="10000" />
       <property name="millisecBetweenHostCertRefresh" value="#{ ${hostCertificateRefreshPeriod} * 1000 }" />
       <property name="millisecBetweenTrustAnchorRefresh" value="#{ ${trustAnchorRefreshPeriod} * 1000 }" />
+        <property name="excludeCipherSuites" ref="banned-ciphers"/>
     </bean>
 
     <bean id="ssl-connector"
@@ -492,6 +498,7 @@
       <property name="handshakeTimeout" value="10000" />
       <property name="millisecBetweenHostCertRefresh" value="#{ ${hostCertificateRefreshPeriod} * 1000 }" />
       <property name="millisecBetweenTrustAnchorRefresh" value="#{ ${trustAnchorRefreshPeriod} * 1000 }" />
+        <property name="excludeCipherSuites" ref="banned-ciphers"/>
     </bean>
   </beans>
 

--- a/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
+++ b/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
@@ -4,41 +4,48 @@
 
 package javatunnel;
 
-import java.io.*;
-import java.util.Iterator;
-
-//jgss
-import javax.security.auth.Subject;
-import org.dcache.auth.FQANPrincipal;
-import org.dcache.gplazma.util.CertificateUtils;
-import org.ietf.jgss.*;
-
-// globus gsi
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.glite.voms.FQAN;
-import org.globus.gsi.GSIConstants;
-import org.globus.gsi.X509Credential;
 import org.globus.gsi.CredentialException;
+import org.globus.gsi.GSIConstants;
 import org.globus.gsi.TrustedCertificates;
+import org.globus.gsi.X509Credential;
 import org.globus.gsi.gssapi.GSSConstants;
 import org.globus.gsi.gssapi.GlobusGSSCredentialImpl;
 import org.globus.gsi.gssapi.auth.AuthorizationException;
 import org.globus.gsi.jaas.GlobusPrincipal;
 import org.gridforum.jgss.ExtendedGSSContext;
 import org.gridforum.jgss.ExtendedGSSManager;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.security.auth.Subject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Iterator;
+
+import org.dcache.auth.FQANPrincipal;
+import org.dcache.gplazma.util.CertificateUtils;
 import org.dcache.util.Crypto;
 
-import static org.dcache.util.Files.checkFile;
 import static org.dcache.util.Files.checkDirectory;
+import static org.dcache.util.Files.checkFile;
+
+//jgss
+// globus gsi
 
 
 class GsiTunnel extends GssTunnel  {
 
-    private final static Logger _log = LoggerFactory.getLogger(GsiTunnel.class);
+    private static final Logger _log = LoggerFactory.getLogger(GsiTunnel.class);
 
     private ExtendedGSSContext _e_context = null;
+
+    private static final String CIPHER_FLAGS = "ciphers";
 
     private static final String service_key           = "/etc/grid-security/hostkey.pem";
     private static final String service_cert          = "/etc/grid-security/hostcert.pem";
@@ -46,13 +53,16 @@ class GsiTunnel extends GssTunnel  {
     private Subject _subject = new Subject();
 
     // Creates a new instance of GssTunnel
-    public GsiTunnel(String dummy) throws GSSException, IOException {
-        this(dummy, true);
+    public GsiTunnel(String args) throws GSSException, IOException {
+        this(args, true);
     }
 
 
-    public GsiTunnel(String dummy, boolean init)
+    public GsiTunnel(String args, boolean init)
             throws GSSException, IOException {
+
+        Args arguments = new Args(args);
+
         if( init ) {
 
             X509Credential serviceCredential;
@@ -76,7 +86,8 @@ class GsiTunnel extends GssTunnel  {
             _e_context = (ExtendedGSSContext) manager.createContext(cred);
             _e_context.setOption(GSSConstants.GSS_MODE, GSIConstants.MODE_GSI);
             _e_context.setOption(GSSConstants.TRUSTED_CERTIFICATES, trusted_certs);
-            _e_context.setBannedCiphers(Crypto.BANNED_CIPHERS);
+            _e_context.setBannedCiphers(
+                    Crypto.getBannedCipherSuitesFromConfigurationValue(arguments.getOpt(CIPHER_FLAGS)));
             _context = _e_context;
             // do not use channel binding with GSIGSS
             super.useChannelBinding(false);

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -539,6 +539,27 @@ sshPort=22124
 #
 listen=
 
+#   Comma separated list of flags related to ciphers
+#
+#   DISABLE_BROKEN_DH
+#
+#   Diffie-Hellman is broken in Java 1.7u6 and forward. If  DISABLE_BROKEN_DH is
+#   included, dCache will disable all cipher families involving Diffie-Hellman on
+#   those versions of Java. Depending on the client, this may result in less
+#   secure SSL/TLS/GSI connections.
+#
+#   The symptoms of running with broken Diffie-Hellman enabled is that approximately
+#   0.4% of all connections will fail during handshake.
+#
+#   DISABLE_EC
+#
+#   Elliptic Curve ciphers are broken in Java 1.7 on Linux. The problem is that the
+#   JRE successfully negotiates the use of cipher variants not supported by libnss3.
+#   If this option is specified, dCache will disable all cipher families involving
+#   Elliptic Curve ciphers.
+#
+dcache.security.ciphers=DISABLE_EC,DISABLE_BROKEN_DH
+
 #  -----------------------------------------------------------------------
 #          Database Configuration
 #  -----------------------------------------------------------------------

--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -61,6 +61,9 @@ kerberosdcap/kerberos.service-principle-name=host/${host.fqdn}@${kerberos.realm}
 #
 (one-of?true|false)truncate=false
 
+#  Security related properties
+gsidcap.security.ciphers=${dcache.security.ciphers}
+
 #
 # This property controls how an anonymous user may access dCache.
 #

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -173,6 +173,8 @@ ftp.read-only=false
 #
 ftp/ftp.read-only=true
 
+#  Security related properties
+gridftp.security.ciphers=${dcache.security.ciphers}
 
 #
 #   Document which TCP ports are opened

--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -35,6 +35,9 @@ httpd.static-content.plots.subdir=/plots
 #
 (one-of?true|false)generatePlots=true
 
+#  Security related properties
+httpd.security.ciphers=${dcache.security.ciphers}
+
 #
 #   Document which TCP ports are opened
 #

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -575,6 +575,8 @@ qosConfigFile=
 (one-of?true|false)srmImplicitSpaceManagerEnabled=true
 (one-of?true|false)srmSpaceReservationStrict=true
 
+#  Security related properties
+srm.security.ciphers=${dcache.security.ciphers}
 
 #
 #   Document which TCP ports are opened

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -287,6 +287,9 @@ webdav.templates.html=file:${dcache.paths.share}/webdav/templates/html.stg
 #
 (immutable)webdav/net.ports.tcp=${port}
 
+#  Security related properties
+webdav.security.ciphers=${dcache.security.ciphers}
+
 #  ---- Artwork elements
 #
 #  These properties are obsolete. Modify the template to customize the

--- a/skel/share/services/gridftp.batch
+++ b/skel/share/services/gridftp.batch
@@ -29,6 +29,7 @@ check -strong ftp.read-only
 check -strong grid.hostcert.key
 check -strong grid.hostcert.cert
 check -strong grid.ca.path
+check gridftp.security.ciphers
 check FtpTLogDir
 check listen
 
@@ -93,5 +94,6 @@ create dmg.cells.services.login.LoginManager ${cell.name} \
              -service-key=${grid.hostcert.key} \
              -service-cert=${grid.hostcert.cert} \
              -service-trusted-certs=${grid.ca.path} \
+             -gridftp.security.ciphers=\"${gridftp.security.ciphers}\" \
 "
 

--- a/skel/share/services/gsidcap.batch
+++ b/skel/share/services/gsidcap.batch
@@ -16,6 +16,7 @@ check -strong dcapReadOnly
 check -strong dcapAnonymousAccessLevel
 check gsidcapIoQueue
 check listen
+check gsidcap.security.ciphers
 
 #
 #  ----  Usage of Srm Space Manager
@@ -55,7 +56,7 @@ create dmg.cells.services.login.LoginManager ${cell.name} \
               -stageConfigurationFilePath=${stageConfigurationFilePath} \
               -io-queue=${gsidcapIoQueue} \
               -io-queue-overwrite=${gsidcapIoQueueOverwrite} \
-              -socketfactory=javatunnel.TunnelServerSocketCreator,javatunnel.GsiTunnel,dummy \
+              -socketfactory=\"javatunnel.TunnelServerSocketCreator,javatunnel.GsiTunnel,-ciphers='${gsidcap.security.ciphers}'\" \
               -read-only=${dcapReadOnly} \
               -anonymous-access=${dcapAnonymousAccessLevel} \
               "

--- a/skel/share/services/srm.batch
+++ b/skel/share/services/srm.batch
@@ -160,6 +160,8 @@ check -strong grid.hostcert.key
 check -strong grid.hostcert.cert
 check -strong grid.ca.path
 
+check srm.security.ciphers
+
 
 #
 # Force space manager related settings to off if space manager is
@@ -329,4 +331,5 @@ create org.dcache.cells.UniversalSpringCell ${cell.name} \
         -service-key=${grid.hostcert.key} \
         -service-cert=${grid.hostcert.cert} \
         -service-trusted-certs=${grid.ca.path} \
+        -srm.security.ciphers=\"${srm.security.ciphers}\" \
 "

--- a/skel/share/services/webdav.batch
+++ b/skel/share/services/webdav.batch
@@ -42,6 +42,8 @@ check webdavInternalAddress
 check webdavIoQueue
 check loginBroker
 
+check webdav.security.ciphers
+
 define env verify-http.exe enddefine
 enddefine
 
@@ -139,4 +141,6 @@ create org.dcache.cells.UniversalSpringCell ${cell.name} \
     -webdav.templates.html=${webdav.templates.html} \
     -webdav.redirect.on-read=${webdav.redirect.on-read} \
     -webdav.overwrite=${webdav.overwrite} \
-    -export -cellClass=WebDAVDoor"
+    -export -cellClass=WebDAVDoor \
+    -webdav.security.ciphers=\"${webdav.security.ciphers}\" \
+    "


### PR DESCRIPTION
Addresses an issue in SSL/TLS/GSI sessions that approximately one
out of 256 connections fail with an 'invalid padding' error. This
affects gridftp, webdav with https, httpd with https, SRM and gsidcap.
It should be noted that this significantly reduces the number of
available ciphers.

It appears that Diffie-Hellman is broken in Java 1.7.0_6 and higher. This
patch bans those ciphers if a broken version of Java is used.

The patch adds new configuration properties for configuring whether
certain cipher families are banned:

dcache.security.ciphers
webdav.security.ciphers
httpd.security.ciphers
gsidcap.security.ciphers
srm.security.ciphers
gridftp.security.ciphers

The latter are defined in terms of the first. The property names follow
the schema agreed upon at the 2013 developers workshop. The patch
introduces a new configuration property group called security. It is
intended for general security related properties like authentication,
authorization, cryptography, etc.

Target: trunk
Request: 2.6
Request: 2.2-sha2
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@gnal.gov
Patch: http://rb.dcache.org/r/5616/
