### PR TITLE
System cell: fix kill command

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
@@ -241,42 +241,49 @@ public class      SystemCell
             return ;
          }
         Object obj  = msg.getMessageObject() ;
+        Object reply = null; // dummy value needed for Java, not used.
+        boolean processed = false;
+
         if( obj instanceof String ){
            String command = (String)obj ;
            if( command.length() < 1 )return ;
-           Object reply = null ;
            _log.info( "Command : "+command ) ;
            reply = _cellShell.objectCommand2( command ) ;
-           _log.info( "Reply : "+reply ) ;
-           msg.setMessageObject( reply ) ;
-           _packetsAnswered ++ ;
+           processed = true;
         }else if( obj instanceof AuthorizedString ){
            AuthorizedString as = (AuthorizedString)obj ;
            String command = as.toString() ;
            if( command.length() < 1 )return ;
-           Object reply = null ;
            _log.info( "Command(p="+as.getAuthorizedPrincipal()+") : "+command ) ;
            reply = _cellShell.objectCommand2( command ) ;
-           _log.info( "Reply : "+reply ) ;
-           msg.setMessageObject( reply ) ;
-           _packetsAnswered ++ ;
+           processed = true;
         }else if( obj instanceof CommandRequestable ){
            CommandRequestable request = (CommandRequestable)obj ;
-           Object reply = null ;
            try{
               _log.info( "Command : "+request.getRequestCommand() ) ;
               reply = _cellShell.command( request ) ;
            }catch( CommandException cee ){
               reply = cee ;
            }
-           _log.info( "Reply : "+reply ) ;
-           msg.setMessageObject( reply ) ;
-           _packetsAnswered ++ ;
+           processed = true;
         }
+
+        if (processed) {
+            _log.debug("Reply : {}", reply);
+            _packetsAnswered++;
+        }
+
+        msg.revertDirection();
+
         try{
-           msg.revertDirection() ;
-           sendMessage( msg ) ;
-           _log.info( "Sending : "+msg ) ;
+            if (processed && reply instanceof Reply) {
+                ((Reply)reply).deliver(this, msg);
+            } else {
+                if (processed) {
+                    sendMessage(msg);
+                    _log.debug("Sending : {}", msg);
+                }
+            }
            _packetsReplied++ ;
         }catch( Exception e ){
            _exceptionCounter ++ ;


### PR DESCRIPTION
The patch http://rb.dcache.org/r/4278/, committed to master@7071473dc27df13
(pre-2.2) and merged 1.9.12@51e03907399a510 fixes the problem that a
kill command may take time to complete. In particular, when working
around a configuration issue, an existing gPlazma is killed before a
fresh gPlazma is started. If the new gPlazma is started before the old
cell has died then the new gPlazma will not start. This is the
race-condition the patch fixes.

Unfortunately, the patch also introduces a deadlock. When attempting
to kill the System cell, the message-processing thread is blocked
waiting for a signal that the cell has died. This signal is generated
when processing an event by the message-processing thread which,
because the kill command is blocking, will never happen.

This patch fixes the problem by replying with a DelayedReply; an
implementation of the future Reply. The patch also adds support for
replying with a Reply to SystemCell.

Target: trunk
Request: 2.2
Request: 1.9.12
Require-notes: yes
Require-book: no
Patch: http://rb.dcache.org/r/5115/
Acked-by: Gerd Behrmann
Committed: master@d20662a349d6a520fa1dd3b5dba61d7b905b9d97
