### PR TITLE
nfs4: include open stateid into diagnostic printouts

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -481,8 +481,13 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         pw.println();
         pw.println("  Known movers (layouts):");
-        for(Transfer io: _ioMessages.values()) {
-            pw.println( String.format("    %s : %s@%s", io.getPnfsId(), io.getMoverId(), io.getPool() ));
+        for (NfsTransfer io : _ioMessages.values()) {
+            pw.println(String.format(" %s : %s@%s, OS=%s,cl=[%s]",
+                    io.getPnfsId(),
+                    io.getMoverId(),
+                    io.getPool(),
+                    io.getProtocolInfoForPool().stateId(),
+                    io.getProtocolInfoForPool().getSocketAddress().getAddress().getHostAddress()));
         }
 
         pw.println();

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv41ProtocolMover.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv41ProtocolMover.java
@@ -91,4 +91,8 @@ public class NFSv41ProtocolMover implements ManualMover {
         _lastAccessTime = System.currentTimeMillis();
     }
 
+    @Override
+    public String toString() {
+        return "NFSv4.1/pNFS";
+    }
 }


### PR DESCRIPTION
a variation of https://github.com/dCache/dcache/commit/c51805311b3131abdbca635fc47235a97d6aec09

for 2.6
