### PR TITLE
(2.6) dcache: httpd service, add RequestLog to Jetty handler

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
@@ -3,12 +3,16 @@ package org.dcache.services.httpd;
 import com.google.common.collect.Maps;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.server.ssl.SslSelectChannelConnector;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
@@ -101,6 +105,13 @@ public class HttpServiceCell extends AbstractCell implements EnvironmentAware {
                     throws InterruptedException, ExecutionException {
         super(name, args);
         doInit();
+    }
+
+    private static class HttpdRequestLog extends AbstractLifeCycle
+        implements RequestLog {
+        public void log(Request request, Response response) {
+            logger.trace("request: {}; response: {}", request, response);
+        }
     }
 
     public static final String hh_ls_alias = "[<alias>]";
@@ -233,8 +244,10 @@ public class HttpServiceCell extends AbstractCell implements EnvironmentAware {
 
     private void createAndSetHandlers() {
         final HandlerCollection handlers = new HandlerCollection();
+        RequestLogHandler requestLogHandler = new RequestLogHandler();
+        requestLogHandler.setRequestLog(new HttpdRequestLog());
         handlers.setHandlers(new Handler[] { new HandlerDelegator(aliases),
-                        new DefaultHandler(), new RequestLogHandler() });
+                        new DefaultHandler(), requestLogHandler });
         server.setHandler(handlers);
     }
 


### PR DESCRIPTION
If the Jetty RequestLogHandler is not given a request log implementation, it logs at the WARN level a message and then sets an internal Null implementation.

Given that the log message is annoying, we have provided a simple implementation of the log which delegates to the slf4j logger at the TRACE level.

Testing:

Before patch, with logger for domain set to WARN or higher, we see the jetty warning

15 Oct 2013 08:45:28 (httpd) [] !RequestLog

With patch, this disappears.  Logging of request/response, set at trace, looks like this:

15 Oct 2013 09:41:39 (httpd) [] request: [GET /webadmin/cellinfo]@794262320 org.eclipse.jetty.server.Request@2f577b30; response: HTTP/1.1 302
Date: Tue, 15 Oct 2013 14:41:39 GMT
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Pragma: no-cache
Cache-Control: no-cache, no-store
Location: http://localhost:2288/webadmin/cellinfo?1

Target: 2.6
Patch: http://rb.dcache.org/r/6115
Require-notes: no
Require-book: no
Bug: http://rt.dcache.org/Ticket/Display.html?id=8050
Acked-by: Gerd
Committed: c2fa9e254699d993ce0f0789b271fdbcbcb8d7c5
