### PR TITLE
(2.2) skel: exclude unneeded freehep/aida dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -628,29 +628,72 @@
 	  <version>${version.jglobus}</version>
 	</dependency>
 
-        <dependency>
-            <groupId>org.freehep</groupId>
-            <artifactId>freehep-jaida</artifactId>
-            <version>3.4.1</version>
-            <exclusions>
-                <exclusion>
-                    <!-- We manually have a dependency on the
-                         org.apache.xerces variant of Xerces -->
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.freehep</groupId>
-            <artifactId>freehep-graphics2d</artifactId>
-            <version>2.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.freehep</groupId>
-            <artifactId>freehep-graphicsio</artifactId>
-            <version>2.2.1</version>
-        </dependency>
+    <dependency>
+        <groupId>org.freehep</groupId>
+        <artifactId>freehep-jaida</artifactId>
+        <version>3.4.1</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-commandline</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-commanddispatcher</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-argv</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-jaida-xml</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.freehep</groupId>
+                <artifactId>freehep-xml</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>hep.aida</groupId>
+                <artifactId>aida-test</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.l2fprod</groupId>
+                <artifactId>l2fprod-common-all</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>commons-math</groupId>
+                <artifactId>commons-math</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>javax.help</groupId>
+                <artifactId>javahelpr</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>jdom</groupId>
+                <artifactId>jdom</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>net.java.dev</groupId>
+                <artifactId>net.java.dev:truezip</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+
+    <dependency>
+        <groupId>org.freehep</groupId>
+        <artifactId>freehep-graphics2d</artifactId>
+        <version>2.2.1</version>
+    </dependency>
+    <dependency>
+        <groupId>org.freehep</groupId>
+        <artifactId>freehep-graphicsio</artifactId>
+        <version>2.2.1</version>
+    </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The freehep maven repository pulls in a number of dependencies which are not necessary for our runtime requirements.

After trial-and-error twiddling, I have determined that the following constitute the minimal set:

freehep-application-2.0.3.jar
freehep-graphics2d-2.2.1.jar
freehep-graphicsbase-2.2.1.jar
freehep-graphicsio-2.2.1.jar
freehep-io-2.2.2.jar
freehep-jaida-3.4.1.jar
freehep-swing-2.0.6.jar
freehep-util-2.0.5.jar
aida-3.3.1.jar
aida-dev-3.3.jar
jel-2.0.1.jar
openide-lookup-1.9-patched-1.0.jar

Hence the pom.xml has been modified to exclude those that are safe to eliminate.  Note that direct dependencies only is not an option as freehep-jaida-3.4.1.jar is needed, but carries many of the other unnecessary dependencies with it.

Testing:

Excluded subsidiary dependencies then added them back in until plots were generated without error.

Target: 2.2
Patch: http://rb.dcache.org/r/6117
Require-notes: no
Require-book: no
Acked-by: Gerd
Committed: df5cb39
