### PR TITLE
srmspacemanager: catch and ignore SQL exception on error handling path w...

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
@@ -4641,7 +4641,12 @@ public final class Manager
                          *
                          */
                         if (selectWritePool.getReturnCode()!=0) {
-                                file = getFile(pnfsId);
+                                try {
+                                        file = getFile(pnfsId);
+                                } catch(SQLException ignored) {
+                                        logger.trace(ignored.getMessage());
+                                        return;
+                                }
                                 Connection connection = null;
                                 try {
                                         connection = connection_pool.getConnection();
@@ -4652,7 +4657,7 @@ public final class Manager
                                         connection = null;
                                 }
                                 catch(SQLException sqle) {
-                                        logger.error("failed to remove file {}: {}",
+                                        logger.error("Failed to nullify pnfsid of file {}: {}",
                                                      file, sqle.getMessage());
                                         if (connection!=null) {
                                                 try {
@@ -4671,7 +4676,6 @@ public final class Manager
                         }
                 }
         }
-
 
     private void forwardToPoolManager(CellMessage cellMessage)
         {


### PR DESCRIPTION
...hen processing PoolMgrSelectWritePool on reply from PoolManager

In the previous version of selectPool the srmspace file has always been
defined (even if id had no pnfsid associdated). Recent changes introduced
better separation of handling messages to PoolManager and from PoolManager.
In case of reply only error handling part is needed (nullify pnfsid of
srmspacefile record).

Ticket: 8087
Acked-by:
Request: 2.7
Require-book: no
Require-notes: no
