### PR TITLE
Allow retry on transient transfer failures

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -1038,13 +1038,14 @@ public class Transfer implements Comparable<Transfer>
                     }
                     continue;
                 case CacheException.FILE_IN_CACHE:
+                case CacheException.INVALID_ARGS:
                     throw e;
                 case CacheException.NO_POOL_CONFIGURED:
                     _log.error(e.getMessage());
                     throw e;
                 case CacheException.NO_POOL_ONLINE:
                     _log.warn(e.getMessage());
-                    throw e;
+                    break;
                 default:
                     _log.error(e.getMessage());
                     break;


### PR DESCRIPTION
This patch fixes a minor regression introduced in 2.8 that prevents retry
on a transient error. The patch also removes retry on a permanent error.

Target: trunk
Request: 2.8
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6707/
(cherry picked from commit ef8ef96c690b3f005c4388e404f2fc7faf8f6993)
