### PR TITLE
srm: Refactor persistence architecture

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -784,10 +784,10 @@ public final class Storage
     }
 
     public final static String fh_ls_completed= " Syntax: ls completed [-get] [-put]" +
-        " [-copy] [-l] [max_count]"+
+        " [-copy] [max_count]"+
             " #will list completed (done, failed or canceled) requests, " +
         "if max_count is not specified, it is set to 50";
-    public final static String hh_ls_completed= " [-get] [-put] [-copy] [-l] [max_count]";
+    public final static String hh_ls_completed= " [-get] [-put] [-copy] [max_count]";
     public String ac_ls_completed_$_0_1(Args args) throws Exception{
         boolean get=args.hasOption("get");
         boolean put=args.hasOption("put");

--- a/modules/srm/pom.xml
+++ b/modules/srm/pom.xml
@@ -67,6 +67,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+
+    <dependency>
         <groupId>org.dcache</groupId>
         <artifactId>dcache-common</artifactId>
         <version>${project.version}</version>

--- a/modules/srm/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm/src/main/java/org/dcache/srm/SRM.java
@@ -280,7 +280,7 @@ public class SRM {
         SchedulerFactory.initSchedulerFactory(config, name);
         DatabaseJobStorageFactory afactory = new DatabaseJobStorageFactory(configuration);
         JobStorageFactory.initJobStorageFactory(afactory);
-        afactory.loadExistingJobs();
+        afactory.init();
 
         host = InetAddress.getLocalHost();
 
@@ -323,7 +323,6 @@ public class SRM {
     }
 
     public void stop() {
-        Job.shutdown();
         SchedulerFactory.getSchedulerFactory().shutdown();
     }
 
@@ -1459,7 +1458,9 @@ public class SRM {
         return getScheduler(LsFileRequest.class);
     }
 
-    public static <T extends Job> Set<Long> getActiveJobIds(Class<T> type, String description) {
+    public static <T extends Job> Set<Long> getActiveJobIds(Class<T> type, String description)
+            throws SQLException
+    {
         Set<T> jobs = Job.getActiveJobs(type);
         Set<Long> ids = new HashSet<>();
         for(Job job: jobs) {
@@ -1477,12 +1478,12 @@ public class SRM {
         return ids;
     }
 
-    public boolean isFileBusy(URI surl)
+    public boolean isFileBusy(URI surl) throws SQLException
     {
         return hasActivePutRequests(surl);
     }
 
-    private boolean hasActivePutRequests(URI surl)
+    private boolean hasActivePutRequests(URI surl) throws SQLException
     {
         Set<PutFileRequest> requests = Job.getActiveJobs(PutFileRequest.class);
         for (PutFileRequest request: requests) {
@@ -1494,6 +1495,7 @@ public class SRM {
     }
 
     public <T extends FileRequest<?>> Iterable<T> getActiveFileRequests(Class<T> type, final URI surl)
+            throws SQLException
     {
         return Iterables.filter(Job.getActiveJobs(type),
                 new Predicate<T>()

--- a/modules/srm/src/main/java/org/dcache/srm/handler/SrmMv.java
+++ b/modules/srm/src/main/java/org/dcache/srm/handler/SrmMv.java
@@ -113,30 +113,29 @@ public class SrmMv {
 			return getFailedResponse(" target or destination are not defined");
 		}
 
-                // [SRM 2.2, 4.6.3]     SRM_INVALID_PATH: status of fromSURL is SRM_FILE_BUSY.
-                // [SRM 2.2, 4.6.2, c)] srmMv must fail on SURL that its status is SRM_FILE_BUSY,
-                //                      and SRM_FILE_BUSY must be returned.
-                // [SRM 2.2, 4.6.2, e)] When moving an SURL to already existing SURL,
-                //                      SRM_DUPLICATION_ERROR must be returned.
-                //
-                // The SRM spec is somewhat inconsistent on what the correct return code should be.
-                // Instead we use SRM_DUPLICATION_ERROR if the target SURL is busy (consistent with
-                // how this situation is handled in srmPrepareToPut) and SRM_FILE_BUSY if the source
-                // SURL is busy.
-                SRM srm = SRM.getSRM();
-                if (srm.isFileBusy(from_surl)) {
-                    response.getReturnStatus().setStatusCode(TStatusCode.SRM_FILE_BUSY);
-                    response.getReturnStatus().setExplanation("The source SURL is being used by another client.");
-                    return response;
-                }
-                if (srm.isFileBusy(to_surl)) {
-                    response.getReturnStatus().setStatusCode(TStatusCode.SRM_DUPLICATION_ERROR);
-                    response.getReturnStatus().setExplanation("The target SURL is being used by another client.");
-                    return response;
-                }
-
                 try {
-                        storage.moveEntry(user, from_surl, to_surl);
+                    // [SRM 2.2, 4.6.3]     SRM_INVALID_PATH: status of fromSURL is SRM_FILE_BUSY.
+                    // [SRM 2.2, 4.6.2, c)] srmMv must fail on SURL that its status is SRM_FILE_BUSY,
+                    //                      and SRM_FILE_BUSY must be returned.
+                    // [SRM 2.2, 4.6.2, e)] When moving an SURL to already existing SURL,
+                    //                      SRM_DUPLICATION_ERROR must be returned.
+                    //
+                    // The SRM spec is somewhat inconsistent on what the correct return code should be.
+                    // Instead we use SRM_DUPLICATION_ERROR if the target SURL is busy (consistent with
+                    // how this situation is handled in srmPrepareToPut) and SRM_FILE_BUSY if the source
+                    // SURL is busy.
+                    SRM srm = SRM.getSRM();
+                    if (srm.isFileBusy(from_surl)) {
+                        response.getReturnStatus().setStatusCode(TStatusCode.SRM_FILE_BUSY);
+                        response.getReturnStatus().setExplanation("The source SURL is being used by another client.");
+                        return response;
+                    }
+                    if (srm.isFileBusy(to_surl)) {
+                        response.getReturnStatus().setStatusCode(TStatusCode.SRM_DUPLICATION_ERROR);
+                        response.getReturnStatus().setExplanation("The target SURL is being used by another client.");
+                        return response;
+                    }
+                    storage.moveEntry(user, from_surl, to_surl);
                 }
 		catch (Exception e) {
 		    logger.warn(e.toString());

--- a/modules/srm/src/main/java/org/dcache/srm/handler/SrmReleaseFiles.java
+++ b/modules/srm/src/main/java/org/dcache/srm/handler/SrmReleaseFiles.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -31,12 +32,8 @@ import org.dcache.srm.request.GetFileRequest;
 import org.dcache.srm.request.GetRequest;
 import org.dcache.srm.request.Job;
 import org.dcache.srm.request.RequestCredential;
-import org.dcache.srm.request.sql.DatabaseFileRequestStorage;
 import org.dcache.srm.scheduler.IllegalStateTransition;
-import org.dcache.srm.scheduler.JobStorage;
-import org.dcache.srm.scheduler.JobStorageFactory;
 import org.dcache.srm.scheduler.Scheduler;
-import org.dcache.srm.scheduler.SchedulerFactory;
 import org.dcache.srm.scheduler.State;
 import org.dcache.srm.util.Configuration;
 import org.dcache.srm.v2_2.ArrayOfTSURLReturnStatus;
@@ -45,6 +42,8 @@ import org.dcache.srm.v2_2.SrmReleaseFilesResponse;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TSURLReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
+
+import static java.util.Arrays.asList;
 
 
 /**
@@ -410,84 +409,28 @@ public class SrmReleaseFiles {
 
     }
 
-    private Set<BringOnlineFileRequest> findBringOnlineFileRequestBySURLs(URI[] surls) {
-        Scheduler scheduler =
-                SchedulerFactory.getSchedulerFactory().
-                getScheduler(BringOnlineFileRequest.class);
-        Set<BringOnlineFileRequest> foundRequests =
-            new HashSet<>();
-        JobStorage<BringOnlineFileRequest> js =
-                JobStorageFactory.getJobStorageFactory().getJobStorage(BringOnlineFileRequest.class);
-        if(js instanceof DatabaseFileRequestStorage) {
-            DatabaseFileRequestStorage<?> reqstorage = (DatabaseFileRequestStorage<?>) js;
-            Set<Long> activeRequestIds ;
-            try {
-                activeRequestIds =
-                   reqstorage.getActiveFileRequestIds(scheduler.getId());
-            } catch (SQLException sqle) {
-                logger.warn(sqle.toString());
-                //just return empty
-                return foundRequests;
-            }
-
-            for(Long requestId:activeRequestIds) {
-                BringOnlineFileRequest bofr;
-
-                try {
-                    bofr = Job.getJob(requestId, BringOnlineFileRequest.class);
-                } catch (SRMInvalidRequestException ire) {
-                    logger.error(ire.toString());
-                    continue;
-                }
-
-                for(URI surl: surls) {
-                    if(bofr.getSurl().equals(surl)) {
-                        foundRequests.add(bofr);
-                    }
-                }
+    private Set<BringOnlineFileRequest> findBringOnlineFileRequestBySURLs(URI[] surls)
+            throws SQLException
+    {
+        Collection<URI> surlList = (surls.length > 2) ? new HashSet<>(asList(surls)) : asList(surls);
+        Set<BringOnlineFileRequest> requests = new HashSet<>();
+        for (BringOnlineFileRequest request : Job.getActiveJobs(BringOnlineFileRequest.class)) {
+            if (surlList.contains(request.getSurl())) {
+                requests.add(request);
             }
         }
-        return foundRequests;
+        return requests;
     }
 
-    private Set<GetFileRequest> findGetFileRequestBySURLs(URI[] surls)  {
-        Scheduler scheduler = srm.getGetRequestScheduler();
-        Set<GetFileRequest> foundRequests =
-            new HashSet<>();
-        JobStorage<GetFileRequest> js =
-                JobStorageFactory.getJobStorageFactory().getJobStorage(GetFileRequest.class);
-        if(js instanceof DatabaseFileRequestStorage) {
-           DatabaseFileRequestStorage<?>  reqstorage =
-                   (DatabaseFileRequestStorage<?>) js;
-        Set<Long> activeRequestIds ;
-        try {
-            activeRequestIds =
-                reqstorage.getActiveFileRequestIds(scheduler.getId());
-        } catch (SQLException sqle) {
-            logger.warn(sqle.toString());
-            //just return empty
-            return foundRequests;
-        }
-
-
-        for(Long requestId:activeRequestIds) {
-            GetFileRequest gfr;
-            try {
-                gfr = Job.getJob(requestId, GetFileRequest.class);
-            } catch (SRMInvalidRequestException ire) {
-                logger.error(ire.toString());
-                continue;
-            }
-
-            for(URI surl: surls) {
-                if(gfr.getSurl().equals(surl)) {
-                    foundRequests.add(gfr);
-                }
+    private Set<GetFileRequest> findGetFileRequestBySURLs(URI[] surls) throws SQLException
+    {
+        Collection<URI> surlList = (surls.length > 2) ? new HashSet<>(asList(surls)) : asList(surls);
+        Set<GetFileRequest> requests = new HashSet<>();
+        for (GetFileRequest request : Job.getActiveJobs(GetFileRequest.class)) {
+            if (surlList.contains(request.getSurl())) {
+                requests.add(request);
             }
         }
-        }
-        return foundRequests;
+        return requests;
     }
-
-
 }

--- a/modules/srm/src/main/java/org/dcache/srm/handler/SrmRm.java
+++ b/modules/srm/src/main/java/org/dcache/srm/handler/SrmRm.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.sql.SQLException;
 import java.util.concurrent.CountDownLatch;
 
 import org.dcache.srm.AbstractStorageElement;
@@ -85,6 +86,9 @@ public class SrmRm {
             } catch(SRMException srme) {
                 logger.error(srme.toString());
                 response = getFailedResponse(srme.toString());
+            } catch (SQLException e) {
+                logger.error(e.toString());
+                response = getResponse("Internal failure: " + e.toString(), TStatusCode.SRM_INTERNAL_ERROR);
             }
             return response;
 	}
@@ -112,7 +116,7 @@ public class SrmRm {
      */
 
 	public SrmRmResponse srmRm()
-                throws SRMException, URISyntaxException
+                throws SRMException, SQLException, URISyntaxException
         {
 		if(request==null) {
 			return getResponse(" null request passed to SrmRm()",

--- a/modules/srm/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
@@ -128,7 +128,6 @@ public final class BringOnlineFileRequest extends FileRequest<BringOnlineRequest
                 maxNumberOfRetries);
         logger.debug("BringOnlineFileRequest, requestId="+requestId+" fileRequestId = "+getId());
         this.surl = surl;
-        updateMemoryCache();
     }
 
     /**
@@ -363,7 +362,7 @@ public final class BringOnlineFileRequest extends FileRequest<BringOnlineRequest
                     return;
                 }
             }
-        } catch(SRMException | IllegalStateTransition e) {
+        } catch(SRMException | SQLException | IllegalStateTransition e) {
             // FIXME some SRMExceptions are permanent failures while others
             // are temporary.  Code currently doesn't distinguish, so will
             // always retry internally even if problem isn't transitory.

--- a/modules/srm/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
@@ -145,7 +145,6 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
             requests.add(request);
         }
         setFileRequests(requests);
-        updateMemoryCache();
     }
 
     /**

--- a/modules/srm/src/main/java/org/dcache/srm/request/CopyFileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/CopyFileRequest.java
@@ -164,7 +164,6 @@ public final class CopyFileRequest extends FileRequest<CopyRequest> {
 		this.from_surl = URI.create(from_surl);
 		this.to_surl = URI.create(to_surl);
 		this.spaceReservationId = spaceToken;
-                updateMemoryCache();
 		logger.debug("constructor from_url=" +from_surl+" to_url="+to_surl);
 	}
 

--- a/modules/srm/src/main/java/org/dcache/srm/request/CopyRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/CopyRequest.java
@@ -227,7 +227,6 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest> impleme
         this.targetRetentionPolicy = targetRetentionPolicy;
         this.overwriteMode = overwriteMode;
         this.targetSpaceToken = spaceToken;
-        updateMemoryCache();
         logger.debug("Request.createCopyRequest : created new request succesfully");
     }
 

--- a/modules/srm/src/main/java/org/dcache/srm/request/GetFileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/GetFileRequest.java
@@ -132,9 +132,8 @@ public final class GetFileRequest extends FileRequest<GetRequest> {
             maxNumberOfRetries);
         logger.debug("GetFileRequest, requestId="+requestId+" fileRequestId = "+getId());
         surl = URI.create(url);
-        updateMemoryCache();
-
     }
+
     /**
      * restore constructore, used for restoring the existing
      * file request from the database
@@ -458,7 +457,7 @@ public final class GetFileRequest extends FileRequest<GetRequest> {
                     return;
                 }
             }
-        } catch (IllegalStateTransition | SRMException e) {
+        } catch (IllegalStateTransition | SQLException | SRMException e) {
             // FIXME some SRMException failures are temporary and others are
             // permanent.  Code currently doesn't distinguish between them and
             // always retries, even if problem isn't transitory.

--- a/modules/srm/src/main/java/org/dcache/srm/request/GetRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/GetRequest.java
@@ -136,7 +136,6 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
             requests.add(request);
         }
         setFileRequests(requests);
-        updateMemoryCache();
     }
 
     /**

--- a/modules/srm/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/Job.java
@@ -72,11 +72,9 @@ COPYRIGHT STATUS:
 
 package org.dcache.srm.request;
 
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.ref.WeakReference;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
@@ -85,14 +83,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Timer;
 import java.util.TimerTask;
-import java.util.WeakHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
@@ -109,7 +104,6 @@ import org.dcache.srm.scheduler.JobStorageFactory;
 import org.dcache.srm.scheduler.NonFatalJobFailure;
 import org.dcache.srm.scheduler.Scheduler;
 import org.dcache.srm.scheduler.SchedulerFactory;
-import org.dcache.srm.scheduler.SharedMemoryCache;
 import org.dcache.srm.scheduler.State;
 import org.dcache.srm.util.JDC;
 
@@ -124,14 +118,6 @@ public abstract class Job  {
     private static final Logger logger = LoggerFactory.getLogger(Job.class);
 
     private static final String ISO8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXX";
-
-    // this is the map from jobIds to jobs
-    // job ids are referenced from jobs
-    // jobs are wrapped into WeakReferences to prevent
-    // creation hard references to jobIdsA
-
-    private static final Map<Long, WeakReference<Job>> weakJobStorage =
-            new WeakHashMap<>();
 
     //this is used to build the queue of jobs.
     protected Long nextJobId;
@@ -154,24 +140,10 @@ public abstract class Job  {
     protected int maxNumberOfRetries;
     private long lastStateTransitionTime = System.currentTimeMillis();
 
-    private static volatile ImmutableMap<Class<? extends Job>, JobStorage<?>> jobStorages = ImmutableMap.of();
     private final List<JobHistory> jobHistory = new ArrayList<>();
     private transient JobIdGenerator generator;
 
     private transient TimerTask retryTimer;
-
-    // this instance is registered as a terracotta root
-    // the objects put in this cache are clustered,
-    // but they are not guaranteed to present in local
-    // memory
-    private static final SharedMemoryCache sharedMemoryCache =
-            new SharedMemoryCache();
-
-    // this instance is not registered as a terracotta root
-    // the objects put in this cache are guaranteed to present in
-    // local memory, for as long as their state is not final
-    private static final SharedMemoryCache localMemoryCache =
-            new SharedMemoryCache();
 
     private transient boolean savedInFinalState;
 
@@ -180,15 +152,6 @@ public abstract class Job  {
     private final ReentrantReadWriteLock reentrantReadWriteLock =
             new ReentrantReadWriteLock();
     private final WriteLock writeLock = reentrantReadWriteLock.writeLock();
-
-    public static final void registerJobStorages(ImmutableMap<Class<? extends Job>, JobStorage<?>> jobStorages)
-    {
-        Job.jobStorages = jobStorages;
-    }
-
-    public static void shutdown() {
-        LifetimeExpiration.shutdown();
-    }
 
     // this constructor is used for restoring the job from permanent storage
     // should be called through the Job.getJob only, otherwise the expireRestoredJobOrCreateExperationTimer
@@ -236,28 +199,6 @@ public abstract class Job  {
         }
     }
 
-    /**
-     * NEED TO CALL THIS METHOD FROM THE CONCRETE SUBCLASS
-     * RESTORE CONSTRUCTOR
-     */
-    private void expireRestoredJobOrCreateExperationTimer()  {
-        wlock();
-        try {
-            if( ! state.isFinalState() ) {
-                long newLifetime =
-                        creationTime + lifetime - System.currentTimeMillis();
-                /* We schedule a timer even if the job has already
-                 * expired.  This is to avoid a restore loop in which
-                 * expiring a job during restore causes the job to be read
-                 * recursively.
-                 */
-                LifetimeExpiration.schedule(id, Math.max(0, newLifetime));
-            }
-        } finally {
-            wunlock();
-        }
-    }
-
     /** Creates a new instance of Job */
 
     public Job(long lifetime,
@@ -268,17 +209,7 @@ public abstract class Job  {
         this.lifetime = lifetime;
         this.maxNumberOfRetries = maxNumberOfRetries;
         this.jdc = new JDC();
-
-        LifetimeExpiration.schedule(id, lifetime);
-        synchronized (weakJobStorage) {
-            weakJobStorage.put(id, new WeakReference<>(this));
-        }
-        jobHistory.add( new JobHistory(nextLong(),state,"created",lastStateTransitionTime));
-    }
-
-    protected final void updateMemoryCache () {
-        sharedMemoryCache.updateSharedMemoryChache(this);
-        localMemoryCache.updateSharedMemoryChache(this);
+        jobHistory.add(new JobHistory(nextLong(), state, "created", lastStateTransitionTime));
     }
 
     protected JobStorage<Job> getJobStorage() {
@@ -299,7 +230,7 @@ public abstract class Job  {
             if(savedInFinalState){
                 return;
             }
-            boolean isFinalState = State.isFinalState(this.getState());
+            boolean isFinalState = this.getState().isFinalState();
             getJobStorage().saveJob(this, isFinalState || force);
             savedInFinalState = isFinalState;
         } catch (SQLException e) {
@@ -344,82 +275,30 @@ public abstract class Job  {
     public static <T extends Job> T getJob(Long jobId, Class<T> type, Connection _con)
             throws SRMInvalidRequestException
     {
-        synchronized(weakJobStorage) {
-            WeakReference<Job> ref = weakJobStorage.get(jobId);
-            if(ref!= null) {
-                Job o1 = ref.get();
-                if(o1 != null) {
-                    return toType(type, o1);
-                }
-            }
-        }
-
-        Job job;
-
-        //
-        // This will allow to retrieve a job put in
-        // a shared cache by a different instance of SRM
-        // in a cluster
-        job = sharedMemoryCache.getJob(jobId);
-        boolean restoredFromDb=false;
-        if (job == null) {
-            for (Map.Entry<Class<? extends Job>, JobStorage<?>> entry: jobStorages.entrySet()) {
-                if (type.isAssignableFrom(entry.getKey())) {
-                    try {
-                        if(_con == null) {
-                            job = entry.getValue().getJob(jobId);
-                        } else {
-                            job = entry.getValue().getJob(jobId, _con);
-                        }
-                    } catch (SQLException e){
-                        logger.error("Failed to read job", e);
+        for (Map.Entry<Class<? extends Job>, JobStorage<?>> entry: JobStorageFactory.getJobStorageFactory().getJobStorages().entrySet()) {
+            if (type.isAssignableFrom(entry.getKey())) {
+                try {
+                    Job job;
+                    if (_con == null) {
+                        job = entry.getValue().getJob(jobId);
+                    } else {
+                        job = entry.getValue().getJob(jobId, _con);
                     }
                     if (job != null) {
-                        restoredFromDb = true;
-                        break;
+                        return type.cast(job);
                     }
+                } catch (SQLException e){
+                    logger.error("Failed to read job", e);
                 }
             }
         }
-        //since we do not synchronize  on the jobStorages or the job class
-        // in this method, some other thread could have got to the same point, and created
-        // an instance of the job for the same job id
-        // but we always want the same instance to be available to ewveryone
-        // only one of them  should win in storing his object in weakJobStorage
-        // the object stored by the winner is the one we want to return
-        //System.out.println("checking weakJobStorage");
-        synchronized(weakJobStorage) {
-            WeakReference<Job> ref = weakJobStorage.get(jobId);
-            if(ref!= null) {
-                Job o1 = ref.get();
-                if (o1 != null) {
-                    return toType(type, o1);
-                }
-            }
-
-            if (job != null)
-            {
-                weakJobStorage.put(job.id,new WeakReference<>(job));
-                job.updateMemoryCache();
-            }
-        }
-
-        if(job != null ) {
-            if(restoredFromDb) {
-                job.expireRestoredJobOrCreateExperationTimer();
-            }
-            return toType(type, job);
-        }
-        throw new SRMInvalidRequestException("jobId = "+jobId+" does not correspond to any known job");
+        throw new SRMInvalidRequestException("jobId = " + jobId + " does not correspond to any known job");
     }
 
-    private static <T extends Job> T toType(Class<T> type, Job job)
-            throws SRMInvalidRequestException
+    public static <T extends Job> Set<T> getActiveJobs(Class<T> type) throws SQLException
     {
-        if (!type.isAssignableFrom(job.getClass())) {
-            throw new SRMInvalidRequestException("Job has wrong type, actual type is " + job.getClass().getSimpleName() + " and expected type is " + type.getSimpleName());
-        }
-        return type.cast(job);
+        JobStorage<T> jobStorage = JobStorageFactory.getJobStorageFactory().getJobStorage(type);
+        return (jobStorage == null) ? Collections.<T>emptySet() : jobStorage.getActiveJobs();
     }
 
     /** Performs state transition checking the legality first.
@@ -587,19 +466,11 @@ public abstract class Job  {
 
             notifySchedulerOfStateChange(old, state);
 
-            if(state.isFinalState()) {
-                LifetimeExpiration.cancel(id);
-            }
-            else {
-                if(schedulerId == null) {
-                    throw new IllegalStateTransition("Scheduler ID is null");
-                }
-            }
-            if(!old.isFinalState() && state.isFinalState()) {
-                 updateMemoryCache();
+            if (!state.isFinalState() && schedulerId == null) {
+                throw new IllegalStateTransition("Scheduler ID is null");
             }
             stateChanged(old);
-            if(save) {
+            if(save || !old.isFinalState() && state.isFinalState()) {
                 saveJob();
             }
         } finally {
@@ -884,27 +755,26 @@ public abstract class Job  {
     public long extendLifetimeMillis(long newLifetimeInMillis) throws SRMException {
         wlock();
         try {
-            if(State.isFinalState(state)){
-                if(state == State.CANCELED) {
+            if (state.isFinalState()){
+                switch (state) {
+                case CANCELED:
                     throw new SRMAbortedException("can't extend lifetime, job was aborted");
-                } else if(state == State.DONE) {
+                case DONE:
                     throw new SRMReleasedException("can't extend lifetime, job has finished");
-                } else {
-                    throw new SRMException("can't extend lifetime, job state is "+state);
+                default:
+                    throw new SRMException("can't extend lifetime, job state is " + state);
                 }
             }
 
-            long remainingLifetime = getRemainingLifetime();
-            if(remainingLifetime >=newLifetimeInMillis) {
+            long now = System.currentTimeMillis();
+            long remainingLifetime = creationTime + lifetime - now;
+            if (remainingLifetime >= newLifetimeInMillis) {
                 return remainingLifetime;
             }
 
-            if (!LifetimeExpiration.cancel(id)) {
-                throw new SRMException (" job expiration has started already ");
-            }
-            LifetimeExpiration.schedule(id, newLifetimeInMillis);
-
-            return 0;
+            lifetime = now + newLifetimeInMillis - creationTime;
+            saveJob();
+            return newLifetimeInMillis;
         } finally {
             wunlock();
         }
@@ -938,91 +808,22 @@ public abstract class Job  {
         return getGenerator().nextLong();
     }
 
-
-
-
-    private static class LifetimeExpiration extends TimerTask
+    public void checkExpiration()
     {
-        static private Map<Long,LifetimeExpiration> _instances =
-            new HashMap<>();
-
-        static private Timer _timer = new Timer();
-
-        private Long _id;
-
-        static public void shutdown()
-        {
-            _timer.cancel();
-        }
-
-        static synchronized public void schedule(Long id, long time)
-        {
-            if (!_instances.containsKey(id)) {
-                LifetimeExpiration task = new LifetimeExpiration(id);
-                _instances.put(id, task);
-                _timer.schedule(task, time);
-            }
-        }
-
-        static synchronized public boolean contains(Long id)
-        {
-            return _instances.containsKey(id);
-        }
-
-        static synchronized public boolean cancel(Long id)
-        {
-            LifetimeExpiration task = _instances.remove(id);
-            if (task == null) {
-                return false;
-            } else {
-                return task.cancel();
-            }
-        }
-
-        static synchronized private void remove(Long id)
-        {
-            _instances.remove(id);
-        }
-
-        private LifetimeExpiration(Long id)
-        {
-            _id = id;
-        }
-
-        @Override
-        public void run()
-        {
-            remove(_id);
-            try {
-                expireJob(Job.getJob(_id, Job.class));
-            } catch (IllegalArgumentException e) {
-                // Job is already gone
-            } catch (Exception e) {
-                logger.error("Unexpected exception during job timeout", e);
-            }
-        }
-    }
-
-    public static final void expireJob(Job job) {
+        wlock();
         try {
-            job.wlock();
-            try {
-                logger.debug("expiring job id="+job.getId());
-                if(job.state == State.READY ||
-                job.state == State.TRANSFERRING) {
-                    job.setState(State.DONE,"lifetime expired");
-                    return;
+            if (creationTime + lifetime < System.currentTimeMillis()) {
+                logger.debug("expiring job #{}", getId());
+                if (state == State.READY || state == State.TRANSFERRING) {
+                    setState(State.DONE, "lifetime expired");
+                } else if (!state.isFinalState()) {
+                    setState(State.FAILED, "lifetime expired");
                 }
-                if(State.isFinalState(job.state)) {
-                    return;
-                }
-                job.setState(State.FAILED,"lifetime expired");
-            } finally {
-                job.wunlock();
             }
-        }
-        catch(IllegalStateTransition ist) {
-            // todo: need to add log when adding logger ("Illegal State Transition : " +ist.getMessage());
+        } catch (IllegalStateTransition e) {
+            logger.error("Illegal state transition while expiring job: {}", e.toString());
+        } finally {
+            wunlock();
         }
     }
 
@@ -1074,16 +875,15 @@ public abstract class Job  {
     }
 
     public long getRemainingLifetime() {
-        wlock();
+        rlock();
         try {
-            if(State.isFinalState(this.state)) {
+            if (state.isFinalState()) {
                 return 0;
             }
-            long remianingLifetime = creationTime+
-                    lifetime - System.currentTimeMillis();
-            return remianingLifetime >0?remianingLifetime:0;
+            long remainingLifetime = creationTime + lifetime - System.currentTimeMillis();
+            return remainingLifetime > 0 ? remainingLifetime : 0;
         } finally {
-            wunlock();
+            runlock();
         }
     }
 
@@ -1257,12 +1057,6 @@ public abstract class Job  {
         } finally {
             wunlock();
         }
-    }
-
-
-
-    public static <T extends Job> Set<T > getActiveJobs(Class<T> type) {
-        return sharedMemoryCache.getJobs(type);
     }
 
     /**

--- a/modules/srm/src/main/java/org/dcache/srm/request/LsFileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/LsFileRequest.java
@@ -76,7 +76,6 @@ public final class LsFileRequest extends FileRequest<LsRequest> {
                       lifetime,
                       maxNumberOfRetries);
                 this.surl = URI.create(url.toString());
-                updateMemoryCache();
         }
 
         public LsFileRequest(
@@ -197,7 +196,7 @@ public final class LsFileRequest extends FileRequest<LsRequest> {
                         }
                         setState(State.DONE, State.DONE.toString());
                 }
-                catch (SRMException | URISyntaxException | IllegalStateTransition e) {
+                catch (SRMException | SQLException | URISyntaxException | IllegalStateTransition e) {
                         wlock();
                         try {
                                 TReturnStatus status;
@@ -221,6 +220,11 @@ public final class LsFileRequest extends FileRequest<LsRequest> {
                                         status = new TReturnStatus(TStatusCode.SRM_INVALID_PATH,
                                                                    msg);
                                         setStatusCode(TStatusCode.SRM_INVALID_PATH);
+                                }
+                                else if (e instanceof SQLException) {
+                                    status = new TReturnStatus(TStatusCode.SRM_INTERNAL_ERROR,
+                                            msg);
+                                    setStatusCode(TStatusCode.SRM_INTERNAL_ERROR);
                                 }
                                 else {
                                         if (e instanceof RuntimeException) {

--- a/modules/srm/src/main/java/org/dcache/srm/request/LsRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/LsRequest.java
@@ -73,7 +73,6 @@ public final class LsRequest extends ContainerRequest<LsFileRequest> {
                     requests.add(fileRequest);
                 }
                 setFileRequests(requests);
-                updateMemoryCache();
         }
 
         public  LsRequest(

--- a/modules/srm/src/main/java/org/dcache/srm/request/PutFileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/PutFileRequest.java
@@ -153,7 +153,6 @@ public final class PutFileRequest extends FileRequest<PutRequest> {
         if(retentionPolicy != null ) {
             this.retentionPolicy = retentionPolicy;
         }
-        updateMemoryCache();
     }
 
 
@@ -566,7 +565,7 @@ public final class PutFileRequest extends FileRequest<PutRequest> {
             }
             logger.debug("run() returns, scheduler should bring file request into the ready state eventually");
         }
-        catch(SRMException | IllegalStateTransition e) {
+        catch(SRMException | SQLException | IllegalStateTransition e) {
             throw new FatalJobFailure("cannot prepare to put: " + e.getMessage());
         }
     }

--- a/modules/srm/src/main/java/org/dcache/srm/request/PutRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/PutRequest.java
@@ -157,8 +157,6 @@ public final class PutRequest extends ContainerRequest<PutFileRequest> {
             requests.add(request);
         }
         setFileRequests(requests);
-        updateMemoryCache();
-
     }
 
     public  PutRequest(

--- a/modules/srm/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
@@ -139,9 +139,6 @@ public final class ReserveSpaceRequest extends Request {
         this.retentionPolicy = retentionPolicy;
         this.accessLatency = accessLatency;
         this.spaceReservationLifetime = spaceReservationLifetime;
-        updateMemoryCache();
-        logger.debug("created");
-
     }
 
     /** this constructor is used for restoring the previously

--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseFileRequestStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseFileRequestStorage.java
@@ -9,10 +9,8 @@ package org.dcache.srm.request.sql;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Set;
 
 import org.dcache.srm.request.FileRequest;
-import org.dcache.srm.scheduler.State;
 import org.dcache.srm.util.Configuration;
 
 /**
@@ -154,14 +152,4 @@ public abstract class DatabaseFileRequestStorage<F extends FileRequest<?>> exten
     /*protected java.util.Set getFileRequests(String requestId) throws java.sql.SQLException{
         return getJobsByCondition(" REQUESTID = '"+requestId+"'");
     }*/
-
-
-    public Set<Long> getActiveFileRequestIds(String schedulerid)  throws SQLException {
-        String condition = " SCHEDULERID='"+schedulerid+
-        "' AND STATE !="+State.DONE.getStateId()+
-        " AND STATE !="+State.CANCELED.getStateId()+
-        " AND STATE !="+State.FAILED.getStateId();
-        return getJobIdsByCondition(condition);
-    }
-
 }

--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
@@ -77,6 +77,7 @@ import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.PreparedStatementCreator;
 
 import java.lang.reflect.Field;
 import java.sql.Connection;
@@ -355,6 +356,11 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
             int next_index) throws SQLException;
 
     @Override
+    public void init() throws SQLException
+    {
+    }
+
+    @Override
     public J getJob(Long jobId) throws SQLException {
 
         if(jobId == null) {
@@ -404,36 +410,41 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
             if(!set.next()) {
                 return null;
             }
-            Long ID = set.getLong(1);
-            Long NEXTJOBID = set.getLong(2);
-            long CREATIONTIME = set.getLong(3);
-            long LIFETIME = set.getLong(4);
-            int STATE = set.getInt(5);
-            String ERRORMESSAGE = set.getString(6);
-            String SCHEDULERID=set.getString(7);
-            long SCHEDULER_TIMESTAMP=set.getLong(8);
-            int NUMOFRETR = set.getInt(9);
-            int MAXNUMOFRETR = set.getInt(10);
-            long LASTSTATETRANSITIONTIME = set.getLong(11);
-            J job = getJob(_con,
-                    ID,
-                    NEXTJOBID ,
-                    CREATIONTIME,
-                    LIFETIME,
-                    STATE,
-                    ERRORMESSAGE,
-                    SCHEDULERID,
-                    SCHEDULER_TIMESTAMP,
-                    NUMOFRETR,
-                    MAXNUMOFRETR,
-                    LASTSTATETRANSITIONTIME,
-                    set,
-                    12 );
-            return job;
+            return getJob(_con, set);
         } finally {
             SqlHelper.tryToClose(set);
             SqlHelper.tryToClose(statement);
         }
+    }
+
+    private J getJob(Connection _con, ResultSet set) throws SQLException
+    {
+        Long ID = set.getLong(1);
+        Long NEXTJOBID = set.getLong(2);
+        long CREATIONTIME = set.getLong(3);
+        long LIFETIME = set.getLong(4);
+        int STATE = set.getInt(5);
+        String ERRORMESSAGE = set.getString(6);
+        String SCHEDULERID=set.getString(7);
+        long SCHEDULER_TIMESTAMP=set.getLong(8);
+        int NUMOFRETR = set.getInt(9);
+        int MAXNUMOFRETR = set.getInt(10);
+        long LASTSTATETRANSITIONTIME = set.getLong(11);
+        J job = getJob(_con,
+                ID,
+                NEXTJOBID ,
+                CREATIONTIME,
+                LIFETIME,
+                STATE,
+                ERRORMESSAGE,
+                SCHEDULERID,
+                SCHEDULER_TIMESTAMP,
+                NUMOFRETR,
+                MAXNUMOFRETR,
+                LASTSTATETRANSITIONTIME,
+                set,
+                12 );
+        return job;
     }
 
     @Override
@@ -578,84 +589,21 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
     public abstract PreparedStatement getCreateStatement(Connection connection, Job job) throws SQLException;
     public abstract PreparedStatement getUpdateStatement(Connection connection, Job job) throws SQLException;
 
-    //
-    // this method should be run only once by the scheduler itself
-    // otherwise it is possible to create multiple inconsistent copies of the
-    // job
-    private boolean getJobsRan;
     @Override
-    public Set<J> getJobs(String schedulerId) throws SQLException{
-        if(getJobsRan)
+    public Set<J> getJobs(final String schedulerId) throws SQLException
+    {
+        return getJobs(new PreparedStatementCreator()
         {
-            throw new SQLException("getJobs("+schedulerId+") has already run" );
-        }
-        getJobsRan = true;
-
-        Set<J> jobs = new HashSet<>();
-        Connection _con =null;
-
-        try {
-            _con = pool.getConnection();
-            String sql = "SELECT * FROM ? WHERE SCHEDULERID=?";
-            PreparedStatement sqlStatement = _con.prepareStatement(sql);
-            sqlStatement.setString(1, getTableName());
-            sqlStatement.setString(2, schedulerId);
-            logger.debug("Selecting everything of Scheduler {} from table {}",
-                    schedulerId,getTableName());
-            ResultSet set = sqlStatement.executeQuery();
-            while(set.next()) {
-                Long ID = set.getLong(1);
-                Long NEXTJOBID = set.getLong(2);
-                //Date CREATIONTIME = set.getDate(3);
-                long CREATIONTIME = set.getLong(3);
-                long LIFETIME = set.getLong(4);
-                int STATE = set.getInt(5);
-                String ERRORMESSAGE = set.getString(6);
-                String SCHEDULERID=set.getString(7);
-                long SCHEDULER_TIMESTAMP=set.getLong(8);
-                int NUMOFRETR = set.getInt(9);
-                int MAXNUMOFRETR = set.getInt(10);
-                long LASTSTATETRANSITIONTIME = set.getLong(11);
-                J job = getJob(
-                        _con,
-                        ID,
-                        NEXTJOBID ,
-                        CREATIONTIME,
-                        LIFETIME,
-                        STATE,
-                        ERRORMESSAGE,
-                        SCHEDULERID,
-                        SCHEDULER_TIMESTAMP,
-                        NUMOFRETR,
-                        MAXNUMOFRETR,
-                        LASTSTATETRANSITIONTIME,
-                        set,
-                        13 );
-
-                logger.debug("==========> deserialization from database of job id {}", job.getId());
-                logger.debug("==========> jobs submitter id is {}", job.getSubmitterId());
-                jobs.add(job);
+            @Override
+            public PreparedStatement createPreparedStatement(Connection connection)
+                    throws SQLException
+            {
+                String sql = "SELECT * FROM " + getTableName() + " WHERE SCHEDULERID=?";
+                PreparedStatement stmt = connection.prepareStatement(sql);
+                stmt.setString(1, schedulerId);
+                return stmt;
             }
-
-            set.close();
-            sqlStatement.close();
-            pool.returnConnection(_con);
-            _con = null;
-            return jobs;
-        }
-        catch(SQLException sqle1) {
-            if(_con != null) {
-                pool.returnFailedConnection(_con);
-                _con = null;
-            }
-            throw sqle1;
-        }
-        finally {
-            if(_con != null) {
-                pool.returnConnection(_con);
-            }
-        }
-
+        });
     }
 
     protected Job.JobHistory[] getJobHistory(Long jobId,Connection _con) throws SQLException{
@@ -689,8 +637,6 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
         statement.close();
         return l.toArray(new Job.JobHistory[l.size()]);
     }
-
-    private boolean updatePendingJobsRan;
 
     public void schedulePendingJobs(Scheduler scheduler)
             throws SQLException,
@@ -741,56 +687,6 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
         }
     }
 
-    public void updatePendingJobs() throws SQLException, InterruptedException,IllegalStateTransition{
-        if(updatePendingJobsRan)
-        {
-            throw new SQLException("updatePendingJobs() has already ran" );
-        }
-        updatePendingJobsRan = true;
-        Connection _con =null;
-        try {
-            _con = pool.getConnection();
-            Statement sqlStatement = _con.createStatement();
-            String sqlStatementString = "SELECT ID FROM " + getTableName() +
-                    " WHERE SCHEDULERID is NULL and State="+State.PENDING.getStateId();
-            logger.debug("executing statement: {}", sqlStatementString);
-            ResultSet set = sqlStatement.executeQuery(sqlStatementString);
-            //save in the memory the ids to prevent the exhaust of the connections
-            // so we return connections before trying to restore the pending
-            // requests
-            Set<Long> idsSet = new HashSet<>();
-            while(set.next()) {
-                idsSet.add(set.getLong(1));
-            }
-
-            set.close();
-            sqlStatement.close();
-            pool.returnConnection(_con);
-            _con = null;
-            for(Long ID : idsSet) {
-                // we just restore the job, which will triger the experation of the job, if its lifetime
-                // is over
-                try {
-                    Job.getJob(ID, Job.class, _con);
-                } catch (SRMInvalidRequestException ire) {
-                    logger.error(ire.toString());
-                }
-
-            }
-        }
-        catch(SQLException sqle1) {
-            if(_con != null) {
-                pool.returnFailedConnection(_con);
-                _con = null;
-            }
-            throw sqle1;
-        }
-        finally {
-            if(_con != null) {
-                pool.returnConnection(_con);
-            }
-        }
-    }
     // this method returns ids as a set of "Long" id
     protected Set<Long> getJobIdsByCondition(String sqlCondition) throws SQLException{
         Set<Long> jobIds = new HashSet<>();
@@ -829,109 +725,109 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
     }
 
     @Override
-    public Set<Long> getLatestCompletedJobIds(int maxNum) throws SQLException
-    {
-        return Collections.emptySet();
+    public Set<Long> getLatestCompletedJobIds(int maxNum)  throws SQLException {
+        return getJobIdsByCondition(
+                " STATE =" + State.DONE.getStateId() +
+                        " OR STATE =" + State.CANCELED.getStateId() +
+                        " OR STATE = " + State.FAILED.getStateId() +
+                        " ORDER BY ID DESC" +
+                        " LIMIT " + maxNum + " ");
     }
 
     @Override
-    public Set<Long> getLatestDoneJobIds(int maxNum) throws SQLException
-    {
-        return Collections.emptySet();
+    public Set<Long> getLatestDoneJobIds(int maxNum)  throws SQLException {
+        return getJobIdsByCondition("STATE ="+State.DONE.getStateId()+
+                " ORDERED BY ID DESC"+
+                " LIMIT "+maxNum+" ");
     }
 
     @Override
-    public Set<Long> getLatestFailedJobIds(int maxNum) throws SQLException
-    {
-        return Collections.emptySet();
+    public Set<Long> getLatestFailedJobIds(int maxNum)  throws SQLException {
+        return getJobIdsByCondition("STATE !="+State.FAILED.getStateId()+
+                " ORDERED BY ID DESC"+
+                " LIMIT "+maxNum+" ");
     }
 
     @Override
-    public Set<Long> getLatestCanceledJobIds(int maxNum) throws SQLException
-    {
-        return Collections.emptySet();
+    public Set<Long> getLatestCanceledJobIds(int maxNum)  throws SQLException {
+        return getJobIdsByCondition("STATE != "+State.CANCELED.getStateId()+
+                " ORDERED BY ID DESC"+
+                " LIMIT "+maxNum+" ");
     }
 
-    @Override
-    public Set<J> getJobs(String schedulerId, State state) throws SQLException {
+    private Set<J> getJobs(PreparedStatementCreator psc) throws SQLException
+    {
         Set<J> jobs = new HashSet<>();
-        Connection _con =null;
+        Connection _con = pool.getConnection();
         PreparedStatement sqlStatement = null;
         ResultSet set = null;
         try {
-            _con = pool.getConnection();
-            String sql = "SELECT * FROM " +getTableName() +" WHERE SCHEDULERID";
-            if(schedulerId == null) {
-                sql += " is NULL";
-            } else {
-                sql += "=?";
-            }
-            sql += " AND STATE=? ";
-            sqlStatement = _con.prepareStatement(sql);
-            if(schedulerId == null) {
-                sqlStatement.setInt(1, state.getStateId());
-            } else {
-                sqlStatement.setString(1,schedulerId);
-                sqlStatement.setInt(2, state.getStateId());
-            }
-            logger.debug("executing statement {} ,values: {} ,{} ,{}", sql, getTableName(), schedulerId,
-                         state.getStateId());
+            sqlStatement = psc.createPreparedStatement(_con);
             set = sqlStatement.executeQuery();
-            while(set.next()) {
-                Long ID = set.getLong(1);
-                Long NEXTJOBID = set.getLong(2);
-                //Date CREATIONDATE = set.getDate(3);
-                long CREATIONTIME = set.getLong(3);
-                long LIFETIME = set.getLong(4);
-                int STATE = set.getInt(5);
-                String ERRORMESSAGE = set.getString(6);
-                String SCHEDULERID=set.getString(7);
-                long SCHEDULER_TIMESTAMP=set.getLong(8);
-                int NUMOFRETR = set.getInt(9);
-                int MAXNUMOFRETR = set.getInt(10);
-                long LASTSTATETRANSITIONTIME = set.getLong(11);
-                J job = getJob(
-                        _con,
-                        ID,
-                        NEXTJOBID ,
-                        CREATIONTIME,
-                        LIFETIME,
-                        STATE,
-                        ERRORMESSAGE,
-                        SCHEDULERID,
-                        SCHEDULER_TIMESTAMP,
-                        NUMOFRETR,
-                        MAXNUMOFRETR,
-                        LASTSTATETRANSITIONTIME,
-                        set,
-                        13 );
-                logger.debug("==========> deserialization from database of {}",
-                             job);
-                logger.debug("==========> jobs creator is {}",
-                             job.getSubmitterId());
+            while (set.next()) {
+                J job = getJob(_con, set);
+                logger.debug("==========> deserialization from database of job id {}", job.getId());
+                logger.debug("==========> jobs submitter id is {}", job.getSubmitterId());
                 jobs.add(job);
             }
 
+            set.close();
+            sqlStatement.close();
             pool.returnConnection(_con);
             _con = null;
             return jobs;
-        }
-        catch(SQLException sqle1) {
-            if(_con != null) {
-                pool.returnFailedConnection(_con);
-                _con = null;
-            }
-            throw sqle1;
-        }
-        finally {
+        } finally {
             SqlHelper.tryToClose(set);
             SqlHelper.tryToClose(sqlStatement);
-            if(_con != null) {
-                pool.returnConnection(_con);
+            if (_con != null) {
+                pool.returnFailedConnection(_con);
             }
         }
     }
 
+    @Override
+    public Set<J> getActiveJobs() throws SQLException
+    {
+        return getJobs(new PreparedStatementCreator()
+        {
+            @Override
+            public PreparedStatement createPreparedStatement(Connection connection)
+                    throws SQLException
+            {
+                String sql =
+                        "SELECT * FROM " + getTableName() +
+                                " WHERE STATE !=" + State.DONE.getStateId() +
+                                " AND STATE !=" + State.CANCELED.getStateId() +
+                                " AND STATE !=" + State.FAILED.getStateId();
+                return connection.prepareStatement(sql);
+            }
+        });
+    }
+
+    @Override
+    public Set<J> getJobs(final String schedulerId, final State state) throws SQLException
+    {
+        return getJobs(new PreparedStatementCreator()
+        {
+            @Override
+            public PreparedStatement createPreparedStatement(Connection connection)
+                    throws SQLException
+            {
+                PreparedStatement stmt;
+                if (schedulerId == null) {
+                    stmt = connection
+                            .prepareStatement("SELECT * FROM " + getTableName() + " WHERE SCHEDULERID IS NULL AND STATE=?");
+                    stmt.setInt(1, state.getStateId());
+                } else {
+                    stmt = connection
+                            .prepareStatement("SELECT * FROM " + getTableName() + " WHERE SCHEDULERID=? AND STATE=?");
+                    stmt.setString(1, schedulerId);
+                    stmt.setInt(2, state.getStateId());
+                }
+                return stmt;
+            }
+        });
+    }
 
     protected void createTable(String tableName, String createStatement) throws SQLException {
         createTable(tableName, createStatement,false,false);

--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseRequestStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseRequestStorage.java
@@ -12,12 +12,10 @@ package org.dcache.srm.request.sql;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Set;
 
 import org.dcache.srm.SRMUser;
 import org.dcache.srm.SRMUserPersistenceManager;
 import org.dcache.srm.request.Request;
-import org.dcache.srm.scheduler.State;
 import org.dcache.srm.util.Configuration;
 
 
@@ -132,60 +130,6 @@ public abstract class DatabaseRequestStorage<R extends Request> extends Database
                 next_index );
     }
     private static int ADDITIONAL_FIELDS_NUM=7;
-
-    public Set<Long> getActiveRequestIds(String schedulerid)  throws SQLException {
-        String condition = " SCHEDULERID='"+schedulerid+
-                "' AND STATE !="+State.DONE.getStateId()+
-                " AND STATE !="+State.CANCELED.getStateId()+
-                " AND STATE !="+State.FAILED.getStateId();
-        return getJobIdsByCondition(condition);
-    }
-
-    public Set<Long> getActiveRequestIds(String schedulerid,
-            SRMUser user,
-            String description )  throws SQLException {
-        String condition = " SCHEDULERID='"+schedulerid+
-                "' AND STATE !="+State.DONE.getStateId()+
-                " AND STATE !="+State.CANCELED.getStateId()+
-                " AND STATE !="+State.FAILED.getStateId()+
-                " AND USERID = '"+user.getId()+'\'';
-        if(description != null) {
-            condition += " AND DESCRIPTION = '"+
-                    description+'\'';
-        }
-        return getJobIdsByCondition(condition);
-    }
-
-    @Override
-    public Set<Long> getLatestCompletedJobIds(int maxNum)  throws SQLException {
-        return getJobIdsByCondition(
-                " STATE ="+State.DONE.getStateId()+
-                " OR STATE ="+State.CANCELED.getStateId()+
-                " OR STATE = "+State.FAILED.getStateId()+
-                " ORDER BY ID"+
-                " LIMIT "+maxNum+" ");
-    }
-
-    @Override
-    public Set<Long> getLatestDoneJobIds(int maxNum)  throws SQLException {
-        return getJobIdsByCondition("STATE ="+State.DONE.getStateId()+
-                " ORDERED BY ID"+
-                " LIMIT "+maxNum+" ");
-    }
-
-    @Override
-    public Set<Long> getLatestFailedJobIds(int maxNum)  throws SQLException {
-        return getJobIdsByCondition("STATE !="+State.FAILED.getStateId()+
-                " ORDERED BY ID"+
-                " LIMIT "+maxNum+" ");
-    }
-
-    @Override
-    public Set<Long> getLatestCanceledJobIds(int maxNum)  throws SQLException {
-        return getJobIdsByCondition("STATE != "+State.CANCELED.getStateId()+
-                " ORDERED BY ID"+
-                " LIMIT "+maxNum+" ");
-    }
 
     protected abstract void __verify(int nextIndex, int columnIndex, String tableName, String columnName, int columnType) throws SQLException ;
 

--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/CanonicalizingJobStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/CanonicalizingJobStorage.java
@@ -1,0 +1,151 @@
+package org.dcache.srm.scheduler;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.MapMaker;
+import com.google.common.collect.Sets;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+import org.dcache.srm.request.Job;
+
+/**
+ * Canonicalizing job storage.
+ *
+ * Guarantees that for a given job ID, the same Job instance is returned as long as
+ * that instance is not garbage collected.
+ *
+ * The canonicalizing map is shared among all instances of CanonicalizingJobStorage,
+ * thus Job IDs must be unique over all instances. This has the benefit
+ * that the map allows early detection of job IDs that don't belong to the
+ * decorated job storage and avoid an expensive load from the storage.
+ */
+public class CanonicalizingJobStorage<J extends Job> implements JobStorage<J>
+{
+    private static final ConcurrentMap<Long, Job> map = new MapMaker().weakValues().makeMap();
+    private final JobStorage<J> storage;
+    private final Class<J> type;
+
+    public CanonicalizingJobStorage(JobStorage<J> storage, Class<J> type)
+    {
+        this.storage = storage;
+        this.type = type;
+    }
+
+    private J canonicalize(Long jobId, J job)
+    {
+        if (job != null) {
+            Job other = map.putIfAbsent(jobId, job);
+            if (other != null) {
+                job = type.cast(other);
+            }
+        }
+        return job;
+    }
+
+    private Set<J> canonicalize(Set<J> jobs)
+    {
+        return Sets.newHashSet(Collections2.transform(jobs, new Function<J, J>()
+        {
+            @Override
+            public J apply(J job)
+            {
+                return canonicalize(job.getId(), job);
+            }
+        }));
+    }
+
+
+    @Override
+    public void init() throws SQLException
+    {
+        storage.init();
+    }
+
+    @Override
+    public J getJob(Long jobId) throws SQLException
+    {
+        Job job = map.get(jobId);
+        if (job == null) {
+            return canonicalize(jobId, storage.getJob(jobId));
+        } else if (type.isInstance(job)) {
+            return type.cast(job);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public J getJob(Long jobId, Connection connection) throws SQLException
+    {
+        Job job = map.get(jobId);
+        if (job == null) {
+            return canonicalize(jobId, storage.getJob(jobId, connection));
+        } else if (type.isInstance(job)) {
+            return type.cast(job);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Set<J> getJobs(String scheduler) throws SQLException
+    {
+        return canonicalize(storage.getJobs(scheduler));
+    }
+
+    @Override
+    public Set<J> getJobs(String scheduler, State state) throws SQLException
+    {
+        return canonicalize(storage.getJobs(scheduler, state));
+    }
+
+    @Override
+    public void saveJob(J job, boolean saveIfMonitoringDisabled) throws SQLException
+    {
+        Job other = map.putIfAbsent(job.getId(), job);
+        if (other != null && other != job) {
+            throw new IllegalStateException("Duplicate job #" + job.getId());
+        }
+        storage.saveJob(job, saveIfMonitoringDisabled);
+    }
+
+    @Override
+    public boolean isJdbcLogRequestHistoryInDBEnabled()
+    {
+        return storage.isJdbcLogRequestHistoryInDBEnabled();
+    }
+
+    @Override
+    public Set<Long> getLatestCompletedJobIds(int maxNum) throws SQLException
+    {
+        return storage.getLatestCompletedJobIds(maxNum);
+    }
+
+    @Override
+    public Set<Long> getLatestDoneJobIds(int maxNum) throws SQLException
+    {
+        return storage.getLatestDoneJobIds(maxNum);
+    }
+
+    @Override
+    public Set<Long> getLatestFailedJobIds(int maxNum) throws SQLException
+    {
+        return storage.getLatestFailedJobIds(maxNum);
+    }
+
+    @Override
+    public Set<Long> getLatestCanceledJobIds(int maxNum) throws SQLException
+    {
+        return storage.getLatestCanceledJobIds(maxNum);
+    }
+
+    @Override
+    public Set<J> getActiveJobs() throws SQLException
+    {
+        return canonicalize(storage.getActiveJobs());
+    }
+}

--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/FinalStateOnlyJobStorageDecorator.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/FinalStateOnlyJobStorageDecorator.java
@@ -2,6 +2,7 @@ package org.dcache.srm.scheduler;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Set;
 
 import org.dcache.srm.request.Job;
@@ -15,6 +16,12 @@ public class FinalStateOnlyJobStorageDecorator<J extends Job> implements JobStor
     private final JobStorage<J> jobStorage;
     public FinalStateOnlyJobStorageDecorator(JobStorage<J> jobStorage ) {
         this.jobStorage = jobStorage;
+    }
+
+    @Override
+    public void init() throws SQLException
+    {
+        jobStorage.init();
     }
 
     @Override
@@ -66,6 +73,12 @@ public class FinalStateOnlyJobStorageDecorator<J extends Job> implements JobStor
     public Set<Long> getLatestCanceledJobIds(int maxNum) throws SQLException
     {
         return jobStorage.getLatestCanceledJobIds(maxNum);
+    }
+
+    @Override
+    public Set<J> getActiveJobs()
+    {
+        return Collections.emptySet();
     }
 
     @Override

--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/JobStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/JobStorage.java
@@ -84,6 +84,7 @@ import org.dcache.srm.request.Job;
  * @author  timur
  */
 public interface JobStorage<J extends Job> {
+    void init() throws SQLException;
     J getJob(Long jobId) throws SQLException;
     J getJob(Long jobId, Connection connection) throws SQLException;
     Set<J> getJobs(String scheduler) throws SQLException;
@@ -104,4 +105,6 @@ public interface JobStorage<J extends Job> {
     Set<Long> getLatestDoneJobIds(int maxNum) throws SQLException;
     Set<Long> getLatestFailedJobIds(int maxNum) throws SQLException;
     Set<Long> getLatestCanceledJobIds(int maxNum) throws SQLException;
+
+    Set<J> getActiveJobs() throws SQLException;
 }

--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/JobStorageFactory.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/JobStorageFactory.java
@@ -1,5 +1,7 @@
 package org.dcache.srm.scheduler;
 
+import java.util.Map;
+
 import org.dcache.srm.request.Job;
 
 /**
@@ -10,6 +12,7 @@ public abstract class JobStorageFactory {
     private static JobStorageFactory factory;
     public abstract <J extends Job> JobStorage<J> getJobStorage(J job);
     public abstract <J extends Job> JobStorage<J> getJobStorage(Class<? extends J> jobClass);
+    public abstract Map<Class<? extends Job>, JobStorage<?>> getJobStorages();
 /**
  * This method is expected to be run only once in the srm constructor
  * and variable factory is not to be modified, once it is initialized

--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/NoopJobStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/NoopJobStorage.java
@@ -17,6 +17,11 @@ public class NoopJobStorage<J extends Job> implements JobStorage<J> {
     }
 
     @Override
+    public void init() throws SQLException
+    {
+    }
+
+    @Override
     public J getJob(Long jobId) throws SQLException {
         return null;
     }
@@ -60,6 +65,12 @@ public class NoopJobStorage<J extends Job> implements JobStorage<J> {
 
     @Override
     public Set<Long> getLatestCanceledJobIds(int maxNum) throws SQLException
+    {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<J> getActiveJobs()
     {
         return Collections.emptySet();
     }

--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/SharedMemoryCache.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/SharedMemoryCache.java
@@ -1,8 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
-
 package org.dcache.srm.scheduler;
 
 import org.slf4j.Logger;
@@ -42,29 +37,61 @@ public class SharedMemoryCache {
     private  Map<Long,Job> sharedMemoryCache =
             new HashMap<>();
 
-   public  void updateSharedMemoryChache(Job job) {
-        if(job == null) {
-            return;
-        }
-        State state = job.getState();
+
+    /**
+     * Canonicalizes non-final jobs.
+     *
+     * @throws IllegalStateException if the canonical instance has a different type than {@code job}
+     * @return a canonical instance of {@code job}, which may be job itself
+     */
+    public <T extends Job> T canonicalize(T job)
+    {
         sharedMemoryWriteLock.lock();
         try {
-            boolean cached =sharedMemoryCache.containsKey(job.getId());
-            _log.debug("updateSharedMemoryChache for job ="+job.getId()+
-                    " state="+state+ " cached ="+cached);
-            if(cached  && state.isFinalState()) {
-                _log.debug("removing job #"+job.getId() +" from memory cache");
-                sharedMemoryCache.remove(job.getId());
-            }
-            if(!cached && !state.isFinalState()) {
-                _log.debug("putting job #"+job.getId() +" to memory cache");
-                sharedMemoryCache.put(job.getId(),job);
+            Job other = sharedMemoryCache.get(job.getId());
+            if (other != null) {
+                if (!job.getClass().isInstance(other)) {
+                    throw new IllegalStateException("Conflicting types for request " + job.getId() + ": " + job.getClass() + " and " + other.getClass());
+                }
+                job = (T) other;
+            } else if (!job.getState().isFinalState()) {
+                sharedMemoryCache.put(job.getId(), job);
             }
         } finally {
             sharedMemoryWriteLock.unlock();
         }
+        return job;
+    }
 
-
+    /**
+     * Updates the registration of job in the cache.
+     *
+     * A post-condition of this method is that job is in the cache if and only if
+     * {@code job} is not final.
+     *
+     * @param job The canonical instance of a job
+     * @throws IllegalArgumentException if {@code job} is not the canonical instance
+     */
+    public <T extends Job> void update(T job)
+    {
+        sharedMemoryWriteLock.lock();
+        try {
+            Job other = sharedMemoryCache.get(job.getId());
+            if (other != null) {
+                if (other != job) {
+                    throw new IllegalArgumentException("Duplicate job #" + job.getId());
+                }
+                if (job.getState().isFinalState()) {
+                    sharedMemoryCache.remove(job.getId());
+                }
+            } else {
+                if (!job.getState().isFinalState()) {
+                    sharedMemoryCache.put(job.getId(), job);
+                }
+            }
+        } finally {
+            sharedMemoryWriteLock.unlock();
+        }
     }
 
     public Job getJob(Long jobId) {

--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
@@ -1,0 +1,177 @@
+package org.dcache.srm.scheduler;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.dcache.srm.request.Job;
+
+/**
+ * Canonicalizing and caching job storage decorator suitable for Terracotta.
+ *
+ * Guarantees that for a given job ID, the same Job instance is returned as long
+ * as the job is not in a final state. Jobs in a final state are not canonicalized.
+ *
+ * All non-final jobs are cached in a static SharedMemoryCache instance suitable
+ * for use as a root object with Terracotta. The expiration time of such jobs are
+ * periodically checked and if passed the jobs are expired.
+ *
+ * Since the cache is shared among all instances of SharedMemoryCacheJobStorage,
+ * Job IDs must be unique over all instances. This has the additional benefit
+ * that the cache allows early detection of job IDs that don't belong to the
+ * decorated job storage: We can detect if an ID belongs to a job storage with a
+ * different type and avoid an expensive probe from the decorated storage.
+ */
+public class SharedMemoryCacheJobStorage<J extends Job> implements JobStorage<J>
+{
+    private static final SharedMemoryCache sharedMemoryCache =
+            new SharedMemoryCache();
+
+    private static final Timer timer = new Timer("Job expiration", true);
+    private final JobStorage<J> storage;
+    private final Class<J> type;
+    private final Set<J> jobsToExpire = Collections.newSetFromMap(new ConcurrentHashMap<J, Boolean>());
+
+    public SharedMemoryCacheJobStorage(JobStorage<J> storage, Class<J> type) throws SQLException
+    {
+        this.storage = storage;
+        this.type = type;
+    }
+
+    private J canonicalize(J job)
+    {
+        if (job == null) {
+            return null;
+        }
+        J canonicalJob = sharedMemoryCache.canonicalize(job);
+        if (job == canonicalJob) {
+            updateExpirationSet(job);
+        }
+        return canonicalJob;
+    }
+
+    private void updateExpirationSet(J job)
+    {
+        if (job.getState().isFinalState()) {
+            jobsToExpire.remove(job);
+        } else {
+            jobsToExpire.add(job);
+        }
+    }
+
+    @Override
+    public void init() throws SQLException
+    {
+        storage.init();
+        for (J job : storage.getActiveJobs()) {
+            canonicalize(job);
+        }
+        timer.schedule(new ExpirationTask(), 10, 60);
+    }
+
+    @Override
+    public J getJob(Long jobId) throws SQLException
+    {
+        Job jobFromCache = sharedMemoryCache.getJob(jobId);
+        if (jobFromCache == null) {
+            return canonicalize(storage.getJob(jobId));
+        } else if (type.isInstance(jobFromCache)) {
+            return type.cast(jobFromCache);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public J getJob(Long jobId, Connection connection) throws SQLException
+    {
+        Job jobFromCache = sharedMemoryCache.getJob(jobId);
+        if (jobFromCache == null) {
+            return canonicalize(storage.getJob(jobId, connection));
+        } else if (type.isInstance(jobFromCache)) {
+            return type.cast(jobFromCache);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Set<J> getJobs(String scheduler) throws SQLException
+    {
+        Set<J> result = new HashSet<>();
+        for (J job : storage.getJobs(scheduler)) {
+            result.add(canonicalize(job));
+        }
+        return result;
+    }
+
+    @Override
+    public Set<J> getJobs(String scheduler, State state) throws SQLException
+    {
+        Set<J> result = new HashSet<>();
+        for (J job : storage.getJobs(scheduler, state)) {
+            result.add(canonicalize(job));
+        }
+        return result;
+    }
+
+    @Override
+    public void saveJob(J job, boolean saveIfMonitoringDisabled) throws SQLException
+    {
+        storage.saveJob(job, saveIfMonitoringDisabled);
+        sharedMemoryCache.update(job);
+        updateExpirationSet(job);
+    }
+
+    @Override
+    public boolean isJdbcLogRequestHistoryInDBEnabled()
+    {
+        return storage.isJdbcLogRequestHistoryInDBEnabled();
+    }
+
+    @Override
+    public Set<Long> getLatestCompletedJobIds(int maxNum) throws SQLException
+    {
+        return storage.getLatestCompletedJobIds(maxNum);
+    }
+
+    @Override
+    public Set<Long> getLatestDoneJobIds(int maxNum) throws SQLException
+    {
+        return storage.getLatestDoneJobIds(maxNum);
+    }
+
+    @Override
+    public Set<Long> getLatestFailedJobIds(int maxNum) throws SQLException
+    {
+        return storage.getLatestFailedJobIds(maxNum);
+    }
+
+    @Override
+    public Set<Long> getLatestCanceledJobIds(int maxNum) throws SQLException
+    {
+        return storage.getLatestCanceledJobIds(maxNum);
+    }
+
+    @Override
+    public Set<J> getActiveJobs()
+    {
+        return sharedMemoryCache.getJobs(type);
+    }
+
+    private class ExpirationTask extends TimerTask
+    {
+        @Override
+        public void run()
+        {
+            for (J job : jobsToExpire) {
+                job.checkExpiration();
+            }
+        }
+    }
+}

--- a/modules/srm/src/main/java/org/dcache/srm/unixfs/Main.java
+++ b/modules/srm/src/main/java/org/dcache/srm/unixfs/Main.java
@@ -268,14 +268,13 @@ public class Main extends CommandInterpreter implements  Runnable {
             }
         }
 
-        public static final String fh_ls_completed= " Syntax: ls completed [-get] [-put] [-copy] [-l] [max_count]"+
+        public static final String fh_ls_completed= " Syntax: ls completed [-get] [-put] [-copy] [max_count]"+
         " #will list completed (done, failed or canceled) requests, if max_count is not specified, it is set to 50";
-        public static final String hh_ls_completed= " [-get] [-put] [-copy] [-l] [max_count]";
+        public static final String hh_ls_completed= " [-get] [-put] [-copy] [[max_count]";
         public String ac_ls_completed_$_0_1(Args args) throws Exception{
             boolean get=args.hasOption("get");
             boolean put=args.hasOption("put");
             boolean copy=args.hasOption("copy");
-            boolean longformat = args.hasOption("l");
             int max_count=50;
             if(args.argc() == 1) {
                 max_count = Integer.parseInt(args.argv(0));

--- a/skel/etc/tc-config.xml
+++ b/skel/etc/tc-config.xml
@@ -26,11 +26,11 @@
 
   <application>
     <dso>
-      <!-- The following declarations tells DSO which classes should be instrumented to 
+      <!-- The following declarations tells DSO which classes should be instrumented to
       allow sharing. When the app runs under DSO, shared instances of these classes will
       broadcast changes in their state.
 
-      A good idiom when writing an app that you intend to cluster via TC DSO is to group the 
+      A good idiom when writing an app that you intend to cluster via TC DSO is to group the
       classes you wish to share under a single package (although if you follow the MVC pattern
       this tends to happen naturally) - this way the list of classes you wish to instrument
       can be concise -->
@@ -192,8 +192,8 @@
 
       <!-- Declare which web application context names should use DSO sessions -->
       <roots>
-        <root>        
-          <field-name>org.dcache.srm.scheduler.Job.sharedMemoryCache</field-name>
+        <root>
+          <field-name>org.dcache.srm.scheduler.SharedMemoryCacheJobStorage.sharedMemoryCache</field-name>
         </root>
       </roots>
 
@@ -202,7 +202,7 @@
            <method-expression>* org.dcache.srm.scheduler.Job.*(..)</method-expression>
            <!-- note that write is the default level, so strictly speaking, it's not
                 required to specify the lock-level for a write, but it's good practice
-                anyway  
+                anyway
             -->
            <lock-level>write</lock-level>
         </autolock>
@@ -211,7 +211,7 @@
            <method-expression>* org.dcache.srm.request.*.*(..)</method-expression>
            <!-- note that write is the default level, so strictly speaking, it's not
                 required to specify the lock-level for a write, but it's good practice
-                anyway  
+                anyway
             -->
            <lock-level>write</lock-level>
         </autolock>
@@ -228,7 +228,7 @@
         <include>java.lang.StringBuilder</include>
         <include>java.util.TimeZone</include>
         <include>sun.util.calendar.ZoneInfo</include>
-      </additional-boot-jar-classes> 
+      </additional-boot-jar-classes>
 
     <!-- This section specifies methods to invoke in a distributed
          fashion via Terracotta DSO. When a method matching one of the


### PR DESCRIPTION
Addresses several issues related to persistence of SRM requests:
- Non-strict layering of JobStorage: Jobs could be loaded either from
  a JobStorage or through static methods in the Job class. The latter
  would canonicalize job instances and implement sharing throughout
  a terracotta cluster and it was thus essential that the Job methods
  were used. Yet, in several places the JobStorage would be accessed
  directly.
  
  This problem is resolved by implementing the shared memory cache and
  canonicalization code through JobStorage decorators, thus enforcing
  strict layering.
- Use of non-bulk loading of jobs during startup. Since the static
  methods of the Job class only supported loading one job at a time,
  restarting an SRM would be very slow if the database contained
  many non-final jobs.
  
  This is addressed by relying on bulk operations instead. Since
  shared memory caching and canonicalization are now implemented as
  decorators to JobStorage, bulk operations are now "safe" to use as
  they are intercepted and processed by the decorators too.
- Several pieces of code would cast JobStorage to DatabaseJobStorage
  to perform special queries, e.g. SrmReleaseFiles. This lead to
  several problems: If database persistence is disabled or configured
  to only store requests in a final-state, the type cast would not
  be possible and thus said functionality would no longer work. The
  cast also bypassed the shared memory cache and canonicalization,
  and finally the data read from the database may be stale as updates
  are written asynchronously.
  
  This is addressed by extending the JobStorage interface with
  an operation to fetch non-final jobs, thus allowing these jobs
  to be obtained without casting the JobStorage instance and without
  bypassing the canonicalization and caching layers.
- During restart, only unscheduled pending jobs would be loaded back
  from the database. Thus code that relied on being able to fetch
  active jobs from the caching layer would not work after a restart.
  In particular the SRM_FILE_BUSY logic would no longer detect busy
  files after a restart.
  
  This is addressed by populating the cache with all non-final jobs
  during restart. As before, only unscheduled pending jobs are scheduled
  for further execution - this can certainly be improved, however
  for the purpose of implementing SRM_FILE_BUSY and for properly
  releasing TURLs at the end of the transfer, the current logic
  suffices.
- Canonicalization relied on a WeakHashMap, which meant that the particular
  instance of the request ID (a Long) was significant for the caching. If
  that particular Long would no longer have a reference, the entry
  would be released.
  
  This is addressed by using a map with weak values created by Guava. This
  also means that in a subsequent patch we can replace all those Long IDs
  with long.

Target: trunk
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/5929/
(cherry picked from commit 9650be1f8ee50876a58fc116c1ad258b240ee274)
