### PR TITLE
(2.6) statistics: Fix NPE in Html tree creation

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -464,7 +464,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
       list = resortFileList( list , -1 ) ;
 
-      long [] counter      = null ;
+      long [] counter      = new long[12] ;
       long [] total        = new long[12] ;
       long [] lastInMonth  = new long[12] ;
 
@@ -493,7 +493,6 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
                   st.nextToken() ;
                   String key =  _dayOfCalendar.format( new Date( Long.parseLong( st.nextToken() ) ) ) ;
-                  counter = new long[12] ;
                   for( int  j = 0 ; j < counter.length ; j++ ){
                       counter[j] = Long.parseLong(st.nextToken()) ;
                   }
@@ -517,7 +516,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
        }
 
 
-       total[YESTERDAY]   = counter[YESTERDAY] ;
+      total[YESTERDAY]   = counter[YESTERDAY] ;
       total[YESTERDAY+1] = counter[YESTERDAY+1] ;
       total[TODAY]       = lastInMonth[TODAY] ;
       total[TODAY+1]     = lastInMonth[TODAY+1] ;
@@ -530,7 +529,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
       list = resortFileList( list , -1  ) ;
 
-      long [] counter      = null ;
+      long [] counter      = new long[12] ;
       long [] total        = new long[12] ;
       long [] lastInMonth  = new long[12] ;
 
@@ -558,7 +557,6 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
                   st.nextToken() ;
                   String key =  _monthOfCalendar.format( new Date( Long.parseLong( st.nextToken() ) ) ) ;
-                  counter = new long[12] ;
                   for( int  j = 0 ; j < counter.length ; j++ ){
                       counter[j] = Long.parseLong(st.nextToken()) ;
                   }
@@ -594,7 +592,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
       list = resortFileList( list , -1  ) ;
 
-      long [] counter     = null ;
+      long [] counter     = new long[12] ;
       long [] total       = new long[12] ;
       long [] lastInYear  = new long[12] ;
 
@@ -622,7 +620,6 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
                   st.nextToken() ;
                   String key =  _yearOfCalendar.format( new Date( Long.parseLong( st.nextToken() ) ) ) ;
-                  counter = new long[12] ;
                   for( int  j = 0 ; j < counter.length ; j++ ){
                       counter[j] = Long.parseLong(st.nextToken()) ;
                   }
@@ -1464,11 +1461,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
        Map<String,Map<String,long[]>> generic = (Map<String,Map<String,long[]>>) o;
        _log.info("getBillingStatistics :  billing replied with "+generic);
 
-       Iterator<String> poolNames = generic.keySet().iterator() ;
-
-       for( int i = 0 ; poolNames.hasNext() ; i++ ){
-
-          String poolName = poolNames.next() ;
+       for (String poolName: generic.keySet()) {
 
           m = new CellMessage( new CellPath("billing") , GET_POOL_STATISTICS+" "+poolName ) ;
           try{


### PR DESCRIPTION
It has been noted that the statistics module fails to produce the top level html and to run the collection cron correctly.  In the first case, one sees an error such as the first reported below.  In the second, a different error occurs.  These two errors, however, appear to be related.

As the code currently stands, the "count" array used in several methods remains uninitialized until inside the subsequent loop.  However, initialization is not loop-invariant, as those loops may fail to run under certain conditions, in particular when the list of statistics files is empty.

This patch provides the appropriate pre-loop initialization of the array.

Note that this class has a number of dead variables and methods.  I did not eliminate them, however, as it occurs to me that one might wish to do a bit more cleanup and "modernize" this code.  I leave this to another patch.

Before this patch, one observes the following.
1.  Using the admin command create html, one sees:

Exception in creating html tree for : /var/lib/dcache/billing/2013/06/05/2013-06-05-13.raw
java.lang.NullPointerException: null
at diskCacheV111.services.PoolStatisticsV0.printTotal(PoolStatisticsV0.java:1204) ~[dcache-core-2.6.1.jar:2.6.1]
at diskCacheV111.services.PoolStatisticsV0.prepareDailyHtml(PoolStatisticsV0.java:1136) ~[dcache-core-2.6.1.jar:2.6.1]
at diskCacheV111.services.PoolStatisticsV0.prepareDailyHtmlFiles(PoolStatisticsV0.java:1041) ~[dcache-core-2.6.1.jar:2.6.1]
at diskCacheV111.services.PoolStatisticsV0.access$1100(PoolStatisticsV0.java:116) ~[dcache-core-2.6.1.jar:2.6.1]
at diskCacheV111.services.PoolStatisticsV0$HourlyRunner.run(PoolStatisticsV0.java:432) ~[dcache-core-2.6.1.jar:2.6.1]
at dmg.cells.nucleus.CellNucleus$1.run(CellNucleus.java:657) [cells-2.6.1.jar:2.6.1]
at java.lang.Thread.run(Thread.java:722) [na:1.7.0_09]
1.  Using the admin command create stat, one sees:

at diskCacheV111.services.PoolStatisticsV0.getPoolRepositoryStatistics(PoolStatisticsV0.java:1361) ~[dcache-core-2.6.6-SNAPSHOT.jar:2.6.6-SNAPSHOT]
at diskCacheV111.services.PoolStatisticsV0.createStatisticsMap(PoolStatisticsV0.java:838) ~[dcache-core-2.6.6-SNAPSHOT.jar:2.6.6-SNAPSHOT]
at diskCacheV111.services.PoolStatisticsV0.createHourlyRawFile(PoolStatisticsV0.java:973) ~[dcache-core-2.6.6-SNAPSHOT.jar:2.6.6-SNAPSHOT]
at diskCacheV111.services.PoolStatisticsV0.access$500(PoolStatisticsV0.java:116) ~[dcache-core-2.6.6-SNAPSHOT.jar:2.6.6-SNAPSHOT]
at diskCacheV111.services.PoolStatisticsV0 $HourlyRunner.run(PoolStatisticsV0.java:400) ~[dcache-core-2.6.6-SNAPSHOT.jar:2.6.6-SNAPSHOT]
at dmg.cells.nucleus.CellNucleus$1.run(CellNucleus.java:657) [cells-2.6.6-SNAPSHOT.jar:2.6.6-SNAPSHOT]
at java.lang.Thread.run(Thread.java:722) [na:1.7.0]
15 Jul 2013 15:57:08 (PoolStatistics) [] prepareDailyHtmlFiles : File not found : /var/lib/dcache/statistics/2013/07/15/2013-07-15-day.drw

After the patch is applied, both of these commands work again, and the top index.html is produced.

Target: master@1ab1d24b01a614e8011a3be0915dced3dbb90ee8
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=785
Bug: http://rt.dcache.org/Ticket/Display.html?id=785
Acked-by: Gerd

RELEASE NOTES:

Fixes NullPointer bug which prevents under certain conditions top-level index.html from being created (and the statistics page being found in the browser).
