### PR TITLE
dcap: convert ClosedByInterruptException into InterruptException

### DIFF
--- a/modules/dcache-dcap/src/main/java/org/dcache/pool/movers/DCapProtocol_3_nio.java
+++ b/modules/dcache-dcap/src/main/java/org/dcache/pool/movers/DCapProtocol_3_nio.java
@@ -30,6 +30,7 @@ import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellMessage;
 import dmg.cells.nucleus.CellPath;
 import dmg.util.Args;
+import java.nio.channels.ClosedByInterruptException;
 
 import org.dcache.net.ProtocolConnectionPool;
 import org.dcache.net.ProtocolConnectionPoolFactory;
@@ -729,6 +730,10 @@ public class DCapProtocol_3_nio implements MoverProtocol, ChecksumMover {
         }catch(RuntimeException e){
             _log.error("Problem in command block : "+requestBlock, e);
             ioException = e;
+        } catch (ClosedByInterruptException ee) {
+            // clear interrupted state
+            Thread.interrupted();
+            ioException = new InterruptedException(ee.getMessage());
         }catch(Exception e){
             ioException = e;
         }finally{
@@ -802,6 +807,10 @@ public class DCapProtocol_3_nio implements MoverProtocol, ChecksumMover {
                     if(rc <= 0) {
                         break;
                     }
+                }catch (ClosedByInterruptException ee) {
+                    // clear interrupted state
+                    Thread.interrupted();
+                    throw new InterruptedException(ee.getMessage());
                 }catch(IOException ee){
                     _io_ok = false;
                     break;
@@ -1003,8 +1012,11 @@ public class DCapProtocol_3_nio implements MoverProtocol, ChecksumMover {
                         _bigBuffer.flip();
                         bytesAdded += fileChannel.write(_bigBuffer);
                         updateChecksum(_bigBuffer);
-
-                    }catch(Exception ioe){
+                    } catch (ClosedByInterruptException ee) {
+                        // clear interrupted state
+                        Thread.interrupted();
+                        throw new InterruptedException(ee.getMessage());
+                    }catch(IOException ioe){
                         _log.error("IOException in writing data to disk : {}", ioe.toString());
                         _io_ok = false;
                     }
@@ -1061,6 +1073,10 @@ public class DCapProtocol_3_nio implements MoverProtocol, ChecksumMover {
                 if(rc <= 0) {
                     break;
                 }
+            } catch (ClosedByInterruptException ee) {
+                // clear interrupted state
+                Thread.interrupted();
+                throw new InterruptedException(ee.getMessage());
             }catch(IOException ee){
                 _io_ok = false;
                 break;


### PR DESCRIPTION
this prevents pools to disable by JTM or mover kill

Acked-by: Paul Millar
Target: master, 2.6
Require-book: no
Require-notes: no
(cherry picked from commit aaf19b4c88d023183daf0e409bfebf0eee848c39)
