### PR TITLE
spacemanager: Fix database sequence initialization

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/services/space/db/spacemanager.changelog-2.8.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/services/space/db/spacemanager.changelog-2.8.xml
@@ -206,14 +206,14 @@
         <rollback/>
     </changeSet>
 
-    <changeSet id="7" author="behrmann" dbms="postgresql">
+    <changeSet id="7.1" author="behrmann" dbms="postgresql">
         <!-- A workaround to https://liquibase.jira.com/browse/CORE-1705 -->
         <comment>Postgresql specific auto increment sequences initialization</comment>
 
         <sql>
-            SELECT setval('srmlinkgroup_id_seq', (SELECT max(id) FROM srmlinkgroup));
-            SELECT setval('srmspace_id_seq', (SELECT max(id) FROM srmspace));
-            SELECT setval('srmspacefile_id_seq', (SELECT max(id) FROM srmspacefile));
+            SELECT setval('srmlinkgroup_id_seq', (SELECT greatest(max(id), 1) FROM srmlinkgroup));
+            SELECT setval('srmspace_id_seq', (SELECT greatest(max(id), 1) FROM srmspace));
+            SELECT setval('srmspacefile_id_seq', (SELECT greatest(max(id), 1) FROM srmspacefile));
         </sql>
 
         <!-- This rollback really belongs to changeset 6. It is however postgresql


### PR DESCRIPTION
The default range for sequences starts at 1. This caused failures
with the schema changeset when migrating from a database where the
largest id was smaller than 1.

Target: trunk
Request: 2.8
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6711/
(cherry picked from commit e3ac8f69bd2e42b33066d169b6dd7ff95f476a6e)
