### PR TITLE
nfs-proxy: add support for open-less read requests

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
@@ -20,6 +21,7 @@ import org.dcache.nfs.v4.OperationREAD;
 import org.dcache.nfs.v4.StateDisposeListener;
 import org.dcache.nfs.v4.xdr.READ4res;
 import org.dcache.nfs.v4.xdr.READ4resok;
+import org.dcache.nfs.v4.xdr.nfs4_prot;
 import org.dcache.nfs.v4.xdr.nfs_argop4;
 import org.dcache.nfs.v4.xdr.nfs_opnum4;
 import org.dcache.nfs.v4.xdr.nfs_resop4;
@@ -31,6 +33,10 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
 
     private static final Logger _log = LoggerFactory.getLogger(ProxyIoREAD.class.getName());
     private final DcapProxyIoFactory proxyIoFactory;
+
+    // FIXME: this should be imported form org.dcache.nfs.v4.Stateids
+    private final static stateid4 ZERO_STATEID
+	    = new stateid4(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0);
 
     public ProxyIoREAD(nfs_argop4 args, DcapProxyIoFactory proxyIoFactory) {
         super(args, nfs_opnum4.OP_READ);
@@ -56,9 +62,30 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
             int count = _args.opread.count.value.value;
             stateid4 stateid = _args.opread.stateid;
 
-            ProxyIoAdapter proxyIoAdapter = getOrCreateProxy(inode, stateid, context);
-            ByteBuffer bb = ByteBuffer.allocate(count);
-            int bytesReaded = proxyIoAdapter.read(bb, offset);
+	    int bytesReaded;
+	    boolean stateLess = isStateLess(stateid);
+	    ProxyIoAdapter proxyIoAdapter;
+	    ByteBuffer bb = ByteBuffer.allocate(count);
+	    if (stateLess) {
+
+		/*
+		 * As there was no open, we have to check  permissions.
+		 */
+		if (context.getFs().access(inode, nfs4_prot.ACCESS4_READ) == 0) {
+		    throw new ChimeraNFSException(nfsstat.NFSERR_ACCESS, "Permission denied.");
+		}
+
+		/*
+		 * use try-with-resource as wee need to close adapter on each request
+		 */
+		try (ProxyIoAdapter oneUseProxyIoAdapter = createIoAdapter(inode, context)) {
+		    proxyIoAdapter = oneUseProxyIoAdapter;
+		    bytesReaded = oneUseProxyIoAdapter.read(bb, offset);
+		}
+	    } else {
+		proxyIoAdapter = getOrCreateProxy(inode, stateid, context);
+		bytesReaded = proxyIoAdapter.read(bb, offset);
+	    }
 
             res.status = nfsstat.NFS_OK;
             res.resok4 = new READ4resok();
@@ -90,21 +117,14 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
 
                         @Override
                         public ProxyIoAdapter call() throws Exception {
-                            final RpcCall call = context.getRpcCall();
                             final NFS4State state = context.getStateHandler().getClientIdByStateId(stateid).state(stateid);
-
-                            final ProxyIoAdapter adapter = proxyIoFactory.getAdapter(inode, call.getCredential().getSubject(),
-                                    call.getTransport().getRemoteSocketAddress());
+                            final ProxyIoAdapter adapter = createIoAdapter(inode, context);
 
                             state.addDisposeListener( new StateDisposeListener() {
 
                                 @Override
                                 public void notifyDisposed(NFS4State state) {
-                                    try {
-                                        adapter.close();
-                                    }catch (IOException e) {
-                                        _log.error("failed fo close io adapter: ", e.getMessage());
-                                    }
+				    tryToClose(adapter);
                                     _prioxyIO.invalidate(state.stateid());
                                 }
                             });
@@ -126,6 +146,31 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
             }
             throw new ChimeraNFSException(status, t.getMessage());
         }
+    }
+
+    private boolean isStateLess(stateid4 stateid) {
+	/*
+	 * As stateid4#equals() does not check seqid,
+	 * we need a special equality check
+	 */
+	return stateid.seqid.value == ZERO_STATEID.seqid.value  &&
+		Arrays.equals(stateid.other, ZERO_STATEID.other);
+    }
+
+    private ProxyIoAdapter createIoAdapter(final Inode inode, final CompoundContext context)
+	    throws CacheException, InterruptedException, IOException {
+
+	RpcCall call = context.getRpcCall();
+	return proxyIoFactory.getAdapter(inode, call.getCredential().getSubject(),
+		call.getTransport().getRemoteSocketAddress());
+    }
+
+    private static void tryToClose(ProxyIoAdapter adapter) {
+	try {
+	    adapter.close();
+	} catch (IOException e) {
+	    _log.error("failed fo close io adapter: ", e.getMessage());
+	}
     }
 
     private static final Cache<stateid4, ProxyIoAdapter> _prioxyIO=


### PR DESCRIPTION
in a production we observe situations, where client
decides to perform IO through MDS (door) with
all-zero stateid. Such behavior is  allowed by
rfc5661 (#8.2.3) and should be supported
to keep clients happy.

Acked-by: Gerd Behrmann
Target: master, 2.8, 2.7
Require-book: no
Require-notes: no
(cherry picked from commit f29613b1859c22b99abbcd3de063a15fd7a01831)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
