### PR TITLE
spacemanager: Fix forwarding when disabled and add fast forward path

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
@@ -86,11 +86,10 @@ import diskCacheV111.vehicles.DoorTransferFinishedMessage;
 import diskCacheV111.vehicles.Message;
 import diskCacheV111.vehicles.PnfsDeleteEntryNotificationMessage;
 import diskCacheV111.vehicles.PoolAcceptFileMessage;
-import diskCacheV111.vehicles.PoolDeliverFileMessage;
 import diskCacheV111.vehicles.PoolFileFlushedMessage;
+import diskCacheV111.vehicles.PoolIoFileMessage;
 import diskCacheV111.vehicles.PoolLinkGroupInfo;
 import diskCacheV111.vehicles.PoolMgrGetPoolLinkGroups;
-import diskCacheV111.vehicles.PoolMgrSelectPoolMsg;
 import diskCacheV111.vehicles.PoolMgrSelectWritePoolMsg;
 import diskCacheV111.vehicles.PoolRemoveFilesMessage;
 import diskCacheV111.vehicles.ProtocolInfo;
@@ -3479,71 +3478,78 @@ public final class Manager
         }
 
         @Override
-        public void messageArrived(final CellMessage cellMessage)
+        public void messageArrived(final CellMessage envelope)
         {
-            if(spaceManagerEnabled) {
-                ThreadManager.execute(new Runnable() {
-                        @Override
-                        public void run()
-                        {
-                                processMessage(cellMessage);
-                        }
-                    });
-            } else {
-                handleMessageAsDisabled(cellMessage);
-            }
-        }
-
-        private void handleMessageAsDisabled(CellMessage cellMessage)
-        {
-            Object rawPayload = cellMessage.getMessageObject();
-
-            if (!(rawPayload instanceof Message)) {
-                logger.warn("unknown payload {}: {}", rawPayload.getClass().
-                        getCanonicalName(), rawPayload);
+            Object rawMessage = envelope.getMessageObject();
+            logger.trace("Message  arrived: {} from {}", rawMessage, envelope.getSourcePath());
+            if (!(rawMessage instanceof Message)) {
+                logger.warn("Unknown payload {}: {}", rawMessage.getClass().getCanonicalName(), rawMessage);
                 return;
             }
 
-            Message message = (Message) cellMessage.getMessageObject();
+            final Message message = (Message) rawMessage;
 
-            if (message instanceof PoolFileFlushedMessage ||
-                    message instanceof PoolRemoveFilesMessage ||
-                    message instanceof PnfsDeleteEntryNotificationMessage) {
-
-                // Simply ignore these notification messages
-
-            } else if (message instanceof Reserve
-                    || message instanceof GetSpaceTokensMessage
-                    || message instanceof GetSpaceTokenIdsMessage
-                    || message instanceof GetLinkGroupsMessage
-                    || message instanceof GetLinkGroupNamesMessage
-                    || message instanceof GetLinkGroupIdsMessage
-                    || message instanceof Release
-                    || message instanceof Use
-                    || message instanceof CancelUse
-                    || message instanceof GetSpaceMetaData
-                    || message instanceof GetSpaceTokens
-                    || message instanceof ExtendLifetime
-                    || message instanceof GetFileSpaceTokensMessage ) {
-
-                returnFailedResponse("SpaceManager is disabled in configuration",
-                        message, cellMessage);
-
+            if (spaceManagerEnabled) {
+                if (isNotificationMessage(message) || isSpaceManagerMessage(message) || isInterceptedMessage(message)) {
+                    ThreadManager.execute(new Runnable() {
+                        @Override
+                        public void run()
+                        {
+                            processMessage(envelope, message);
+                        }
+                    });
+                } else if (!message.isReply()) {
+                    forwardToPoolmanager(envelope);
+                }
             } else {
-                forwardToPoolmanager(cellMessage);
+                if (!isNotificationMessage(message)) {
+                    if (isSpaceManagerMessage(message)) {
+                        returnFailedResponse("SpaceManager is disabled in configuration", message, envelope);
+                    } else if (!message.isReply()) {
+                        forwardToPoolmanager(envelope);
+                    }
+                }
             }
         }
 
-        private void processMessage( CellMessage cellMessage ) {
-                Object object = cellMessage.getMessageObject();
-                logger.debug("Message  arrived: {} from {}", object,
-                        cellMessage.getSourcePath());
-                if (!(object instanceof Message)) {
-                        logger.error("unexpected message class {}",
-                                object.getClass());
-                        return;
-                }
-                Message spaceMessage = (Message)object;
+    /** Returns true if message is of a type processed exclusively by SpaceManager */
+    private boolean isSpaceManagerMessage(Object message)
+    {
+        return message instanceof Reserve
+                || message instanceof GetSpaceTokensMessage
+                || message instanceof GetSpaceTokenIdsMessage
+                || message instanceof GetLinkGroupsMessage
+                || message instanceof GetLinkGroupNamesMessage
+                || message instanceof GetLinkGroupIdsMessage
+                || message instanceof Release
+                || message instanceof Use
+                || message instanceof CancelUse
+                || message instanceof GetSpaceMetaData
+                || message instanceof GetSpaceTokens
+                || message instanceof ExtendLifetime
+                || message instanceof GetFileSpaceTokensMessage;
+    }
+
+    /** Returns true if message is a notification to which SpaceManager subscribes */
+    private boolean isNotificationMessage(Object message)
+    {
+        return message instanceof PoolFileFlushedMessage
+                || message instanceof PoolRemoveFilesMessage
+                || message instanceof PnfsDeleteEntryNotificationMessage;
+    }
+
+    /**
+     * Returns true if message is of a type that needs processing by SpaceManager even if
+     * SpaceManager is not the intended final destination.
+     */
+    private boolean isInterceptedMessage(Object message)
+    {
+        return message instanceof PoolMgrSelectWritePoolMsg
+                || message instanceof DoorTransferFinishedMessage
+                || message instanceof PoolAcceptFileMessage;
+    }
+
+    private void processMessage(CellMessage cellMessage, Message spaceMessage) {
                 boolean replyRequired = spaceMessage.getReplyRequired();
                 try {
                         if(spaceMessage instanceof Reserve) {
@@ -3587,8 +3593,8 @@ public final class Manager
                                 CancelUse cancelUse = (CancelUse) spaceMessage;
                                 cancelUseSpace(cancelUse);
                         }
-                        else if(spaceMessage instanceof PoolMgrSelectPoolMsg) {
-                                selectPool(cellMessage,false);
+                        else if(spaceMessage instanceof PoolMgrSelectWritePoolMsg) {
+                                selectPool(cellMessage, (PoolMgrSelectWritePoolMsg) spaceMessage, false);
                                 replyRequired = false;
                         }
                         else if(spaceMessage instanceof GetSpaceMetaData){
@@ -3628,24 +3634,21 @@ public final class Manager
                                 markFileDeleted(msg);
                         }
                         else {
-                            if (!spaceMessage.isReply()) {
-                                forwardToPoolmanager(cellMessage);
-                            }
-                            return;
+                            throw new RuntimeException("Unexpected " + spaceMessage.getClass() + ": Please report this to support@dcache.org");
                         }
                 }
                 catch(SpaceException se) {
                         logger.error("failed to process message: {}", se.getMessage());
-                        spaceMessage.setFailed(-2,se);
+                        spaceMessage.setFailed(-2, se);
                 }
                 catch(SQLException e) {
                         logger.error("database activity failed: {}",
                                 e.getMessage());
-                        spaceMessage.setFailed(-1,e);
+                        spaceMessage.setFailed(-1, e);
                 }
                 catch(Throwable t) {
                         logger.error("an operation failed:", t);
-                        spaceMessage.setFailed(-1,t);
+                        spaceMessage.setFailed(-1, t);
                 }
                 if (replyRequired) {
                         try {
@@ -3664,33 +3667,36 @@ public final class Manager
         }
 
         @Override
-        public void messageToForward(final CellMessage cellMessage)
+        public void messageToForward(final CellMessage envelope)
         {
-            if (spaceManagerEnabled) {
-                ThreadManager.execute(new Runnable() {
+            final Serializable message = envelope.getMessageObject();
+            if (spaceManagerEnabled && isInterceptedMessage(message)) {
+                    ThreadManager.execute(new Runnable() {
                         @Override
                         public void run()
                         {
-                            processMessageToForward(cellMessage);
+                            processMessageToForward(envelope, (Message) message);
                         }
                     });
             } else {
-                super.messageToForward(cellMessage);
+                if (message instanceof PoolIoFileMessage && !((Message) message).isReply()) {
+                    envelope.getDestinationPath().insert(poolManager);
+                }
+                super.messageToForward(envelope);
             }
         }
 
-        public void processMessageToForward(CellMessage cellMessage ) {
-                Object object = cellMessage.getMessageObject();
-                logger.debug("messageToForward,  arrived: type={} value={} " +
-                        "from {} going to {}", object.getClass().getName(),
-                        object, cellMessage.getSourcePath(),
-                        cellMessage.getDestinationPath());
+        public void processMessageToForward(CellMessage envelope, Message message) {
+                logger.trace("messageToForward,  arrived: type={} value={} " +
+                        "from {} going to {}", message.getClass().getName(),
+                        message, envelope.getSourcePath(),
+                        envelope.getDestinationPath());
                 try {
-                        if( object instanceof PoolMgrSelectPoolMsg) {
-                                selectPool(cellMessage,true);
+                        if( message instanceof PoolMgrSelectWritePoolMsg) {
+                                selectPool(envelope, (PoolMgrSelectWritePoolMsg) message, true);
                         }
-                        else if(object instanceof PoolAcceptFileMessage ) {
-                                PoolAcceptFileMessage poolRequest = (PoolAcceptFileMessage)object;
+                        else if(message instanceof PoolAcceptFileMessage ) {
+                                PoolAcceptFileMessage poolRequest = (PoolAcceptFileMessage)message;
                                 if(poolRequest.isReply()) {
                                         PnfsId pnfsId = poolRequest.getPnfsId();
                                         //mark file as being transfered
@@ -3700,18 +3706,11 @@ public final class Manager
                                         // this message on its way to the pool
                                         // we need to set the AccessLatency, RetentionPolicy and StorageGroup
                                         transferToBeStarted(poolRequest);
-                                        cellMessage.getDestinationPath().insert(poolManager);
+                                        envelope.getDestinationPath().insert(poolManager);
                                 }
                         }
-                        else if (object instanceof PoolDeliverFileMessage) {
-                                PoolDeliverFileMessage poolRequest =
-                                        (PoolDeliverFileMessage)object;
-                                if (!poolRequest.isReply()) {
-                                        cellMessage.getDestinationPath().insert(poolManager);
-                                }
-                        }
-                        else if ( object instanceof DoorTransferFinishedMessage) {
-                                DoorTransferFinishedMessage finished = (DoorTransferFinishedMessage) object;
+                        else if ( message instanceof DoorTransferFinishedMessage) {
+                                DoorTransferFinishedMessage finished = (DoorTransferFinishedMessage) message;
                                 try {
                                         transferFinished(finished);
                                 }
@@ -3727,7 +3726,7 @@ public final class Manager
                         logger.error("forwarding msg failed: {}",
                                 e.getMessage(), e);
                 }
-                super.messageToForward(cellMessage) ;
+                super.messageToForward(envelope) ;
         }
 
         @Override
@@ -4807,13 +4806,13 @@ public final class Manager
         }
 
         public void selectPool(CellMessage cellMessage,
+                               PoolMgrSelectWritePoolMsg selectWritePool,
                                boolean isReply )
                 throws Exception{
-                PoolMgrSelectPoolMsg selectPool = (PoolMgrSelectPoolMsg)cellMessage.getMessageObject();
-                logger.debug("selectPool({})", selectPool);
-                String pnfsPath = selectPool.getPnfsPath();
-                PnfsId pnfsId   = selectPool.getPnfsId();
-                if( !(selectPool instanceof PoolMgrSelectWritePoolMsg)||pnfsPath == null) {
+                logger.debug("selectPool({})", selectWritePool);
+                String pnfsPath = selectWritePool.getPnfsPath();
+                PnfsId pnfsId   = selectWritePool.getPnfsId();
+                if (pnfsPath == null) {
                         logger.debug("selectPool: pnfsPath is null");
                         if(!isReply) {
                                 logger.debug("just forwarding the message to {}", poolManager);
@@ -4823,7 +4822,6 @@ public final class Manager
                         }
                         return;
                 }
-                PoolMgrSelectWritePoolMsg selectWritePool = (PoolMgrSelectWritePoolMsg) selectPool;
                 File file = null;
                 try {
                         logger.debug("selectPool: getFiles({})", pnfsPath);
@@ -4838,7 +4836,7 @@ public final class Manager
                 catch (Exception e) {
                         logger.info("failed to find pool: {}", e.getMessage());
                 }
-                FileAttributes fileAttributes = selectPool.getFileAttributes();
+                FileAttributes fileAttributes = selectWritePool.getFileAttributes();
                 if(file==null) {
                         AccessLatency al = fileAttributes.getAccessLatency();
                         RetentionPolicy rp = fileAttributes.getRetentionPolicy();


### PR DESCRIPTION
Addresses a bug in which PoolIoFileMessage was not forwarded to pool
manager when spacemanager was disabled.

Addresses a performance issue in which spacemanager congestion caused
by heavy write activity slows down read requests, even though read
requests are simply forwarded by pool manager. The issue is that the
forwarding of messages related to a read request happens on a thread
pool (manager by ThreadManager) that is also used by write requests.
This patch addresses the problem by forwarding such message immediately
rather than scheduling them on a different thread pool.

Note that read requests may still suffer from write congestion as
DoorTransferFinished must be intercepted by space manager and we
cannot distinguish between read and write requests without a
database lookup.

Target: trunk
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7902
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/5886/
Committed: 8270b5e105ead8c8b65881684949245e67f52fce
