### PR TITLE
info-provider: Fix regression caused by info-provider using a deprecated...

### DIFF
--- a/skel/sbin/dcache-info-provider
+++ b/skel/sbin/dcache-info-provider
@@ -75,7 +75,7 @@ EOF
 xsltProcessor="$(getProperty info-provider.processor)"
 xylophoneXMLFile="$(getProperty info-provider.configuration.location)"
 host="$(getProperty info-provider.http.host)"
-port="$(getProperty httpdPort)"
+port="$(getProperty info-provider.http.port)"
 xylophoneXSLTDir="$(getProperty info-provider.xylophone.dir)"
 saxonDir="$(getProperty info-provider.saxon.dir)"
 
@@ -85,11 +85,11 @@ if [ -n "$XSLT_PROCESSOR" ]; then
 fi
 
 if [ -n "$HTTP_HOST" ]; then
-    httpHost=$HTTP_HOST
+    host=$HTTP_HOST
 fi
 
 if [ -n "$HTTP_PORT" ]; then
-    httpPort=$HTTP_PORT
+    port=$HTTP_PORT
 fi
 
 

--- a/skel/share/defaults/info-provider.properties
+++ b/skel/share/defaults/info-provider.properties
@@ -165,9 +165,15 @@ info-provider.paths.tape-info=${dcache.paths.share}/xml/tape-info-empty.xml
 #
 #   The name of the machine that is running the dCache web server.
 #   This is used to build the URI for fetching dCache's current state.
-#   The port is defined elsewhere as httpdPort property.
 #
 info-provider.http.host = localhost
+
+#  ---- Port on which the web service runs
+#
+#   The TCP port the dCache web server is running on. This is used to
+#   build the URI for fetching dCache's current state.
+#
+info-provider.http.port = ${httpd.net.port}
 
 #  ---- The GLUE versions that are published
 #


### PR DESCRIPTION
... property

Introduces the new property 'info-provider.http.port', which defines
the TCP port the info-provider will contact the httpd service on.

Sites that previously relied on redefining httpdPort will have to
set this new info-provider property.

Also fixed a bug that caused the HTTP_PORT and HTTP_HOST environment
variables to be ignored by the info-provider.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.7
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6217/
(cherry picked from commit a16d3ebcb5e9afb25d538bdd8a573c393d9f583f)
