### PR TITLE
pom: enforce maven-release-plugin 2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1086,6 +1086,23 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+               <!--
+                  2.4.2 fersion fixes bug which affect releasing with git:
+                  http://jira.codehaus.org/browse/MRELEASE-812
+               -->
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-release-plugin</artifactId>
+               <version>2.4.2</version>
+               <dependencies>
+                  <dependency>
+                     <groupId>org.apache.maven.scm</groupId>
+                     <artifactId>maven-scm-provider-gitexe</artifactId>
+                     <version>1.9</version>
+                 </dependency>
+               </dependencies>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
the latest plugin broke git support.

Acked-by: Gerd Behrmann
Target: master, 2.7, 2.6
Require-book: no
Require-notes: no
(cherry picked from commit 5a5ccd2d5c3353331881dc5df0645a429df836e9)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
