### PR TITLE
packages, fhs: fix saxon includes/excludes expression

### DIFF
--- a/modules/fhs/src/main/assembly/fhs.xml
+++ b/modules/fhs/src/main/assembly/fhs.xml
@@ -6,7 +6,7 @@
         <dependencySet>
             <excludes>
                 <exclude>*:*:war:*</exclude>
-                <exclude>saxon:saxon:*:*</exclude>
+                <exclude>*saxon:saxon*:*:*</exclude>
             </excludes>
             <outputDirectory>usr/share/dcache/classes</outputDirectory>
             <useProjectArtifact>false</useProjectArtifact>
@@ -25,7 +25,7 @@
         </dependencySet>
         <dependencySet>
             <includes>
-                <include>saxon:saxon:*:*</include>
+                <include>*saxon:saxon*:*:*</include>
             </includes>
             <outputDirectory>usr/share/dcache/classes/saxon</outputDirectory>
             <fileMode>644</fileMode>


### PR DESCRIPTION
```
The current includes/excludes expression in the fhs package assembly xml fails to move the saxon jars with groupId net.sf.saxon or with artifact "saxon-dom" into the saxon subdirectory.

Added the appropriate globbing to fix this.

Target: 2.6
Patch: http://rb.dcache.org/r/6566/
Require-book: no
Require-notes: no
Acked-by: Gerd
```
