### PR TITLE
srm: Fix regression in listing busy SURLs

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/request/LsFileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/LsFileRequest.java
@@ -170,11 +170,20 @@ public final class LsFileRequest extends FileRequest {
                         }
 
                         if (SRM.getSRM().isFileBusy(surl)) {
-                            // [SRM 2.2, 4.4.3] client requests for a file which there is an active
-                            // srmPrepareToPut (no srmPutDone is yet called) request for.
-                            metaDataPathDetail = new TMetaDataPathDetail();
-                            metaDataPathDetail.setPath(getPath(surl));
-                            metaDataPathDetail.setType(TFileType.FILE);
+                            // [SRM 2.2, 4.4.3]
+                            //
+                            // SRM_FILE_BUSY
+                            //
+                            //     client requests for a file which there is an active
+                            //     srmPrepareToPut (no srmPutDone is yet called) request for.
+                            try {
+                                metaDataPathDetail =
+                                        getMetaDataPathDetail(surl, 0, 0, 0, 0, parent.getLongFormat());
+                            } catch (SRMInvalidPathException e) {
+                                metaDataPathDetail = new TMetaDataPathDetail();
+                                metaDataPathDetail.setPath(getPath(surl));
+                                metaDataPathDetail.setType(TFileType.FILE);
+                            }
                             metaDataPathDetail.setStatus(new TReturnStatus(TStatusCode.SRM_FILE_BUSY,
                                     "The requested SURL is being used by another client."));
                         } else {


### PR DESCRIPTION
Addresses an ARC compatibility issue.

ARC issues an srmLs against a SURL after uploading a file, but
before calling srmPutDone. It does this to verify file size and
checksum before releasing the SURL to other clients.

Ever since we implemented SRM_FILE_BUSY, this logic no longer works,
as we skip the meta data lookup for busy files. This issue is
addressed by this patch.

Target: trunk
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6147/
(cherry picked from commit 96e4b6147b3769de835b6ec0beef66c58d038383)
