### PR TITLE
(2.2) httpd: fix botched plot db initialization

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/BaseBillingInfoAccess.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/BaseBillingInfoAccess.java
@@ -79,12 +79,13 @@ public abstract class BaseBillingInfoAccess implements IBillingInfoAccess {
         logger.debug("maxInsertsBeforeCommit {}", maxInsertsBeforeCommit);
         logger.debug("maxTimeBeforeCommit {}", maxTimeBeforeCommit);
 
+        setRunning(true);
+
         /*
          * if using delayed commits, run a flush thread
          */
         if (maxTimeBeforeCommit > 0) {
             flushD = new TimedCommitter();
-            setRunning(true);
             flushD.start();
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/html/HttpBillingHistoryEngine.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/html/HttpBillingHistoryEngine.java
@@ -59,7 +59,6 @@ public final class HttpBillingHistoryEngine extends BillingHistory implements
                 _log.warn("Interrupted while waiting for BillingHistory thread to terminate");
             }
         }
-        close();
     }
 
     @Override

--- a/modules/dcache/src/main/resources/org/dcache/services/billing/plot/billinghistory.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/plot/billinghistory.xml
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
-    xmlns:context="http://www.springframework.org/schema/context"
-    xsi:schemaLocation="
-           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
-           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
     <bean id="properties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <description>Imported configuration data</description>
         <property name="location" value="arguments:"/>
     </bean>
 
-    <bean id="jdbc-billing-info-access" class="${dbAccess}">
+    <bean id="jdbc-billing-info-access" class="${dbAccess}"
+             init-method="initialize" destroy-method="close">
         <property name="jdbcUrl" value="${dbUrl}"/>
         <property name="jdbcDriver" value="${dbDriver}"/>
         <property name="jdbcUser" value="${dbUser}"/>
         <property name="jdbcPassword" value="#{ T(diskCacheV111.util.Pgpass).getPassword('${pgPass}', '${dbUrl}', '${dbUser}', '${dbPass}') }"/>
-        <property name="maxInsertsBeforeCommit" value="${dbAccessMaxInsertsBeforeCommit}"/>
-        <property name="maxTimeBeforeCommit" value="${dbAccessMaxTimeBeforeCommit}"/>
         <property name="propertiesPath" value="${dbAccessProperties}"/>
     </bean>
 </beans>

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -130,8 +130,6 @@ define context billingHistory-db-yes.exe endDefine
      -dbAccessContext=classpath:org/dcache/services/billing/plot/billinghistory.xml \
      -dbAccess=${billingInfoAccess} \
      -dbAccessProperties=${billingInfoAccessPropertiesFile} \
-     -dbAccessMaxInsertsBeforeCommit=${billingMaxInsertsBeforeCommit} \
-     -dbAccessMaxTimeBeforeCommit=${billingMaxTimeBeforeCommitInSecs} \
      -dbUrl=${billingDbUrl} \
      -dbDriver=${billingDbDriver} \
      -dbUser=${billingDbUser} \


### PR DESCRIPTION
An early version of the original billing/plotting for dcache 2.2 had the cell and the plotting agent both accessing the same spring configuration.  This was at one point changed, but left the initialization procedure inconsistent.  This patch addresses this, by
1.  Updating the billinghistory.xml to be in sync with the spring schema versions used in billing.xml
2.  Moving all initialization and close calls to the bean definition, so that the database wrapper lifecycle is entirely managed by Spring
3.  Removing the batching properties from the billinghistory.xml so that the DAO layer does not spawn an unnecessary thread (plotting does not insert into the db)
4.  Moved the setRunning(true) outside the condition which starts that thread, where it belongs.

Testing:

Redeployed and checked for presence of plots, checked log for errors.

Target: 2.2
Patch: http://rb.dcache.org/r/5870
Require-book: no
Require-notes: no
Acked-by: Gerd
