### PR TITLE
chimera: Fix major performance issue on file creation with ACL enabled

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-1.9.12.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-1.9.12.xml
@@ -5,7 +5,7 @@
      xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <changeSet author="tigran" id="7" dbms="postgresql">
+    <changeSet author="tigran" id="7.1" dbms="postgresql">
         <createProcedure>
             DROP TRIGGER IF EXISTS tgr_insertACL ON t_dirs;
 
@@ -14,9 +14,8 @@
                 msk INTEGER;
                 flag INTEGER;
                 rstype INTEGER;
-                id character(36);
-                parentid character(36);
-
+                id character varying(36);
+                parentid character varying(36);
             BEGIN
                 IF (TG_OP = 'INSERT') THEN
                     msk := 0;
@@ -28,7 +27,6 @@
                         rstype := 1;    -- inserted object is a file
                         flag := 1;      -- check flags for 'f' bit
                         msk := 11;      -- mask contains 'o','d' and 'f' bits
-
                     ELSIF (rstype = 16384 AND NEW.iname = '..') THEN
                         id := NEW.iparent;
                         parentid := NEW.ipnfsid;


### PR DESCRIPTION
Chimera uses a trigger on insert into t_dirs to copy the ACLs of the
parent directory to the newly created inode. The stored procedure used
for this uses character(36) to represent PNFS IDs. This causes a
problem with postgresql and it refuses to use the indexes when the
type of the value you search for is different from the type of the
column - even if one is character(36) and the other character varying(36).

The consequence is that every insert into t_dirs causes a linear
scan of t_acl - something that becomes slow and cpu intensive once
you have millions of entries.

Insertion time into t_dirs dropped from around 2 seconds to 2 milliseconds
when we applied this patch at NDGF.

Implementation note: I replaced the existing changeset as it uses
create or replace anyway. That way new sites will never see the buggy
implementation, and old sites will execute the change set as it has
a new id.

Target: trunk
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6049/
(cherry picked from commit 780a19ac41c08faad5992925129e909b7ed41f94)
