### PR TITLE
ftp: Fix race condition in command dispatching

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/SequentialExecutor.java
+++ b/modules/dcache/src/main/java/org/dcache/util/SequentialExecutor.java
@@ -7,11 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -35,13 +32,7 @@ public class SequentialExecutor extends AbstractExecutorService
         }
     };
 
-    private final RunnableFuture<Void> worker =
-            new FutureTask<Void>(new Worker()) {
-                public void run()
-                {
-                    runAndReset();
-                }
-            };
+    private final Worker worker = new Worker();
     private boolean isShutdown;
     private boolean isRunning;
 
@@ -132,8 +123,8 @@ public class SequentialExecutor extends AbstractExecutorService
             }
             tasks.add(task);
             if (!isRunning) {
-                isRunning = true;
                 executor.execute(worker);
+                isRunning = true;
             }
         } finally {
             monitor.leave();
@@ -155,10 +146,10 @@ public class SequentialExecutor extends AbstractExecutorService
         }
     }
 
-    private class Worker implements Callable<Void>
+    private class Worker implements Runnable
     {
         @Override
-        public Void call()
+        public void run()
         {
             Runnable task = getTask();
             while (task != null) {
@@ -170,7 +161,6 @@ public class SequentialExecutor extends AbstractExecutorService
                 }
                 task = getTask();
             }
-            return null;
         }
     }
 }


### PR DESCRIPTION
Fixes a race condition that lead to hanging FTP sessions.

A FutureTask is not thread safe in the sense that it cannot be
submitted concurrently for several executions.

I must admit, I have no idea why the code was like it was. The future
must have been part of an earlier revision of the code.

Target: trunk
Request: 2.8
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6704/
(cherry picked from commit 93fe7514823281aaa22bdafca005dec602effa6d)
