### PR TITLE
billing: Add shebang header to indexer cronjob

### DIFF
--- a/packages/fhs/src/main/deb/dcache.cron.daily
+++ b/packages/fhs/src/main/deb/dcache.cron.daily
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 /usr/sbin/dcache-billing-indexer -yesterday -compress


### PR DESCRIPTION
Addresses an issue with the billing indexer cronjob, that
prevented it from being executed.

Target: trunk
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6249/
(cherry picked from commit d73114fca0cf47942b68a275de296e3b6d5fc3c3)
