### PR TITLE
srm: Fix authorization for srmv1 requests

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/auth/AuthorizationRecord.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/AuthorizationRecord.java
@@ -24,7 +24,6 @@ import org.dcache.auth.attributes.HomeDirectory;
 import org.dcache.auth.attributes.LoginAttribute;
 import org.dcache.auth.attributes.ReadOnly;
 import org.dcache.auth.attributes.RootDirectory;
-import org.dcache.srm.SRMUser;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.persistence.CascadeType.ALL;
@@ -40,7 +39,7 @@ import static javax.persistence.FetchType.EAGER;
 
 @Entity
 @Table(name="authrecord")
-public class AuthorizationRecord implements SRMUser{
+public class AuthorizationRecord {
 
     private static final String PRIMARY_ATTRIBUTE_PREFIX_THAT_RETURN_IDENTITY_AS_VO_GROUP = "/Role=";
 
@@ -223,7 +222,6 @@ public class AuthorizationRecord implements SRMUser{
      * it is set to a unique value by gPlazma
      * It has nothing to do with user id
      */
-    @Override
     @Id  // property access is used
     @Column( name="id")
     public long getId() {
@@ -284,7 +282,6 @@ public class AuthorizationRecord implements SRMUser{
         this.groupLists = groupLists;
     }
 
-    @Override
     @Basic
     @Column( name="priority")
     public int getPriority() {

--- a/modules/dcache/src/main/java/org/dcache/auth/persistence/AuthRecordPersistenceManager.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/persistence/AuthRecordPersistenceManager.java
@@ -17,8 +17,6 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
 import javax.persistence.Persistence;
 
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -30,25 +28,18 @@ import java.util.Set;
 import org.dcache.auth.AuthorizationRecord;
 import org.dcache.auth.Group;
 import org.dcache.auth.GroupList;
-import org.dcache.srm.SRMUserPersistenceManager;
 
 /**
  *
  * @author timur
  */
-public class  AuthRecordPersistenceManager implements SRMUserPersistenceManager{
+public class  AuthRecordPersistenceManager {
 
     private Map<Long,AuthorizationRecord> authRecCache  =
         new HashMap<>();
     private static final Logger _logJpa =
             LoggerFactory.getLogger( AuthRecordPersistenceManager.class);
-    EntityManager em ;
-    public AuthRecordPersistenceManager(String propertiesFile) throws IOException {
-        Properties p = new Properties();
-        p.load(new FileInputStream(propertiesFile));
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory("AuthRecordPersistenceUnit",p );
-        em = emf.createEntityManager();
-    }
+    private final EntityManager em ;
 
     public AuthRecordPersistenceManager(String jdbcUrl,
     String jdbcDriver,
@@ -113,7 +104,6 @@ public class  AuthRecordPersistenceManager implements SRMUserPersistenceManager{
 
     }
 
-    @Override
     public synchronized AuthorizationRecord find(long id) {
         if(authRecCache.containsKey(id)) {
             return authRecCache.get(id);

--- a/modules/srm/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm/src/main/java/org/dcache/srm/SRM.java
@@ -772,7 +772,7 @@ public class SRM {
             if (r != null) {
                 // we found one make sure it is the same  user
                 SRMUser requestUser = r.getUser();
-                if (requestUser == null || requestUser.equals(user)) {
+                if (requestUser == null || requestUser.getId() == user.getId()) {
                     // and return the request status
                     RequestStatus rs = r.getRequestStatus();
                     logger.debug("obtained request status, returning rs for request id=" + requestId);
@@ -932,7 +932,7 @@ public class SRM {
 
             // check that user is the same
             SRMUser req_user = r.getUser();
-            if (req_user != null && !req_user.equals(user)) {
+            if (req_user != null && req_user.getId() != user.getId()) {
                 return createFailedRequestStatus(
                         "request #" + requestId + " owned by "+req_user +" does not belong to user " + user);
             }


### PR DESCRIPTION
Addresses an authorization regression in SRMv1 support.

When AuthorizationRecord was replaced by DcacheUser, SRMv1 authorization
broke. The SRMv1 code relies on SRMUser#equals to determine whether
the request query or update came from the same user that created the
request in the first place. Since DcacheUser doesn't implement equals,
this check always fails.

Rather than implement DcacheUser#equals, the SRM code is updated to
compare the IDs of the users instead. This SRM specific user identifier
is what is stored in the database, and in contrast to the DcacheUser
record, the ID can be restored from disk. The ID also ignores principals
like the Origin, which means that a request query or update will be
authorized even when issued from a different client host.

The patch only affects srmv1. Apparantly srmv2 doesn't do any
authorization checks.

Target: trunk
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6023/
(cherry picked from commit f7b11cd1a7d1a488dda1fb64fad15ca2c8009fa6)
