### PR TITLE
admin: fix batch file of acm cell

### DIFF
--- a/skel/share/cells/acm.fragment
+++ b/skel/share/cells/acm.fragment
@@ -1,2 +1,2 @@
 create dmg.cells.services.login.user.AclCell acm \
-          ${dcache.paths.admin}/users -export -egpassword=${dcache.paths.config}/passwd
+          "${dcache.paths.admin}/users -export -egpassword=${dcache.paths.config}/passwd"


### PR DESCRIPTION
cells arguments should be quoted

Acked-by: Albert Rossi
Target: master, 2.7
Require-book: no
Require-notes: no
(cherry picked from commit c6949ce10b2c1ff304b7e403303ada247526e9a5)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
