### PR TITLE
Fix quickJava for some shell versions

### DIFF
--- a/skel/share/lib/loadConfig.sh
+++ b/skel/share/lib/loadConfig.sh
@@ -69,6 +69,7 @@ bootLoader()
 
 quickJava()
 {
+    export CLASSPATH
     "$JAVA" $(getProperty dcache.java.options.short-lived) "$@"
 }
 


### PR DESCRIPTION
The current implementation and usage of quickJava relies on a shell-
specific behaviour; specifically, that specifying a environment
variable for a command that is actually a shell function becomes
an environment variable for that shell function.

Although this works for some versions of bash, it's now clear that
there are other versions of bash (and perhaps other shells) for
which this does not hold.

This patch fixes this problem by explicitly exporting the CLASSPATH
variable as an environment variable.

Patch: http://rb.dcache.org/r/5603
Acked-by: Tigran Mkrtchyan
Target: master
Requires-book: no
Requires-notes: yes
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7889
(cherry picked from commit 083a7eb7263186d4cc72d2e8123459ab286d81e7)
