### PR TITLE
srm: provide better logging for internal errors

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/server/SRMServerV2.java
+++ b/modules/srm/src/main/java/org/dcache/srm/server/SRMServerV2.java
@@ -312,10 +312,20 @@ public class SRMServerV2 implements org.dcache.srm.v2_2.ISRM  {
                     Object response = handleGetResponseMethod.invoke(handler,(Object[])null);
                     return response;
                 } catch(Exception e) {
-                    log.error("handler invocation failed",e);
+                    Throwable cause = e;
+                    String message = e.toString();
+
+                    if (e instanceof java.lang.reflect.InvocationTargetException) {
+                        cause = e.getCause();
+                        message = "InvocationTargetException: " +
+                                cause.toString();
+                    }
+
+                    log.error("Bug detected; please report to " +
+                                "support@dCache.org: {}", message, cause);
+                    srmServerCounters.incrementFailed(requestClass);
                     return getFailedResponse(capitalizedRequestName,
-                            TStatusCode.SRM_FAILURE,
-                         "handler invocation failed"+ e.getMessage());
+                            TStatusCode.SRM_FAILURE, "internal error");
                 }
             } catch(Exception e) {
                 log.error(" handleRequest: ",e);


### PR DESCRIPTION
The SRM builds an object for each user request that is responsible
for generating the response.  If there is a bug in that object's
class then an InvocationTargetException is thrown.  This is logged
with the stack-trace from the ITE along with the message from the
underlying RuntimeException.

There are two problems: first, the stack-trace is from the ITE, not
the RuntimeException (therefore we don't know where the bug is);
second, the message is logged.  There are several RuntimeExceptions
that have null message, therefore seeing 'null' means we don't know
what went wrong.

This patch fixes these problems.  If the captured problem is an ITE
then the stack-trace of underlying problem reported, not that of the
ITE.  Also, the logged message includes that the problem is due to
an ITE and reports the triggering Exception's toString.

The patch also alters the message send back to the user to simply
"internal error".  Previously the exception's error message was
reported, but I believe that almost all users can do nothing with
this information (it will only confuse them) and the admin should
check the log files when investigating a problem.

Target: master
Request: 2.7
Request: 2.6
Request: 2.2
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7986
Patch: http://rb.dcache.org/r/5936/
Acked-by: Karsten Schwank
Requires-book: no
Requires-notes: no
