### PR TITLE
gPlazma: add public key size information to gPlazma results printer

### DIFF
--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
@@ -10,6 +10,7 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.glite.voms.ac.AttributeCertificate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.security.rsa.RSAPublicKeyImpl;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -17,6 +18,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.Principal;
+import java.security.PublicKey;
+import java.security.cert.CertPath;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.text.ParseException;
@@ -238,6 +241,7 @@ public class LoginResultPrinter
         }
         sb.append("  +--Validity: ").append(validityStatementFor(certificate)).append('\n');
         sb.append("  +--Algorithm: ").append(nameForOid(certificate.getSigAlgOID())).append('\n');
+        sb.append("  +--Public key: ").append(describePublicKey(certificate.getPublicKey())).append('\n');
 
         String sanInfo = subjectAlternateNameInfoFor(certificate);
         if(!sanInfo.isEmpty()) {
@@ -278,6 +282,23 @@ public class LoginResultPrinter
 
         if(!extendedKeyUsage.isEmpty()) {
             sb.append("  +--Key usage: ").append(extendedKeyUsage).append('\n');
+        }
+
+        return sb.toString();
+    }
+
+    private static String describePublicKey(PublicKey key)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(key.getAlgorithm());
+
+        if (key instanceof RSAPublicKeyImpl) {
+            int bits = (((RSAPublicKeyImpl)key).getModulus().bitLength() + 7) & ~7;
+            sb.append(' ').append(bits).append(" bits");
+        } else {
+            sb.append(" (unknown ").append(key.getClass().getCanonicalName()).
+                    append(")");
         }
 
         return sb.toString();


### PR DESCRIPTION
Recent changes to JVMs have shown that key-size can be an importact
factor when understanding why a login has failed; specifically,
new JVMs now disallow certificates with RSA keys with less than 1024
bits.

This patch adds support for printing the number of bits in the public
key(s).  Unfortunately the interface (PublicKey) provides no mechanism
for discovering this information so we must down-cast to known
classes to discover the information.

Requires-notes: yes
Requires-book: no
Target: master
Request: 2.7
Request: 2.6
Request: 2.2

Conflicts:
    modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
