### PR TITLE
packaging: Obsolete dcache-server to make dcache package directly releas...

### DIFF
--- a/pkgs/rpm/dcache-server-fhs.spec.template
+++ b/pkgs/rpm/dcache-server-fhs.spec.template
@@ -8,8 +8,8 @@ Prefix: /
 Packager: dCache.org <support@dcache.org>.
 
 Obsoletes: dCacheConfigure
+Obsoletes: dcache-server
 Provides: dCachePostInstallConfigurationScripts
-Provides: dcache-server
 AutoReqProv: no
 Requires(pre): shadow-utils
 Requires(post): chkconfig


### PR DESCRIPTION
...able to EMI, EGI*

Obsolete dcache-server to make dcache package directly releasable to EMI, EGI*

Target: 2.2
Acked-by:Paul
Requires-notes: no
Requires-book: no
