### PR TITLE
libs: update nfs code to 0.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -777,7 +777,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.7.1</version>
+            <version>0.7.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
The libdcap can distinct between regular file systems
and dCache's NFS. This is achieved by existence of a
magic file '.(get)(cursor)', which can be accessed in
any directory in dCache's namespace. Nevertheless, this
behaviour prevents dcap-aware clients to access dcache
through NFSv4.1.

The updated version of nfs library adds a possibility to
hide magic file from dcap client and force them to treat
dCache's NFS as a regular file system.

New export options added: dcap(defualt) and no_dcap.

Example:

/pnfs 10.0.1.1/24(rw,acl,no_dcap)

Changelog for nfs4j-0.7.1..nfs4j-0.7.2
    \* [5c4808c] vfs: add a special option to hide dcache from dcap clients

Acked-by: Gerd Behrmann
Target: master, 2.7, 2.8
Require-book: yes
Require-notes: yes
(cherry picked from commit a6bb4b079662d48a74558fc3c7188beb4db15ece)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
