### PR TITLE
Add DB driver to the list of classes to load

### DIFF
--- a/skel/bin/chimera-cli
+++ b/skel/bin/chimera-cli
@@ -86,7 +86,8 @@ dbpass=$(getProperty chimera.db.password)
 
 classpath=$(printLimitedClassPath chimera bonecp \
     guava slf4j-api dcache-common logback-classic \
-    logback-core logback-console-config)
+    logback-core logback-console-config \
+    $(getProperty chimera.db.jar))
 
 quickJava -Xbootclasspath/a:$classpath \
     -Dlog=${DCACHE_LOG:-warn} \

--- a/skel/share/defaults/chimera.properties
+++ b/skel/share/defaults/chimera.properties
@@ -42,4 +42,15 @@ chimera.db.password =
 #
 chimera.db.driver = org.postgresql.Driver
 
+
+#  ---- JDBC driver jar name.
+#
+#  The name of the jar file containing the driver.  This is only
+#  needed for chimera-cli.
+#
+chimera.db.jar = ${chimera.db.jar-when-${chimera.db.dialect}}
+chimera.db.jar-when-PgSQL = postgresql
+chimera.db.jar-when-HsqlDB = hsqldb
+chimera.db.jar-when-H2 = h2
+
 chimera.db.schema.changelog = org/dcache/chimera/changelog/changelog-master.xml


### PR DESCRIPTION
The chimera-cli command was overhauled to make it significantly faster.
One technique used was to limit the classes in the classpath to only
those needed.

Unfortunately, this work excluded the database-driver jar. The current
chimera-cli works for system-test, as the plugin mechanism ensures the
database-driver jar is included; however, the PostgreSQL driver is not
included, resulting in chimera-cli no longer working for machines using
PostgreSQL.  The error message is a stack-trace that starts:

[root@bes-srm dcache]# chimera-cli ls /
Exception in thread "main" java.lang.ClassNotFoundException:
org/postgresql/Driver

[reported in user-forum]

Target: master
Request: 2.6
Requires-notes: yes
Requires-book: no
Patch: http://rb.dcache.org/r/5755/
Acked-by: Gerd Behrmann
