### PR TITLE
srm: Make Scheduler and ModifiableQueue type aware

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -190,15 +190,15 @@ public final class Scheduler implements Runnable  {
             return schedulers.get(id);
 	}
 
-	public Scheduler(String id) {
+	public Scheduler(String id, Class<? extends Job> type) {
 		if(id == null || id.equals("")) {
 			throw new IllegalArgumentException(" need non-null non-empty string as an id");
 		}
 		this.id = id;
 		schedulers.put(id, this);
-        threadQueue = new ModifiableQueue("ThreadQueue",id,maxThreadQueueSize);
-		priorityThreadQueue = new ModifiableQueue("PriorityThreadQueue",id,maxThreadQueueSize);
-		readyQueue = new ModifiableQueue("ReadyQueue",id,maxReadyQueueSize);
+                threadQueue = new ModifiableQueue("ThreadQueue", id, type, maxThreadQueueSize);
+		priorityThreadQueue = new ModifiableQueue("PriorityThreadQueue", id, type, maxThreadQueueSize);
+		readyQueue = new ModifiableQueue("ReadyQueue", id, type, maxReadyQueueSize);
 
 
 		String className="org.dcache.srm.scheduler.policies."+priorityPolicyPlugin;

--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/SchedulerFactory.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/SchedulerFactory.java
@@ -27,7 +27,7 @@ public class SchedulerFactory {
     private SchedulerFactory(Configuration config, String name) {
         schedulerMap = new HashMap<>();
 
-        Scheduler lsRequestScheduler = new Scheduler("ls_" + name);
+        Scheduler lsRequestScheduler = new Scheduler("ls_" + name, LsFileRequest.class);
         // scheduler parameters
         lsRequestScheduler.setMaxThreadQueueSize(config.getLsReqTQueueSize());
         lsRequestScheduler.setThreadPoolSize(config.getLsThreadPoolSize());
@@ -42,7 +42,7 @@ public class SchedulerFactory {
         schedulerMap.put(LsFileRequest.class,lsRequestScheduler);
 
 
-        Scheduler getRequestScheduler = new Scheduler("get_" + name);
+        Scheduler getRequestScheduler = new Scheduler("get_" + name, GetFileRequest.class);
         // scheduler parameters
         getRequestScheduler.setMaxThreadQueueSize(config.getGetReqTQueueSize());
         getRequestScheduler.setThreadPoolSize(config.getGetThreadPoolSize());
@@ -57,7 +57,7 @@ public class SchedulerFactory {
         schedulerMap.put(GetFileRequest.class,getRequestScheduler);
 
 
-        Scheduler bringOnlineRequestScheduler = new Scheduler("bring_online_" + name);
+        Scheduler bringOnlineRequestScheduler = new Scheduler("bring_online_" + name, BringOnlineFileRequest.class);
         // scheduler parameters
         bringOnlineRequestScheduler.setMaxThreadQueueSize(config.getBringOnlineReqTQueueSize());
         bringOnlineRequestScheduler.setThreadPoolSize(config.getBringOnlineThreadPoolSize());
@@ -72,7 +72,7 @@ public class SchedulerFactory {
         schedulerMap.put(BringOnlineFileRequest.class,bringOnlineRequestScheduler);
 
 
-        Scheduler putRequestScheduler = new Scheduler("put_" + name);
+        Scheduler putRequestScheduler = new Scheduler("put_" + name, PutFileRequest.class);
         // scheduler parameters
         putRequestScheduler.setMaxThreadQueueSize(config.getPutReqTQueueSize());
         putRequestScheduler.setThreadPoolSize(config.getPutThreadPoolSize());
@@ -86,7 +86,7 @@ public class SchedulerFactory {
         putRequestScheduler.start();
         schedulerMap.put(PutFileRequest.class,putRequestScheduler);
 
-        Scheduler copyRequestScheduler = new Scheduler("copy_" + name);
+        Scheduler copyRequestScheduler = new Scheduler("copy_" + name, CopyRequest.class);
         // scheduler parameters
         copyRequestScheduler.setMaxThreadQueueSize(config.getCopyReqTQueueSize());
         copyRequestScheduler.setThreadPoolSize(config.getCopyThreadPoolSize());
@@ -98,7 +98,7 @@ public class SchedulerFactory {
         copyRequestScheduler.start();
         schedulerMap.put(CopyRequest.class,copyRequestScheduler);
 
-        Scheduler reserveSpaceScheduler = new Scheduler("reserve_space_" + name);
+        Scheduler reserveSpaceScheduler = new Scheduler("reserve_space_" + name, ReserveSpaceRequest.class);
         reserveSpaceScheduler.setMaxThreadQueueSize(config.getReserveSpaceReqTQueueSize());
         reserveSpaceScheduler.setThreadPoolSize(config.getReserveSpaceThreadPoolSize());
         reserveSpaceScheduler.setMaxWaitingJobNum(config.getReserveSpaceMaxWaitingRequests());


### PR DESCRIPTION
Addresses the problem that ModifiableQueue restores jobs without
knowing their type, thus incurring extra overhead as several
job storages have to be consulted.

Target: trunk
Request: 2.7
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/5944/
(cherry picked from commit b5f77a6707762b21d8e9227fdd846933f5ee6878)
