### PR TITLE
srm: Fix regression in srmGetSpaceMetaData

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/ReturnStatuses.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/ReturnStatuses.java
@@ -57,7 +57,9 @@ public class ReturnStatuses
         boolean hasFailure = false;
         boolean hasSuccess = false;
         for (TMetaDataSpace metaDataSpace : metadataSpaces) {
-            if (metaDataSpace.getStatus().getStatusCode() == TStatusCode.SRM_SUCCESS) {
+            if (metaDataSpace.getStatus().getStatusCode() == TStatusCode.SRM_SUCCESS ||
+                    metaDataSpace.getStatus().getStatusCode() == TStatusCode.SRM_SPACE_LIFETIME_EXPIRED ||
+                    metaDataSpace.getStatus().getStatusCode() == TStatusCode.SRM_EXCEED_ALLOCATION) {
                 hasSuccess = true;
             } else {
                 hasFailure = true;


### PR DESCRIPTION
The spec is not precise about what file requests level statuses should
be considered a non-success return code for the srmGetSpaceMetaData
operation itself. It seems however logical to not consider
space-lifetime-expired and exceeded-allocation as failures of the
getSpaceMetaData operation.

Atlas transfers currently fail at NDGF due to this problem.

Target: trunk
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6218/
(cherry picked from commit 264ebd20e480b63e1eb0c470efe8774069470cb6)
