### PR TITLE
chimera: use path to get files parent on remove

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -606,13 +606,14 @@ public class JdbcFs implements FileSystemProvider {
     @Override
     public boolean remove(String path) throws ChimeraFsException {
 
-        FsInode inode = path2inode(path);
-        FsInode parent = this.getParentOf(inode);
-        if (parent == null) {
-            return false;
+        File filePath = new File(path);
+
+        String parentPath = filePath.getParent();
+        if (parentPath == null) {
+            throw new ChimeraFsException("Cannot delete file system root.");
         }
 
-        File filePath = new File(path);
+        FsInode parent = path2inode(parentPath);
         String name = filePath.getName();
 
         return this.remove(parent, name);

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -300,6 +300,28 @@ public class BasicTest extends ChimeraTestCaseHelper {
 
     }
 
+    @Test
+    public void testRemoveLinkToSomewhare() throws Exception {
+
+        FsInode linkBase = _rootInode.mkdir("links");
+
+        _fs.createLink(linkBase, "file123", 0, 0, 0644, "/files/file123".getBytes(Charsets.UTF_8));
+        _fs.remove("/links/file123");
+    }
+
+    @Test
+    public void testRemoveLinkToFile() throws Exception {
+
+        FsInode fileBase = _rootInode.mkdir("files");
+        FsInode linkBase = _rootInode.mkdir("links");
+        FsInode fileInode = fileBase.create("file123", 0, 0, 0644);
+
+        _fs.createLink(linkBase, "file123", 0, 0, 0644, "/files/file123".getBytes(Charsets.UTF_8));
+        _fs.remove("/links/file123");
+
+        assertTrue("original file is gone!", fileInode.exists());
+    }
+
     @Ignore("broken test, normal filesystems do not allow directory hard-links. Why does chimera?")
     @Test
     public void testDirHardLink() throws Exception {


### PR DESCRIPTION
while in most of the cases we need to resolve symbolic links,
on delete we must only link and not the target

Acked-by: Gerd Behrmann
Target: master, 2.6, 2.7, 2.2
Require-book: no
Require-notes: no
(cherry picked from commit b1c04d4f22230cbff4ba53f40d97178944c0bb8e)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de

Conflicts:
    modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
