### PR TITLE
dcap: separate protocol name and client ip in DCapProtocolInfo#toString(...

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/DCapProtocolInfo.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/DCapProtocolInfo.java
@@ -89,7 +89,7 @@ public class DCapProtocolInfo implements IpProtocolInfo {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append(getVersionString());
+        sb.append(getVersionString()).append(',');
         sb.append(_addr.getAddress().getHostAddress());
         sb.append(":").append(_addr.getPort());
 


### PR DESCRIPTION
...)

from
   DCap-3.0141.34.224.41:20009
to
   DCap-3.0,141.34.224.41:20009

Acked-by: Paul Millar
Target: master, 2.6, 2.7
Require-book: no
Require-notes: no
(cherry picked from commit 63ff338551f77e709f43fd3ea38a5fee1cf7a87c)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
