### PR TITLE
(2.6) webadmin: fix regressions in PoolList and ActiveTransfers blocking...

### DIFF
--- a/modules/webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardActiveTransfersService.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardActiveTransfersService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.dcache.admin.webadmin.datacollector.datatypes.MoverInfo;
+import org.dcache.pool.classic.IoRequestState;
 import org.dcache.webadmin.controller.ActiveTransfersService;
 import org.dcache.webadmin.controller.exceptions.ActiveTransfersServiceException;
 import org.dcache.webadmin.controller.util.BeanDataMapper;
@@ -71,6 +72,7 @@ public class StandardActiveTransfersService implements ActiveTransfersService {
         if (failedIdsExist) {
             throw new ActiveTransfersServiceException(failedIds.toString());
         }
+        markPending(transfers);
     }
 
     private void killMoversOfPool(String pool, Set<Integer> jobIds) throws DAOException {
@@ -92,6 +94,16 @@ public class StandardActiveTransfersService implements ActiveTransfersService {
             }
         }
         return pools;
+    }
+
+    private void markPending(List<SelectableWrapper<ActiveTransfersBean>> transfers) {
+        for (SelectableWrapper<ActiveTransfersBean> transfer : transfers) {
+            if (transfer.isSelected() && !transfer.getWrapped().getPool().isEmpty()) {
+                transfer.setSelected(false);
+                transfer.setPending(true);
+                transfer.getWrapped().setState(IoRequestState.CANCELED.toString());
+            }
+        }
     }
 
     public void setDAOFactory(DAOFactory daoFactory) {

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardPoolSpaceService.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardPoolSpaceService.java
@@ -87,6 +87,7 @@ public class StandardPoolSpaceService implements PoolSpaceService {
         for (PoolSpaceBean pool: pools) {
             if (poolIds.contains(pool.getName())) {
                 pool.setPoolMode(poolMode);
+                pool.setSelected(false);
             }
         }
     }

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
@@ -22,7 +22,6 @@ import org.dcache.webadmin.view.beans.PoolSpaceBean;
 import org.dcache.webadmin.view.beans.SelectOption;
 import org.dcache.webadmin.view.pages.basepage.BasePage;
 import org.dcache.webadmin.view.panels.poollist.PoolListPanel;
-import org.dcache.webadmin.view.util.EvenOddListView;
 import org.dcache.webadmin.view.util.Role;
 
 /**
@@ -35,7 +34,7 @@ public class PoolList extends BasePage {
     private static final long serialVersionUID = -3519762401458479856L;
     private List<PoolSpaceBean> _poolBeans;
     private SelectOption _selectedOption;
-    private final EvenOddListView view;
+    private final PoolListPanel poolListPanel;
     private static final Logger _log = LoggerFactory.getLogger(PoolList.class);
 
     public PoolList() {
@@ -43,9 +42,8 @@ public class PoolList extends BasePage {
         poolUsageForm.add(createPoolModeDropDown("mode"));
         poolUsageForm.add(new FeedbackPanel("feedback"));
         getPoolSpaceBeans();
-        PoolListPanel poolListPanel = new PoolListPanel("poolListPanel",
+        poolListPanel = new PoolListPanel("poolListPanel",
                 new PropertyModel(this, "_poolBeans"), true);
-        view = poolListPanel.getView();
         poolUsageForm.add(poolListPanel);
         add(poolUsageForm);
     }
@@ -97,10 +95,8 @@ public class PoolList extends BasePage {
 
         public PoolUsageForm(String id) {
             super(id);
-            Button button = new Button("submit");
-            MetaDataRoleAuthorizationStrategy.authorize(button, RENDER, Role.ADMIN);
-            _log.debug("submit isEnabled : {}", String.valueOf(button.isEnabled()));
-            this.add(button);
+            Button submit = new Button("submit");
+            this.add(submit);;
         }
 
         @Override
@@ -112,11 +108,11 @@ public class PoolList extends BasePage {
                     PoolV2Mode poolMode = new PoolV2Mode(_selectedOption.getKey());
                     getPoolSpaceService().changePoolMode(_poolBeans, poolMode,
                             getWebadminSession().getUserName());
-                    view.render();
                 } catch (PoolSpaceServiceException ex) {
                     _log.error("something went wrong with enable/disable");
                     this.error(getStringResource("error.changePoolModeFailed") + ex.getMessage());
                 }
+                poolListPanel.render();
             }
         }
     }

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/activetransfers/ActiveTransfersPanel.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/activetransfers/ActiveTransfersPanel.java
@@ -11,6 +11,7 @@ import org.apache.wicket.model.PropertyModel;
 import java.util.List;
 
 import org.dcache.webadmin.view.beans.ActiveTransfersBean;
+import org.dcache.webadmin.view.pages.activetransfers.ActiveTransfers;
 import org.dcache.webadmin.view.panels.basepanel.BasePanel;
 import org.dcache.webadmin.view.util.EvenOddListView;
 import org.dcache.webadmin.view.util.Role;
@@ -23,6 +24,8 @@ import org.dcache.webadmin.view.util.SelectableWrapper;
 public class ActiveTransfersPanel extends BasePanel {
 
     private static final long serialVersionUID = -4054050417645444230L;
+
+    private ActiveTransfers _activeTransfers;
 
     public ActiveTransfersPanel(String id,
             IModel<? extends List<SelectableWrapper<ActiveTransfersBean>>> model) {
@@ -55,6 +58,14 @@ public class ActiveTransfersPanel extends BasePanel {
         }
 
         @Override
+        protected void onBeforeRender() {
+            if (_activeTransfers != null) {
+                setList(_activeTransfers.getListViewList());
+            }
+            super.onBeforeRender();
+        }
+
+        @Override
         protected void populateItem(
                 final ListItem<SelectableWrapper<ActiveTransfersBean>> item) {
             SelectableWrapper<ActiveTransfersBean> wrapper = item.getModelObject();
@@ -67,6 +78,7 @@ public class ActiveTransfersPanel extends BasePanel {
                     new PropertyModel<Boolean>(wrapper, "selected"));
             checkboxColumn.add(checkbox);
             item.add(checkboxColumn);
+            String qualifier = wrapper.isPending() ? " (pending)" : "";
             Label doorLabel = new Label("activeTransfersPanel.door", activeTransfer.getCellName());
             MetaDataRoleAuthorizationStrategy.authorize(doorLabel, RENDER, Role.ADMIN);
             item.add(doorLabel);
@@ -84,7 +96,7 @@ public class ActiveTransfersPanel extends BasePanel {
             item.add(hostLabel);
             item.add(new Label("activeTransfersPanel.status", activeTransfer.getStatus()));
             item.add(new Label("activeTransfersPanel.since", activeTransfer.getWaitingSinceTime()));
-            item.add(new Label("activeTransfersPanel.health", activeTransfer.getState()));
+            item.add(new Label("activeTransfersPanel.health", activeTransfer.getState() + qualifier));
             item.add(new Label("activeTransfersPanel.transferred",
                     Long.valueOf(activeTransfer.getTransferred()).toString()));
             item.add(new Label("activeTransfersPanel.speed", activeTransfer.getTransferRate()));
@@ -92,5 +104,9 @@ public class ActiveTransfersPanel extends BasePanel {
                     Long.valueOf(activeTransfer.getJobId()).toString()));
 
         }
+    }
+
+    public void setActiveTransfersPage(ActiveTransfers activeTransfers) {
+        _activeTransfers = activeTransfers;
     }
 }

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/poollist/PoolListPanel.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/poollist/PoolListPanel.java
@@ -25,7 +25,6 @@ public class PoolListPanel extends BasePanel {
 
     private static final long serialVersionUID = 8191342980744557065L;
     private boolean _showCheckbox;
-    private final PoolBeanListView view;
 
     public PoolListPanel(String id, IModel<? extends List<PoolSpaceBean>> model,
             boolean showCheckbox) {
@@ -38,7 +37,7 @@ public class PoolListPanel extends BasePanel {
                 RENDER, Role.ADMIN);
         add(selectBoxHeaderLabel);
         add(new LayoutHeaderPanel("PoolPanel.layoutHeaderPanel"));
-        view = new PoolBeanListView("poolPanelListview", model);
+        PoolBeanListView view = new PoolBeanListView("poolPanelListview", model);
         add(view);
     }
 
@@ -78,9 +77,5 @@ public class PoolListPanel extends BasePanel {
                     poolBean.getPercentageRemovable(),
                     poolBean.getPercentageFree()));
         }
-    }
-
-    public EvenOddListView getView() {
-        return view;
     }
 }

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/util/SelectableWrapper.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/util/SelectableWrapper.java
@@ -11,6 +11,7 @@ public class SelectableWrapper<T extends Serializable> implements Serializable {
     private static final long serialVersionUID = 2540365244546137089L;
     private T _wrapped;
     private Boolean _selected = Boolean.FALSE;
+    private boolean _pending = false;
 
     public SelectableWrapper(T wrapped) {
         _wrapped = wrapped;
@@ -30,5 +31,13 @@ public class SelectableWrapper<T extends Serializable> implements Serializable {
 
     public void setWrapped(T wrapped) {
         _wrapped = wrapped;
+    }
+
+    public void setPending(boolean pending) {
+        _pending = pending;
+    }
+
+    public boolean isPending() {
+        return _pending;
     }
 }


### PR DESCRIPTION
... command submission

This patch combines the fixes from patches 6061 and 6062, adapted to these pages which do not have auto-refresh.

See http://rb.dcache.org/r/6161 and http://rb.dcache.org/r/6162 for details.

Target: 2.6
Require-notes: yes
Require-book: no

Testing done:

As with the patches for master.
