### PR TITLE
(2.2) dcache-core (statistics): fix yet another potential NPE in tree cr...

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -421,7 +421,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
    }
    private void updateHtmlMonth( Calendar calendar ) throws IOException {
       File    dir  = getHtmlPath(calendar).getParentFile() ;
-
+      dir.mkdirs();
       File [] list = dir.listFiles( new MonthFileFilter() ) ;
 
       list = resortFileList( list , -1 ) ;
@@ -484,6 +484,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
    }
    private void updateHtmlYear( Calendar calendar ) throws IOException {
       File    dir  = getHtmlPath(calendar).getParentFile().getParentFile() ;
+      dir.mkdirs();
       File [] list = dir.listFiles( new MonthFileFilter() ) ;
 
       list = resortFileList( list , -1  ) ;
@@ -544,6 +545,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
    }
    private void updateHtmlTop(  ) throws IOException {
       File    dir  = _htmlBase ;
+      dir.mkdirs();
       File [] list = dir.listFiles( new YearFileFilter() ) ;
 
       list = resortFileList( list , -1  ) ;


### PR DESCRIPTION
...eation

If the user runs the admin command create html <yyyy> or create html <yyyy> <mm> and those directories do not exist, an NPE is thrown when the list of subfiles is sorted, since the list ends up being a NULL array.

It costs little to ensure the presence of those directories in each of the three methods, so dir.mkdirs() has been added there.

Testing:

Running commands in absence of the statistics directory tree now avoids the NPE and creates the necessary empty directories.

Target: 2.2
Patch: http://rb.dcache.org/r/6341/
Require-book: no
Require-notes: yes
Acked-by: Tigran
Committed: 020025653d1533f28e33ef9ac13d61fa6e4e45f8

RELEASE NOTES:

Fixes potential Null Pointer Exception thrown when create html <yyyy> or create html <yyyy> <mm> is run and those directories do not yet exist.
