### PR TITLE
spacemanager: Fix typo in property name

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/services/space/spacemanager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/services/space/spacemanager.xml
@@ -94,7 +94,7 @@
 		     '${spacemanager.expire-space-reservation.period.unit}')}" />
     <property name="defaultRetentionPolicy" value="#{T(diskCacheV111.util.RetentionPolicy).getRetentionPolicy('${spacemanager.default-retention-policy}')}" />
     <property name="defaultAccessLatency" value="#{T(diskCacheV111.util.AccessLatency).getAccessLatency('${spacemanager.default-access-latency}')}" />
-    <property name="reserveSpaceForNonSRMTransfers" value="${spacemanager.enable.reserve-space-for-non-srm-tranfers}" />
+    <property name="reserveSpaceForNonSRMTransfers" value="${spacemanager.enable.reserve-space-for-non-srm-transfers}" />
     <property name="deleteStoredFileRecord" value="false" />
     <property name="cleanupExpiredSpaceFiles" value="true" />
     <property name="returnFlushedSpaceToReservation" value="true" />

--- a/skel/share/defaults/spacemanager.properties
+++ b/skel/share/defaults/spacemanager.properties
@@ -53,6 +53,7 @@ spacemanager.cell.name=SrmSpaceManager
 #
 (deprecated,one-of?true|false)SpaceManagerReserveSpaceForNonSRMTransfers=false
 (one-of?true|false|${SpaceManagerReserveSpaceForNonSRMTransfers})spacemanager.enable.reserve-space-for-non-srm-tranfers=${SpaceManagerReserveSpaceForNonSRMTransfers}
+(one-of?true|false|${spacemanager.enable.reserve-space-for-non-srm-tranfers})spacemanager.enable.reserve-space-for-non-srm-transfers=${spacemanager.enable.reserve-space-for-non-srm-tranfers}
 
 # ---- Location of LinkGroupAuthorizationFile
 #

--- a/skel/share/services/spacemanager.batch
+++ b/skel/share/services/spacemanager.batch
@@ -13,7 +13,7 @@ check -strong spacemanager.db.driver
 check -strong spacemanager.db.user
 check -strong spacemanager.db.password
 check -strong spacemanager.default-access-latency
-check -strong spacemanager.enable.reserve-space-for-non-srm-tranfers
+check -strong spacemanager.enable.reserve-space-for-non-srm-transfers
 check spacemanager.authz.link-group-file-name
 check -strong spacemanager.enable.space-reservation
 check -strong spacemanager.service.poolmanager


### PR DESCRIPTION
Introduces spacemanager.enable.reserve-space-for-non-srm-transfers.

Target: trunk
Request: 2.7
Require-notes: yes
Require-book: yes
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/6340/
