### PR TITLE
ftp: Reenable support for RFC 2428

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -2105,51 +2105,57 @@ public abstract class AbstractFtpDoorV1
               port % 256 + ")");
     }
 
-// IPv6 support disable because IPv4 client use these commands too. The use
-// of these commands is not compatible with redirected FTP.
-//
-//    public void ftp_eprt(String arg)
-//            throws FTPCommandException
-//    {
-//        checkLoggedIn();
-//
-//        setActive(getExtendedAddressOf(arg));
-//
-//        reply(ok("EPRT"));
-//    }
-//
-//    public void ftp_epsv(String arg)
-//        throws FTPCommandException
-//    {
-//        checkLoggedIn();
-//
-//        if  ("ALL".equalsIgnoreCase(arg)) {
-//            _sessionAllPassive = true;
-//            reply(ok("EPSV ALL"));
-//            return;
-//        }
-//        if (arg.isEmpty()) {
-//            /* If already in passive mode then we close the previous
-//             * socket and allocate a new one. This is a defensive move to
-//             * recover from the server socket having been closed by some
-//             * error condition.
-//             */
-//            closePassiveModeServerSocket();
-//            InetSocketAddress address = setPassive();
-//            reply("229 Entering Extended Passive Mode (|||"+address.getPort()+"|)");
-//        } else {
-//            try {
-//                _preferredProtocol = Protocol.find(arg);
-//                reply(ok("EPSV" +arg));
-//            } catch (NumberFormatException nfe) {
-//                throw new FTPCommandException(501, "Syntax error: '"+
-//                        arg+"' is not a valid argument for EPSV.");
-//            } catch (IllegalArgumentException e) {
-//                throw new FTPCommandException(522, "Protocol family '"+
-//                        arg+"'is not supported, use one of (1,2)");
-//            }
-//        }
-//    }
+    public void ftp_eprt(String arg)
+            throws FTPCommandException
+    {
+        checkIpV6();
+        checkLoggedIn();
+
+        setActive(getExtendedAddressOf(arg));
+
+        reply(ok("EPRT"));
+    }
+
+    public void ftp_epsv(String arg)
+        throws FTPCommandException
+    {
+        checkIpV6();
+        checkLoggedIn();
+
+        if  ("ALL".equalsIgnoreCase(arg)) {
+            _sessionAllPassive = true;
+            reply(ok("EPSV ALL"));
+            return;
+        }
+        if (arg.isEmpty()) {
+            /* If already in passive mode then we close the previous
+             * socket and allocate a new one. This is a defensive move to
+             * recover from the server socket having been closed by some
+             * error condition.
+             */
+            closePassiveModeServerSocket();
+            InetSocketAddress address = setPassive();
+            reply("229 Entering Extended Passive Mode (|||"+address.getPort()+"|)");
+        } else {
+            try {
+                _preferredProtocol = Protocol.find(arg);
+                reply(ok("EPSV" +arg));
+            } catch (NumberFormatException nfe) {
+                throw new FTPCommandException(501, "Syntax error: '"+
+                        arg+"' is not a valid argument for EPSV.");
+            } catch (IllegalArgumentException e) {
+                throw new FTPCommandException(522, "Protocol family '"+
+                        arg+"'is not supported, use one of (1,2)");
+            }
+        }
+    }
+
+    private void checkIpV6() throws FTPCommandException
+    {
+        if (!_localAddress.getAddress().getClass().equals(Inet6Address.class)) {
+            throw new FTPCommandException(502, "Command only supported for IPv6");
+        }
+    }
 
     public void ftp_mode(String arg)
     {

--- a/modules/dcache-ftp/src/test/java/org/dcache/ftp/door/AbstractFtpDoorV1Test.java
+++ b/modules/dcache-ftp/src/test/java/org/dcache/ftp/door/AbstractFtpDoorV1Test.java
@@ -13,7 +13,6 @@ import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
 
 import java.net.Inet4Address;
-import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.EnumSet;
@@ -161,229 +160,249 @@ public class AbstractFtpDoorV1Test {
         orderedReplies.verify(door).reply(startsWith("250"));
     }
 
-//    @Test
-//    public void EPRTshouldReply200ForValidIP4Arg()
-//            throws FTPCommandException {
-//            doCallRealMethod().when(door).ftp_eprt(anyString());
-//            doCallRealMethod().when(door).getExtendedAddressOf(anyString());
-//            doCallRealMethod().when(door).ok(anyString());
-//
-//            door.ftp_eprt("|1|127.0.0.1|22|");
-//
-//            verify(door).reply(startsWith("200"));
-//        }
-//
-//    @Test
-//    public void EPRTshouldReply200ForValidIP6Arg()
-//            throws FTPCommandException {
-//            doCallRealMethod().when(door).ftp_eprt(anyString());
-//            doCallRealMethod().when(door).getExtendedAddressOf(anyString());
-//            doCallRealMethod().when(door).ok(anyString());
-//
-//            door.ftp_eprt("|2|::1|22|");
-//
-//            verify(door).reply(startsWith("200"));
-//        }
-//
-//    @Test
-//    public void EPRTshouldReply501ForInvalidIP4Arg()
-//            throws FTPCommandException {
-//            doCallRealMethod().when(door).ftp_eprt(anyString());
-//            doCallRealMethod().when(door).getExtendedAddressOf(anyString());
-//
-//            thrown.expectCode(501);
-//            door.ftp_eprt("|1|999.0.0.0|22|");
-//        }
-//
-//    @Test
-//    public void EPRTshouldReply501ForInvalidIP6Arg()
-//            throws FTPCommandException {
-//            doCallRealMethod().when(door).ftp_eprt(anyString());
-//            doCallRealMethod().when(door).getExtendedAddressOf(anyString());
-//
-//            thrown.expectCode(501);
-//            door.ftp_eprt("|2|:999999::1|22|");
-//        }
-//
-//    @Test
-//    public void EPRTshouldReply522ForMissingProtocolArg()
-//            throws FTPCommandException {
-//            doCallRealMethod().when(door).ftp_eprt(anyString());
-//            doCallRealMethod().when(door).getExtendedAddressOf(anyString());
-//
-//            thrown.expectCode(501);
-//            door.ftp_eprt("|127.0.0.1|22|");
-//        }
-//
-//    @Test
-//    public void EPRTshouldReply522ForEmptyProtocolArg()
-//            throws FTPCommandException {
-//            doCallRealMethod().when(door).ftp_eprt(anyString());
-//            doCallRealMethod().when(door).getExtendedAddressOf(anyString());
-//
-//            thrown.expectCode(522);
-//            door.ftp_eprt("||127.0.0.1|22|");
-//        }
-//
-//    @Test
-//    public void EPRTshouldReply501ForMissingArg()
-//            throws FTPCommandException {
-//            doCallRealMethod().when(door).ftp_eprt(anyString());
-//            doCallRealMethod().when(door).getExtendedAddressOf(anyString());
-//
-//            thrown.expectCode(501);
-//            door.ftp_eprt("");
-//        }
-//
-//    @Test
-//    public void EPRTshouldReply501ForTooManyArgs()
-//            throws FTPCommandException {
-//        doCallRealMethod().when(door).ftp_eprt(anyString());
-//        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
-//
-//        thrown.expectCode(501);
-//        door.ftp_eprt("||||1|||127.0.0.1||22||||");
-//    }
-//
-//    @Test
-//    public void EPRTshouldReply522ForUnsupportedProtocol()
-//            throws FTPCommandException {
-//            doCallRealMethod().when(door).ftp_eprt(anyString());
-//            doCallRealMethod().when(door).getExtendedAddressOf(anyString());
-//
-//            thrown.expectCode(522);
-//            door.ftp_eprt("|3|127.0.0.1|22|");
-//        }
-//
-//    @Test
-//    public void EPSVshouldReply200WhenConnectionEstablished()
-//            throws FTPCommandException, UnknownHostException {
-//            doCallRealMethod().when(door).ftp_epsv(anyString());
-//            when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
-//
-//            door.ftp_epsv("");
-//
-//            verify(door).reply(startsWith("229"));
-//        }
-//
-//    @Test
-//    public void EPSVshouldReply522WhenRequestingInvalidProtocol()
-//            throws FTPCommandException, UnknownHostException {
-//            doCallRealMethod().when(door).ftp_epsv(anyString());
-//            when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
-//
-//            thrown.expectCode(522);
-//            door.ftp_epsv("3");
-//        }
-//
-//    @Test
-//    public void EPSVshouldReply200WhenRequestingAll()
-//            throws FTPCommandException, UnknownHostException
-//    {
-//            doCallRealMethod().when(door).ftp_epsv(anyString());
-//            doCallRealMethod().when(door).ok(anyString());
-//            when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
-//
-//            door.ftp_epsv("all");
-//
-//            verify(door).reply(startsWith("200"));
-//    }
-//
-//    @Test
-//    public void EPSVshouldReply229WhenRequestingAllFollowedByEPSVwithoutArgument()
-//            throws FTPCommandException, UnknownHostException
-//    {
-//        doCallRealMethod().when(door).ftp_epsv(anyString());
-//        doCallRealMethod().when(door).ok(anyString());
-//        when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
-//
-//        door.ftp_epsv("all");
-//
-//        door.ftp_epsv("");
-//
-//        verify(door).reply(startsWith("229"));
-//    }
-//
-//    @Test
-//    public void PASVshouldBeRejectedAfterEPSVallCall()
-//            throws FTPCommandException, UnknownHostException
-//    {
-//            doCallRealMethod().when(door).ftp_epsv(anyString());
-//            doCallRealMethod().when(door).ftp_pasv(anyString());
-//            when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
-//
-//            door.ftp_epsv("all");
-//            thrown.expectCode(503);
-//            door.ftp_pasv("192,168,1,1,6666");
-//        }
-//
-//    @Test
-//    public void PORTshouldBeRejectedAfterEPSVallCall()
-//            throws FTPCommandException, UnknownHostException
-//    {
-//            doCallRealMethod().when(door).ftp_epsv(anyString());
-//            doCallRealMethod().when(door).ftp_port(anyString());
-//            doCallRealMethod().when(door).setActive((InetSocketAddress)any());
-//            when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
-//
-//            door.ftp_epsv("all");
-//            thrown.expectCode(503);
-//            door.ftp_port("192,168,1,1,0,20");
-//        }
-//
-//    @Test
-//    public void EPRTshouldBeRejectedAfterEPSVallCall()
-//            throws FTPCommandException, UnknownHostException
-//    {
-//            doCallRealMethod().when(door).ftp_epsv(anyString());
-//            doCallRealMethod().when(door).ftp_eprt(anyString());
-//            doCallRealMethod().when(door).setActive((InetSocketAddress)any());
-//            when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
-//
-//            door.ftp_epsv("all");
-//            thrown.expectCode(503);
-//            door.ftp_eprt("|3|127.0.0.1|22|");
-//        }
-//
-//    @Test
-//    public void EPSVshouldRebindIpWhenRequestedIPv6Protocol()
-//            throws Exception {
-//            doCallRealMethod().when(door).ftp_epsv(anyString());
-//            doCallRealMethod().when(door).setPassive();
-//            door._localAddress = new InetSocketAddress(forString("127.0.0.1"), 22);
-//
-//            door._passiveModePortRange = new PortRange(0);
-//
-//            door.ftp_epsv("2");
-//            door.ftp_epsv("");
-//
-//            assertThat(door._preferredProtocol, is(AbstractFtpDoorV1.Protocol.IPV6));
-//            assertEquals(Inet6Address.class, ((InetSocketAddress)door._passiveModeServerSocket.getLocalAddress()).getAddress().getClass());
-//        }
-//
-//    @Test
-//    public void EPSVshouldRebindIpWhenRequestedIPv4Protocol()
-//            throws Exception {
-//            doCallRealMethod().when(door).ftp_epsv(anyString());
-//            doCallRealMethod().when(door).setPassive();
-//            door._localAddress = new InetSocketAddress(forString("::1"), 22);
-//            door._passiveModePortRange = new PortRange(0);
-//
-//            door.ftp_epsv("1");
-//            door.ftp_epsv("");
-//
-//            assertThat(door._preferredProtocol, is(AbstractFtpDoorV1.Protocol.IPV4));
-//            assertEquals(Inet4Address.class, ((InetSocketAddress)door._passiveModeServerSocket.getLocalAddress()).getAddress().getClass());
-//        }
-//
-//    @Test
-//    public void EPSVshouldReply522WhenRequestedUnsupportedProtocol()
-//            throws FTPCommandException {
-//            doCallRealMethod().when(door).ftp_epsv(anyString());
-//
-//            thrown.expectCode(522);
-//            door.ftp_epsv("3");
-//        }
+    @Test
+    public void EPRTshouldReply200ForValidIP4Arg()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
+        doCallRealMethod().when(door).ok(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        door.ftp_eprt("|1|127.0.0.1|22|");
+
+        verify(door).reply(startsWith("200"));
+    }
+
+    @Test
+    public void EPRTshouldReply200ForValidIP6Arg()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
+        doCallRealMethod().when(door).ok(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        door.ftp_eprt("|2|::1|22|");
+
+        verify(door).reply(startsWith("200"));
+    }
+
+    @Test
+    public void EPRTshouldReply501ForInvalidIP4Arg()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        thrown.expectCode(501);
+        door.ftp_eprt("|1|999.0.0.0|22|");
+    }
+
+    @Test
+    public void EPRTshouldReply501ForInvalidIP6Arg()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        thrown.expectCode(501);
+        door.ftp_eprt("|2|:999999::1|22|");
+    }
+
+    @Test
+    public void EPRTshouldReply522ForMissingProtocolArg()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        thrown.expectCode(501);
+        door.ftp_eprt("|127.0.0.1|22|");
+    }
+
+    @Test
+    public void EPRTshouldReply522ForEmptyProtocolArg()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        thrown.expectCode(522);
+        door.ftp_eprt("||127.0.0.1|22|");
+    }
+
+    @Test
+    public void EPRTshouldReply501ForMissingArg()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        thrown.expectCode(501);
+        door.ftp_eprt("");
+    }
+
+    @Test
+    public void EPRTshouldReply501ForTooManyArgs()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        thrown.expectCode(501);
+        door.ftp_eprt("||||1|||127.0.0.1||22||||");
+    }
+
+    @Test
+    public void EPRTshouldReply522ForUnsupportedProtocol()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).getExtendedAddressOf(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        thrown.expectCode(522);
+        door.ftp_eprt("|3|127.0.0.1|22|");
+    }
+
+    @Test
+    public void EPSVshouldReply200WhenConnectionEstablished()
+            throws FTPCommandException, UnknownHostException {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+        when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
+
+        door.ftp_epsv("");
+
+        verify(door).reply(startsWith("229"));
+    }
+
+    @Test
+    public void EPSVshouldReply522WhenRequestingInvalidProtocol()
+            throws FTPCommandException, UnknownHostException {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+        when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
+
+        thrown.expectCode(522);
+        door.ftp_epsv("3");
+    }
+
+    @Test
+    public void EPSVshouldReply200WhenRequestingAll()
+            throws FTPCommandException, UnknownHostException
+    {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        doCallRealMethod().when(door).ok(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+        when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
+
+        door.ftp_epsv("all");
+
+        verify(door).reply(startsWith("200"));
+    }
+
+    @Test
+    public void EPSVshouldReply229WhenRequestingAllFollowedByEPSVwithoutArgument()
+            throws FTPCommandException, UnknownHostException
+    {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        doCallRealMethod().when(door).ok(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+        when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
+
+        door.ftp_epsv("all");
+
+        door.ftp_epsv("");
+
+        verify(door).reply(startsWith("229"));
+    }
+
+    @Test
+    public void PASVshouldBeRejectedAfterEPSVallCall()
+            throws FTPCommandException, UnknownHostException
+    {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        doCallRealMethod().when(door).ftp_pasv(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+        when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
+
+        door.ftp_epsv("all");
+        thrown.expectCode(503);
+        door.ftp_pasv("192,168,1,1,6666");
+    }
+
+    @Test
+    public void PORTshouldBeRejectedAfterEPSVallCall()
+            throws FTPCommandException, UnknownHostException
+    {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        doCallRealMethod().when(door).ftp_port(anyString());
+        doCallRealMethod().when(door).setActive((InetSocketAddress)any());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+        when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
+
+        door.ftp_epsv("all");
+        thrown.expectCode(503);
+        door.ftp_port("192,168,1,1,0,20");
+    }
+
+    @Test
+    public void EPRTshouldBeRejectedAfterEPSVallCall()
+            throws FTPCommandException, UnknownHostException
+    {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        doCallRealMethod().when(door).setActive((InetSocketAddress)any());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+        when(door.setPassive()).thenReturn(new InetSocketAddress(forString("::1"), 20));
+
+        door.ftp_epsv("all");
+        thrown.expectCode(503);
+        door.ftp_eprt("|3|127.0.0.1|22|");
+    }
+
+    @Test
+    public void EPSVshouldRebindIpWhenRequestedIPv4Protocol()
+            throws Exception {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        doCallRealMethod().when(door).setPassive();
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+        door._passiveModePortRange = new PortRange(0);
+
+        door.ftp_epsv("1");
+        door.ftp_epsv("");
+
+        assertThat(door._preferredProtocol, is(AbstractFtpDoorV1.Protocol.IPV4));
+        assertEquals(Inet4Address.class, ((InetSocketAddress)door._passiveModeServerSocket.getLocalAddress()).getAddress().getClass());
+    }
+
+    @Test
+    public void EPSVshouldReply522WhenRequestedUnsupportedProtocol()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        door._localAddress = new InetSocketAddress(forString("::1"), 21);
+
+        thrown.expectCode(522);
+        door.ftp_epsv("3");
+    }
+
+    @Test
+    public void EPSVshouldReply500WhenRequestedOnIpV4()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_epsv(anyString());
+        door._localAddress = new InetSocketAddress(forString("127.0.0.1"), 21);
+        thrown.expectCode(502);
+        door.ftp_epsv("1");
+    }
+
+    @Test
+    public void EPRTshouldReply500WhenRequestedOnIpV4()
+            throws FTPCommandException {
+        doCallRealMethod().when(door).ftp_eprt(anyString());
+        door._localAddress = new InetSocketAddress(forString("127.0.0.1"), 21);
+        thrown.expectCode(502);
+        door.ftp_eprt("|3|127.0.0.1|22|");
+    }
+
     @Test
     public void whenMkdSuccessfulReply257() throws Exception {
         doCallRealMethod().when(door).ftp_mkd(anyString());


### PR DESCRIPTION
To avoid that IPv6 enabled clients use extended passive and extended port
commands on IPv4 connections, support for these commands is limited to
IPv6 connections. This is necessary as using these commands prevents
ftp data connections from being redirected to pools.

Target: trunk
Require-notes: yes
Require-book: yes
Acked-by: Karsten Schwank karsten.schwank@desy.de
Patch: http://rb.dcache.org/r/6525/
