### PR TITLE
pool: Fix command string output for migration commands

### DIFF
--- a/modules/cells/src/test/java/dmg/util/command/AnnotatedCommandScannerTest.java
+++ b/modules/cells/src/test/java/dmg/util/command/AnnotatedCommandScannerTest.java
@@ -651,4 +651,41 @@ public class AnnotatedCommandScannerTest
 
         _scanner.scan(new SUT());
     }
+
+    @Test
+    public void shouldUseCommandOfSubClassWhenInjectingCommandLine() throws Exception
+    {
+        class SUT
+        {
+            @Command(name = "base")
+            class BaseCommand implements Callable<String>
+            {
+                @CommandLine
+                public String line;
+
+                @Override
+                public String call() throws Exception
+                {
+                    assertThat(line, is("base"));
+                    return null;
+                }
+            }
+
+            @Command(name = "test")
+            class TestCommand extends BaseCommand
+            {
+                @Override
+                public String call() throws Exception
+                {
+                    assertThat(line, is("test"));
+                    return null;
+                }
+            }
+        }
+
+        Map<List<String>,? extends CommandExecutor> commands =
+                _scanner.scan(new SUT());
+        commands.get(asList("base")).execute(new Args(""), CommandInterpreter.ASCII);
+        commands.get(asList("test")).execute(new Args(""), CommandInterpreter.ASCII);
+    }
 }


### PR DESCRIPTION
Addresses the issue that 'migration move' and 'migration cache' commands
are shown as 'migration copy' commands in the output of 'migration ls',
'migration info' and when saved to the setup file.

Target: trunk
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6278/
(cherry picked from commit a6500bb2148cd9c87d27dfc2eaa73638457e659f)
