### PR TITLE
xrootd: Upgrade to xrootd4j 1.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <version.xerces>2.9.1</version.xerces>
         <version.jetty>7.6.10.v20130312</version.jetty>
         <version.wicket>1.5.10</version.wicket>
-        <version.xrootd4j>1.2.4</version.xrootd4j>
+        <version.xrootd4j>1.2.5</version.xrootd4j>
         <version.jglobus>2.0.6-rc5.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 


### PR DESCRIPTION
Fixes spec compliance issues related to null-terminated strings.
Affects the locate, login and open responses.

Target: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6678/
(cherry picked from commit 191ef0c45de7df148b8e4a09ec4d7d48213f7c16)

Conflicts:
    pom.xml
