### PR TITLE
(2.2) dcache (billing) improve error handling in plotting classes

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/exceptions/TimeFrameFactoryInitializationException.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/exceptions/TimeFrameFactoryInitializationException.java
@@ -3,7 +3,7 @@ package org.dcache.services.billing.plots.exceptions;
 /**
  * @author arossi
  */
-public class TimeFrameFactoryInitializationException extends Throwable {
+public class TimeFrameFactoryInitializationException extends Exception {
 
     private static final long serialVersionUID = -5160138147238131675L;
 

--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/jaida/JaidaTimeFrameHistogram.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/jaida/JaidaTimeFrameHistogram.java
@@ -37,8 +37,7 @@ public final class JaidaTimeFrameHistogram extends AbstractTimeFrameHistogram {
      * @see org.dcache.billing.statistics.util.ITimeFrameHistogram#setData()
      */
     @Override
-    public void setData(Collection<IPlotData> data, String field, Double dfactor)
-                    throws Throwable {
+    public void setData(Collection<IPlotData> data, String field, Double dfactor) {
         if (field != null) {
             if (dfactor != null) {
                 for (IPlotData d : data) {

--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/jaida/JaidaTimeFrameHistogramFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/jaida/JaidaTimeFrameHistogramFactory.java
@@ -39,8 +39,6 @@ import org.dcache.services.billing.plots.util.ITimeFrameHistogram;
 import org.dcache.services.billing.plots.util.ITimeFramePlot;
 import org.dcache.services.billing.plots.util.TimeFrame;
 import org.dcache.services.billing.plots.util.TimeFrame.BinType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Wraps IHistogramFactory.
@@ -50,10 +48,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class JaidaTimeFrameHistogramFactory extends
                 AbstractTimeFrameHistogramFactory {
-
-    private static final Logger logger
-        = LoggerFactory.getLogger(JaidaTimeFrameHistogramFactory.class);
-
     /**
      * Stand-in aggregate object for hits data.
      *
@@ -101,7 +95,7 @@ public final class JaidaTimeFrameHistogramFactory extends
             if (propertiesPath != null) {
                 properties.load(new FileInputStream(new File(propertiesPath)));
             }
-        } catch (Throwable t) {
+        } catch (Exception t) {
             throw new TimeFrameFactoryInitializationException(t);
         }
     }
@@ -123,7 +117,7 @@ public final class JaidaTimeFrameHistogramFactory extends
 
     @Override
     public ITimeFrameHistogram createDcBytesHistogram(TimeFrame timeFrame,
-                    boolean write) {
+                    boolean write) throws BillingQueryException {
         String title = write ? getProperty(ITimeFramePlot.LABEL_DC_WR)
                         : getProperty(ITimeFramePlot.LABEL_DC_RD);
         ITimeFrameHistogram histogram = new JaidaTimeFrameHistogram(factory,
@@ -134,31 +128,23 @@ public final class JaidaTimeFrameHistogramFactory extends
         Collection<IPlotData> plotData = null;
         if (BinType.HOUR == timeFrame.getTimebin()) {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_GBYTES_HR));
-            try {
-                if (write) {
-                    plotData = getViewData(DcacheWritesHourly.class);
-                    histogram.setData(plotData, DcacheWritesHourly.SIZE, GB);
-                } else {
-                    plotData = getViewData(DcacheReadsHourly.class);
-                    histogram.setData(plotData, DcacheReadsHourly.SIZE, GB);
-                }
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
+            if (write) {
+                plotData = getViewData(DcacheWritesHourly.class);
+                histogram.setData(plotData, DcacheWritesHourly.SIZE, GB);
+            } else {
+                plotData = getViewData(DcacheReadsHourly.class);
+                histogram.setData(plotData, DcacheReadsHourly.SIZE, GB);
             }
         } else {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_GBYTES_DY));
-            try {
-                if (write) {
-                    plotData = getCoarseGrainedPlotData(
-                                    DcacheWritesDaily.class, timeFrame);
-                    histogram.setData(plotData, DcacheWritesDaily.SIZE, GB);
-                } else {
-                    plotData = getCoarseGrainedPlotData(DcacheReadsDaily.class,
-                                    timeFrame);
-                    histogram.setData(plotData, DcacheReadsDaily.SIZE, GB);
-                }
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
+            if (write) {
+                plotData = getCoarseGrainedPlotData(DcacheWritesDaily.class,
+                                                    timeFrame);
+                histogram.setData(plotData, DcacheWritesDaily.SIZE, GB);
+            } else {
+                plotData = getCoarseGrainedPlotData(DcacheReadsDaily.class,
+                                                    timeFrame);
+                histogram.setData(plotData, DcacheReadsDaily.SIZE, GB);
             }
         }
         return histogram;
@@ -166,7 +152,7 @@ public final class JaidaTimeFrameHistogramFactory extends
 
     @Override
     public ITimeFrameHistogram createDcTransfersHistogram(TimeFrame timeFrame,
-                    boolean write) throws Throwable {
+                    boolean write) throws BillingQueryException {
         String title = write ? getProperty(ITimeFramePlot.LABEL_DC_WR)
                         : getProperty(ITimeFramePlot.LABEL_DC_RD);
         ITimeFrameHistogram histogram = new JaidaTimeFrameHistogram(factory,
@@ -177,31 +163,23 @@ public final class JaidaTimeFrameHistogramFactory extends
         Collection<IPlotData> plotData = null;
         if (BinType.HOUR == timeFrame.getTimebin()) {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_TRANSF_HR));
-            try {
-                if (write) {
-                    plotData = getViewData(DcacheWritesHourly.class);
-                    histogram.setData(plotData, DcacheWritesHourly.COUNT, null);
-                } else {
-                    plotData = getViewData(DcacheReadsHourly.class);
-                    histogram.setData(plotData, DcacheReadsHourly.COUNT, null);
-                }
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
+            if (write) {
+                plotData = getViewData(DcacheWritesHourly.class);
+                histogram.setData(plotData, DcacheWritesHourly.COUNT, null);
+            } else {
+                plotData = getViewData(DcacheReadsHourly.class);
+                histogram.setData(plotData, DcacheReadsHourly.COUNT, null);
             }
         } else {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_TRANSF_DY));
-            try {
-                if (write) {
-                    plotData = getCoarseGrainedPlotData(
-                                    DcacheWritesDaily.class, timeFrame);
-                    histogram.setData(plotData, DcacheWritesDaily.COUNT, null);
-                } else {
-                    plotData = getCoarseGrainedPlotData(DcacheReadsDaily.class,
-                                    timeFrame);
-                    histogram.setData(plotData, DcacheReadsDaily.COUNT, null);
-                }
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
+            if (write) {
+                plotData = getCoarseGrainedPlotData(DcacheWritesDaily.class,
+                                                    timeFrame);
+                histogram.setData(plotData, DcacheWritesDaily.COUNT, null);
+            } else {
+                plotData = getCoarseGrainedPlotData(DcacheReadsDaily.class,
+                                                    timeFrame);
+                histogram.setData(plotData, DcacheReadsDaily.COUNT, null);
             }
         }
         return histogram;
@@ -209,7 +187,7 @@ public final class JaidaTimeFrameHistogramFactory extends
 
     @Override
     public ITimeFrameHistogram createHsmBytesHistogram(TimeFrame timeFrame,
-                    boolean write) {
+                    boolean write) throws BillingQueryException {
         String title = write ? getProperty(ITimeFramePlot.LABEL_HSM_WR)
                         : getProperty(ITimeFramePlot.LABEL_HSM_RD);
         ITimeFrameHistogram histogram = new JaidaTimeFrameHistogram(factory,
@@ -220,31 +198,23 @@ public final class JaidaTimeFrameHistogramFactory extends
         Collection<IPlotData> plotData = null;
         if (BinType.HOUR == timeFrame.getTimebin()) {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_GBYTES_HR));
-            try {
-                if (write) {
-                    plotData = getViewData(HSMWritesHourly.class);
-                    histogram.setData(plotData, HSMWritesHourly.SIZE, GB);
-                } else {
-                    plotData = getViewData(HSMReadsHourly.class);
-                    histogram.setData(plotData, HSMReadsHourly.SIZE, GB);
-                }
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
+            if (write) {
+                plotData = getViewData(HSMWritesHourly.class);
+                histogram.setData(plotData, HSMWritesHourly.SIZE, GB);
+            } else {
+                plotData = getViewData(HSMReadsHourly.class);
+                histogram.setData(plotData, HSMReadsHourly.SIZE, GB);
             }
         } else {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_GBYTES_DY));
-            try {
-                if (write) {
-                    plotData = getCoarseGrainedPlotData(HSMWritesDaily.class,
-                                    timeFrame);
-                    histogram.setData(plotData, HSMWritesDaily.SIZE, GB);
-                } else {
-                    plotData = getCoarseGrainedPlotData(HSMReadsDaily.class,
-                                    timeFrame);
-                    histogram.setData(plotData, HSMReadsDaily.SIZE, GB);
-                }
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
+            if (write) {
+                plotData = getCoarseGrainedPlotData(HSMWritesDaily.class,
+                                                    timeFrame);
+                histogram.setData(plotData, HSMWritesDaily.SIZE, GB);
+            } else {
+                plotData = getCoarseGrainedPlotData(HSMReadsDaily.class,
+                                                    timeFrame);
+                histogram.setData(plotData, HSMReadsDaily.SIZE, GB);
             }
         }
         return histogram;
@@ -252,7 +222,7 @@ public final class JaidaTimeFrameHistogramFactory extends
 
     @Override
     public ITimeFrameHistogram createHsmTransfersHistogram(TimeFrame timeFrame,
-                    boolean write) throws Throwable {
+                    boolean write) throws BillingQueryException {
         String title = write ? getProperty(ITimeFramePlot.LABEL_HSM_WR)
                         : getProperty(ITimeFramePlot.LABEL_HSM_RD);
         ITimeFrameHistogram histogram = new JaidaTimeFrameHistogram(factory,
@@ -263,31 +233,23 @@ public final class JaidaTimeFrameHistogramFactory extends
         Collection<IPlotData> plotData = null;
         if (BinType.HOUR == timeFrame.getTimebin()) {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_TRANSF_HR));
-            try {
-                if (write) {
-                    plotData = getViewData(HSMWritesHourly.class);
-                    histogram.setData(plotData, HSMWritesHourly.COUNT, null);
-                } else {
-                    plotData = getViewData(HSMReadsHourly.class);
-                    histogram.setData(plotData, HSMReadsHourly.COUNT, null);
-                }
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
+            if (write) {
+                plotData = getViewData(HSMWritesHourly.class);
+                histogram.setData(plotData, HSMWritesHourly.COUNT, null);
+            } else {
+                plotData = getViewData(HSMReadsHourly.class);
+                histogram.setData(plotData, HSMReadsHourly.COUNT, null);
             }
         } else {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_TRANSF_DY));
-            try {
-                if (write) {
-                    plotData = getCoarseGrainedPlotData(HSMWritesDaily.class,
-                                    timeFrame);
-                    histogram.setData(plotData, HSMWritesDaily.COUNT, null);
-                } else {
-                    plotData = getCoarseGrainedPlotData(HSMReadsDaily.class,
-                                    timeFrame);
-                    histogram.setData(plotData, HSMReadsDaily.COUNT, null);
-                }
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
+            if (write) {
+                plotData = getCoarseGrainedPlotData(HSMWritesDaily.class,
+                                                    timeFrame);
+                histogram.setData(plotData, HSMWritesDaily.COUNT, null);
+            } else {
+                plotData = getCoarseGrainedPlotData(HSMReadsDaily.class,
+                                                    timeFrame);
+                histogram.setData(plotData, HSMReadsDaily.COUNT, null);
             }
         }
         return histogram;
@@ -295,21 +257,13 @@ public final class JaidaTimeFrameHistogramFactory extends
 
     @Override
     public ITimeFrameHistogram[] createDcConnectTimeHistograms(
-                    TimeFrame timeFrame) throws Throwable {
+                    TimeFrame timeFrame) throws BillingQueryException {
         Collection<IPlotData> plotData = null;
         if (BinType.HOUR == timeFrame.getTimebin()) {
-            try {
-                plotData = getViewData(DcacheTimeHourly.class);
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
-            }
+            plotData = getViewData(DcacheTimeHourly.class);
         } else {
-            try {
-                plotData = getCoarseGrainedPlotData(DcacheTimeDaily.class,
-                                timeFrame);
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
-            }
+            plotData = getCoarseGrainedPlotData(DcacheTimeDaily.class,
+                            timeFrame);
         }
 
         String[] title = new String[] { getProperty(ITimeFramePlot.LABEL_MIN),
@@ -337,7 +291,8 @@ public final class JaidaTimeFrameHistogramFactory extends
     }
 
     @Override
-    public ITimeFrameHistogram createCostHistogram(TimeFrame timeFrame) {
+    public ITimeFrameHistogram createCostHistogram(TimeFrame timeFrame)
+                    throws BillingQueryException {
         ITimeFrameHistogram histogram = new JaidaTimeFrameHistogram(factory,
                         timeFrame, getProperty(ITimeFramePlot.LABEL_COST));
         histogram.setXLabel(getProperty(ITimeFramePlot.LABEL_X_AXIS));
@@ -348,41 +303,25 @@ public final class JaidaTimeFrameHistogramFactory extends
         Collection<IPlotData> plotData = null;
         if (BinType.HOUR == timeFrame.getTimebin()) {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_COST_HR));
-            try {
-                /*
-                 * COST HAS NEVER BEEN ACTIVATED AND IS REMOVED IN 2.4+
-                 */
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
-            }
+            /*
+             * COST HAS NEVER BEEN ACTIVATED AND IS REMOVED IN 2.4+
+             */
         } else {
             histogram.setYLabel(getProperty(ITimeFramePlot.LABEL_Y_AXIS_COST_DY));
-            try {
-                plotData = getCoarseGrainedPlotData(CostDaily.class, timeFrame);
-                histogram.setData(plotData, CostDaily.TOTAL_COST, null);
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
-            }
+            plotData = getCoarseGrainedPlotData(CostDaily.class, timeFrame);
+            histogram.setData(plotData, CostDaily.TOTAL_COST, null);
         }
         return histogram;
     }
 
     @Override
     public ITimeFrameHistogram[] createHitHistograms(TimeFrame timeFrame)
-                    throws Throwable {
+                    throws BillingQueryException {
         Collection<IPlotData> plotData = null;
         if (BinType.HOUR == timeFrame.getTimebin()) {
-            try {
-                plotData = getHourlyAggregateForHits(timeFrame);
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
-            }
+            plotData = getHourlyAggregateForHits(timeFrame);
         } else {
-            try {
-                plotData = getCoarseGrainedPlotData(HitsDaily.class, timeFrame);
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
-            }
+            plotData = getCoarseGrainedPlotData(HitsDaily.class, timeFrame);
         }
         ITimeFrameHistogram[] histogram = new ITimeFrameHistogram[2];
         histogram[0] = new JaidaTimeFrameHistogram(factory, timeFrame,
@@ -430,8 +369,7 @@ public final class JaidaTimeFrameHistogramFactory extends
 
     private Collection<IPlotData> getHourlyAggregateForHits(TimeFrame timeFrame)
                     throws BillingQueryException {
-        Map<String, HourlyHitData> hourlyAggregate
-            = new TreeMap<String, HourlyHitData>();
+        Map<String, HourlyHitData> hourlyAggregate = new TreeMap<String, HourlyHitData>();
         Collection<IPlotData> plotData = getViewData(HitsHourly.class);
         for (IPlotData d : plotData) {
             Date date = normalizeForHour(d.timestamp());

--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/jaida/JaidaTimeFramePlot.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/jaida/JaidaTimeFramePlot.java
@@ -17,9 +17,6 @@ import org.dcache.services.billing.plots.util.AbstractTimeFramePlot;
 import org.dcache.services.billing.plots.util.ITimeFrameHistogram;
 import org.dcache.services.billing.plots.util.PlotGridPosition;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
-
 /**
  * Wraps IPlotterFactory and IPlotter.
  *
@@ -28,7 +25,6 @@ import org.slf4j.Logger;
  * @author arossi
  */
 public final class JaidaTimeFramePlot extends AbstractTimeFramePlot {
-    private static final Logger _log = LoggerFactory.getLogger(JaidaTimeFramePlot.class);
     private final IPlotterFactory factory;
     private final IPlotter plotter;
     private List<IPlotterStyle> styles;
@@ -59,7 +55,7 @@ public final class JaidaTimeFramePlot extends AbstractTimeFramePlot {
      * @see org.dcache.billing.statistics.util.ITimeFramePlot#plot()
      */
     @Override
-    public void plot() {
+    public void plot() throws IOException {
         setHistogramStyles();
         plotter.createRegions(rows, cols);
         int region = 0;
@@ -76,9 +72,8 @@ public final class JaidaTimeFramePlot extends AbstractTimeFramePlot {
                     if (region < titles.length) {
                         plotter.region(region).setTitle(titles[region]);
                     }
-                    plotter.region(region)
-                    .plot(((JaidaTimeFrameHistogram) h)
-                                    .getHistogram(),
+                    plotter.region(region).plot(
+                                    ((JaidaTimeFrameHistogram) h).getHistogram(),
                                     style);
                 }
                 region++;
@@ -95,14 +90,10 @@ public final class JaidaTimeFramePlot extends AbstractTimeFramePlot {
     /**
      * create image file
      */
-    private void exportPlot() {
+    private void exportPlot() throws IOException {
         File path = new File(exportSubdir, name + extension);
-        try {
-            PlotterUtilities.writeToFile(plotter, path.getAbsolutePath(),
-                            imageType, properties);
-        } catch (IOException e) {
-            _log.error("Cannot write billing plot: " + e.getMessage());
-        }
+        PlotterUtilities.writeToFile(plotter, path.getAbsolutePath(),
+                        imageType, properties);
     }
 
     /**
@@ -132,13 +123,11 @@ public final class JaidaTimeFramePlot extends AbstractTimeFramePlot {
      * @param style
      */
     private void normalizeTitleStyle(IPlotterStyle style) {
-        style.titleStyle()
-        .textStyle()
-        .setFontSize(Integer.parseInt(properties
-                        .getProperty(PLOT_TITLE_SIZE)));
+        style.titleStyle().textStyle().setFontSize(
+                        Integer.parseInt(properties.getProperty(PLOT_TITLE_SIZE)));
         style.titleStyle().textStyle().setBold(true);
-        style.titleStyle().textStyle()
-        .setColor(properties.getProperty(PLOT_TITLE_COLOR));
+        style.titleStyle().textStyle().setColor(
+                        properties.getProperty(PLOT_TITLE_COLOR));
         style.titleStyle().textStyle().setVisible(true);
     }
 
@@ -156,18 +145,13 @@ public final class JaidaTimeFramePlot extends AbstractTimeFramePlot {
         histogramStyle.dataStyle().showInStatisticsBox(false);
 
         histogramStyle.dataStyle().outlineStyle().setVisible(true);
-        histogramStyle.dataStyle().outlineStyle()
-        .setColor(histogram.getColor());
-        histogramStyle.dataStyle()
-        .outlineStyle()
-        .setThickness(Integer.parseInt(properties
-                        .getProperty(CURVE_THICKNESS)));
-        histogramStyle.dataStyle().markerStyle()
-        .setShape(properties.getProperty(MARKER_SHAPE));
-        histogramStyle.dataStyle()
-        .markerStyle()
-        .setSize(Integer.parseInt(properties
-                        .getProperty(MARKER_SIZE)));
+        histogramStyle.dataStyle().outlineStyle().setColor(histogram.getColor());
+        histogramStyle.dataStyle().outlineStyle().setThickness(
+                        Integer.parseInt(properties.getProperty(CURVE_THICKNESS)));
+        histogramStyle.dataStyle().markerStyle().setShape(
+                        properties.getProperty(MARKER_SHAPE));
+        histogramStyle.dataStyle().markerStyle().setSize(
+                        Integer.parseInt(properties.getProperty(MARKER_SIZE)));
         histogramStyle.dataStyle().markerStyle().setColor(histogram.getColor());
         histogramStyle.dataStyle().markerStyle().setVisible(true);
     }
@@ -184,22 +168,16 @@ public final class JaidaTimeFramePlot extends AbstractTimeFramePlot {
                         properties.getProperty(X_AXIS_TYPE));
         histogramStyle.xAxisStyle().setLabel(histogram.getXLabel());
         histogramStyle.xAxisStyle().labelStyle().setBold(true);
-        histogramStyle.xAxisStyle()
-        .labelStyle()
-        .setFontSize(Integer.parseInt(properties
-                        .getProperty(X_AXIS_SIZE)));
+        histogramStyle.xAxisStyle().labelStyle().setFontSize(
+                        Integer.parseInt(properties.getProperty(X_AXIS_SIZE)));
         histogramStyle.xAxisStyle().labelStyle().setItalic(true);
-        histogramStyle.xAxisStyle().labelStyle()
-        .setColor(properties.getProperty(X_AXIS_LABEL_COLOR));
-        histogramStyle.xAxisStyle()
-        .tickLabelStyle()
-        .setFontSize(Integer.parseInt(properties
-                        .getProperty(X_AXIS_TICK_SIZE)));
+        histogramStyle.xAxisStyle().labelStyle().setColor(
+                        properties.getProperty(X_AXIS_LABEL_COLOR));
+        histogramStyle.xAxisStyle().tickLabelStyle().setFontSize(
+                        Integer.parseInt(properties.getProperty(X_AXIS_TICK_SIZE)));
         histogramStyle.xAxisStyle().tickLabelStyle().setBold(true);
-        histogramStyle.xAxisStyle()
-        .tickLabelStyle()
-        .setColor(properties
-                        .getProperty(X_AXIS_TICK_LABEL_COLOR));
+        histogramStyle.xAxisStyle().tickLabelStyle().setColor(
+                        properties.getProperty(X_AXIS_TICK_LABEL_COLOR));
     }
 
     /**
@@ -212,22 +190,16 @@ public final class JaidaTimeFramePlot extends AbstractTimeFramePlot {
                     ITimeFrameHistogram histogram) {
         histogramStyle.yAxisStyle().setLabel(histogram.getYLabel());
         histogramStyle.yAxisStyle().labelStyle().setBold(true);
-        histogramStyle.yAxisStyle()
-        .labelStyle()
-        .setFontSize(Integer.parseInt(properties
-                        .getProperty(Y_AXIS_SIZE)));
+        histogramStyle.yAxisStyle().labelStyle().setFontSize(
+                        Integer.parseInt(properties.getProperty(Y_AXIS_SIZE)));
         histogramStyle.yAxisStyle().labelStyle().setItalic(true);
-        histogramStyle.yAxisStyle().labelStyle()
-        .setColor(properties.getProperty(Y_AXIS_LABEL_COLOR));
-        histogramStyle.yAxisStyle()
-        .tickLabelStyle()
-        .setFontSize(Integer.parseInt(properties
-                        .getProperty(Y_AXIS_TICK_SIZE)));
+        histogramStyle.yAxisStyle().labelStyle().setColor(
+                        properties.getProperty(Y_AXIS_LABEL_COLOR));
+        histogramStyle.yAxisStyle().tickLabelStyle().setFontSize(
+                        Integer.parseInt(properties.getProperty(Y_AXIS_TICK_SIZE)));
         histogramStyle.yAxisStyle().tickLabelStyle().setBold(true);
-        histogramStyle.yAxisStyle()
-        .tickLabelStyle()
-        .setColor(properties
-                        .getProperty(Y_AXIS_TICK_LABEL_COLOR));
+        histogramStyle.yAxisStyle().tickLabelStyle().setColor(
+                        properties.getProperty(Y_AXIS_TICK_LABEL_COLOR));
         histogramStyle.yAxisStyle().setScaling(histogram.getScaling());
         histogramStyle.yAxisStyle().setParameter("allowZeroSuppression",
                         properties.getProperty(Y_AXIS_ALLOW_ZERO_SUPPRESSION));

--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/AbstractTimeFrameHistogramFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/AbstractTimeFrameHistogramFactory.java
@@ -18,7 +18,7 @@ import org.dcache.services.billing.plots.exceptions.TimeFrameFactoryInitializati
  * @author arossi
  */
 public abstract class AbstractTimeFrameHistogramFactory implements
-ITimeFrameHistogramFactory {
+                ITimeFrameHistogramFactory {
 
     protected IBillingInfoAccess access;
 
@@ -29,14 +29,14 @@ ITimeFrameHistogramFactory {
 
     protected <T extends IPlotData> Collection<IPlotData> getCoarseGrainedPlotData(
                     Class<T> clzz, TimeFrame timeFrame)
-                                    throws BillingQueryException {
+                    throws BillingQueryException {
         return getPlotData(clzz, "date >= date1 && date <= date2",
                         "java.util.Date date1, java.util.Date date2",
                         timeFrame.getLow(), timeFrame.getHigh());
     }
 
-    protected <T extends IPlotData> Collection<IPlotData> getViewData(Class<T> clzz)
-                                    throws BillingQueryException {
+    protected <T extends IPlotData> Collection<IPlotData> getViewData(
+                    Class<T> clzz) throws BillingQueryException {
         Collection<T> c = (Collection<T>) access.get(clzz);
         Collection<IPlotData> plotData = new ArrayList<IPlotData>();
         plotData.addAll(c);

--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/ITimeFrameHistogram.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/ITimeFrameHistogram.java
@@ -21,10 +21,8 @@ public interface ITimeFrameHistogram {
      *            the Y-axis data to be plotted.
      * @param dfactor
      *            (optional) scaling factor for Y-axis data.
-     * @throws Throwable
      */
-    void setData(Collection<IPlotData> data, String field, Double dfactor)
-                    throws Throwable;
+    void setData(Collection<IPlotData> data, String field, Double dfactor);
 
     /**
      * @return the TimeFrame

--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/ITimeFrameHistogramFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/ITimeFrameHistogramFactory.java
@@ -3,6 +3,7 @@ package org.dcache.services.billing.plots.util;
 import java.util.Properties;
 
 import org.dcache.services.billing.db.IBillingInfoAccess;
+import org.dcache.services.billing.db.exceptions.BillingQueryException;
 import org.dcache.services.billing.plots.exceptions.TimeFrameFactoryInitializationException;
 
 /**
@@ -62,7 +63,7 @@ public interface ITimeFrameHistogramFactory {
      * @return histogram
      */
     ITimeFrameHistogram createDcBytesHistogram(TimeFrame timeFrame,
-                    boolean write) throws Throwable;
+                    boolean write) throws BillingQueryException;
 
     /**
      * Histogram for HSM system stage/store (size).
@@ -73,7 +74,7 @@ public interface ITimeFrameHistogramFactory {
      * @return histogram
      */
     ITimeFrameHistogram createHsmBytesHistogram(TimeFrame timeFrame,
-                    boolean write) throws Throwable;
+                    boolean write) throws BillingQueryException;
 
     /**
      * Histogram for DCache number of read/write operations.
@@ -83,7 +84,7 @@ public interface ITimeFrameHistogramFactory {
      * @return histogram
      */
     ITimeFrameHistogram createDcTransfersHistogram(TimeFrame timeFrame,
-                    boolean write) throws Throwable;
+                    boolean write) throws BillingQueryException;
 
     /**
      * Histogram for HSM number of stage/store operations.
@@ -94,7 +95,7 @@ public interface ITimeFrameHistogramFactory {
      * @return histogram
      */
     ITimeFrameHistogram createHsmTransfersHistogram(TimeFrame timeFrame,
-                    boolean write) throws Throwable;
+                    boolean write) throws BillingQueryException;
 
     /**
      * Histograms for connection time on DCache operations.
@@ -103,7 +104,7 @@ public interface ITimeFrameHistogramFactory {
      * @return triple histogram array (minimum, maximum, average)
      */
     public ITimeFrameHistogram[] createDcConnectTimeHistograms(
-                    TimeFrame timeFrame) throws Throwable;
+                    TimeFrame timeFrame) throws BillingQueryException;
 
     /**
      * Histogram for pool cost.
@@ -112,7 +113,7 @@ public interface ITimeFrameHistogramFactory {
      * @return histogram
      */
     public ITimeFrameHistogram createCostHistogram(TimeFrame timeFrame)
-                    throws Throwable;
+                    throws BillingQueryException;
 
     /**
      * Histogram for cache hits/misses.
@@ -121,5 +122,5 @@ public interface ITimeFrameHistogramFactory {
      * @return histogram pair (cached, notcached)
      */
     ITimeFrameHistogram[] createHitHistograms(TimeFrame timeFrame)
-                    throws Throwable;
+                    throws BillingQueryException;
 }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/ITimeFramePlot.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/ITimeFramePlot.java
@@ -1,5 +1,6 @@
 package org.dcache.services.billing.plots.util;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -158,5 +159,5 @@ public interface ITimeFramePlot {
     /**
      * implementation-specific callout
      */
-    void plot();
+    void plot() throws IOException;
 }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/TimeFrame.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/TimeFrame.java
@@ -80,6 +80,10 @@ public class TimeFrame {
         timeframe = Type.DAY;
     }
 
+    public String toString() {
+        return timeframe + "-" + timebin;
+    }
+
     /**
      * computes boundaries, number of bins and bin width.
      */

--- a/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/TimeFramePlotFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/plots/util/TimeFramePlotFactory.java
@@ -42,7 +42,7 @@ public class TimeFramePlotFactory {
      * @return implementation factory
      * @throws Throwable
      */
-    public ITimeFrameHistogramFactory create(String className) throws Throwable {
+    public ITimeFrameHistogramFactory create(String className) throws Exception {
         return create(className, null);
     }
 
@@ -55,7 +55,7 @@ public class TimeFramePlotFactory {
      * @throws Throwable
      */
     public ITimeFrameHistogramFactory create(String className,
-                    Properties properties) throws Throwable {
+                    Properties properties) throws Exception {
         ClassLoader classLoader = Thread.currentThread()
                         .getContextClassLoader();
         Class clzz = Class.forName(className, true, classLoader);


### PR DESCRIPTION
module: dcache (billing plots)

In version 2.2, the plotting code is still from the original version of billing plots (2011), and thus has a number of places which were catching Throwable, or where duplicate logging was implemented.  I had promised to fix these but never got around to it.

This patch changes the Throwable to Exception or something more specific where possible, and eliminates the duplicate logging.  It also eliminates the stack trace at the error level.

Note that DataNucleus unfortunately will continue to log the entire stack trace for errors at the query level.  This is seen from the code, for instance, to

 protected Object performExecuteTask(final Object... args) {
  ...
        catch (ExecutionException e)
        {
            // Exception thrown executing the query
            tasks.remove(Thread.currentThread());
            NucleusLogger.QUERY.error(LOCALISER.msg("021021", toString()), e);
            throw (NucleusException)e.getCause();
        }
 }

where 021021 is the externalized local message "An error occurred when executing query {0}".  This is what we observe still in our logs when there is an SQL error.

I have also decided it makes sense to exit from the plotting loop in this case.

Some of this behavior was modified when I rewrote this code for 2.6/2.7.  I will nevertheless still check that the error handling conforms there with the current changes.

Testing done:

After application of patches, noise level in log on SQL errors is greatly reduced, and plotting is shut off on an error.

Target: 2.2
Patch: http://rb.dcache.org/r/5666
Require-notes: yes
Require-book: no
Acked-by: Gerd

RELEASE NOTES:

The log for the domain where billing plots are generated has been made less verbose at the error level.  If there is a critical/severe (i.e., SQL) error encountered, plotting will stop and will only restart if the domain is restarted.
