### PR TITLE
skel: mark as obsolete/deprecated certain dropped properties

### DIFF
--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -17,9 +17,11 @@ alarms.dir=@dcache.paths.alarms@
 #
 alarms.server.config=${alarms.dir}/logback-server.xml
 
+(deprecated,one-of?off|error|warn|info|debug)alarms.remote-logging.level=off
+
 #  ---- Server root log level.
 #
-(one-of?off|error|warn|info|debug)alarms.server.log.level=warn
+(one-of?off|error|warn|info|debug|${alarms.remote-logging.level})alarms.server.log.level=${alarms.remote-logging.level}
 
 #  ---- Server side custom alarm definitions
 #

--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -301,7 +301,8 @@ billingPlotsExportType=png
 
 #   -- refresh the plots after this many minutes
 #
-billing.plot.refresh-threshold=5
+(deprecated)billingPlotsTimeoutInMins=5
+billing.plot.refresh-threshold=${billingPlotsTimeoutInMins}
 
 #  ---- Height of the plot image in pixels
 #

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -71,17 +71,19 @@
 #
 (not-for-services)dcache.log.level.file=warn
 (not-for-services)dcache.log.level.pinboard=info
-(not-for-services)dcache.log.level.remote=off
+(not-for-services)dcache.log.level.remote=${alarms.remote-logging.level}
 (not-for-services)dcache.log.level.events=off
 
 # Host on which the remote log server will run
 # relative to this dCache installation
 #
-(not-for-services)dcache.log.server.host=localhost
+(deprecated,not-for-services)alarms.server.host=localhost
+(not-for-services)dcache.log.server.host=${alarms.server.host}
 
 # Port on which the remote log server will listen
 #
-(not-for-services)dcache.log.server.port=9867
+(deprecated,not-for-services)alarms.server.port=9867
+(not-for-services)dcache.log.server.port=${alarms.server.port}
 
 # Log formats
 #

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -315,6 +315,7 @@ webdav.security.ciphers=${dcache.security.ciphers}
 (obsolete)webdavDirIconPath=modify the template to customize the look and feel
 (obsolete)webdavFileIconPath=modify the template to customize the look and feel
 (obsolete)webdavCssPath=modify the template to customize the look and feel
+(obsolete)webdavChrootToUserRoot=no longer used as dCache always enforces user-root
 (obsolete)logoPath=modify the template to customize the look and feel
 (obsolete)dirIconPath=modify the template to customize the look and feel
 (obsolete)fileIconPath=modify the template to customize the look and feel


### PR DESCRIPTION
Due to confusion as to what was and was not released, some properties in 2.6 where changed but not marked as deprecated or obsolete.

Repaired by this patch.

Reinstalled and ran instance.  Ran dcache check-config to make sure warnings were correct.

Target: 2.6
Patch: http://rb.dcache.org/r/5793/
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7925
Require-book: no
Require-notes: no
Acked-by: Gerd
