### PR TITLE
gplazma: Fix DN extraction from proxy certificates

### DIFF
--- a/modules/dcache-gsi/src/main/java/org/dcache/auth/util/X509Utils.java
+++ b/modules/dcache-gsi/src/main/java/org/dcache/auth/util/X509Utils.java
@@ -6,7 +6,6 @@ import org.bouncycastle.asn1.DERObjectIdentifier;
 import org.bouncycastle.asn1.DERString;
 import org.bouncycastle.asn1.x509.TBSCertificateStructure;
 import org.bouncycastle.asn1.x509.X509Name;
-import org.globus.gsi.GSIConstants;
 import org.globus.gsi.bc.BouncyCastleUtil;
 
 import java.io.IOException;
@@ -33,46 +32,26 @@ import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
 public class X509Utils {
 
     /**
-     * Extracts the user subject from the certificate chain. <br>
-     * <br>
-     * Code adapted from gplazma1 (gplazma.authz.util.X509CertUtil).
+     * Extracts the user subject from the certificate chain.
      *
      * @return Subject as Globus-style DN.
      */
     public static String getSubjectFromX509Chain(X509Certificate[] chain,
                     boolean omitEmail) throws AuthenticationException {
-        String subjectDN = null;
-        TBSCertificateStructure tbsCert = null;
-        X509Certificate clientcert = null;
         try {
-            for (X509Certificate testcert : chain) {
-                tbsCert = BouncyCastleUtil.getTBSCertificateStructure(testcert);
-                GSIConstants.CertificateType certType = BouncyCastleUtil.getCertificateType(testcert);
-                if (certType != GSIConstants.CertificateType.GSI_3_IMPERSONATION_PROXY &&
-                    certType != GSIConstants.CertificateType.GSI_4_IMPERSONATION_PROXY ) {
-                    clientcert = testcert;
-                    break;
-                }
-             }
+            X509Certificate clientcert = BouncyCastleUtil.getIdentityCertificate(chain);
+            checkAuthentication(clientcert != null, "no client certificate");
+            TBSCertificateStructure tbsCert = BouncyCastleUtil.getTBSCertificateStructure(clientcert);
+            return toGlobusString(
+                    (ASN1Sequence) tbsCert.getSubject().getDERObject(),
+                    omitEmail);
         } catch (IOException | CertificateException e) {
             throw new AuthenticationException(e.getMessage(), e);
         }
-
-        checkAuthentication(clientcert != null, "no client certificate");
-
-        if (tbsCert != null) {
-            subjectDN = toGlobusString(
-                            (ASN1Sequence) tbsCert.getSubject().getDERObject(),
-                            omitEmail);
-        }
-
-        return subjectDN;
     }
 
     /**
-     * Finds the certificate authority which issued the user proxy. <br>
-     * <br>
-     * Code adapted from gplazma1 (gplazma.authz.util.X509CertUtil).
+     * Finds the certificate authority which issued the user proxy.
      *
      * @param skipImpersonation
      *            tells the method to look for the original cert in the chain
@@ -81,36 +60,27 @@ public class X509Utils {
     @SuppressWarnings("null")
     public static String getSubjectX509Issuer(X509Certificate[] chain,
                     boolean skipImpersonation) throws AuthenticationException {
-        if (chain == null) {
+        if (chain == null || chain.length == 0) {
             return null;
         }
 
-        X509Certificate clientcert = null;
-        for (X509Certificate testcert : chain) {
-            try {
-                if (!skipImpersonation) {
-                    clientcert = testcert;
-                    break;
-                }
-                GSIConstants.CertificateType certType = BouncyCastleUtil.getCertificateType(testcert);
-                if (certType != GSIConstants.CertificateType.GSI_3_IMPERSONATION_PROXY &&
-                    certType != GSIConstants.CertificateType.GSI_4_IMPERSONATION_PROXY ) {
-                    clientcert = testcert;
-                    break;
-                }
-            } catch (CertificateEncodingException t) {
-                throw new AuthenticationException("badly formatted certificate: "
-                        + t.getMessage(), t);
-            } catch (CertificateException t) {
-                throw new AuthenticationException("problem with certificate: "
-                        + t.getMessage(), t);
+        try {
+            X509Certificate clientcert;
+            if (skipImpersonation) {
+                clientcert = chain[0];
+            } else {
+                clientcert = BouncyCastleUtil.getIdentityCertificate(chain);
+                checkAuthentication(clientcert != null, "no client certificate");
             }
+            return toGlobusDN(clientcert.getIssuerDN().toString(),
+                    skipImpersonation); // Is using skipImpression correct?
+        } catch (CertificateEncodingException t) {
+            throw new AuthenticationException("badly formatted certificate: "
+                    + t.getMessage(), t);
+        } catch (CertificateException t) {
+            throw new AuthenticationException("problem with certificate: "
+                    + t.getMessage(), t);
         }
-
-        checkAuthentication(clientcert != null, "no client certificate");
-
-        return toGlobusDN(clientcert.getIssuerDN().toString(),
-                        skipImpersonation);
     }
 
     /**


### PR DESCRIPTION
Addresses an issue in the x509 and xacml plugins in which the DN of
a proxy certificate rather the the DN of the user is extracted.

Extracting the DN of the user owning a proxy certificate involves
traversing the certificate chain, discarding any proxy certificates,
until the user's real certificate is found. The existing code in
dCache is not aware of all possible proxy certificate types, which
in some cases lead it to extract the DN of a proxy certififcate
rather than the user's DN.

Target: trunk
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi arossi@fnal.gov
Patch: http://rb.dcache.org/r/5667/
(cherry picked from commit b848b326b54eec0b5196febbff1201a65d1403d7)
