### PR TITLE
libs: Upgrade to JGlobus 2.0.6-rc3.d

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
       <version.aspectj>1.6.12</version.aspectj>
       <version.smc>5.1.0</version.smc>
       <version.xerces>2.9.1</version.xerces>
-      <version.jglobus>2.0.6-rc2</version.jglobus>
+      <version.jglobus>2.0.6-rc3.d</version.jglobus>
   </properties>
 
   <scm>


### PR DESCRIPTION
Addresses a compatibility issue with some versions of curl and other
clients that send empty SSL messages.

Target: trunk
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5659/
(cherry picked from commit 45c172f2602dde104b2cb31c0caaad923aac596e)
