### PR TITLE
pool: Fix -sticky option in migration module

### DIFF
--- a/modules/cells/src/main/java/dmg/util/command/AnnotatedCommandExecutor.java
+++ b/modules/cells/src/main/java/dmg/util/command/AnnotatedCommandExecutor.java
@@ -574,7 +574,9 @@ public class AnnotatedCommandExecutor implements CommandExecutor
             if (!values.isEmpty()) {
                 List<String> fragments = Lists.newArrayList();
                 for (String value: values) {
-                    addAll(fragments, _splitter.split(value));
+                    if (!value.isEmpty()) {
+                        addAll(fragments, _splitter.split(value));
+                    }
                 }
                 return toArray(transform(fragments, _typeConverter),
                         (Class) _field.getType().getComponentType());


### PR DESCRIPTION
Addresses a regression that causes the -sticky option when
used without a value to not match any files.

The issue was that the empty value of a multi-valued option
was translated to an array with the empty string rather than
the empty array.

Target: trunk
Request: 2.7
Request: 2.6
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8108
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6247/
(cherry picked from commit 7c34310cd369f602258757318ce4dffb970fdb71)
