### PR TITLE
xrootd: Upgrade to xrootd4j 1.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <version.xerces>2.10.0</version.xerces>
         <version.jetty>8.1.13.v20130916</version.jetty>
         <version.wicket>6.9.1</version.wicket>
-        <version.xrootd4j>1.2.4</version.xrootd4j>
+        <version.xrootd4j>1.2.5</version.xrootd4j>
         <version.jglobus>2.0.6-rc5.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 


### PR DESCRIPTION
Fixes spec compliance issues related to null-terminated strings.
Affects the locate, login and open responses.

Target: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6678/
