### PR TITLE
srm: Implement SRM_FILE_BUSY response

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/request/CopyFileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/CopyFileRequest.java
@@ -1063,7 +1063,13 @@ public final class CopyFileRequest extends FileRequest {
 		}
 	}
 
-	public void remoteFileRequestDone(URI SURL,String remoteRequestId,String remoteFileId) {
+    @Override
+    public boolean isTouchingSurl(URI surl)
+    {
+        return surl.equals(getFrom_surl()) || surl.equals(getTo_surl());
+    }
+
+    public void remoteFileRequestDone(URI SURL,String remoteRequestId,String remoteFileId) {
 		try {
 			logger.debug("setting remote file status to Done, SURL="+SURL+" remoteRequestId="+remoteRequestId+
 			    " remoteFileId="+remoteFileId);

--- a/modules/srm/src/main/java/org/dcache/srm/request/FileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/FileRequest.java
@@ -76,6 +76,7 @@ package org.dcache.srm.request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.sql.SQLException;
 
 import diskCacheV111.srm.RequestFileStatus;
@@ -299,6 +300,8 @@ public abstract class FileRequest extends Job {
     public QOSTicket getQOSTicket() {
         return qosTicket;
     }
+
+    public abstract boolean isTouchingSurl(URI surl);
 
    /**
      * @param newLifetime  new lifetime in millis


### PR DESCRIPTION
Addresses the issue, that the SRM is ignorant to other SRM requests
it may have on the same SURL. This leads to the dreaded "Already have 1
record" error in space management, as two concurrent puts on the same
file will be allowed by the SRM, but fail in space manager. More over,
there is currently no way for the user to abort the earlier requests if
they do not have the request number.

The SRM spec says that an upload operation should cause most other
operations on that SURL to fail with SRM_FILE_BUSY. srmRm should cause
existing get and put operations on the SURL to be aborted. This patch
implements those aspects of the SRM spec.

The patch does not implement this logic for srmCopy. This will be done
in a separate patch.

Since the patch addresses a real world issue we (and probably other
sites) suffer from, I request this to be merged into 2.6. Given the
change in observable behaviour, I am reluctant to merge this into 2.2
at this point.

Target: trunk
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/5677/
(cherry picked from commit 074cf4efb5e30bb8e09befad867adbb61fbfdc72)
