### PR TITLE
gplazma2-xacml: revert version of opensaml

### DIFF
--- a/modules/gplazma2-xacml/pom.xml
+++ b/modules/gplazma2-xacml/pom.xml
@@ -53,10 +53,6 @@
             <artifactId>opensaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>opensaml1</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>gplazma2-gsi</artifactId>
             <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -218,10 +218,11 @@
                 <artifactId>jna</artifactId>
                 <version>3.4.0</version>
             </dependency>
+            <!-- xacml client incompatible with the newer opensaml library -->
             <dependency>
                 <groupId>org.opensaml</groupId>
                 <artifactId>opensaml</artifactId>
-                <version>2.6.0</version>
+                <version>2.4.1</version>
                 <exclusions>
                     <exclusion>
                         <!-- We manually pull in a different variant -->
@@ -233,11 +234,6 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.opensaml</groupId>
-                <artifactId>opensaml1</artifactId>
-                <version>1.1</version>
             </dependency>
             <dependency>
                 <groupId>javax.xml</groupId>


### PR DESCRIPTION
The privilege xacml client is incompatible with the newer opensaml library.
In particular, the client bootstrap method calls a method which is missing
in the newer version.

Restores opensaml to 2.4.1 (last compatible).  Also eliminates unused opensaml1 library.

Target: master
Request: 2.8
Patch: http://rb.dcache.org/r/6581/
Bug: http://rt.dcache.org/Ticket/Display.html?id=8244
Requires-book: no
Requires-notes: no
Acked-by: Paul
(cherry picked from commit 71de63c00e30933bfceb6d60ad4f017a6c82694f)

Signed-off-by: alrossi arossi@otfrid.fnal.gov
