### PR TITLE
Fix/2.2 sha2/rb5795

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/Crypto.java
+++ b/modules/common/src/main/java/org/dcache/util/Crypto.java
@@ -1,6 +1,11 @@
 package org.dcache.util;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
+
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
@@ -14,6 +19,20 @@ public class Crypto
     {
         DISABLE_BROKEN_DH,
         DISABLE_EC
+    }
+
+    private static final Splitter CIPHER_FLAG_SPLITTER =
+            Splitter.on(",").omitEmptyStrings().trimResults();
+
+    private static String VERSION = System.getProperty("java.version");
+
+    private Crypto()
+    {
+    }
+
+    static void setJavaVersion(String version)
+    {
+        VERSION = version;
     }
 
     /* The following is a list of cipher suites that are problematic
@@ -265,24 +284,23 @@ public class Crypto
      */
     public static String[] getBannedCipherSuitesFromConfigurationValue(String value)
     {
-        String[] values = value.split(",");
-        CipherFlag[] flags = new CipherFlag[values.length];
-        for (int i = 0; i < values.length; i++) {
-            flags[i] = CipherFlag.valueOf(values[i]);
+        List<String> values = Lists.newArrayList(CIPHER_FLAG_SPLITTER.split(value));
+        CipherFlag[] flags = new CipherFlag[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            flags[i] = CipherFlag.valueOf(values.get(i));
         }
         return getBannedCipherSuites(flags);
     }
 
     public static String[] getBannedCipherSuites(CipherFlag[] flags)
     {
-        String version = System.getProperty("java.version");
         Set<String> banned = new HashSet<String>();
         for (CipherFlag flag : flags) {
             switch (flag) {
             case DISABLE_BROKEN_DH:
-                if (version.startsWith("1.7.0_")) {
+                if (VERSION.startsWith("1.7.0_")) {
                     try {
-                        int update = Integer.parseInt(version.substring(6));
+                        int update = Integer.parseInt(VERSION.substring(6));
                         if (update > 5) {
                             banned.addAll(asList(DH_CIPHERS));
                         }

--- a/modules/common/src/test/java/org/dcache/util/CryptoTest.java
+++ b/modules/common/src/test/java/org/dcache/util/CryptoTest.java
@@ -1,0 +1,66 @@
+package org.dcache.util;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class CryptoTest
+{
+    @Test
+    public void testGetBannedCipherSuitesFromConfigurationValueWithEmptyString()
+    {
+        assertThat(Crypto.getBannedCipherSuitesFromConfigurationValue(""), is(emptyArray()));
+    }
+
+    @Test
+    public void testGetBannedCipherSuitesFromConfigurationValueWithSingleValue()
+    {
+        assertThat(Crypto.getBannedCipherSuitesFromConfigurationValue("DISABLE_EC"),
+                is(arrayContainingInAnyOrder(Crypto.EC_CIPHERS)));
+    }
+
+    @Test
+    public void testGetBannedCipherSuitesFromConfigurationValueWithWhiteSpace()
+    {
+        assertThat(Crypto.getBannedCipherSuitesFromConfigurationValue("   DISABLE_EC   "),
+                is(arrayContainingInAnyOrder(Crypto.EC_CIPHERS)));
+    }
+
+    @Test
+    public void testGetBannedCipherSuitesFromConfigurationValueWithMultipleValues() throws Exception
+    {
+        Crypto.setJavaVersion("1.7.0_20");
+        assertThat(Crypto.getBannedCipherSuitesFromConfigurationValue("   DISABLE_EC , DISABLE_BROKEN_DH  "),
+                is(arrayContainingInAnyOrder(concat(Crypto.EC_CIPHERS, Crypto.DH_CIPHERS))));
+    }
+
+    @Test
+    public void testGetBannedCipherSuitesFromConfigurationValueWithEmptyValues() throws Exception
+    {
+        Crypto.setJavaVersion("1.7.0_20");
+        assertThat(Crypto.getBannedCipherSuitesFromConfigurationValue("   DISABLE_EC , , DISABLE_BROKEN_DH  "),
+                is(arrayContainingInAnyOrder(concat(Crypto.EC_CIPHERS, Crypto.DH_CIPHERS))));
+    }
+
+    @Test
+    public void testGetBannedCipherSuitesFromConfigurationValueWithNonBrokenDH() throws Exception
+    {
+        Crypto.setJavaVersion("1.7.0_1");
+        assertThat(Crypto.getBannedCipherSuitesFromConfigurationValue("   DISABLE_BROKEN_DH  "),
+                is(emptyArray()));
+    }
+
+    private static String[] concat(String[]... arrays)
+    {
+        Set<String> result = new HashSet<>();
+        for (String[] array: arrays) {
+            result.addAll(asList(array));
+        }
+        return result.toArray(new String[result.size()]);
+    }
+}

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CheckHealthTask.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CheckHealthTask.java
@@ -2,11 +2,11 @@ package org.dcache.pool.repository.v5;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.dcache.pool.FaultAction;
-import org.dcache.pool.repository.SpaceRecord;
-import org.dcache.pool.repository.FileStore;
-import org.dcache.pool.repository.MetaDataStore;
 import org.dcache.pool.repository.Account;
+import org.dcache.pool.repository.MetaDataStore;
+import org.dcache.pool.repository.SpaceRecord;
 
 class CheckHealthTask implements Runnable
 {


### PR DESCRIPTION
doors: Fix parsing of cipher flags …
Addresses the problem that the empty string was not accepted for
*.security.ciphers configuration properties.

Target: trunk
Request: 2.6
Request: 2.2-sha2
Require-book: no
Require-notes: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5795/
(cherry picked from commit 1faf6fc)
