### PR TITLE
poolmanager: Restore compatibility with pre 2.2.13 and earlier releases

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
@@ -102,6 +102,8 @@ public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg
      */
     public static class Context implements Serializable
     {
+        static final long serialVersionUID = 5542068315211674363L;
+
         private final int _retryCounter;
         private final String _previousStageHost;
         private final String _previousStagePool;


### PR DESCRIPTION
dCache 2.2.14 introduced an incompatibility with previous versions. This
patch addresses the issue by restoring compatibility with version 2.2.13
and earlier.

Note that sites that already upgraded to dCache 2.2.14 will have to update
all doors and pool manager together: dCache 2.2.14 doors and pool manager
cannot be mixed with 2.2.13 or earlier nor 2.2.15 and later.

Target: 2.2
Require-notes: yes
Require-book: no
