### PR TITLE
libs: update jglobus library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <version.jetty>7.6.10.v20130312</version.jetty>
         <version.wicket>1.5.10</version.wicket>
         <version.xrootd4j>1.2.1</version.xrootd4j>
-        <version.jglobus>2.0.6-rc3.d</version.jglobus>
+        <version.jglobus>2.0.6-rc4.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
updated library contains fix which changes a way how
CA and it's signing_policy file are processed.

Changelog for v2.0.6-rc3.d..v2.0.6-rc4.d
    \* [b3dd9f1] Make input streams buffered and close them after use
    \* [c3bfef4] issue102: fix - index caches against domain name rather than hash of encodings

GGUS: https://ggus.eu/ws/ticket_info.php?ticket=98570
Acked-by: Albert Rossi
Acked-by: Gerd Behrmann
Acked-by: Paul Millar
Target: master, 2.6, 2.7
Require-book: no
Require-notes: yes
(cherry picked from commit 01f06295dfa37fd648c3df4366401b9feafb0b61)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
