### PR TITLE
Add a new gPlazma account phase plugin

### DIFF
--- a/modules/gplazma2-banfile/pom.xml
+++ b/modules/gplazma2-banfile/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+      <groupId>org.dcache</groupId>
+      <artifactId>dcache-parent</artifactId>
+      <version>2.6.6-SNAPSHOT</version>
+      <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>gplazma2-banfile</artifactId>
+  <packaging>jar</packaging>
+
+  <name>gPlazma 2 principal ban file plugin</name>
+
+  <dependencies>
+      <dependency>
+          <groupId>org.dcache</groupId>
+          <artifactId>gplazma2</artifactId>
+          <version>${project.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-library</artifactId>
+      </dependency>
+  </dependencies>
+
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>net.alchim31.maven</groupId>
+              <artifactId>scala-maven-plugin</artifactId>
+              <executions>
+                  <execution>
+                      <id>scala-compile-first</id>
+                      <phase>process-resources</phase>
+                      <goals>
+                          <goal>add-source</goal>
+                          <goal>compile</goal>
+                      </goals>
+                  </execution>
+                  <execution>
+                      <id>scala-test-compile</id>
+                      <phase>process-test-resources</phase>
+                      <goals>
+                          <goal>testCompile</goal>
+                      </goals>
+                  </execution>
+              </executions>
+          </plugin>
+      </plugins>
+  </build>
+</project>

--- a/modules/gplazma2-banfile/src/main/resources/META-INF/gplazma-plugins.xml
+++ b/modules/gplazma2-banfile/src/main/resources/META-INF/gplazma-plugins.xml
@@ -1,0 +1,6 @@
+<plugins>
+    <plugin>
+        <name>banfile</name>
+        <class>org.dcache.gplazma.plugins.BanFilePlugin</class>
+    </plugin>
+</plugins>

--- a/modules/gplazma2-banfile/src/main/scala/org/dcache/gplazma/plugins/BanFilePlugin.scala
+++ b/modules/gplazma2-banfile/src/main/scala/org/dcache/gplazma/plugins/BanFilePlugin.scala
@@ -1,0 +1,104 @@
+package org.dcache.gplazma.plugins
+
+import scala.collection.JavaConversions._
+
+import java.util
+import java.util.Properties
+import java.security.Principal
+
+import org.dcache.auth.Subjects
+import org.dcache.gplazma.AuthenticationException
+import scala.io.Source
+
+object BanFilePlugin {
+  val BAN_FILE = "gplazma.banfile.path"
+}
+
+class BanFilePlugin(properties : Properties) extends GPlazmaAccountPlugin with FileCache[Set[Principal]] {
+
+  /**
+   * Get the filename of the ban file from the properties.
+   */
+  val banFile = {
+    if (properties == null) {
+      throw new IllegalArgumentException("properties is null")
+    }
+    val filename = properties getProperty BanFilePlugin.BAN_FILE
+    if (filename == null) {
+      throw new IllegalArgumentException(BanFilePlugin.BAN_FILE + " not set")
+    }
+
+    filename
+  }
+
+  private[plugins] def fromSource : Source = try {
+    Source fromFile banFile
+  } catch {
+    case e:Exception => throw new IllegalStateException("cannot read file " + banFile +": "+e.getMessage, e)
+  }
+
+  /**
+   * Create a list of principals from the source file.
+   * principalsFromSource filters out empty lines and comments, i.e., lines starting with #
+   * It expects the file to be of the format:
+   *   alias <alias>=<full qualified classname>
+   *   ban <full qualified classname or alias>:<principal string>
+   * e.g.,
+   *   alias username=org.dcache.auth.LoginNamePrincipal
+   *   ban username:Someuser
+   * or
+   *   ban org.dcache.auth.LoginNamePrincipal:Someuser
+   *
+   * @return a set of banned principals
+   */
+  private def principalsFromFile(filename : String) = {
+
+    def filteredLines(lines : List[String], filtered : List[String], aliases : Map[String, String]) : List[String] = {
+      lines match {
+        case Nil => filtered
+        case line :: rest if line startsWith "#" => filteredLines(rest, filtered, aliases)
+        case line :: rest if line.trim == "" => filteredLines(rest, filtered, aliases)
+        case line :: rest if line startsWith "alias" => {
+          """^alias\s+([^:]+)=(.*)$""".r("alias", "class") findFirstMatchIn line match {
+            case None => throw new IllegalArgumentException("Bad alias line format: '"+line+"', expected 'alias <alias>=<class>'")
+            case Some(m) => filteredLines(rest, filtered, aliases + (m.group("alias").trim -> m.group("class").trim))
+          }
+        }
+        case line :: rest if line startsWith "ban" => {
+          """^ban\s+([^:]+):(.*)$""".r("class", "params") findFirstMatchIn line match {
+            case None => throw new IllegalArgumentException("Bad ban line format: '"+line+"', expected 'ban <classOrAlias>:<value>'")
+            case Some(m) => filteredLines(rest, {
+              aliases.get(m.group("class").trim) match {
+                case None => m.group("class").trim
+                case Some(a) => a
+              }
+            }+":"+m.group("params") :: filtered, aliases)
+          }
+        }
+        case line :: _ => throw new IllegalArgumentException("Line has bad format: '"+line+"', expected '[alias|ban] <key>:<value>'")
+      }
+    }
+
+    Subjects.principalsFromArgs(filteredLines(fromSource.getLines().toList, Nil, Map())).toSet
+  }
+
+  /**
+   * Get banned principals from file
+   * @return a set of banned principals
+   */
+  private def bannedPrincipals = getOrFetch(banFile)(principalsFromFile)
+
+  /**
+   * Check if any of the principals in authorizedPrincipals is blacklisted in the
+   * file specified by the dCache property gplazma.banfile.uri.
+   *
+   * @param authorizedPrincipals principals associated with a user
+   * @throws AuthenticationException indicating a banned user
+   */
+  def account(authorizedPrincipals: util.Set[Principal]) {
+    if ((authorizedPrincipals intersect bannedPrincipals).nonEmpty) {
+      throw new AuthenticationException("user banned")
+    }
+  }
+}
+

--- a/modules/gplazma2-banfile/src/main/scala/org/dcache/gplazma/plugins/FileCache.scala
+++ b/modules/gplazma2-banfile/src/main/scala/org/dcache/gplazma/plugins/FileCache.scala
@@ -1,0 +1,20 @@
+package org.dcache.gplazma.plugins
+
+import scala.collection.mutable
+import java.io.File
+
+trait FileCache[T] {
+
+  private var cache = new mutable.HashMap[String, (Long, T)]()
+
+  def getOrFetch(filename : String)(fetch : (String) => T) : T = {
+    val file = new File(filename)
+    cache.get(filename) match {
+      case None => cache += (filename -> (file.lastModified, fetch(filename)))
+      case Some((lastFetch, _)) if file.lastModified > lastFetch => cache(filename) = (file.lastModified, fetch(filename))
+      case _ => // entry exists and is up to date
+    }
+    cache(filename)._2
+  }
+
+}

--- a/modules/gplazma2-banfile/src/test/resources/ban.conf
+++ b/modules/gplazma2-banfile/src/test/resources/ban.conf
@@ -1,0 +1,1 @@
+# this is just an empty file for testing plugin initialisation

--- a/modules/gplazma2-banfile/src/test/scala/org/dcache/gplazma/plugins/BanFilePluginTest.scala
+++ b/modules/gplazma2-banfile/src/test/scala/org/dcache/gplazma/plugins/BanFilePluginTest.scala
@@ -1,0 +1,176 @@
+package org.dcache.gplazma.plugins
+
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+import org.junit.runner.RunWith
+
+import scala.collection.JavaConversions._
+import scala.io.Source
+
+import java.util.Properties
+import java.security.Principal
+
+import org.dcache.gplazma.AuthenticationException
+import com.google.common.io.Resources.getResource
+
+class TestPrincipal(name : String) extends Principal {
+  override def getName: String = name
+  override def equals(other : Any) =
+       other.getClass == this.getClass &&
+       other.asInstanceOf[TestPrincipal].getName ==  name
+}
+
+// used in test "should not ban on equal names in different principal classes"
+class TestPrincipalB(name : String) extends TestPrincipal(name)
+
+trait stringSource extends BanFilePlugin {
+  var sourceString : String = _
+  override def fromSource : Source = Source fromString sourceString
+}
+
+@RunWith(classOf[JUnitRunner])
+class BanFilePluginTest extends FlatSpec {
+
+  def validProperties = {
+    val properties = new Properties()
+    properties.put(BanFilePlugin.BAN_FILE, getResource("ban.conf").getPath)
+    properties
+  }
+
+  "The BanFilePlugin" should "throw an IllegalArgumentException if properties is null" in {
+    intercept[IllegalArgumentException] {
+      new BanFilePlugin(null)
+    }
+  }
+
+  it should "throw an IllegalArgumentException if the gplazma.banfile.path property is not set" in {
+    intercept[IllegalArgumentException] {
+      new BanFilePlugin(new Properties)
+    }
+  }
+
+  it should "throw an IllegalStateException if the config file does not exist at start time" in {
+    val properties = new Properties()
+    properties.put(BanFilePlugin.BAN_FILE, "/file/does/not/exist")
+
+    intercept[IllegalStateException] {
+      new BanFilePlugin(properties).account(null)
+    }
+  }
+
+  it should "allow a not banned user" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |ban org.dcache.gplazma.plugins.TestPrincipal:bert
+      """.stripMargin
+    plugin.account(Set[Principal](new TestPrincipal("ernie")))
+  }
+
+  it should "not ban on equal names in different principal classes" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |ban org.dcache.gplazma.plugins.TestPrincipalB:ernie
+      """.stripMargin
+    plugin.account(Set[Principal](new TestPrincipal("ernie")))
+  }
+
+  it should "throw an AuthenticatedException for a banned user" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |ban org.dcache.gplazma.plugins.TestPrincipal:bert
+      """.stripMargin
+    intercept[AuthenticationException] {
+      plugin.account(Set[Principal](new TestPrincipal("bert")))
+    }
+  }
+
+  it should "work multiple times" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |ban org.dcache.gplazma.plugins.TestPrincipal:bert
+      """.stripMargin
+    plugin.account(Set[Principal](new TestPrincipal("ernie")))
+    intercept[AuthenticationException] {
+      plugin.account(Set[Principal](new TestPrincipal("bert")))
+    }
+    intercept[AuthenticationException] {
+      plugin.account(Set[Principal](new TestPrincipal("bert")))
+    }
+    plugin.account(Set[Principal](new TestPrincipal("ernie")))
+  }
+
+  it should "ban user if any principal is blacklisted" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |ban org.dcache.gplazma.plugins.TestPrincipal:bert
+      """.stripMargin
+    intercept[AuthenticationException] {
+      plugin.account(Set[Principal](new TestPrincipal("ernie"), new TestPrincipal("bert")))
+    }
+  }
+
+  it should "use configured aliases" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |alias name=org.dcache.gplazma.plugins.TestPrincipal
+        |ban name:bert
+      """.stripMargin
+    intercept[AuthenticationException] {
+      plugin.account(Set[Principal](new TestPrincipal("bert")))
+    }
+  }
+
+  it should "understand 'standard' principals without alias" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |ban name:bert
+      """.stripMargin
+    intercept[AuthenticationException] {
+      plugin.account(Set[Principal](new org.dcache.auth.LoginNamePrincipal("bert")))
+    }
+  }
+
+  it should "ignore comments" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |# some comment
+        |alias name=org.dcache.gplazma.plugins.TestPrincipal
+        |ban name:bert
+      """.stripMargin
+    intercept[AuthenticationException] {
+      plugin.account(Set[Principal](new TestPrincipal("bert")))
+    }
+  }
+
+  it should "ignore whitespace lines" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |alias name=org.dcache.gplazma.plugins.TestPrincipal
+        |
+        |ban name:bert
+      """.stripMargin
+    intercept[AuthenticationException] {
+      plugin.account(Set[Principal](new TestPrincipal("bert")))
+    }
+  }
+
+  it should "throw an IllegalArgumentException on malformed lines" in {
+    val plugin = new BanFilePlugin(validProperties) with stringSource
+    plugin.sourceString =
+      """
+        |this is not a valid line
+      """.stripMargin
+    intercept[IllegalArgumentException] {
+      plugin.account(Set[Principal](new TestPrincipal("bert")))
+    }
+  }
+}

--- a/modules/packaging/pom.xml
+++ b/modules/packaging/pom.xml
@@ -114,6 +114,11 @@
     </dependency>
     <dependency>
         <groupId>org.dcache</groupId>
+        <artifactId>gplazma2-banfile</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.dcache</groupId>
         <artifactId>gplazma2-kpwd</artifactId>
         <version>${project.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>2.10.2</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${version.slf4j}</version>
@@ -771,6 +776,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.10</artifactId>
+            <version>2.0.M6-SNAP28</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>logback-test-config</artifactId>
             <version>${project.version}</version>
@@ -788,14 +799,14 @@
                     <version>3.2</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.scala-tools</groupId>
-                    <artifactId>maven-scala-plugin</artifactId>
-                    <version>2.15.2</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1120,6 +1131,7 @@
         <module>modules/gplazma2-jaas</module>
         <module>modules/gplazma2-nis</module>
         <module>modules/gplazma2-nsswitch</module>
+        <module>modules/gplazma2-banfile</module>
         <module>modules/gplazma2-voms</module>
         <module>modules/gplazma2-kpwd</module>
         <module>modules/gplazma2-xacml</module>

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -266,6 +266,12 @@ gplazma.ldap.organization = o=SITE,c=CONTRY
 gplazma.ldap.tree.people = People
 gplazma.ldap.tree.groups = Groups
 
+# ---- BanFile plugin
+#
+
+# BanFile config file
+gplazma.banfile.path = ${dcache.paths.etc}/ban.conf
+
 #  -----------------------------------------------------------------------
 #         Obsolete properties.
 #  -----------------------------------------------------------------------


### PR DESCRIPTION
gPlazma2 was still missing a simple way to ban users. This patch adds a
new plugin that allows blacklisting users based on <principal
type>:<value>
pairs given in a plain text file.

Example file:

---

alias name=org.dcache.auth.LoginNamePrincipal
alias dn=org.globus.gsi.jaas.GlobusPrincipal

ban dn:/C=XY/O=org/OU=Some Where/CN=Some One
ban javax.security.auth.kerberos.KerberosPrincipal:SOMEONE@SOMEWHERE.ORG
ban name:someone
ban dn:/C=XY/O=org/OU=Some Where/CN=Some One Else
## ban javax.security.auth.kerberos.KerberosPrincipal:SOMEONEELSE@SOMEWHERE.ORG

Acked-by: Paul
Acked-by: Gerd
Target: master
Request: 2.6
Require-book: yes
Require-notes: yes
Patch: http://rb.dcache.org/r/5777/
