### PR TITLE
scripts: fix dcache script for Solaris machines

### DIFF
--- a/skel/share/lib/loadConfig.sh
+++ b/skel/share/lib/loadConfig.sh
@@ -67,6 +67,13 @@ bootLoader()
 	org.dcache.boot.BootLoader "$@"
 }
 
+shortHostname()
+{
+    local host
+    host=$(hostname)
+    echo ${host%%.*}
+}
+
 quickJava()
 {
     export CLASSPATH
@@ -109,9 +116,10 @@ fi
 
 if [ -s $DCACHE_CACHED_CONFIG ]; then
     . $DCACHE_CACHED_CONFIG
+   # NB. "hostname -s" does not work on Solaris machines
    if ! eval isCacheValidForFiles $(getProperty dcache.config.files) ||
       ! eval isCacheValidForDirs $(getProperty dcache.config.dirs) ||
-      [ "$(getProperty host.name)" != "$(hostname -s)" ]; then
+      [ "$(getProperty host.name)" != "$(shortHostname)" ]; then
        loadConfig
    fi
 else


### PR DESCRIPTION
Patch http://rb.dcache.org/r/6293/ (committed as 19c2b522)
fixed a problem with the configuration cache not being
invalidated.

Unfortunately, in fixing a Mac-specific issue, the patch
introduced a Solaris-specific issue; specifically, that
Solaris machines do not support any options to the hostname
command.  The result is that calls like 'hostname -s' will
set the hostname to '-s'.

This patch fixes the problem by using shell's built in
filtering.

Target: master
Ticket: https://github.com/dCache/dcache/issues/335
Request: 2.7
Request: 2.6
Request: 2.2
Patch: http://rb.dcache.org/r/6315/
Acked-by: Gerd Behrmann
