### PR TITLE
ssh1: Fix typo in service batch file

### DIFF
--- a/skel/share/services/ssh1.batch
+++ b/skel/share/services/ssh1.batch
@@ -61,7 +61,7 @@ create dmg.cells.services.login.LoginManager ${ssh1.cell.name} \
       "${ssh1.net.port}  \
        dmg.cells.services.login.StreamObjectCell \
        -prot=ssh -auth=dmg.cells.services.login.SshSAuth_A \
-       -history=${ssh1.paths.histor} \
+       -history=${ssh1.paths.history} \
        -listen=${ssh1.net.listen} \
        -useColors=${ssh1.enable.colors} \
        diskCacheV111.admin.UserAdminShell"


### PR DESCRIPTION
The typo prevented the use of a history file.

Target: trunk
Request: 2.8
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6697/
(cherry picked from commit 465705ba177ac75bfc247f4798778d3d2e631edd)
