### PR TITLE
libs: update jpnfs library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -737,7 +737,7 @@
         <dependency>
             <groupId>org.dcache.chimera</groupId>
             <artifactId>jpnfs</artifactId>
-            <version>0.5.2</version>
+            <version>0.5.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
update to a bugfix relase of NFS code:

this fixes enforce security flavor in the export file.

Example entry in export file:

/some/export/path *(rw,sec=krb5)

Changelog for jpnfs-0.5.2..jpnfs-0.5.5
    \* [178bddd] nfs: added support for sec flavor in export file
    \* [91f4cba] vfs: check security flavor used by client
    \* [2cd3029] nfsv3: reply correct auth flavor of mount
    \* [ca91195] nfs: ignore and log export entries with unsupported options
    \* [be6ff36] junit: refactor v4 test to reduce code duplication
    \* [485b6a4] nfsv41: fix open stateid leak

Acked-by: Paul Millar
Target: master, 2.7, 2.6
Require-book: yes
Require-notes: yes
