### PR TITLE
libs: update nfs to 0.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -781,7 +781,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.7.3</version>
+            <version>0.7.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
minor bugfix to support chimera's rename fixes

Changelog for nfs4j-0.7.3..nfs4j-0.7.4
    \* [b11ec2a] nfs4: fix lookupp on the root of the tree
    \* [f99922b] nfs4: fix handling of illegal operations
    \* [5646570] vfs: chimera: translate exceptions to nfs errors

Acked-by: Gerd Behrmann
Target: master, 2.8, 2.7
Require-book: no
Require-notes: no
(cherry picked from commit fb72047265ae500fbdad0d26eef35d0028781339)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
