### PR TITLE
correcting IoMode check for SEEK_AND_WRITE

### DIFF
--- a/modules/dcache-dcap/src/main/java/org/dcache/pool/movers/DCapProtocol_3_nio.java
+++ b/modules/dcache-dcap/src/main/java/org/dcache/pool/movers/DCapProtocol_3_nio.java
@@ -611,7 +611,7 @@ public class DCapProtocol_3_nio implements MoverProtocol, ChecksumMover {
                         _log.error(errmsg);
                         cntOut.writeACK(DCapConstants.IOCMD_SEEK_AND_WRITE, CacheException.ERROR_IO_DISK, errmsg);
                         socketChannel.write(cntOut.buffer());
-                    } else if (access == IoMode.WRITE) {
+                    } else if (access != IoMode.WRITE) {
                         String errmsg = "SEEK_AND_WRITE denied (not allowed)";
                         _log.error(errmsg);
                         cntOut.writeACK(DCapConstants.IOCMD_SEEK_AND_WRITE, CacheException.ERROR_IO_DISK, errmsg);


### PR DESCRIPTION
as discussed in ticket #8105 this corrects the IoMode check for the SEEK_AND_WRITE command in the dcap module
