### PR TITLE
cells: Fix login manager login limit interpretation

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -826,7 +826,7 @@ public void cleanUp(){
                          currentChildHash = _childCount;
                      }
                      _log.info("New connection : " + currentChildHash);
-                     if ((_maxLogin > 0) && (currentChildHash > _maxLogin)) {
+                     if ((_maxLogin > -1) && (currentChildHash >= _maxLogin)) {
                          _connectionDeniedCounter++;
                          _log.warn("Connection denied " + currentChildHash + " > " + _maxLogin);
                          _logSocketIO.warn("number of allowed logins exceeded.");


### PR DESCRIPTION
Addresses an issue in FTP and DCAP doors in which the login limit
was would allow n + 1 logins when n was given as a limit. Also
addresses an issue in which a limit of zero was considered to
be no limit at all. The correct value for disabling the limit is
-1.

Target: trunk
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Christian Bernardt christian.bernardt@desy.de
Patch: http://rb.dcache.org/r/5676/
(cherry picked from commit b83bcd5a62ca84fbef1ff5dcc0e7a8bcb9eeaff3)
