### PR TITLE
Fix NPE in save command

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
@@ -441,15 +441,20 @@ public class UniversalSpringCell
         String controller = args.getOpt("sc");
         String file = args.getOpt("file");
 
+        File path;
         if ("none".equals(controller)) {
             controller = null;
-            file = _setupFile.getPath();
+            path = _setupFile;
         } else if (file == null && controller == null) {
             controller = _setupController;
-            file = _setupFile.getPath();
+            path = _setupFile;
+        } else if (file != null) {
+            path = new File(file);
+        } else {
+            path = null;
         }
 
-        checkArgument(file != null || controller != null,
+        checkArgument(path != null || controller != null,
                 "Either a setup controller or setup file must be specified");
 
         if (controller != null) {
@@ -470,8 +475,7 @@ public class UniversalSpringCell
             }
         }
 
-        if (file != null) {
-            File path = new File(file).getAbsoluteFile();
+        if (path != null) {
             File directory = path.getParentFile();
             File temp = File.createTempFile(path.getName(), null, directory);
             temp.deleteOnExit();


### PR DESCRIPTION
Fixes

java.lang.NullPointerException: null
    at org.dcache.cells.UniversalSpringCell.ac_save(UniversalSpringCell.java:455) ~[dcache-core-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.7.0_51]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) ~[na:1.7.0_51]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_51]
    at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_51]
    at dmg.util.command.AcCommandExecutor.execute(AcCommandExecutor.java:157) ~[cells-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at dmg.util.CommandInterpreter$CommandEntry.execute(CommandInterpreter.java:385) ~[cells-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at dmg.util.CommandInterpreter.execute(CommandInterpreter.java:281) ~[cells-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at dmg.util.CommandInterpreter.command(CommandInterpreter.java:215) ~[cells-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at dmg.cells.nucleus.CellAdapter.executeLocalCommand(CellAdapter.java:1025) ~[cells-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:952) ~[cells-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.innerRun(CellNucleus.java:1070) ~[cells-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at dmg.cells.nucleus.CellNucleus$AbstractNucleusTask.run(CellNucleus.java:975) ~[cells-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_51]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_51]
    at dmg.cells.nucleus.CellNucleus$1.run(CellNucleus.java:687) [cells-2.8.1-SNAPSHOT.jar:2.8.1-SNAPSHOT]
    at java.lang.Thread.run(Thread.java:744) [na:1.7.0_51]

Affects all services that use UniversalSpringCell and do not have a default
setup file.

Target: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Albert Rossi arossi@fnal.gov
Patch: http://rb.dcache.org/r/6576/
(cherry picked from commit 4f7d02d9c2e5d6e3eeded68acf00352689905bd4)
