### PR TITLE
(2.7) dcache-webadmin: reformat html pages

### DIFF
--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfers.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfers.html
@@ -1,23 +1,30 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="ActiveTransfers.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="ActiveTransfers.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <form wicket:id="activeTransfersForm">
-        <h1><wicket:message key="header1"></wicket:message></h1>
-        <div>
-            <input type="submit" wicket:message="value:submitButton" wicket:id="submit" />
-            <span wicket:id="feedback"/>
-        </div>
-        <span wicket:id="activeTransfersPanel"></span>
-    </form>
-</wicket:extend>
+    <wicket:extend>
+        <form wicket:id="activeTransfersForm">
+            <h1>
+                <wicket:message key="header1"></wicket:message>
+            </h1>
+            <div>
+                <input
+                    type="submit"
+                    wicket:message="value:submitButton"
+                    wicket:id="submit" />
+                <span wicket:id="feedback" />
+            </div>
+            <span wicket:id="activeTransfersPanel"></span>
+        </form>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/alarms/AlarmsPage.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/alarms/AlarmsPage.html
@@ -2,22 +2,27 @@
 <head>
 <title><wicket:message key="title"></wicket:message></title>
 <wicket:head>
-	<wicket:link>
-		<link href="Alarms.css" rel="stylesheet" type="text/css" />
-	</wicket:link>
+    <wicket:link>
+        <link
+            href="Alarms.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
 </wicket:head>
 </head>
 <body>
-    <h1><wicket:message key="title"></wicket:message></h1>
-    <p/>
-	<wicket:extend>
-		 <form wicket:id="form">
-		     <span wicket:id="filterPanel"></span>
-		     <br>
-		     <hr color="red">
-		     <br>
-		     <span wicket:id="displayPanel"></span>
-	     </form>
-	</wicket:extend>
+    <h1>
+        <wicket:message key="title"></wicket:message>
+    </h1>
+    <p />
+    <wicket:extend>
+        <form wicket:id="form">
+            <span wicket:id="filterPanel"></span>
+            <br>
+            <hr color="red">
+            <br>
+            <span wicket:id="displayPanel"></span>
+        </form>
+    </wicket:extend>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/basepage/BasePage.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/basepage/BasePage.html
@@ -1,48 +1,70 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-    <head>
-       <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-        <title wicket:id="pageTitle" >missing</title>
-        <!-- add your meta tags here -->
-        <link href="css/common.css" rel="stylesheet" type="text/css" />
-        <wicket:head>
-            <wicket:link>
-                <link href="BasePage.css" rel="stylesheet" type="text/css" />
-            </wicket:link>
-        </wicket:head>
-    </head>
-    <body>
-        <div class="page_margins">
-            <!-- start: skip link navigation -->
-            <a class="skip" title="skip link" href="#navigation">Skip to the navigation</a><span class="hideme">.</span>
-            <a class="skip" title="skip link" href="#content">Skip to the content</a><span class="hideme">.</span>
-            <!-- end: skip link navigation -->
-            <div id="border-top">
-                <div id="edge-tl"></div>
-                <div id="edge-tr"></div>
-            </div>
-            <div class="page">
-                <div id="header">
-                    <div wicket:id="headerPanel"></div>
-                    <span class="userLogin">
-                        <div wicket:id="userPanel"></div>
-                    </span>
-                </div>
-                <div id="nav">
-                    <!-- skiplink anchor: navigation -->
-                    <a id="navigation" name="navigation"></a>
-                    <div class="hlist" wicket:id="navigationPanel">
-                    </div>
-                </div>
-                <div id="main">
-                    <wicket:child></wicket:child>
-                </div>
-                <!-- begin: #footer -->
-            </div>
-            <div id="border-bottom">
-                <div id="edge-bl"></div>
-                <div id="edge-br"></div>
-            </div>
+<html
+    xmlns="http://www.w3.org/1999/xhtml"
+    xml:lang="en"
+    lang="en">
+<head>
+<meta
+    http-equiv="content-type"
+    content="text/html; charset=utf-8" />
+<title wicket:id="pageTitle">missing</title>
+<!-- add your meta tags here -->
+<link
+    href="css/common.css"
+    rel="stylesheet"
+    type="text/css" />
+<wicket:head>
+    <wicket:link>
+        <link
+            href="BasePage.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
+</head>
+<body>
+    <div class="page_margins">
+        <!-- start: skip link navigation -->
+        <a
+            class="skip"
+            title="skip link"
+            href="#navigation">Skip to the navigation</a>
+        <span class="hideme">.</span>
+        <a
+            class="skip"
+            title="skip link"
+            href="#content">Skip to the content</a>
+        <span class="hideme">.</span>
+        <!-- end: skip link navigation -->
+        <div id="border-top">
+            <div id="edge-tl"></div>
+            <div id="edge-tr"></div>
         </div>
-    </body>
+        <div class="page">
+            <div id="header">
+                <div wicket:id="headerPanel"></div>
+                <span class="userLogin">
+                    <div wicket:id="userPanel"></div>
+                </span>
+            </div>
+            <div id="nav">
+                <!-- skiplink anchor: navigation -->
+                <a
+                    id="navigation"
+                    name="navigation"></a>
+                <div
+                    class="hlist"
+                    wicket:id="navigationPanel"></div>
+            </div>
+            <div id="main">
+                <wicket:child></wicket:child>
+            </div>
+            <!-- begin: #footer -->
+        </div>
+        <div id="border-bottom">
+            <div id="edge-bl"></div>
+            <div id="edge-br"></div>
+        </div>
+    </div>
+</body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/billingplots/BillingPlots.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/billingplots/BillingPlots.html
@@ -3,24 +3,27 @@
 <head>
 <title></title>
 <wicket:head>
-	<wicket:link>
-		<link href="BillingPlots.css" rel="stylesheet" type="text/css" />
-	</wicket:link>
+    <wicket:link>
+        <link
+            href="BillingPlots.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
 </wicket:head>
 </head>
 <body id="billingBody">
-   <h1>
-       <wicket:message key="header1"></wicket:message>
-   </h1>
-   <br>
-   <wicket:extend>
-         <form wicket:id="billingForm">
-             <span wicket:id="optionPanel"></span>
-             <br>
-             <hr style="color:#880000">
-             <br>
-             <span wicket:id="plotsPanel"></span>
-         </form>
-   </wicket:extend>
+    <h1>
+        <wicket:message key="header1"></wicket:message>
+    </h1>
+    <br>
+    <wicket:extend>
+        <form wicket:id="billingForm">
+            <span wicket:id="optionPanel"></span>
+            <br>
+            <hr style="color: #880000">
+            <br>
+            <span wicket:id="plotsPanel"></span>
+        </form>
+    </wicket:extend>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/celladmin/CellAdmin.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/celladmin/CellAdmin.html
@@ -1,30 +1,42 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="CellAdmin.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="CellAdmin.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <form wicket:id="cellAdminForm">
-        <h1><wicket:message key="header1"></wicket:message></h1>
-        <select wicket:id="cellAdminDomain"/>&nbsp;<select wicket:id="cellAdminCell"/>
-        <div class="clear">&nbsp;</div>
-        <div>
-            <span wicket:id="feedback"></span>
-            <input wicket:id="commandText" type="text"/>
-            <input type="submit" wicket:message="value:submitButton" wicket:id="submit" />
+    <wicket:extend>
+        <form wicket:id="cellAdminForm">
+            <h1>
+                <wicket:message key="header1"></wicket:message>
+            </h1>
+            <select wicket:id="cellAdminDomain" />&nbsp;<select
+                wicket:id="cellAdminCell" />
             <div class="clear">&nbsp;</div>
-            <span wicket:id="lastCommand"></span>
-        </div>
-        <div class="clear">&nbsp;</div>
-        <h2><span wicket:id="cellAdmin.receiver"></span></h2>
-        <br/><span wicket:id="cellAdmin.cellresponsevalue"></span>
-    </form>
-</wicket:extend>
+            <div>
+                <span wicket:id="feedback"></span>
+                <input
+                    wicket:id="commandText"
+                    type="text" /> <input
+                    type="submit"
+                    wicket:message="value:submitButton"
+                    wicket:id="submit" />
+                <div class="clear">&nbsp;</div>
+                <span wicket:id="lastCommand"></span>
+            </div>
+            <div class="clear">&nbsp;</div>
+            <h2>
+                <span wicket:id="cellAdmin.receiver"></span>
+            </h2>
+            <br />
+            <span wicket:id="cellAdmin.cellresponsevalue"></span>
+        </form>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/cellservices/CellServices.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/cellservices/CellServices.html
@@ -1,18 +1,22 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="CellServices.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="CellServices.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <h1><wicket:message key="header1"></wicket:message></h1>
-    <span wicket:id="feedback"/>
-    <span wicket:id="cellServicesPanel"></span>
-</wicket:extend>
+    <wicket:extend>
+        <h1>
+            <wicket:message key="header1"></wicket:message>
+        </h1>
+        <span wicket:id="feedback" />
+        <span wicket:id="cellServicesPanel"></span>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/dcacheservices/DCacheServices.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/dcacheservices/DCacheServices.html
@@ -1,27 +1,40 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="DCacheServices.css" rel="stylesheet" type="text/css"  />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="DCacheServices.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <h1><span wicket:id="dCacheInstanceName"></span></h1>
-    <div class="clear">&nbsp;</div>
-    <span wicket:id="feedback"></span>
-    <p><wicket:message key="loginLinkMessage"></wicket:message>
-    <a href="#" wicket:id="loginLink">
-        <img wicket:id="loginImage" class="login"></img>
-
-    </a></p>
-<p><wicket:message key="logoutLinkMessage"></wicket:message>
-<a href="#" wicket:id="logoutLink">
-    <img wicket:id="logoutImage" class="logout"></img>
-</a></p>
-</wicket:extend>
+    <wicket:extend>
+        <h1>
+            <span wicket:id="dCacheInstanceName"></span>
+        </h1>
+        <div class="clear">&nbsp;</div>
+        <span wicket:id="feedback"></span>
+        <p>
+            <wicket:message key="loginLinkMessage"></wicket:message>
+            <a
+                href="#"
+                wicket:id="loginLink"> <img
+                wicket:id="loginImage"
+                class="login"></img>
+            </a>
+        </p>
+        <p>
+            <wicket:message key="logoutLinkMessage"></wicket:message>
+            <a
+                href="#"
+                wicket:id="logoutLink"> <img
+                wicket:id="logoutImage"
+                class="logout"></img>
+            </a>
+        </p>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/info/Info.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/info/Info.html
@@ -1,12 +1,7 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-    </wicket:head>
+<head>
+<title></title>
 </head>
 <body>
-<wicket:extend>
-</wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/infoxml/InfoXml.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/infoxml/InfoXml.html
@@ -1,28 +1,46 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="InfoXml.css" rel="stylesheet" type="text/css"  />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="InfoXml.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <form wicket:id="requestInfoXmlForm">
-        <h1><wicket:message key="header1"></wicket:message></h1>
-        <span><wicket:message key="commandLine.Explain"></wicket:message></span>
-        <span wicket:id="feedback"/>
-        <div>
-            <span><wicket:message key="statepath.example"></wicket:message></span>
-            <div class="clear">&nbsp;</div>
-            <input wicket:id="statepath" type="text" value="" size="30"/>
-            <input type="submit" wicket:message="value:submitButton"wicket:id="submit"/>
-            <input type="submit" wicket:message="value:downloadButton" wicket:id="downloadXml"/>
-        </div>
-        <span wicket:id="xmlOutput"><p></p></span>
-    </form>
-</wicket:extend>
+    <wicket:extend>
+        <form wicket:id="requestInfoXmlForm">
+            <h1>
+                <wicket:message key="header1"></wicket:message>
+            </h1>
+            <span>
+                <wicket:message key="commandLine.Explain"></wicket:message>
+            </span>
+            <span wicket:id="feedback" />
+            <div>
+                <span>
+                    <wicket:message key="statepath.example"></wicket:message>
+                </span>
+                <div class="clear">&nbsp;</div>
+                <input
+                    wicket:id="statepath"
+                    type="text"
+                    value=""
+                    size="30" /> <input
+                    type="submit"
+                    wicket:message="value:submitButton"
+                    wicket:id="submit" /> <input
+                    type="submit"
+                    wicket:message="value:downloadButton"
+                    wicket:id="downloadXml" />
+            </div>
+            <span wicket:id="xmlOutput">
+                <p></p>
+            </span>
+        </form>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/login/LogIn.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/login/LogIn.html
@@ -1,47 +1,66 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="LogIn.css" rel="stylesheet" type="text/css"  />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="LogIn.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <h1><span wicket:id="dCacheInstanceName"></span></h1>
-    <h5><span><wicket:message key="adminuser">missing</wicket:message></span></h5>
-    <span wicket:id="feedback"/>
-    <form wicket:id="LogInForm">
-        <div class="clear">&nbsp;</div>
-        <table>
-            <tr>
-                <td align="right"><wicket:message key="table1.row1">missing</wicket:message></td>
-            <td>
-                <input wicket:id="username" type="text" value="" size="30"/>
-            </td>
-            </tr>
-            <tr>
-                <td align="right"><wicket:message key="table1.row2">missing</wicket:message></td>
-            <td>
-                <input wicket:id="password" type="password" value="password" size="30"/>
-            </td>
-            </tr>
-            <tr wicket:id="rememberMeRow">
-                <td></td>
-                <td> <input wicket:id="remembering" type="checkbox" /><wicket:message key="table1.checkbox">missing</wicket:message></td>
-            </tr>
-            <tr>
-                <td></td>
-                <td>
-                    <input type="submit" wicket:id="submit" wicket:message="value:submitButton"/>
-                    <input type="reset" wicket:message="value:resetButton"/>
-                    <input type="submit" wicket:id="certsignin" wicket:message="value:certSignInButton"/>
-                </td>
-            </tr>
-        </table>
-    </form>
-</wicket:extend>
+    <wicket:extend>
+        <h1>
+            <span wicket:id="dCacheInstanceName"></span>
+        </h1>
+        <h5>
+            <span>
+                <wicket:message key="adminuser">missing</wicket:message>
+            </span>
+        </h5>
+        <span wicket:id="feedback" />
+        <form wicket:id="LogInForm">
+            <div class="clear">&nbsp;</div>
+            <table>
+                <tr>
+                    <td align="right"><wicket:message key="table1.row1">missing</wicket:message></td>
+                    <td><input
+                        wicket:id="username"
+                        type="text"
+                        value=""
+                        size="30" /></td>
+                </tr>
+                <tr>
+                    <td align="right"><wicket:message key="table1.row2">missing</wicket:message></td>
+                    <td><input
+                        wicket:id="password"
+                        type="password"
+                        value="password"
+                        size="30" /></td>
+                </tr>
+                <tr wicket:id="rememberMeRow">
+                    <td></td>
+                    <td><input
+                        wicket:id="remembering"
+                        type="checkbox" />
+                    <wicket:message key="table1.checkbox">missing</wicket:message></td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td><input
+                        type="submit"
+                        wicket:id="submit"
+                        wicket:message="value:submitButton" /> <input
+                        type="reset"
+                        wicket:message="value:resetButton" /> <input
+                        type="submit"
+                        wicket:id="certsignin"
+                        wicket:message="value:certSignInButton" /></td>
+                </tr>
+            </table>
+        </form>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.html
@@ -1,56 +1,76 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="PoolAdmin.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="PoolAdmin.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <form wicket:id="poolAdminForm">
-        <h1><wicket:message key="header1"></wicket:message></h1>
-        <div>
-            <span wicket:id="feedback"></span>
-            <input wicket:id="commandText" type="text"/>
-            <input type="submit" wicket:message="value:submitButton" wicket:id="submit" />
+    <wicket:extend>
+        <form wicket:id="poolAdminForm">
+            <h1>
+                <wicket:message key="header1"></wicket:message>
+            </h1>
+            <div>
+                <span wicket:id="feedback"></span>
+                <input
+                    wicket:id="commandText"
+                    type="text" /> <input
+                    type="submit"
+                    wicket:message="value:submitButton"
+                    wicket:id="submit" />
+                <div class="clear">&nbsp;</div>
+                <span wicket:id="lastCommand"></span>
+            </div>
+            <h2>
+                <wicket:message key="header2"></wicket:message>
+            </h2>
+            <span class="horizontalNav">
+                <ul>
+                    <li wicket:id="poolGroupList"><a
+                        href="#"
+                        wicket:id="poolGroupLink"> <span
+                                wicket:id="poolGroupLinkMessage"></span>
+                    </a></li>
+                </ul>
+            </span>
             <div class="clear">&nbsp;</div>
-            <span wicket:id="lastCommand"></span>
-        </div>
-        <h2><wicket:message key="header2"></wicket:message></h2>
-        <span class="horizontalNav">
-            <ul>
-                <li wicket:id="poolGroupList">
-                    <a href="#" wicket:id="poolGroupLink">
-                        <span wicket:id="poolGroupLinkMessage"></span>
-                    </a>
-                </li>
-            </ul>
-        </span>
-        <div class="clear">&nbsp;</div>
-        <input type="submit" wicket:id="selectAllButton" wicket:message="value:selectAllButton"/>
-        <input type="submit" wicket:id="deselectAllButton" wicket:message="value:deselectAllButton"/>
-        <table>
-            <thead>
-                <tr>
-                    <th><wicket:message key="poolAdmin.selected"></wicket:message></th>
-            <th><wicket:message key="poolAdmin.poolname"></wicket:message></th>
-            <th><wicket:message key="poolAdmin.pooldomain"></wicket:message></th>
-            <th><wicket:message key="poolAdmin.poolresponse"></wicket:message></th>
-            </tr>
-            </thead>
-            <tbody>
-                <tr wicket:id="poolItems">
-                    <td id="poolAdminLine"><input type="checkbox" wicket:id="poolAdmin.poolselected"></input></td>
-                    <td id="poolAdminLine"><span wicket:id="poolAdmin.poolnamevalue"></span></td>
-                    <td id="poolAdminLine"><span wicket:id="poolAdmin.pooldomainvalue"></span></td>
-                    <td id="poolAdminLine"><span wicket:id="poolAdmin.poolresponsevalue"></span></td>
-                </tr>
-            </tbody>
-        </table>
-    </form>
-</wicket:extend>
+            <input
+                type="submit"
+                wicket:id="selectAllButton"
+                wicket:message="value:selectAllButton" /> <input
+                type="submit"
+                wicket:id="deselectAllButton"
+                wicket:message="value:deselectAllButton" />
+            <table>
+                <thead>
+                    <tr>
+                        <th><wicket:message key="poolAdmin.selected"></wicket:message></th>
+                        <th><wicket:message key="poolAdmin.poolname"></wicket:message></th>
+                        <th><wicket:message key="poolAdmin.pooldomain"></wicket:message></th>
+                        <th><wicket:message key="poolAdmin.poolresponse"></wicket:message></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr wicket:id="poolItems">
+                        <td id="poolAdminLine"><input
+                            type="checkbox"
+                            wicket:id="poolAdmin.poolselected"></input></td>
+                        <td id="poolAdminLine"><span
+                                wicket:id="poolAdmin.poolnamevalue"></span></td>
+                        <td id="poolAdminLine"><span
+                                wicket:id="poolAdmin.pooldomainvalue"></span></td>
+                        <td id="poolAdminLine"><span
+                                wicket:id="poolAdmin.poolresponsevalue"></span></td>
+                    </tr>
+                </tbody>
+            </table>
+        </form>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.html
@@ -1,66 +1,83 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="PoolGroupView.css" rel="stylesheet" type="text/css"  />
-            <script type="text/javascript" src="js/infobox.js"></script>
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="PoolGroupView.css"
+            rel="stylesheet"
+            type="text/css" />
+        <script
+            type="text/javascript"
+            src="js/infobox.js"></script>
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <form wicket:id="poolGroupsForm">
-        <h1><wicket:message key="header1"></wicket:message></h1>
-        <span wicket:id="feedback"/>
-
-        <div id="infobox" style="position:absolute;visibility:show; left:25px; top:-100px; z-index:+1" onmouseover="overdiv='1';" onmouseout="overdiv='0'; setTimeout('hideBox()',2000)">
-        </div>
-
-        <table class="sortable">
-            <thead>
-                <tr>
-                    <th><wicket:message key="PoolGroupView.poolGroup.header"></wicket:message></th>
-            <th><wicket:message key="PoolGroupView.total.header"></wicket:message></th>
-            <th><wicket:message key="PoolGroupView.free.header"></wicket:message></th>
-            <th><wicket:message key="PoolGroupView.precious.header"></wicket:message></th>
-            <th><span wicket:id="layoutHeaderPanel"></span></th>
-            </tr>
-            </thead>
-            <tbody>
-                <tr wicket:id="poolGroupView">
-                    <td><a wicket:id="nameLink"><span wicket:id="nameMessage"></span></a></td>
-                    <td><span wicket:id="totalSpace"></span></td>
-                    <td><span wicket:id="freeSpace"></span></td>
-                    <td><span wicket:id="preciousSpace"></span></td>
-                    <td><span wicket:id="layoutItemPanel"></span></td>
-                </tr>
-            </tbody>
-        </table>
-        <h2><span wicket:id="specialPoolGroupHeader"></span></h2>
-        <wicket:fragment wicket:id="navigationFragment">
-            <ul>
-                <li>
-                    <a href="#" wicket:id="cellViewLink">
-                        <span wicket:id="cellViewMessage"></span>
-                    </a>
-                </li>
-                <li>
-                    <a href="#" wicket:id="spaceUsageLink">
-                        <span wicket:id="spaceUsageMessage"></span>
-                    </a>
-                </li>
-                <li>
-                    <a href="#" wicket:id="moverViewLink">
-                        <span wicket:id="moverViewMessage"></span>
-                    </a>
-                </li>
-            </ul>
-        </wicket:fragment>
-        <span class="horizontalNav" wicket:id="miniNavigationFragment"></span>
-        <div id="main"><span wicket:id="specialPoolGroupPanel"></span></div>
-    </form>
-</wicket:extend>
+    <wicket:extend>
+        <form wicket:id="poolGroupsForm">
+            <h1>
+                <wicket:message key="header1"></wicket:message>
+            </h1>
+            <span wicket:id="feedback" />
+            <div
+                id="infobox"
+                style="position: absolute; visibility: show; left: 25px; top: -100px; z-index: +1"
+                onmouseover="overdiv='1';"
+                onmouseout="overdiv='0'; setTimeout('hideBox()',2000)"></div>
+            <table class="sortable">
+                <thead>
+                    <tr>
+                        <th><wicket:message
+                                key="PoolGroupView.poolGroup.header"></wicket:message></th>
+                        <th><wicket:message
+                                key="PoolGroupView.total.header"></wicket:message></th>
+                        <th><wicket:message key="PoolGroupView.free.header"></wicket:message></th>
+                        <th><wicket:message
+                                key="PoolGroupView.precious.header"></wicket:message></th>
+                        <th><span wicket:id="layoutHeaderPanel"></span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr wicket:id="poolGroupView">
+                        <td><a wicket:id="nameLink"><span
+                                    wicket:id="nameMessage"></span></a></td>
+                        <td><span wicket:id="totalSpace"></span></td>
+                        <td><span wicket:id="freeSpace"></span></td>
+                        <td><span wicket:id="preciousSpace"></span></td>
+                        <td><span wicket:id="layoutItemPanel"></span></td>
+                    </tr>
+                </tbody>
+            </table>
+            <h2>
+                <span wicket:id="specialPoolGroupHeader"></span>
+            </h2>
+            <wicket:fragment wicket:id="navigationFragment">
+                <ul>
+                    <li><a
+                        href="#"
+                        wicket:id="cellViewLink"> <span
+                                wicket:id="cellViewMessage"></span>
+                    </a></li>
+                    <li><a
+                        href="#"
+                        wicket:id="spaceUsageLink"> <span
+                                wicket:id="spaceUsageMessage"></span>
+                    </a></li>
+                    <li><a
+                        href="#"
+                        wicket:id="moverViewLink"> <span
+                                wicket:id="moverViewMessage"></span>
+                    </a></li>
+                </ul>
+            </wicket:fragment>
+            <span
+                class="horizontalNav"
+                wicket:id="miniNavigationFragment"></span>
+            <div id="main">
+                <span wicket:id="specialPoolGroupPanel"></span>
+            </div>
+        </form>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poollist/PoolList.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poollist/PoolList.html
@@ -1,31 +1,40 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="PoolList.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-        <wicket:link>
-            <script type="text/javascript" src="js/infobox.js"></script>
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="PoolList.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+    <wicket:link>
+        <script
+            type="text/javascript"
+            src="js/infobox.js"></script>
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <form wicket:id="poolUsageForm">
-        <h1><wicket:message key="header1"></wicket:message></h1>
-        <div>
-            <select wicket:id="mode"/>
-            <input type="submit" wicket:message="value:submitButton" wicket:id="submit" />
-            <span wicket:id="feedback"/>
-        </div>
-
-        <div id="infobox" style="position:absolute;visibility:show; left:25px; top:-100px; z-index:+1" onmouseover="overdiv='1';" onmouseout="overdiv='0'; setTimeout('hideBox()',2000)">
-        </div>
-
-        <span wicket:id="poolListPanel"></span>
-    </form>
-</wicket:extend>
+    <wicket:extend>
+        <form wicket:id="poolUsageForm">
+            <h1>
+                <wicket:message key="header1"></wicket:message>
+            </h1>
+            <div>
+                <select wicket:id="mode" /> <input
+                    type="submit"
+                    wicket:message="value:submitButton"
+                    wicket:id="submit" />
+                <span wicket:id="feedback" />
+            </div>
+            <div
+                id="infobox"
+                style="position: absolute; visibility: show; left: 25px; top: -100px; z-index: +1"
+                onmouseover="overdiv='1';"
+                onmouseout="overdiv='0'; setTimeout('hideBox()',2000)"></div>
+            <span wicket:id="poolListPanel"></span>
+        </form>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolqueues/PoolQueuePlots.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolqueues/PoolQueuePlots.html
@@ -3,19 +3,21 @@
 <head>
 <title></title>
 <wicket:head>
-	<wicket:link>
-		<link href="PoolQueuePlots.css" rel="stylesheet" type="text/css" />
-	</wicket:link>
+    <wicket:link>
+        <link
+            href="PoolQueuePlots.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
 </wicket:head>
 </head>
 <body>
     <wicket:extend>
-         <form wicket:id="form">
-             <span wicket:id="controlPanel"></span>
-             <br>
-             <br>
-             <span wicket:id="displayPanel"></span>
-         </form>
+        <form wicket:id="form">
+            <span wicket:id="controlPanel"></span>
+            <br> <br>
+            <span wicket:id="displayPanel"></span>
+        </form>
     </wicket:extend>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolqueues/PoolQueues.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolqueues/PoolQueues.html
@@ -1,17 +1,21 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="PoolQueues.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="PoolQueues.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <h1><wicket:message key="header1"></wicket:message></h1>
-    <span wicket:id="poolQueuesPanel"></span>
-</wicket:extend>
+    <wicket:extend>
+        <h1>
+            <wicket:message key="header1"></wicket:message>
+        </h1>
+        <span wicket:id="poolQueuesPanel"></span>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolselectionsetup/PoolSelectionSetup.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolselectionsetup/PoolSelectionSetup.html
@@ -1,133 +1,165 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="PoolSelectionSetup.css" rel="stylesheet" type="text/css"  />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="PoolSelectionSetup.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <h1><wicket:message key="header1"></wicket:message></h1>
-    <span wicket:id="feedback"></span>
-    <table class="selection">
-        <tr>
-            <td><a wicket:id="partitionsLink"><wicket:message key="partitionsLink"></wicket:message></a></td>
-            <td><a wicket:id="poolsLink"><wicket:message key="poolsLink"></wicket:message></a></td>
-            <td><a wicket:id="poolGroupsLink"><wicket:message key="poolGroupsLink"></wicket:message></a></td>
-            <td><a wicket:id="selectionLink"><wicket:message key="selectionLink"></wicket:message></a></td>
-        </tr>
-        <tr>
-            <td><a wicket:id="selectionGroupsLink"><wicket:message key="selectionGroupsLink"></wicket:message></a></td>
-            <td><a wicket:id="linksLink"><wicket:message key="linksLink"></wicket:message></a></td>
-            <td><a wicket:id="linkListLink"><wicket:message key="linkListLink"></wicket:message></a></td>
-            <td><a wicket:id="matchLink"><wicket:message key="matchLink"></wicket:message></a></td>
-        </tr>
-    </table>
-    <div class="clear">&nbsp;</div>
-    <span wicket:id="resultPanel"></span>
-    <wicket:fragment wicket:id="entityListShowingFragment">
-        <h3><span wicket:id="listTitle"></span></h3>
-        <table class="content">
-            <tr wicket:id="entityRows">
-                <td wicket:id="cols">
-                    <a href="#" wicket:id="link">
-                        <span wicket:id="name"></span>
-                    </a>
-                </td>
-            </tr>
-        </table>
-    </wicket:fragment>
-    <wicket:fragment wicket:id="particularEntityFragment">
-        <h2><span wicket:id="entityTitle"></span></h2>
-        <span wicket:id="particularProperties"></span>
-        <span wicket:id="firstLinkList"></span>
-        <span wicket:id="secondLinkList"></span>
-    </wicket:fragment>
-    <wicket:fragment wicket:id="poolFragment">
-        <table class="content_1">
-            <tr><th><wicket:message key="poolFragment.enabled"></wicket:message></th>
-            <td><span wicket:id="_isEnabled"></span></td>
-            </tr>
-            <tr><th><wicket:message key="poolFragment.mode"></wicket:message></th>
-            <td><span wicket:id="_mode"></span></td>
-            </tr>
-            <tr><th><wicket:message key="poolFragment.active"></wicket:message></th>
-            <td><span wicket:id="_isActive"></span></td>
-            </tr>
-        </table>
-    </wicket:fragment>
-    <wicket:fragment wicket:id="poolGroupFragment">
-        <table class="content_1">
-            <tr><th><wicket:message key="poolGroupFragment.name"></wicket:message></th>
-            <td><span wicket:id="_name"></span></td>
-            </tr>
-        </table>
-    </wicket:fragment>
-    <wicket:fragment wicket:id="linkFragment">
-        <table class="content_1">
-            <tr><th><wicket:message key="linkFragment.properties"></wicket:message></th>
-            <td><span wicket:id="_name"></span></td>
-            <td><span wicket:id="_writePreference"></span></td>
-            <td><span wicket:id="_readPreference"></span></td>
-            <td><span wicket:id="_restorePreference"></span></td>
-            <td><span wicket:id="_p2pPreference"></span></td>
-            <td><span wicket:id="_partition"></span></td>
-            </tr>
-        </table>
-    </wicket:fragment>
-    <wicket:fragment wicket:id="unitFragment">
-        <table class="content_1">
-            <tr><th><wicket:message key="unitFragment.name"></wicket:message></th>
-            <td><span wicket:id="_name"></span></td>
-            <td><span wicket:id="_type"></span></td>
-            </tr>
-        </table>
-    </wicket:fragment>
-    <wicket:fragment wicket:id="unitGroupFragment">
-        <table class="content_1">
-            <tr><th><wicket:message key="unitGroupFragment.name"></wicket:message></th>
-            <td><span wicket:id="_name"></span></td>
-            </tr>
-        </table>
-    </wicket:fragment>
-    <wicket:fragment wicket:id="linkListFragment">
-        <table class="content">
-            <thead>
-                <tr>
-                    <th rowspan=2><wicket:message key="linkListFragment.name"></wicket:message></th>
-            <th rowspan=2><wicket:message key="linkListFragment.partition"></wicket:message></th>
-            <th colspan=4><wicket:message key="linkListFragment.preferences"></wicket:message></th>
-            <th rowspan=2 colspan=4><wicket:message key="linkListFragment.unitGroups"></wicket:message></th>
-            <th rowspan=2><wicket:message key="linkListFragment.poolGroups"></wicket:message></th>
-            <th rowspan=2><wicket:message key="linkListFragment.pools"></wicket:message></th>
+    <wicket:extend>
+        <h1>
+            <wicket:message key="header1"></wicket:message>
+        </h1>
+        <span wicket:id="feedback"></span>
+        <table class="selection">
+            <tr>
+                <td><a wicket:id="partitionsLink"><wicket:message
+                            key="partitionsLink"></wicket:message></a></td>
+                <td><a wicket:id="poolsLink"><wicket:message
+                            key="poolsLink"></wicket:message></a></td>
+                <td><a wicket:id="poolGroupsLink"><wicket:message
+                            key="poolGroupsLink"></wicket:message></a></td>
+                <td><a wicket:id="selectionLink"><wicket:message
+                            key="selectionLink"></wicket:message></a></td>
             </tr>
             <tr>
-                <th><wicket:message key="linkListFragment.read"></wicket:message></th>
-            <th><wicket:message key="linkListFragment.write"></wicket:message></th>
-            <th><wicket:message key="linkListFragment.cache"></wicket:message></th>
-            <th><wicket:message key="linkListFragment.p2p"></wicket:message></th>
+                <td><a wicket:id="selectionGroupsLink"><wicket:message
+                            key="selectionGroupsLink"></wicket:message></a></td>
+                <td><a wicket:id="linksLink"><wicket:message
+                            key="linksLink"></wicket:message></a></td>
+                <td><a wicket:id="linkListLink"><wicket:message
+                            key="linkListLink"></wicket:message></a></td>
+                <td><a wicket:id="matchLink"><wicket:message
+                            key="matchLink"></wicket:message></a></td>
             </tr>
-            </thead><tbody>
-                <tr wicket:id="linkListView">
-                    <td><a wicket:id="linkLink"><span wicket:id="_name"></span></a></td>
-                    <td><span wicket:id="_partition"></span></td>
-                    <td><span wicket:id="_readPreference"></span></td>
+        </table>
+        <div class="clear">&nbsp;</div>
+        <span wicket:id="resultPanel"></span>
+        <wicket:fragment wicket:id="entityListShowingFragment">
+            <h3>
+                <span wicket:id="listTitle"></span>
+            </h3>
+            <table class="content">
+                <tr wicket:id="entityRows">
+                    <td wicket:id="cols"><a
+                        href="#"
+                        wicket:id="link"> <span wicket:id="name"></span>
+                    </a></td>
+                </tr>
+            </table>
+        </wicket:fragment>
+        <wicket:fragment wicket:id="particularEntityFragment">
+            <h2>
+                <span wicket:id="entityTitle"></span>
+            </h2>
+            <span wicket:id="particularProperties"></span>
+            <span wicket:id="firstLinkList"></span>
+            <span wicket:id="secondLinkList"></span>
+        </wicket:fragment>
+        <wicket:fragment wicket:id="poolFragment">
+            <table class="content_1">
+                <tr>
+                    <th><wicket:message key="poolFragment.enabled"></wicket:message></th>
+                    <td><span wicket:id="_isEnabled"></span></td>
+                </tr>
+                <tr>
+                    <th><wicket:message key="poolFragment.mode"></wicket:message></th>
+                    <td><span wicket:id="_mode"></span></td>
+                </tr>
+                <tr>
+                    <th><wicket:message key="poolFragment.active"></wicket:message></th>
+                    <td><span wicket:id="_isActive"></span></td>
+                </tr>
+            </table>
+        </wicket:fragment>
+        <wicket:fragment wicket:id="poolGroupFragment">
+            <table class="content_1">
+                <tr>
+                    <th><wicket:message key="poolGroupFragment.name"></wicket:message></th>
+                    <td><span wicket:id="_name"></span></td>
+                </tr>
+            </table>
+        </wicket:fragment>
+        <wicket:fragment wicket:id="linkFragment">
+            <table class="content_1">
+                <tr>
+                    <th><wicket:message key="linkFragment.properties"></wicket:message></th>
+                    <td><span wicket:id="_name"></span></td>
                     <td><span wicket:id="_writePreference"></span></td>
+                    <td><span wicket:id="_readPreference"></span></td>
                     <td><span wicket:id="_restorePreference"></span></td>
                     <td><span wicket:id="_p2pPreference"></span></td>
-                    <td><span wicket:id="storage"></span></td>
-                    <td><span wicket:id="net"></span></td>
-                    <td><span wicket:id="protocol"></span></td>
-                    <td><span wicket:id="cacheClass"></span></td>
-                    <td><span wicket:id="poolGroups"></span></td>
-                    <td><span wicket:id="pools"></span></td>
+                    <td><span wicket:id="_partition"></span></td>
                 </tr>
-            </tbody>
-        </table>
-    </wicket:fragment>
-</wicket:extend>
+            </table>
+        </wicket:fragment>
+        <wicket:fragment wicket:id="unitFragment">
+            <table class="content_1">
+                <tr>
+                    <th><wicket:message key="unitFragment.name"></wicket:message></th>
+                    <td><span wicket:id="_name"></span></td>
+                    <td><span wicket:id="_type"></span></td>
+                </tr>
+            </table>
+        </wicket:fragment>
+        <wicket:fragment wicket:id="unitGroupFragment">
+            <table class="content_1">
+                <tr>
+                    <th><wicket:message key="unitGroupFragment.name"></wicket:message></th>
+                    <td><span wicket:id="_name"></span></td>
+                </tr>
+            </table>
+        </wicket:fragment>
+        <wicket:fragment wicket:id="linkListFragment">
+            <table class="content">
+                <thead>
+                    <tr>
+                        <th rowspan=2><wicket:message
+                                key="linkListFragment.name"></wicket:message></th>
+                        <th rowspan=2><wicket:message
+                                key="linkListFragment.partition"></wicket:message></th>
+                        <th colspan=4><wicket:message
+                                key="linkListFragment.preferences"></wicket:message></th>
+                        <th
+                            rowspan=2
+                            colspan=4><wicket:message
+                                key="linkListFragment.unitGroups"></wicket:message></th>
+                        <th rowspan=2><wicket:message
+                                key="linkListFragment.poolGroups"></wicket:message></th>
+                        <th rowspan=2><wicket:message
+                                key="linkListFragment.pools"></wicket:message></th>
+                    </tr>
+                    <tr>
+                        <th><wicket:message key="linkListFragment.read"></wicket:message></th>
+                        <th><wicket:message key="linkListFragment.write"></wicket:message></th>
+                        <th><wicket:message key="linkListFragment.cache"></wicket:message></th>
+                        <th><wicket:message key="linkListFragment.p2p"></wicket:message></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr wicket:id="linkListView">
+                        <td><a wicket:id="linkLink"><span
+                                    wicket:id="_name"></span></a></td>
+                        <td><span wicket:id="_partition"></span></td>
+                        <td><span wicket:id="_readPreference"></span></td>
+                        <td><span wicket:id="_writePreference"></span></td>
+                        <td><span wicket:id="_restorePreference"></span></td>
+                        <td><span wicket:id="_p2pPreference"></span></td>
+                        <td><span wicket:id="storage"></span></td>
+                        <td><span wicket:id="net"></span></td>
+                        <td><span wicket:id="protocol"></span></td>
+                        <td><span wicket:id="cacheClass"></span></td>
+                        <td><span wicket:id="poolGroups"></span></td>
+                        <td><span wicket:id="pools"></span></td>
+                    </tr>
+                </tbody>
+            </table>
+        </wicket:fragment>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.html
@@ -1,44 +1,56 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="SpaceTokens.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="SpaceTokens.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <h1><wicket:message key="header1"></wicket:message></h1>
-    <span wicket:id="feedback"/>
-    <table class="sortable">
-        <thead>
-            <tr>
-                <th><wicket:message key="linkGroupView.linkGroup.header"></wicket:message></th>
-    <th><wicket:message key="linkGroupView.id.header"></wicket:message></th>
-    <th><wicket:message key="linkGroupView.allowed.header"></wicket:message></th>
-    <th><wicket:message key="linkGroupView.vo.header"></wicket:message></th>
-    <th><wicket:message key="linkGroupView.availableSpace.header"></wicket:message></th>
-    <th><wicket:message key="linkGroupView.reservedSpace.header"></wicket:message></th>
-    <th><wicket:message key="linkGroupView.freeSpace.header"></wicket:message></th>
-    <th><wicket:message key="linkGroupView.totalSpace.header"></wicket:message></th>
-    </tr>
-    </thead>
-    <tbody>
-        <tr wicket:id="linkGroupView">
-            <td><a wicket:id="linkGroupLink"><span wicket:id="nameMessage"></span></a></td>
-            <td><span wicket:id="id"></span></td>
-            <td><span wicket:id="allowed"></span></td>
-            <td><span wicket:id="vo"></span></td>
-            <td><span wicket:id="availableSpace"></span></td>
-            <td><span wicket:id="reservedSpace"></span></td>
-            <td><span wicket:id="freeSpace"></span></td>
-            <td><span wicket:id="totalSpace"></span></td>
-        </tr>
-    </tbody>
-    </table>
-    <div id="main"><span wicket:id="spaceReservationsPanel"></span></div>
-</wicket:extend>
+    <wicket:extend>
+        <h1>
+            <wicket:message key="header1"></wicket:message>
+        </h1>
+        <span wicket:id="feedback" />
+        <table class="sortable">
+            <thead>
+                <tr>
+                    <th><wicket:message
+                            key="linkGroupView.linkGroup.header"></wicket:message></th>
+                    <th><wicket:message key="linkGroupView.id.header"></wicket:message></th>
+                    <th><wicket:message key="linkGroupView.allowed.header"></wicket:message></th>
+                    <th><wicket:message key="linkGroupView.vo.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="linkGroupView.availableSpace.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="linkGroupView.reservedSpace.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="linkGroupView.freeSpace.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="linkGroupView.totalSpace.header"></wicket:message></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr wicket:id="linkGroupView">
+                    <td><a wicket:id="linkGroupLink">
+                        <span wicket:id="nameMessage"></span></a></td>
+                    <td><span wicket:id="id"></span></td>
+                    <td><span wicket:id="allowed"></span></td>
+                    <td><span wicket:id="vo"></span></td>
+                    <td><span wicket:id="availableSpace"></span></td>
+                    <td><span wicket:id="reservedSpace"></span></td>
+                    <td><span wicket:id="freeSpace"></span></td>
+                    <td><span wicket:id="totalSpace"></span></td>
+                </tr>
+            </tbody>
+        </table>
+        <div id="main">
+            <span wicket:id="spaceReservationsPanel"></span>
+        </div>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/spacetokens/spacereservationpanel/SpaceReservationPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/spacetokens/spacereservationpanel/SpaceReservationPanel.html
@@ -1,49 +1,67 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="SpaceReservationPanel.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="SpaceReservationPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <h1><span wicket:id="spaceReservationHeader"></span><span wicket:id="headerLinkgroup"></span></h1>
-    <table class="sortable">
-        <thead>
-            <tr>
-                <th><wicket:message key="SpaceReservationPanel.id.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.description.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.linkGroupId.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.storage.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.vogroup.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.state.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.size.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.used.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.allocated.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.created.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.lifetime.header"></wicket:message></th>
-        <th><wicket:message key="SpaceReservationPanel.expiration.header"></wicket:message></th>
-        </tr>
-        </thead>
-        <tbody>
-            <tr wicket:id="spaceReservationPanelListview">
-                <td><span wicket:id="id"></span></td>
-                <td><span wicket:id="description"></span></td>
-                <td><span wicket:id="linkGroupId"></span></td>
-                <td><span wicket:id="storage"></span></td>
-                <td><span wicket:id="vogroup"></span></td>
-                <td><span wicket:id="state"></span></td>
-                <td><span wicket:id="size"></span></td>
-                <td><span wicket:id="used"></span></td>
-                <td><span wicket:id="allocated"></span></td>
-                <td><span wicket:id="created"></span></td>
-                <td><span wicket:id="lifetime"></span></td>
-                <td><span wicket:id="expiration"></span></td>
-            </tr>
-        </tbody>
-    </table>
-</wicket:panel>
+    <wicket:panel>
+        <h1>
+            <span wicket:id="spaceReservationHeader"></span>
+            <span wicket:id="headerLinkgroup"></span>
+        </h1>
+        <table class="sortable">
+            <thead>
+                <tr>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.id.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.description.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.linkGroupId.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.storage.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.vogroup.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.state.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.size.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.used.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.allocated.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.created.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.lifetime.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="SpaceReservationPanel.expiration.header"></wicket:message></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr wicket:id="spaceReservationPanelListview">
+                    <td><span wicket:id="id"></span></td>
+                    <td><span wicket:id="description"></span></td>
+                    <td><span wicket:id="linkGroupId"></span></td>
+                    <td><span wicket:id="storage"></span></td>
+                    <td><span wicket:id="vogroup"></span></td>
+                    <td><span wicket:id="state"></span></td>
+                    <td><span wicket:id="size"></span></td>
+                    <td><span wicket:id="used"></span></td>
+                    <td><span wicket:id="allocated"></span></td>
+                    <td><span wicket:id="created"></span></td>
+                    <td><span wicket:id="lifetime"></span></td>
+                    <td><span wicket:id="expiration"></span></td>
+                </tr>
+            </tbody>
+        </table>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.html
@@ -1,43 +1,53 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="TapeTransferQueue.css" rel="stylesheet" type="text/css"  />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="TapeTransferQueue.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:extend>
-    <h1><wicket:message key="header1"></wicket:message></h1>
-    <span wicket:id="feedback"/>
-    <table id="sortable">
-        <thead>
-            <tr>
-                <th><wicket:message key="TapeTransferQueue.pnfsid.header"></wicket:message></th>
-    <th><wicket:message key="TapeTransferQueue.subnet.header"></wicket:message></th>
-    <th><wicket:message key="TapeTransferQueue.candidate.header"></wicket:message></th>
-    <th><wicket:message key="TapeTransferQueue.started.header"></wicket:message></th>
-    <th><wicket:message key="TapeTransferQueue.clients.header"></wicket:message></th>
-    <th><wicket:message key="TapeTransferQueue.retries.header"></wicket:message></th>
-    <th><wicket:message key="TapeTransferQueue.status.header"></wicket:message>
-    </th>
-    </tr>
-    </thead>
-    <tbody>
-        <tr wicket:id="TapeTransferQueueListview">
-            <td><span wicket:id="pnfsid"></span></td>
-            <td><span wicket:id="subnet"></span></td>
-            <td><span wicket:id="candidate"></span></td>
-            <td><span wicket:id="started"></span></td>
-            <td><span wicket:id="clients"></span></td>
-            <td><span wicket:id="retries"></span></td>
-            <td><span wicket:id="status"></span>
-            </td>
-        </tr>
-    </tbody>
-    </table>
-</wicket:extend>
+    <wicket:extend>
+        <h1>
+            <wicket:message key="header1"></wicket:message>
+        </h1>
+        <span wicket:id="feedback" />
+        <table id="sortable">
+            <thead>
+                <tr>
+                    <th><wicket:message
+                            key="TapeTransferQueue.pnfsid.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="TapeTransferQueue.subnet.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="TapeTransferQueue.candidate.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="TapeTransferQueue.started.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="TapeTransferQueue.clients.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="TapeTransferQueue.retries.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="TapeTransferQueue.status.header"></wicket:message>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr wicket:id="TapeTransferQueueListview">
+                    <td><span wicket:id="pnfsid"></span></td>
+                    <td><span wicket:id="subnet"></span></td>
+                    <td><span wicket:id="candidate"></span></td>
+                    <td><span wicket:id="started"></span></td>
+                    <td><span wicket:id="clients"></span></td>
+                    <td><span wicket:id="retries"></span></td>
+                    <td><span wicket:id="status"></span></td>
+                </tr>
+            </tbody>
+        </table>
+    </wicket:extend>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/unavailable/UnavailablePage.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/unavailable/UnavailablePage.html
@@ -1,9 +1,12 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
-<title><h1><wicket:message key="title"></wicket:message></h1></title>
+<title><h1>
+        <wicket:message key="title"></wicket:message>
+    </h1></title>
 </head>
 <body>
-	<h2><wicket:message key="message"></wicket:message></h2>
+    <h2>
+        <wicket:message key="message"></wicket:message>
+    </h2>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/activetransfers/ActiveTransfersPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/activetransfers/ActiveTransfersPanel.html
@@ -1,62 +1,87 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="ActiveTransfersPanel.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="ActiveTransfersPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <wicket:message key="activeTransfersPanel.quickFind"></wicket:message>&nbsp;<input type="text" id="quickfind"/>&nbsp;
-    <input type="button" value="Clear Filters" id="cleanfilters">
-    <div class="clear"></div>
-    <br>
-    <table  id="sortable">
-        <thead>
-            <tr>
-                <th wicket:id="selectBoxHeader"/>
-                <th wicket:id="doorHeader"/>
-                <th filter-type="ddl"><wicket:message key="activeTransfersPanel.domain.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.seq.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.protocol.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.owner.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.process.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.pnfsid.header"></wicket:message></th>
-        <th filter-type="ddl"><wicket:message key="activeTransfersPanel.pool.header"></wicket:message></th>
-        <th wicket:id="hostHeader"/>
-        <th><wicket:message key="activeTransfersPanel.status.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.since.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.state.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.transferred.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.speed.header"></wicket:message></th>
-        <th><wicket:message key="activeTransfersPanel.jobid.header"></wicket:message></th>
-        </tr>
-        </thead>
-        <tbody>
-            <tr wicket:id="activeTransfersPanelListview">
-                <td wicket:id="activeTransfersPanel.checkboxRow">
-                    <input type="checkbox" wicket:id="activeTransfersPanel.selected"/></td>
-                <td wicket:id="activeTransfersPanel.door"/>
-                <td><span wicket:id="activeTransfersPanel.domain"></span></td>
-                <td><span wicket:id="activeTransfersPanel.seq"></span></td>
-                <td><span wicket:id="activeTransfersPanel.protocol"></span></td>
-                <td><span wicket:id="activeTransfersPanel.owner"></span></td>
-                <td><span wicket:id="activeTransfersPanel.process"></span></td>
-                <td><span wicket:id="activeTransfersPanel.pnfsid"></span></td>
-                <td><span wicket:id="activeTransfersPanel.pool"></span></td>
-                <td wicket:id="activeTransfersPanel.host"/>
-                <td><span wicket:id="activeTransfersPanel.status"></span></td>
-                <td><span wicket:id="activeTransfersPanel.since"></span></td>
-                <td><span wicket:id="activeTransfersPanel.health"></span></td>
-                <td><span wicket:id="activeTransfersPanel.transferred"></span></td>
-                <td><span wicket:id="activeTransfersPanel.speed"></span></td>
-                <td><span wicket:id="activeTransfersPanel.jobid"></span>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</wicket:panel>
+    <wicket:panel>
+        <wicket:message key="activeTransfersPanel.quickFind"></wicket:message>
+        &nbsp;
+        <input
+            type="text"
+            id="quickfind" />
+        &nbsp;
+        <input
+            type="button"
+            value="Clear Filters"
+            id="cleanfilters" />
+        <div class="clear"></div>
+        <br>
+        <table id="sortable">
+            <thead>
+                <tr>
+                    <th wicket:id="selectBoxHeader" />
+                    <th wicket:id="doorHeader" />
+                    <th filter-type="ddl"><wicket:message
+                            key="activeTransfersPanel.domain.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.seq.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.protocol.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.owner.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.process.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.pnfsid.header"></wicket:message></th>
+                    <th filter-type="ddl"><wicket:message
+                            key="activeTransfersPanel.pool.header"></wicket:message></th>
+                    <th wicket:id="hostHeader" />
+                    <th><wicket:message
+                            key="activeTransfersPanel.status.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.since.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.state.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.transferred.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.speed.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="activeTransfersPanel.jobid.header"></wicket:message></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr wicket:id="activeTransfersPanelListview">
+                    <td wicket:id="activeTransfersPanel.checkboxRow"><input
+                        type="checkbox"
+                        wicket:id="activeTransfersPanel.selected" /></td>
+                    <td wicket:id="activeTransfersPanel.door" />
+                    <td><span wicket:id="activeTransfersPanel.domain"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.seq"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.protocol"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.owner"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.process"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.pnfsid"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.pool"></span></td>
+                    <td wicket:id="activeTransfersPanel.host" />
+                    <td><span wicket:id="activeTransfersPanel.status"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.since"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.health"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.transferred"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.speed"></span></td>
+                    <td><span wicket:id="activeTransfersPanel.jobid"></span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/CheckPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/CheckPanel.html
@@ -2,9 +2,12 @@
 <wicket:head>
 </wicket:head>
 <body>
-	<wicket:panel>
-	    <span wicket:id="label"></span>
-		<input wicket:id="check" type="checkbox" value="false" />
-	</wicket:panel>
+    <wicket:panel>
+        <span wicket:id="label"></span>
+        <input
+            wicket:id="check"
+            type="checkbox"
+            value="false" />
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/DisplayPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/DisplayPanel.html
@@ -2,18 +2,23 @@
 <head>
 <title><wicket:message key="tableTitle"></wicket:message></title>
 <wicket:head>
-	<wicket:link>
-		<link href="Alarms.css" rel="stylesheet" type="text/css" />
-	</wicket:link>
+    <wicket:link>
+        <link
+            href="Alarms.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
 </wicket:head>
 </head>
 <body>
-	<wicket:panel>
-		<h1>
-           <span wicket:id="tableTitle"></span>
+    <wicket:panel>
+        <h1>
+            <span wicket:id="tableTitle"></span>
         </h1>
-        <table width="100%" wicket:id="alarms"
-               class="display"/>
-	</wicket:panel>
+        <table
+            width="100%"
+            wicket:id="alarms"
+            class="display" />
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/ErrorPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/ErrorPanel.html
@@ -2,16 +2,19 @@
 <head>
 <title><wicket:message key="tableTitle"></wicket:message></title>
 <wicket:head>
-	<wicket:link>
-		<link href="Alarms.css" rel="stylesheet" type="text/css" />
-	</wicket:link>
+    <wicket:link>
+        <link
+            href="Alarms.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
 </wicket:head>
 </head>
 <body>
-	<wicket:panel>
-		<h2>
+    <wicket:panel>
+        <h2>
             <wicket:message key="errorMessage"></wicket:message>
         </h2>
-	</wicket:panel>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
@@ -1,69 +1,96 @@
 <html>
 <head>
-<title><wicket:message key="queryTitle"></wicket:message>
-</title>
+<title><wicket:message key="queryTitle"></wicket:message></title>
 <wicket:head>
-	<wicket:link>
-		<link href="Alarms.css" rel="stylesheet" type="text/css" />
-	</wicket:link>
+    <wicket:link>
+        <link
+            href="Alarms.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
 </wicket:head>
 </head>
 <body>
-	<wicket:panel>
-	    <h3>
+    <wicket:panel>
+        <h3>
             <wicket:message key="queryTitle"></wicket:message>
         </h3>
-		<table>
-		    <tr>
+        <table>
+            <tr>
                 <td><b><wicket:message key="selection" /> </b></td>
-                <td>
-                    <span wicket:id="selectgroup">
-                        <b><wicket:message key="all"/> </b><input wicket:id="all" type="radio"/>
-                        <b><wicket:message key="onlyAlarms"/></b><input wicket:id="alarmsonly" type="radio"/>
-                        <b><wicket:message key="noAlarms"/></b><input wicket:id="noalarms" type="radio" />
-                    </span>
-                </td>
+                <td><span wicket:id="selectgroup">
+                        <b><wicket:message key="all" /> </b>
+                        <input
+                            wicket:id="all"
+                            type="radio" />
+                        <b><wicket:message
+                                key="onlyAlarms" /></b>
+                        <input
+                            wicket:id="alarmsonly"
+                            type="radio" />
+                        <b><wicket:message key="noAlarms" /></b>
+                        <input
+                            wicket:id="noalarms"
+                            type="radio" />
+                    </span></td>
                 <td><span>
-                    <b><wicket:message key="showClosed" /> </b>
-                    <input wicket:id="showClosed" type="checkbox" />
-                    </span>
-                </td>
+                        <b><wicket:message key="showClosed" /> </b>
+                        <input
+                            wicket:id="showClosed"
+                            type="checkbox" />
+                    </span></td>
             </tr>
-			<tr>
-				<td><b><wicket:message key="dateRange" /> </b></td>
-				<td><b><wicket:message key="beginning" /> </b> <input
-					wicket:id="beginDate" type="text" /></td>
-				<td><b><wicket:message key="ending" /> </b> <input
-					wicket:id="endDate" type="text" /></td>
-			</tr>
-			<tr>
-				<td><b><wicket:message key="severity" /> </b></td>
-				<td><select wicket:id="levels"/></td>
-				<td><input wicket:id="refresh" type="submit"
-                    wicket:message="value:refreshButton" /></td>
-			</tr>
-			<tr>
-				<td><b><wicket:message key="type" /> </b></td>
-				<td><input wicket:id="typeField" type="text" /></td>
-				<td />
-			</tr>
-			<tr>
-				<td><b><wicket:message key="filter" /> </b></td>
-				<td><input wicket:id="filterField" type="text" />
-				</td>
-				<td><b><wicket:message key="useRegex" /> </b> <input
-					wicket:id="regex" type="checkbox" />
-				</td>
-			</tr>
-			<tr>
+            <tr>
+                <td><b><wicket:message key="dateRange" /> </b></td>
+                <td><b><wicket:message key="beginning" /> </b>
+                    <input
+                        wicket:id="beginDate"
+                        type="text" /></td>
+                <td><b><wicket:message key="ending" /> </b>
+                    <input
+                        wicket:id="endDate"
+                        type="text" /></td>
+            </tr>
+            <tr>
+                <td><b><wicket:message key="severity" /> </b></td>
+                <td><select wicket:id="levels" /></td>
+                <td><input
+                        wicket:id="refresh"
+                        type="submit"
+                        wicket:message="value:refreshButton" /></td>
+            </tr>
+            <tr>
+                <td><b><wicket:message key="type" /> </b></td>
+                <td><input
+                        wicket:id="typeField"
+                        type="text" /></td>
+                <td />
+            </tr>
+            <tr>
+                <td><b><wicket:message key="filter" /> </b></td>
+                <td><input
+                        wicket:id="filterField"
+                        type="text" /></td>
+                <td><b><wicket:message key="useRegex" /> </b>
+                    <input
+                        wicket:id="regex"
+                        type="checkbox" /></td>
+            </tr>
+            <tr>
                 <td><b><wicket:message key="range" /> </b></td>
                 <td><b><wicket:message key="from" /></b>
-                    <input wicket:id="rangeFrom" type="text" style="width: 40px;"/>
+                    <input
+                        wicket:id="rangeFrom"
+                        type="text"
+                        style="width: 40px;" />
                     <b><wicket:message key="to" /></b>
-                    <input wicket:id="rangeTo" type="text" style="width: 40px;"/></td>
-                <td/>
+                    <input
+                        wicket:id="rangeTo"
+                        type="text"
+                        style="width: 40px;" /></td>
+                <td />
             </tr>
-		</table>
-	</wicket:panel>
+        </table>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/billingplots/OptionPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/billingplots/OptionPanel.html
@@ -2,12 +2,15 @@
 <head>
 </head>
 <body>
-	<wicket:panel>
-		<table class="options">
+    <wicket:panel>
+        <table class="options">
             <tr>
-                <td><h4><b><i><span wicket:id="lastupdate"></span></i></b></h4></td>
-			</tr>
-		</table>
-	</wicket:panel>
+                <td><h4>
+                        <b><i><span wicket:id="lastupdate"></span></i></b>
+                    </h4>
+                </td>
+            </tr>
+        </table>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/billingplots/PlotsPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/billingplots/PlotsPanel.html
@@ -1,4 +1,3 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
 </head>
@@ -9,106 +8,234 @@
         </h1>
         <div class="clear">&nbsp;</div>
         <table class="plots">
-                <thead>
-                    <tr>
-                        <th>Plot Type</th>
-                        <th>24-Hour</th>
-                        <th>Weekly</th>
-                        <th>Monthly</th>
-                        <th>Yearly</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-					<td><wicket:message key="bytes.read"></wicket:message></td>
-					<td><a href="#" wicket:id="link_00"><img wicket:id="image_00" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_01"><img wicket:id="image_01" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_02"><img wicket:id="image_02" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_03"><img wicket:id="image_03" width="80%" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><wicket:message key="bytes.written"></wicket:message></td>
-                        <td><a href="#" wicket:id="link_10"><img wicket:id="image_10" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_11"><img wicket:id="image_11" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_12"><img wicket:id="image_12" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_13"><img wicket:id="image_13" width="80%" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><wicket:message key="bytes.p2p"></wicket:message></td>
-                        <td><a href="#" wicket:id="link_20"><img wicket:id="image_20" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_21"><img wicket:id="image_21" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_22"><img wicket:id="image_22" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_23"><img wicket:id="image_23" width="80%" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><wicket:message key="transfers.read"></wicket:message></td>
-                        <td><a href="#" wicket:id="link_30"><img wicket:id="image_30" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_31"><img wicket:id="image_31" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_32"><img wicket:id="image_32" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_33"><img wicket:id="image_33" width="80%" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><wicket:message key="transfers.write"></wicket:message></td>
-                        <td><a href="#" wicket:id="link_40"><img wicket:id="image_40" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_41"><img wicket:id="image_41" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_42"><img wicket:id="image_42" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_43"><img wicket:id="image_43" width="80%" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><wicket:message key="transfers.p2p"></wicket:message></td>
-                        <td><a href="#" wicket:id="link_50"><img wicket:id="image_50" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_51"><img wicket:id="image_51" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_52"><img wicket:id="image_52" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_53"><img wicket:id="image_53" width="80%" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><wicket:message key="connection.time"></wicket:message></td>
-                        <td><a href="#" wicket:id="link_60"><img wicket:id="image_60" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_61"><img wicket:id="image_61" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_62"><img wicket:id="image_62" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_63"><img wicket:id="image_63" width="80%" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><wicket:message key="cache.hits"></wicket:message></td>
-                        <td><a href="#" wicket:id="link_70"><img wicket:id="image_70" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_71"><img wicket:id="image_71" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_72"><img wicket:id="image_72" width="80%" /></a>
-                        </td>
-                        <td><a href="#" wicket:id="link_73"><img wicket:id="image_73" width="80%" /></a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <thead>
+                <tr>
+                    <th>Plot Type</th>
+                    <th>24-Hour</th>
+                    <th>Weekly</th>
+                    <th>Monthly</th>
+                    <th>Yearly</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><wicket:message key="bytes.read"></wicket:message></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_00">
+                        <img
+                            wicket:id="image_00"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_01">
+                        <img
+                            wicket:id="image_01"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_02">
+                        <img
+                            wicket:id="image_02"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_03">
+                        <img
+                            wicket:id="image_03"
+                            width="80%" /></a></td>
+                </tr>
+                <tr>
+                    <td><wicket:message key="bytes.written"></wicket:message></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_10">
+                        <img
+                            wicket:id="image_10"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_11">
+                        <img
+                            wicket:id="image_11"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_12">
+                        <img
+                            wicket:id="image_12"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_13">
+                        <img
+                            wicket:id="image_13"
+                            width="80%" /></a></td>
+                </tr>
+                <tr>
+                    <td><wicket:message key="bytes.p2p"></wicket:message></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_20">
+                        <img
+                            wicket:id="image_20"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_21">
+                        <img
+                            wicket:id="image_21"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_22">
+                        <img
+                            wicket:id="image_22"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_23">
+                        <img
+                            wicket:id="image_23"
+                            width="80%" /></a></td>
+                </tr>
+                <tr>
+                    <td><wicket:message key="transfers.read"></wicket:message></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_30">
+                        <img
+                            wicket:id="image_30"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_31">
+                        <img
+                            wicket:id="image_31"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_32">
+                        <img
+                            wicket:id="image_32"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_33">
+                        <img
+                            wicket:id="image_33"
+                            width="80%" /></a></td>
+                </tr>
+                <tr>
+                    <td><wicket:message key="transfers.write"></wicket:message></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_40">
+                        <img
+                            wicket:id="image_40"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_41">
+                        <img
+                            wicket:id="image_41"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_42">
+                        <img
+                            wicket:id="image_42"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_43">
+                        <img
+                            wicket:id="image_43"
+                            width="80%" /></a></td>
+                </tr>
+                <tr>
+                    <td><wicket:message key="transfers.p2p"></wicket:message></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_50">
+                        <img
+                            wicket:id="image_50"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_51">
+                        <img
+                            wicket:id="image_51"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_52">
+                        <img
+                            wicket:id="image_52"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_53">
+                        <img
+                            wicket:id="image_53"
+                            width="80%" /></a></td>
+                </tr>
+                <tr>
+                    <td><wicket:message key="connection.time"></wicket:message></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_60">
+                        <img
+                            wicket:id="image_60"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_61">
+                        <img
+                            wicket:id="image_61"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_62">
+                        <img
+                            wicket:id="image_62"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_63">
+                        <img
+                            wicket:id="image_63"
+                            width="80%" /></a></td>
+                </tr>
+                <tr>
+                    <td><wicket:message key="cache.hits"></wicket:message></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_70">
+                        <img
+                            wicket:id="image_70"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_71">
+                        <img
+                            wicket:id="image_71"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_72">
+                        <img
+                            wicket:id="image_72"
+                            width="80%" /></a></td>
+                    <td><a
+                        href="#"
+                        wicket:id="link_73">
+                        <img
+                            wicket:id="image_73"
+                            width="80%" /></a></td>
+                </tr>
+            </tbody>
+        </table>
     </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/cellservices/CellServicesPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/cellservices/CellServicesPanel.html
@@ -1,44 +1,60 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="CellServicesPanel.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="CellServicesPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <wicket:message key="CellServicesPanel.quickFind"></wicket:message>&nbsp;<input type="text" id="quickfind"/>&nbsp;
-    <input type="button" value="Clear Filters" id="cleanfilters">
-    <div class="clear"></div>
-    <br>
-    <table id="sortable">
-        <thead>
-            <tr>
-               <th><wicket:message key="CellServicesPanel.name.header"></wicket:message></th>
-        <th><wicket:message key="CellServicesPanel.domainName.header"></wicket:message></th>
-        <th><wicket:message key="CellServicesPanel.EventQueues.header"></wicket:message></th>
-        <th><wicket:message key="CellServicesPanel.Threadcount.header"></wicket:message></th>
-        <th><wicket:message key="CellServicesPanel.Ping.header"></wicket:message></th>
-        <th><wicket:message key="CellServicesPanel.CreationTime.header"></wicket:message></th>
-        <th><wicket:message key="CellServicesPanel.Version.header"></wicket:message>
-        </th>
-        </tr>
-        </thead>
-        <tbody>
-            <tr wicket:id="CellServicesPanelListview">
-                <td><span wicket:id="CellServicesPanel.name"></span></td>
-                <td><span wicket:id="CellServicesPanel.domainName"></span></td>
-                <td><span wicket:id="CellServicesPanel.EventQueues"></span></td>
-                <td><span wicket:id="CellServicesPanel.Threadcount"></span></td>
-                <td><span wicket:id="CellServicesPanel.Ping"></span></td>
-                <td><span wicket:id="CellServicesPanel.CreationTime"></span></td>
-                <td><span wicket:id="CellServicesPanel.Version"></span>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</wicket:panel>
+    <wicket:panel>
+        <wicket:message key="CellServicesPanel.quickFind"></wicket:message>
+        &nbsp;
+        <input
+            type="text"
+            id="quickfind"/>
+        &nbsp;
+        <input
+            type="button"
+            value="Clear Filters"
+            id="cleanfilters"/>
+        <div class="clear"></div>
+        <br>
+        <table id="sortable">
+            <thead>
+                <tr>
+                    <th><wicket:message key="CellServicesPanel.name.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="CellServicesPanel.domainName.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="CellServicesPanel.EventQueues.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="CellServicesPanel.Threadcount.header"></wicket:message></th>
+                    <th><wicket:message key="CellServicesPanel.Ping.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="CellServicesPanel.CreationTime.header"></wicket:message></th>
+                    <th><wicket:message
+                            key="CellServicesPanel.Version.header"></wicket:message>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr wicket:id="CellServicesPanelListview">
+                    <td><span wicket:id="CellServicesPanel.name"></span></td>
+                    <td><span wicket:id="CellServicesPanel.domainName"></span></td>
+                    <td><span wicket:id="CellServicesPanel.EventQueues"></span></td>
+                    <td><span wicket:id="CellServicesPanel.Threadcount"></span></td>
+                    <td><span wicket:id="CellServicesPanel.Ping"></span></td>
+                    <td><span wicket:id="CellServicesPanel.CreationTime"></span></td>
+                    <td><span wicket:id="CellServicesPanel.Version"></span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/header/HeaderPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/header/HeaderPanel.html
@@ -1,22 +1,28 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="HeaderPanel.css" rel="stylesheet" type="text/css" />
-            <link rel="shortcut icon" type="image/x-icon" href="dCache.png"/>
-
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="HeaderPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+        <link
+            rel="shortcut icon"
+            type="image/x-icon"
+            href="dCache.png" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <div id="bird_large">
-        <wicket:link>
-            <img src="dCache.png" class="bird"></img>
-        </wicket:link>
-    </div>
-</wicket:panel>
+    <wicket:panel>
+        <div id="bird_large">
+            <wicket:link>
+                <img
+                    src="dCache.png"
+                    class="bird"></img>
+            </wicket:link>
+        </div>
+    </wicket:panel>
 </body>
 </html>
-

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/layout/LayoutHeaderPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/layout/LayoutHeaderPanel.html
@@ -1,16 +1,21 @@
 
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="LayoutHeaderPanel.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="LayoutHeaderPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <span><wicket:message key="LayoutHeaderPanel.layout.header1"></wicket:message></span>
-</wicket:panel>
+    <wicket:panel>
+        <span>
+            <wicket:message key="LayoutHeaderPanel.layout.header1"></wicket:message>
+        </span>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/layout/LayoutItemPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/layout/LayoutItemPanel.html
@@ -1,21 +1,29 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="LayoutItemPanel.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="LayoutItemPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <div wicket:id="createInfoBox"  onmouseover="infotext" onmouseout="window.setTimeout('hideBox()',5000)" href="javascript:void(0)">
-
-        <div wicket:id="layouts">
-            <div wicket:id="percentage" class="layout_class" style="width: 10.0%"></div>
+    <wicket:panel>
+        <div
+            wicket:id="createInfoBox"
+            onmouseover="infotext"
+            onmouseout="window.setTimeout('hideBox()',5000)"
+            href="javascript:void(0)">
+            <div wicket:id="layouts">
+                <div
+                    wicket:id="percentage"
+                    class="layout_class"
+                    style="width: 10.0%"></div>
+            </div>
         </div>
-
-    </div>
-</wicket:panel>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/navigation/BasicNavigationPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/navigation/BasicNavigationPanel.html
@@ -1,22 +1,24 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="BasicNavigationPanel.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="BasicNavigationPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <!-- main navigation: horizontal list -->
-    <ul>
-        <li wicket:id="linkList">
-            <a href="#" wicket:id="link">
-                <span wicket:id="linkMessage"></span>
-            </a>
-        </li>
-    </ul>
-</wicket:panel>
+    <wicket:panel>
+        <!-- main navigation: horizontal list -->
+        <ul>
+            <li wicket:id="linkList"><a
+                href="#"
+                wicket:id="link"> <span wicket:id="linkMessage"></span>
+            </a></li>
+        </ul>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poolQueuesPanel/PoolQueuesPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poolQueuesPanel/PoolQueuesPanel.html
@@ -1,53 +1,79 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="PoolQueuesPanel.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="PoolQueuesPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <wicket:message key="poolQueuesPanel.quickFind"></wicket:message>&nbsp;<input type="text" id="quickfind"/>&nbsp;
-    <input type="button" value="Clear Filters" id="cleanfilters">
-    <div class="clear"></div>
-    <br>
-    <table id="sortable">
-        <thead>
-            <tr>
-                <th rowspan="2" filter-type="ddl"><wicket:message key="poolName.header"></wicket:message></th>
-        <th rowspan="2" filter-type="ddl"><wicket:message key="pooldomainName.header"></wicket:message></th>
-        <th wicket:id="tableHeaderView" colspan="3"><span wicket:id="requestQueueName"></span></th>
-        </tr>
-        <tr>
-        <wicket:fragment wicket:id="headerFragment">
-            <th><wicket:message key="active"></wicket:message></th>
-            <th><wicket:message key="max"></wicket:message></th>
-            <th><wicket:message key="queued"></wicket:message></th>
-        </wicket:fragment>
-        <span wicket:id="headerFragmentView"><span wicket:id="colheader"></span></span>
-        </tr>
-        </thead>
-        <tbody>
-            <tr wicket:id="poolsListview">
-        <span wicket:id="pool"></span>
-        </tr>
-        <tr>
-        <span wicket:id="total"></span>
-        </tr>
-        <wicket:fragment wicket:id="queueFragment">
-            <td><span wicket:id="active"></span></td>
-            <td><span wicket:id="max"></span></td>
-            <td><span wicket:id="queued"></span></td>
-        </wicket:fragment>
-        <wicket:fragment wicket:id="poolFragment">
-            <td><span wicket:id="poolName"></span></td>
-            <td><span wicket:id="pooldomainName"></span></td>
-            <span wicket:id="poolMoversView"><span wicket:id="movers"></span></span>
-        </wicket:fragment>
-        </tbody>
-    </table>
-</wicket:panel>
+    <wicket:panel>
+        <wicket:message key="poolQueuesPanel.quickFind"></wicket:message>
+        &nbsp;
+        <input
+            type="text"
+            id="quickfind" />
+        &nbsp;
+        <input
+            type="button"
+            value="Clear Filters"
+            id="cleanfilters"/>
+        <div class="clear"></div>
+        <br>
+        <table id="sortable">
+            <thead>
+                <tr>
+                    <th
+                        rowspan="2"
+                        filter-type="ddl">
+                        <wicket:message
+                            key="poolName.header"></wicket:message></th>
+                    <th
+                        rowspan="2"
+                        filter-type="ddl">
+                        <wicket:message
+                            key="pooldomainName.header"></wicket:message></th>
+                    <th
+                        wicket:id="tableHeaderView"
+                        colspan="3">
+                        <span wicket:id="requestQueueName"></span></th>
+                </tr>
+                <tr>
+                    <wicket:fragment wicket:id="headerFragment">
+                        <th><wicket:message key="active"></wicket:message></th>
+                        <th><wicket:message key="max"></wicket:message></th>
+                        <th><wicket:message key="queued"></wicket:message></th>
+                    </wicket:fragment>
+                    <span wicket:id="headerFragmentView">
+                        <span wicket:id="colheader"></span>
+                    </span>
+                </tr>
+            </thead>
+            <tbody>
+                <tr wicket:id="poolsListview">
+                    <span wicket:id="pool"></span>
+                </tr>
+                <tr>
+                    <span wicket:id="total"></span>
+                </tr>
+                <wicket:fragment wicket:id="queueFragment">
+                    <td><span wicket:id="active"></span></td>
+                    <td><span wicket:id="max"></span></td>
+                    <td><span wicket:id="queued"></span></td>
+                </wicket:fragment>
+                <wicket:fragment wicket:id="poolFragment">
+                    <td><span wicket:id="poolName"></span></td>
+                    <td><span wicket:id="pooldomainName"></span></td>
+                    <span wicket:id="poolMoversView">
+                        <span wicket:id="movers"></span>
+                    </span>
+                </wicket:fragment>
+            </tbody>
+        </table>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poollist/PoolListPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poollist/PoolListPanel.html
@@ -1,43 +1,47 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-        <wicket:link>
-            <link href="PoolListPanel.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="PoolListPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <table id="sortable">
-        <thead>
-            <tr>
-                <th wicket:id="selectBoxHeader"/>
-        <th><wicket:message key="PoolPanel.name.header"></wicket:message></th>
-        <th><wicket:message key="PoolPanel.domainName.header"></wicket:message></th>
-        <th><wicket:message key="PoolPanel.poolMode.header"></wicket:message></th>
-        <th><wicket:message key="PoolPanel.total.header"></wicket:message></th>
-        <th><wicket:message key="PoolPanel.free.header"></wicket:message></th>
-        <th><wicket:message key="PoolPanel.precious.header"></wicket:message></th>
-        <th><span wicket:id="PoolPanel.layoutHeaderPanel"></span>
-        </th>
-        </tr>
-        </thead>
-        <tbody>
-            <tr wicket:id="poolPanelListview">
-                <td wicket:id="PoolPanel.checkboxRow">
-                    <input type="checkbox" wicket:id="PoolPanel.selected"/></td>
-                <td><span wicket:id="PoolPanel.name"></span></td>
-                <td><span wicket:id="PoolPanel.domainName"></span></td>
-                <td><span wicket:id="PoolPanel.poolMode"></span></td>
-                <td><span wicket:id="PoolPanel.totalSpace"></span></td>
-                <td><span wicket:id="PoolPanel.freeSpace"></span></td>
-                <td><span wicket:id="PoolPanel.preciousSpace"></span></td>
-                <td><span wicket:id="PoolPanel.layoutItemPanel"></span>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</wicket:panel>
+    <wicket:panel>
+        <table id="sortable">
+            <thead>
+                <tr>
+                    <th wicket:id="selectBoxHeader" />
+                    <th><wicket:message key="PoolPanel.name.header"></wicket:message></th>
+                    <th><wicket:message key="PoolPanel.domainName.header"></wicket:message></th>
+                    <th><wicket:message key="PoolPanel.poolMode.header"></wicket:message></th>
+                    <th><wicket:message key="PoolPanel.total.header"></wicket:message></th>
+                    <th><wicket:message key="PoolPanel.free.header"></wicket:message></th>
+                    <th><wicket:message key="PoolPanel.precious.header"></wicket:message></th>
+                    <th><span wicket:id="PoolPanel.layoutHeaderPanel"></span>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr wicket:id="poolPanelListview">
+                    <td wicket:id="PoolPanel.checkboxRow"><input
+                        type="checkbox"
+                        wicket:id="PoolPanel.selected" /></td>
+                    <td><span wicket:id="PoolPanel.name"></span></td>
+                    <td><span wicket:id="PoolPanel.domainName"></span></td>
+                    <td><span wicket:id="PoolPanel.poolMode"></span></td>
+                    <td><span wicket:id="PoolPanel.totalSpace"></span></td>
+                    <td><span wicket:id="PoolPanel.freeSpace"></span></td>
+                    <td><span wicket:id="PoolPanel.preciousSpace"></span></td>
+                    <td><span wicket:id="PoolPanel.layoutItemPanel"></span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poolqueues/PoolQueuePlotsControlPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poolqueues/PoolQueuePlotsControlPanel.html
@@ -3,27 +3,41 @@
 <head>
 </head>
 <body>
-	<wicket:panel>
-	    <h3><wicket:message key="filterTitle"></wicket:message></h3>
-		<table class="control">
-			<tr class="control">
-				<td class="control"><b><wicket:message key=sortOrder /> </b></td>
-				<td class="control">
-				    <span wicket:id="sortgroup">
-				        <b>up</b><input wicket:id="ascending" type="radio"/>
-				        <b>down</b><input wicket:id="descending" type="radio" />
-				    </span>
-			    </td>
-			    <td class="control"><input wicket:id="refresh" type="submit"
+    <wicket:panel>
+        <h3>
+            <wicket:message key="filterTitle"></wicket:message>
+        </h3>
+        <table class="control">
+            <tr class="control">
+                <td class="control"><b><wicket:message key=sortOrder /></b></td>
+                <td class="control"><span wicket:id="sortgroup">
+                        <b>up</b>
+                        <input
+                            wicket:id="ascending"
+                            type="radio" />
+                        <b>down</b>
+                        <input
+                            wicket:id="descending"
+                            type="radio" />
+                    </span></td>
+                <td class="control">
+                <input
+                    wicket:id="refresh"
+                    type="submit"
                     wicket:message="value:refreshButton" /></td>
-			</tr>
-			<tr class="control">
-                <td class="control"><b><wicket:message key="filter" /> </b></td>
-                <td class="control"><input wicket:id="filterField" type="text" /></td>
-                <td class="control"><b><wicket:message key="useRegex" /> </b><input
-                    wicket:id="regex" type="checkbox" /></td>
             </tr>
-		</table>
-	</wicket:panel>
+            <tr class="control">
+                <td class="control"><b><wicket:message key="filter" /></b></td>
+                <td class="control">
+                <input
+                    wicket:id="filterField"
+                    type="text" /></td>
+                <td class="control"><b><wicket:message key="useRegex" /></b>
+                <input
+                    wicket:id="regex"
+                    type="checkbox" /></td>
+            </tr>
+        </table>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poolqueues/PoolQueuePlotsDisplayPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poolqueues/PoolQueuePlotsDisplayPanel.html
@@ -3,26 +3,36 @@
 <head>
 </head>
 <body>
-	<wicket:panel>
-		<h1>
-			<wicket:message key="title"></wicket:message>
-		</h1>
-		<p />
-		<table class="display">
-			<tr class="display" wicket:id="PoolQueuePlotsGridView">
-				<td class="display" wicket:id="cols">
-					<table class="thumbnail">
-						<tr class="thumbnail">
-							<td class="thumbnail"><a href="#" wicket:id="plotlink"><img
-									class="thumbnail" wicket:id="thumbnail" /></a></td>
-						</tr>
-						<tr class="thumbnail">
-							<td class="thumbnail"><b><span wicket:id="poolname"></span></b></td>
-						</tr>
-					</table>
-				</td>
-			</tr>
-		</table>
-	</wicket:panel>
+    <wicket:panel>
+        <h1>
+            <wicket:message key="title"></wicket:message>
+        </h1>
+        <p />
+        <table class="display">
+            <tr
+                class="display"
+                wicket:id="PoolQueuePlotsGridView">
+                <td
+                    class="display"
+                    wicket:id="cols">
+                    <table class="thumbnail">
+                        <tr class="thumbnail">
+                            <td class="thumbnail">
+                            <a
+                                href="#"
+                                wicket:id="plotlink">
+                                <img
+                                    class="thumbnail"
+                                    wicket:id="thumbnail" /></a></td>
+                        </tr>
+                        <tr class="thumbnail">
+                            <td class="thumbnail">
+                            <b><span wicket:id="poolname"></span></b></td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </wicket:panel>
 </body>
 </html>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/userpanel/UserPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/userpanel/UserPanel.html
@@ -1,18 +1,23 @@
 <html>
-    <head>
-        <title></title>
-    <wicket:head>
-     <wicket:link>
-            <link href="UserPanel.css" rel="stylesheet" type="text/css" />
-        </wicket:link>
-    </wicket:head>
+<head>
+<title></title>
+<wicket:head>
+    <wicket:link>
+        <link
+            href="UserPanel.css"
+            rel="stylesheet"
+            type="text/css" />
+    </wicket:link>
+</wicket:head>
 </head>
 <body>
-<wicket:panel>
-    <wicket:enclosure child="logout">Logged in as <b><span wicket:id="username">[name]</span></b><span class="stripe">&nbsp;&nbsp;&#124;&nbsp;&nbsp;</span><a wicket:id="logout">logout</a>
-    </wicket:enclosure>
-    <a wicket:id="login">login</a>
-</wicket:panel>
+    <wicket:panel>
+        <wicket:enclosure child="logout">Logged in as <b><span
+                    wicket:id="username">[name]</span></b>
+            <span class="stripe">&nbsp;&nbsp;&#124;&nbsp;&nbsp;</span>
+            <a wicket:id="logout">logout</a>
+        </wicket:enclosure>
+        <a wicket:id="login">login</a>
+    </wicket:panel>
 </body>
 </html>
-


### PR DESCRIPTION
Wicket mark-up was messy.  All html resources for webadmin have been reformatted for regularity and readability.

(The extra indentation is easier to maintain in my HTML editor.)

Testing: Redeployed and checked webadmin pages.

Target: 2.7
Patch: http://rb.dcache.org/r/6077
Require-notes: no
Require-book: no
Acked-by: Tigran
Committed: 381bc322096bb7fbb82d6b0e83156f164ebdd438
