### PR TITLE
info-provider: Escape percent sign in entity values

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/boot/XmlEntityLayoutPrinter.java
+++ b/modules/dcache/src/main/java/org/dcache/boot/XmlEntityLayoutPrinter.java
@@ -138,6 +138,6 @@ public class XmlEntityLayoutPrinter implements LayoutPrinter {
 
     private static String entityValueFrom( String s)
     {
-        return s.replace("&","&amp;").replace("\"", "&quot;").replace("'", "&apos;").replace("<", "&lt;");
+        return s.replace("&","&amp;").replace("\"", "&quot;").replace("'", "&apos;").replace("<", "&lt;").replace("%", "&#37;");
     }
 }


### PR DESCRIPTION
Percent signs are the only characters not allowed literally
in entity values, thus these must be escaped when exporting
the dCache configuration to an XML DTD.

The patch addresses the problem that info-provider is broken
by a recent patch adding logback formatting strings as
configuration values.

Target: trunk
Request: 2.6
Require-book: no
Require-notes: yes
Acked-by: Christian Bernardt christian.bernardt@desy.de
Patch: http://rb.dcache.org/r/5673/
(cherry picked from commit 9b4a81ca5f627227e6fba4b66b671ffed87916b1)
