### PR TITLE
logging: Set remote appender log level to off by default

### DIFF
--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -11,7 +11,7 @@ alarms/cell.name=alarms
 
 #  ---- Level of events to send via the socket appender to the remote server
 #
-(one-of?off|error|warn)alarms.remote-logging.level=error
+(one-of?off|error|warn)alarms.remote-logging.level=off
 
 #  ---- Host on which the alarm server will run
 #       relative to this dCache installation


### PR DESCRIPTION
Unless explicitly configured, we should not attempt to send any log events to
the remote appender (both for performance reasons and as a workaround for the
problem with the socket appender connecting to itself).

Target: trunk
Request: 2.6
Require-book: yes
Require-notes: yes
Patch: http://rb.dcache.org/r/5664/
Acked-by: Albert Rossi arossi@fnal.gov
