### PR TITLE
(2.7) dcache-fhs: fix missing chown for httpd directory in debian postin...

### DIFF
--- a/packages/fhs/src/main/deb/postinst
+++ b/packages/fhs/src/main/deb/postinst
@@ -25,6 +25,7 @@ Please fix this and reinstall this package." >&2
     chown dcache:dcache /var/lib/dcache/alarms
     chown dcache:dcache /var/lib/dcache/config
     chown dcache:dcache /var/lib/dcache/billing
+    chown dcache:dcache /var/lib/dcache/httpd
     chown dcache:dcache /var/lib/dcache/plots
     chown dcache:dcache /var/lib/dcache/statistics
     chown dcache:dcache /var/lib/dcache/credentials


### PR DESCRIPTION
...st

Target: 2.7
Require-book: no
Require-notes: yes
Acked-by: Gerd
Committed: 9249dcbbf42eaa9477658ec54395f950d5a0206f

RELEASE NOTES
Fixes bug in debian installation preventing writes to the httpd directory and thus blocking creation of webadmin directory.
