### PR TITLE
(2.2) javatunnel: add certificate chain to subject

### DIFF
--- a/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
+++ b/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
@@ -26,6 +26,7 @@ import javax.security.auth.Subject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.cert.X509Certificate;
 import java.util.Iterator;
 
 import dmg.util.Args;
@@ -96,14 +97,16 @@ class GsiTunnel extends GssTunnel  {
     }
 
     @Override
-    public boolean verify( InputStream in, OutputStream out, Object addon) {
-
+    public boolean verify(InputStream in, OutputStream out, Object addon) {
         try {
-        	if( super.verify(in, out, addon) ) {
-                    _subject.getPrincipals().add( new GlobusPrincipal(_e_context.getSrcName().toString()) );
-        		scanExtendedAttributes(_e_context);
-        	}
-        } catch( GSSException e) {
+            if (super.verify(in, out, addon)) {
+                X509Certificate[] chain = (X509Certificate[]) _e_context.inquireByOid(GSSConstants.X509_CERT_CHAIN);
+                _subject.getPublicCredentials().add(chain);
+                _subject.getPrincipals().add(new GlobusPrincipal(
+                                       _e_context.getSrcName().toString()));
+                scanExtendedAttributes(_e_context);
+            }
+        } catch (GSSException e) {
             _log.error("Failed to verify: {}", e.toString());
         }
 


### PR DESCRIPTION
Failing XACML authentication through the gsidcap door.

The issue is that XACML, being both an auth and map plugin, requires the full certificate chain to be in the Subject.  The gsi tunnel was

The tunnel now extracts the chain from the GSSCredential object and places it in the public credentials set of the subject.

Testing:

Before the patch, the XACML plugin would fail because it had incomplete information and which it processed in a faulty manner.  The error

```
[DCap-gsi-00-fndca4a-/DC=com/DC=DigiCert-Grid/O=Open Science
Grid/OU=People/CN=Kenneth Herner 1385-133 Login AUTH xacml] mapping
service
https://gums.fnal.gov:8443/gums/services/GUMSXACMLAuthorizationServicePort
returned localId LocalId[] for VomsExtensions[X509Subject='/fermilab',
X509SubjectIssuer='null', fqan='null', primary=false, VO='null',
VOMSSubject='null', VOMSSubjectIssuer='null']
```

After the patch, the dccp operation succeeds.

Target: 2.2
Patch: http://rb.dcache.org/r/6112/
Require-book: no
Require-notes: yes
Acked-by: Tigran
Committed: 43d81f7b167ddfeec311f6eb24283e1251e6d0b5

RELEASE NOTES:
Fixes a bug whereby a combination of gsidcap with a VOMS cert and XACML authentication/mapping failed to authorize the user.
