### PR TITLE
(2.6) dcache-webadmin (alarms): provide option for absence of alarms dat...

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/server/LogEntryServerWrapper.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/server/LogEntryServerWrapper.java
@@ -65,18 +65,19 @@ COPYRIGHT STATUS:
  */
 package org.dcache.alarms.server;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.io.File;
-
-import org.dcache.cells.UniversalSpringCell;
-import org.slf4j.LoggerFactory;
-
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.classic.net.SimpleSocketServer;
 import ch.qos.logback.core.joran.spi.JoranException;
+import com.google.common.base.Strings;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import org.dcache.cells.UniversalSpringCell;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Simple POJO wrapper around {@link SimpleSocketServer} to be run inside a
@@ -144,10 +145,18 @@ public class LogEntryServerWrapper {
     }
 
     public void shutDown() {
-        server.close();
+        if (server != null) {
+            server.close();
+        }
     }
 
+
     public void startUp() throws JoranException {
+        if (Strings.isNullOrEmpty(url)) {
+            LoggerFactory.getLogger("root")
+                .warn("alarms database type is OFF; server will not be started");
+            return;
+        }
         checkNotNull(configFile);
         checkNotNull(baseDir);
         File f = new File(baseDir);

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/impl/DataNucleusAlarmStore.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/impl/DataNucleusAlarmStore.java
@@ -103,6 +103,7 @@ public class DataNucleusAlarmStore implements ILogEntryDAO, Runnable {
 
     private final Properties properties;
     private final File xml;
+    private final boolean active;
     private final boolean usesXml;
 
     /**
@@ -135,17 +136,24 @@ public class DataNucleusAlarmStore implements ILogEntryDAO, Runnable {
         properties.put("javax.jdo.PersistenceManagerFactoryClass",
                         "org.datanucleus.api.jdo.JDOPersistenceManagerFactory");
 
-        this.usesXml = properties.getProperty("datanucleus.ConnectionURL")
-                                 .startsWith("xml:");
+        String url = properties.getProperty("datanucleus.ConnectionURL");
 
-        xml = Strings.isNullOrEmpty(xmlPath) ? null : new File(xmlPath);
+        if (Strings.isNullOrEmpty(url)) {
+           active = false;
+           xml = null;
+           usesXml = false;
+        } else {
+           active = true;
 
-        checkArgument(!(usesXml && xml == null));
+           usesXml = url.startsWith("xml:");
+           xml = Strings.isNullOrEmpty(xmlPath) ? null : new File(xmlPath);
+           checkArgument(!(usesXml && xml == null));
 
-        if (enableCleaner) {
-            checkArgument(cleanerSleepInterval > 0);
-            checkArgument(cleanerDeleteThreshold > 0);
-            cleanerThread = new Thread(this, "alarm-cleanup-daemon");
+           if (enableCleaner) {
+               checkArgument(cleanerSleepInterval > 0);
+               checkArgument(cleanerDeleteThreshold > 0);
+               cleanerThread = new Thread(this, "alarm-cleanup-daemon");
+           }
         }
     }
 
@@ -183,6 +191,10 @@ public class DataNucleusAlarmStore implements ILogEntryDAO, Runnable {
     }
 
     public void initialize() {
+        if (!active) {
+            return;
+        }
+
         if (cleanerThread != null && !cleanerThread.isAlive()) {
             cleanerThread.start();
         }
@@ -190,7 +202,7 @@ public class DataNucleusAlarmStore implements ILogEntryDAO, Runnable {
 
     public boolean isConnected() {
         try {
-            return (getManager() != null);
+            return active && (getManager() != null);
         } catch (DAOException t) {
             return false;
         }
@@ -329,7 +341,7 @@ public class DataNucleusAlarmStore implements ILogEntryDAO, Runnable {
     }
 
     private synchronized boolean isRunning() {
-        return cleanerThread != null && !cleanerThread.isInterrupted();
+        return active && cleanerThread != null && !cleanerThread.isInterrupted();
     }
 
     /**

--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/ErrorPanel.properties
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/ErrorPanel.properties
@@ -1,2 +1,2 @@
-errorMessage=The datastore for alarms and warnings has been disabled due to \
-             configuration issues; please check the log file for errors.
+errorMessage=The datastore for alarms and warnings has been disabled \
+             (see the configuration alarm properties).

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -39,7 +39,7 @@ alarms.definitions.path=${alarms.dir}/alarm-definitions.xml
 
 #  ---- Defines what kind of database (currently either XML or Postgres)
 #
-(one-of?xml|rdbms)alarms.store.db.type=rdbms
+(one-of?off|xml|rdbms)alarms.store.db.type=off
 
 # ---- Liquibase master changelog
 #
@@ -90,5 +90,6 @@ alarms.store.db.properties=${alarms.dir}/datanucleus.properties
 #
 alarms.store.db.url=${url-when-type-is-${alarms.store.db.type}}
 
+(immutable)url-when-type-is-off=
 (immutable)url-when-type-is-xml=xml:file:${alarms.store.path}
 (immutable)url-when-type-is-rdbms=jdbc:${alarms.store.db.rdbms}://${alarms.store.db.host}/alarms


### PR DESCRIPTION
...abase

module: dcache-webadmin, dcache (alarms)

The ticket reported an SQL stack trace error in the httpd log under the condition that they (a) are not running an alarmserver, and (b) have left the default settings for alarms alone.

The immediate fix was for them to set alarms.store.db.type=xml, but it makes sense for there to be an "off" option on this property as well.

This patch adds this option and makes it the default.  This complements the change of the remote log level default to off as well.

Testing done:

The following configurations were checked:
1.  type = off, alarmserver started
   (a) alarmserver reports: 21 Jun 2013 09:29:53 (alarms) [] alarms database type is OFF; server will not be started
   (b) httpd reports: nothing
   (c) page: The datastore for alarms and warnings has been disabled (see the configuration alarm properties).
2.  type = xml, no store.xml, alarmserver not started
   (b) httpd reports: nothing
   (c) page: The datastore for alarms and warnings has been disabled (see the configuration alarm properties).
3.  type = xml, alarmserver started
   everything is sane
4.  type = xml, with store.xml, alarmserver not started
   (b) httpd reports: nothing
   (c) page: query returns only what is currently in db.
5.  type = rdbms, no alarms db; alarmserver not started
   (b) httpd reports the underlying DataNucleus stack traces for "alarms database does not exist"
   (c) page: reports Internal error
   I would argue this is the correct behavior.  It is a misconfiguration.
6.  type = rdbms, no alarms db; alarmserver started
   (a) alarmserver reports Failed to create bean 'liquibase' : FATAL: database "alarms" does not exist from ac_create_$_2_3
       stops and tries to restart
   (b)/(c) same as above
   Again, this is correct behavior.
7.  type = rdbms, alarmserver not started
   (b) httpd reports: nothing
   (c) page: query returns only what is currently in db.
8.  type = rdbms, alarmserver started
   everything is sane

Target: master
Patch: http://rb.dcache.org/r/5668
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7887
Request: 2.6
Require-notes: yes
Require-book: yes
Acked-by: Gerd

RELEASE NOTES:
BOOK:

The options for alarms.store.db.type are not off,xml,rdbms, with off being the default.  If no alarms service is desired, the off option will prevent the web page from trying to establish a connection the the database.
