### PR TITLE
pool: fix startup for pools that saved configuration earlier than 2.2

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumModuleV1.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumModuleV1.java
@@ -279,6 +279,12 @@ public class ChecksumModuleV1
                 usage = "Verbose.")
         boolean verbose;
 
+        @Option(name = "frequently",
+                metaVar = "IGNORED_VALUE",
+                usage = "This option is accepted but ignored.  It exists only " +
+                "for backwards compatibility with older dCache pool 'setup' files")
+        String ignoredValue;
+
         private void updatePolicy(String value, PolicyFlag flag)
         {
             if (value != null) {

--- a/skel/share/services/pool.batch
+++ b/skel/share/services/pool.batch
@@ -48,7 +48,6 @@ define context PoolDefaults endDefine
    jtm set timeout -queue=io -lastAccess=0 -total=0
    jtm set timeout -queue=p2p -lastAccess=0 -total=0
    csm set checksumtype adler32
-   csm set policy -frequently=off
    csm set policy -onread=off -onwrite=on -onrestore=off -ontransfer=off -enforcecrc=on -getcrcfromhsm=off
 
    movermap define DCap-3  org.dcache.pool.movers.DCapProtocol_3_nio


### PR DESCRIPTION
A recent patch introduced strict checking of command options: if a
command supplies an option that is not recognised then the command will
fail.  This is limited to annotated commands.

Pools save their configuration in a 'setup' file as a series of
commands that are to be run on startup.  Unfortunately, this includes a
command with an option that isn't currently accepted. The result is
that pools with 'setup' files created earlier than 1.9.13 do not start.

This patch fixes the problem by updating the command to accept the
option but ignore it.  This is functionally the same as before
introducing the strict checking.

This patch also updates the pool defaults.  This is a set of commands
that are always executed before 'setup' to provide a base-line for
pools.  The current defaults includes the problematic command.

FOR RELEASE NOTES:

A change included in 2.6.8 prevented pools from starting up where the
pool has a 'setup' file created with a version of dCache before
v1.9.13.  This patch fixes this issue.

Target: master
Request: 2.7
Request: 2.6
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8006
Requires-notes: yes
Requires-book: no
