### PR TITLE
gplazma-xacml: remove dependency on org.apache.xalan

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,10 @@
                         <groupId>org.bouncycastle</groupId>
                         <artifactId>bcprov-ext-jdk15</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>xalan</groupId>
+                        <artifactId>xalan</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
There is a xalan implementation which ships with Java.  This dependency does not seem necessary.

We now have all saxon jars in a saxon subdirectory, and no other XSLT libraries on the classpath.

Side benefit is that we can use datanucleus-xml 3.2.1 (without the fix I provided) if needed.

Target: master
Request: 2.8
Request: 2.7
Request: 2.6
Patch: http://rb.dcache.org/r/6582/
Require-book: no
Require-notes: no
Acked-by: Tigran
(cherry picked from commit 18e90f3571bb727c93f8dd219a0260a32e638db9)

Signed-off-by: alrossi arossi@otfrid.fnal.gov
