### PR TITLE
nfs4: clean failed request from pending queue

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -426,8 +426,10 @@ public class NFSv41Door extends AbstractCellComponent implements
             return new Layout(true, stateid, new layout4[]{layout});
 
         } catch (FileInCacheException e) {
+	    _ioMessages.remove(stateid);
             throw new ChimeraNFSException(nfsstat.NFSERR_IO, e.getMessage());
         } catch (InterruptedException | CacheException e) {
+	    _ioMessages.remove(stateid);
             throw new ChimeraNFSException(nfsstat.NFSERR_LAYOUTTRYLATER,
                     e.getMessage());
         }


### PR DESCRIPTION
if door have failed to start a mover, then we have to
clean pending message queue to avoid dead records. A
new entry will be created on client retry.

Acked-by: Gerd Behrmann
Target: master, 2.7, 2.8
Require-book: no
Require-notes: no
(cherry picked from commit 9f78b39ca1aac8418e9adea9c1ab219316178ce8)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
