### PR TITLE
srm-client: fix building of tagged RPMs

### DIFF
--- a/modules/srm-client/pom.xml
+++ b/modules/srm-client/pom.xml
@@ -121,6 +121,7 @@
                                     <value>${project.version}</value>
                                     <regex>-</regex>
                                     <replacement />
+                                    <failIfNoMatch>false</failIfNoMatch>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
The master and 2.7 branches contain code to build the srm-client RPMs when
dCache has a "-SNAPSHOT" in the version (e.g., "2.7.0-SNAPSHOT").  The "-"
is illegal in the RPM name and the build-helper maven plugin is used to
remove it (to "2.7.0SNAPSHOT").

Tagged versions of dCache code do not contain the "-SNAPSHOT", so
the regexp in the build-helper maven plugin has nothing to replace.
Unfortunately, a failure to match results in the build process failing.

This patch fixes the problem by making the replacement optional.

Target: master
Request: 2.7
Requires-notes: no
Requires-book: no
Patch: http://rb.dcache.org/r/6242/
Acked-by: Gerd Behrmann
