### PR TITLE
pool: Fix pf command regression

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -37,7 +37,6 @@ import diskCacheV111.util.CacheFileAvailable;
 import diskCacheV111.util.FileInCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FileNotInCacheException;
-import diskCacheV111.util.FsPath;
 import diskCacheV111.util.HsmSet;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
@@ -1640,9 +1639,9 @@ public class PoolV4
 
     public static final String hh_pf = "<pnfsId>";
 
-    public FsPath ac_pf_$_1(Args args) throws CacheException, IllegalArgumentException
+    public String ac_pf_$_1(Args args) throws CacheException, IllegalArgumentException
     {
-        return _pnfs.getPathByPnfsId(new PnfsId(args.argv(0)));
+        return _pnfs.getPathByPnfsId(new PnfsId(args.argv(0))).toString();
     }
 
     public static final String hh_set_replication = "[-off] [<mgr> [<host>]]";


### PR DESCRIPTION
A recent patch changed a number of variables and fields from String to
FsPath. Inadvertently the return message of the 'pf' command in the pool
was changed to, leading to Serialization errors.

Target: trunk
Request: 2.8
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6713/
(cherry picked from commit baff93afad3518e64ab0075904fedba0b7612d48)
