### PR TITLE
ssh2: fix int overflow with timeout

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -220,8 +220,11 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
     }
 
     private void startServer() {
-        long effectiveTimeout = _idleTimeoutUnit.toMillis(_idleTimeout > 0? _idleTimeout : Long.MAX_VALUE);
-        _server.getProperties().put(SshServer.IDLE_TIMEOUT, Long.toString(effectiveTimeout));
+        // MINA SSH uses int to store timeout. Strip the long valued to max int if required.
+        int effectiveTimeout = (int)Math.min((long)Integer.MAX_VALUE,
+                _idleTimeoutUnit.toMillis(_idleTimeout > 0? _idleTimeout : Long.MAX_VALUE));
+
+        _server.getProperties().put(SshServer.IDLE_TIMEOUT, Integer.toString(effectiveTimeout));
         _server.setPort(_port);
         _server.setHost(_host);
 


### PR DESCRIPTION
As mina sshd used int as timeout value, max long
converted into negative number and ignored.

Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit 8608b98be3206351acda3a8e4389b072f2df089e)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
