### PR TITLE
pool: Fix access time update

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -747,8 +747,8 @@ public class PoolV4
             } else {
                 Set<Repository.OpenFlags> openFlags =
                         message.isPool2Pool()
-                                ? EnumSet.noneOf(Repository.OpenFlags.class)
-                                : EnumSet.of(Repository.OpenFlags.NOATIME);
+                                ? EnumSet.of(Repository.OpenFlags.NOATIME)
+                                : EnumSet.noneOf(Repository.OpenFlags.class);
                 handle = _repository.openEntry(pnfsId, openFlags);
             }
         } catch (FileNotInCacheException e) {


### PR DESCRIPTION
The bug causes access time update to happen on pool to pool and not on regular
downloads - the reverse is supposed to happen.

This affects sweeper garbage collection order, space cost calculation, and
access time update in the name space.

Target: trunk
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8234
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6564/
(cherry picked from commit 05cb3fcab635d741210801efbcc39bd2590dead1)
