### PR TITLE
libs: use buxfix jpnfs-0.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -737,7 +737,7 @@
         <dependency>
             <groupId>org.dcache.chimera</groupId>
             <artifactId>jpnfs</artifactId>
-            <version>0.5.6</version>
+            <version>0.5.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>
@@ -754,6 +754,10 @@
                 <exclusion>
                     <groupId>com.sun.jna</groupId>
                     <artifactId>jna</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
```
* [968bdd3] core: limit number of states owned by client
* [9f9863a] vfs: use inodeToBytes to generate file handle for chimera
```

exclude h2 dependency

Target: 2.6
Require-book: no
Require-notes: no
