### PR TITLE
(2.2) billing: improve the insert queue logic

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/IBillingInfoAccess.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/IBillingInfoAccess.java
@@ -2,6 +2,7 @@ package org.dcache.services.billing.db;
 
 import java.util.Collection;
 
+import org.dcache.services.billing.db.data.IPlotData;
 import org.dcache.services.billing.db.exceptions.BillingInitializationException;
 import org.dcache.services.billing.db.exceptions.BillingQueryException;
 import org.dcache.services.billing.db.exceptions.BillingStorageException;
@@ -13,16 +14,7 @@ import org.dcache.services.billing.db.exceptions.BillingStorageException;
  */
 public interface IBillingInfoAccess {
 
-    void initialize() throws BillingInitializationException;
-
     void close();
-
-    /**
-     * @param data
-     *            mapped type to be stored
-     * @throws BillingStorageException
-     */
-    <T> void put(T data) throws BillingStorageException;
 
     /**
      * @param type
@@ -58,6 +50,14 @@ public interface IBillingInfoAccess {
      */
     <T> Collection<T> get(Class<T> type, String filter, String parameters,
                     Object... values) throws BillingQueryException;
+
+    void initialize() throws BillingInitializationException;
+
+    /**
+     * @param data
+     *            mapped type to be stored
+     */
+    void put(IPlotData data) throws BillingStorageException;
 
     /**
      * @param type

--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/DirectQueueDelegate.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/DirectQueueDelegate.java
@@ -1,0 +1,76 @@
+package org.dcache.services.billing.db.impl;
+
+import org.dcache.services.billing.db.data.DoorRequestData;
+import org.dcache.services.billing.db.data.IPlotData;
+import org.dcache.services.billing.db.data.MoverData;
+import org.dcache.services.billing.db.data.PoolHitData;
+import org.dcache.services.billing.db.data.StorageData;
+import org.dcache.services.billing.db.exceptions.BillingInitializationException;
+import org.dcache.services.billing.db.exceptions.BillingStorageException;
+
+public class DirectQueueDelegate extends QueueDelegate {
+
+    @Override
+    protected void handlePut(DoorRequestData data)
+                    throws BillingStorageException {
+        if (!dropMessagesAtLimit) {
+            try {
+                doorQueue.put(data);
+            } catch (InterruptedException t) {
+                throw new BillingStorageException(t.getMessage(), t.getCause());
+            }
+        } else if (!doorQueue.offer(data)) {
+            processDroppedData(data);
+        }
+    }
+
+    @Override
+    protected void handlePut(MoverData data) throws BillingStorageException {
+        if (!dropMessagesAtLimit) {
+            try {
+                moverQueue.put(data);
+            } catch (InterruptedException t) {
+                throw new BillingStorageException(t.getMessage(), t.getCause());
+            }
+        } else if (!moverQueue.offer(data)) {
+            processDroppedData(data);
+        }
+    }
+
+    @Override
+    protected void handlePut(PoolHitData data) throws BillingStorageException {
+        if (!dropMessagesAtLimit) {
+            try {
+                hitQueue.put(data);
+            } catch (InterruptedException t) {
+                throw new BillingStorageException(t.getMessage(), t.getCause());
+            }
+        } else if (!hitQueue.offer(data)) {
+            processDroppedData(data);
+        }
+    }
+
+    @Override
+    protected void handlePut(StorageData data) throws BillingStorageException {
+        if (!dropMessagesAtLimit) {
+            try {
+                storageQueue.put(data);
+            } catch (InterruptedException t) {
+                throw new BillingStorageException(t.getMessage(), t.getCause());
+            }
+        } else if (!storageQueue.offer(data)) {
+            processDroppedData(data);
+        }
+    }
+
+    @Override
+    protected void initializeInternal() throws BillingInitializationException {
+    }
+
+    private void processDroppedData(IPlotData data) {
+        dropped.incrementAndGet();
+        logger.info("encountered max queue limit; "
+                        + "{} entries have been dropped", dropped.get());
+        logger.debug("queue limit prevented storage of {}", data);
+    }
+}

--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/QueueDelegate.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/QueueDelegate.java
@@ -1,0 +1,221 @@
+package org.dcache.services.billing.db.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.dcache.services.billing.db.data.DoorRequestData;
+import org.dcache.services.billing.db.data.IPlotData;
+import org.dcache.services.billing.db.data.MoverData;
+import org.dcache.services.billing.db.data.PoolHitData;
+import org.dcache.services.billing.db.data.StorageData;
+import org.dcache.services.billing.db.exceptions.BillingInitializationException;
+import org.dcache.services.billing.db.exceptions.BillingStorageException;
+
+/**
+ * @author arossi
+ */
+public abstract class QueueDelegate {
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    protected int maxBatchSize;
+    protected int maxQueueSize;
+    protected boolean dropMessagesAtLimit;
+    protected AtomicLong dropped = new AtomicLong(0);
+    protected AtomicLong committed = new AtomicLong(0);
+
+    protected BlockingQueue moverQueue;
+    protected BlockingQueue doorQueue;
+    protected BlockingQueue storageQueue;
+    protected BlockingQueue hitQueue;
+
+    private Thread moverConsumer;
+    private Thread doorConsumer;
+    private Thread storageConsumer;
+    private Thread hitConsumer;
+
+    private BaseBillingInfoAccess callback;
+
+    private boolean running;
+
+    private class Consumer extends Thread {
+        private BlockingQueue queue;
+
+        private Consumer(String name, BlockingQueue queue) {
+            super(name);
+            this.queue = queue;
+        }
+
+        public void run() {
+            try {
+                while (isRunning()) {
+                    Collection<IPlotData> data = new ArrayList<IPlotData>();
+
+                    /*
+                     * blocks until non-empty
+                     */
+                    logger.trace("calling queue.take()");
+                    data.add((IPlotData) queue.take());
+
+                    /*
+                     * add to data and remove from queue any accumulated entries
+                     */
+                    logger.trace("calling queue.drainTo(), queue size {}",
+                                    queue.size());
+                    queue.drainTo(data, maxBatchSize);
+
+                    try {
+                        logger.trace("calling commit");
+                        callback.commit(data);
+                        committed.addAndGet(data.size());
+                    } catch (BillingStorageException t) {
+                        logger.warn("commit failed; retrying once ...");
+                        try {
+                            callback.commit(data);
+                        } catch (BillingStorageException t1) {
+                            logger.error("commit retry failed, "
+                                            + "{} inserts have been lost",
+                                            data.size());
+                            logger.debug("exception in run(), commit", t1);
+                        }
+                    }
+                }
+            } catch (InterruptedException t) {
+                logger.warn("queue take() was interrupted; "
+                                + "this is probably due to cell shutdown; "
+                                + "exiting thread ...");
+            } finally {
+                setRunning(false);
+            }
+        }
+    }
+
+    public void close() {
+        setRunning(false);
+
+        if (moverConsumer != null) {
+            moverConsumer.interrupt();
+            try {
+                moverConsumer.join();
+            } catch (InterruptedException e) {
+                logger.trace("join on moverConsumer interrupted");
+            }
+        }
+        if (doorConsumer != null) {
+            doorConsumer.interrupt();
+            try {
+                doorConsumer.join();
+            } catch (InterruptedException e) {
+                logger.trace("join on doorConsumer interrupted");
+            }
+        }
+        if (storageConsumer != null) {
+            storageConsumer.interrupt();
+            try {
+                storageConsumer.join();
+            } catch (InterruptedException e) {
+                logger.trace("join on storageConsumer interrupted");
+            }
+        }
+        if (hitConsumer != null) {
+            hitConsumer.interrupt();
+            try {
+                hitConsumer.join();
+            } catch (InterruptedException e) {
+                logger.trace("join on hitConsumer interrupted");
+            }
+        }
+
+        logger.debug("{} close exiting", this);
+    }
+
+    public long getCommitted() {
+        return committed.get();
+    }
+
+    public long getDropped() {
+        return dropped.get();
+    }
+
+    public long getQueueSize() {
+        return moverQueue.size() + doorQueue.size() + storageQueue.size()
+                        + hitQueue.size();
+    }
+
+    public void handlePut(IPlotData data) throws BillingStorageException {
+        if (data instanceof MoverData) {
+            handlePut((MoverData) data);
+        } else if (data instanceof StorageData) {
+            handlePut((StorageData) data);
+        } else if (data instanceof DoorRequestData) {
+            handlePut((DoorRequestData) data);
+        } else if (data instanceof PoolHitData) {
+            handlePut((PoolHitData) data);
+        }
+    }
+
+    public void initialize() throws BillingInitializationException {
+        initializeInternal();
+
+        moverQueue = new LinkedBlockingQueue(maxQueueSize);
+        doorQueue = new LinkedBlockingQueue(maxQueueSize);
+        storageQueue = new LinkedBlockingQueue(maxQueueSize);
+        hitQueue = new LinkedBlockingQueue(maxQueueSize);
+
+        setRunning(true);
+
+        moverConsumer = new Consumer("mover data consumer", moverQueue);
+        doorConsumer = new Consumer("door request data consumer", doorQueue);
+        storageConsumer = new Consumer("storage data consumer", storageQueue);
+        hitConsumer = new Consumer("cache hit data consumer", hitQueue);
+
+        moverConsumer.start();
+        doorConsumer.start();
+        storageConsumer.start();
+        hitConsumer.start();
+    }
+
+    public void setCallback(BaseBillingInfoAccess callback) {
+        this.callback = callback;
+    }
+
+    public void setDropMessagesAtLimit(boolean dropMessagesAtLimit) {
+        this.dropMessagesAtLimit = dropMessagesAtLimit;
+    }
+
+    public void setMaxQueueSize(int maxQueueSize) {
+        this.maxQueueSize = maxQueueSize;
+    }
+
+    public void setMaxBatchSize(int maxBatchSize) {
+        this.maxBatchSize = maxBatchSize;
+    }
+
+    protected abstract void handlePut(DoorRequestData data)
+                    throws BillingStorageException;
+
+    protected abstract void handlePut(MoverData data)
+                    throws BillingStorageException;
+
+    protected abstract void handlePut(PoolHitData data)
+                    throws BillingStorageException;
+
+    protected abstract void handlePut(StorageData data)
+                    throws BillingStorageException;
+
+    protected abstract void initializeInternal()
+                    throws BillingInitializationException;
+
+    protected synchronized boolean isRunning() {
+        return running;
+    }
+
+    protected synchronized void setRunning(boolean running) {
+        this.running = running;
+    }
+}

--- a/modules/dcache/src/main/resources/org/dcache/services/billing/cells/billing.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/cells/billing.xml
@@ -33,7 +33,6 @@
     <property name="poolManagerStub" ref="poolmanager-stub"/>
   </bean>
 
-
   <!-- Set of beans instantiated if database is enabled -->
   <beans profile="db-yes">
     <!-- rather than allow an arbitrary number of access beans, two
@@ -47,11 +46,11 @@
       <property name="jdbcUser" value="${dbUser}"/>
       <property name="jdbcPassword"
 		value="#{ T(diskCacheV111.util.Pgpass).getPassword('${pgPass}', '${dbUrl}', '${dbUser}', '${dbPass}') }"/>
-      <property name="maxInsertsBeforeCommit"
-		value="${dbAccessMaxInsertsBeforeCommit}"/>
-      <property name="maxTimeBeforeCommit"
-		value="${dbAccessMaxTimeBeforeCommit}"/>
       <property name="propertiesPath" value="${dbAccessProperties}"/>
+      <property name="delegateType" value="${billing.db.inserts.queue-delegate.type}"/>
+      <property name="maxQueueSize" value="${billing.db.inserts.max-queue-size}"/>
+      <property name="maxBatchSize" value="${billing.db.inserts.max-batch-size}"/>
+      <property name="dropMessagesAtLimit" value="${billing.db.inserts.drop-messages-at-limit}"/>
     </bean>
 
     <bean id="billing-database"

--- a/modules/dcache/src/main/resources/org/dcache/services/billing/plot/billinghistory.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/plot/billinghistory.xml
@@ -11,13 +11,13 @@
         <property name="location" value="arguments:"/>
     </bean>
 
+    <!-- delegateType should remain unset so as not to initialize an insert thread (plotting does not insert) -->
     <bean id="jdbc-billing-info-access" class="${dbAccess}">
         <property name="jdbcUrl" value="${dbUrl}"/>
         <property name="jdbcDriver" value="${dbDriver}"/>
         <property name="jdbcUser" value="${dbUser}"/>
         <property name="jdbcPassword" value="#{ T(diskCacheV111.util.Pgpass).getPassword('${pgPass}', '${dbUrl}', '${dbUser}', '${dbPass}') }"/>
-        <property name="maxInsertsBeforeCommit" value="${dbAccessMaxInsertsBeforeCommit}"/>
-        <property name="maxTimeBeforeCommit" value="${dbAccessMaxTimeBeforeCommit}"/>
         <property name="propertiesPath" value="${dbAccessProperties}"/>
+        <property name="delegateType" value=""/>
     </bean>
 </beans>

--- a/modules/dcache/src/test/java/org/dcache/services/billing/db/BaseBillingInfoAccessTest.java
+++ b/modules/dcache/src/test/java/org/dcache/services/billing/db/BaseBillingInfoAccessTest.java
@@ -1,25 +1,25 @@
 package org.dcache.services.billing.db;
 
+import junit.framework.TestCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.Random;
 
-import junit.framework.TestCase;
-
-import org.apache.log4j.Logger;
 import org.dcache.services.billing.db.exceptions.BillingQueryException;
 import org.dcache.services.billing.db.impl.BaseBillingInfoAccess;
 import org.dcache.services.billing.db.impl.datanucleus.DataNucleusBillingInfo;
 
 /**
  * @author arossi
- *
  */
 public abstract class BaseBillingInfoAccessTest extends TestCase {
 
-    protected static final Logger logger = Logger
+    protected static final Logger logger = LoggerFactory
                     .getLogger(BaseBillingInfoAccessTest.class);
     private static final String URL = "jdbc:hsqldb:mem:billing_test";
     private static final String DRIVER = "org.hsqldb.jdbcDriver";
@@ -27,8 +27,6 @@ public abstract class BaseBillingInfoAccessTest extends TestCase {
     private static final String PASS = "";
 
     protected InfoMessageGenerator messageGenerator;
-    protected int timeout = 5;
-    protected int maxBefore = 2000;
     protected Random r = new Random(System.currentTimeMillis());
 
     private File testProperties;
@@ -96,8 +94,9 @@ public abstract class BaseBillingInfoAccessTest extends TestCase {
             access.setJdbcUrl(URL);
             access.setJdbcUser(USER);
             access.setJdbcPassword(PASS);
-            access.setMaxInsertsBeforeCommit(maxBefore);
-            access.setMaxTimeBeforeCommit(timeout);
+            access.setDelegateType("org.dcache.services.billing.db.impl.DirectQueueDelegate");
+            access.setMaxBatchSize(1000);
+            access.setMaxQueueSize(1000);
             access.initialize();
         } catch (Throwable t) {
             throw new Exception(t.getMessage(), t.getCause());

--- a/modules/dcache/src/test/java/org/dcache/services/billing/db/InfoMessageGenerator.java
+++ b/modules/dcache/src/test/java/org/dcache/services/billing/db/InfoMessageGenerator.java
@@ -1,19 +1,9 @@
 package org.dcache.services.billing.db;
 
-import java.net.InetSocketAddress;
-import java.util.Random;
 import javax.security.auth.Subject;
 
-import org.dcache.services.billing.db.data.DoorRequestData;
-import org.dcache.services.billing.db.data.MoverData;
-import org.dcache.services.billing.db.data.PnfsBaseInfo;
-import org.dcache.services.billing.db.data.PoolCostData;
-import org.dcache.services.billing.db.data.PoolHitData;
-import org.dcache.services.billing.db.data.StorageData;
-
-import org.dcache.auth.UserNamePrincipal;
-import org.dcache.auth.UidPrincipal;
-import org.dcache.auth.GidPrincipal;
+import java.net.InetSocketAddress;
+import java.util.Random;
 
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.DoorRequestInfoMessage;
@@ -25,6 +15,15 @@ import diskCacheV111.vehicles.PoolHitInfoMessage;
 import diskCacheV111.vehicles.ProtocolInfo;
 import diskCacheV111.vehicles.StorageInfo;
 import diskCacheV111.vehicles.StorageInfoMessage;
+
+import org.dcache.auth.GidPrincipal;
+import org.dcache.auth.UidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
+import org.dcache.services.billing.db.data.DoorRequestData;
+import org.dcache.services.billing.db.data.MoverData;
+import org.dcache.services.billing.db.data.PnfsBaseInfo;
+import org.dcache.services.billing.db.data.PoolHitData;
+import org.dcache.services.billing.db.data.StorageData;
 
 /**
  * Generates InfoMessage with randomized values.
@@ -45,8 +44,6 @@ public class InfoMessageGenerator {
         case 2:
             return new StorageData(newStorageMessage());
         case 3:
-            return new PoolCostData(newCostMessage());
-        case 4:
             return new PoolHitData(newHitMessage());
         }
         return null;

--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -236,7 +236,9 @@ billing.format.StorageInfoMessage=$date$ [$cellType$:$cellName$:$type$] [$pnfsid
 (one-of?yes|no)billingToDb=no
 
 # ---- Use DAO access layer to persistence
-#
+#      org.dcache.services.billing.db.impl.datanucleus.DataNucleusBillingInfo
+#                                 -OR-
+#      org.dcache.services.billing.db.impl.postgresql.BillingPostgreSQLAccess
 billingInfoAccess=org.dcache.services.billing.db.impl.datanucleus.DataNucleusBillingInfo
 
 # ---- If this is set, it overrides the jar-resident configuration resource
@@ -245,8 +247,31 @@ billingInfoAccessPropertiesFile=
 
 # ---- Commit optimizations: in-memory caching thresholds
 #
+# NOTE: no longer used, but not marked obsolete
+#
 billingMaxInsertsBeforeCommit=10000
 billingMaxTimeBeforeCommitInSecs=5
+
+# ---- Data insert logic
+#      controls which handler delegate to use (currently only one available)
+#
+(one-of?org.dcache.services.billing.db.impl.DirectQueueDelegate)billing.db.inserts.queue-delegate.type=org.dcache.services.billing.db.impl.DirectQueueDelegate
+
+# ---- Data insert logic
+#      maximum queue size (four queues, each gets this size)
+#
+billing.db.inserts.max-queue-size=100000
+
+# ---- Data insert logic
+#      maximum batch size (for database batched insert; recommended not to be
+#      greater than 2000)
+#
+billing.db.inserts.max-batch-size=1000
+
+# ---- Data insert logic
+#      drop messages when the queue maximum is reached
+#
+(one-of?true|false)billing.db.inserts.drop-messages-at-limit=true
 
 # ---- liquibase changelog
 billingChangelog=org/dcache/services/billing/db/sql/billing.changelog-master.xml

--- a/skel/share/services/billing.batch
+++ b/skel/share/services/billing.batch
@@ -23,8 +23,10 @@ define env billingToDb.exe endExe
 
   check -strong billingInfoAccess
   check billingInfoAccessPropertiesFile
-  check billingMaxInsertsBeforeCommit
-  check billingMaxTimeBeforeCommitInSecs
+  check -strong billing.db.inserts.max-queue-size
+  check -strong billing.db.inserts.max-batch-size
+  check -strong billing.db.inserts.queue-delegate.type
+  check -strong billing.db.inserts.drop-messages-at-limit
 endExe
 
 onerror continue
@@ -42,13 +44,15 @@ create org.dcache.cells.UniversalSpringCell ${cell.name} \
         -billingDisableTxt=${billingDisableTxt} \
         -dbAccess=${billingInfoAccess} \
         -dbAccessProperties=${billingInfoAccessPropertiesFile} \
-        -dbAccessMaxInsertsBeforeCommit=${billingMaxInsertsBeforeCommit} \
-        -dbAccessMaxTimeBeforeCommit=${billingMaxTimeBeforeCommitInSecs} \
         -dbUrl=${db.url} \
         -dbDriver=${db.driver} \
         -dbUser=${db.user} \
         -dbPass=${db.password} \
         -pgPass=${db.password.file} \
+        -billing.db.inserts.queue-delegate.type=${billing.db.inserts.queue-delegate.type} \
+        -billing.db.inserts.max-queue-size=${billing.db.inserts.max-queue-size} \
+        -billing.db.inserts.max-batch-size=${billing.db.inserts.max-batch-size} \
+        -billing.db.inserts.drop-messages-at-limit=${billing.db.inserts.drop-messages-at-limit} \
         -billingChangelog=${db.schema.changelog} \
         -shouldUpdate=${db.schema.auto} \
         -poolManager=${poolManager} \

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -130,8 +130,6 @@ define context billingHistory-db-yes.exe endDefine
      -dbAccessContext=classpath:org/dcache/services/billing/plot/billinghistory.xml \
      -dbAccess=${billingInfoAccess} \
      -dbAccessProperties=${billingInfoAccessPropertiesFile} \
-     -dbAccessMaxInsertsBeforeCommit=${billingMaxInsertsBeforeCommit} \
-     -dbAccessMaxTimeBeforeCommit=${billingMaxTimeBeforeCommitInSecs} \
      -dbUrl=${billingDbUrl} \
      -dbDriver=${billingDbDriver} \
      -dbUser=${billingDbUser} \


### PR DESCRIPTION
version for 2.2 of http://rb.dcache.org/r/5992

See that patch for details.

Target: 2.2
Request: 2.2
Patch: http://rb.dcache.org/r/5993
Require-notes: yes
Require-book: yes

RELEASE NOTES:
BOOK:

An improved insert strategy for the billing database has been implemented.  The following changes to billing properties should be noted:

billingMaxInsertsBeforeCommit
billingMaxTimeBeforeCommitInSecs

(one-of?org.dcache.services.billing.db.impl.DirectQueueDelegate)billing.db.inserts.queue-delegate.type=org.dcache.services.billing.db.impl.DirectQueueDelegate

billing.db.inserts.max-queue-size=100000

billing.db.inserts.max-batch-size=1000

(one-of?true|false)billing.db.inserts.drop-messages-at-limit=true

It should be noted that, in conjunction with http://rb.dcache.org/r/5983, which modifies the database triggers, insertion should now perform without message loss (and without running out of memory) under most conditions (3000Hz or less).
