### PR TITLE
pnfsmanager: Fix compatibility with 2.6 pools

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsGetStorageInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsGetStorageInfoMessage.java
@@ -1,0 +1,19 @@
+package diskCacheV111.vehicles;
+
+import java.util.EnumSet;
+
+import diskCacheV111.util.PnfsId;
+
+import org.dcache.namespace.FileAttribute;
+import org.dcache.vehicles.PnfsGetFileAttributes;
+
+@Deprecated // Kept for compatibility with 2.6 pools
+public class PnfsGetStorageInfoMessage extends PnfsGetFileAttributes {
+
+    private static final long serialVersionUID = -2574949600859502380L;
+
+    private PnfsGetStorageInfoMessage()
+    {
+        super((PnfsId) null, EnumSet.noneOf(FileAttribute.class));
+    }
+}


### PR DESCRIPTION
2.6 pools send PnfsGetStorageInfoMessage upon issuing the 'rh restore' command.
This message has been removed and thus pool compatibility with 2.6 is broken.
This patch adds a minimal version of that message back to ensure compatibility
with old pools.

Target: trunk
Request: 2.8
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6696/
(cherry picked from commit 3158ca2f03b6bda16c1723d52873882b86721454)
