### PR TITLE
xrootd: Fix regression in GSI support

### DIFF
--- a/skel/share/defaults/xrootd-gsi.properties
+++ b/skel/share/defaults/xrootd-gsi.properties
@@ -10,6 +10,8 @@
 xrootd.gsi.hostcert.key=${grid.hostcert.key}
 xrootd.gsi.hostcert.cert=${grid.hostcert.cert}
 xrootd.gsi.hostcert.refresh=${grid.hostcert.refresh}
+(immutable)xrootd.gsi.hostcert.refresh.unit=SECONDS
 xrootd.gsi.hostcert.verify=${grid.hostcert.verify}
 xrootd.gsi.ca.path=${grid.ca.path}
 xrootd.gsi.ca.refresh=${grid.ca.refresh}
+(immutable)xrootd.gsi.ca.refresh.unit=SECONDS


### PR DESCRIPTION
xrootd4j 1.2.1 requires the unit of the time values in
configuration properties to be defined. Otherwise the
GSI plugin fails to start up.

Target: 2.6
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6229/
