### PR TITLE
transfermanagers, replica, admin: Fix pool to pool transfers

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/CostModuleV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/CostModuleV1.java
@@ -435,7 +435,7 @@ public class CostModuleV1
             destinationCostInfo.getSpaceInfo();
 
         int diff = msg.isReply() ? -1 : 1;
-        long pinned = msg.getFileAttributes().getSize();
+        long pinned = msg.getFileAttributes().isDefined(FileAttribute.SIZE) ? msg.getFileAttributes().getSize() : 0;
 
         sourceQueue.modifyQueue(diff);
         destinationQueue.modifyQueue(diff);

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/Pool2PoolTransferMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/Pool2PoolTransferMsg.java
@@ -40,7 +40,7 @@ public class Pool2PoolTransferMsg extends PoolMessage {
         super( sourcePoolName ) ;
 
         checkNotNull(fileAttributes);
-        checkArgument(fileAttributes.isDefined(EnumSet.of(PNFSID, SIZE)));
+        checkArgument(fileAttributes.isDefined(EnumSet.of(PNFSID)));
 
         _fileAttributes = fileAttributes;
         _pnfsId      = fileAttributes.getPnfsId();


### PR DESCRIPTION
Addresses problems in transfer managers, replica managers, and the
admin p2p command that prevented these services from starting
pool to pool transfers.

Although CostModuleV1 requires the size field, the above services
don't tunnel the request message through the pool manager and thus
the size field is not strictly required.

Target: trunk
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
(cherry picked from commit 4609b0705c25a5fecfaf75ebb34ee22f055fa96d)

Conflicts:
    modules/dcache/src/main/java/diskCacheV111/vehicles/Pool2PoolTransferMsg.java
