### PR TITLE
srm: Respect read-only session in 2.2 (equivalent of http://rb.dcache.or...

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/SRMUser.java
+++ b/modules/srm/src/main/java/org/dcache/srm/SRMUser.java
@@ -25,28 +25,28 @@ COPYRIGHT STATUS:
   and software for U.S. Government purposes.  All documents and software
   available from this server are protected under the U.S. and Foreign
   Copyright Laws, and FNAL reserves all rights.
- 
- 
+
+
  Distribution of the software available from this server is free of
  charge subject to the user following the terms of the Fermitools
  Software Legal Information.
- 
+
  Redistribution and/or modification of the software shall be accompanied
  by the Fermitools Software Legal Information  (including the copyright
  notice).
- 
+
  The user is asked to feed back problems, benefits, and/or suggestions
  about the software to the Fermilab Software Providers.
- 
- 
+
+
  Neither the name of Fermilab, the  URA, nor the names of the contributors
  may be used to endorse or promote products derived from this software
  without specific prior written permission.
- 
- 
- 
+
+
+
   DISCLAIMER OF LIABILITY (BSD):
- 
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
   "AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
   LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -59,10 +59,10 @@ COPYRIGHT STATUS:
   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
   SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
- 
- 
+
+
   Liabilities of the Government:
- 
+
   This software is provided by URA, independent from its Prime Contract
   with the U.S. Department of Energy. URA is acting independently from
   the Government and in its own private capacity and is not acting on
@@ -72,10 +72,10 @@ COPYRIGHT STATUS:
   be liable for nor assume any responsibility or obligation for any claim,
   cost, or damages arising out of or resulting from the use of the software
   available from this server.
- 
- 
+
+
   Export Control:
- 
+
   All documents and software available from this server are subject to U.S.
   export control laws.  Anyone downloading information from this server is
   obligated to secure any necessary Government licenses before exporting
@@ -99,4 +99,5 @@ package org.dcache.srm;
 public interface SRMUser{
     public int getPriority();
     public long getId();
+    public boolean isReadOnly();
 }

--- a/modules/srm/src/main/java/org/dcache/srm/server/SRMServerV1.java
+++ b/modules/srm/src/main/java/org/dcache/srm/server/SRMServerV1.java
@@ -98,6 +98,9 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
               log.debug("SRMServerV1.put() : role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
               user = srmAuth.getRequestUser(requestCredential,null,userCred.context);
+              if (user.isReadOnly()) {
+                  throw new SRMAuthorizationException("Session is read-only");
+              }
           }
           catch (SRMAuthorizationException sae) {
               String msg = "SRM Authorization failed: " + sae.getMessage();
@@ -579,7 +582,10 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
               String role = roles.isEmpty() ? null : (String) roles.toArray()[0];
               log.debug("SRMServerV1.advisoryDelete() : role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
-             user = srmAuth.getRequestUser(requestCredential,null,userCred.context);
+              user = srmAuth.getRequestUser(requestCredential,null,userCred.context);
+              if (user.isReadOnly()) {
+                  throw new SRMAuthorizationException("Session is read-only");
+              }
           }
           catch (SRMAuthorizationException sae) {
               String msg = "SRM Authorization failed: " + sae.getMessage();

--- a/modules/srm/src/main/java/org/dcache/srm/server/SRMServerV2.java
+++ b/modules/srm/src/main/java/org/dcache/srm/server/SRMServerV2.java
@@ -258,6 +258,17 @@ public class SRMServerV2 implements org.dcache.srm.v2_2.ISRM  {
                         requestCredential,
                         (String) null,
                         userCred.context);
+                    if ((requestName.equals("srmRmdir") ||
+                         requestName.equals("srmMkdir") ||
+                         requestName.equals("srmPrepareToPut") ||
+                         requestName.equals("srmRm") ||
+                         requestName.equals("srmMv") ||
+                         requestName.equals("srmSetPermission")) &&
+                        user.isReadOnly()) {
+                        return getFailedResponse(capitalizedRequestName,
+                                                 TStatusCode.SRM_AUTHORIZATION_FAILURE,
+                                                 "Session is read-only");
+                    }
                 } catch (SRMAuthorizationException sae) {
                     log.info("SRM Authorization failed: {}", sae.getMessage());
                     return getFailedResponse(capitalizedRequestName,

--- a/modules/srm/src/main/java/org/dcache/srm/unixfs/UnixfsUser.java
+++ b/modules/srm/src/main/java/org/dcache/srm/unixfs/UnixfsUser.java
@@ -24,7 +24,7 @@ public class UnixfsUser implements SRMUser
   private int gid = -1;
 
   private static final long serialVersionUID = -1244019880191669699L;
-  
+
   /** Creates a new instance of User. */
   public UnixfsUser(String name, String root, int uid, int gid) {
       synchronized(UnixfsUser.class) {
@@ -40,12 +40,12 @@ public class UnixfsUser implements SRMUser
     this.uid  = uid;
     this.gid  = gid;
   }
-  
-  
+
+
  public long getId() { return id; }
- 
+
  public int getPriority() { return 0; }
-  
+
   /** */
   public String getName() {  return name; }
   /** */
@@ -86,6 +86,10 @@ public class UnixfsUser implements SRMUser
 
     public String getVoGroup() {
         return name;
+    }
+
+    public boolean isReadOnly() {
+        return false;
     }
 }
 


### PR DESCRIPTION
...g/r/5633/ for java 6 based 2.2)

This patch fixes the issues by attempting to failfast - fail SRM request even before the request handler is invoked and
there fore before requests are scheduled (in case of srmput). It is achieved by adding isReadOnly() method to SRMUser interface.

Ticket: 7842
Acked-by: Al Rossi
Target: 2.2
Bug: http://rt.dcache.org/Ticket/Display.html?id=7842
Request: 1.9.12
Require-book: no
Require-notes: yes

RELEASE NOTES
SRM respects read-only session qualifier (as specified in storage-authzb or dcache.kpwd). That is
if login record contains "read-only" qualifier SRM will refuse performing namespace modification
functions with SRM_AUTHORIZATION_FAILURE error code
