### PR TITLE
pnfsmanager: Addresses compatibility issue with pre 2.6 pools

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsGetStorageInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsGetStorageInfoMessage.java
@@ -46,6 +46,11 @@ public class PnfsGetStorageInfoMessage extends PnfsGetFileMetaDataMessage {
     @Override
     public void setFileAttributes(FileAttributes fileAttributes)
     {
+        // For compatibility with pre 2.6 pools: 'rh restore' issues a PnfsGetStorageInfoMessage
+        // and expects the size to be part of the storage info.
+        if (fileAttributes.isDefined(STORAGEINFO) && fileAttributes.isDefined(SIZE)) {
+            fileAttributes.getStorageInfo().setLegacySize(fileAttributes.getSize());
+        }
         super.setFileAttributes(fileAttributes);
     }
 


### PR DESCRIPTION
Address a compatibility issue that prevents the use of the 'rh restore' command
in pre 2.6 pools when used with a 2.6 pnfsmanager.

Target: 2.6
Require-notes: yes
Require-book: no
Patch: http://rb.dcache.org/r/5679/
Acked-by: Albert Rossi arossi@fnal.gov
