### PR TITLE
webdav: log why request is rejected with permission denied

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/SecurityFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/SecurityFilter.java
@@ -85,6 +85,8 @@ public class SecurityFilter implements Filter
         Subject subject = new Subject();
 
         if (!isAllowedMethod(request.getMethod())) {
+            _log.debug("Failing {} from {} as door is read-only",
+                    request.getMethod(), request.getRemoteAddr());
             manager.getResponseHandler().respondMethodNotAllowed(new EmptyResource(request), response, request);
             return;
         }
@@ -100,7 +102,8 @@ public class SecurityFilter implements Filter
             subject = login.getSubject();
 
             if (!isAuthorizedMethod(request.getMethod(), login)) {
-                throw new PermissionDeniedCacheException("Permission denied");
+                throw new PermissionDeniedCacheException("Permission denied: " +
+                        "read-only user");
             }
 
             checkRootPath(request, login);
@@ -164,7 +167,8 @@ public class SecurityFilter implements Filter
         FsPath fullPath = new FsPath(_rootPath, new FsPath(path));
         if (!fullPath.startsWith(userRoot)) {
             if (!path.equals("/")) {
-                throw new PermissionDeniedCacheException("Permission denied");
+                throw new PermissionDeniedCacheException("Permission denied: " +
+                        "path outside user's root");
             }
 
             try {


### PR DESCRIPTION
Certain configuration can lead to a user's request being rejected
inside the webdav door.  These are currently either not logged or
logged with limited information.  Either way, it is hard to
understand why a request is failing.

Target: master
Request: 2.7
Request: 2.6
Request: 2.2
Patch: http://rb.dcache.org/r/6319/
Acked-by: Gerd Behrmann
