### PR TITLE
srm: Fix NPE and timer thread kill when restoring jobs

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
@@ -172,7 +172,12 @@ public class SharedMemoryCacheJobStorage<J extends Job> implements JobStorage<J>
         public void run()
         {
             for (J job : jobsToExpire) {
-                job.checkExpiration();
+                try {
+                    job.checkExpiration();
+                } catch (RuntimeException e) {
+                    Thread thread = Thread.currentThread();
+                    thread.getUncaughtExceptionHandler().uncaughtException(thread, e);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes the fulling bug:

07 Nov 2013 10:11:35 (SRM-gonzo) [] Uncaught exception in thread Job expiration
java.lang.NullPointerException: null
        at org.dcache.srm.request.GetRequest.stateChanged(GetRequest.java:248) ~[srm-server-2.7.0~ndgf2.jar:2.7.0~ndgf2]
        at org.dcache.srm.request.Job.setState(Job.java:361) ~[srm-server-2.7.0~ndgf2.jar:2.7.0~ndgf2]
        at org.dcache.srm.request.Job.setState(Job.java:321) ~[srm-server-2.7.0~ndgf2.jar:2.7.0~ndgf2]
        at org.dcache.srm.request.Job.checkExpiration(Job.java:815) ~[srm-server-2.7.0~ndgf2.jar:2.7.0~ndgf2]
        at org.dcache.srm.scheduler.SharedMemoryCacheJobStorage$ExpirationTask.run(SharedMemoryCacheJobStorage.java:175) ~[srm-server-2.7.0~ndgf2.jar:2.7.0~ndgf2]
        at java.util.TimerThread.mainLoop(Timer.java:555) ~[na:1.7.0_45]
        at java.util.TimerThread.run(Timer.java:505) ~[na:1.7.0_45]

The exception kills the timer thread. This is fixed by this patch. The patch
also fixes the NPE itself. It is unknown why exactly some file requests
cannot be found in the database, but I suspect that old file requests are
removed concurrently.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.7
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6215/
(cherry picked from commit ca144ff3c6b56c0f7802f27f627f58ece3909a18)
