### PR TITLE
(2.2) dcache (billing): fix typo in liquibase changelog

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
@@ -629,9 +629,9 @@
 		</sql>
 	</changeSet>
     <!-- VARCHAR ADJUSTMENTS (previous changeset has bug and has never run; this one corrects it)-->
-    <changeSet author="arossi" id="4.1.7.1" context="billing" failOnError="false">
+    <changeSet author="arossi" id="4.1.7.2" context="billing" failOnError="false">
         <sql splitStatements="false">
-            INSERT INTO costinfo (pnsfid, errormessage)
+            INSERT INTO costinfo (pnfsid, errormessage)
             VALUES('-1', '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789');
         </sql>
     </changeSet>
@@ -653,10 +653,7 @@
         <modifyDataType tableName="hitinfo" columnName="pnfsid" newDataType="VARCHAR(36)" />
         <modifyDataType tableName="hitinfo" columnName="errormessage" newDataType="VARCHAR(8000)" />
     </changeSet>
-    <changeSet author="arossi" id="4.1.9.1" context="billing">
-        <preConditions onError="CONTINUE" onFail="MARK_RAN">
-            <sqlCheck expectedResult="1">select count(*) from costinfo where pnfsid='-1'</sqlCheck>
-        </preConditions>
+    <changeSet author="arossi" id="4.1.9.2" context="billing">
         <sql splitStatements="false">
             DELETE FROM costinfo WHERE pnfsid='-1';
         </sql>


### PR DESCRIPTION
module:  dcache (billing)

Undiscovered typo which makes the precondition always fail.

Once again, the consequences of this error will be felt only where 2.2 was installed over previous installations where the billing database was not generated via our liquibase changeset.

I have also eliminated the precondition on 4.1.9.1 because (a) it is not necessary, and (b) will never run again if it failed for some reason on the first pass to delete entries (the result then being > 1 rather than 1, which would make the precondition test false).

Target: 2.2
Patch: http://rb.dcache.org/r/5661
Require-notes: yes
Require-book: no
Acked-by: Gerd

RELEASE NOTES:  The liquibase changeset which checks to see if preexisting tables need to have certain varchar field lengths changed always failed (and hence the changes always ran) because of a typographical error.  This is now fixed, to avoid alteration of field type (which could potentially take time) where not necessary.

Testing procedure:
1.  Fresh install on new database:
   [root@otfrid dcache]# createdb -U srmdcache billing_2_2
   [root@otfrid dcache]# dcache start httpdDomain
2.  Observe in log correct behavior (changeset adjusts the fields):

INFO 6/19/13 8:17 AM:liquibase: Change set org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml::4.1.7.2::arossi failed, but failOnError was false.  Error: Error executing SQL INSERT INTO costinfo (pnfsid, errormessage)
            VALUES('-1', '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789');: ERROR: value too long for type character varying(256)
INFO 6/19/13 8:17 AM:liquibase: ChangeSet org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml::4.1.8.1::arossi ran successfully in 567ms
INFO 6/19/13 8:17 AM:liquibase: ChangeSet org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml::4.1.9.2::arossi ran successfully in 4ms
1.  Stop dcache, alter the database to look like one which was created by hand without length of varchar specified, and rerun:
   [root@otfrid dcache]# dcache stop
   [root@otfrid dcache]# psql -U srmdcache billing_2_2
    psql (9.2.2)
    Type "help" for help.
   
    billing_2_2=> drop table databasechangelog; drop table databasechangeloglock ;
    DROP TABLE
    DROP TABLE
    billing_2_2=> alter table costinfo alter column errormessage type character varying;
    ALTER TABLE
    billing_2_2=> alter table costinfo alter column transaction type character varying;
    ALTER TABLE
    billing_2_2=> alter table costinfo alter column pnfsid type character varying;
    ALTER TABLE
    billing_2_2=> alter table costinfo alter column cellname type character varying;
    ALTER TABLE
    billing_2_2=> alter table costinfo alter column action type character varying;
    ALTER TABLE
    billing_2_2=> \d costinfo
   
   ```
           Table "public.costinfo"
   ```
   
   Column    |           Type           | Modifiers
   --------------+--------------------------+-----------
   cost         | double precision         |
   action       | character varying        |
   cellname     | character varying        |
   datestamp    | timestamp with time zone |
   errorcode    | integer                  |
   errormessage | character varying        |
   pnfsid       | character varying        |
   transaction  | character varying        |
   Indexes:
   "costinfo_date_idx" btree (datestamp)
   Triggers:
   tgr_update_costinfo_daily AFTER INSERT ON costinfo FOR EACH ROW EXECUTE PROCEDURE f_update_costinfo_daily()
   
   billing_2_2=> \q
   [root@otfrid dcache]# dcache start httpdDomain
2.  Observe in log correct behavior (changeset marked as ran):

INFO 6/19/13 8:20 AM:liquibase: ChangeSet org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml::4.1.7.2::arossi ran successfully in 7ms
INFO 6/19/13 8:20 AM:liquibase: Marking ChangeSet: org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml::4.1.8.1::arossi::(Checksum: 3:faff07731c4ac867864824ca31e8ae81) ran despite precondition failure due to onFail='MARK_RAN':
          classpath:org/dcache/services/billing/db/sql/billing.changelog-master.xml : SQL Precondition failed.  Expected '0' got '1'

INFO 6/19/13 8:20 AM:liquibase: ChangeSet org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml::4.1.9.2::arossi ran successfully in 6ms
