### PR TITLE
pool: Do not save terminated jobs to setup file

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
@@ -80,13 +80,13 @@ public class Job
     enum State { INITIALIZING, RUNNING, SLEEPING, PAUSED, SUSPENDED,
             STOPPING, CANCELLING, CANCELLED, FINISHED, FAILED }
 
-    private final static Logger _log = LoggerFactory.getLogger(Job.class);
+    private static final Logger _log = LoggerFactory.getLogger(Job.class);
 
-    private final Set<PnfsId> _queued = new LinkedHashSet();
-    private final Map<PnfsId,Long> _sizes = new HashMap();
-    private final Map<PnfsId,Task> _running = new HashMap();
+    private final Set<PnfsId> _queued = new LinkedHashSet<>();
+    private final Map<PnfsId,Long> _sizes = new HashMap<>();
+    private final Map<PnfsId,Task> _running = new HashMap<>();
     private final Future<?> _refreshTask;
-    private final BlockingQueue<Error> _errors = new ArrayBlockingQueue(15);
+    private final BlockingQueue<Error> _errors = new ArrayBlockingQueue<>(15);
     private final Map<PoolMigrationJobCancelMessage,DelayedReply> _cancelRequests =
         new HashMap<>();
 
@@ -202,7 +202,7 @@ public class Job
 
         pw.println("Concurrency: " + _concurrency);
         pw.println("Running tasks:");
-        List<Task> tasks = new ArrayList(_running.values());
+        List<Task> tasks = new ArrayList<>(_running.values());
         Collections.sort(tasks, new Comparator<Task>() {
                 @Override
                 public int compare(Task t1, Task t2)

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -959,6 +959,7 @@ public class MigrationModule
                 Job job = i.next();
                 switch (job.getState()) {
                 case CANCELLED:
+                case FAILED:
                 case FINISHED:
                     i.remove();
                     _commands.remove(job);
@@ -1069,7 +1070,17 @@ public class MigrationModule
         pw.println("#\n# MigrationModule\n#");
         for (Job job: _jobs.values()) {
             if (job.getDefinition().isPermanent) {
-                pw.println(_commands.get(job));
+                switch (job.getState()) {
+                case CANCELLED:
+                case CANCELLING:
+                case STOPPING:
+                case FAILED:
+                case FINISHED:
+                    break;
+                default:
+                    pw.println(_commands.get(job));
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Without this patch, cancelled permanent jobs will resurrect after a
pool restart. Also fixes the 'migration clear' command to remove
failed jobs too.

Target: trunk
Request: 2.7
Request: 2.6
Require-book: no
Require-notes: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6420/
(cherry picked from commit 9ba476abe7b1432c4300b12edc36a57c2f150e18)
