### PR TITLE
spacemanager: do not generate bogus error fix Already have 1 record(s) w...

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/Manager.java
@@ -5104,7 +5104,7 @@ public final class Manager
                                                            selectWritePool.getFileSize(),
                                                            lifetime,
                                                            pnfsPath,
-                                                           selectWritePool.getPnfsId());
+                                                           null);
                                 file = getFile(fileId);
                         }
                 }


### PR DESCRIPTION
...ith pnfsPath= in implicit space reservations

do not generate bogus error fix Already have 1 record(s) with pnfsPath= in implicit space reservations

Patch: http://rb.dcache.org/r/5671/
Ticket: #number
Acked-by: Gerd, Al
Request: 2.2
Require-book: no
Require-notes: yes
