### PR TITLE
pool: Fixing rep ls output, RT 8203

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -1,22 +1,19 @@
 package org.dcache.pool.repository;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileNotInCacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.StorageInfo;
-
+import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.DelayedReply;
 import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.util.Args;
 import dmg.util.Formats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.dcache.cells.CellCommandListener;
 
@@ -130,10 +127,18 @@ public class RepositoryInterpreter
     {
         if (args.argc() > 0) {
             StringBuilder sb   = new StringBuilder();
+            List<FileNotInCacheException> cacheExceptions = new ArrayList<>();
             for (int i = 0; i < args.argc(); i++) {
                 PnfsId pnfsid = new PnfsId(args.argv(i));
-                sb.append(_repository.getEntry(pnfsid));
-                sb.append("\n");
+                try {
+                    sb.append(_repository.getEntry(pnfsid));
+                    sb.append("\n");
+                } catch (FileNotInCacheException fnice) {
+                    cacheExceptions.add(fnice);
+                }
+            }
+            for (FileNotInCacheException cacheException : cacheExceptions) {
+                sb.append(cacheException).append("\n");
             }
             return sb.toString();
         }


### PR DESCRIPTION
Output of rep ls <pnfsID that exists> <pnfsID that does not exist> <another pnfsID that exists> would show:
<pnfsID that exists> <C-------X--L(0)[0]> 2255071 si={test:disk}
CacheException(rc=10007;msg=Entry not in repository : <pnfsID that does not exist would show>)
<another pnfsID that exists> <C-------X--L(0)[0]> 2255071 si={test:disk}

Now it show this:

[wla000617wpa.desy.de](pool_write) admin > rep ls 0000B27FEE232A7840A7ADCBEBEE57886730 00000DC04577984D4FCD9610F44B19CF3BD7 00000DC04577984D4FCD9610F44B19CF3B23 00000DC04577984D4FCD9610F44B19CF3B45
0000B27FEE232A7840A7ADCBEBEE57886730 <C-------X--L(0)[0]> 2255071 si={test:disk}
00000DC04577984D4FCD9610F44B19CF3BD7 <C-------X--L(0)[0]> 10002434 si={test:disk}
CacheException(rc=10007;msg=Entry not in repository : 00000DC04577984D4FCD9610F44B19CF3B23)
CacheException(rc=10007;msg=Entry not in repository : 00000DC04577984D4FCD9610F44B19CF3B45)

Ticket: 8203
Acked-by: Gerd
Target: trunk
Require-book: no
Require-notes: yes
