### PR TITLE
(2.7) chimera: fix get locality to work with id-type FsInode

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInodeType.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInodeType.java
@@ -27,7 +27,8 @@ public enum FsInodeType {
     NAMEOF(6),   // the content of the inode is the name of the inode
     PGET(7),     // the content of the inode is the value of requested attributes
     PSET(8),     // by updating mtime of the inode the the defined attribute value is updated
-    CONST(9);    // the content of the inode is a free form information
+    CONST(9),    // the content of the inode is a free form information
+    PLOC(10);     // the content of the inode is the value of requested attributes
 
     private final int _id;
 

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PLOC.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PLOC.java
@@ -1,0 +1,69 @@
+/*
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program (see the file COPYING.LIB for more
+ * details); if not, write to the Free Software Foundation, Inc.,
+ * 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.dcache.chimera;
+
+import org.dcache.chimera.posix.Stat;
+
+/**
+ * This class retrieves file locality metadata via an invocation of
+ * the pool manager.
+ *
+ * @author arossi
+ */
+public class FsInode_PLOC extends FsInode {
+    private String _locality;
+
+    public FsInode_PLOC(FileSystemProvider fs, String id) {
+        super(fs, id, FsInodeType.PLOC);
+    }
+
+    @Override
+    public int read(long pos, byte[] data, int offset, int len) {
+        String output = _locality == null? "\n" : _locality;
+
+        byte[] b = output.getBytes();
+
+        if (pos > b.length) {
+            return 0;
+        }
+
+        int copyLen = Math.min(len, b.length - (int) pos);
+        System.arraycopy(b, (int) pos, data, 0, copyLen);
+
+        return copyLen;
+    }
+
+
+    public void setLocality(String locality) {
+        _locality = locality + "\n";
+    }
+
+    @Override
+    public Stat stat() throws ChimeraFsException {
+        Stat ret = super.stat();
+        ret.setMode((ret.getMode() & 0000777) | UnixPermission.S_IFREG);
+        ret.setSize(_locality == null ? 0 : _locality.length());
+        // invalidate NFS cache
+        ret.setMTime(System.currentTimeMillis());
+        return ret;
+    }
+
+    @Override
+    public int write(long pos, byte[] data, int offset, int len) {
+        return -1;
+    }
+}

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -1072,12 +1072,20 @@ public class JdbcFs implements FileSystemProvider {
                     throw new FileNotFoundHimeraFsException(name);
                 }
 
+                if (cmd[2].equals("locality")) {
+                    inode = inodeOf(parent, cmd[1]);
+                    if (!inode.exists()) {
+                        throw new FileNotFoundHimeraFsException(name);
+                    }
+                    return getPLOC(inode.toString());
+                }
+
                 /*
                  * pass in the name too (args 1 to n)
                  */
                 String[] args = new String[cmd.length - 1];
                 System.arraycopy(cmd, 1, args, 0, args.length);
-                inode = getPGET(parent, args);
+                inode = new FsInode_PGET(this, parent.toString(), args);
                 if (!inode.exists()) {
                     throw new FileNotFoundHimeraFsException(name);
                 }
@@ -2811,8 +2819,13 @@ public class JdbcFs implements FileSystemProvider {
                 break;
 
             case PGET:
-                inode = getPGET(inodeId, getArgs(opaque));
+                inode = new FsInode_PGET(this, inodeId, getArgs(opaque));
                 break;
+
+            case PLOC:
+                inode = getPLOC(inodeId);
+                break;
+
             default:
                 throw new FileNotFoundHimeraFsException("Unsupported file handle type: " + inodeType);
         }
@@ -2908,7 +2921,12 @@ public class JdbcFs implements FileSystemProvider {
                     for (int i = 0; i < argc; i++) {
                         args[i] = st.nextToken();
                     }
-                    inode = getPGET(id, args);
+                    inode = new FsInode_PGET(this, id, args);
+                    break;
+
+                case PLOC:
+                    id = st.nextToken();
+                    inode = getPLOC(id);
                     break;
 
             }
@@ -2926,18 +2944,12 @@ public class JdbcFs implements FileSystemProvider {
     }
 
     /**
-     * So that subclasses can do something different (like caching).
+     * Subclass should cache the inode object for proper handling.
+     * This implementation will not work correctly by itself.  The
+     * adapter here is a placeholder.
      */
-    protected FsInode_PGET getPGET(String id, String[] args)
+    protected FsInode_PLOC getPLOC(String id)
                     throws ChimeraFsException {
-        return new FsInode_PGET(this, id, args);
-    }
-
-    /**
-     * So that subclasses can do something different (like caching).
-     */
-    protected FsInode_PGET getPGET(FsInode parent, String[] args)
-                    throws ChimeraFsException {
-        return new FsInode_PGET(this, parent.toString(), args);
+        return new FsInode_PLOC(this, id);
     }
 }


### PR DESCRIPTION
The current implementation of ".(get)(filename)(locality)" relies on an FsInode type which embeds the filename and the "locality" argument.  Since the filename is arbitrarily long, the encoded handle length could exceed the file handle length specified by NFS4.

The solution is to change the handling of this command (file) to use the id FsInode type and to encode the operation directly into it.  The id (pnfsid) is of fixed length, as is the code for the op.

A new FsInode type (PLOC) has been created for this purpose.  Several auxiliary methods and private classes which are no longer necessary have also been eliminated.

The new code allows this operation to work successfully with both v4 and with the smaller handle size of v3 as well (both were tested).

Target: 2.7
Patch: http://rb.dcache.org/r/6404
Require-book: no
Require-notes: yes
Acked-by: Tigran
Committed: 9657929930ea0503462116835ecb98f1cc4587ba

RELEASE NOTES:  Fixes a bug in the ".(get)(filename)(locality)" preventing successful completion of the call when the filename is very long.
