### PR TITLE
cells: Remove "Sending CellException to" log message

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -669,7 +669,8 @@ class CellGlue {
             // here we try to inform the last sender that we are
             // not able to deliver the packet.
             //
-            LOGGER.debug("sendMessage : Route target Not found: {}", routeTarget);
+            LOGGER.debug("Message from {} could not be delivered because no route to {} is known; the sender will be notified.",
+                    msg.getSourcePath(), routeTarget);
             NoRouteToCellException exception =
                  new   NoRouteToCellException(
                               msg.getUOID() ,
@@ -679,7 +680,6 @@ class CellGlue {
             CellPath retAddr = msg.getSourcePath().revert();
             CellExceptionMessage ret =
                  new CellExceptionMessage( retAddr , exception )  ;
-            LOGGER.warn("Sending CellException to {}", retAddr);
             ret.setLastUOID( msg.getUOID() ) ;
             sendMessage( nucleus , ret ) ;
 


### PR DESCRIPTION
Addresses an issue of frequent "Sending CellException to" messages in log files.
This is a regression introduced when we removed the last pieces of the old
logging system from dCache. These messages used to be surpressed, but now
happen to be logged.

The patch improves the text of the log message and changes the log level to
debug.

Target: trunk
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi arossi@fnal.gov
Patch: http://rb.dcache.org/r/5665/
(cherry picked from commit b419ba459fd57eeac1bd0af4554340436a364360)
