### PR TITLE
dcache-webadmin: avoid rrd4j timestep error statement

### DIFF
--- a/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/util/RrdPoolInfoAgent.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/util/RrdPoolInfoAgent.java
@@ -316,20 +316,22 @@ public class RrdPoolInfoAgent implements Runnable {
         }
 
         try {
-            Sample sample = rrdDb.createSample();
-            sample.setTime(now);
-            Map<String, Double> values = data.data();
+            if (now - rrdDb.getLastUpdateTime() >= 1) {
+                Sample sample = rrdDb.createSample();
+                sample.setTime(now);
+                Map<String, Double> values = data.data();
 
-            for (RrdHistogram h : RrdHistogram.values()) {
-                sample.setValue(RrdHistogram.getSourceName(h),
-                                values.get(h.toString()));
+                for (RrdHistogram h : RrdHistogram.values()) {
+                    sample.setValue(RrdHistogram.getSourceName(h),
+                                    values.get(h.toString()));
+                }
+
+                logger.debug("{}\t{}", new Date(TimeUnit.SECONDS.toMillis(now)),
+                                sample.dump());
+
+                sample.update();
+                logger.debug(rrdDb.dump());
             }
-
-            logger.debug("{}\t{}", new Date(TimeUnit.SECONDS.toMillis(now)),
-                            sample.dump());
-
-            sample.update();
-            logger.debug(rrdDb.dump());
         } catch (IOException t) {
             logger.error("problem writing data to RrdDb", t);
         } finally {


### PR DESCRIPTION
module: dcache-webadmin (pool queue plots)

Under certain restart conditions, the rrd4j utility will report that the call to write is doing so with a timestamp which is less than 1 second since the last update.  While this error is not fatal, it is annoying to see in the log.

The extra check simply avoids writing the data under these conditions and waits till the next iteration.

Target: master@39b9580e1820d1599399db78665ad37c386c7018
Patch: http://rb.dcache.org/r/5680
Require-notes: yes
Require-book: no
Request: 2.6
Acked-by: Gerd

Testing Done:

Without the patch, rapid multiple restarts of the webadmin service/httpd domain will probably produce a trace similar to this:

26 Jun 2013 09:32:47 (System) [] problem running collectPoolSeclectionUnit
java.lang.IllegalArgumentException: Bad sample time: 1372257000. Last update time was 1372257000, at least one second step is required
        at org.rrd4j.core.RrdDb.store(RrdDb.java:553) ~[rrd4j-2.1.1.jar:na]
        at org.rrd4j.core.Sample.update(Sample.java:197) ~[rrd4j-2.1.1.jar:na]
        at org.dcache.webadmin.model.dataaccess.util.RrdPoolInfoAgent.storeToRRD(RrdPoolInfoAgent.java:331) ~[classes/:na]
        at org.dcache.webadmin.model.dataaccess.util.RrdPoolInfoAgent.processPools(RrdPoolInfoAgent.java:291) ~[classes/:na]
        at org.dcache.webadmin.model.dataaccess.util.RrdPoolInfoAgent.run(RrdPoolInfoAgent.java:138) ~[classes/:na]
        at java.lang.Thread.run(Thread.java:722) [na:1.7.0]

With the patch, the log remains clean during multiple successive attempts to restart.

RELEASE NOTES:  The cause of the stack trace occasionally seen in the webadmin log file (on restart of the service) has been addressed.
