### PR TITLE
defaults: add common explanation of annotations

### DIFF
--- a/packages/fhs/src/main/assembly/filter.properties
+++ b/packages/fhs/src/main/assembly/filter.properties
@@ -16,6 +16,50 @@ DCACHE_LOAD_CONFIG=                                         \n\
   DCACHE_CACHED_CONFIG=/var/lib/dcache/config/cache         \n\
   . ${DCACHE_HOME}/lib/loadConfig.sh
 
+
+##  This is used by the defaults files to populate the default
+##  information at the top of each file.  The value of this field
+##  should be identical in all three locations:
+##  packages/fhs/src/main/assembly/filter.properties,
+##  packages/tar/src/main/assembly/filter.properties and
+##  packages/system-test/src/main/assembly/filter.properties.
+DEFAULTS_HEADER = #                                                          \n\
+#   This Java properties file contains some of the default values used by    \n\
+#   dCache.  The values may be updated in either etc/dcache.conf or your     \n\
+#   layout file.  Do not modify this file as your changes will be lost when  \n\
+#   you next upgrade dCache.                                                 \n\
+#                                                                            \n\
+#   Some property definitions in this file have annotations: a comma-        \n\
+#   separated list of additional information within parentheses.  When       \n\
+#   configuring dCache, do not copy any annotations.  The following          \n\
+#   annotations are understood:                                              \n\
+#                                                                            \n\
+#     one-of      a |-separated list of valid values.  Configuring an invalid\n\
+#                 value prevents dCache from starting.                       \n\
+#                                                                            \n\
+#     any-of      a |-separated list of valid items for a comma-separated    \n\
+#                 list value.  Including an invalid item prevents dCache from\n\
+#                 starting.                                                  \n\
+#                                                                            \n\
+#     immutable   a property that may not be altered.  Configuring this      \n\
+#                 property prevents dCache from starting.                    \n\
+#                                                                            \n\
+#     depricated  support for this property will be removed after the next   \n\
+#                 long-term support release.                                 \n\
+#                                                                            \n\
+#     obsolete    property is no longer supported.  Configuring this property\n\
+#                 has no effect.                                             \n\
+#                                                                            \n\
+#     forbidden   property is no longer supported.  Configuring this property\n\
+#                 prevents dCache from starting.                             \n\
+#                                                                            \n\
+#     not-for-services  property only affects domains.  Configuring this     \n\
+#                 property in a service context has no effect.               \n\
+#                                                                            \n\
+#   Use the 'dcache check-config' to verify your configuration.              \n\
+
+
+
 # These are used by dCache itself
 dcache.paths.plugins=/usr/share/dcache/plugins:/usr/local/share/dcache/plugins
 dcache.paths.setup=${dcache.paths.etc}/dcache.conf

--- a/packages/system-test/src/main/assembly/filter.properties
+++ b/packages/system-test/src/main/assembly/filter.properties
@@ -37,6 +37,50 @@ DCACHE_DEFAULTS=${DCACHE_HOME}/share/defaults               \n\
 DCACHE_CACHED_CONFIG=${DCACHE_HOME}/var/config/cache        \n\
 . ${DCACHE_HOME}/share/lib/loadConfig.sh
 
+
+##  This is used by the defaults files to populate the default
+##  information at the top of each file.  The value of this field
+##  should be identical in all three locations:
+##  packages/fhs/src/main/assembly/filter.properties,
+##  packages/tar/src/main/assembly/filter.properties and
+##  packages/system-test/src/main/assembly/filter.properties.
+DEFAULTS_HEADER = #                                                          \n\
+#   This Java properties file contains some of the default values used by    \n\
+#   dCache.  The values may be updated in either etc/dcache.conf or your     \n\
+#   layout file.  Do not modify this file as your changes will be lost when  \n\
+#   you next upgrade dCache.                                                 \n\
+#                                                                            \n\
+#   Some property definitions in this file have annotations: a comma-        \n\
+#   separated list of additional information within parentheses.  When       \n\
+#   configuring dCache, do not copy any annotations.  The following          \n\
+#   annotations are understood:                                              \n\
+#                                                                            \n\
+#     one-of      a |-separated list of valid values.  Configuring an invalid\n\
+#                 value prevents dCache from starting.                       \n\
+#                                                                            \n\
+#     any-of      a |-separated list of valid items for a comma-separated    \n\
+#                 list value.  Including an invalid item prevents dCache from\n\
+#                 starting.                                                  \n\
+#                                                                            \n\
+#     immutable   a property that may not be altered.  Configuring this      \n\
+#                 property prevents dCache from starting.                    \n\
+#                                                                            \n\
+#     depricated  support for this property will be removed after the next   \n\
+#                 long-term support release.                                 \n\
+#                                                                            \n\
+#     obsolete    property is no longer supported.  Configuring this property\n\
+#                 has no effect.                                             \n\
+#                                                                            \n\
+#     forbidden   property is no longer supported.  Configuring this property\n\
+#                 prevents dCache from starting.                             \n\
+#                                                                            \n\
+#     not-for-services  property only affects domains.  Configuring this     \n\
+#                 property in a service context has no effect.               \n\
+#                                                                            \n\
+#   Use the 'dcache check-config' to verify your configuration.              \n\
+
+
+
 # These are used by dCache itself
 dcache.paths.plugins=${dcache.home}/plugins
 dcache.paths.setup=${dcache.paths.etc}/dcache.conf

--- a/packages/tar/src/main/assembly/filter.properties
+++ b/packages/tar/src/main/assembly/filter.properties
@@ -37,6 +37,49 @@ DCACHE_DEFAULTS=${DCACHE_HOME}/share/defaults               \n\
 DCACHE_CACHED_CONFIG=${DCACHE_HOME}/var/config/cache        \n\
 . ${DCACHE_HOME}/share/lib/loadConfig.sh
 
+
+##  This is used by the defaults files to populate the default
+##  information at the top of each file.  The value of this field
+##  should be identical in all three locations:
+##  packages/fhs/src/main/assembly/filter.properties,
+##  packages/tar/src/main/assembly/filter.properties and
+##  packages/system-test/src/main/assembly/filter.properties.
+DEFAULTS_HEADER = #                                                          \n\
+#   This Java properties file contains some of the default values used by    \n\
+#   dCache.  The values may be updated in either etc/dcache.conf or your     \n\
+#   layout file.  Do not modify this file as your changes will be lost when  \n\
+#   you next upgrade dCache.                                                 \n\
+#                                                                            \n\
+#   Some property definitions in this file have annotations: a comma-        \n\
+#   separated list of additional information within parentheses.  When       \n\
+#   configuring dCache, do not copy any annotations.  The following          \n\
+#   annotations are understood:                                              \n\
+#                                                                            \n\
+#     one-of      a |-separated list of valid values.  Configuring an invalid\n\
+#                 value prevents dCache from starting.                       \n\
+#                                                                            \n\
+#     any-of      a |-separated list of valid items for a comma-separated    \n\
+#                 list value.  Including an invalid item prevents dCache from\n\
+#                 starting.                                                  \n\
+#                                                                            \n\
+#     immutable   a property that may not be altered.  Configuring this      \n\
+#                 property prevents dCache from starting.                    \n\
+#                                                                            \n\
+#     depricated  support for this property will be removed after the next   \n\
+#                 long-term support release.                                 \n\
+#                                                                            \n\
+#     obsolete    property is no longer supported.  Configuring this property\n\
+#                 has no effect.                                             \n\
+#                                                                            \n\
+#     forbidden   property is no longer supported.  Configuring this property\n\
+#                 prevents dCache from starting.                             \n\
+#                                                                            \n\
+#     not-for-services  property only affects domains.  Configuring this     \n\
+#                 property in a service context has no effect.               \n\
+#                                                                            \n\
+#   Use the 'dcache check-config' to verify your configuration.              \n\
+
+
 # These are used by dCache itself
 dcache.paths.plugins=/usr/share/dcache/plugins:/usr/local/share/dcache/plugins
 dcache.paths.setup=${dcache.paths.etc}/dcache.conf

--- a/skel/share/defaults/admin.properties
+++ b/skel/share/defaults/admin.properties
@@ -1,11 +1,8 @@
 #  -----------------------------------------------------------------------
 #     Default values for admin doors
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for admin
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
+
 
 # Cell name
 (deprecated)cell.nameSsh2=admin

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -1,9 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for embedded alarm server
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for the alarm
-#   server which may run inside a standalone domain.
+@DEFAULTS_HEADER@
 
 #  ---- Cell name of the alarm service
 #

--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for billing
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for billing
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  ---- Cell name of billing service
 #

--- a/skel/share/defaults/broadcast.properties
+++ b/skel/share/defaults/broadcast.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for broadcast
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for broadcast
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 broadcast.cell.name=broadcast
 

--- a/skel/share/defaults/chimera.properties
+++ b/skel/share/defaults/chimera.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for Chimera namespace DB configuration
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for Chimera DB
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  ---- Chimera database name
 #

--- a/skel/share/defaults/cleaner.properties
+++ b/skel/share/defaults/cleaner.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for Cleaner
 #  -----------------------------------------------------------------------
-#
-#  This Java properties file contains default values for the cleaner
-#  service.  All values can be redefined in etc/dcache.conf. Do not
-#  modify any values here as your changes will be lost when you next
-#  upgrade.
+@DEFAULTS_HEADER@
 #
 #  The cleaner is the component that watches for files being deleted
 #  in the namespace.  There must be at most one cleaner per dCache
@@ -24,7 +20,6 @@
 #  they couldn't respond in time.  The cleaner will periodically try
 #  to delete data on pools in this list but, between such retries,
 #  these pools are excluded from cleaner activity.
-#
 
 # Cell name
 cleaner.cell.name=cleaner

--- a/skel/share/defaults/cns.properties
+++ b/skel/share/defaults/cns.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for cns
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for cns
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 cns.cell.name=cns
 

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     dCache default values
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for dCache
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 #
 #   Properties prefixed by 'dcache' are either not specific to any
 #   particular service, or used by several services. In the former case,

--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for DCAP doors
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for DCAP
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 # Cell names for DCAP doors
 dcap.cell.name=${dcap.cell.name.${dcap.authn.protocol}}

--- a/skel/share/defaults/dir.properties
+++ b/skel/share/defaults/dir.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for dir
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for dir service
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 # Cell name
 dir.cell.name=dirLookupPool

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for FTP doors
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for FTP
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  Cell names for FTP doors
 #

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for gPlazma configuration
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for gPlazma
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 
 #  ---- Name of the gPlazma cell

--- a/skel/share/defaults/hoppingmanager.properties
+++ b/skel/share/defaults/hoppingmanager.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for hoppingmanager configuration
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for hoppingmanager
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 hoppingmanager.cell.name=HoppingManager
 

--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for httpd
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for the httpd
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 httpd.cell.name=httpd
 

--- a/skel/share/defaults/info-provider.properties
+++ b/skel/share/defaults/info-provider.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     info-provider default values
 #  -----------------------------------------------------------------------
-#
-#   This properties file contains default values for dCache
-#   info-provider. All values can be redefined in etc/dcache.conf. Do
-#   not modify any values here as your changes will be lost when you
-#   next upgrade.
+@DEFAULTS_HEADER@
 #
 #   The info-provider generates LDIF-formatted data conforming to the
 #   GLUE information model's LDAP bindings.  It takes information from

--- a/skel/share/defaults/info.properties
+++ b/skel/share/defaults/info.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for info service
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for the info service
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 info.cell.name = info
 

--- a/skel/share/defaults/loginbroker.properties
+++ b/skel/share/defaults/loginbroker.properties
@@ -1,12 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for loginbroker
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for loginbroker
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
-
+@DEFAULTS_HEADER@
 #
 #   A login broker maintains a list of doors in dCache. Each door is
 #   configured to register with zero or more login brokers. By default

--- a/skel/share/defaults/missing-files.properties
+++ b/skel/share/defaults/missing-files.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for missing-files
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for missing-files
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  ---- cell names
 #

--- a/skel/share/defaults/missingfiles-semsg.properties
+++ b/skel/share/defaults/missingfiles-semsg.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for missing-files 'semsg' plugin
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for missing-files
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 
 #  --- Basic communication settings

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for nfs
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for nfsv41
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 nfs.cell.name=NFS-${host.name}
 

--- a/skel/share/defaults/paths.properties
+++ b/skel/share/defaults/paths.properties
@@ -1,5 +1,7 @@
-# Various paths used by dCache shell scripts and configuration
-# defaults.
+#  -----------------------------------------------------------------------
+#     Default paths used by dCache shell scripts and configuration
+#  -----------------------------------------------------------------------
+@DEFAULTS_HEADER@
 #
 # These parameters may change in future versions. Avoid redefining
 # them.

--- a/skel/share/defaults/pinmanager.properties
+++ b/skel/share/defaults/pinmanager.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for pinmanager
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for pinmanager
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  ---- Cell name of pin manager service
 #

--- a/skel/share/defaults/pnfsmanager.properties
+++ b/skel/share/defaults/pnfsmanager.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for pnfsmanager
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for pnfsmanager
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 # Cell name of pnfsmanager service
 pnfsmanager.cell.name=PnfsManager

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for pools
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for pool
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 # Pool name
 #

--- a/skel/share/defaults/poolmanager.properties
+++ b/skel/share/defaults/poolmanager.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for pool manager
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for pool manager
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 # Cell name of poolmanager
 poolmanager.cell.name=PoolManager

--- a/skel/share/defaults/replica.properties
+++ b/skel/share/defaults/replica.properties
@@ -1,13 +1,8 @@
 #  -----------------------------------------------------------------------
 #     Default values for replica
 #  -----------------------------------------------------------------------
+@DEFAULTS_HEADER@
 #
-#   This Java properties file contains default values for replica
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
-
-
 #   To activate Replica Manager you need make changes in 3 places:
 #    1) you need to run the replica service somewhere in your
 #       dCache installation by enabling it in a layout file

--- a/skel/share/defaults/spacemanager.properties
+++ b/skel/share/defaults/spacemanager.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for spacemanager
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for spacemanager
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  ---- Whether space reservation should be supported.
 #

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -1,11 +1,7 @@
 # -----------------------------------------------------------------------
 #    Default values for srm
 # -----------------------------------------------------------------------
-#
-# This Java properties file contains default values for srm
-# configuration parameters. All values can be redefined in
-# etc/dcache.conf. Do not modify any values here as your changes will
-# be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 # ---- Cell names
 #

--- a/skel/share/defaults/ssh1.properties
+++ b/skel/share/defaults/ssh1.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for ssh1 service
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for ssh1
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  ----  LoginManager name
 #

--- a/skel/share/defaults/star.properties
+++ b/skel/share/defaults/star.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for Storage Accounting Records (StAR)
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for pool manager
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 
 #

--- a/skel/share/defaults/statistics.properties
+++ b/skel/share/defaults/statistics.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for statistics
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for the statistics
-#   service configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 statistics.cell.name=PoolStatistics
 

--- a/skel/share/defaults/topo.properties
+++ b/skel/share/defaults/topo.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for topo configuration
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for topo
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 # Cell name of topo service
 topo.cell.name=topo

--- a/skel/share/defaults/transfermanagers.properties
+++ b/skel/share/defaults/transfermanagers.properties
@@ -1,11 +1,7 @@
 # -----------------------------------------------------------------------
 #    Default values for transfermanagers
 # -----------------------------------------------------------------------
-#
-# This Java properties file contains default values for transfermanagers
-# configuration parameters. All values can be redefined in
-# etc/dcache.conf. Do not modify any values here as your changes will
-# be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 transfermanagers.cell.name=RemoteTransferManager
 

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for WebDAV doors
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for WebDAV
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  ---- Cell name of WebDAV door
 #

--- a/skel/share/defaults/xrootd-alice-token.properties
+++ b/skel/share/defaults/xrootd-alice-token.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for alice-token xrootd authorization plugin
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for alice-token
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  ---- Key store file
 #

--- a/skel/share/defaults/xrootd-gsi.properties
+++ b/skel/share/defaults/xrootd-gsi.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for xrootd GSI plugin
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for xrootd
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 xrootd.gsi.hostcert.key=${dcache.authn.hostcert.key}
 xrootd.gsi.hostcert.cert=${dcache.authn.hostcert.cert}

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -1,11 +1,7 @@
 #  -----------------------------------------------------------------------
 #     Default values for xrootd
 #  -----------------------------------------------------------------------
-#
-#   This Java properties file contains default values for xrootd
-#   configuration parameters. All values can be redefined in
-#   etc/dcache.conf. Do not modify any values here as your changes
-#   will be lost when you next upgrade.
+@DEFAULTS_HEADER@
 
 #  ---- Cell name of Xrootd door
 #


### PR DESCRIPTION
We don't explain what the annotations in mean in the defaults file.  This
has led to confusion with people misunderstanding the annotation and
mistakenly copying the annotation with configuring dCache.

This patch adds a common information about what the annotations mean.  It
also refactors the common explanation so the current duplication is reduced
(but not eliminated).

Target: master
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8166
Patch: http://rb.dcache.org/r/6346/
Acked-by: Karsten Schwank
Request: 2.7
Request: 2.6
Request: 2.2
