### PR TITLE
(2.6) Fix fix Already have 1 record(s) with pnfsPath= ...

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
@@ -4903,7 +4903,7 @@ public final class Manager
                                                            selectWritePool.getPreallocated(),
                                                            lifetime,
                                                            pnfsPath,
-                                                           selectWritePool.getPnfsId());
+                                                           null);
                                 file = getFile(fileId);
                         }
                 }


### PR DESCRIPTION
Fix Already have 1 record(s) with pnfsPath=...

"error" generated when transferring files to directories containing writetoken flags 

Stripped down patch http://rb.dcache.org/r/5671

```
(commit 635a05a78debe247c717b6fd27c18067af676ccb to master)
```

RELEASE NOTES 

Eliminate bogus error "Already have 1 record(s) with pnfsPath=..." when transferring files to directories containing writetoken tags.

Ticket: 7888
Acked-by:
Target: trunk
Request: 2.6
Request: 2.2
Require-book: no
Require-notes: yes
