### PR TITLE
xrootd: Make xrootdPlugins unscoped for door

### DIFF
--- a/modules/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/modules/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -100,7 +100,7 @@ xrootdAllowedWritePaths=/
 [dCacheDomain/xrootd]
 cell.name=Xrootd-gsi-${host.name}
 port=1095
-xrootd/xrootdPlugins=gplazma:gsi
+xrootdPlugins=gplazma:gsi
 xrootdAllowedWritePaths=/
 
 [dCacheDomain/webdav]

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -150,12 +150,6 @@ xrootdMoverMaxFrameSize=2097152
 #
 #    authz:alice-token - ALICE token based authorization plugin.
 #
-#   The property applies to both the xrootd door and the xrootd mover.
-#   The defaults are scoped to the xrootd service and pool service,
-#   respectively. Hence the property must either be defined per service
-#   or with an explicit scope prefix. See pool.properties for information
-#   about xrootd plugins for doors.
-#
 #   For pools no plugins are required. If an authentication plugin is
 #   specified, then note that the subject will *not* be mapped by
 #   gPlazma.
@@ -170,7 +164,8 @@ xrootdMoverMaxFrameSize=2097152
 #   and authorization plugins can be loaded as authn:<plugin> and
 #   authz:<plugin> respectively.
 #
-pool/xrootdPlugins=
+pool.mover.xrootd.plugins=
+pool/xrootdPlugins=${pool.mover.xrootd.plugins}
 
 
 #  ---- Thread pool size for http disk IO threads

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -129,12 +129,6 @@ xrootdAllowedWritePaths=
 #
 #    authz:alice-token - ALICE token based authorization plugin.
 #
-#   The property applies to both the xrootd door and the xrootd mover.
-#   The defaults are scoped to the xrootd service and pool service,
-#   respectively. Hence the property must either be defined per service
-#   or with an explicit scope prefix. See pool.properties for information
-#   about xrootd plugins for pools.
-#
 #   For xrootd doors, a gplazma authentication plugin is required; use
 #   gplazma:none if no authentication is desired. Authorization plugins
 #   have to be placed after the authentication plugin.
@@ -144,7 +138,7 @@ xrootdAllowedWritePaths=
 #   third party authentication plugins have to be loaded with
 #   gplazma:<plugin> in doors.
 #
-xrootd/xrootdPlugins=gplazma:${xrootdAuthNPlugin},authz:${xrootdAuthzPlugin}
+xrootdPlugins=gplazma:${xrootdAuthNPlugin},authz:${xrootdAuthzPlugin}
 
 #  ---- User identity used for authorizing operations
 #


### PR DESCRIPTION
The consequences of accidentally configuring xrootdPlugins in
dcache.conf can be quite big: Access to the door would be
unauthenticated, and possible name space mapping plugins would
not be applied.

To reduce the risk of this problem, and since we removed the
scoping operator in 2.7 anyway, this patch makes xrootdPlugins
unscoped for the door. Pools continue to use the scoped xrootdPlugins
property, but the patch introduces the pool.mover.xrootd.plugins
name as an alternative. This is the same name that was introduced
in 2.7.

Target: 2.6
Require-notes: yes
Require-book: yes
