### PR TITLE
info-provider: Fix regression in publishing GlueServiceEndpoint

### DIFF
--- a/skel/share/info-provider/glue-1.3-defn.xml
+++ b/skel/share/info-provider/glue-1.3-defn.xml
@@ -933,7 +933,7 @@
                 classes="GlueTop GlueKey GlueSchemaVersion GlueService">
 
           <!-- Publish only SRM door here -->
-          <allow test="SRM">
+          <allow test="srm">
             <lookup path="d:protocol/d:metric[@name='family']"/>
           </allow>
 


### PR DESCRIPTION
Target: trunk
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6246/
(cherry picked from commit fb55fb8498c16a7353d1e3a6169d5ac31058ca7f)
