### PR TITLE
httpd: revert datanucleus-xml version (pom.xml)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,10 +380,11 @@
                 <artifactId>datanucleus-rdbms</artifactId>
                 <version>3.2.10</version>
             </dependency>
+            <!-- 3.2.1 has a saxon/XSLT bug -->
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-xml</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.0-release</version>
             </dependency>
             <dependency>
                 <groupId>net.sf.saxon</groupId>


### PR DESCRIPTION
The latest version of the datanucleus-xml library has introduced a regression in involving the XSLT properties.

In particular, at org.datanucleus.store.xml.ConnectionFactoryImpl$ManagedConnectionImpl.close calls the release() method:

```
    public void release()
    {
        if (commitOnRelease)
        {
            try
            {
                TransformerFactory tf = TransformerFactory.newInstance();
                tf.setAttribute("indent-number", indent);
```

However, "indent-number" is not supported; OutputKeys.INDENT should be used
(see http://stackoverflow.com/questions/15134861/java-lang-illegalargumentexception-not-supported-indent-number).

Until the datanucleus team fixes this, we need to revert to the previous version (3.2.0-release, which is used by branches previous to 2.8).

TESTING:

Before patch, refreshing the Alarms table in webadmin produces:

05 Feb 2014 12:11:57 (httpd) [] Exception closing connection to XML file
java.lang.IllegalArgumentException: Unknown attribute indent-number
        at net.sf.saxon.Configuration.setConfigurationProperty(Configuration.java:2185) ~[saxon-8.7.jar:na]
        at net.sf.saxon.TransformerFactoryImpl.setAttribute(TransformerFactoryImpl.java:342) ~[saxon-8.7.jar:na]
        at org.datanucleus.store.xml.ConnectionFactoryImpl$ManagedConnectionImpl.close(ConnectionFactoryImpl.java:194) ~[datanucleus-xml-3.2.1.jar:na]
        at org.datanucleus.store.connection.ConnectionManagerImpl$2.transactionCommitted(ConnectionManagerImpl.java:413) [datanucleus-core-3.2.11.jar:na]
        at org.datanucleus.TransactionImpl.internalPostCommit(TransactionImpl.java:554) [datanucleus-core-3.2.11.jar:na]
        at org.datanucleus.TransactionImpl.commit(TransactionImpl.java:335) [datanucleus-core-3.2.11.jar:na]
        at org.datanucleus.api.jdo.JDOTransaction.commit(JDOTransaction.java:98) [datanucleus-api-jdo-3.2.7.jar:na]
        at org.dcache.webadmin.model.dataaccess.impl.DataNucleusAlarmStore.get(DataNucleusAlarmStore.java:181) [classes/:na]

The xml database remains inaccessible.

After patch, page refresh works normally and displays the entries from the xml database.

Target: trunk
Request: 2.8
Patch: http://rb.dcache.org/r/6540/
Require-book: no
Require-notes: no
Acked-by: Gerd
(cherry picked from commit 3dee98213f75ebd100e81c7ee9e129b7decd2b73)

Signed-off-by: alrossi arossi@otfrid.fnal.gov
