### PR TITLE
info-provider: Fix publishing of SRM

### DIFF
--- a/skel/share/info-provider/glue-1.3-defn.xml
+++ b/skel/share/info-provider/glue-1.3-defn.xml
@@ -63,7 +63,7 @@
                   select="/d:dCache/d:doors/d:door"
                   classes="GlueSETop GlueSEAccessProtocol GlueKey GlueSchemaVersion">
             <!-- Never publish SRM here -->
-            <suppress test="SRM">
+            <suppress test="srm">
               <lookup path="d:protocol/d:metric[@name='family']"/>
             </suppress>
 
@@ -106,7 +106,7 @@
                   select-mode="default-suppress"
                   classes="GlueSETop GlueSEControlProtocol GlueKey GlueSchemaVersion">
             <!-- Only publish the SRM door here -->
-            <allow test="SRM">
+            <allow test="srm">
               <lookup path="d:protocol/d:metric[@name='family']"/>
             </allow>
 

--- a/skel/share/info-provider/glue-2.0-defn.xml
+++ b/skel/share/info-provider/glue-2.0-defn.xml
@@ -380,7 +380,7 @@
                   select="/d:dCache/d:doors/d:door"
                   classes="GLUE2StorageAccessProtocol">
 
-            <suppress test="SRM">
+            <suppress test="srm">
               <lookup path="d:protocol/d:metric[@name='family']"/>
             </suppress>
 
@@ -450,7 +450,7 @@
 
             <choose>
               <optionally>
-                <when test="SRM">
+                <when test="srm">
                   <lookup path="d:protocol/d:metric[@name='family']"/>
                 </when>
                 <attr name="GLUE2EndpointInterfaceVersion">2.2</attr>


### PR DESCRIPTION
When srm-loginbroker was removed as a service, publishing the
srm to loginbroker was altered to publish the family name as
'srm' rather than 'SRM'. This is in line with our other doors,
but I was unaware that info-provider checks for this particular
string and that the check is case sensitive.

This patch updates info-provider to check for the lower case
string.

Target: trunk
Request: 2.7
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6222/
(cherry picked from commit 74a070b89280c79f5aa45ed8df253e58b604141f)
