### PR TITLE
chimera: compact hadles passed to NFS server

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInodeType.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInodeType.java
@@ -18,14 +18,33 @@ package org.dcache.chimera;
 
 public enum FsInodeType {
 
-    INODE, // regular inode
-    TAG, // the content of the inode is a directory tag
-    TAGS, // the content of the inode is a list of a directory tags
-    ID, // the content of the inode is the id of the inode
-    PATHOF, // the content of the inode is the absolute path of the inode
-    PARENT, // the content of the inode is the of the parent inode
-    NAMEOF, // the content of the inode is the name of the inode
-    PGET, // the content of the inode is the value of requested attributes
-    PSET, // by updating mtime of the inode the the defined attribute value is updated
-    CONST    // the content of the inode is a free form information
+    INODE(0),    // regular inode
+    TAG(1),      // the content of the inode is a directory tag
+    TAGS(2),     // the content of the inode is a list of a directory tags
+    ID(3),       // the content of the inode is the id of the inode
+    PATHOF(4),   // the content of the inode is the absolute path of the inode
+    PARENT(5),   // the content of the inode is the of the parent inode
+    NAMEOF(6),   // the content of the inode is the name of the inode
+    PGET(7),     // the content of the inode is the value of requested attributes
+    PSET(8),     // by updating mtime of the inode the the defined attribute value is updated
+    CONST(9);    // the content of the inode is a free form information
+
+    private final int _id;
+
+    private FsInodeType(int id) {
+        _id = id;
+    }
+
+    public int getType() {
+        return _id;
+    }
+
+    public static FsInodeType valueOf(int id) {
+        for (FsInodeType type : FsInodeType.values()) {
+            if (type.getType() == id) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("No such type: " + id);
+    }
 }

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_CONST.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_CONST.java
@@ -16,6 +16,7 @@
  */
 package org.dcache.chimera;
 
+import com.google.common.base.Charsets;
 import org.dcache.chimera.posix.Stat;
 
 public class FsInode_CONST extends FsInode {
@@ -23,12 +24,12 @@ public class FsInode_CONST extends FsInode {
     private static final String _title = "\n >> Chimera FS Engine Version 0.0.9 $Rev: 897 $ << \n";
     private final byte[] _version;
 
-    public FsInode_CONST(FileSystemProvider fs, String cnst) {
-        super(fs, cnst, FsInodeType.CONST);
+    public FsInode_CONST(FileSystemProvider fs, String id) {
+        super(fs, id, FsInodeType.CONST);
         StringBuilder sb = new StringBuilder(_title);
         sb.append("\n").append(_fs.getInfo()).append("\n");
 
-        _version = sb.toString().getBytes();
+        _version = sb.toString().getBytes(Charsets.UTF_8);
     }
 
     @Override

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PGET.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PGET.java
@@ -16,6 +16,7 @@
  */
 package org.dcache.chimera;
 
+import com.google.common.base.Charsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -108,24 +109,18 @@ public class FsInode_PGET extends FsInode {
     }
 
     @Override
-    public String toFullString() {
+    public byte[] getIdentifier() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(_fs.getFsId())
-          .append(":")
-          .append(type())
-          .append(":")
-          .append(_id);
-
-        if (_name != null) {
-            sb.append(":").append(_name);
+        if(_name != null) {
+            sb.append(_name).append(':');
         }
 
         for (String arg : _metadata.keySet()) {
-            sb.append(":").append(arg);
+            sb.append(arg).append(':');
         }
 
-        return sb.toString();
+        return byteBase(sb.toString().getBytes(Charsets.UTF_8));
     }
 
     @Override

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PSET.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PSET.java
@@ -16,6 +16,7 @@
  */
 package org.dcache.chimera;
 
+import com.google.common.base.Charsets;
 import java.util.Arrays;
 
 import org.dcache.chimera.posix.Stat;
@@ -96,16 +97,14 @@ public class FsInode_PSET extends FsInode {
     }
 
     @Override
-    public String toFullString() {
+    public byte[] getIdentifier() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(_fs.getFsId()).append(":").append(type()).append(":").append(_id);
-
         for (String arg : _args) {
-            sb.append(":").append(arg);
+            sb.append(arg).append(':');
         }
 
-        return sb.toString();
+        return byteBase(sb.toString().getBytes(Charsets.UTF_8));
     }
 
     @Override

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_TAG.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_TAG.java
@@ -16,6 +16,7 @@
  */
 package org.dcache.chimera;
 
+import com.google.common.base.Charsets;
 import org.dcache.chimera.posix.Stat;
 
 public class FsInode_TAG extends FsInode {
@@ -90,8 +91,8 @@ public class FsInode_TAG extends FsInode {
     }
 
     @Override
-    public String toFullString() {
-        return _fs.getFsId() + ":" + type() + ":" + _id + ":" + _tag;
+    public byte[] getIdentifier() {
+        return byteBase(_tag.getBytes(Charsets.UTF_8));
     }
 
 

--- a/modules/chimera/src/main/java/org/dcache/chimera/InodeId.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/InodeId.java
@@ -56,4 +56,35 @@ public class InodeId {
         long hi = 1L << (digits * 4);
         return Long.toHexString(hi | (val & (hi - 1))).substring(1);
     }
+
+    public static byte[] hexStringToByteArray(String id) {
+
+        if (id.length() % 2 != 0) {
+            throw new IllegalArgumentException("The string needs to be even-length: " + id);
+        }
+
+        int len = id.length() / 2;
+        byte[] bytes = new byte[len];
+
+        for (int i = 0; i < len; i++) {
+            final int charIndex = i * 2;
+            final int d0 = toDigit(id.charAt(charIndex));
+            final int d1 = toDigit(id.charAt(charIndex + 1));
+            bytes[i] = (byte) ((d0 << 4) + d1);
+        }
+        return bytes;
+    }
+
+    private static int toDigit(char ch) throws NumberFormatException {
+        if (ch >= '0' && ch <= '9') {
+            return ch - '0';
+        }
+        if (ch >= 'A' && ch <= 'F') {
+            return ch - 'A' + 10;
+        }
+        if (ch >= 'a' && ch <= 'f') {
+            return ch - 'a' + 10;
+        }
+        throw new NumberFormatException("illegal character '" + ch + "'");
+    }
 }

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -25,6 +25,7 @@ import javax.sql.DataSource;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -61,6 +62,11 @@ public class JdbcFs implements FileSystemProvider {
     static private final int LEVELS_NUMBER = 7;
     private final FsInode _rootInode;
     private final String _wormID;
+
+    /**
+     * minimal binary handle size which can be processed.
+    */
+    private final static int MIN_HANDLE_LEN = 4;
     /**
      * SQL query engine
      */
@@ -991,7 +997,7 @@ public class JdbcFs implements FileSystemProvider {
                 if (cmd.length != 2) {
                     throw new FileNotFoundHimeraFsException(name);
                 }
-                FsInode constInode = new FsInode_CONST(this, cmd[1]);
+                FsInode constInode = new FsInode_CONST(this, parent.toString());
                 if (!constInode.exists()) {
                     throw new FileNotFoundHimeraFsException(name);
                 }
@@ -2678,9 +2684,142 @@ public class JdbcFs implements FileSystemProvider {
         }
     }
 
+    private final static byte[] FH_V0_BIN = new byte[] {0x30, 0x30, 0x30, 0x30};
+    private final static byte[] FH_V0_REG = new byte[]{0x30, 0x3a};
+    private final static byte[] FH_V0_PFS = new byte[]{0x32, 0x35, 0x35, 0x3a};
+
+    private static boolean arrayStartsWith(byte[] a1, byte[] a2) {
+        if (a1.length < a2.length) {
+            return false;
+        }
+        for (int i = 0; i < a2.length; i++) {
+            if (a1[i] != a2[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public FsInode inodeFromBytes(byte[] handle) throws ChimeraFsException {
 
+        if (arrayStartsWith(handle, FH_V0_REG) || arrayStartsWith(handle, FH_V0_PFS)) {
+            return inodeFromBytesOld(handle);
+        } else if (arrayStartsWith(handle, FH_V0_BIN)) {
+            return inodeFromBytesNew(InodeId.hexStringToByteArray(new String(handle)));
+        } else {
+            return inodeFromBytesNew(handle);
+        }
+    }
+
+    private final static char[] HEX = new char[]{
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    };
+
+    /**
+     * Returns a hexadecimal representation of given byte array.
+     *
+     * @param bytes whose string representation to return
+     * @return a string representation of <tt>bytes</tt>
+     */
+    public static String toHexString(byte[] bytes) {
+
+        char[] chars = new char[bytes.length * 2];
+        int p = 0;
+        for (byte b : bytes) {
+            int i = b & 0xff;
+            chars[p++] = HEX[i / 16];
+            chars[p++] = HEX[i % 16];
+        }
+        return new String(chars);
+    }
+
+    private String[] getArgs(byte[] bytes) {
+
+        StringTokenizer st = new StringTokenizer(new String(bytes), "[:]");
+        int argc = st.countTokens();
+        String[] args = new String[argc];
+        for (int i = 0; i < argc; i++) {
+            args[i] = st.nextToken();
+        }
+
+        return args;
+    }
+
+    FsInode inodeFromBytesNew(byte[] handle) throws ChimeraFsException {
+
+        FsInode inode;
+
+        if (handle.length < MIN_HANDLE_LEN) {
+            throw new FileNotFoundHimeraFsException("File handle too short");
+        }
+
+        ByteBuffer b = ByteBuffer.wrap(handle);
+        int fsid = b.get();
+        int type = b.get();
+        int idLen = b.get();
+        byte[] id = new byte[idLen];
+        b.get(id);
+        int opaqueLen = b.get();
+        if (opaqueLen > b.remaining()) {
+            throw new FileNotFoundHimeraFsException("Bad Opaque len");
+        }
+
+        byte[] opaque = new byte[opaqueLen];
+        b.get(opaque);
+
+        FsInodeType inodeType = FsInodeType.valueOf(type);
+        String inodeId = toHexString(id);
+
+        switch (inodeType) {
+            case INODE:
+                int level = Integer.parseInt( new String(opaque));
+                inode = new FsInode(this, inodeId, level);
+                break;
+
+            case ID:
+                inode = new FsInode_ID(this, inodeId);
+                break;
+
+            case TAGS:
+                inode = new FsInode_TAGS(this, inodeId);
+                break;
+
+            case TAG:
+                String tag = new String(opaque);
+                inode = new FsInode_TAG(this, inodeId, tag);
+                break;
+
+            case NAMEOF:
+                inode = new FsInode_NAMEOF(this, inodeId);
+                break;
+            case PARENT:
+                inode = new FsInode_PARENT(this, inodeId);
+                break;
+
+            case PATHOF:
+                inode = new FsInode_PATHOF(this, inodeId);
+                break;
+
+            case CONST:
+                inode = new FsInode_CONST(this, inodeId);
+                break;
+
+            case PSET:
+                inode = new FsInode_PSET(this, inodeId, getArgs(opaque));
+                break;
+
+            case PGET:
+                inode = getPGET(inodeId, getArgs(opaque));
+                break;
+            default:
+                throw new FileNotFoundHimeraFsException("Unsupported file handle type: " + inodeType);
+        }
+        return inode;
+    }
+
+    FsInode inodeFromBytesOld(byte[] handle) throws ChimeraFsException {
         FsInode inode = null;
 
         String strHandle = new String(handle);
@@ -2783,7 +2922,7 @@ public class JdbcFs implements FileSystemProvider {
 
     @Override
     public byte[] inodeToBytes(FsInode inode) throws ChimeraFsException {
-        return inode.toFullString().getBytes();
+        return inode.getIdentifier();
     }
 
     /**

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -1,5 +1,6 @@
 package org.dcache.chimera;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.junit.Ignore;
@@ -918,5 +919,17 @@ public class BasicTest extends ChimeraTestCaseHelper {
         _fs.setInodeAttributes(tagInode, 0, stat);
 
         assertEquals(baseStat, base.stat());
+    }
+
+    @Test
+    public void testBackwardCompatibility() throws Exception {
+
+        byte[] oldId = "0:TAG:0000DA875B38D9E0461F9ADFEA7C7422A956:somelongtagname".getBytes(Charsets.UTF_8);
+        final FsInode inodeWithOldId = _fs.inodeFromBytes(oldId);
+        byte[] newId = inodeWithOldId.getIdentifier();
+        final FsInode inodeWithNewId = _fs.inodeFromBytes(newId);
+
+        assertTrue(newId.length < oldId.length);
+        assertEquals(inodeWithOldId, inodeWithNewId);
     }
 }


### PR DESCRIPTION
The chimera IDs on the wire presented as:

0:TAG:0000DA875B38D9E0461F9ADFEA7C7422A956:OSMTemplate

This change introduses a binary form with backward compatibility,
e.q. new version can understand and decode old forms.

The new form:

<byte 1> : fsid
<byte 2> : inode type
<byte 3> : len of the id
<byte 4:id len> id of the file
<byte ~22> : len of inode specific data
<byte 24:opque len> specific data.

For example above, ithe old encoding: will produce 68 byte nfs file handle,
with new scheme - 47.

Ticket: #7927
Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit 6aa5a402b63af49e12c280a9bc264b6a44c1d434)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
