### PR TITLE
all: Update voms-api to 2.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>eu.emi</groupId>
             <artifactId>vomsjapi</artifactId>
-            <version>2.0.0-1</version>
+            <version>2.0.6</version>
         </dependency>
         <dependency>
             <groupId>org.glite.authz</groupId>


### PR DESCRIPTION
We are using an unsupported and buggy voms-api version
Switch to voms-api to 2.0.6 fixing "Certificate verification: Maximum certification path length exceeded." exception problem. For 2.2 I only tested the mvn build. Did not deploy and did NOT run s2, g2 tests.

This commit is similar to master commit 5d4f99b5e9e284630d78744f3edc5f6c9c62189d. Cherry-picking did not work, which is why I recreated this patch for 2.2

Ticket: http://rt.dcache.org/Ticket/Display.html?id=7848
Acked-by: Gerd
Target: 2.2
Require-book: no
Require-notes: yes
