### PR TITLE
Fix log message containing invalid access latency and retention policy v...

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
@@ -33,6 +33,7 @@ import diskCacheV111.vehicles.PoolCostCheckable;
 import diskCacheV111.vehicles.PoolManagerPoolInformation;
 import diskCacheV111.vehicles.ProtocolInfo;
 import diskCacheV111.vehicles.StorageInfo;
+import diskCacheV111.vehicles.StorageInfos;
 
 import dmg.cells.nucleus.CellMessage;
 
@@ -146,7 +147,7 @@ public class PoolMonitorV5
             return _selectionUnit.match(direction,
                                         hostName,
                                         protocol,
-                                        _fileAttributes.getStorageInfo(),
+                                        StorageInfos.extractFrom(_fileAttributes),
                                         _linkGroup);
         }
 
@@ -180,7 +181,7 @@ public class PoolMonitorV5
             if (levels.length == 0) {
                 throw new CacheException(19,
                                          "No write pools configured for <" +
-                                         _fileAttributes.getStorageInfo() +
+                                                 StorageInfos.extractFrom(_fileAttributes) +
                                          "> in the linkGroup " +
                                          (_linkGroup == null ? "[none]" : _linkGroup));
             }
@@ -196,7 +197,7 @@ public class PoolMonitorV5
             }
 
             throw new CacheException(20,
-                                     "No write pool available for <" +  _fileAttributes.getStorageInfo() +
+                                     "No write pool available for <" +  StorageInfos.extractFrom(_fileAttributes) +
                                      "> in the linkGroup " +
                                      (_linkGroup == null ? "[none]" : _linkGroup));
         }
@@ -525,7 +526,7 @@ public class PoolMonitorV5
             return FileLocality.NONE;
         }
 
-        StorageInfo storageInfo = attributes.getStorageInfo();
+        StorageInfo storageInfo = StorageInfos.extractFrom(attributes);
         PoolPreferenceLevel[] levels =
             _selectionUnit.match(DirectionType.READ,
                                  hostName,

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileNotInCacheException;
 import diskCacheV111.util.PnfsId;
+import diskCacheV111.vehicles.StorageInfos;
 
 import dmg.util.Args;
 import dmg.util.Formats;
@@ -258,7 +259,7 @@ public class SpaceSweeper2
                     if (s) {
                         FileAttributes attributes = entry.getFileAttributes();
                         if (attributes.isDefined(FileAttribute.STORAGEINFO)) {
-                            sb.append("\n    ").append(attributes.getStorageInfo());
+                            sb.append("\n    ").append(StorageInfos.extractFrom(attributes));
                         }
                     }
                     sb.append("\n");

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/DCapClientProtocol_1.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/DCapClientProtocol_1.java
@@ -23,6 +23,7 @@ import diskCacheV111.vehicles.DCapClientPortAvailableMessage;
 import diskCacheV111.vehicles.DCapClientProtocolInfo;
 import diskCacheV111.vehicles.ProtocolInfo;
 import diskCacheV111.vehicles.StorageInfo;
+import diskCacheV111.vehicles.StorageInfos;
 
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellMessage;
@@ -74,7 +75,7 @@ public class DCapClientProtocol_1 implements MoverProtocol
         throws Exception
     {
         PnfsId pnfsId = fileAttributes.getPnfsId();
-        StorageInfo storage = fileAttributes.getStorageInfo();
+        StorageInfo storage = StorageInfos.extractFrom(fileAttributes);
         say("runIO()\n\tprotocol="+
             protocol+",\n\tStorageInfo="+storage+",\n\tPnfsId="+pnfsId+
             ",\n\taccess ="+access);

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol_1.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol_1.java
@@ -90,6 +90,7 @@ import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.ProtocolInfo;
 import diskCacheV111.vehicles.StorageInfo;
+import diskCacheV111.vehicles.StorageInfos;
 import diskCacheV111.vehicles.transferManager.RemoteGsiftpTransferProtocolInfo;
 
 import dmg.cells.nucleus.CellEndpoint;
@@ -174,11 +175,12 @@ public class RemoteGsiftpTransferProtocol_1
                CredentialException, GSSException
     {
         _pnfsId = fileAttributes.getPnfsId();
-        StorageInfo storage = fileAttributes.getStorageInfo();
-        _log.debug("runIO()\n\tprotocol="
-            + protocol + ",\n\tStorageInfo=" + storage + ",\n\tPnfsId="
-            + _pnfsId + ",\n\taccess ="
-            + access );
+        if (_log.isDebugEnabled()) {
+            _log.debug("runIO()\n\tprotocol="
+                    + protocol + ",\n\tStorageInfo=" + StorageInfos.extractFrom(fileAttributes) + ",\n\tPnfsId="
+                    + _pnfsId + ",\n\taccess ="
+                    + access );
+        }
         if (!(protocol instanceof RemoteGsiftpTransferProtocolInfo)) {
             throw new CacheException("protocol info is not RemoteGsiftpransferProtocolInfo");
         }
@@ -203,11 +205,11 @@ public class RemoteGsiftpTransferProtocol_1
 
         if ( access == IoMode.WRITE) {
             gridFTPRead(remoteGsiftpProtocolInfo,
-                        storage,
+                    fileAttributes.getStorageInfo(),
                         allocator);
         } else {
             gridFTPWrite(remoteGsiftpProtocolInfo,
-                         storage);
+                    fileAttributes.getStorageInfo());
         }
         _log.debug(" runIO() done");
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol_1.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol_1.java
@@ -16,7 +16,7 @@ import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.ProtocolInfo;
 import diskCacheV111.vehicles.RemoteHttpDataTransferProtocolInfo;
-import diskCacheV111.vehicles.StorageInfo;
+import diskCacheV111.vehicles.StorageInfos;
 
 import dmg.cells.nucleus.CellEndpoint;
 
@@ -49,9 +49,10 @@ public class RemoteHttpDataTransferProtocol_1 implements MoverProtocol
         throws CacheException, IOException, InterruptedException
     {
         PnfsId pnfsId = fileAttributes.getPnfsId();
-        StorageInfo storage = fileAttributes.getStorageInfo();
-        _log.info("Active HTTP: Protocol={}, StorageInfo={}, PnfsId={}, Access={}",
-                  new Object[] { protocol, storage, pnfsId, access });
+        if (_log.isInfoEnabled()) {
+            _log.info("Active HTTP: Protocol={}, StorageInfo={}, PnfsId={}, Access={}",
+                    protocol, StorageInfos.extractFrom(fileAttributes), pnfsId, access);
+        }
         if (!(protocol instanceof RemoteHttpDataTransferProtocolInfo)) {
             throw new CacheException("protocol info is not RemoteHttpDataTransferProtocolInfo");
         }


### PR DESCRIPTION
...alues

Addresses an issue in which log messages would show values for
access latency and retention policy from uninitialized fields,
rather than the actual values of the file the log message is
refering to.

The regression was introduced when these fields got deprecated
in storage info. dCache doesn't make use of the fields anymore,
however they still appear in the toString version of storage info
and thus appear in various log outputs and error message.

Target: trunk
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6273/
(cherry picked from commit efd4dee76e0915289dea80c8833f21d952833857)

Conflicts:
    modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol_1.java
