### PR TITLE
dcache-webadmin: fix ArrayIndexOutOfBounds exception in ListView (Tape T...

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.java
@@ -26,12 +26,15 @@ public class TapeTransferQueue extends SortableBasePage {
     private static final long serialVersionUID = 8313857084027604473L;
     private static final Logger _log = LoggerFactory.getLogger(TapeTransferQueue.class);
 
+    final List<RestoreBean> _restoreBeans;
+
     public TapeTransferQueue() {
         Form<?> form = new Form<Void>("tapeTransferQueueForm");
         form.add(new FeedbackPanel("feedback"));
+        _restoreBeans = getRestoreBeans();
         ListView<RestoreBean> listview =
                 new EvenOddListView<RestoreBean>("TapeTransferQueueListview",
-                new PropertyModel(this, "restoreBeans")) {
+                new PropertyModel(this, "_restoreBeans")) {
 
                     private static final long serialVersionUID = 9166078572922366382L;
 


### PR DESCRIPTION
...ransfers page)

The Wicket PropertyModel requires either an object field name or a getter/setter
name which can be used to invoke by reflection in order to store and retrieve the property value.

In the case of a ListView, the PropertyModel value is a list; in the case of the TapeTransfersQueue page,
this list is provided by a service whose DAO abstraction accesses a page cache that is refreshed
periodically by calling "xrc ls" on the PoolManager.  The current implementation uses a getter
which extracts a new copy of the list from cache.

This getter, however, is invoked each time the "populateItem" method is called (that is, for each list item);
aside from being inefficient, this could cause an indexing problem if the size of the underlying
list changes in the middle of the procedure to populate the entire list; specifically, the
reported bug suggests that either the original or the current list size is used to determine
the successive iteration, but on that successive call, the list size has been reduced (by one),
causing an IndexOutOfBounds exception.

The solution here is to associate a stable instance of the list with the page constructor.
There is no problem in terms of updating the page values, since this particular page is only
refreshed manually by reloading. A fresh copy of the list will be obtained from the cache on
each reload, which calls the page constructor.

Testing:

Before this patch, loading the page causes the browser to hang and
the following stack trace is observed in the log:

1.04.37 [qtp1040303644-45] [] Unexpected error occurred
org.apache.wicket.WicketRuntimeException: Error attaching this container for
rendering: [Page class = org.dcache.webadmin.view.pages.tapetransferqueue.TapeTransferQueue, id = 0, render count = 1]
...
Caused by: java.lang.IndexOutOfBoundsException: Index: 9739, Size: 9739
at java.util.ArrayList.rangeCheck(ArrayList.java:604) ~[na:1.7.0_25]
at java.util.ArrayList.get(ArrayList.java:382) ~[na:1.7.0_25]
at org.apache.wicket.markup.html.list.ListItemModel.getObject(ListItemModel.java:58) ~[wicket-core-1.5.10.jar:1.5.10]

After patch application, the error no longer occurs.

Target: master
Request: 2.8
Request: 2.7
Request: 2.6
Patch: http://rb.dcache.org/r/6527
Require-book: no
Require-notes: yes
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8225
Acked-by: Tigran

RELEASE NOTES:  Fixes a bug in the TapeTransferQueue page whereby an IndexOutOfBounds error
can occur (and hang the page).
(cherry picked from commit ed919cf0eb99da85d594ebbc4d27fba6b1c9d09e)

Signed-off-by: alrossi arossi@otfrid.fnal.gov
