### PR TITLE
nfs4: fix orphan proxy movers

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
@@ -81,11 +81,11 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
                         @Override
                         public ProxyIoAdapter call() throws Exception {
                             final RpcCall call = context.getRpcCall();
+                            final NFS4State state = context.getStateHandler().getClientIdByStateId(stateid).state(stateid);
+
                             final ProxyIoAdapter adapter = proxyIoFactory.getAdapter(inode, call.getCredential().getSubject(),
                                     call.getTransport().getRemoteSocketAddress());
 
-
-                            final NFS4State state = context.getStateHandler().getClientIdByStateId(stateid).state(stateid);
                             state.addDisposeListener( new StateDisposeListener() {
 
                                 @Override


### PR DESCRIPTION
Check client state before starting a proxy mover.
This prevents orphan movers when client recovery failed
or stateid provided by client is not valid.

Acked-by: Gerd Behrmann
Target: master, 2.7
Require-book: no
Require-notes: no
(cherry picked from commit b9d945f9e1dfb47bf501870cc91f1334b33fb6dc)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
