### PR TITLE
chimera: fix sql exception if file name too long

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/InvalidNameChimeraException.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/InvalidNameChimeraException.java
@@ -1,0 +1,29 @@
+/*
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program (see the file COPYING.LIB for more
+ * details); if not, write to the Free Software Foundation, Inc.,
+ * 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.dcache.chimera;
+
+public class InvalidNameChimeraException extends ChimeraFsException {
+    static final long serialVersionUID = -8838867882017718935L;
+
+    public InvalidNameChimeraException(String msg) {
+        super(msg);
+    }
+
+    public InvalidNameChimeraException() {
+        super();
+    }
+}

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -84,6 +84,11 @@ public class JdbcFs implements FileSystemProvider {
      */
     private static final long TOTAL_FILES = 62914560L;
 
+    /**
+     * maximal length of an object name in a directory.
+     */
+    private final static int MAX_NAME_LEN = 256;
+
     public JdbcFs(DataSource dataSource, String dialect) {
         this(dataSource, dialect, 0);
     }
@@ -182,6 +187,8 @@ public class JdbcFs implements FileSystemProvider {
     @Override
     public FsInode createLink(FsInode parent, String name, int uid, int gid, int mode, byte[] dest) throws ChimeraFsException {
 
+        checkNameLength(name);
+
         Connection dbConnection;
         try {
             // get from pool
@@ -230,6 +237,8 @@ public class JdbcFs implements FileSystemProvider {
      */
     @Override
     public FsInode createHLink(FsInode parent, FsInode inode, String name) throws ChimeraFsException {
+
+        checkNameLength(name);
 
         Connection dbConnection;
         try {
@@ -382,6 +391,8 @@ public class JdbcFs implements FileSystemProvider {
 
             try {
 
+                checkNameLength(name);
+
                 if (!parent.exists()) {
                     throw new FileNotFoundHimeraFsException("parent=" + parent.toString());
                 }
@@ -436,6 +447,8 @@ public class JdbcFs implements FileSystemProvider {
      */
     @Override
     public void createFileWithId(FsInode parent, FsInode inode, String name, int owner, int group, int mode, int type) throws ChimeraFsException {
+
+        checkNameLength(name);
 
         Connection dbConnection;
         try {
@@ -766,6 +779,8 @@ public class JdbcFs implements FileSystemProvider {
 
     @Override
     public FsInode mkdir(FsInode parent, String name, int owner, int group, int mode) throws ChimeraFsException {
+
+        checkNameLength(name);
 
         Connection dbConnection;
         try {
@@ -1295,6 +1310,8 @@ public class JdbcFs implements FileSystemProvider {
     @Override
     public void setFileName(FsInode dir, String oldName, String newName) throws ChimeraFsException {
 
+        checkNameLength(newName);
+
         Connection dbConnection;
         try {
             // get from pool
@@ -1733,6 +1750,8 @@ public class JdbcFs implements FileSystemProvider {
 
     @Override
     public boolean move(FsInode srcDir, String source, FsInode destDir, String dest) throws ChimeraFsException {
+
+        checkNameLength(dest);
 
         Connection dbConnection;
         try {
@@ -2558,6 +2577,12 @@ public class JdbcFs implements FileSystemProvider {
             throw new IOHimeraFsException(e.getMessage());
         } finally {
             tryToClose(dbConnection);
+        }
+    }
+
+    private static void checkNameLength(String name) throws InvalidNameChimeraException {
+        if (name.length() > MAX_NAME_LEN) {
+            throw new InvalidNameChimeraException("Name too long");
         }
     }
 

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -1,5 +1,6 @@
 package org.dcache.chimera;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -795,6 +796,25 @@ public class BasicTest extends ChimeraTestCaseHelper {
         level1of1.write(0, data, 0, data.length);
         assertTrue(_fs.move(base, "testCreateFile2", base, "testCreateFile1"));
 
+    }
+
+    @Test(expected = InvalidNameChimeraException.class)
+    public void testNameTooDirLong() throws Exception {
+        String tooLongName = Strings.repeat("a", 257);
+        FsInode base = _rootInode.mkdir(tooLongName);
+    }
+
+    @Test(expected = InvalidNameChimeraException.class)
+    public void testNameTooFileLong() throws Exception {
+        String tooLongName = Strings.repeat("a", 257);
+        FsInode base = _rootInode.create(tooLongName, 0, 0, 0644);
+    }
+
+    @Test(expected = InvalidNameChimeraException.class)
+    public void testNameTooMoveLong() throws Exception {
+        String tooLongName = Strings.repeat("a", 257);
+        _rootInode.mkdir("testNameTooMoveLong");
+        _fs.move(_rootInode, "testNameTooMoveLong", _rootInode, tooLongName);
     }
 
     @Test


### PR DESCRIPTION
in some cases (at least during testing) we see names longer that
256 symbols. This results into naasty exceptions which is fixed
by this patch.

Patch: http://rb.dcache.org/r/5490
Target: trunk
Request: 2.6
Require-book: no
Require-notes: no
