### PR TITLE
chimera-nfs: add bringonline command to ".(fset)"

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FileSystemProvider.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FileSystemProvider.java
@@ -330,4 +330,20 @@ public interface FileSystemProvider extends Closeable {
      */
     public String getFileLocality(FsInode_PLOC node) throws ChimeraFsException;
 
+    /**
+     * Implementation-specific.  Can be NOP.
+     *
+     * @param pnfsid
+     * @param lifetime
+     * @throws ChimeraFsException
+     */
+    public void pin(String pnfsid, long lifetime) throws ChimeraFsException;
+
+    /**
+     * Implementation-specific.  Can be NOP.
+     *
+     * @param pnfsid
+     * @throws ChimeraFsException
+     */
+    public void unpin(String pnfsid) throws ChimeraFsException;
 }

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -53,6 +53,13 @@ import static org.dcache.commons.util.SqlHelper.tryToClose;
  * @Threadsafe
  */
 public class JdbcFs implements FileSystemProvider {
+    /**
+     * common error message for unimplemented
+     */
+    private static final String NOT_IMPL =
+                    "this operation is unsupported for this "
+                                    + "file system; please install a dCache-aware "
+                                    + "implementation of the file system interface";
 
     /**
      * logger
@@ -2961,8 +2968,24 @@ public class JdbcFs implements FileSystemProvider {
 
     @Override
     public String getFileLocality(FsInode_PLOC node) throws ChimeraFsException {
-        throw new ChimeraFsException("this operation is unsupported for this "
-                        + "file system; please install a dCache-aware "
-                        + "implementation of the file system interface");
+        throw new ChimeraFsException(NOT_IMPL);
+    }
+
+    /**
+     * To maintain the abstraction level, we relegate the actual
+     * callout to the subclass.
+     */
+    @Override
+    public void pin(String pnfsid, long lifetime) throws ChimeraFsException {
+       throw new ChimeraFsException(NOT_IMPL);
+    }
+
+   /**
+    * To maintain the abstraction level, we relegate the actual
+    * callout to the subclass.
+    */
+    @Override
+    public void unpin(String pnfsid) throws ChimeraFsException {
+       throw new ChimeraFsException(NOT_IMPL);
     }
 }

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -45,6 +45,7 @@ import org.dcache.chimera.DirectoryStreamB;
 import org.dcache.chimera.FileExistsChimeraFsException;
 import org.dcache.chimera.FileNotFoundHimeraFsException;
 import org.dcache.chimera.FsInode;
+import org.dcache.chimera.FsInode_PSET;
 import org.dcache.chimera.HimeraDirectoryEntry;
 import org.dcache.chimera.JdbcFs;
 import org.dcache.chimera.NotDirChimeraException;

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/DummyFileSystemProvider.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/mover/DummyFileSystemProvider.java
@@ -280,6 +280,11 @@ public class DummyFileSystemProvider implements FileSystemProvider {
     }
 
     @Override
+    public void pin(String pnfsid, long lifetime) throws ChimeraFsException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
     public int read(FsInode arg0, int arg1, long arg2, byte[] arg3, int arg4,
             int arg5) throws ChimeraFsException {
         // TODO Auto-generated method stub
@@ -507,6 +512,11 @@ public class DummyFileSystemProvider implements FileSystemProvider {
     public String[] tags(FsInode arg0) throws ChimeraFsException {
         // TODO Auto-generated method stub
         return null;
+    }
+
+    @Override
+    public void unpin(String pnfsid) throws ChimeraFsException{
+        // TODO Auto-generated method stub
     }
 
     @Override

--- a/modules/dcache/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -21,12 +21,18 @@
         </property>
     </bean>
 
-
     <bean id="poolManagerStub" class="org.dcache.cells.CellStub">
         <description>Pool manager cell stub</description>
         <property name="timeout" value="${nfs.service.poolmanager.timeout}"/>
         <property name="timeoutUnit" value="${nfs.service.poolmanager.timeout.unit}"/>
         <property name="destination" value="${nfs.service.poolmanager}"/>
+    </bean>
+
+    <bean id="pinManagerStub" class="org.dcache.cells.CellStub">
+        <description>Pin manager cell stub</description>
+        <property name="timeout" value="${nfs.service.pinmanager.timeout}"/>
+        <property name="timeoutUnit" value="${nfs.service.pinmanager.timeout.unit}"/>
+        <property name="destination" value="${nfs.service.pinmanager}"/>
     </bean>
 
     <bean id="pool-stub" class="org.dcache.cells.CellStub">
@@ -77,6 +83,7 @@
         <constructor-arg value="${nfs.db.dialect}" />
         <property name="pnfsHandler" ref="pnfs"/>
         <property name="poolManagerStub" ref="poolManagerStub"/>
+        <property name="pinManagerStub" ref="pinManagerStub"/>
     </bean>
 
     <bean id="export" class="org.dcache.nfs.ExportFile">

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -88,6 +88,10 @@ nfs.service.poolmanager=${dcache.service.poolmanager}
 nfs.service.poolmanager.timeout=${nfs.poolmanager.timeout}
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)nfs.service.poolmanager.timeout.unit=MILLISECONDS
 
+nfs.service.pinmanager=${dcache.service.pinmanager}
+nfs.service.pinmanager.timeout=300000
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)nfs.service.pinmanager.timeout.unit=MILLISECONDS
+
 (deprecated)nfs.pool.timeout=10000
 nfs.service.pool.timeout=${nfs.pool.timeout}
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)nfs.service.pool.timeout.unit=MILLISECONDS

--- a/skel/share/services/nfs.batch
+++ b/skel/share/services/nfs.batch
@@ -15,6 +15,9 @@ check -strong nfs.service.loginbroker.version
 check -strong nfs.service.poolmanager
 check -strong nfs.service.poolmanager.timeout
 check -strong nfs.service.poolmanager.timeout.unit
+check -strong nfs.service.pinmanager
+check -strong nfs.service.pinmanager.timeout
+check -strong nfs.service.pinmanager.timeout.unit
 check -strong nfs.service.pool.timeout
 check -strong nfs.service.pool.timeout.unit
 check -strong nfs.service.pnfsmanager


### PR DESCRIPTION
This patch depends on 6409, but also on current trunk/master being fixed (see testing below).  Currently, these changes have not been tested because of the bug blocking their operation.

Adds an operation type to the ".(fset)" dot command to be able to bring a file on line from an archived state.  As with the ".(get)()(locality)" operation, this requires a file system interface in Chimera which is also dCache aware, so that calls can be made to the PoolManager and PinManager.

The following changes have been made:
1.  FileSystemProvider API extended with two methods, pin() and unpin().
2.  PSET inode slightly refactored, with additional call to the filesystem to set pinned state.
3.  PinManager cell endpoint added to DCacheAware filesystem, in order to implement the two added methods.
4.  Relevant timeout properties for the PinManager instance added.

TESTING:

on testbed, using 4.1.  Pinning and unpinning, along with lifetime, works as it should.

Target: master
Request: 2.8
Request: 2.7
Request: 2.6
Patch: http://rb.dcache.org/r/6410
Require-notes: yes
Require-book: yes
Depends-on: http://rb.dcache.org/r/6409

BOOK:
RELEASE NOTES:

A new command has been added to the NFS dot-command set to allow users to pin and unpin files.  Files which are not on disk will be brought on line.

The command takes the following form:

```
        touch ".(fset)(filename)(pin|stage|bringonline)(duration)([SECONDS|MINUTES|HOURS|DAYS])"
```

The variants of the third argument are equivalent in effect.

The last argument is optional and defaults to SECONDS.

A duration value of 0 will unpin the file.  The command does not allow the user to pin the file indefinitely (the duration value must be a positive integer).

Three new properties associated with the configuration of the pinmanager have been added to nfs.properties:

nfs.service.pinmanager=${dcache.service.pinmanager}
nfs.service.pinmanager.timeout=300000
(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)nfs.service.pinmanager.timeout.unit=MILLISECONDS
(cherry picked from commit 79d9b47c96140eb70d8bdc66e9af45b376f49504)

Signed-off-by: alrossi arossi@otfrid.fnal.gov
