### PR TITLE
transfermanagers, replica, admin: Fix pool to pool transfers

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/CostModuleV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/CostModuleV1.java
@@ -396,7 +396,7 @@ public class CostModuleV1
             destinationCostInfo.getSpaceInfo();
 
         int diff = msg.isReply() ? -1 : 1;
-        long pinned = msg.getFileAttributes().getSize();
+        long pinned = msg.getFileAttributes().isDefined(FileAttribute.SIZE) ? msg.getFileAttributes().getSize() : 0;
 
         sourceQueue.modifyQueue(diff);
         destinationQueue.modifyQueue(diff);

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/Pool2PoolTransferMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/Pool2PoolTransferMsg.java
@@ -11,7 +11,6 @@ import org.dcache.vehicles.FileAttributes;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.dcache.namespace.FileAttribute.PNFSID;
-import static org.dcache.namespace.FileAttribute.SIZE;
 
 
 public class Pool2PoolTransferMsg extends PoolMessage {
@@ -33,7 +32,7 @@ public class Pool2PoolTransferMsg extends PoolMessage {
         super( sourcePoolName ) ;
 
         checkNotNull(fileAttributes);
-        checkArgument(fileAttributes.isDefined(EnumSet.of(PNFSID, SIZE)));
+        checkArgument(fileAttributes.isDefined(EnumSet.of(PNFSID)));
 
         _fileAttributes = fileAttributes;
         _destinationPoolName = destinationPoolName ;


### PR DESCRIPTION
Addresses problems in transfer managers, replica managers, and the
admin p2p command that prevented these services from starting
pool to pool transfers.

Although CostModuleV1 requires the size field, the above services
don't tunnel the request message through the pool manager and thus
the size field is not strictly required.

Target: trunk
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
(cherry picked from commit 4609b0705c25a5fecfaf75ebb34ee22f055fa96d)
