### PR TITLE
module: Obsolete dcache-server to make dcache package directly releasabl...

### DIFF
--- a/pkgs/rpm/dcache-server.spec.template
+++ b/pkgs/rpm/dcache-server.spec.template
@@ -8,8 +8,8 @@ Prefix: /
 Packager: dCache.org <support@dcache.org>.
 
 Obsoletes: dCacheConfigure
+Obsoletes: dcache-server
 Provides: dCachePostInstallConfigurationScripts
-Provides: dcache-server
 AutoReqProv: no
 Requires(pre): shadow-utils
 Requires(post): chkconfig


### PR DESCRIPTION
...e to EMI, EGI*

Obsolete dcache-server to make dcache package directly releasable to EMI, EGI*

This patch in master has the same purpose:
ae694c2329c11092d5d5f3d83a7fbff7cdb47837@master

Target: 2.6
Acked-by:Paul
Requires-notes: no
Requires-book: no
