### PR TITLE
cells: Fix race conditions in cell lookup

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -1,13 +1,17 @@
 package dmg.cells.nucleus ;
 
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -29,11 +33,9 @@ class CellGlue {
             LoggerFactory.getLogger(CellGlue.class);
 
     private final String    _cellDomainName      ;
-    private final Map<String, CellNucleus> _cellList =
-       CollectionFactory.newConcurrentHashMap();
+    private final ConcurrentMap<String, CellNucleus> _cellList = Maps.newConcurrentMap();
+    private final Set<CellNucleus> _killedCells = Collections.newSetFromMap(Maps.<CellNucleus, Boolean>newConcurrentMap());
     private final Map<String,List<CellEventListener>> _cellEventListener =
-       CollectionFactory.newConcurrentHashMap();
-    private final Map<String, CellNucleus> _killedCellList =
        CollectionFactory.newConcurrentHashMap();
     private final Map<String, Object> _cellContext =
        CollectionFactory.newConcurrentHashMap();
@@ -82,18 +84,12 @@ class CellGlue {
    }
    ThreadGroup getMasterThreadGroup(){return _masterThreadGroup ; }
 
-   synchronized void addCell( String name , CellNucleus cell )
-        throws IllegalArgumentException {
-
-      if(  _killedCellList.get( name ) != null ) {
-          throw new IllegalArgumentException("Name Mismatch ( cell " + name + " exist  )");
-      }
-      if(  _cellList.get( name ) != null ) {
+   void addCell(String name, CellNucleus cell)
+        throws IllegalArgumentException
+   {
+      if (_cellList.putIfAbsent(name, cell) != null) {
           throw new IllegalArgumentException("Name Mismatch ( cell " + name + " exist )");
       }
-
-      _cellList.put( name , cell ) ;
-
       sendToAll( new CellEvent( name , CellEvent.CELL_CREATED_EVENT ) ) ;
    }
 
@@ -262,30 +258,22 @@ class CellGlue {
    }
    CellRoutingTable getRoutingTable(){ return _routingTable ; }
    CellRoute [] getRoutingList(){ return _routingTable.getRoutingList() ; }
-   synchronized CellTunnelInfo [] getCellTunnelInfos(){
 
-      List<CellTunnelInfo> v = new ArrayList<>() ;
-
-      for( CellNucleus cellNucleus : _cellList.values() ){
-
-         Cell c = cellNucleus.getThisCell() ;
-
-         if( c instanceof CellTunnel ){
-            v.add( ((CellTunnel)c).getCellTunnelInfo() ) ;
+   List<CellTunnelInfo> getCellTunnelInfos()
+   {
+      List<CellTunnelInfo> v = new ArrayList<>();
+      for (CellNucleus cellNucleus: _cellList.values()) {
+         Cell c = cellNucleus.getThisCell();
+         if (c instanceof CellTunnel) {
+            v.add(((CellTunnel) c).getCellTunnelInfo());
          }
       }
-
-      return v.toArray( new CellTunnelInfo[v.size()] ) ;
-
+      return v;
    }
 
-    synchronized List<String> getCellNames()
+    List<String> getCellNames()
     {
-        int size = _cellList.size() + _killedCellList.size();
-        List<String> allCells = new ArrayList<>(size);
-        allCells.addAll(_cellList.keySet());
-        allCells.addAll(_killedCellList.keySet());
-        return allCells;
+        return new ArrayList<>(_cellList.keySet());
     }
 
    int getUnique(){ return _uniqueCounter.incrementAndGet() ; }
@@ -347,7 +335,7 @@ class CellGlue {
    void   kill( CellNucleus sender , String cellName )
           throws IllegalArgumentException {
       CellNucleus nucleus =  _cellList.get( cellName ) ;
-      if(  nucleus == null ) {
+      if(  nucleus == null || _killedCells.contains(nucleus)) {
           throw new IllegalArgumentException("Cell Not Found : " + cellName);
       }
       _kill( sender , nucleus , 0 ) ;
@@ -361,12 +349,7 @@ class CellGlue {
    void threadGroupList(String cellName)
    {
        CellNucleus nucleus =  _cellList.get(cellName);
-
-       if(nucleus == null ) {
-           nucleus = _killedCellList.get(cellName);
-       }
-
-       if(nucleus != null) {
+       if (nucleus != null) {
            nucleus.threadGroupList();
        } else {
            LOGGER.warn("cell {} is not running", cellName);
@@ -381,13 +364,9 @@ class CellGlue {
      * @return The cell with the given name or null if there is no such
      * cell.
      */
-    synchronized CellNucleus getCell(String cellName)
+    CellNucleus getCell(String cellName)
     {
-        CellNucleus nucleus = _cellList.get(cellName);
-        if (nucleus == null) {
-            nucleus = _killedCellList.get(cellName);
-        }
-        return nucleus;
+        return _cellList.get(cellName);
     }
 
     /**
@@ -420,10 +399,11 @@ class CellGlue {
         }
     }
 
-   synchronized void destroy( CellNucleus nucleus ){
-       String name = nucleus.getCellName() ;
-       _killedCellList.remove( name ) ;
-       LOGGER.trace("destroy : sendToAll : killed {}", name);
+   synchronized void destroy(CellNucleus nucleus)
+   {
+       _cellList.remove(nucleus.getCellName());
+       _killedCells.remove(nucleus);
+       LOGGER.trace("destroy : sendToAll : killed {}", nucleus.getCellName());
        notifyAll();
 //
 //        CELL_DIED_EVENT moved to _kill. Otherwise
@@ -433,31 +413,24 @@ class CellGlue {
 //       sendToAll( new CellEvent( name , CellEvent.CELL_DIED_EVENT ) ) ;
    }
 
-    private synchronized void _kill(CellNucleus source,
-                                    CellNucleus destination,
-                                    long to)
+    private void _kill(CellNucleus source, final CellNucleus destination, long to)
     {
-        CellPath sourceAddr = new CellPath(source.getCellName(),
-                                           getCellDomainName());
-        final KillEvent killEvent = new KillEvent(sourceAddr, to);
         String cellToKill = destination.getCellName();
-        final CellNucleus destNucleus = _cellList.remove(cellToKill);
-
-        if (destNucleus == null) {
-            LOGGER.trace("Warning : (name not found in _kill) {}", cellToKill);
+        if (!_killedCells.add(destination)) {
+            LOGGER.trace("Cell is being killed: {}", cellToKill);
             return;
         }
 
-        _cellEventListener.remove(cellToKill);
+        CellPath sourceAddr = new CellPath(source.getCellName(), getCellDomainName());
+        final KillEvent killEvent = new KillEvent(sourceAddr, to);
         sendToAll(new CellEvent(cellToKill, CellEvent.CELL_DIED_EVENT));
-        _killedCellList.put(cellToKill, destNucleus);
 
         Runnable command = new Runnable()
         {
             @Override
             public void run()
             {
-                destNucleus.shutdown(killEvent);
+                destination.shutdown(killEvent);
             }
         };
         try {
@@ -535,6 +508,9 @@ class CellGlue {
          //  now we try to find the destination cell in our domain
          //
          CellNucleus destNucleus = _cellList.get( cellName ) ;
+         if (destNucleus != null && _killedCells.contains(destNucleus)) {
+             destNucleus = null;
+         }
          if( domainName.equals( _cellDomainName ) ){
             if( cellName.equals("*") ){
                   LOGGER.trace("sendMessagex : * detected ; skipping destination");

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -913,7 +913,7 @@ public class CellNucleus implements ThreadFactory
     CellRoutingTable getRoutingTable() { return __cellGlue.getRoutingTable(); }
     CellRoute [] getRoutingList() { return __cellGlue.getRoutingList(); }
     //
-    CellTunnelInfo [] getCellTunnelInfos() { return __cellGlue.getCellTunnelInfos(); }
+    List<CellTunnelInfo> getCellTunnelInfos() { return __cellGlue.getCellTunnelInfos(); }
     //
 
     private static final MessageEvent LAST_MESSAGE_EVENT = new LastMessageEvent();

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
@@ -324,29 +324,7 @@ public class      CellShell
           return super.command(c);
       }
    }
-   public Object binCommand( String c ){
-      Args args = new Args( c ) ;
-      if( args.argc() == 0 ) {
-          return "";
-      }
-      String cs = args.argv(0) ;
-       switch (cs) {
-       case ".getroutes":
-           return _nucleus.getRoutingList();
-       case ".getcelltunnelinfos":
-           return _nucleus.getCellTunnelInfos();
-       case ".getcellinfos":
-           List<String> list = _nucleus.getCellNames();
-           CellInfo[] info = new CellInfo[list.size()];
-           for (int i = 0; i < list.size(); i++) {
-               info[i] = _nucleus.getCellInfo(list.get(i));
-           }
-           return info;
-       default:
-           return null;
-       }
 
-   }
    ////////////////////////////////////////////////////////////
    //
    //  version
@@ -375,8 +353,9 @@ public class      CellShell
    public Object ac_getroutes( Args args ){
        return _nucleus.getRoutingList() ;
    }
-   public Object ac_getcelltunnelinfos( Args args ){
-       return _nucleus.getCellTunnelInfos() ;
+   public CellTunnelInfo[] ac_getcelltunnelinfos( Args args ){
+       List<CellTunnelInfo> cellTunnelInfos = _nucleus.getCellTunnelInfos();
+       return cellTunnelInfos.toArray(new CellTunnelInfo[cellTunnelInfos.size()]);
    }
    public Object ac_getcellinfo_$_1( Args args ) throws CommandException {
       CellInfo info = _nucleus.getCellInfo( args.argv(0) ) ;


### PR DESCRIPTION
When cells are killed, they are moved from one map to another map. This operation
is not atomic and methods that look in both places need to be synchronized.

This addresses a null pointer exception experienced in the DCAP door:

java.lang.NullPointerException: null
        at diskCacheV111.doors.DCapDoorInterpreterV3.ac_get_door_info(DCapDoorInterpreterV3.java:733) ~[dcache-dcap-2.2.13.jar:2.2.13]
        at sun.reflect.GeneratedMethodAccessor10.invoke(Unknown Source) ~[na:na]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_19]
        at java.lang.reflect.Method.invoke(Method.java:601) ~[na:1.7.0_19]
        at dmg.util.CommandInterpreter.execute(CommandInterpreter.java:609) ~[cells-2.2.13.jar:2.2.13]
        at dmg.util.CommandInterpreter.command(CommandInterpreter.java:486) ~[cells-2.2.13.jar:2.2.13]
        at dmg.cells.nucleus.CellAdapter.executeLocalCommand(CellAdapter.java:1020) ~[cells-2.2.13.jar:2.2.13]
        at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:940) ~[cells-2.2.13.jar:2.2.13]
        at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.innerRun(CellNucleus.java:1051) ~[cells-2.2.13.jar:2.2.13]
        at dmg.cells.nucleus.CellNucleus$AbstractNucleusTask.run(CellNucleus.java:949) ~[cells-2.2.13.jar:2.2.13]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_19]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_19]
        at dmg.cells.nucleus.CellNucleus$1.run(CellNucleus.java:654) [cells-2.2.13.jar:2.2.13]
        at java.lang.Thread.run(Thread.java:722) [na:1.7.0_19]

Target: trunk
Request: 2.6
Request: 2.2
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7896
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5700/
(cherry picked from commit 45850f5d50d867772d91b8526d9b7210ae9aaa55)
