### PR TITLE
(2.7) dcache-webadmin: fix page update

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfers.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfers.java
@@ -1,6 +1,10 @@
 package org.dcache.webadmin.view.pages.activetransfers;
 
 import org.apache.wicket.authroles.authorization.strategies.role.metadata.MetaDataRoleAuthorizationStrategy;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
+import org.apache.wicket.markup.head.OnLoadHeaderItem;
+import org.apache.wicket.markup.head.StringHeaderItem;
 import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
@@ -8,11 +12,8 @@ import org.apache.wicket.model.PropertyModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
-import org.apache.wicket.markup.head.IHeaderResponse;
-import org.apache.wicket.markup.head.JavaScriptHeaderItem;
-import org.apache.wicket.markup.head.OnLoadHeaderItem;
-import org.apache.wicket.markup.head.StringHeaderItem;
 
 import org.dcache.webadmin.controller.ActiveTransfersService;
 import org.dcache.webadmin.controller.exceptions.ActiveTransfersServiceException;
@@ -26,7 +27,6 @@ public class ActiveTransfers extends BasePage {
 
     private static final Logger _log = LoggerFactory.getLogger(ActiveTransfers.class);
     private static final long serialVersionUID = -1360523434922193867L;
-    private List<SelectableWrapper<ActiveTransfersBean>> _activeTransfers;
 
     public ActiveTransfers() {
         Form activeTransfersForm = new Form("activeTransfersForm");
@@ -36,7 +36,7 @@ public class ActiveTransfers extends BasePage {
         activeTransfersForm.add(button);
         getActiveTransfers();
         activeTransfersForm.add(new ActiveTransfersPanel("activeTransfersPanel",
-                new PropertyModel(this, "_activeTransfers")));
+                new PropertyModel(this, "activeTransfers")));
         add(activeTransfersForm);
     }
 
@@ -44,14 +44,14 @@ public class ActiveTransfers extends BasePage {
         return getWebadminApplication().getActiveTransfersService();
     }
 
-    private void getActiveTransfers() {
+    public List<SelectableWrapper<ActiveTransfersBean>> getActiveTransfers() {
         try {
             _log.debug("getActiveTransfers called");
-            _activeTransfers = getActiveTransfersService().getActiveTransferBeans();
+            return getActiveTransfersService().getActiveTransferBeans();
         } catch (ActiveTransfersServiceException ex) {
             this.error(getStringResource("error.getActiveTransfersFailed") + ex.getMessage());
             _log.debug("getActiveTransfers failed {}", ex.getMessage());
-            _activeTransfers = null;
+            return Collections.emptyList();
         }
     }
 
@@ -67,7 +67,7 @@ public class ActiveTransfers extends BasePage {
         public void onSubmit() {
             try {
                 _log.debug("Kill Movers submitted");
-                getActiveTransfersService().killTransfers(_activeTransfers);
+                getActiveTransfersService().killTransfers(getActiveTransfers());
             } catch (ActiveTransfersServiceException e) {
                 _log.info("couldn't kill some movers - jobIds: {}",
                         e.getMessage());

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/celladmin/CellAdmin.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/celladmin/CellAdmin.java
@@ -37,7 +37,6 @@ public class CellAdmin extends BasePage implements AuthenticatedWebPage {
     private static final String EMPTY_STRING = "";
     private static final Logger _log = LoggerFactory.getLogger(CellAdmin.class);
     private static final long serialVersionUID = -61395248592530110L;
-    private Map<String, List<String>> _domainMap = new HashMap<>();
     private String _selectedDomain;
     private String _selectedCell;
     private String _command = "";
@@ -45,16 +44,16 @@ public class CellAdmin extends BasePage implements AuthenticatedWebPage {
     private String _response = "";
 
     public CellAdmin() {
-        initDomainMap();
         addMarkup();
     }
 
-    private void initDomainMap() {
+    private  Map<String, List<String>> getDomainMap() {
         try {
-            _domainMap = getCellAdminService().getDomainMap();
+            return getCellAdminService().getDomainMap();
         } catch (CellAdminServiceException e) {
             error(getStringResource("error.noCells"));
             _log.error("could not retrieve cells: {}", e.getMessage());
+            return Collections.emptyMap();
         }
     }
 
@@ -156,7 +155,7 @@ public class CellAdmin extends BasePage implements AuthenticatedWebPage {
 
         @Override
         public List<String> getObject() {
-            List<String> domains = new ArrayList<>(_domainMap.keySet());
+            List<String> domains = new ArrayList<>(getDomainMap().keySet());
             Collections.sort(domains);
             return domains;
         }
@@ -168,7 +167,7 @@ public class CellAdmin extends BasePage implements AuthenticatedWebPage {
 
         @Override
         public List<String> getObject() {
-            List<String> cells = _domainMap.get(_selectedDomain);
+            List<String> cells = getDomainMap().get(_selectedDomain);
             if (cells == null) {
                 cells = Collections.emptyList();
             }

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.java
@@ -16,7 +16,7 @@ import org.apache.wicket.protocol.https.RequireHttps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.dcache.webadmin.controller.PoolAdminService;
@@ -40,13 +40,11 @@ public class PoolAdmin extends BasePage implements AuthenticatedWebPage {
     public static final int RESPONSE_CUTOFF_INDEX_MULTIPLE_POOLS = 120;
     private static final Logger _log = LoggerFactory.getLogger(PoolAdmin.class);
     private static final long serialVersionUID = -3790266074783564167L;
-    private List<PoolAdminBean> _poolGroups = new ArrayList<>();
     private PoolAdminBean _currentPoolGroup;
     private String _command = "";
     private String _lastCommand = "";
 
     public PoolAdmin() {
-        getPoolGroupsAction();
         addMarkup();
     }
 
@@ -117,12 +115,13 @@ public class PoolAdmin extends BasePage implements AuthenticatedWebPage {
         return oneIsSelected;
     }
 
-    private void getPoolGroupsAction() {
+    public List<PoolAdminBean> getPoolGroups() {
         try {
-            _poolGroups = getPoolAdminService().getPoolGroups();
+            return getPoolAdminService().getPoolGroups();
         } catch (PoolAdminServiceException e) {
             error(getStringResource("error.noPoolGroups"));
             _log.error("could not retrieve Pool Groups: {}", e.getMessage());
+            return Collections.emptyList();
         }
     }
 
@@ -133,7 +132,7 @@ public class PoolAdmin extends BasePage implements AuthenticatedWebPage {
     private ListView<PoolAdminBean> buildPoolGroupView(String id) {
         return new ListView<PoolAdminBean>(
                 id, new PropertyModel<List<PoolAdminBean>>(
-                this, "_poolGroups")) {
+                this, "poolGroups")) {
 
             private static final long serialVersionUID = 6196065833753259467L;
 

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
@@ -1,6 +1,10 @@
 package org.dcache.webadmin.view.pages.poollist;
 
 import org.apache.wicket.authroles.authorization.strategies.role.metadata.MetaDataRoleAuthorizationStrategy;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
+import org.apache.wicket.markup.head.OnLoadHeaderItem;
+import org.apache.wicket.markup.head.StringHeaderItem;
 import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
@@ -12,13 +16,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import diskCacheV111.pools.PoolV2Mode;
-import org.apache.wicket.markup.head.IHeaderResponse;
-import org.apache.wicket.markup.head.JavaScriptHeaderItem;
-import org.apache.wicket.markup.head.OnLoadHeaderItem;
-import org.apache.wicket.markup.head.StringHeaderItem;
 
 import org.dcache.webadmin.controller.PoolSpaceService;
 import org.dcache.webadmin.controller.exceptions.PoolSpaceServiceException;
@@ -36,7 +37,6 @@ public class PoolList extends BasePage {
 
     private static final int DEFAULT_DROP_DOWN_CHOICE = 0;
     private static final long serialVersionUID = -3519762401458479856L;
-    private List<PoolSpaceBean> _poolBeans;
     private SelectOption _selectedOption;
     private static final Logger _log = LoggerFactory.getLogger(PoolList.class);
 
@@ -44,9 +44,8 @@ public class PoolList extends BasePage {
         Form poolUsageForm = new PoolUsageForm("poolUsageForm");
         poolUsageForm.add(createPoolModeDropDown("mode"));
         poolUsageForm.add(new FeedbackPanel("feedback"));
-        getPoolsAction();
         PoolListPanel poolListPanel = new PoolListPanel("poolListPanel",
-                new PropertyModel(this, "_poolBeans"), true);
+                new PropertyModel(this, "poolSpaceBeans"), true);
         poolUsageForm.add(poolListPanel);
         add(poolUsageForm);
     }
@@ -81,14 +80,14 @@ public class PoolList extends BasePage {
         return getWebadminApplication().getPoolSpaceService();
     }
 
-    private void getPoolsAction() {
+    public List<PoolSpaceBean> getPoolSpaceBeans() {
         try {
             _log.debug("getPoolListAction called");
-            this._poolBeans = getPoolSpaceService().getPoolBeans();
+            return getPoolSpaceService().getPoolBeans();
         } catch (PoolSpaceServiceException ex) {
             this.error(getStringResource("error.getPoolsFailed") + ex.getMessage());
             _log.debug("getPoolListAction failed {}", ex.getMessage());
-            this._poolBeans = null;
+            return Collections.emptyList();
         }
     }
 
@@ -107,13 +106,13 @@ public class PoolList extends BasePage {
         @Override
         protected void onSubmit() {
             _log.debug("button pressed");
-            if (_poolBeans != null && _selectedOption != null) {
+            List<PoolSpaceBean> poolBeans = getPoolSpaceBeans();
+            if (poolBeans != null && _selectedOption != null) {
                 try {
                     _log.debug("selected: {}", _selectedOption.getValue());
                     PoolV2Mode poolMode = new PoolV2Mode(_selectedOption.getKey());
-                    getPoolSpaceService().changePoolMode(_poolBeans, poolMode,
+                    getPoolSpaceService().changePoolMode(poolBeans, poolMode,
                             getWebadminSession().getUserName());
-                    getPoolsAction();
                 } catch (PoolSpaceServiceException ex) {
                     _log.error("something went wrong with enable/disable");
                     this.error(getStringResource("error.changePoolModeFailed") + ex.getMessage());

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolqueues/PoolQueues.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolqueues/PoolQueues.java
@@ -1,15 +1,16 @@
 package org.dcache.webadmin.view.pages.poolqueues;
 
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
+import org.apache.wicket.markup.head.OnLoadHeaderItem;
+import org.apache.wicket.markup.head.StringHeaderItem;
 import org.apache.wicket.model.PropertyModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import org.apache.wicket.markup.head.IHeaderResponse;
-import org.apache.wicket.markup.head.JavaScriptHeaderItem;
-import org.apache.wicket.markup.head.OnLoadHeaderItem;
-import org.apache.wicket.markup.head.StringHeaderItem;
 
 import org.dcache.webadmin.controller.PoolQueuesService;
 import org.dcache.webadmin.controller.exceptions.PoolQueuesServiceException;
@@ -27,32 +28,35 @@ public class PoolQueues extends BasePage {
 
     private static final Logger _log = LoggerFactory.getLogger(PoolQueues.class);
     private static final long serialVersionUID = -6482302256752371950L;
-    private PoolGroupBean _allPoolsGroup = new PoolGroupBean("all",
-            new ArrayList<PoolSpaceBean>(), new ArrayList<PoolQueueBean>());
 
     public PoolQueues() {
         add(new PoolQueuesPanel("poolQueuesPanel",
-                new PropertyModel<PoolGroupBean>(this, "_allPoolsGroup")));
-        getPoolQueuesAction();
+                        new PropertyModel<PoolGroupBean>(this, "allPoolsGroup")));
+    }
+
+    public PoolGroupBean getAllPoolsGroup() {
+        PoolGroupBean allPoolsGroup = new PoolGroupBean("all",
+                        new ArrayList<PoolSpaceBean>(),
+                        new ArrayList<PoolQueueBean>());
+        getPoolQueuesAction(allPoolsGroup);
+        return allPoolsGroup;
     }
 
     private PoolQueuesService getPoolQueuesService() {
         return getWebadminApplication().getPoolQueuesService();
     }
 
-    private void getPoolQueuesAction() {
+    private void getPoolQueuesAction(PoolGroupBean bean) {
+        List<PoolQueueBean> poolQueues;
         try {
             _log.debug("getPoolQueuesAction called");
-            setPoolQueues(getPoolQueuesService().getPoolQueues());
+            poolQueues = getPoolQueuesService().getPoolQueues();
         } catch (PoolQueuesServiceException ex) {
             this.error(getStringResource("error.getPoolsQueuesFailed") + ex.getMessage());
             _log.debug("getPoolQueuesAction failed {}", ex.getMessage());
-            setPoolQueues(null);
+            poolQueues = Collections.emptyList();
         }
-    }
-
-    private void setPoolQueues(List<PoolQueueBean> poolQueues) {
-        _allPoolsGroup.setPoolQueues(poolQueues);
+        bean.setPoolQueues(poolQueues);
     }
 
     @Override

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolselectionsetup/PoolSelectionSetup.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolselectionsetup/PoolSelectionSetup.java
@@ -48,11 +48,10 @@ public class PoolSelectionSetup extends BasePage {
     private static final String PARTICULAR_PROPERTIES_ID = "particularProperties";
     private static final long serialVersionUID = 4020499606063085733L;
     private WebMarkupContainer _results = new EmptyPanel(RESULT_PANEL_ID);
-    private DCacheEntityContainerBean _entityContainer = new DCacheEntityContainerBean();
 
     public PoolSelectionSetup() {
         super();
-        retrieveEntityContainer();
+        entityContainer();
         addMarkup();
     }
 
@@ -74,17 +73,18 @@ public class PoolSelectionSetup extends BasePage {
         return getWebadminApplication().getPoolSelectionSetupService();
     }
 
-    private void retrieveEntityContainer() {
+    private DCacheEntityContainerBean entityContainer() {
         try {
-            _entityContainer = getPoolSelectionSetupService().getEntityContainer();
+            return getPoolSelectionSetupService().getEntityContainer();
         } catch (PoolSelectionSetupServiceException ex) {
             error("No Data available yet, please reload page: " + ex.getMessage());
             _log.debug("no Data: " + ex.getMessage());
+            return new DCacheEntityContainerBean();
         }
     }
 
     public Link getLinkToPool(String linkId, String name) {
-        PoolEntity entity = _entityContainer.getPool(name);
+        PoolEntity entity = entityContainer().getPool(name);
         if (entity != null) {
             return new ParticularEntityLink<>(linkId, entity);
         } else {
@@ -143,7 +143,7 @@ public class PoolSelectionSetup extends BasePage {
 
                         @Override
                         public void onClick() {
-//                           do nothing is on purpose - just an empty column
+                           //do nothing is on purpose - just an empty column
                         }
                     };
                     link.add(new Label("name", EMPTY_STRING));
@@ -192,7 +192,7 @@ public class PoolSelectionSetup extends BasePage {
         private List<DCacheEntity> extractEntitiesFromContainer(List<EntityReference> references) {
             List<DCacheEntity> entites = new ArrayList<>();
             for (EntityReference ref : references) {
-                entites.add(_entityContainer.getEntity(ref.getName(), ref.getEntityType()));
+                entites.add(entityContainer().getEntity(ref.getName(), ref.getEntityType()));
             }
             return entites;
         }
@@ -254,7 +254,7 @@ public class PoolSelectionSetup extends BasePage {
         @Override
         public void onClick() {
             Fragment results = new EntityListShowingFragment<>(
-                    RESULT_PANEL_ID, _entityContainer.getPools(), getStringResource(
+                    RESULT_PANEL_ID, entityContainer().getPools(), getStringResource(
                     "pools.header"));
             _results.replaceWith(results);
             _results = results;
@@ -272,7 +272,7 @@ public class PoolSelectionSetup extends BasePage {
         @Override
         public void onClick() {
             Fragment results = new EntityListShowingFragment<>(
-                    RESULT_PANEL_ID, _entityContainer.getPoolGroups(), getStringResource(
+                    RESULT_PANEL_ID, entityContainer().getPoolGroups(), getStringResource(
                     "poolGroups.header"));
             _results.replaceWith(results);
             _results = results;
@@ -290,7 +290,7 @@ public class PoolSelectionSetup extends BasePage {
         @Override
         public void onClick() {
             Fragment results = new EntityListShowingFragment<>(
-                    RESULT_PANEL_ID, _entityContainer.getUnits(), getStringResource(
+                    RESULT_PANEL_ID, entityContainer().getUnits(), getStringResource(
                     "units.header"));
             _results.replaceWith(results);
             _results = results;
@@ -308,7 +308,7 @@ public class PoolSelectionSetup extends BasePage {
         @Override
         public void onClick() {
             Fragment results = new EntityListShowingFragment<>(
-                    RESULT_PANEL_ID, _entityContainer.getUnitGroups(), getStringResource(
+                    RESULT_PANEL_ID, entityContainer().getUnitGroups(), getStringResource(
                     "unitGroups.header"));
             _results.replaceWith(results);
             _results = results;
@@ -327,7 +327,7 @@ public class PoolSelectionSetup extends BasePage {
         @Override
         public void onClick() {
             Fragment results = new EntityListShowingFragment<>(
-                    RESULT_PANEL_ID, _entityContainer.getLinks(), getStringResource(
+                    RESULT_PANEL_ID, entityContainer().getLinks(), getStringResource(
                     "links.header"));
             _results.replaceWith(results);
             _results = results;
@@ -345,7 +345,7 @@ public class PoolSelectionSetup extends BasePage {
 
         @Override
         public void onClick() {
-            Fragment results = new LinkListFragment(RESULT_PANEL_ID, _entityContainer.getLinks());
+            Fragment results = new LinkListFragment(RESULT_PANEL_ID, entityContainer().getLinks());
             _results.replaceWith(results);
             _results = results;
         }
@@ -445,7 +445,6 @@ public class PoolSelectionSetup extends BasePage {
                 @Override
                 protected void populateItem(ListItem<LinkEntity> item) {
                     LinkEntity entity = item.getModelObject();
-//                    item.add(new Label("_name", link.getName()));
                     Link link = new ParticularEntityLink<>("linkLink", entity);
                     link.add(new Label("_name", entity.getName()));
                     item.add(link);
@@ -468,7 +467,8 @@ public class PoolSelectionSetup extends BasePage {
                     String[] unitGroups = new String[4];
                     int counter = 0;
                     for (EntityReference unitGroup : list) {
-// just show the first 4 UnitGroups -- more are not even a sensible configuration of dCache
+                        // just show the first 4 UnitGroups
+                        // -- more are not even a sensible configuration of dCache
                         if (counter > 3) {
                             break;
                         }

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.java
@@ -9,7 +9,7 @@ import org.apache.wicket.model.PropertyModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.dcache.webadmin.controller.exceptions.LinkGroupsServiceException;
@@ -28,9 +28,8 @@ public class SpaceTokens extends BasePage {
     private SpaceReservationPanel _spaceReservationsPanel =
             new SpaceReservationPanel("spaceReservationsPanel",
             new PropertyModel<List<SpaceReservationBean>>(
-            this, "_currentLinkGroup._reservations"));
+            this, "reservations"));
     private LinkGroupBean _currentLinkGroup;
-    private List<LinkGroupBean> _linkGroups;
     private static final Logger _log = LoggerFactory.getLogger(SpaceTokens.class);
 
     public SpaceTokens() {
@@ -41,17 +40,24 @@ public class SpaceTokens extends BasePage {
     private void createMarkup() {
         add(new FeedbackPanel("feedback"));
         add(new LinkGroupListView("linkGroupView", new PropertyModel(this,
-                "_linkGroups")));
+                "tokenInfo")));
         add(_spaceReservationsPanel);
     }
 
-    private void getTokenInfo() {
+    public List<SpaceReservationBean> getReservations() {
+        if (_currentLinkGroup == null) {
+            return Collections.emptyList();
+        }
+        return _currentLinkGroup.getReservations();
+    }
+
+    public List<LinkGroupBean> getTokenInfo() {
         try {
-            _linkGroups = getWebadminApplication().getLinkGroupsService().getLinkGroups();
+            return getWebadminApplication().getLinkGroupsService().getLinkGroups();
         } catch (LinkGroupsServiceException ex) {
             this.error(getStringResource("error.getTokenInfoFailed") + ex.getMessage());
             _log.debug("getTokenInfo failed {}", ex.getMessage());
-            _linkGroups = new ArrayList<>();
+            return Collections.emptyList();
         }
     }
 

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.java
@@ -8,9 +8,9 @@ import org.apache.wicket.model.PropertyModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 
-import org.dcache.webadmin.controller.TapeTransfersService;
 import org.dcache.webadmin.controller.exceptions.TapeTransfersServiceException;
 import org.dcache.webadmin.view.pages.basepage.BasePage;
 import org.dcache.webadmin.view.pages.tapetransferqueue.beans.RestoreBean;
@@ -23,14 +23,13 @@ import org.dcache.webadmin.view.util.EvenOddListView;
 public class TapeTransferQueue extends BasePage {
 
     private static final long serialVersionUID = 8313857084027604473L;
-    private List<RestoreBean> _restoreBeans;
     private static final Logger _log = LoggerFactory.getLogger(TapeTransferQueue.class);
 
     public TapeTransferQueue() {
         add(new FeedbackPanel("feedback"));
         ListView<RestoreBean> listview =
                 new EvenOddListView<RestoreBean>("TapeTransferQueueListview",
-                new PropertyModel(this, "_restoreBeans")) {
+                new PropertyModel(this, "restoreBeans")) {
 
                     private static final long serialVersionUID = 9166078572922366382L;
 
@@ -54,21 +53,16 @@ public class TapeTransferQueue extends BasePage {
                     }
                 };
         add(listview);
-        getRestoresAction();
     }
 
-    private TapeTransfersService getTapeTransferService() {
-        return getWebadminApplication().getTapeTransfersService();
-    }
-
-    private void getRestoresAction() {
+    public List<RestoreBean> getRestoreBeans() {
         try {
             _log.debug("getRestoresAction called");
-            _restoreBeans = getTapeTransferService().getRestores();
+            return getWebadminApplication().getTapeTransfersService().getRestores();
         } catch (TapeTransfersServiceException ex) {
             this.error(getStringResource("error.getRestoresFailed") + ex.getMessage());
             _log.debug("getRestoresAction failed {}", ex.getMessage());
-            _restoreBeans = null;
+            return Collections.emptyList();
         }
     }
 }


### PR DESCRIPTION
This patch addresses several RT tickets stemming from the same problem, one which has already been corrected for the CellServices page (see http://rb.dcache.org/r/5807).

This has to do with the way Wicket PropertyModels were provided for pages which maintain lists which need to be updated through the service layer.  In most of these cases, the list was set in the constructor but was never updated during page/form refresh.  The changes adopted here follow the same general pattern of replacing the field accessed by the model with a getter method which also takes care of calling the service to update the collection in question.

Testing: Redeployed and checked updating by enabling/disabling pools.

Target: 2.7
Patch: http://rb.dcache.org/r/6080
Require-notes: yes
Require-book: no
Bug: http://rt.dcache.org/Ticket/Display.html?id=7929
Bug: http://rt.dcache.org/Ticket/Display.html?id=7964
Bug: http://rt.dcache.org/Ticket/Display.html?id=7983
Acked-by: Gerd
Acked-by: Tigran
Committed: cc7166ad47b6aeada7f2c9ef5ef0a0183d93bb8a

RELEASE NOTES:
Fixes an issue with some of the tables in the webadmin service which were not refreshing.  Update correctly occurs now on reload, resubmission of the form through link clicking
