### PR TITLE
libs: use bugfix release of jpnfs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -737,7 +737,7 @@
         <dependency>
             <groupId>org.dcache.chimera</groupId>
             <artifactId>jpnfs</artifactId>
-            <version>0.5.5</version>
+            <version>0.5.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
chagelog:
- [adfcb19] nfs: fix readdir caching

Ticket: #7978
Acked-by: Paul Millar
Target: master, 2.6
Require-book: no
Require-notes: yes
(cherry picked from commit a15706f84fad25d13dcdcf68d1674472925d3e3a)
