### PR TITLE
(2.6)dcache: httpd service, remove ipv4 specific binding

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
@@ -31,7 +31,6 @@ import org.dcache.services.httpd.util.AliasEntry;
 import org.dcache.util.Crypto;
 
 public class HttpServiceCell extends AbstractCell implements EnvironmentAware {
-    private static final String IPV4_INETADDR_ANY = "0.0.0.0";
     private static final Logger logger
         = LoggerFactory.getLogger(HttpServiceCell.class);
     private final ConcurrentMap<String, AliasEntry> aliases
@@ -254,7 +253,6 @@ public class HttpServiceCell extends AbstractCell implements EnvironmentAware {
     private Connector createSslConnector() {
         final SslSelectChannelConnector connector = new SslSelectChannelConnector();
         connector.setPort(httpsPort);
-        connector.setHost(IPV4_INETADDR_ANY);
         connector.setExcludeCipherSuites(Crypto.getBannedCipherSuitesFromConfigurationValue(cipherFlags));
         final SslContextFactory factory = connector.getSslContextFactory();
         factory.setKeyStorePath(keystore);


### PR DESCRIPTION
The Jetty ssl connector was hardcoded to listen on "0.0.0.0".  This is an ipv4-specific mask.  The simple connector and the ssl connector also did not allow for a different net binding.

This patch removes the hardcoded binding of host name and exposes an httpd.net.listen property which defaults to dcache.net.listen.

Since new properties cannot be ported to 2.6, a separate patch which simply removes the hard-coded ipv4 setting will be provided.

Testing:

Checked that the default settings still work.

Target: 2.6
Patch: http://rb.dcache.org/r/6116
Require-notes: yes
Require-book: no
Acked-by: Gerd
Committed: 4c32223de86e57ef42c0052c024f81b6187a504a

RELEASE NOTES:
Allows for ipv6 binding of httpd service.
