### PR TITLE
dcache: yet another fix to datanucleus dependency

### DIFF
--- a/modules/dcache/pom.xml
+++ b/modules/dcache/pom.xml
@@ -306,7 +306,7 @@
 
           <plugin>
               <groupId>org.datanucleus</groupId>
-              <artifactId>maven-datanucleus-plugin</artifactId>
+              <artifactId>datanucleus-maven-plugin</artifactId>
               <configuration>
                   <verbose>false</verbose>
               </configuration>
@@ -350,7 +350,7 @@
                             <pluginExecution>
                                 <pluginExecutionFilter>
                                     <groupId>org.datanucleus</groupId>
-                                    <artifactId>maven-datanucleus-plugin</artifactId>
+                                    <artifactId>datanucleus-maven-plugin</artifactId>
                                     <goals>
                                         <goal>enhance</goal>
                                     </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <bouncycastle.bcprov>bcprov-jdk16</bouncycastle.bcprov>
         <bouncycastle.version>1.43</bouncycastle.version>
         <datanucleus-core.version>3.2.6</datanucleus-core.version>
-        <datanucleus.plugin.version>3.2.0-m1</datanucleus.plugin.version>
+        <datanucleus.plugin.version>3.2.0-release</datanucleus.plugin.version>
     </properties>
 
     <scm>
@@ -908,7 +908,7 @@
                 </plugin>
                 <plugin>
                     <groupId>org.datanucleus</groupId>
-                    <artifactId>maven-datanucleus-plugin</artifactId>
+                    <artifactId>datanucleus-maven-plugin</artifactId>
                     <version>${datanucleus.plugin.version}</version>
                     <dependencies>
                         <dependency>


### PR DESCRIPTION
Use the release version, not the old pre-release beta with the
old name.

Target: trunk
Request: 2.7
Require-book: no
Require-notes: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5925/
(cherry picked from commit 0b8d5478f31272ca13cae1fa0ffbeaac5de471ad)
