### PR TITLE
xrootd: Upgrade to xrootd4j v1.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <version.xerces>2.9.1</version.xerces>
         <version.jetty>8.1.13.v20130916</version.jetty>
         <version.wicket>6.9.1</version.wicket>
-        <version.xrootd4j>1.2.2</version.xrootd4j>
+        <version.xrootd4j>1.2.4</version.xrootd4j>
         <version.jglobus>2.0.6-rc5.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 


### PR DESCRIPTION
Contains the following changes over v1.2.3:

42101c6 xrootd4j: Make errors null terminated
5ae3a44 Fix read beyond end of file

These changes improve compatibility with the "new xrootd client".

Target: trunk
Request: 2.8
Request: 2.7
Request: 2.6
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8156
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6557/
(cherry picked from commit 68055d49528c12e714928c0d83418798fb8cf793)

Conflicts:
    pom.xml
