### PR TITLE
xrood: Fix root path interpretation

### DIFF
--- a/modules/dCache/org/dcache/auth/AnonymousLoginStrategy.java
+++ b/modules/dCache/org/dcache/auth/AnonymousLoginStrategy.java
@@ -1,7 +1,7 @@
 package org.dcache.auth;
 
 import java.security.Principal;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -9,7 +9,6 @@ import java.util.regex.Pattern;
 import javax.security.auth.Subject;
 
 import org.dcache.auth.attributes.LoginAttribute;
-import org.dcache.auth.attributes.RootDirectory;
 import org.springframework.beans.factory.annotation.Required;
 
 import diskCacheV111.util.CacheException;
@@ -21,11 +20,7 @@ import diskCacheV111.util.CacheException;
  * user based on the configured uid/gid is returned as a result of the
  * login operation.
  *
- * The root path is configurable in the dcache configuration, as is whether the
- * strategy the door is read-only for anonymous access.
- *
  * @author tzangerl
- *
  */
 public class AnonymousLoginStrategy implements LoginStrategy
 {
@@ -34,23 +29,19 @@ public class AnonymousLoginStrategy implements LoginStrategy
     public final static Pattern USER_PATTERN =
         Pattern.compile("(\\d+):((\\d+)(,(\\d+))*)");
 
-    private Subject _subject;
-    private String _rootPath;
+    private final static Set<LoginAttribute> NO_ATTRIBUTES =
+            Collections.emptySet();
 
-    public AnonymousLoginStrategy() {
+    private Subject _subject;
+
+    public AnonymousLoginStrategy()
+    {
     }
 
     @Override
-    public LoginReply login(Subject subject) throws CacheException {
-
-        LoginAttribute rootPath = new RootDirectory(_rootPath);
-
-        Set<LoginAttribute> attributes = new HashSet<LoginAttribute>();
-        attributes.add(rootPath);
-
-        LoginReply reply = new LoginReply(_subject, attributes);
-
-        return reply;
+    public LoginReply login(Subject subject) throws CacheException
+    {
+        return new LoginReply(_subject, NO_ATTRIBUTES);
     }
 
     @Override
@@ -100,17 +91,5 @@ public class AnonymousLoginStrategy implements LoginStrategy
         } else {
             _subject = parseUidGidList(user);
         }
-    }
-
-    /**
-     * Sets the root path.
-     *
-     * The root path forms the root of the name space of the xrootd
-     * server. Xrootd paths are translated to full PNFS paths by
-     * predending the root path.
-     */
-    @Required
-    public void setRootPath(String rootPath) {
-        _rootPath = rootPath;
     }
 }

--- a/modules/dCache/org/dcache/xrootd2/door/NettyXrootdServer.java
+++ b/modules/dCache/org/dcache/xrootd2/door/NettyXrootdServer.java
@@ -2,6 +2,8 @@ package org.dcache.xrootd2.door;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
+
+import diskCacheV111.util.FsPath;
 import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelFactory;
@@ -41,6 +43,7 @@ public class NettyXrootdServer
     private AuthorizationFactory _authorizationFactory;
     private ChannelFactory _channelFactory;
     private ConnectionTracker _connectionTracker;
+    private FsPath _rootPath;
 
     /**
      * Switch Netty to slf4j for logging.
@@ -85,6 +88,11 @@ public class NettyXrootdServer
         _door = door;
     }
 
+    public int getBacklog()
+    {
+        return _backlog;
+    }
+
     @Required
     public void setAuthenticationFactory(AbstractAuthenticationFactory factory)
     {
@@ -105,6 +113,20 @@ public class NettyXrootdServer
     public AuthorizationFactory getAuthorizationFactory()
     {
         return _authorizationFactory;
+    }
+
+    public String getRootPath()
+    {
+        return (_rootPath == null) ? null : _rootPath.toString();
+    }
+
+    /**
+     * Sets the root path of the name space exported by this xrootd door.
+     */
+    @Required
+    public void setRootPath(String s)
+    {
+        _rootPath = new FsPath(s);
     }
 
     public void init()
@@ -128,6 +150,7 @@ public class NettyXrootdServer
                     pipeline.addLast("handshake", new XrootdHandshakeHandler(XrootdProtocol.LOAD_BALANCER));
                     pipeline.addLast("executor", new ExecutionHandler(_requestExecutor));
                     pipeline.addLast("redirector", new XrootdRedirectHandler(_door,
+                                                                             _rootPath,
                                                                              _authenticationFactory,
                                                                              _authorizationFactory));
                     return pipeline;

--- a/modules/dCache/org/dcache/xrootd2/door/xrootd.xml
+++ b/modules/dCache/org/dcache/xrootd2/door/xrootd.xml
@@ -85,6 +85,7 @@
     <property name="door" ref="door"/>
     <property name="authenticationFactory" ref="${xrootdAuthNPlugin}-factory"/>
     <property name="authorizationFactory" ref="authorization-factory"/>
+    <property name="rootPath" value="${xrootdRootPath}"/>
   </bean>
 
   <bean id="pnfs" class="diskCacheV111.util.PnfsHandler">
@@ -142,7 +143,6 @@
   <bean id="none-loginstrategy" class="org.dcache.auth.AnonymousLoginStrategy">
     <description>Login strategy used for unauthenticated login</description>
     <property name="user" value="${xrootdUser}"/>
-    <property name="rootPath" value="${xrootdRootPath}"/>
   </bean>
 
   <bean id="gsi-loginstrategy" class="org.dcache.services.login.RemoteLoginStrategy">


### PR DESCRIPTION
The xrootd door allows the root path (the name space export point) to be
defined. The documentation states that the property applies to the door
in all cases, however in reality it was only used for anonymous
sessions. For authentication sessions the users private root path was
used.

There is the choice of either changing the documentation or the
implementation. I choose to change the implementation for two reasons:
- The SRM generates xrootd URIs based on the assumption that the root
  path is fixed for xrootd doors, ie that is doesn't change for each
  user.
- Personal preference that I want URIs to refer to the same resource no
  matter who uses them.

Even though the patch changes the interpretation of properties, I request
a merge to stable branches, as the bug is a potential security risk.

Target: trunk
Request: 1.9.12
Patch: http://rb.dcache.org/r/4756
Committed: master@1da8f36a0e9d46536324121005112d5afd5db01c
Committed: 2.2@b2ef8072e7a4dbead26f28770923ba9f06db581b
