### PR TITLE
(2.7) dcache-core (billing): modify changesets to do concurrent index cr...

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-1.9.13.xml
@@ -112,88 +112,74 @@
 			<column name="transaction" type="character varying(256)"/>
 		</createTable>
 	</changeSet>
-	<changeSet id="1.0" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<and>
-				<tableExists tableName="billinginfo"/>
-				<not>
-					<indexExists indexName="billinginfo_date_idx"/>
-				</not>
-				<not>
-					<indexExists indexName="billinginfo_isnew_idx"/>
-				</not>
-			</and>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="billinginfo_date_idx" tableName="billinginfo">
-			<column name="datestamp"/>
-		</createIndex>
-		<createIndex indexName="billinginfo_isnew_idx" tableName="billinginfo">
-			<column name="isnew"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="1.1" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<and>
-				<tableExists tableName="storageinfo"/>
-				<not>
-					<indexExists indexName="storageinfo_date_idx"/>
-				</not>
-				<not>
-					<indexExists indexName="storageinfo_action_idx"/>
-				</not>
-			</and>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="storageinfo_date_idx" tableName="storageinfo">
-			<column name="datestamp"/>
-		</createIndex>
-		<createIndex indexName="storageinfo_action_idx" tableName="storageinfo">
-			<column name="action"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="1.2" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<and>
-				<tableExists tableName="doorinfo"/>
-				<not>
-					<indexExists indexName="doorinfo_date_idx"/>
-				</not>
-			</and>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="doorinfo_date_idx" tableName="doorinfo">
-			<column name="datestamp"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="1.3" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<and>
-				<tableExists tableName="costinfo"/>
-				<not>
-					<indexExists indexName="costinfo_date_idx"/>
-				</not>
-			</and>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="costinfo_date_idx" tableName="costinfo">
-			<column name="datestamp"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="1.4" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<and>
-				<tableExists tableName="hitinfo"/>
-				<not>
-					<indexExists indexName="hitinfo_date_idx"/>
-				</not>
-			</and>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="hitinfo_date_idx" tableName="hitinfo">
-			<column name="datestamp"/>
-		</createIndex>
-	</changeSet>
+    <changeSet id="1.0-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="billinginfo"/>
+                <not>
+                    <indexExists indexName="billinginfo_date_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="billinginfo_isnew_idx"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_date_idx on billinginfo(datestamp);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_isnew_idx on billinginfo(isnew);
+        </sql>
+    </changeSet>
+    <changeSet id="1.1-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="storageinfo"/>
+                <not>
+                    <indexExists indexName="storageinfo_date_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="storageinfo_action_idx"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY storageinfo_date_idx on storageinfo(datestamp);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY storageinfo_action_idx on storageinfo(action);
+        </sql>
+    </changeSet>
+    <changeSet id="1.2-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="doorinfo"/>
+                <not>
+                    <indexExists indexName="doorinfo_date_idx"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY doorinfo_date_idx on doorinfo(datestamp);
+        </sql>
+    </changeSet>
+    <changeSet id="1.4-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="hitinfo"/>
+                <not>
+                    <indexExists indexName="hitinfo_date_idx"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY hitinfo_date_idx on hitinfo(datestamp);
+        </sql>
+    </changeSet>
 	<changeSet id="2.0" author="arossi" context="billing">
 		<preConditions onFail="MARK_RAN">
 			<not>
@@ -290,83 +276,72 @@
 			<column name="totalcost" type="double precision"/>
 		</createTable>
 	</changeSet>
-	<changeSet id="3.0" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<not>
-				<indexExists indexName="billinginfo_rd_daily_date_idx"/>
-			</not>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="billinginfo_rd_daily_date_idx" tableName="billinginfo_rd_daily">
-			<column name="date"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="3.1" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<not>
-				<indexExists indexName="billinginfo_wr_daily_date_idx"/>
-			</not>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="billinginfo_wr_daily_date_idx" tableName="billinginfo_wr_daily">
-			<column name="date"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="3.2" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<not>
-				<indexExists indexName="billinginfo_tm_daily_date_idx"/>
-			</not>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="billinginfo_tm_daily_date_idx" tableName="billinginfo_tm_daily">
-			<column name="date"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="3.3" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<not>
-				<indexExists indexName="storageinfo_rd_daily_date_idx"/>
-			</not>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="storageinfo_rd_daily_date_idx" tableName="storageinfo_rd_daily">
-			<column name="date"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="3.4" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<not>
-				<indexExists indexName="storageinfo_wr_daily_date_idx"/>
-			</not>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="storageinfo_wr_daily_date_idx" tableName="storageinfo_wr_daily">
-			<column name="date"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="3.5" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<not>
-				<indexExists indexName="costinfo_daily_date_idx"/>
-			</not>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="costinfo_daily_date_idx" tableName="costinfo_daily">
-			<column name="date"/>
-		</createIndex>
-	</changeSet>
-	<changeSet id="3.6" author="arossi" context="billing">
-		<preConditions onFail="MARK_RAN">
-			<not>
-				<indexExists indexName="hitinfo_daily_date_idx"/>
-			</not>
-		</preConditions>
-		<comment>read optimization</comment>
-		<createIndex indexName="hitinfo_daily_date_idx" tableName="hitinfo_daily">
-			<column name="date"/>
-		</createIndex>
-	</changeSet>
+    <changeSet id="3.0-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="billinginfo_rd_daily_date_idx"/>
+            </not>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_rd_daily_date_idx on billinginfo_rd_daily(date);
+        </sql>
+    </changeSet>
+    <changeSet id="3.1-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="billinginfo_wr_daily_date_idx"/>
+            </not>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_wr_daily_date_idx on billinginfo_wr_daily(date);
+        </sql>
+    </changeSet>
+    <changeSet id="3.2-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="billinginfo_tm_daily_date_idx"/>
+            </not>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_tm_daily_date_idx on billinginfo_tm_daily(date);
+        </sql>
+    </changeSet>
+    <changeSet id="3.3-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="storageinfo_rd_daily_date_idx"/>
+            </not>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY storageinfo_rd_daily_date_idx on storageinfo_rd_daily(date);
+        </sql>
+    </changeSet>
+    <changeSet id="3.4-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="storageinfo_wr_daily_date_idx"/>
+            </not>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY storageinfo_wr_daily_date_idx on storageinfo_wr_daily(date);
+        </sql>
+    </changeSet>
+    <changeSet id="3.6-v2" author="arossi" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="hitinfo_daily_date_idx"/>
+            </not>
+        </preConditions>
+        <comment>read optimization</comment>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY hitinfo_daily_date_idx on hitinfo_daily(date);
+        </sql>
+    </changeSet>
     <changeSet id="4.0.0" author="arossi" context="billing">
         <preConditions onError="CONTINUE" onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from pg_catalog.pg_language where lanname='plpgsql'</sqlCheck>

--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.6.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.6.xml
@@ -3,117 +3,117 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
 				       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
-  <preConditions>
-    <dbms type="postgresql"/>
-  </preConditions>
+    <preConditions>
+        <dbms type="postgresql"/>
+    </preConditions>
 
-  <changeSet id="6.0.0" author="litvinse" context="billing">
-    <preConditions onFail="MARK_RAN">
-      <and>
-	<tableExists tableName="billinginfo"/>
-	<not>
-	  <indexExists indexName="billinginfo_client_idx"/>
-	</not>
-	<not>
-	  <indexExists indexName="billinginfo_initiator_idx"/>
-	</not>
-	<not>
-	  <indexExists indexName="billinginfo_pnfsid_idx"/>
-	</not>
-	<not>
-	  <indexExists indexName="billinginfo_storageclass_idx"/>
-	</not>
-	<not>
-	  <indexExists indexName="billinginfo_transaction_idx"/>
-	</not>
-      </and>
-    </preConditions>
-    <createIndex indexName="billinginfo_client_idx" tableName="billinginfo">
-      <column name="client"/>
-    </createIndex>
-    <createIndex indexName="billinginfo_initiator_idx" tableName="billinginfo">
-      <column name="initiator"/>
-    </createIndex>
-    <createIndex indexName="billinginfo_pnfsid_idx" tableName="billinginfo">
-      <column name="pnfsid"/>
-    </createIndex>
-    <createIndex indexName="billinginfo_storageclass_idx" tableName="billinginfo">
-      <column name="storageclass"/>
-    </createIndex>
-    <createIndex indexName="billinginfo_transaction_idx" tableName="billinginfo">
-      <column name="transaction"/>
-    </createIndex>
-  </changeSet>
-  <changeSet id="6.0.1" author="litvinse" context="billing">
-    <preConditions onFail="MARK_RAN">
-      <and>
-	<tableExists tableName="doorinfo"/>
-	<not>
-	  <indexExists indexName="doorinfo_owner_idx"/>
-	</not>
-	<not>
-	  <indexExists indexName="doorinfo_pnfsid_idx"/>
-	</not>
-	<not>
-	  <indexExists indexName="doorinfo_transaction_idx"/>
-	</not>
-      </and>
-    </preConditions>
-    <createIndex indexName="doorinfo_owner_idx" tableName="doorinfo">
-      <column name="owner"/>
-    </createIndex>
-    <createIndex indexName="doorinfo_pnfsid_idx" tableName="doorinfo">
-      <column name="pnfsid"/>
-    </createIndex>
-    <createIndex indexName="doorinfo_transaction_idx" tableName="doorinfo">
-      <column name="transaction"/>
-    </createIndex>
-  </changeSet>
-  <changeSet id="6.0.2" author="litvinse" context="billing">
-    <preConditions onFail="MARK_RAN">
-      <and>
-	<tableExists tableName="storageinfo"/>
-	<not>
-	  <indexExists indexName="storageinfo_pnfsid_idx"/>
-	</not>
-	<not>
-	  <indexExists indexName="storageinfo_transaction_idx"/>
-	</not>
-	<not>
-	  <indexExists indexName="storageinfo_storageclass_idx"/>
-	</not>
-      </and>
-    </preConditions>
-    <createIndex indexName="storageinfo_pnfsid_idx" tableName="storageinfo">
-      <column name="pnfsid"/>
-    </createIndex>
-    <createIndex indexName="storageinfo_transaction_idx" tableName="storageinfo">
-      <column name="transaction"/>
-    </createIndex>
-    <createIndex indexName="storageinfo_storageclass_idx" tableName="storageinfo">
-      <column name="storageclass"/>
-    </createIndex>
-  </changeSet>
-  <changeSet id="6.0.3" author="litvinse" context="billing">
-    <preConditions onFail="MARK_RAN">
-      <and>
-	<tableExists tableName="hitinfo"/>
-	<not>
-	  <indexExists indexName="hitinfo_pnfsid_idx"/>
-	</not>
-	<not>
-	  <indexExists indexName="hitinfo_transaction_idx"/>
-	</not>
-      </and>
-    </preConditions>
-    <createIndex indexName="hitinfo_pnfsid_idx" tableName="hitinfo">
-      <column name="pnfsid"/>
-    </createIndex>
-    <createIndex indexName="hitinfo_transaction_idx" tableName="hitinfo">
-      <column name="transaction"/>
-    </createIndex>
-  </changeSet>
-  <changeSet id="6.1.0" author="arossi" context="billing">
+    <changeSet id="6.0.0-v2" author="litvinse" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="billinginfo"/>
+                <not>
+                    <indexExists indexName="billinginfo_client_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="billinginfo_initiator_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="billinginfo_pnfsid_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="billinginfo_storageclass_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="billinginfo_transaction_idx"/>
+                </not>
+            </and>
+        </preConditions>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_client_idx on billinginfo(client);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_initiator_idx on billinginfo(initiator);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_pnfsid_date_idx on billinginfo(pnfsid);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_storageclass_date_idx on billinginfo(storageclass);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_transaction_date_idx on billinginfo(transaction);
+        </sql>
+    </changeSet>
+    <changeSet id="6.0.1-v2" author="litvinse" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="doorinfo"/>
+                <not>
+                    <indexExists indexName="doorinfo_owner_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="doorinfo_pnfsid_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="doorinfo_transaction_idx"/>
+                </not>
+            </and>
+        </preConditions>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY doorinfo_owner_idx on doorinfo(owner);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY doorinfo_pnfsid_idx on doorinfo(pnfsid);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY doorinfo_transaction_idx on doorinfo(transaction);
+        </sql>
+    </changeSet>
+    <changeSet id="6.0.2-v2" author="litvinse" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="storageinfo"/>
+                <not>
+                    <indexExists indexName="storageinfo_pnfsid_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="storageinfo_transaction_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="storageinfo_storageclass_idx"/>
+                </not>
+            </and>
+        </preConditions>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY storageinfo_pnfsid_idx on storageinfo(pnfsid);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY storageinfo_transaction_idx on storageinfo(transaction);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY storageinfo_storageclass_idx on storageinfo(storageclass);
+        </sql>
+    </changeSet>
+    <changeSet id="6.0.3-v2" author="litvinse" context="billing" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="hitinfo"/>
+                <not>
+                    <indexExists indexName="hitinfo_pnfsid_idx"/>
+                </not>
+                <not>
+                    <indexExists indexName="hitinfo_transaction_idx"/>
+                </not>
+            </and>
+        </preConditions>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY hitinfo_pnfsid_idx on hitinfo(pnfsid);
+        </sql>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY hitinfo_transaction_idx on hitinfo(transaction);
+        </sql>
+    </changeSet>
+    <changeSet id="6.1.0" author="arossi" context="billing">
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists columnName="p2p" tableName="billinginfo"/>
@@ -122,16 +122,16 @@
         <comment>add p2p column to billinginfo</comment>
         <addColumn tableName="billinginfo"><column name="p2p" type="boolean"/></addColumn>
     </changeSet>
-    <changeSet id="6.1.1" author="arossi" context="billing">
+    <changeSet id="6.1.1-v2" author="arossi" context="billing" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="billinginfo_p2p_idx"/>
             </not>
         </preConditions>
         <comment>read optimization</comment>
-        <createIndex indexName="billinginfo_p2p_idx" tableName="billinginfo">
-            <column name="p2p"/>
-        </createIndex>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY billinginfo_p2p_idx on billinginfo(p2p);
+        </sql>
     </changeSet>
     <changeSet id="6.1.2" author="arossi" context="billing">
         <preConditions onError="WARN" onFail="WARN">


### PR DESCRIPTION
...eation

As suggested in support ticket 7947: slow start on create index in billing.

Note that two modifications were necessary:
1.  Because CREATE INDEX CONCURRENTLY is not supported by the Liquibase createIndex task, these were changed to raw <sql> calls.
2.  Because this command cannot run inside a transaction, each of these changeset is marked runInTransaction=false, with cognizance taken of the risks.

The old changesets were eliminated and replaced with new ones having a different id.

Testing:

Deployed new changesets.  Eliminated all indices from billing database and booted billing domain.

Here are the stats for the largest tables (the fine-grained data):

billing=> select count(*) from billinginfo;
##   count

 8070858
(1 row)

billing=> select count(*) from storageinfo;
##   count

 1862998
(1 row)

billing=> select count(*) from doorinfo;
##   count

 1902624
(1 row)

billing=> select count(*) from hitinfo;
##  count

 58028
(1 row)

11 Dec 2013 14:02:58 (billing) [] Continuing past: liquibase.precondition.core.PreconditionContainer@5303eb4 despite precondition error:
 ...
11 Dec 2013 14:24:36 (System) [] created : billing

(Total initialization time of about 22 minutes with 8M, 2M and 2M rows in the three main tables).

Target: 2.7
Patch: http://rb.dcache.org/r/6343/diff/#index_header
Require-notes: yes
Require-book: no
Acked-by: Tigran
Bug: http://rt.dcache.org/Ticket/Display.html?id=7947
Committed: 94030f5d673303b45765cfa08d6c5e45b3100063

RELEASE NOTES:

Indices on the billing database are now created concurrently, so database (re)initialization should be sped up by a modest linear factor.
