### PR TITLE
srm,srm-client: Report failure for failed SRM v1 transfers

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm/src/main/java/org/dcache/srm/SRM.java
@@ -938,7 +938,7 @@ public class SRM {
             int requestId, int fileRequestId, String state) {
         try {
             logger.debug(" setFileStatus(" + requestId + "," + fileRequestId + "," + state + ");");
-            if (!state.equalsIgnoreCase("done") && !state.equalsIgnoreCase("running")) {
+            if (!state.equalsIgnoreCase("done") && !state.equalsIgnoreCase("running") && !state.equalsIgnoreCase("failed")) {
                 return createFailedRequestStatus("setFileStatus(): incorrect state " + state);
             }
 

--- a/modules/srm/src/main/java/org/dcache/srm/request/FileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/FileRequest.java
@@ -248,6 +248,9 @@ public abstract class FileRequest extends Job {
                 else if(status.equalsIgnoreCase("Running")) {
                     setState(State.TRANSFERRING,"set by setStatus to \"Running\"");
                 }
+                else if(status.equalsIgnoreCase("Failed")) {
+                    setState(State.FAILED, "SRM client set state to Failed.");
+                }
                 else {
                     String error =  "Can't set Status to "+status;
                     logger.error(error);

--- a/modules/srmclient/src/main/java/gov/fnal/srm/util/SRMV1CopyJob.java
+++ b/modules/srmclient/src/main/java/gov/fnal/srm/util/SRMV1CopyJob.java
@@ -76,6 +76,7 @@ package gov.fnal.srm.util;
 import org.globus.util.GlobusURL;
 
 import diskCacheV111.srm.ISRM;
+import diskCacheV111.srm.RequestStatus;
 
 import org.dcache.srm.Logger;
 /**
@@ -154,6 +155,24 @@ public class SRMV1CopyJob implements CopyJob {
                 return;
             }
         }
+
+        if(srm != null) {
+            if (success) {
+                logger.log("setting file request "+fileID +" status to Done");
+                RequestStatus status = srm.setFileStatus(requestID, fileID, "Done");
+                if (!status.state.equalsIgnoreCase("Done")) {
+                    success = false;
+                    error = status.errorMessage;
+                    logger.elog(error);
+                }
+            }
+            else
+            {
+                logger.log("setting file request "+fileID +" status to Failed");
+                srm.setFileStatus(requestID,fileID, "Failed");
+            }
+        }
+
         if(success) {
             if(isSrmPrepareToGet) {
                 client.setReportSucceeded(surl,null);
@@ -171,11 +190,6 @@ public class SRMV1CopyJob implements CopyJob {
                 client.setReportFailed(null,surl,error);
             }
 
-        }
-
-        if(srm != null) {
-            logger.log("setting file request "+fileID +" status to Done");
-            srm.setFileStatus(requestID,fileID,"Done");
         }
         synchronized(this) {
             isDone = true;


### PR DESCRIPTION
Fixes the following bugs:
- The srm client ignored failures to set the file status to 'Done'.
- The srm client changed the file status to 'Done' even when the
  transfer failed.
- The srm server did not accept 'Failed' as a file status even
  though the spec lists it as a valid status for setFileStatus.

I am requesting a merge to stable branches as this bug may report
failed uploads as having been successful.

Target: master
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6629/
(cherry picked from commit 7e516df626977241271855398249cd75bffe65e3)
