### PR TITLE
srm: Fix cut'n'paste error in request history period configuration

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
@@ -407,8 +407,8 @@
                      '${srm.limits.request.put.remove-expired-period.unit}')}" />
     <property name="databaseParametersForPut.keepRequestHistoryPeriod"
               value="#{T(java.util.concurrent.TimeUnit).DAYS.convert(
-                     ${srm.limits.request.put.remove-expired-period},
-                     '${srm.limits.request.put.remove-expired-period.unit}')}" />
+                     ${srm.limits.request.put.keep-history-period},
+                     '${srm.limits.request.put.keep-history-period.unit}')}" />
     <property name="databaseParametersForPut.requestHistoryDatabaseEnabled"
               value="${srm.request.put.enable.history-database}"/>
     <property name="databaseParametersForPut.cleanPendingRequestsOnRestart"


### PR DESCRIPTION
Addresses premature garbage collection of put requests.

Target: trunk
Request: 2.7
Require-notes: no
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/5930/
(cherry picked from commit dcec5dab99e62e0c488889e3b452397bc9ce57c2)
