### PR TITLE
(2.2) dcache-core: fix statistics totals for top, year and month

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -426,7 +426,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
       list = resortFileList( list , -1 ) ;
 
-      long [] counter      = new long[12] ;
+      long [] counter      = null ;
       long [] total        = new long[12] ;
       long [] lastInMonth  = new long[12] ;
 
@@ -451,6 +451,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
                   st.nextToken() ;
                   String key =  _dayOfCalendar.format( new Date( Long.parseLong( st.nextToken() ) ) ) ;
+                  counter = new long[12] ;
                   for( int  j = 0 ; j < counter.length ; j++ ){
                       counter[j] = Long.parseLong(st.nextToken()) ;
                   }
@@ -475,8 +476,10 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
           pw.close() ;
       }
 
-      total[YESTERDAY]   = counter[YESTERDAY] ;
-      total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      if (counter != null) {
+          total[YESTERDAY]   = counter[YESTERDAY] ;
+          total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      }
       total[TODAY]       = lastInMonth[TODAY] ;
       total[TODAY+1]     = lastInMonth[TODAY+1] ;
 
@@ -488,7 +491,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
       list = resortFileList( list , -1  ) ;
 
-      long [] counter      = new long[12] ;
+      long [] counter      = null ;
       long [] total        = new long[12] ;
       long [] lastInMonth  = new long[12] ;
 
@@ -512,6 +515,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
                   st.nextToken() ;
                   String key =  _monthOfCalendar.format( new Date( Long.parseLong( st.nextToken() ) ) ) ;
+                  counter = new long[12] ;
                   for( int  j = 0 ; j < counter.length ; j++ ){
                       counter[j] = Long.parseLong(st.nextToken()) ;
                   }
@@ -535,8 +539,10 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
            pw.close() ;
       }
 
-      total[YESTERDAY]   = counter[YESTERDAY] ;
-      total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      if (counter != null) {
+          total[YESTERDAY]   = counter[YESTERDAY] ;
+          total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      }
       total[TODAY]       = lastInMonth[TODAY] ;
       total[TODAY+1]     = lastInMonth[TODAY+1] ;
 
@@ -548,7 +554,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
       list = resortFileList( list , -1  ) ;
 
-      long [] counter     = new long[12] ;
+      long [] counter     = null ;
       long [] total       = new long[12] ;
       long [] lastInYear  = new long[12] ;
 
@@ -572,6 +578,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
                   st.nextToken() ;
                   String key =  _yearOfCalendar.format( new Date( Long.parseLong( st.nextToken() ) ) ) ;
+                  counter = new long[12] ;
                   for( int  j = 0 ; j < counter.length ; j++ ){
                       counter[j] = Long.parseLong(st.nextToken()) ;
                   }
@@ -595,8 +602,10 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
            pw.close() ;
       }
 
-      total[YESTERDAY]   = counter[YESTERDAY] ;
-      total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      if (counter != null) {
+          total[YESTERDAY]   = counter[YESTERDAY] ;
+          total[YESTERDAY+1] = counter[YESTERDAY+1] ;
+      }
       total[TODAY]       = lastInYear[TODAY] ;
       total[TODAY+1]     = lastInYear[TODAY+1] ;
 


### PR DESCRIPTION
http://rb.dcache.org/r/5768 attempted to fix an NPE when the the topmost element of the statistics tree had not yet been generated.

The fix applied there, however, changed the loop invariant inadvertently, causing the summary pages to reflect the same stats for all nodes (based on the oldest node).

This patch restores the original invariant and places a guard against the NPE after the loop, where it does not interfere.

Testing:

redeployed, eliminated current total.raw files and index.html files and regenerated html tree from the admin interface, observing correct totals.

Target: 2.2
Patch: http://rb.dcache.org/r/6335
Require-book: no
Require-notes: yes
Bug: http://rt.dcache.org/Ticket/Display.html?id=8147
Acked-by: Gerd
Committed: f6855eefd944ceafb1bcc56b8b47535ca8a83a1e

RELEASE NOTES:

Fixes bug in the statistics page which caused the summary tables for top, year and month to report uniformly the data for the oldest date.
