### PR TITLE
dcache-xrootd: Upgrade to xrootd4j 1.2.1

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -810,7 +810,7 @@ public class XrootdDoor
                 flags |= kXR_readable;
             }
             if (attributes.getStorageInfo().isCreatedOnly()) {
-                flags |= kXR_opscpend;
+                flags |= kXR_poscpend;
             }
             break;
         default:

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -213,7 +213,7 @@ public class XrootdRedirectHandler extends XrootdRequestHandler
         } catch (PermissionDeniedCacheException e) {
             throw new XrootdException(kXR_NotAuthorized, e.getMessage());
         } catch (FileIsNewCacheException e) {
-            throw new XrootdException(kXR_FileLockedr, "File is locked by upload");
+            throw new XrootdException(kXR_FileLocked, "File is locked by upload");
         } catch (NotFileCacheException e) {
             throw new XrootdException(kXR_NotFile, "Not a file");
         } catch (CacheException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <version.xerces>2.9.1</version.xerces>
         <version.jetty>7.6.10.v20130312</version.jetty>
         <version.wicket>1.5.10</version.wicket>
-        <version.xrootd4j>1.2.0</version.xrootd4j>
+        <version.xrootd4j>1.2.1</version.xrootd4j>
         <version.jglobus>2.0.6-rc3.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 
@@ -590,12 +590,6 @@
                 <groupId>org.dcache</groupId>
                 <artifactId>xrootd4j-gsi</artifactId>
                 <version>${version.xrootd4j}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.dcache</groupId>
-                        <artifactId>cog-jglobus</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.dcache</groupId>


### PR DESCRIPTION
Target: trunk
Request: 2.6
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6192/
(cherry picked from commit d36ae0cc58c6a2cb99aa1ada3b4a04a62f07d1cc)

Conflicts:
    pom.xml
