### PR TITLE
(2.7) dcache-core: fix statistics totals for top, year and month

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -464,7 +464,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
       list = resortFileList( list , -1 ) ;
 
-      long [] counter      = new long[12] ;
+      long [] counter      = null ;
       long [] total        = new long[12] ;
       long [] lastInMonth  = new long[12] ;
 
@@ -493,6 +493,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
                   st.nextToken() ;
                   String key =  _dayOfCalendar.format( new Date( Long.parseLong( st.nextToken() ) ) ) ;
+                  counter = new long[12] ;
                   for( int  j = 0 ; j < counter.length ; j++ ){
                       counter[j] = Long.parseLong(st.nextToken()) ;
                   }
@@ -515,9 +516,10 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
            html.dump();
        }
 
-
-      total[YESTERDAY]   = counter[YESTERDAY] ;
-      total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      if (counter != null) {
+          total[YESTERDAY]   = counter[YESTERDAY] ;
+          total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      }
       total[TODAY]       = lastInMonth[TODAY] ;
       total[TODAY+1]     = lastInMonth[TODAY+1] ;
 
@@ -529,7 +531,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
       list = resortFileList( list , -1  ) ;
 
-      long [] counter      = new long[12] ;
+      long [] counter      = null ;
       long [] total        = new long[12] ;
       long [] lastInMonth  = new long[12] ;
 
@@ -557,6 +559,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
                   st.nextToken() ;
                   String key =  _monthOfCalendar.format( new Date( Long.parseLong( st.nextToken() ) ) ) ;
+                  counter = new long[12] ;
                   for( int  j = 0 ; j < counter.length ; j++ ){
                       counter[j] = Long.parseLong(st.nextToken()) ;
                   }
@@ -579,8 +582,10 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
        }
 
 
-       total[YESTERDAY]   = counter[YESTERDAY] ;
-      total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      if (counter != null) {
+          total[YESTERDAY]   = counter[YESTERDAY] ;
+          total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      }
       total[TODAY]       = lastInMonth[TODAY] ;
       total[TODAY+1]     = lastInMonth[TODAY+1] ;
 
@@ -592,7 +597,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
       list = resortFileList( list , -1  ) ;
 
-      long [] counter     = new long[12] ;
+      long [] counter     = null ;
       long [] total       = new long[12] ;
       long [] lastInYear  = new long[12] ;
 
@@ -620,6 +625,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
                   st.nextToken() ;
                   String key =  _yearOfCalendar.format( new Date( Long.parseLong( st.nextToken() ) ) ) ;
+                  counter = new long[12] ;
                   for( int  j = 0 ; j < counter.length ; j++ ){
                       counter[j] = Long.parseLong(st.nextToken()) ;
                   }
@@ -641,9 +647,10 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
            html.dump();
        }
 
-
-       total[YESTERDAY]   = counter[YESTERDAY] ;
-      total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      if (counter != null) {
+          total[YESTERDAY]   = counter[YESTERDAY] ;
+          total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      }
       total[TODAY]       = lastInYear[TODAY] ;
       total[TODAY+1]     = lastInYear[TODAY+1] ;
 


### PR DESCRIPTION
http://rb.dcache.org/r/5768 attempted to fix an NPE when the the topmost element of the statistics tree had not yet been generated.

The fix applied there, however, changed the loop invariant inadvertently, causing the summary pages to reflect the same stats for all nodes (based on the oldest node).

This patch restores the original invariant and places a guard against the NPE after the loop, where it does not interfere.

Testing:

redeployed, eliminated current total.raw files and index.html files and regenerated html tree from the admin interface, observing correct totals.

Target: 2.7
Patch: http://rb.dcache.org/r/6335
Require-book: no
Require-notes: yes
Bug: http://rt.dcache.org/Ticket/Display.html?id=8147
Acked-by: Gerd
Committed: f6855eefd944ceafb1bcc56b8b47535ca8a83a1e

RELEASE NOTES:

Fixes bug in the statistics page which caused the summary tables for top, year and month to report uniformly the data for the oldest date.
