### PR TITLE
chimera: use path to get files parent on remove

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -576,13 +576,14 @@ public class JdbcFs implements FileSystemProvider {
 
     public boolean remove(String path) throws ChimeraFsException {
 
-        FsInode inode = path2inode(path);
-        FsInode parent = this.getParentOf(inode);
-        if (parent == null) {
-            return false;
+        File filePath = new File(path);
+
+        String parentPath = filePath.getParent();
+        if (parentPath == null) {
+            throw new ChimeraFsException("Cannot delete file system root.");
         }
 
-        File filePath = new File(path);
+        FsInode parent = path2inode(parentPath);
         String name = filePath.getName();
 
         return this.remove(parent, name);

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.*;
 
 import org.dcache.chimera.posix.Stat;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import org.dcache.acl.ACE;
@@ -283,6 +284,28 @@ public class BasicTest extends ChimeraTestCaseHelper {
         boolean removed = _fs.remove(base, "aLink");
         assertTrue("failed to remove symbolic link", removed);
 
+    }
+
+    @Test
+    public void testRemoveLinkToSomewhare() throws Exception {
+
+        FsInode linkBase = _rootInode.mkdir("links");
+
+        _fs.createLink(linkBase, "file123", 0, 0, 0644, "/files/file123".getBytes(Charsets.UTF_8));
+        _fs.remove("/links/file123");
+    }
+
+    @Test
+    public void testRemoveLinkToFile() throws Exception {
+
+        FsInode fileBase = _rootInode.mkdir("files");
+        FsInode linkBase = _rootInode.mkdir("links");
+        FsInode fileInode = fileBase.create("file123", 0, 0, 0644);
+
+        _fs.createLink(linkBase, "file123", 0, 0, 0644, "/files/file123".getBytes(Charsets.UTF_8));
+        _fs.remove("/links/file123");
+
+        assertTrue("original file is gone!", fileInode.exists());
     }
 
     @Ignore("broken test, normal filesystems do not allow directory hard-links. Why does chimera?")


### PR DESCRIPTION
while in most of the cases we need to resolve symbolic links,
on delete we must only link and not the target

Acked-by: Gerd Behrmann
Target: master, 2.6, 2.7, 2.2
Require-book: no
Require-notes: no
(cherry picked from commit b1c04d4f22230cbff4ba53f40d97178944c0bb8e)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
