### PR TITLE
srm: Fix regression in srmCopy

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/scheduler/SchedulerFactory.java
+++ b/modules/srm/src/main/java/org/dcache/srm/scheduler/SchedulerFactory.java
@@ -86,7 +86,7 @@ public class SchedulerFactory {
         putRequestScheduler.start();
         schedulerMap.put(PutFileRequest.class,putRequestScheduler);
 
-        Scheduler copyRequestScheduler = new Scheduler("copy_" + name, CopyRequest.class);
+        Scheduler copyRequestScheduler = new Scheduler("copy_" + name, Job.class);
         // scheduler parameters
         copyRequestScheduler.setMaxThreadQueueSize(config.getCopyReqTQueueSize());
         copyRequestScheduler.setThreadPoolSize(config.getCopyThreadPoolSize());


### PR DESCRIPTION
CopyRequest and CopyFileRequest are both processed by the
same SRM scheduler. Thus the scheduler must be configured
for a common base class of these two jobs.

Target: trunk
Request: 2.7
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/5996/
(cherry picked from commit a4ce5adfa8e080a3999b9c6243a6857486e6d564)
