### PR TITLE
system-test: Fix authzdb generation when htpasswd is not installed

### DIFF
--- a/packages/system-test/src/main/skel/bin/populate
+++ b/packages/system-test/src/main/skel/bin/populate
@@ -17,9 +17,9 @@ if [ ! -f etc/dcache.kpwd ]; then
         bin/dcache kpwd dcmapadd "$DN" "$username"
     fi
 
+    echo "version 2.1" > etc/grid-security/storage-authzdb
     if which htpasswd; then
       htpasswd -b -c etc/htpasswd admin dickerelch
-      echo "version 2.1" >> etc/grid-security/storage-authzdb
       echo "authorize admin read-write 0 0 / / /" >> etc/grid-security/storage-authzdb
     else
       bin/dcache kpwd dcuseradd -u 0 -g 0 -h / -r / -f / \


### PR DESCRIPTION
Otherwise gPlazma will fail due to the missing configuration file.

Target: trunk
Request: 2.7
Require-notes: no
Require-book: no
Acked-by: Karsten Schwank karsten.schwank@desy.de
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5927/
(cherry picked from commit 9895d4a4d978ecc8d0f8e4d89c1ffb026fbd2003)
