### PR TITLE
(2.6) dcache-webadmin: wget xml statepath (Info page) fails with HTML 50...

### DIFF
--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/pages/info/Info.properties
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/pages/info/Info.properties
@@ -1,0 +1,1 @@
+title=Info


### PR DESCRIPTION
...0 error

All pages which extend BasePage require a "title" property.  Info was missing the properties file.

Testing:

Before (example from ticket):

[mol@lxplus0443 ~]$ wget http://cmsdcacheweb-kit.gridka.de:2288/webadmin/info?statepath=pools/f01-065-105-e_1D_cms
--2013-11-08 13:07:41-- http://cmsdcacheweb-kit.gridka.de:2288/webadmin/info?statepath=pools/f01-065-105-e_1D_cms
Resolving cmsdcacheweb-kit.gridka.de (cmsdcacheweb-kit.gridka.de)... 192.108.45.36
Connecting to cmsdcacheweb-kit.gridka.de (cmsdcacheweb-kit.gridka.de)|192.108.45.36|:2288... connected.
HTTP request sent, awaiting response... 500 Server Error
2013-11-08 13:07:41 ERROR 500: Server Error.

After:

info.xml is successfully fetched.

Target: 2.6
Patch: http://rb.dcache.org/r/6342/
Require-book: no
Require-notes: yes
Bug: http://rt.dcache.org/Ticket/Display.html?id=8097
Acked-by: Tigran
Committed: e30a4ae1c54b5a8490e271d17b4c5fd6f7ee53be

RELEASE NOTES:

Fixes bug (HTML 500 is reported) preventing wget of Info.xml.
