### PR TITLE
cells: Catch UnresolvedAddressException

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/network/LocationManagerConnector.java
+++ b/modules/cells/src/main/java/dmg/cells/network/LocationManagerConnector.java
@@ -9,6 +9,8 @@ import java.io.PrintWriter;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.UnresolvedAddressException;
+import java.nio.channels.UnsupportedAddressTypeException;
 import java.util.Random;
 
 import dmg.cells.nucleus.CellAdapter;
@@ -100,7 +102,16 @@ public class LocationManagerConnector
 
 
         setStatus("Connecting to " + address);
-        Socket socket = SocketChannel.open(address).socket();
+        Socket socket;
+        try {
+            socket = SocketChannel.open(address).socket();
+        } catch (UnsupportedAddressTypeException e) {
+            throw new IOException("Unsupported address type: " + address, e);
+        } catch (UnresolvedAddressException e) {
+            throw new IOException("Unable to resolve " + address, e);
+        } catch (IOException e) {
+            throw new IOException("Failed to connect to " + address + ": " + e.toString(), e);
+        }
         socket.setKeepAlive(true);
 
         String security = reply.getOpt("security");


### PR DESCRIPTION
We have observed the following error in our logs:

13 Jan 2014 13:26:20 (lm) [] Uncaught exception in thread TunnelConnector
java.nio.channels.UnresolvedAddressException: null
        at sun.nio.ch.Net.checkAddress(Net.java:127) ~[na:1.7.0_45]
        at sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:640) ~[na:1.7.0_45]
        at java.nio.channels.SocketChannel.open(SocketChannel.java:184) ~[na:1.7.0_45]
        at dmg.cells.network.LocationManagerConnector.connect(LocationManagerConnector.java:103) ~[cells-2.7.4.jar:2.7.4]
        at dmg.cells.network.LocationManagerConnector.run(LocationManagerConnector.java:153) ~[cells-2.7.4.jar:2.7.4]
        at dmg.cells.nucleus.CellNucleus$1.run(CellNucleus.java:674) ~[cells-2.7.4.jar:2.7.4]
        at java.lang.Thread.run(Thread.java:744) ~[na:1.7.0_45]

This patch fixes this problem by translating the exception to an
IOException with additional information about the address that could
not be resovled.

Target: trunk
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Acked-by: Paul Millar paul.millar@desy.de
(cherry picked from commit 50084af73b3b5ead96b9e675fd8c723f09c60d56)
