### PR TITLE
pool: Make xrootd max frame size configurable

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolNettyServer.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolNettyServer.java
@@ -45,6 +45,7 @@ public class XrootdPoolNettyServer
     private Timer _timer;
 
     private final long _clientIdleTimeout;
+    private final int _maxFrameSize;
 
     private int _numberClientConnections;
     private List<ChannelHandlerFactory> _plugins;
@@ -53,11 +54,13 @@ public class XrootdPoolNettyServer
                                  int memoryPerConnection,
                                  int maxMemory,
                                  long clientIdleTimeout,
+                                 int maxFrameSize,
                                  List<ChannelHandlerFactory> plugins) {
         this(threadPoolSize,
              memoryPerConnection,
              maxMemory,
              clientIdleTimeout,
+             maxFrameSize,
              plugins,
              -1);
     }
@@ -66,16 +69,23 @@ public class XrootdPoolNettyServer
                                  int memoryPerConnection,
                                  int maxMemory,
                                  long clientIdleTimeout,
+                                 int maxFrameSize,
                                  List<ChannelHandlerFactory> plugins,
                                  int socketThreads) {
         super("xrootd", threadPoolSize, memoryPerConnection, maxMemory, socketThreads);
         _clientIdleTimeout = clientIdleTimeout;
+        _maxFrameSize = maxFrameSize;
         _plugins = plugins;
 
         String range = System.getProperty("org.globus.tcp.port.range");
         PortRange portRange =
             (range != null) ? PortRange.valueOf(range) : DEFAULT_PORTRANGE;
         setPortRange(portRange);
+    }
+
+    public int getMaxFrameSize()
+    {
+        return _maxFrameSize;
     }
 
     @Override

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -74,12 +74,6 @@ public class XrootdPoolRequestHandler extends XrootdRequestHandler
     private static final int DEFAULT_FILESTATUS_MODTIME = 0;
 
     /**
-     * Maximum frame size of a read or readv reply. Does not include the size
-     * of the frame header.
-     */
-    private static final int MAX_FRAME_SIZE = 2 << 20;
-
-    /**
      * Store file descriptors of open files.
      */
     private final List<FileDescriptor> _descriptors =
@@ -373,7 +367,7 @@ public class XrootdPoolRequestHandler extends XrootdRequestHandler
         if (msg.bytesToRead() == 0) {
             return withOk(msg);
         } else {
-            return new ChunkedFileDescriptorReadResponse(msg, MAX_FRAME_SIZE, _descriptors.get(fd));
+            return new ChunkedFileDescriptorReadResponse(msg, _server.getMaxFrameSize(), _descriptors.get(fd));
         }
     }
 
@@ -411,15 +405,15 @@ public class XrootdPoolRequestHandler extends XrootdRequestHandler
             int totalBytesToRead = req.BytesToRead() +
                 ReadResponse.READ_LIST_HEADER_SIZE;
 
-            if (totalBytesToRead > MAX_FRAME_SIZE) {
+            if (totalBytesToRead > _server.getMaxFrameSize()) {
                 _log.warn("Vector read of {} bytes requested, exceeds " +
                           "maximum frame size of {} bytes!", totalBytesToRead,
-                          MAX_FRAME_SIZE);
+                          _server.getMaxFrameSize());
                 throw new XrootdException(kXR_ArgInvalid, "Single readv transfer is too large");
             }
         }
 
-        return new ChunkedFileDescriptorReadvResponse(msg, MAX_FRAME_SIZE, new ArrayList<>(_descriptors));
+        return new ChunkedFileDescriptorReadvResponse(msg, _server.getMaxFrameSize(), new ArrayList<>(_descriptors));
     }
 
     /**

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdTransferService.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdTransferService.java
@@ -105,6 +105,7 @@ public class XrootdTransferService
     private int maxMemoryPerConnection;
     private int maxMemory;
     private long clientIdleTimeout;
+    private int maxFrameSize;
     private Integer socketThreads;
     private List<ChannelHandlerFactory> plugins;
 
@@ -183,6 +184,12 @@ public class XrootdTransferService
         this.plugins = plugins;
     }
 
+    @Required
+    public void setMaxFrameSize(int maxFrameSize)
+    {
+        this.maxFrameSize = maxFrameSize;
+    }
+
     public List<ChannelHandlerFactory> getPlugins()
     {
         return plugins;
@@ -197,6 +204,7 @@ public class XrootdTransferService
                     maxMemoryPerConnection,
                     maxMemory,
                     clientIdleTimeout,
+                    maxFrameSize,
                     plugins);
         } else {
             server = new XrootdPoolNettyServer(
@@ -204,6 +212,7 @@ public class XrootdTransferService
                     maxMemoryPerConnection,
                     maxMemory,
                     clientIdleTimeout,
+                    maxFrameSize,
                     plugins,
                     socketThreads);
         }

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -356,6 +356,7 @@
       <property name="maxMemory" value="${xrootd-mover-max-memory}"/>
       <property name="clientIdleTimeout" value="${xrootd-mover-idle-client-timeout}"/>
       <property name="socketThreads" value="${xrootd-mover-socket-threads}"/>
+      <property name="maxFrameSize" value="${xrootd-mover-max-frame-size}"/>
       <property name="plugins">
           <bean class="org.dcache.xrootd.spring.ChannelHandlerFactoryFactoryBean">
               <property name="plugins" value="${xrootd-plugins}"/>


### PR DESCRIPTION
Addresses the issue that the xrootdMoverMaxFrameSize property was
ignored by the xrootd mover.

Target: trunk
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/5622/
(cherry picked from commit da723b40be7477b0568769cdc25020425d9acacf)
