### PR TITLE
chimera: use ArrayList instead of LinedList

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/DirectoryStreamHelper.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/DirectoryStreamHelper.java
@@ -17,7 +17,7 @@
 package org.dcache.chimera;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 public class DirectoryStreamHelper {
@@ -30,7 +30,7 @@ public class DirectoryStreamHelper {
      */
     public static List<HimeraDirectoryEntry> listOf(FsInode inode) throws IOException, IOHimeraFsException {
 
-        List<HimeraDirectoryEntry> directoryList = new LinkedList<>();
+        List<HimeraDirectoryEntry> directoryList = new ArrayList<>(inode.statCache().getNlink());
         try (DirectoryStreamB<HimeraDirectoryEntry> dirStream =
                 inode.newDirectoryStream()) {
             for (HimeraDirectoryEntry e : dirStream) {


### PR DESCRIPTION
NFS listing is heavy with List#get operations, which
is the weakest point for LinkedList. This change improves
listing of jumbo directories ( ~100k files ) by factor of 10.

RELEASE NOTES:
speedup directory listing of large directories

Acked-by: Paul Millar
Target: master, 2.6
Require-book: no
Require-notes: yes
(cherry picked from commit 8529a07133b827cf407cb3da370b8698b34aa735)
