### PR TITLE
pool: Add missing attributes in replicateOnArrival request

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -911,6 +911,8 @@ public class PoolV4
             attributes.setStorageInfo(storageInfo);
             attributes.setLocations(Collections.singleton(_poolName));
             attributes.setSize(fileAttributes.getSize());
+            attributes.setAccessLatency(fileAttributes.getAccessLatency());
+            attributes.setRetentionPolicy(fileAttributes.getRetentionPolicy());
 
             PoolMgrReplicateFileMsg req =
                 new PoolMgrReplicateFileMsg(attributes,


### PR DESCRIPTION
Addresses an issue in the pool's replicateOnArrival feature. If enabled it
failed with an error stating that required attributes where missing.

Target: trunk
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5715/
(cherry picked from commit a4188cfc4e89e2c5310fef52fc16f120d9c915db)
