### PR TITLE
srm: add missing information from "ls queues" command

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -729,7 +729,7 @@ public final class Storage
             sb.append("Get Request Scheduler:\n");
             srm.printGetSchedulerThreadQueue(sb);
             srm.printGetSchedulerPriorityThreadQueue(sb);
-            srm.printCopySchedulerReadyThreadQueue(sb);
+            srm.printGetSchedulerReadyThreadQueue(sb);
             sb.append('\n');
         }
         if(put) {


### PR DESCRIPTION
The 'ls queues' command prints detailed information about the current
status of different queues within the SRM.  The output claims to
show the current status of download (get) requests, but one part of
this output is actually showing 3rd-party copy activity.

This patch fixes the simple typo to show the correct information.

Target: master
Request: 2.7
Request: 2.6
Request: 2.2
Patch: http://rb.dcache.org/r/6316/
Acked-by: Dmitry Litvintsev
