### PR TITLE
nfsv41: garbage-collect expired moved

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
@@ -44,6 +44,7 @@ public class EDSOperationREAD extends AbstractNFSv4Operation {
                 throw new ChimeraNFSException(nfsstat.NFSERR_BAD_STATEID,
                         "No mover associated with given stateid");
             }
+            mover.attachSession(context.getSession());
 
             ByteBuffer bb = ByteBuffer.allocate(count);
             RepositoryChannel fc = mover.getMoverChannel();

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationWRITE.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationWRITE.java
@@ -49,6 +49,7 @@ public class EDSOperationWRITE extends AbstractNFSv4Operation {
                         "No mover associated with given stateid");
             }
 
+            mover.attachSession(context.getSession());
             if( mover.getIoMode() != IoMode.WRITE ) {
                 throw new ChimeraNFSException(nfsstat.NFSERR_PERM, "an attempt to write without IO mode enabled");
             }

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -17,14 +17,22 @@
  */
 package org.dcache.chimera.nfsv41.mover;
 
+import java.io.IOException;
+import java.nio.channels.CompletionHandler;
 import java.util.Collections;
 import java.util.Set;
 
-import diskCacheV111.vehicles.PoolIoFileMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import diskCacheV111.util.DiskErrorCacheException;
+import diskCacheV111.vehicles.PoolIoFileMessage;
 import dmg.cells.nucleus.CellPath;
 
+import org.dcache.nfs.v4.NFS4State;
+import org.dcache.nfs.v4.NFSv41Session;
 import org.dcache.nfs.v4.xdr.stateid4;
+import org.dcache.pool.classic.Cancellable;
 import org.dcache.pool.classic.PostTransferService;
 import org.dcache.pool.movers.MoverChannelMover;
 import org.dcache.pool.repository.ReplicaDescriptor;
@@ -32,10 +40,18 @@ import org.dcache.util.Checksum;
 
 public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
 
+    private static final Logger _log = LoggerFactory.getLogger(NfsTransferService.class);
+    private NFSv41Session _session;
+    private final NFSv4MoverHandler _nfsIO;
+    private final NFS4State _state;
+    private volatile CompletionHandler<Void, Void> _completionHandler;
+
     public NfsMover(ReplicaDescriptor handle, PoolIoFileMessage message, CellPath pathToDoor,
             NfsTransferService nfsTransferService,
             PostTransferService postTransferService) {
         super(handle, message, pathToDoor, nfsTransferService, postTransferService);
+        _nfsIO = nfsTransferService.getNfsMoverHandler();
+        _state = new MoverState();
     }
 
     @Override
@@ -61,5 +77,81 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
                 .append(getProtocolInfo().getSocketAddress().getAddress().getHostAddress())
                 .append("]");
         return s.toString();
+    }
+
+    /**
+     * Enable access with this mover.
+     * @param completionHandler to be called when mover finishes.
+     * @return handle to cancel mover if needed
+     * @throws DiskErrorCacheException
+     */
+    public Cancellable enable(final CompletionHandler<Void,Void> completionHandler) throws DiskErrorCacheException {
+
+        open();
+        _completionHandler = completionHandler;
+        _nfsIO.add(this);
+        return new Cancellable() {
+            @Override
+            public void cancel() {
+                disable(null);
+            }
+        };
+
+    }
+
+    /**
+     * Disable access with this mover. If {@code error} is not a {@code null},
+     * the {@link CompletionHandler#failed(Throwable, A)} method will be called.
+     * @param error error to report, or {@code null} on success
+     */
+    private void disable(Throwable error) {
+        _nfsIO.remove(NfsMover.this);
+        detachSession();
+        try {
+            getMoverChannel().close();
+        } catch (IOException e) {
+            _log.error("failed to close RAF {}", e.toString());
+        }
+        if(error == null) {
+            _completionHandler.completed(null, null);
+        } else {
+            _completionHandler.failed(error, null);
+        }
+    }
+
+    /**
+     * Attach mover tho the client's NFSv41 session.
+     * @param session to attach to
+     */
+    synchronized void attachSession(NFSv41Session session) {
+        if (_session == null) {
+            _session = session;
+            _session.getClient().attachState(_state);
+        }
+    }
+
+    /**
+     * Detach mover from the client's session.
+     */
+    synchronized void detachSession() {
+        if (_session != null) {
+            _session.getClient().detachState(_state);
+            _session = null;
+        }
+    }
+
+    /**
+     * A special {@link NFS4State} to kill the mover when disposed.
+     */
+    private class MoverState extends NFS4State {
+
+        MoverState() {
+            super(NfsMover.this.getProtocolInfo().stateId());
+        }
+
+        @Override
+        protected void dispose() {
+            disable(new InterruptedException("Killing mover due to client inactivity"));
+        }
     }
 }


### PR DESCRIPTION
kill movers if NFS client did not show up within session lease time.
Notice, this functionality is independent of timeout manager and
complaint with NFS spec

This is fully working code (the early versions was available in 1
March (http://rb.dcache.org/r/5239/)), nevertheless, still some
thinking required :)

Ticket: #8044
Acked-by: Karsten Schwank
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit 3caea8024da54b7a97de4e7081f35641e25fa530)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
