### PR TITLE
libs: update nfs library to 0.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -777,7 +777,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.7.0</version>
+            <version>0.7.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
fixes IO on 'dot' files.
fixes misbehavior in reboot recovery

Changelog for nfs4j-0.7.0..nfs4j-0.7.1
    \* [eb6adf4] vfs: chimera: let inode to call setStat()
    \* [d5b5a52] nfs4: implement missing RECLAIM_COMPLETE
    \* [f361946] nfs4: fix open CLAIM_PREVIOUS
    \* [a6d7c13] pom: enforce  maven-release-plugin 2.4.2

Acked-by: Albert Rossi
Target: master, 2.7

Require-book: no
Require-notes: yes
(cherry picked from commit dfeaa7c3fe5f984e8a3a364d5e4a3d78c3bc4497)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
