### PR TITLE
poolmanager, doors: Don't retry stage requests on the same pool

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -734,6 +734,14 @@ public class RequestContainerV5
         private   String     _stageCandidateHost;
 
         /**
+         * The name of the pool used for staging.
+         *
+         * Serves a critical role when retrying staging to avoid that
+         * the same pool is chosen twice in a row.
+         */
+        private   String     _stageCandidatePool;
+
+        /**
          * The destination of a pool to pool transfer. Set by
          * askForPoolToPool() when it returns RT_FOUND.
          */
@@ -912,6 +920,7 @@ public class RequestContainerV5
 
            _retryCounter = request.getContext().getRetryCounter();
            _stageCandidateHost = request.getContext().getPreviousStageHost();
+           _stageCandidatePool = request.getContext().getPreviousStagePool();
 
            if( request instanceof PoolMgrReplicateFileMsg ){
               _enforceP2P            = true ;
@@ -1138,7 +1147,7 @@ public class RequestContainerV5
                 CellMessage m =  messages.next();
                 PoolMgrSelectReadPoolMsg rpm =
                     (PoolMgrSelectReadPoolMsg) m.getMessageObject();
-                rpm.setContext(_retryCounter + 1, _stageCandidateHost);
+                rpm.setContext(_retryCounter + 1, _stageCandidateHost, _stageCandidatePool);
                 if (_currentRc == 0) {
                     rpm.setPoolName(_poolCandidate.getName());
                     rpm.setPoolAddress(_poolCandidate.getAddress());
@@ -2108,9 +2117,9 @@ public class RequestContainerV5
         {
             try {
                 PoolInfo pool =
-                    _poolSelector.selectStagePool((_poolCandidate == null) ? null : _poolCandidate.getName(),
-                                                      _stageCandidateHost);
+                    _poolSelector.selectStagePool(_stageCandidatePool, _stageCandidateHost);
                 _poolCandidate = pool;
+                _stageCandidatePool = pool.getName();
                 _stageCandidateHost = pool.getHostName();
 
                 _log.info("[staging] poolCandidate -> {}", _poolCandidate);
@@ -2124,6 +2133,7 @@ public class RequestContainerV5
             } catch (CostException e) {
                if (e.getPool() != null) {
                    _poolCandidate = e.getPool();
+                   _stageCandidatePool = e.getPool().getName();
                    _stageCandidateHost = e.getPool().getHostName();
                    return RT_FOUND;
                }

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
@@ -90,9 +90,9 @@ public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg
         _context = context;
     }
 
-    public void setContext(int retryCounter, String previousStageHost)
+    public void setContext(int retryCounter, String previousStageHost, String previousStagePool)
     {
-        setContext(new Context(retryCounter, previousStageHost));
+        setContext(new Context(retryCounter, previousStageHost, previousStagePool));
     }
 
     /**
@@ -105,17 +105,20 @@ public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg
         private static final long serialVersionUID = -1896293244725567276L;
         private final int _retryCounter;
         private final String _previousStageHost;
+        private final String _previousStagePool;
 
         public Context()
         {
             _retryCounter = 0;
             _previousStageHost = null;
+            _previousStagePool = null;
         }
 
-        public Context(int retryCounter, String previousStageHost)
+        public Context(int retryCounter, String previousStageHost, String previousStagePool)
         {
             _retryCounter = retryCounter;
             _previousStageHost = previousStageHost;
+            _previousStagePool = previousStagePool;
         }
 
         public int getRetryCounter()
@@ -126,6 +129,11 @@ public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg
         public String getPreviousStageHost()
         {
             return _previousStageHost;
+        }
+
+        public String getPreviousStagePool()
+        {
+            return _previousStagePool;
         }
     }
 }


### PR DESCRIPTION
Addresses a regression introduced between 1.9.12 and 2.2. The regression
means that poolmanager would not remember the previously tried stage pool
and thus could select the same pool twice in a row when retrying failed
stage requests.

The patches addresses this problem. To be effective, both pool manager
and doors have to be updated, although the patch does not break any
version compatibility.

Target: trunk
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi arossi@fnal.gov
Patch: http://rb.dcache.org/r/5678/
(cherry picked from commit 4174110f6d6083908a8937e42e1c4969596e53ac)
