### PR TITLE
nfs: fix compatibility with 2.6

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/chimera/nfs/v4/xdr/stateid4.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfs/v4/xdr/stateid4.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2009 - 2014 Deutsches Elektronen-Synchroton,
+ * Member of the Helmholtz Association, (DESY), HAMBURG, GERMANY
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program (see the file COPYING.LIB for more
+ * details); if not, write to the Free Software Foundation, Inc.,
+ * 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.dcache.chimera.nfs.v4.xdr;
+import java.util.Arrays;
+
+import java.io.Serializable;
+import org.dcache.utils.Bytes;
+
+public class stateid4 implements  Serializable {
+
+    static final long serialVersionUID = -6677150504723505919L;
+
+    public uint32_t seqid;
+    public byte [] other;
+
+    public stateid4(byte[] other, int seq) {
+        this.other = other;
+        seqid = new uint32_t(seq);
+    }
+
+    public stateid4(org.dcache.nfs.v4.xdr.stateid4 stateid) {
+        this(stateid.other, stateid.seqid.value);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if( obj == this) return true;
+        if( !(obj instanceof stateid4) ) return false;
+
+        final stateid4 other_id = (stateid4) obj;
+
+        return Arrays.equals(this.other, other_id.other);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(other);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("[");
+        sb.append(Bytes.toHexString(other));
+        sb.append(", seq: ").append(seqid.value).append("]");
+        return sb.toString();
+    }
+
+}
+// End of stateid4.java

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfs/v4/xdr/uint32_t.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfs/v4/xdr/uint32_t.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2009 - 2014 Deutsches Elektronen-Synchroton,
+ * Member of the Helmholtz Association, (DESY), HAMBURG, GERMANY
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program (see the file COPYING.LIB for more
+ * details); if not, write to the Free Software Foundation, Inc.,
+ * 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.dcache.chimera.nfs.v4.xdr;
+
+import java.io.Serializable;
+
+public class uint32_t implements Serializable {
+
+    static final long serialVersionUID = -6603937444681096490L;
+
+    public int value;
+
+    public uint32_t(int value) {
+        this.value = value;
+    }
+
+}
+// End of uint32_t.java

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NFS4ProtocolInfo.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NFS4ProtocolInfo.java
@@ -10,7 +10,7 @@ import diskCacheV111.vehicles.IpProtocolInfo;
 
 import dmg.cells.nucleus.CellPath;
 
-import org.dcache.nfs.v4.xdr.stateid4;
+import org.dcache.chimera.nfs.v4.xdr.stateid4;
 
 public class NFS4ProtocolInfo implements IpProtocolInfo {
 

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -65,7 +65,8 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
     }
 
     public stateid4 getStateId() {
-        return getProtocolInfo().stateId();
+        org.dcache.chimera.nfs.v4.xdr.stateid4 legacyStateid =  getProtocolInfo().stateId();
+        return new stateid4(legacyStateid.other, legacyStateid.seqid.value);
     }
 
     @Override
@@ -146,7 +147,7 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
     private class MoverState extends NFS4State {
 
         MoverState() {
-            super(NfsMover.this.getProtocolInfo().stateId());
+            super(NfsMover.this.getStateId());
         }
 
         @Override

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -101,7 +101,8 @@ public class NfsTransferService extends AbstractCellComponent
             final Cancellable cancellableMover = mover.enable(completionHandler);
 
             CellPath directDoorPath = new CellPath(mover.getPathToDoor().getDestinationAddress());
-            _door.send(directDoorPath, new PoolPassiveIoFileMessage<>(getCellName(), _localSocketAddresses, mover.getStateId()));
+            final org.dcache.chimera.nfs.v4.xdr.stateid4 legacyStateId = mover.getProtocolInfo().stateId();
+            _door.send(directDoorPath, new PoolPassiveIoFileMessage<>(getCellName(), _localSocketAddresses, legacyStateId));
 
             /* An NFS mover doesn't complete until it is cancelled (the door sends a mover kill
              * message when the file is closed).


### PR DESCRIPTION
post 2.6 nfs code has changes package name from

org.dcache.chimera.nfs => org.dcache.nfs
Nevertheless one class is used inside
a message sent to a pool and brakes
compatibility with.

this change restores compatibility.

Notice, this makes 2.7.6 not compatible in mixed
setup.

Acked-by: Gerd Behrmann
Target: master, 2.7
Require-book: no
Require-notes: no
(cherry picked from commit be1b718cd6ea67a35bb98ad0e758580cade4fa46)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
