### PR TITLE
(skel): time-unit corrections to billing migration scripts

### DIFF
--- a/skel/share/migration/migrate_from_messageinfo.sql
+++ b/skel/share/migration/migrate_from_messageinfo.sql
@@ -10,37 +10,37 @@
 
 INSERT into billinginfo_rd_daily (transferred, size, count, date) SELECT SUM(transfersize),
  SUM(fullsize), COUNT(datestamp), (DATE(datestamp)) from billinginfo
- where isnew ='f' group by DATE(datestamp) ;
+ where isnew ='f' and errorcode = 0 group by DATE(datestamp) ;
 
 INSERT into billinginfo_wr_daily (transferred, size, count, date) SELECT SUM(transfersize),
  SUM(fullsize), COUNT(datestamp), (DATE(datestamp)) from billinginfo
- where isnew ='t' group by DATE(datestamp) ;
+ where isnew ='t' and errorcode = 0 group by DATE(datestamp) ;
 
 INSERT into storageinfo_rd_daily (size, count, date) SELECT SUM(fullsize), COUNT(datestamp),
  (DATE(datestamp)) from storageinfo
- where action ='restore' group by DATE(datestamp) ;
+ where action ='restore' and errorcode = 0 group by DATE(datestamp) ;
 
 INSERT into storageinfo_wr_daily (size, count, date) SELECT SUM(fullsize), COUNT(datestamp),
  (DATE(datestamp)) from storageinfo
- where action ='store' group by DATE(datestamp) ;
+ where action ='store' and errorcode = 0 group by DATE(datestamp) ;
 
 INSERT into billinginfo_tm_daily (maximum, minimum, totaltime, count, date)
  SELECT MAX(connectiontime), MIN(connectiontime), SUM(connectiontime),
  COUNT(datestamp), (DATE(datestamp))
- from billinginfo group by DATE(datestamp) ;
+ from billinginfo where errorcode = 0 group by DATE(datestamp) ;
 
 INSERT into costinfo_daily (totalcost, count, date) SELECT SUM(cost), COUNT(datestamp),
- (DATE(datestamp)) from costinfo group by DATE(datestamp) ;
+ (DATE(datestamp)) from costinfo where errorcode = 0 group by DATE(datestamp) ;
 
 CREATE TEMPORARY TABLE temp_hitinfo_daily (cached bigint, ncached bigint, total bigint, date timestamp);
 
 INSERT into temp_hitinfo_daily (cached, ncached, total, date)
  SELECT COUNT(filecached), 0, COUNT(filecached), DATE(datestamp) from hitinfo
- where filecached = true group by DATE(datestamp);
+ where filecached = true and errorcode = 0 group by DATE(datestamp);
 
 INSERT into temp_hitinfo_daily (cached, ncached, total, date)
  SELECT 0, COUNT(filecached), COUNT(filecached), DATE(datestamp) from hitinfo
- where filecached = false group by DATE(datestamp);
+ where filecached = false and errorcode = 0 group by DATE(datestamp);
 
 INSERT into hitinfo_daily (cached, notcached, count, date)
  SELECT SUM(cached), SUM(ncached), SUM(total), date from temp_hitinfo_daily group by date;

--- a/skel/share/migration/migrate_from_preexistent.sql
+++ b/skel/share/migration/migrate_from_preexistent.sql
@@ -24,7 +24,7 @@ INSERT into storageinfo_wr_daily (size, count, date)
  SELECT fullsize, count, date from en_wr_daily ;
 
 INSERT into billinginfo_tm_daily (maximum, minimum, totaltime, count, date)
- SELECT max, min, avg*count, count, date from dc_tm_daily;
+ SELECT 1000*max, 1000*min, 1000*avg*count, count, date from dc_tm_daily;
 
 INSERT into costinfo_daily (totalcost, count, date)
  SELECT mean*count, count, date from cost_daily;


### PR DESCRIPTION
The scripts contained in skel/share/migration which are intended to aid in migrating preexisting aggregated billing data or in aggregating the data from the main fine-grained tables have two errors in them.
1.  migrate_from_preexistent.sql does not account for the time-unit differences between the original dc_tm_daily tables, which store the data in seconds, and the new tables, which preserve the millisecond unit of the base table.
2.  migrate_from_messageinfo.sql neglected to exclude data from failed operations (errorcode = 0).

This patch repairs these two issues.

Testing done:

Before the patches, stored and displayed data did not correspond with previous installations, nor did the two scripts produce similar results.  After the patch, the results of both migrations are consonant with prior data.

Target: master@ded9bf4766c55e3a2f81f8dc25641a5921030c4c
Request: 2.6
Request: 2.2
Patch: http://rb.dcache.org/r/5732/
Require-book: no
Require-notes: yes
Acked-by: Gerd

RELEASE NOTES:

Fixes two bugs in the migration scripts.  One which neglected to convert from seconds to milliseconds (migrate_from_preexistent.sql) for connection time values, the other which neglected to exclude data from failed operations (error code = 0: migrate_from_messageinfo.sql).

Note for those who already have applied the faulty script: the migration from the preexistent tables does not really affect anyone outside of Fermi.  The other migration error generates differences which are probably negligible.
