### PR TITLE
(2.6) hsqldb-plugin: fix transposed varchar settings

### DIFF
--- a/plugins/hsqldb/src/main/resources/org/dcache/hsqldb/changelog/billing-1.9.13.xml
+++ b/plugins/hsqldb/src/main/resources/org/dcache/hsqldb/changelog/billing-1.9.13.xml
@@ -39,9 +39,9 @@
             "cellname"       varchar(256),
             "datestamp"      timestamp with time zone,
             "errorcode"      integer,
-            "errormessage"   varchar(256),
+            "errormessage"   varchar(8000),
             "pnfsid"         varchar(36),
-            "transaction"    varchar(8000)
+            "transaction"    varchar(256)
             );
 
             CREATE TABLE "doorinfo"
@@ -57,9 +57,9 @@
             "cellname"       varchar(256),
             "datestamp"      timestamp with time zone,
             "errorcode"      integer,
-            "errormessage"   varchar(256),
+            "errormessage"   varchar(8000),
             "pnfsid"         varchar(36),
-            "transaction"    varchar(8000)
+            "transaction"    varchar(256)
             );
 
             CREATE TABLE "hitinfo"


### PR DESCRIPTION
The longer varchar (8000) should appear on errormessage but was erroneously given to a different field in a few of the tables.

Target: 2.6
Require-notes: no
Require-book: no
Acked-by: Gerd
Acked-by: Paul
Committed: c8c4807e2dc2475a47fff94a87eba08bc9ba0651
