### PR TITLE
spacemanager: Fix use of global property in spacemanager configuration

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/services/space/spacemanager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/services/space/spacemanager.xml
@@ -83,7 +83,7 @@
 					 '${spacemanager.db.user}',
 					 '${spacemanager.db.password}')}"/>
     <property name="spaceManagerEnabled"
-              value="${dcache.enable.space-reservation}" />
+              value="${spacemanager.enable.space-reservation}" />
     <property name="updateLinkGroupsPeriod"
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
 		     ${spacemanager.link-groups-update.period},


### PR DESCRIPTION
Spacemanager did not respect the spacemanager.enable.space-reservation
property.

Target: trunk
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/6388/
(cherry picked from commit 4c41bd14ed2e92c8e625ad2f57017ee724b120eb)
