### PR TITLE
srm: Improve error message on file_busy and duplication_errors

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/PutCompanion.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/PutCompanion.java
@@ -312,10 +312,9 @@ public final class PutCompanion extends AbstractMessageCallback<PnfsMessage>
 
     private void fileExists(PnfsMapPathMessage message) {
 
-        if(!overwrite) {
-            String errorString = String.format("file/directory %s exists, overwrite is not allowed ",path);
-            _log.debug(errorString);
-            callbacks.DuplicationError(errorString);
+        if (!overwrite) {
+            _log.debug("Path exists and overwrite is not permitted: {}", path);
+            callbacks.DuplicationError("SURL refers to an existing SURL and overwriting is not permitted.");
             return;
         }
         //

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
@@ -347,7 +347,7 @@ public final class BringOnlineFileRequest extends FileRequest<BringOnlineRequest
                 // [ SRM 2.2, 5.4.3] SRM_FILE_BUSY: client requests for a file which there is an
                 // active srmPrepareToPut (no srmPutDone is yet called) request for.
                 if (SRM.getSRM().isFileBusy(surl)) {
-                    setStateAndStatusCode(State.FAILED, "The requested SURL is being used by another client.",
+                    setStateAndStatusCode(State.FAILED, "The requested SURL is locked by an upload.",
                             TStatusCode.SRM_FILE_BUSY);
                 }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
@@ -383,7 +383,7 @@ public final class GetFileRequest extends FileRequest<GetRequest> {
                 // [ SRM 2.2, 5.1.3] SRM_FILE_BUSY: client requests for a file which there is an
                 // active srmPrepareToPut (no srmPutDone is yet called) request for.
                 if (SRM.getSRM().isFileBusy(surl)) {
-                    setStateAndStatusCode(State.FAILED, "The requested SURL is being used by another client.",
+                    setStateAndStatusCode(State.FAILED, "The requested SURL is locked by an upload.",
                             TStatusCode.SRM_FILE_BUSY);
                     return;
                 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/LsFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/LsFileRequest.java
@@ -184,7 +184,7 @@ public final class LsFileRequest extends FileRequest<LsRequest> {
                                 metaDataPathDetail.setType(TFileType.FILE);
                             }
                             metaDataPathDetail.setStatus(new TReturnStatus(TStatusCode.SRM_FILE_BUSY,
-                                    "The requested SURL is being used by another client."));
+                                    "The requested SURL is locked by an upload."));
                         } else {
                             metaDataPathDetail =
                                     getMetaDataPathDetail(surl,

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
@@ -389,12 +389,12 @@ public final class PutFileRequest extends FileRequest<PutRequest> {
                         if (!getContainerRequest().isOverwrite()) {
                             setStateAndStatusCode(
                                     State.FAILED,
-                                    "SURL exists already",
+                                    "The requested SURL is locked by another upload.",
                                     TStatusCode.SRM_DUPLICATION_ERROR);
                         } else {
                             setStateAndStatusCode(
                                     State.FAILED,
-                                    "The requested file is being used by another client.",
+                                    "The requested SURL is locked by another upload.",
                                     TStatusCode.SRM_FILE_BUSY);
                         }
                         return;


### PR DESCRIPTION
I think these messages are more to the point. The duplication error
message is taken from the SRM spec.

Target: trunk
Request: 2.7
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6223/
(cherry picked from commit 90996939d7cc3bf37f8509e78c0ed54b26db930c)
