### PR TITLE
doors: Allow loginbroker property to be empty

### DIFF
--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -12,7 +12,7 @@ check -strong dcap.service.pnfsmanager
 check -strong dcap.service.gplazma
 check -strong dcap.service.billing
 check -strong dcap.service.pinmanager
-check -strong dcap.service.loginbroker
+check dcap.service.loginbroker
 check -strong dcap.service.loginbroker.update-period
 check -strong dcap.service.loginbroker.update-period.unit
 check -strong dcap.service.loginbroker.update-threshold

--- a/skel/share/services/ftp.batch
+++ b/skel/share/services/ftp.batch
@@ -12,7 +12,7 @@ check -strong ftp.net.port-range
 check -strong ftp.limits.clients
 check -strong ftp.limits.retries
 check -strong ftp.limits.streams-per-client
-check -strong ftp.service.loginbroker
+check ftp.service.loginbroker
 check -strong ftp.service.loginbroker.update-period
 check -strong ftp.service.loginbroker.update-period.unit
 check -strong ftp.service.loginbroker.update-threshold

--- a/skel/share/services/srm.batch
+++ b/skel/share/services/srm.batch
@@ -194,7 +194,7 @@ check -strong srm.service.gplazma
 check -strong srm.service.gplazma.timeout
 check -strong srm.service.gplazma.timeout.unit
 
-check -strong srm.service.loginbroker
+check srm.service.loginbroker
 check -strong srm.service.loginbroker.update-period
 check -strong srm.service.loginbroker.update-period.unit
 check -strong srm.service.loginbroker.update-threshold

--- a/skel/share/services/webdav.batch
+++ b/skel/share/services/webdav.batch
@@ -19,7 +19,7 @@ check -strong webdav.service.gplazma
 check -strong webdav.service.gplazma.timeout
 check -strong webdav.service.gplazma.timeout.unit
 check -strong webdav.service.billing
-check -strong webdav.service.loginbroker
+check webdav.service.loginbroker
 check -strong webdav.service.loginbroker.update-period
 check -strong webdav.service.loginbroker.update-period.unit
 check -strong webdav.service.loginbroker.update-threshold

--- a/skel/share/services/xrootd.batch
+++ b/skel/share/services/xrootd.batch
@@ -23,7 +23,7 @@ check -strong xrootd.service.gplazma
 check -strong xrootd.service.gplazma.timeout
 check -strong xrootd.service.gplazma.timeout.unit
 check -strong xrootd.service.billing
-check -strong xrootd.service.loginbroker
+check xrootd.service.loginbroker
 check -strong xrootd.service.loginbroker.update-period
 check -strong xrootd.service.loginbroker.update-period.unit
 check -strong xrootd.service.loginbroker.update-threshold


### PR DESCRIPTION
It should be possible to not register with any loginbroker.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.7
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/6219/
(cherry picked from commit eb26c213d4ae019eca7bed9c02d30c19c746b1bd)
