### PR TITLE
(2.2) javatunnel: add certificate chain to subject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -628,29 +628,72 @@
 	  <version>${version.jglobus}</version>
 	</dependency>
 
-        <dependency>
-            <groupId>org.freehep</groupId>
-            <artifactId>freehep-jaida</artifactId>
-            <version>3.4.1</version>
-            <exclusions>
-                <exclusion>
-                    <!-- We manually have a dependency on the
-                         org.apache.xerces variant of Xerces -->
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.freehep</groupId>
-            <artifactId>freehep-graphics2d</artifactId>
-            <version>2.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.freehep</groupId>
-            <artifactId>freehep-graphicsio</artifactId>
-            <version>2.2.1</version>
-        </dependency>
+    <dependency>
+        <groupId>org.freehep</groupId>
+        <artifactId>freehep-jaida</artifactId>
+        <version>3.4.1</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-commandline</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-commanddispatcher</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-argv</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-jaida-xml</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-xml</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>hep.aida</groupId>
+                <artifactId>aida-test</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.l2fprod</groupId>
+                <artifactId>l2fprod-common-all</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>commons-math</groupId>
+                <artifactId>commons-math</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>javax.help</groupId>
+                <artifactId>javahelpr</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>jdom</groupId>
+                <artifactId>jdom</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>net.java.dev</groupId>
+                <artifactId>net.java.dev:truezip</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+
+    <dependency>
+        <groupId>org.freehep</groupId>
+        <artifactId>freehep-graphics2d</artifactId>
+        <version>2.2.1</version>
+    </dependency>
+    <dependency>
+        <groupId>org.freehep</groupId>
+        <artifactId>freehep-graphicsio</artifactId>
+        <version>2.2.1</version>
+    </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Failing XACML authentication through the gsidcap door.

The issue is that XACML, being both an auth and map plugin, requires the full certificate chain to be in the Subject.  The gsi tunnel was

The tunnel now extracts the chain from the GSSCredential object and places it in the public credentials set of the subject.

Testing:

Before the patch, the XACML plugin would fail because it had incomplete information and which it processed in a faulty manner.  The error

```
[DCap-gsi-00-fndca4a-/DC=com/DC=DigiCert-Grid/O=Open Science
Grid/OU=People/CN=Kenneth Herner 1385-133 Login AUTH xacml] mapping
service
https://gums.fnal.gov:8443/gums/services/GUMSXACMLAuthorizationServicePort
returned localId LocalId[] for VomsExtensions[X509Subject='/fermilab',
X509SubjectIssuer='null', fqan='null', primary=false, VO='null',
VOMSSubject='null', VOMSSubjectIssuer='null']
```

After the patch, the dccp operation succeeds.

Target: 2.2
Patch: http://rb.dcache.org/r/6112/
Require-book: no
Require-notes: yes
Acked-by: Tigran
Committed: df5cb39f86ada65c965a33456cc7fe98e8e62a30

RELEASE NOTES:
Fixes a bug whereby a combination of gsidcap with a VOMS cert and XACML authentication/mapping failed to authorize the user.
