### PR TITLE
srm: Optimize Job loading logic

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/Job.java
@@ -72,6 +72,7 @@ COPYRIGHT STATUS:
 
 package org.dcache.srm.request;
 
+import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,8 +155,7 @@ public abstract class Job  {
     protected int maxNumberOfRetries;
     private long lastStateTransitionTime = System.currentTimeMillis();
 
-    private static final CopyOnWriteArrayList<JobStorage> jobStorages =
-        new CopyOnWriteArrayList<>();
+    private static volatile ImmutableMap<Class<? extends Job>, JobStorage> jobStorages = ImmutableMap.of();
     private final List<JobHistory> jobHistory = new ArrayList<>();
     private transient JobIdGenerator generator;
 
@@ -182,8 +182,9 @@ public abstract class Job  {
             new ReentrantReadWriteLock();
     private final WriteLock writeLock = reentrantReadWriteLock.writeLock();
 
-    public static final void registerJobStorage(JobStorage jobStorage) {
-            jobStorages.add(jobStorage);
+    public static final void registerJobStorages(ImmutableMap<Class<? extends Job>, JobStorage> jobStorages)
+    {
+        Job.jobStorages = jobStorages;
     }
 
     public static void shutdown() {
@@ -333,17 +334,6 @@ public abstract class Job  {
         return getJob(id, type, null);
     }
 
-    public static final <T extends Job> T getJob(Long id, Class<T> type,
-            Connection connection) throws SRMInvalidRequestException
-    {
-        Job job = getJob(id, connection);
-        try {
-            return type.cast(job);
-        } catch(ClassCastException e) {
-            throw new SRMInvalidRequestException("Job " + id + " has type " + Job.class.getSimpleName() + " and not the expected type " + Job.class.getSimpleName());
-        }
-    }
-
     /**
      * Fetch the Job associated with the supplied ID.  If no such job exists
      * then throw SRMInvalidRequestException.  This method never returns null.
@@ -352,14 +342,15 @@ public abstract class Job  {
      * @return a object representing this job.
      * @throws SRMInvalidRequestException if the job cannot be found
      */
-    private static Job getJob(Long jobId, Connection _con)
-            throws SRMInvalidRequestException  {
+    public static <T extends Job> T getJob(Long jobId, Class<T> type, Connection _con)
+            throws SRMInvalidRequestException
+    {
         synchronized(weakJobStorage) {
             WeakReference<Job> ref = weakJobStorage.get(jobId);
             if(ref!= null) {
                 Job o1 = ref.get();
                 if(o1 != null) {
-                    return o1;
+                    return toType(type, o1);
                 }
             }
         }
@@ -373,19 +364,21 @@ public abstract class Job  {
         job = sharedMemoryCache.getJob(jobId);
         boolean restoredFromDb=false;
         if (job == null) {
-            for (JobStorage storage: jobStorages) {
-                try {
-                    if(_con == null) {
-                        job = storage.getJob(jobId);
-                    } else {
-                        job = storage.getJob(jobId, _con);
+            for (Map.Entry<Class<? extends Job>, JobStorage> entry: jobStorages.entrySet()) {
+                if (type.isAssignableFrom(entry.getKey())) {
+                    try {
+                        if(_con == null) {
+                            job = entry.getValue().getJob(jobId);
+                        } else {
+                            job = entry.getValue().getJob(jobId, _con);
+                        }
+                    } catch (SQLException e){
+                        logger.error("Failed to read job", e);
                     }
-                } catch (SQLException e){
-                    logger.error("Failed to read job", e);
-                }
-                if(job != null) {
-                    restoredFromDb = true;
-                    break;
+                    if (job != null) {
+                        restoredFromDb = true;
+                        break;
+                    }
                 }
             }
         }
@@ -400,8 +393,8 @@ public abstract class Job  {
             WeakReference<Job> ref = weakJobStorage.get(jobId);
             if(ref!= null) {
                 Job o1 = ref.get();
-                if(o1 != null) {
-                    return o1;
+                if (o1 != null) {
+                    return toType(type, o1);
                 }
             }
 
@@ -416,9 +409,18 @@ public abstract class Job  {
             if(restoredFromDb) {
                 job.expireRestoredJobOrCreateExperationTimer();
             }
-            return job;
+            return toType(type, job);
         }
         throw new SRMInvalidRequestException("jobId = "+jobId+" does not correspond to any known job");
+    }
+
+    private static <T extends Job> T toType(Class<T> type, Job job)
+            throws SRMInvalidRequestException
+    {
+        if (!type.isAssignableFrom(job.getClass())) {
+            throw new SRMInvalidRequestException("Job has wrong type, actual type is " + job.getClass().getSimpleName() + " and expected type is " + type.getSimpleName());
+        }
+        return type.cast(job);
     }
 
     /** Performs state transition checking the legality first.

--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorageFactory.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorageFactory.java
@@ -1,6 +1,7 @@
 package org.dcache.srm.request.sql;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,9 +108,7 @@ public class DatabaseJobStorageFactory extends JobStorageFactory{
                 ReserveSpaceRequest.class,
                 ReserveSpaceRequestStorage.class);
 
-            for (JobStorage js: jobStorageMap.values()) {
-                Job.registerJobStorage(js);
-            }
+            Job.registerJobStorages(ImmutableMap.copyOf(jobStorageMap));
         } catch (InstantiationException e) {
             Throwables.propagateIfPossible(e.getCause(), SQLException.class);
             throw new RuntimeException("Request perisistence initialization failed: " + e.toString(), e);


### PR DESCRIPTION
Addresses performance issues in code to read SRM requests from the
SRM database.

The Job class has a static method for retrieving Jobs by id. The method
is unaware of the Job type though, and thus has to use trial and error
to find the right JobStorage from which to load the request.

This patch refines the logic such that the method makes use of a class
parameter to reduce the number of JobStorages to probe.

A subsequent patch will refine callers of the above method to supply
a more narrow type than is currently the case.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.7
Request: 2.6
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5917/
(cherry picked from commit 406f34bfa022dab24eb2db8300f4fbb130585973)
