### PR TITLE
pnfsmanager: Fix null value in diagnostic context

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsMessage.java
@@ -104,7 +104,12 @@ public class PnfsMessage extends Message {
 
     @Override
     public String getDiagnosticContext() {
-        return super.getDiagnosticContext() + " " + getPnfsId();
+        String diagnosticContext = super.getDiagnosticContext();
+        PnfsId pnfsId = getPnfsId();
+        if (pnfsId != null) {
+            diagnosticContext = diagnosticContext + " " + pnfsId;
+        }
+        return diagnosticContext;
     }
 }
 


### PR DESCRIPTION
Adresses the problem that several name space messages add 'null'
to the diagnostic context.

PnfsId is an optional field in PnfsMessage and we thus have to check
for a null value.

Target: trunk
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6053/
(cherry picked from commit cdfad05992506c88744dbeeb8ef8ea9a6fb31134)
