### PR TITLE
pool: Fix logging context for thread pool

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/CDCExecutorServiceDecorator.java
+++ b/modules/dcache/src/main/java/org/dcache/util/CDCExecutorServiceDecorator.java
@@ -93,7 +93,7 @@ public class CDCExecutorServiceDecorator extends ForwardingExecutorService
         _delegate.execute(wrap(command));
     }
 
-    private Runnable wrap(final Runnable task)
+    protected Runnable wrap(final Runnable task)
     {
         final CDC cdc = new CDC();
         return new Runnable()
@@ -111,7 +111,7 @@ public class CDCExecutorServiceDecorator extends ForwardingExecutorService
         };
     }
 
-    private <T> Callable<T> wrap(final Callable<T> task)
+    protected <T> Callable<T> wrap(final Callable<T> task)
     {
         final CDC cdc = new CDC();
         return new Callable<T>() {
@@ -128,7 +128,7 @@ public class CDCExecutorServiceDecorator extends ForwardingExecutorService
         };
     }
 
-    private <T> Collection<? extends Callable<T>> wrap(Collection<? extends Callable<T>> tasks)
+    protected <T> Collection<? extends Callable<T>> wrap(Collection<? extends Callable<T>> tasks)
     {
         return Lists.newArrayList(transform(tasks, new Function<Callable<T>, Callable<T>>()
                 {

--- a/modules/dcache/src/main/java/org/dcache/util/CDCScheduledExecutorServiceDecorator.java
+++ b/modules/dcache/src/main/java/org/dcache/util/CDCScheduledExecutorServiceDecorator.java
@@ -1,0 +1,63 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2014 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class CDCScheduledExecutorServiceDecorator
+        extends CDCExecutorServiceDecorator
+        implements ScheduledExecutorService
+{
+    public CDCScheduledExecutorServiceDecorator(ScheduledExecutorService delegate)
+    {
+        super(delegate);
+    }
+
+    @Override
+    protected ScheduledExecutorService delegate()
+    {
+        return (ScheduledExecutorService) super.delegate();
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit)
+    {
+        return delegate().schedule(wrap(command), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit)
+    {
+        return delegate().schedule(wrap(callable), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit)
+    {
+        return delegate().scheduleAtFixedRate(wrap(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit)
+    {
+        return delegate().scheduleWithFixedDelay(wrap(command), initialDelay, delay, unit);
+    }
+}

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -216,15 +216,19 @@
   </bean>
 
   <bean id="workerThreadPool"
-        class="java.util.concurrent.Executors"
-        factory-method="newScheduledThreadPool"
-        destroy-method="shutdown">
-    <description>Thread pool for background tasks</description>
-    <constructor-arg value="${pool.limits.worker-threads}"/>
-    <property name="executeExistingDelayedTasksAfterShutdownPolicy"
-              value="false"/>
-    <property name="continueExistingPeriodicTasksAfterShutdownPolicy"
-              value="false"/>
+        class="org.dcache.util.CDCScheduledExecutorServiceDecorator">
+      <description>Thread pool for background tasks</description>
+      <constructor-arg>
+          <bean class="java.util.concurrent.Executors"
+                factory-method="newScheduledThreadPool"
+                destroy-method="shutdown">
+              <constructor-arg value="${pool.limits.worker-threads}"/>
+              <property name="executeExistingDelayedTasksAfterShutdownPolicy"
+                        value="false"/>
+              <property name="continueExistingPeriodicTasksAfterShutdownPolicy"
+                        value="false"/>
+          </bean>
+      </constructor-arg>
   </bean>
 
   <bean id="messageThreadPool"


### PR DESCRIPTION
Fixes the logging context in a thread pool used by migration tasks,
pool to pool tasks, and sticky bit expiration.

Target: trunk
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6675/
(cherry picked from commit 4f79cb3dbd2e7662da7f73dacae68a8f129b5101)
