### PR TITLE
pnfsmanager: Use correct queue for create entry and map messages

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsCreateEntryMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsCreateEntryMessage.java
@@ -22,6 +22,7 @@ public class PnfsCreateEntryMessage extends PnfsGetStorageInfoMessage {
         _uid = NameSpaceProvider.DEFAULT;
         _gid = NameSpaceProvider.DEFAULT;
         _mode = NameSpaceProvider.DEFAULT;
+        setPnfsPath(path);
         setReplyRequired(true);
     }
     public PnfsCreateEntryMessage(String path, int uid , int gid , int mode ){
@@ -29,6 +30,7 @@ public class PnfsCreateEntryMessage extends PnfsGetStorageInfoMessage {
         _uid  = uid ;
         _gid  = gid ;
         _mode = mode ;
+        setPnfsPath(path);
         setReplyRequired(true);
     }
 
@@ -42,6 +44,7 @@ public class PnfsCreateEntryMessage extends PnfsGetStorageInfoMessage {
         _uid  = uid ;
         _gid  = gid ;
         _mode = mode ;
+        setPnfsPath(path);
         setReplyRequired(true);
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsMapPathMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsMapPathMessage.java
@@ -13,6 +13,7 @@ public class PnfsMapPathMessage extends PnfsMessage {
 
    public PnfsMapPathMessage( String globalPath ){
       _globalPath = globalPath ;
+      setPnfsPath(globalPath);
       setReplyRequired(true);
    }
    public PnfsMapPathMessage( PnfsId pnfsId ){
@@ -30,6 +31,7 @@ public class PnfsMapPathMessage extends PnfsMessage {
    public String getGlobalPath(){ return _globalPath ; }
    public void setGlobalPath( String globalPath ){
       _globalPath = globalPath ;
+      setPnfsPath(globalPath);
    }
 
     @Override


### PR DESCRIPTION
Messages are put on a pnfs manager queue by pnfs id or path. This is to
ensure that we don't perform concurrent operations on a name space
object and two enforce a happens-before relationship on operations on
a name space object (ie to avoid messages from being processed out of
order). It is also essential for request folding to work correctly.

PnfsCreateEntryMessage and PnfsMapPathMessage however use their own path
field rather than the one in the PnfsMessage base class. Therefore a
random queue was chosen for these messages.

This patch fixes this by also binding the path in the base class. A future
patch for master should remove the redudant fields.

Target: trunk
Request: 2.7
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6051/
(cherry picked from commit f9f050dc52516bf04e8ba1850ad70dde8ffd0276)
