### PR TITLE
(2.7) dcache-webadmin: remove autorefresh on pages with ListViews

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfers.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfers.java
@@ -27,13 +27,6 @@ public class ActiveTransfers extends SortableBasePage {
     private List<SelectableWrapper<ActiveTransfersBean>> _transfers;
 
     /*
-     * set to false when using the Junit FormTester; otherwise, the autorefreshing
-     * form produces incorrect results
-     */
-
-    public static boolean autorefresh = true;
-
-    /*
      * necessary so that submit uses the current list instance
      */
     private boolean submitFormCalled = false;
@@ -63,9 +56,6 @@ public class ActiveTransfers extends SortableBasePage {
                         new PropertyModel(this, "_transfers"));
         panel.setActiveTransfersPage(this);
         activeTransfersForm.add(panel);
-        if (autorefresh) {
-            addAutoRefreshToForm(activeTransfersForm, 1, TimeUnit.MINUTES);
-        }
         add(activeTransfersForm);
     }
 

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/cellservices/CellServices.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/cellservices/CellServices.java
@@ -24,7 +24,7 @@ public class CellServices extends SortableBasePage {
     private static final Logger _log = LoggerFactory.getLogger(CellServices.class);
 
     public CellServices() {
-        Form<?> form = getAutoRefreshingForm("cellServicesForm");
+        Form<?> form = new Form<Void>("cellServicesForm");
         form.add(new FeedbackPanel("feedback"));
         CellServicesPanel cellServicesPanel = new CellServicesPanel("cellServicesPanel",
                 new PropertyModel(this, "cellBeans"));

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.java
@@ -49,7 +49,7 @@ public class PoolAdmin extends SortableBasePage implements AuthenticatedWebPage 
     }
 
     private void addMarkup() {
-        Form<?> poolAdminForm = getAutoRefreshingForm("poolAdminForm");
+        Form<?> poolAdminForm = new Form<Void>("poolAdminForm");
         poolAdminForm.add(new FeedbackPanel("feedback"));
         TextField<Object> commandInput = new TextField<>("commandText",
                 new PropertyModel<>(this, "_command"));

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.java
@@ -57,7 +57,7 @@ public class PoolGroupView extends SortableBasePage {
     }
 
     private void addMarkup() {
-        Form poolGroups = getAutoRefreshingForm("poolGroupsForm");
+        Form poolGroups = new Form<Void>("poolGroupsForm");
         poolGroups.add(new FeedbackPanel("feedback"));
         poolGroups.add(new LayoutHeaderPanel("layoutHeaderPanel"));
         poolGroups.add(createListview());

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.pools.PoolV2Mode;
 
@@ -39,12 +38,6 @@ public class PoolList extends SortableBasePage {
     private static final Logger _log = LoggerFactory.getLogger(PoolList.class);
 
     /*
-     * set to false when using the Junit FormTester; otherwise, the autorefreshing
-     * form produces incorrect results
-     */
-    public static boolean autorefresh = true;
-
-    /*
      * necessary so that submit uses the current list instance
      */
     private boolean submitFormCalled = false;
@@ -58,9 +51,6 @@ public class PoolList extends SortableBasePage {
                 new PropertyModel(this, "_poolBeans"), true);
         poolListPanel.setPoolListPage(this);
         poolUsageForm.add(poolListPanel);
-        if (autorefresh) {
-            addAutoRefreshToForm(poolUsageForm, 1, TimeUnit.MINUTES);
-        }
         add(poolUsageForm);
     }
 

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolqueues/PoolQueues.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolqueues/PoolQueues.java
@@ -27,7 +27,7 @@ public class PoolQueues extends SortableBasePage {
     private static final long serialVersionUID = -6482302256752371950L;
 
     public PoolQueues() {
-        Form<?> form = getAutoRefreshingForm("poolQueuesForm");
+        Form<?> form = new Form<Void>("poolQueuesForm");
         form.add(new PoolQueuesPanel("poolQueuesPanel",
                         new PropertyModel<PoolGroupBean>(this, "allPoolsGroup")));
         add(form);

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.java
@@ -38,7 +38,7 @@ public class SpaceTokens extends SortableBasePage {
     }
 
     private void createMarkup() {
-        Form<?> form = getAutoRefreshingForm("spaceTokensForm");
+        Form<?> form = new Form<Void>("spaceTokensForm");
         form.add(new FeedbackPanel("feedback"));
         form.add(new LinkGroupListView("linkGroupView", new PropertyModel(this,
                 "tokenInfo")));

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.java
@@ -27,7 +27,7 @@ public class TapeTransferQueue extends SortableBasePage {
     private static final Logger _log = LoggerFactory.getLogger(TapeTransferQueue.class);
 
     public TapeTransferQueue() {
-        Form<?> form = getAutoRefreshingForm("tapeTransferQueueForm");
+        Form<?> form = new Form<Void>("tapeTransferQueueForm");
         form.add(new FeedbackPanel("feedback"));
         ListView<RestoreBean> listview =
                 new EvenOddListView<RestoreBean>("TapeTransferQueueListview",

--- a/modules/dcache-webadmin/src/test/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfersTest.java
+++ b/modules/dcache-webadmin/src/test/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfersTest.java
@@ -29,7 +29,6 @@ public class ActiveTransfersTest {
         _activeTransfersService = new StandardActiveTransfersService(daoFactory);
         authenticatedWebApp.setActiveTransfersService(_activeTransfersService);
         _tester = new WicketTester(authenticatedWebApp);
-        ActiveTransfers.autorefresh = false;
         _tester.startPage(ActiveTransfers.class);
     }
 

--- a/modules/dcache-webadmin/src/test/java/org/dcache/webadmin/view/pages/poollist/PoolListTest.java
+++ b/modules/dcache-webadmin/src/test/java/org/dcache/webadmin/view/pages/poollist/PoolListTest.java
@@ -42,7 +42,6 @@ public class PoolListTest {
         _poolSpaceService = new StandardPoolSpaceService(daoFactory);
         authenticatedWebApp.setPoolSpaceService(_poolSpaceService);
         _tester = new WicketTester(authenticatedWebApp);
-        PoolList.autorefresh = false;
         _tester.startPage(PoolList.class);
     }
 


### PR DESCRIPTION
The introduction of autorefresh (the addition of the AjaxSelfUpdatingTimerBehavior) to the Forms on pages containing ListViews that also have javascript sort and search functions associated with their headers has introduced a bug which manifests itself as the disappearance, after refresh, of the search boxes in the header and the inability to sort by clicking on the column title.

After some investigation, it seems that this has to do with the way Wicket handles Ajax requests.

I have not found a way to get this cocktail of javascript, Wicket and Ajax to play correctly for the "repeater" (ListView) classes.  The Alarms page uses a different component, the DataTable, which does not have this issue.  Changing all the ListViews that need to be refreshed into DataTables would be rather invasive, however, so for 2.7 I have decided simply to revert to no autorefresh for these pages, making 2.7 essentially equivalent to 2.6.

I plan to make the component substitution for DataTables in master.

Testing: Redeployed instance behaves as 2.6 (the refreshed data must be obtained by clicking on the navigation link or reloading the page).

Target: 2.7
Patch: http://rb.dcache.org/r/6230/
Require-notes: no
Require-book: no
Acked-by: Gerd
