### PR TITLE
billing: Fix compression of error files

### DIFF
--- a/skel/man/man8/dcache-billing-indexer.8
+++ b/skel/man/man8/dcache-billing-indexer.8
@@ -38,11 +38,11 @@ same billing entry.
 (Re)index all billing files.
 
 .TP
-\fB-compress FILE\fR
+\fB-compress FILE...\fR
 Compress \fBFILE\fR.
 
 .TP
-\fB-decompress FILE
+\fB-decompress FILE...\fR
 Decompress \fBFILE\fR.
 
 .TP
@@ -52,7 +52,7 @@ path, pnfsid, dn and path prefixes of those. Optionally output names
 of billing files that might contain the search term.
 
 .TP
-\fB-index [-fpp=PROP] FILE\fR
+\fB-index [-fpp=PROP] FILE...\fR
 Create index for FILE.
 
 .TP


### PR DESCRIPTION
The billing indexer forgot to compress error files as part of the
nightly run.

I also added support for multi-argument invocation for several
commands.

Target: trunk
Request: 2.7
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6235/
(cherry picked from commit b8907ec8711533530c38cc6a1736289c6a70b6bd)
