### PR TITLE
billing: Fix regression in billing flat file format rendering

### DIFF
--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -54,7 +54,10 @@ billing.enable.text=${billing.enable.text.when-disable-is-${billingDisableTxt}}
 # In its simplest form, the format string contains placeholders using
 # the syntax $attribute$, where attribute is the name of an attribute
 # in the message. The attribute names of each message is listed
-# below. Messages inherited attributes from messages they extend.
+# below. Messages inherited attributes from messages they extend. Beware
+# that the two character sequence $$ is an escaped $ symbol in dCache
+# configuration files. Thus to have two sequential $ symbols in a format
+# string, four $ symbols have to be added.
 #
 # Each attribute has a type. Some types may expose additional fields.
 # The syntax for accessing a field is $attribute.field$, where field
@@ -214,28 +217,28 @@ billing.enable.text=${billing.enable.text.when-disable-is-${billingDisableTxt}}
 #           Please overwrite the default if you wish to be able to distinguish
 #           pool-to-pool transfers from door-initiated uploads or downloads.
 #
-(deprecated)billing.format.MoverInfoMessage=$date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$storage.storageClass$@$storage.hsm$$else$<Unknown>$endif$ $transferred$ $connectionTime$ $created$ {$protocol$} [$initiator$] {$rc$:"$message$"}
+(deprecated)billing.format.MoverInfoMessage=$date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transferred$ $connectionTime$ $created$ {$protocol$} [$initiator$] {$rc$:"$message$"}
 billing.text.format.mover-info-message=${billing.format.MoverInfoMessage}
 
 #  ---- RemoveFileInfoMessage
 #
 #    Submitted by PnfsManager on file removal.
 #
-(deprecated)billing.format.RemoveFileInfoMessage=$date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$storage.storageClass$@$storage.hsm$$else$<Unknown>$endif$ {$rc$:"$message$"}
+(deprecated)billing.format.RemoveFileInfoMessage=$date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ {$rc$:"$message$"}
 billing.text.format.remove-file-info-message=${billing.format.RemoveFileInfoMessage}
 
 #  ---- DoorRequestInfoMessage
 #
 #    Submitted by doors for each file transfer.
 #
-(deprecated)billing.format.DoorRequestInfoMessage=$date$ [$cellType$:$cellName$:$type$] ["$owner$":$uid$:$gid$:$client$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$storage.storageClass$@$storage.hsm$$else$<Unknown>$endif$ $transactionTime$ $queuingTime$ {$rc$:"$message$"}
+(deprecated)billing.format.DoorRequestInfoMessage=$date$ [$cellType$:$cellName$:$type$] ["$owner$":$uid$:$gid$:$client$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transactionTime$ $queuingTime$ {$rc$:"$message$"}
 billing.text.format.door-request-info-message=${billing.format.DoorRequestInfoMessage}
 
 #  ---- StorageInfoMessage
 #
 #    Submitted by pools for each flush to and fetch from tape.
 #
-(deprecated)billing.format.StorageInfoMessage=$date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$storage.storageClass$@$storage.hsm$$else$<Unknown>$endif$ $transferTime$ $queuingTime$ {$rc$:"$message$"}
+(deprecated)billing.format.StorageInfoMessage=$date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transferTime$ $queuingTime$ {$rc$:"$message$"}
 billing.text.format.storage-info-message=${billing.format.StorageInfoMessage}
 
 # ---- communcation timeout


### PR DESCRIPTION
Addresses a regression in rendering the configurable billing format
strings. A bug prevented these formats from being respected. Note
that the format strings are now preprocessed by the dCache
configuration system, which means that escape sequences are
processed. You may have to update custom format strings (in
$$ sequences have to be replaced by $$$$).

Target: trunk
Request: 2.7
Require-notes: yes
Require-book: yes
Acked-by: Albert Rossi arossi@fnal.gov
Patch: http://rb.dcache.org/r/6065/
(cherry picked from commit 2ac4168cfba99743c19c1a6ed7c030d23674c32f)

Conflicts:
    modules/dcache/src/main/java/org/dcache/services/billing/cells/BillingCell.java
