### PR TITLE
Fix building of dcache (server) and srmclient RPMs

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -2,7 +2,7 @@
 libDir=modules/external
 
 # location of temporary generated files ( .class and so on )
-buildDir=build
+buildDir=${buildTop}/build
 
 #location of the Webadmin stuff to be packaged
 webappBuildDir=${buildDir}/webadmin

--- a/modules-builds/rpms.properties
+++ b/modules-builds/rpms.properties
@@ -1,53 +1,20 @@
-#
-# $Id: rpms.properties,v 1.18 2007-10-28 16:58:21 tigran Exp $
-#
 
 rpmTemplateDir=pkgs/rpm
-rpmPrefix=opt/d-cache
-
-rpmRpmDir=${distDir}
-rpmSrpmDir=${distDir}
 
 #
 # server RPM
 #
-server.rpmTopDir=${buildDir}/server-rpm
-server.rpmRcFile=${server.rpmTopDir}/rpmrc
-server.rpmMacrosFile=${server.rpmTopDir}/rpmmacros
-server.rpmDcacheDir=${server.rpmBuildrootDir}/${rpmPrefix}
-server.rpmClassesDir=${server.rpmDcacheDir}/classes
-server.rpmConfigDir=${server.rpmDcacheDir}/config
+server.rpm.topdir=${buildDir}/server-rpm
+server.rpm.specdir=${server.rpm.topdir}/SPECS
+server.rpm.rpmdir=${server.root.dir}
+server.rpm.buildroot=${server.rpm.topdir}/BUILDROOT/dcache-server
 
 
 #
 # SRM client RPM
 #
 
-srmclient.rpmTopDir=${buildDir}/srmclient-rpm
-srmclient.rpmRcFile=${srmclient.rpmTopDir}/rpmrc
-srmclient.rpmMacrosFile=${srmclient.rpmTopDir}/rpmmacros
-srmclient.rpmSpecFile=${srmclient.rpmTopDir}/dcache-client.spec
-srmclient.rpmDcacheDir=${srmclient.rpmBuildrootDir}/${rpmPrefix}
-srmclient.rpmClassesDir="${srmclient.rpmDcacheDir}/classes
-srmclinet.rpmConfigDir=${srmclient.rpmDcacheDir}/config
-
-
-#
-# dcap client RPM
-#
-
-dcapclient.rpmTopDir=${buildDir}/dcapclient-rpm
-dcapclient.rpmRcFile=${dcapclient.rpmTopDir}/rpmrc
-dcapclient.rpmMacrosFile=${dcapclient.rpmTopDir}/rpmmacros
-dcapclient.rpmSpecFile=${dcapclient.rpmTopDir}/dcache-client.spec
-dcapclient.rpmDcacheDir=${dcapclient.rpmBuildrootDir}/${rpmPrefix}
-dcapclient.rpmClassesDir="${dcapclient.rpmDcacheDir}/classes
-dcapclinet.rpmConfigDir=${dcapclient.rpmDcacheDir}/config
-
-
-#
-# spec files
-#
-server.rpmSpecFile=${server.rpmTopDir}/dcache-server.spec
-dcap.rpmSpecFile=${dcapclient.rpmTopDir}/dcache-dcap.spec
-srmclient.rpmSpecFile=${srmclient.rpmTopDir}/dcache-srmclient.spec
+srmclient.rpm.topdir=${buildDir}/srmclient-rpm
+srmclient.rpm.specdir=${srmclient.rpm.topdir}/SPECS
+srmclient.rpm.rpmdir=${srmclient.root.dir}
+srmclient.rpm.buildroot=${srmclient.rpm.topdir}/BUILDROOT/srmclient

--- a/modules-builds/server-rpm-build.xml
+++ b/modules-builds/server-rpm-build.xml
@@ -7,57 +7,47 @@
     <target name="server.rpm" depends="install-server"
             description="Build the dcache-server-xxx.rpm">
 
-        <!--  timestamp for the changelog -->
-        <tstamp>
-            <format property="timestamp" pattern="EEE MMM dd yyyy"
-                    locale="en,UK"/>
-        </tstamp>
-
-        <!-- Create config files for RPM from Templates -->
-
-        <copy todir="${server.rpmTopDir}" overwrite="true">
-            <fileset dir="${rpmTemplateDir}">
-                <or>
-                    <filename name="rpm*.template" />
-                    <filename name="dcache-server.spec.template" />
-                </or>
+        <!-- Populate BUILDROOT with contents of RPM -->
+        <move todir="${server.rpm.buildroot}">
+            <fileset dir="${server.root.dir}">
+                <include name="**"/>
             </fileset>
-            <mapper type="glob" from="*.template" to="*" />
+        </move>
+
+        <mkdir dir="${server.rpm.buildroot}/etc/rc.d/init.d"/>
+        <copy file="${rpmTemplateDir}/dcache-server.init"
+              tofile="${server.rpm.buildroot}/etc/rc.d/init.d/dcache-server"/>
+        <copy file="${rpmTemplateDir}/dcache.bash-completion"
+              tofile="${server.rpm.buildroot}/etc/bash_completion.d/dcache"/>
+
+        <!-- Create spec file from template -->
+        <copy todir="${server.rpm.specdir}" overwrite="true">
+            <fileset dir="${rpmTemplateDir}">
+                <filename name="dcache-server.spec.template" />
+            </fileset>
+            <mapper type="glob" from="*.template" to="*"/>
             <filterset>
-                <filter token="Timestamp" value="${timestamp}" />
-
-                <filter token="rpmMacrosFile" value="${server.rpmMacrosFile}" />
-                <!-- This is only used in the rpmrc file -->
-
-                <filter token="rpmRpmDir" value="${rpmRpmDir}" />
-                <!-- These are used in the rpmmacros file -->
-                <filter token="rpmSrpmDir" value="${rpmSrpmDir}" />
-                <filter token="rpmTopDir" value="${server.rpmTopDir}" />
-                <filter token="rpmBuildDir" value="${server.rpmTopDir}" />
-
                 <filter token="Version" value="${version}" />
                 <filter token="Release" value="${build.number}" />
             </filterset>
         </copy>
 
-        <mkdir dir="${server.root.dir}/etc/rc.d/init.d"/>
-        <copy file="${rpmTemplateDir}/dcache-server.init"
-              tofile="${server.root.dir}/etc/rc.d/init.d/dcache-server"/>
-        <copy file="${rpmTemplateDir}/dcache.bash-completion"
-              tofile="${server.root.dir}/etc/bash_completion.d/dcache"/>
 
         <exec executable="rpmbuild" failonerror="true">
-            <!-- output="${buildDir}/rpm.log" -->
             <arg value="--buildroot" />
-            <arg file="${server.root.dir}" />
-            <arg value="--rcfile" />
-            <arg file="/usr/lib/rpm/rpmrc:${server.rpmRcFile}" />
-            <!-- some documentation claims that /usr/lib/rpm/rpmrc
-                                                            will always be parsed. But it currently isnt if not set here -->
+            <arg file="${server.rpm.buildroot}" />
+
+            <arg value="--define"/>
+            <arg value="_topdir ${server.rpm.topdir}"/>
+
+            <arg value="--define"/>
+            <arg value="_rpmdir ${server.rpm.rpmdir}"/>
+
+            <arg value="--define"/>
+            <arg value="_binary_payload w5.bzdio"/>
+
             <arg value="-bb" />
-            <arg file="${server.rpmTopDir}/dcache-server.spec" />
+            <arg file="${server.rpm.specdir}/dcache-server.spec" />
         </exec>
-
     </target>
-
 </project>

--- a/modules-builds/srmclient-rpm-build.xml
+++ b/modules-builds/srmclient-rpm-build.xml
@@ -3,51 +3,41 @@
     <target name="srmclient.rpm" depends="srmclient"
             description="Build the dcache-srmclient-xxx.rpm">
 
-      <move todir="${srmclient.root.dir}">
+        <!-- Copy files for packaging into BUILDROOT -->
+        <move todir="${srmclient.rpm.buildroot}">
             <cutdirsmapper dirs="1"/>
             <fileset dir="modules/srmclient/target/">
                 <include name="srmclient-*/**"/>
             </fileset>
         </move>
 
-        <!-- Create config files for RPM from Templates -->
-
-        <copy todir="${srmclient.rpmTopDir}" overwrite="true">
+        <!-- Create spec file -->
+        <copy todir="${srmclient.rpm.specdir}" overwrite="true">
             <fileset dir="${rpmTemplateDir}">
-                <or>
-                    <filename name="rpm*.template" />
-                    <filename name="dcache-srmclient.spec.template" />
-                </or>
+                <filename name="dcache-srmclient.spec.template" />
             </fileset>
             <mapper type="glob" from="*.template" to="*" />
             <filterset>
-                <filter token="rpmMacrosFile" value="${srmclient.rpmMacrosFile}" />
-                <!-- This is only used in the rpmrc file -->
-
-                <filter token="rpmRpmDir" value="${rpmRpmDir}" />
-                <!-- These are used in the rpmmacros file -->
-                <filter token="rpmSrpmDir" value="${rpmSrpmDir}" />
-                <filter token="rpmTopDir" value="${srmclient.rpmTopDir}" />
-
                 <filter token="Version" value="${version}" />
                 <filter token="Release" value="${build.number}" />
             </filterset>
         </copy>
 
-        <!-- Call RPM. The rpm task is not sufficient since it doesnt have the rcfile option -->
-
         <exec executable="rpmbuild" failonerror="true">
-            <!-- output="${buildDir}/rpm.log" -->
             <arg value="--buildroot" />
-            <arg file="${package.root.dir}/srmclient" />
-            <arg value="--rcfile" />
-            <arg file="/usr/lib/rpm/rpmrc:${srmclient.rpmRcFile}" />
-            <!-- some documentation claims that /usr/lib/rpm/rpmrc
-                                                            will always be parsed. But it currently isnt if not set here -->
+            <arg file="${srmclient.rpm.buildroot}" />
+
+            <arg value="--define"/>
+            <arg value="_topdir ${srmclient.rpm.topdir}"/>
+
+            <arg value="--define"/>
+            <arg value="_rpmdir ${srmclient.rpm.rpmdir}"/>
+
+            <arg value="--define"/>
+            <arg value="_binary_payload w5.bzdio"/>
+
             <arg value="-bb" />
-            <arg file="${srmclient.rpmSpecFile}" />
+            <arg file="${srmclient.rpm.specdir}/dcache-srmclient.spec" />
         </exec>
-
     </target>
-
 </project>

--- a/pkgs/rpm/rpmmacros.template
+++ b/pkgs/rpm/rpmmacros.template
@@ -1,7 +1,0 @@
-%_topdir @rpmTopDir@
-%_specdir @rpmSpecDir@
-%_rpmdir @rpmRpmDir@
-%_srpmdir @rpmSrpmDir@
-%_builddir @rpmBuildDir@
-%_sourcedir @rpmSourceDir@
-%_binary_payload  w5.bzdio

--- a/pkgs/rpm/rpmrc.template
+++ b/pkgs/rpm/rpmrc.template
@@ -1,1 +1,0 @@
-macrofiles:     /usr/lib/rpm/macros:/usr/lib/rpm/%{_target}/macros:/etc/rpm/macros.specspo:/etc/rpm/macros.prelink:/etc/rpm/macros.solve:/etc/rpm/macros.up2date:/etc/rpm/macros:/etc/rpm/%{_target}/macros:~/.rpmmacros:@rpmMacrosFile@


### PR DESCRIPTION
When building RPM packages of dCache and srm-client, the intent was
that the packages are built within the build directory and the
resulting files end up in the dist directory.  To achieve this,
a complicated hack was employed where the rpmbuild rc file is
loaded from a custom file, which references a new macro to
override existing macro values.

At some point, RPM support for rc files was broken and this
method no longer worked.   New RPM files were written in the
default location (~/rpmbuild/RPMS/...).  Depending on the
build environment, this continued to work, but only "by accident."

This patch removes the fragile rc and macro file approach and
replaces it with direct injection of the values via the command
line.  The --define argument allows overriding of these values
and provides a more robust approach to controlling RPM.

Many properties defined in rpm.properties were simply not used.
These have been removed.

The dist directory was referred to in relative terms.  Since the
RPM command changes directory, this isn't safe.  Therefore the
definition has been updated to use the absolute path.
