### PR TITLE
srm: Optimize Job loading logic

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorageFactory.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorageFactory.java
@@ -1,6 +1,7 @@
 package org.dcache.srm.request.sql;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,9 +108,7 @@ public class DatabaseJobStorageFactory extends JobStorageFactory{
                 ReserveSpaceRequest.class,
                 ReserveSpaceRequestStorage.class);
 
-            for (JobStorage js: jobStorageMap.values()) {
-                Job.registerJobStorage(js);
-            }
+            Job.registerJobStorages(ImmutableMap.copyOf(jobStorageMap));
         } catch (InstantiationException e) {
             Throwables.propagateIfPossible(e.getCause(), SQLException.class);
             throw new RuntimeException("Request perisistence initialization failed: " + e.toString(), e);


### PR DESCRIPTION
Addresses performance issues in code to read SRM requests from the
SRM database.

The Job class has a static method for retrieving Jobs by id. The method
is unaware of the Job type though, and thus has to use trial and error
to find the right JobStorage from which to load the request.

This patch refines the logic such that the method makes use of a class
parameter to reduce the number of JobStorages to probe.

A subsequent patch will refine callers of the above method to supply
a more narrow type than is currently the case.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.7
Request: 2.6
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5917/
(cherry picked from commit 406f34bfa022dab24eb2db8300f4fbb130585973)
