### PR TITLE
srm: Fix and clean up database update logic

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/Job.java
@@ -702,11 +702,10 @@ public abstract class Job  {
        return historyStringBuillder.toString();
     }
 
-
-     public Iterator<JobHistory> getHistoryIterator() {
+     public List<JobHistory> getJobHistory() {
         rlock();
         try {
-            return new ArrayList<>(jobHistory).iterator();
+            return new ArrayList<>(jobHistory);
         } finally {
             runlock();
         }
@@ -1131,15 +1130,16 @@ public abstract class Job  {
     }
 
     public static class JobHistory implements Comparable<JobHistory> {
-        private long id;
-        private State state;
-        private long transitionTime;
-        private String description;
+        private final long id;
+        private final State state;
+        private final long transitionTime;
+        private final String description;
         private boolean saved; //false by default
+
         public JobHistory(long id, State state, String description, long transitionTime) {
             this.id = id;
             this.state = state;
-            this.description = description;
+            this.description = description.replace('\'','`');
             this.transitionTime = transitionTime;
         }
 
@@ -1172,9 +1172,6 @@ public abstract class Job  {
          * @return Value of property description.
          */
         public String getDescription() {
-            if(description.indexOf('\'') != -1 ) {
-                description = description.replace('\'','`');
-            }
             return description;
         }
 
@@ -1224,11 +1221,11 @@ public abstract class Job  {
             return sb.toString();
         }
 
-        public boolean isSaved() {
+        public synchronized boolean isSaved() {
             return saved;
         }
 
-        public void setSaved() {
+        public synchronized void setSaved() {
             this.saved = true;
         }
 

--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/BringOnlineFileRequestStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/BringOnlineFileRequestStorage.java
@@ -114,11 +114,6 @@ public class BringOnlineFileRequestStorage extends DatabaseFileRequestStorage {
         return TABLE_NAME;
     }
 
-    @Override
-    public PreparedStatement[] getAdditionalCreateStatements(Connection connection,
-                                                             Job job) throws SQLException {
-        return null;
-    }
     public PreparedStatement getStatement(Connection connection,
                                           String query,
                                           Job fr) throws SQLException {

--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/BringOnlineRequestStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/BringOnlineRequestStorage.java
@@ -255,24 +255,22 @@ public class BringOnlineRequestStorage extends DatabaseContainerRequestStorage{
         " VALUES (?,?)";
 
     @Override
-    public PreparedStatement[] getAdditionalCreateStatements(Connection connection,
-                                                             Job job) throws SQLException {
+    public PreparedStatement getBatchCreateStatement(Connection connection, Job job) throws SQLException {
         if(job == null || !(job instanceof BringOnlineRequest)) {
             throw new IllegalArgumentException("Request is not BringOnlineRequest" );
         }
-        BringOnlineRequest bor = (BringOnlineRequest)job;
+        BringOnlineRequest bor = (BringOnlineRequest) job;
         String[] protocols = bor.getProtocols();
-        if(protocols ==null) {
+        if (protocols == null) {
             return null;
         }
-        PreparedStatement[] statements  = new PreparedStatement[protocols.length];
-        for(int i=0; i<protocols.length ; ++i){
-            statements[i] = getPreparedStatement(connection,
-                    insertProtocols,
-                    protocols[i],
-                    bor.getId());
+        PreparedStatement statement = connection.prepareStatement(insertProtocols);
+        for (String protocol : protocols) {
+            statement.setString(1, protocol);
+            statement.setLong(2, bor.getId());
+            statement.addBatch();
         }
-        return statements;
+        return statement;
    }
 
 

--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/GetRequestStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/GetRequestStorage.java
@@ -311,24 +311,22 @@ public class GetRequestStorage extends DatabaseContainerRequestStorage{
         " VALUES (?,?)";
 
     @Override
-    public PreparedStatement[] getAdditionalCreateStatements(Connection connection,
-                                                             Job job) throws SQLException {
-        if(job == null || !(job instanceof GetRequest)) {
+    public PreparedStatement getBatchCreateStatement(Connection connection, Job job) throws SQLException {
+        if (job == null || !(job instanceof GetRequest)) {
             throw new IllegalArgumentException("Request is not GetRequest" );
         }
         GetRequest gr = (GetRequest)job;
         String[] protocols = gr.getProtocols();
-        if(protocols ==null) {
+        if (protocols == null) {
             return null;
         }
-        PreparedStatement[] statements  = new PreparedStatement[protocols.length];
-        for(int i=0; i<protocols.length ; ++i){
-            statements[i] = getPreparedStatement(connection,
-                    insertProtocols,
-                    protocols[i],
-                    gr.getId());
+        PreparedStatement statement = connection.prepareStatement(insertProtocols);
+        for (String protocol : protocols) {
+            statement.setString(1, protocol);
+            statement.setLong(2, gr.getId());
+            statement.addBatch();
         }
-        return statements;
+        return statement;
     }
 
     @Override

--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/PutRequestStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/PutRequestStorage.java
@@ -310,24 +310,23 @@ public class PutRequestStorage extends DatabaseContainerRequestStorage{
         " VALUES (?,?)";
 
     @Override
-    public PreparedStatement[] getAdditionalCreateStatements(Connection connection,
-                                                             Job job) throws SQLException {
-        if(job == null || !(job instanceof PutRequest)) {
+    public PreparedStatement getBatchCreateStatement(Connection connection, Job job)
+            throws SQLException {
+        if (job == null || !(job instanceof PutRequest)) {
             throw new IllegalArgumentException("Request is not PutRequest" );
         }
-        PutRequest pr = (PutRequest)job;
+        PutRequest pr = (PutRequest) job;
         String[] protocols = pr.getProtocols();
-        if(protocols ==null) {
+        if (protocols == null) {
             return null;
         }
-        PreparedStatement[] statements  = new PreparedStatement[protocols.length];
-        for(int i=0; i<protocols.length ; ++i){
-            statements[i] = getPreparedStatement(connection,
-                    insertProtocols,
-                    protocols[i],
-                    pr.getId());
+        PreparedStatement statement = connection.prepareStatement(insertProtocols);
+        for (String protocol : protocols) {
+            statement.setString(1, protocol);
+            statement.setLong(2, pr.getId());
+            statement.addBatch();
         }
-        return statements;
+        return statement;
     }
 
     @Override


### PR DESCRIPTION
Addresses several performance issues in SRM database update
handling.

The logic to write requests to the database suffered from several
problems:
- The request read lock was held while writing the data to the DB.
  Due to a workaround for a Terracotta (which I don't date remove
  even if we don't want to support Terracotta), the read lock is
  actually an exclusive lock. Thus while interacting with the
  database, any operation that requires the lock will block. Thus
  a slow database can indeed have a noticable impact on the SRM.
- When a request is modified several times and thus several saves
  are issued for the same request, each request causes a new
  task for updating the DB to be inserted in the queue. Without
  synchronization, executing two of them simultaneously would
  lead to failures (the task attempts to perform an upsert and
  without an exclusive lock it would be wrong). The code happens
  to work by coincidence due to aforementioned workaround that
  turns the read lock into an eclusive lock.
- The competing update tasks will however block on each other
  (we observed this at NDGF) and thus fewer threads than configured
  will actively write data to the DB.
- Since an update task stored the request state at the time of the
  save (as opposed to the state at the point when save was called),
  repeated update tasks for the same request may end up writing
  the same data to the database - this is wasteful.
  
  It can also be debated whether the update task should rather
  store the state as it was when save was called, but fixing that
  requires considerable changes in the code, and I don't want to
  do that on stable branches.
- The update task uses several small transactions rather than simply
  execute all statement in a single transaction (which would be
  faster).
- The update task doesn't make use of prepared statement batching
  when writing job history, even though this is an obvious
  and simple performance improvement.

This patch addresses these issues. Rather than blindly inserting a
new update task, a map is used to keep track of requests that have
already been queued for a DB update. Subsequent save attempts will
not create another update task. Thus only a single update task
at a time will work on a request, and it has the added benefit that
during periods of high load, several save operations can be
collapsed.

The update task itself is rewritten to use a single transaction,
to batch job history inserts and protocol table inserts, and to
release the request lock while executing DB statements.

Target: trunk
Request: 2.7
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5900/
(cherry picked from commit 8ff89b1b7c21c42dc18c5cfcc93907b32bac3307)
