### PR TITLE
srm,gplazma: Use CertPath as x509 cert chain credential in Subject

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/CertPaths.java
+++ b/modules/common/src/main/java/org/dcache/util/CertPaths.java
@@ -1,0 +1,26 @@
+package org.dcache.util;
+
+import com.google.common.base.Preconditions;
+
+import java.security.cert.CertPath;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+public class CertPaths
+{
+    private CertPaths()
+    {
+    }
+
+    public static boolean isX509CertPath(Object credential)
+    {
+        return credential instanceof CertPath && ((CertPath) credential).getType().equals(CertificateFactories.X_509);
+    }
+
+    public static X509Certificate[] getX509Certificates(CertPath certPath)
+    {
+        Preconditions.checkArgument(certPath.getType().equals(CertificateFactories.X_509));
+        List<X509Certificate> certificates = (List<X509Certificate>) certPath.getCertificates();
+        return certificates.toArray(new X509Certificate[certificates.size()]);
+    }
+}

--- a/modules/common/src/main/java/org/dcache/util/CertificateFactories.java
+++ b/modules/common/src/main/java/org/dcache/util/CertificateFactories.java
@@ -1,0 +1,31 @@
+package org.dcache.util;
+
+import java.security.NoSuchProviderException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+
+public class CertificateFactories
+{
+    public static final String X_509 = "X.509";
+    private static final String BOUNCY_CASTLE = "BC";
+
+    private CertificateFactories()
+    {
+    }
+
+    /**
+     * Returns an X.509 CertificateFactory.
+     *
+     * @throws RuntimeException if the factory could not be instantiated
+     */
+    public static CertificateFactory newX509CertificateFactory()
+    {
+        try {
+            return CertificateFactory.getInstance(X_509, BOUNCY_CASTLE);
+        } catch (CertificateException e) {
+            throw new RuntimeException("Failed to create X.509 certificate factory: " + e.getMessage(), e);
+        } catch (NoSuchProviderException e) {
+            throw new RuntimeException("Failed to load bouncy castle provider: " + e.getMessage(), e);
+        }
+    }
+}

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/LoginAuthenticationHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/LoginAuthenticationHandler.java
@@ -6,15 +6,23 @@ import org.slf4j.LoggerFactory;
 
 import javax.security.auth.Subject;
 
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.HashSet;
+import java.util.Set;
+
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PermissionDeniedCacheException;
 
 import org.dcache.auth.LoginReply;
 import org.dcache.auth.LoginStrategy;
+import org.dcache.util.CertificateFactories;
 import org.dcache.xrootd.core.XrootdAuthenticationHandler;
 import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.plugins.AuthenticationFactory;
 
+import static java.util.Arrays.asList;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_NotAuthorized;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
 
@@ -31,11 +39,13 @@ public class LoginAuthenticationHandler
         LoggerFactory.getLogger(LoginAuthenticationHandler.class);
 
     private LoginStrategy _loginStrategy;
+    private CertificateFactory _cf;
 
     public LoginAuthenticationHandler(AuthenticationFactory authenticationFactory, LoginStrategy loginStrategy)
     {
         super(authenticationFactory);
         _loginStrategy = loginStrategy;
+        _cf = CertificateFactories.newX509CertificateFactory();
     }
 
     @Override
@@ -43,17 +53,33 @@ public class LoginAuthenticationHandler
         throws XrootdException
     {
         try {
-            LoginReply reply = _loginStrategy.login(subject);
+            LoginReply reply = _loginStrategy.login(translateSubject(subject));
             context.sendUpstream(new LoginEvent(context.getChannel(), reply));
             return reply.getSubject();
         } catch (PermissionDeniedCacheException e) {
             _log.warn("Authorization denied for {}: {}",
-                      subject, e.getMessage());
+                    subject, e.getMessage());
             throw new XrootdException(kXR_NotAuthorized, e.getMessage());
-        } catch (CacheException e) {
+        } catch (CacheException | CertificateException e) {
             _log.error("Authorization failed for {}: {}",
                        subject, e.getMessage());
             throw new XrootdException(kXR_ServerError, e.getMessage());
         }
+    }
+
+    private Subject translateSubject(Subject subject) throws CertificateException
+    {
+        if (subject == null) {
+            return null;
+        }
+        Set<Object> publicCredentials = new HashSet<>();
+        for (Object credential : subject.getPublicCredentials()) {
+            if (credential instanceof X509Certificate[]) {
+                publicCredentials.add(_cf.generateCertPath(asList((X509Certificate[]) credential)));
+            } else {
+                publicCredentials.add(credential);
+            }
+        }
+        return new Subject(false, subject.getPrincipals(), publicCredentials, subject.getPrivateCredentials());
     }
 }

--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
@@ -3,12 +3,13 @@ package org.dcache.gplazma.plugins;
 import org.globus.gsi.jaas.GlobusPrincipal;
 
 import java.security.Principal;
-import java.security.cert.X509Certificate;
+import java.security.cert.CertPath;
 import java.util.Properties;
 import java.util.Set;
 
 import org.dcache.auth.util.X509Utils;
 import org.dcache.gplazma.AuthenticationException;
+import org.dcache.util.CertPaths;
 
 import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
 
@@ -22,6 +23,7 @@ import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
  */
 public class X509Plugin implements GPlazmaAuthenticationPlugin
 {
+
     public X509Plugin(Properties properties) {}
 
     @Override
@@ -32,10 +34,8 @@ public class X509Plugin implements GPlazmaAuthenticationPlugin
     {
         boolean found = false;
         for (Object credential : publicCredentials) {
-            if (credential instanceof X509Certificate[]) {
-                X509Certificate[] chain = (X509Certificate[]) credential;
-                String dn
-                    = X509Utils.getSubjectFromX509Chain(chain, false);
+            if (CertPaths.isX509CertPath(credential)) {
+                String dn = X509Utils.getSubjectFromX509Chain(CertPaths.getX509Certificates((CertPath) credential), false);
                 identifiedPrincipals.add(new GlobusPrincipal(dn));
                 found = true;
             }

--- a/modules/gplazma2-voms/src/main/java/org/dcache/gplazma/plugins/VomsPlugin.java
+++ b/modules/gplazma2-voms/src/main/java/org/dcache/gplazma/plugins/VomsPlugin.java
@@ -8,14 +8,15 @@ import org.slf4j.MDC;
 import java.io.IOException;
 import java.security.Principal;
 import java.security.cert.CRLException;
+import java.security.cert.CertPath;
 import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import java.util.Properties;
 import java.util.Set;
 
 import org.dcache.auth.FQANPrincipal;
 import org.dcache.auth.util.GSSUtils;
 import org.dcache.gplazma.AuthenticationException;
+import org.dcache.util.CertPaths;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
@@ -56,10 +57,9 @@ public class VomsPlugin implements GPlazmaAuthenticationPlugin {
         boolean hasFQANs = false;
 
         for (Object credential : publicCredentials) {
-            if (credential instanceof X509Certificate[]) {
+            if (CertPaths.isX509CertPath(credential)) {
                 hasX509 = true;
-                X509Certificate[] chain = (X509Certificate[]) credential;
-                validator.setClientChain(chain).validate();
+                validator.setClientChain(CertPaths.getX509Certificates((CertPath) credential)).validate();
                 for (String fqan : validator.getAllFullyQualifiedAttributes()) {
                     hasFQANs = true;
                     identifiedPrincipals.add(new FQANPrincipal(fqan, primary));

--- a/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
+++ b/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
@@ -27,6 +27,7 @@ import java.net.InetAddress;
 import java.net.SocketException;
 import java.security.Principal;
 import java.security.cert.CRLException;
+import java.security.cert.CertPath;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ import org.dcache.auth.UserNamePrincipal;
 import org.dcache.auth.util.GSSUtils;
 import org.dcache.auth.util.X509Utils;
 import org.dcache.gplazma.AuthenticationException;
+import org.dcache.util.CertPaths;
 import org.dcache.util.NetworkUtils;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -355,10 +357,8 @@ public final class XACMLPlugin implements GPlazmaAuthenticationPlugin {
          * extract all sets of extensions from certificate chains
          */
         for (Object credential : publicCredentials) {
-            if (credential instanceof X509Certificate[]) {
-                extractExtensionsFromChain((X509Certificate[])  credential,
-                                                                extensions,
-                                                                validator);
+            if (CertPaths.isX509CertPath(credential)) {
+                extractExtensionsFromChain(CertPaths.getX509Certificates((CertPath) credential), extensions, validator);
             }
         }
 

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/GPlazma.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/GPlazma.java
@@ -2,7 +2,6 @@ package org.dcache.gplazma;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,7 +9,6 @@ import javax.security.auth.Subject;
 
 import java.lang.reflect.Modifier;
 import java.security.Principal;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -149,39 +147,6 @@ public class GPlazma
         }
 
         /**
-         * Some public credentials, when compared, will always be different.
-         * An example of this is the X509Certificate chain.  This is provided
-         * to gPlazma as an array of X509Certificate objects; however, an
-         * array, as an Object, will always be different to any other array.
-         *
-         * To work around this issue, this method normalises the credential;
-         * that is, it converts a credential to one in which two distinct
-         * Objects that represent the same information are equal.
-         * @param storageCredentials the Set into which normalised credentials
-         * are stored.
-         * @param credentials the Set of credentials that are to be normalised
-         */
-        private static void addNormalisedPublicCredentials(
-                Set<Object> storageCredentials, Set<Object> credentials)
-        {
-            for(Object credential : credentials) {
-                Object normalised;
-                if(credential instanceof X509Certificate[]) {
-                    normalised = normalise((X509Certificate[])credential);
-                } else {
-                    normalised = credential;
-                }
-                storageCredentials.add(normalised);
-            }
-        }
-
-        private static Object normalise(X509Certificate[] credential)
-        {
-            return Lists.newArrayList(credential);
-        }
-
-
-        /**
          * Calculate the storage Subject, given an incoming subject.  The
          * storage subject is similar to the supplied Subject but has sensitive
          * material (like passwords) removed and is location agnostic
@@ -191,8 +156,7 @@ public class GPlazma
         {
             Subject storage = new Subject();
 
-            addNormalisedPublicCredentials(storage.getPublicCredentials(),
-                    subject.getPublicCredentials());
+            storage.getPublicCredentials().addAll(subject.getPublicCredentials());
 
             /*
              * Do not store any private credentials as doing so would be a

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.Principal;
+import java.security.cert.CertPath;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.text.ParseException;
@@ -45,6 +46,7 @@ import org.dcache.gplazma.monitor.LoginResult.PhaseResult;
 import org.dcache.gplazma.monitor.LoginResult.SessionPhaseResult;
 import org.dcache.gplazma.monitor.LoginResult.SessionPluginResult;
 import org.dcache.gplazma.monitor.LoginResult.SetDiff;
+import org.dcache.util.CertPaths;
 
 import static java.util.concurrent.TimeUnit.*;
 import static org.dcache.gplazma.configuration.ConfigurationItemControl.*;
@@ -181,8 +183,8 @@ public class LoginResultPrinter
 
     private String print(Object credential)
     {
-        if(credential instanceof X509Certificate[]) {
-            return print((X509Certificate[]) credential);
+        if (CertPaths.isX509CertPath(credential)) {
+            return print(CertPaths.getX509Certificates((CertPath) credential));
         } else {
             return credential.toString();
         }


### PR DESCRIPTION
Addresses that two Subjects cannot be compared using its
equals method if the credential sets contain an certificate
chain.

Addresses a problem in the SRM that causes the gPlazma cache
to never have any hits.

The problem is caused by storing the certificate chain as
an array. Since two arrays are never equal according to
their equals methods, two Subjects cannot be equal either
if they contain X.509 certiticate chains. A consequence of
this bug is that the gPlazma cache in the SRM never finds
a hit as Subjects are never equals to those of a previous
request.

The patch solves the problem by using a CertPath instead.
This class is serializable and implements equals and
hashCode methods. JAAS itself uses CertPath as a public
credential in Subjects.

Target: trunk
Request: 2.7
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5941/
(cherry picked from commit bc81889861236c245ff60e0a3fe73d2d25c0c787)
