### PR TITLE
(2.2) Fix Already have 1 record(s) with pnfsPath= ...

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
@@ -5049,7 +5049,7 @@ public final class Manager
                                                            selectPool.getFileSize(),
                                                            lifetime,
                                                            pnfsPath,
-                                                           selectPool.getPnfsId());
+                                                           null);
                                 file = getFile(fileId);
                         }
                 }


### PR DESCRIPTION
This patch (a modified version of http://rb.dcache.org/r/5671) addresses 

Already have 1 record(s) with pnfsPath= ...

error when transferring files to directories containing writetoken flag

(commit c9fcd4d1779cf2573328c66804df3e9458d25c74 on master)

```
    Ticket: 7888
    Acked-by: Al Rossi
    Target: trunk
    Request: 2.6
    Request: 2.2
    Require-book: no
    Require-notes: no
```
