### PR TITLE
libs: Upgrade to JGlobus 2.0.6-rc3.d

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <version.jetty>7.6.10.v20130312</version.jetty>
         <version.wicket>1.5.10</version.wicket>
         <version.xrootd4j>1.2.0</version.xrootd4j>
-        <version.jglobus>2.0.6-rc2</version.jglobus>
+        <version.jglobus>2.0.6-rc3.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
Addresses a compatibility issue with some versions of curl and other
clients that send empty SSL messages.

Target: trunk
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5659/
(cherry picked from commit 45c172f2602dde104b2cb31c0caaad923aac596e)
