### PR TITLE
namespace: relax HSM URI validation rules

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
@@ -215,8 +215,8 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
                     if(location.toString().isEmpty()) {
                         continue;
                     }
-                    URI validatedUri = HsmLocationExtractorFactory.validate(location);
-                    inode.getFs().addInodeLocation(inode, StorageGenericLocation.TAPE, validatedUri.toString());
+                    HsmLocationExtractorFactory.validate(location);
+                    inode.getFs().addInodeLocation(inode, StorageGenericLocation.TAPE, location.toString());
                 }
             }
 

--- a/modules/dcache/src/main/java/diskCacheV111/util/HsmLocationExtractorFactory.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/HsmLocationExtractorFactory.java
@@ -24,19 +24,19 @@ public class HsmLocationExtractorFactory {
 
     public static HsmLocation extractorOf(URI location) throws IllegalArgumentException {
 
-        URI validatedUri = validate(location);
+        validate(location);
         HsmLocation extractor;
-        String hsmType = validatedUri.getScheme();
+        String hsmType = location.getScheme();
 
         switch (hsmType) {
         case "osm":
-            extractor = new OsmLocationExtractor(validatedUri);
+            extractor = new OsmLocationExtractor(location);
             break;
         case "enstore":
-            extractor = new EnstoreLocationExtractor(validatedUri);
+            extractor = new EnstoreLocationExtractor(location);
             break;
         case "hpss":
-            extractor = new HpssLocationExtractor(validatedUri);
+            extractor = new HpssLocationExtractor(location);
             break;
         default:
             throw new IllegalArgumentException("hsmType " + hsmType
@@ -46,7 +46,7 @@ public class HsmLocationExtractorFactory {
     }
 
     /**
-     * Validate gived URI with hsm location rules:
+     * Validate given URI with hsm location rules:
      * <pre>
      *  <strong>[scheme:][//authority][path][?query][#fragment]</strong>
      *  where:
@@ -55,10 +55,9 @@ public class HsmLocationExtractorFactory {
      * 	path+query: opaque to dCache HSM specific data
      * </pre>
      * @param location
-     * @return location is it's valid
      * @throws IllegalArgumentException if location violates hsm rules.
      */
-    public static URI validate(URI location) throws IllegalArgumentException {
+    public static void validate(URI location) throws IllegalArgumentException {
 
         if(location.getScheme() == null) {
             throw new IllegalArgumentException("hsm type not defined in " + location);
@@ -67,11 +66,5 @@ public class HsmLocationExtractorFactory {
         if(location.getAuthority() == null) {
             throw new IllegalArgumentException("hsm instance id not defined in " + location);
         }
-
-        if (location.getPath() == null || location.getPath().isEmpty() ) {
-            throw new IllegalArgumentException("hsm-specific opaque data not defined in " + location);
-        }
-
-        return location;
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/HsmStorageHandler2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/HsmStorageHandler2.java
@@ -931,7 +931,8 @@ public class HsmStorageHandler2
                                 if(uri.isEmpty()) {
                                     continue;
                                 }
-                                URI location = HsmLocationExtractorFactory.validate(new URI(uri));
+                                URI location = new URI(uri);
+                                HsmLocationExtractorFactory.validate(location);
                                 storageInfo.addLocation(location);
                                 storageInfo.isSetAddLocation(true);
                                 _log.debug(pnfsId.toString()

--- a/modules/dcache/src/test/java/diskCacheV111/util/HsmLocationExtractorFactoryTest.java
+++ b/modules/dcache/src/test/java/diskCacheV111/util/HsmLocationExtractorFactoryTest.java
@@ -31,26 +31,10 @@ public class HsmLocationExtractorFactoryTest {
     }
 
     @Test
-    public void testValidateNoHsmInstance2() throws Exception {
+    public void testValidateNoPath() throws Exception {
 
         URI location = new URI("osm://osm?group");
-        try {
-            HsmLocationExtractorFactory.validate(location);
-            fail("invalid location not detected");
-        } catch (IllegalArgumentException e) {
-            // OK
-        }
-    }
-
-    @Test
-    public void testValidateNoUniqueId() throws Exception {
-        URI location = new URI("osm://aRandomString");
-        try {
-            HsmLocationExtractorFactory.validate(location);
-            fail("invalid location not detected");
-        } catch (IllegalArgumentException e) {
-            // OK
-        }
+        HsmLocationExtractorFactory.validate(location);
     }
 
     @Test


### PR DESCRIPTION
dcache requires hsm type and hsm instance are provided.
Ignore all other rules as it's OPAQUE to us.

Ticket: #7192
Acked-by: Gerd Behrmann
Target: master, 2.7, 2,6
Require-book: no
Require-notes: no
