### PR TITLE
Switch voms-api version to 2.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
             <dependency>
                 <groupId>eu.emi</groupId>
                 <artifactId>vomsjapi</artifactId>
-                <version>2.0.0-1</version>
+                <version>2.0.6</version>
             </dependency>
             <dependency>
                 <groupId>org.glite.authz</groupId>


### PR DESCRIPTION
We are using an unsupported and buggy voms-api version

RELEASE NOTES: Switch to voms-api to 2.0.6 fixing "Certificate verification: Maximum certification path length exceeded." exception problem

Patch: http://rb.dcache.org/r/5712/
Require-notes: yes
Require-book:  no
Bug: http://rt.dcache.org/Ticket/Display.html?id=7848
Acked-by: Gerd
Target: master
Request: 2.2
Request: 2.6

The problem I have, I can not test the solution myself as it only happens with certain proxy certificates, see bug ticket for details.

I have however tested that the update does not break g2 and s2 while I did not test xrootd as I have no idea about it.

G2 testing: http://svn.dcache.org/build/view/emi_certification/job/g2-Certification_oneMachine/243/,

mvn building fine, while testing switched on,

S2 test went through fine except for one test, which I would see as a typical S2 timeout problem: http://svn.dcache.org/build/view/emi_certification/job/S2-certification_oneMachine/21/
