### PR TITLE
Fix/2.6/rb5807

### DIFF
--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/cellservices/CellServices.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/cellservices/CellServices.java
@@ -20,14 +20,12 @@ import org.dcache.webadmin.view.panels.cellservices.CellServicesPanel;
 public class CellServices extends BasePage {
 
     private static final long serialVersionUID = -1276186550495981006L;
-    private List<CellServicesBean> _cellBeans;
     private static final Logger _log = LoggerFactory.getLogger(CellServices.class);
 
     public CellServices() {
         add(new FeedbackPanel("feedback"));
-        getCellServicesAction();
         CellServicesPanel cellServicesPanel = new CellServicesPanel("cellServicesPanel",
-                new PropertyModel(this, "_cellBeans"));
+                new PropertyModel(this, "cellBeans"));
         add(cellServicesPanel);
     }
 
@@ -35,14 +33,15 @@ public class CellServices extends BasePage {
         return getWebadminApplication().getCellsService();
     }
 
-    private void getCellServicesAction() {
+    public List<CellServicesBean> getCellBeans()
+    {
         try {
             _log.debug("getCellServicesAction called");
-            _cellBeans = getCellsService().getCellServicesBeans();
+            return getCellsService().getCellServicesBeans();
         } catch (CellsServiceException ex) {
             this.error(getStringResource("error.getCellsFailed") + ex.getMessage());
             _log.debug("getCellServicesAction failed {}", ex.getMessage());
-            _cellBeans = null;
+            return null;
         }
     }
 }


### PR DESCRIPTION
httpd (webadmin): Fix rerendering of cellInfo page

In Wicket, the BasePage instances is only created once (or at least
not on every page load). The basic structure of a page is cached,
independent of what caching settings have otherwise been defined
for a page.

The CellServices class, which is the implementation of the cellInfo
page, not only builds the basic page structure in the constructor,
it also builds the data model that is driving the rendering. The
CellStatus data is taken out of a shared map object. The shared map
is periodically updated by background threads, however the data is
only ever taken out of the map in the constructor of CellServices.
Wicket, when rendering the page on page reload, will use its model
abstraction to access the model of the CellServices page, however
since it is never updated, the rendering never changes - after the
first load of the cellInfo page, it stays the same (at least for
that browser session).

This patch fixes the problem by replacing the field with a getter.
The getter fetches the data from the shared cache, thus rendering
a different result on every page load.

Target: trunk
Request: 2.6
Request: 2.2 (?)
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi arossi@fnal.gov
Patch: http://rb.dcache.org/r/5807/
(cherry picked from commit 49afa17)
