### PR TITLE
nfs: fall back to numeric mapping by default

### DIFF
--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -52,8 +52,8 @@ nfs.idmap.cache.timeout.unit = SECONDS
 
 
 # Allow legacy numeric strings instead of principals. Used for backward compatibility
-# and for setups without mapping service lile NIS or LDAP.
-(one-of?true|false)nfs.idmap.legacy = false
+# and for setups without mapping service like NIS or LDAP.
+(one-of?true|false)nfs.idmap.legacy = true
 
 #
 # enable RPCSEC_GSS


### PR DESCRIPTION
Linux client uses number based mapping by default.
This makes dCache default configuration to have
'bad' behaviour. Let make our default same as linux
has.

Acked-by: Paul Millar
Target: master, 2.6
Require-book: no
Require-notes: yes
(cherry picked from commit 2d6a1aa51288a4051408b06b467d80b1422ebca9)
