### PR TITLE
Fix configuration cache invalidation

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/boot/LayoutBuilder.java
+++ b/modules/dcache/src/main/java/org/dcache/boot/LayoutBuilder.java
@@ -81,6 +81,12 @@ public class LayoutBuilder
                     }
                 }
             }
+        } else {
+            /* To detect if path is created later, we consider the parent a source
+             * directory. Touching that directory will cause the configuration cache
+             * to be invalidated.
+             */
+            _sourceDirectories.add(path.getParentFile());
         }
         return config;
     }

--- a/skel/share/lib/loadConfig.sh
+++ b/skel/share/lib/loadConfig.sh
@@ -84,7 +84,7 @@ isCacheValidForFiles()
 {
     local f
     for f in "$@"; do
-        test "$f" -ot "$DCACHE_CACHED_CONFIG" || return
+        test -f "$f" && test "$f" -ot "$DCACHE_CACHED_CONFIG" || return
     done
 }
 
@@ -92,7 +92,7 @@ isCacheValidForDirs()
 {
     local d
     for d in "$@"; do
-	test ! -e "$d" || test "$d" -ot "$DCACHE_CACHED_CONFIG" || return
+        test ! -e "$d" || test "$d" -ot "$DCACHE_CACHED_CONFIG" || return
     done
 }
 
@@ -116,8 +116,9 @@ fi
 
 if [ -s $DCACHE_CACHED_CONFIG ]; then
     . $DCACHE_CACHED_CONFIG
-   if ! eval isCacheValidForFiles $(getProperty dcache.config.files) /etc/hostname ||
-      ! eval isCacheValidForDirs $(getProperty dcache.config.dirs); then
+   if ! eval isCacheValidForFiles $(getProperty dcache.config.files) ||
+      ! eval isCacheValidForDirs $(getProperty dcache.config.dirs) ||
+      [ "$(getProperty host.name)" != "$(hostname -s)" ]; then
        loadConfig
    fi
 else


### PR DESCRIPTION
Addresses several issues with configuration cache invalidation.
The symptom of these problems was that the cache was not
invalidated when it should have been.

Specifically:

Fixes an inconsistency between bash and other shell in which
the -ot test behaves differently when the left hand file does
not exist.

Fixes an issue with host name change detection on Mac OS.

Fixes an issue detect that dcache.conf was added.

Target: trunk
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6293/
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8131
(cherry picked from commit 19c2b52293f7cb390291041a9b231c94a4a57f45)
