### PR TITLE
(2.7) dcache-webadmin: fix comparison semantics

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/CellServicesBean.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/CellServicesBean.java
@@ -1,5 +1,8 @@
 package org.dcache.webadmin.view.beans;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+
 import java.io.Serializable;
 
 /**
@@ -94,7 +97,11 @@ public class CellServicesBean implements Comparable<CellServicesBean>,
 
     @Override
     public int compareTo(CellServicesBean other) {
-        return (getName().compareTo(other.getName()) +
-                getDomainName().compareTo(other.getDomainName()));
+        return ComparisonChain.start()
+               .compare(getName(), other.getName(),
+                               Ordering.natural().nullsLast())
+               .compare(getDomainName(), other.getDomainName(),
+                               Ordering.natural().nullsLast())
+               .result();
     }
 }

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolAdminBean.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolAdminBean.java
@@ -1,5 +1,8 @@
 package org.dcache.webadmin.view.beans;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,6 +60,9 @@ public class PoolAdminBean implements Comparable<PoolAdminBean>, Serializable {
 
     @Override
     public int compareTo(PoolAdminBean other) {
-        return getGroupName().compareTo(other.getGroupName());
+        return ComparisonChain.start()
+               .compare(getGroupName(), other.getGroupName(),
+                                        Ordering.natural().nullsLast())
+               .result();
     }
 }

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolCommandBean.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolCommandBean.java
@@ -1,5 +1,8 @@
 package org.dcache.webadmin.view.beans;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+
 import java.io.Serializable;
 
 /**
@@ -58,7 +61,11 @@ public class PoolCommandBean implements Comparable<PoolCommandBean>, Serializabl
 
     @Override
     public int compareTo(PoolCommandBean other) {
-        return (getName().compareTo(other.getName()) +
-                getDomain().compareTo(other.getDomain()));
+        return ComparisonChain.start()
+               .compare(getName(), other.getName(),
+                                   Ordering.natural().nullsLast())
+               .compare(getDomain(), other.getDomain(),
+                                   Ordering.natural().nullsLast())
+               .result();
     }
 }

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolGroupBean.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolGroupBean.java
@@ -1,5 +1,8 @@
 package org.dcache.webadmin.view.beans;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -170,6 +173,9 @@ public class PoolGroupBean implements Comparable<PoolGroupBean>, Serializable {
 
     @Override
     public int compareTo(PoolGroupBean other) {
-        return getName().compareTo(other.getName());
+        return ComparisonChain.start()
+               .compare(getName(), other.getName(),
+                                   Ordering.natural().nullsLast())
+               .result();
     }
 }

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolQueueBean.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolQueueBean.java
@@ -1,5 +1,8 @@
 package org.dcache.webadmin.view.beans;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -68,7 +71,11 @@ public class PoolQueueBean implements Comparable<PoolQueueBean>, Serializable {
 
     @Override
     public int compareTo(PoolQueueBean other) {
-        return (getName().compareTo(other.getName()) +
-                getDomainName().compareTo(other.getDomainName()));
+        return ComparisonChain.start()
+               .compare(getName(), other.getName(),
+                                   Ordering.natural().nullsLast())
+               .compare(getDomainName(), other.getDomainName(),
+                                   Ordering.natural().nullsLast())
+               .result();
     }
 }

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolSpaceBean.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/PoolSpaceBean.java
@@ -1,5 +1,8 @@
 package org.dcache.webadmin.view.beans;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -195,7 +198,10 @@ public class PoolSpaceBean implements Comparable<PoolSpaceBean>, Serializable {
 
     @Override
     public int compareTo(PoolSpaceBean other) {
-        return this.getName().compareTo(other.getName());
+        return ComparisonChain.start()
+               .compare(getName(), other.getName(),
+                                   Ordering.natural().nullsLast())
+               .result();
     }
 
     @Override


### PR DESCRIPTION
Java 1.7 now enforces comparison contracts on sort, and will throw an IllegalArgument exception if the implementation of compareTo violates it.

Several comparisons used in the webadmin beans did not adhere to this contract.  For instance, something like:

a.name.compareTo(b.name) + a.domain.compareTo(b.domain) is incorrect, since this could possibly result in 0 if the two parts evaluate to oppositely signed 1s, when in fact 0 should be reserved for equality.

This patch reimplements all compareTo in the bean classes, modernizing them with a call to Guava's ComparisonChain.

Testing:

Reran junit tests.  Deployed and rechecked.

Target: 2.7
Patch: http://rb.dcache.org/r/6307/
Bug: http://rt.dcache.org/Ticket/Display.html?id=8145
Require-notes: yes
Require-book: no
Acked-by: Tigran
Committed: 5c788be798cae49f489a5c61163b296f52a31f4d

RELEASE NOTES:

Fixes bug which throws java.lang.IllegalArgumentException: Comparison method violates its general contract! when data is being sorted in certain webadmin pages.
