### PR TITLE
dcache-core, alarms: remove postgresql precondition on schema

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/alarms/db/sql/alarms.changelog-2.6.1.xml
+++ b/modules/dcache/src/main/resources/org/dcache/alarms/db/sql/alarms.changelog-2.6.1.xml
@@ -3,9 +3,6 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
-    <preConditions>
-        <dbms type="postgresql"/>
-    </preConditions>
     <changeSet id="2.0.1" author="arossi" context="alarms">
         <preConditions onError="WARN" onFail="MARK_RAN">
             <and>

--- a/modules/dcache/src/main/resources/org/dcache/alarms/db/sql/alarms.changelog-2.6.xml
+++ b/modules/dcache/src/main/resources/org/dcache/alarms/db/sql/alarms.changelog-2.6.xml
@@ -3,9 +3,6 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
-    <preConditions>
-        <dbms type="postgresql"/>
-    </preConditions>
     <changeSet id="1.0.1" author="arossi" context="alarms">
         <preConditions onError="WARN" onFail="MARK_RAN">
             <and>


### PR DESCRIPTION
There is nothing in the liquibase schema for alarms which specifically requires postgresql.
Removing this precondition allows the rdbms option to be tested in system-test using hsqldb.

Target: master
Request: 2.8
Request: 2.7
Request: 2.6
Patch: http://rb.dcache.org/r/6548/
Require-book: no
Require-notes: no
Acked-by: Gerd
(cherry picked from commit b84b3fa2fe66b44a9f24dcdeda8cc344780f492b)

Signed-off-by: alrossi arossi@otfrid.fnal.gov
