### PR TITLE
xrootd: Upgrade to xrootd4j 1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <version.xerces>2.9.1</version.xerces>
         <version.jetty>8.1.13.v20130916</version.jetty>
         <version.wicket>6.9.1</version.wicket>
-        <version.xrootd4j>1.2.1</version.xrootd4j>
+        <version.xrootd4j>1.2.2</version.xrootd4j>
         <version.jglobus>2.0.6-rc4.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 


### PR DESCRIPTION
Fixes compatibility issues with xrootd plugins.

Target: trunk
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6233
(cherry picked from commit 9904943dcd20692379e4408a977ee78532813b3a)
