### PR TITLE
srm: Fix IllegalStateException during startup

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm/src/main/java/org/dcache/srm/SRM.java
@@ -270,7 +270,9 @@ public class SRM {
         requestCredentialStorage = new DatabaseRequestCredentialStorage(config);
         RequestCredential.registerRequestCredentialStorage(requestCredentialStorage);
         SchedulerFactory.initSchedulerFactory(config, name);
-        JobStorageFactory.initJobStorageFactory(new DatabaseJobStorageFactory(configuration));
+        DatabaseJobStorageFactory afactory = new DatabaseJobStorageFactory(configuration);
+        JobStorageFactory.initJobStorageFactory(afactory);
+        afactory.loadExistingJobs();
 
         host = java.net.InetAddress.getLocalHost();
 


### PR DESCRIPTION
When an expired job exists while the SRM is starting, the following exception
is generated:

03 apr 2013 11:07:53 (SRM-Gerds-MacBook-Pro) [] Failed to save SQL request to database. Please report to support@dcache.org.
java.lang.IllegalStateException: not initialized
        at org.dcache.srm.scheduler.JobStorageFactory.getJobStorageFactory(JobStorageFactory.java:36) ~[srm-2.6.0-SNAPSHOT.jar:2.6.0-SNAPSHOT]
        at org.dcache.srm.request.Job.getJobStorage(Job.java:281) [srm-2.6.0-SNAPSHOT.jar:2.6.0-SNAPSHOT]
        at org.dcache.srm.request.Job.saveJob(Job.java:299) [srm-2.6.0-SNAPSHOT.jar:2.6.0-SNAPSHOT]
        at org.dcache.srm.request.Job.saveJob(Job.java:286) [srm-2.6.0-SNAPSHOT.jar:2.6.0-SNAPSHOT]
        at org.dcache.srm.request.Job.setState(Job.java:599) [srm-2.6.0-SNAPSHOT.jar:2.6.0-SNAPSHOT]
        at org.dcache.srm.request.Job.setState(Job.java:440) [srm-2.6.0-SNAPSHOT.jar:2.6.0-SNAPSHOT]
        at org.dcache.srm.request.Job.expireJob(Job.java:1015) [srm-2.6.0-SNAPSHOT.jar:2.6.0-SNAPSHOT]
        at org.dcache.srm.request.Job$LifetimeExpiration.run(Job.java:993) [srm-2.6.0-SNAPSHOT.jar:2.6.0-SNAPSHOT]
        at java.util.TimerThread.mainLoop(Timer.java:555) [na:1.7.0_11]
        at java.util.TimerThread.run(Timer.java:505) [na:1.7.0_11]

This is caused by the expiration task needing access to the JobStorage
before the JobStorageFactory is initialized.

The patch restructures initialization to resolve this problem.

Target: trunk
Request: 2.5
Request: 2.2
Request: 1.9.12
Require-book: no
Require-notes: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5385/
(cherry picked from commit f113467817dbbd29bbe9d9b6f5896f677cd0e92e)

Conflicts:
    modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorageFactory.java
