### PR TITLE
nfs: return NFSERR_IO is we detect broken file on tape

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/CacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/CacheException.java
@@ -18,6 +18,9 @@ public class CacheException extends Exception
     /** Pool already contains a replica. */
     public final static int FILE_IN_CACHE = 210;
 
+    /** File is broken on a tape, can't be staged */
+    public final static int BROKEN_ON_TAPE = 243;
+
     /** Usually followed by component shutdown. */
     public final static int PANIC = 10000;
 

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -428,7 +428,15 @@ public class NFSv41Door extends AbstractCellComponent implements
         } catch (FileInCacheException e) {
 	    _ioMessages.remove(stateid);
             throw new ChimeraNFSException(nfsstat.NFSERR_IO, e.getMessage());
-        } catch (InterruptedException | CacheException e) {
+        } catch (CacheException e) {
+	    _ioMessages.remove(stateid);
+            /*
+             * error 243: file is broken on tape.
+             * can't do a much. Tell it to client.
+             */
+            int status = e.getRc() == CacheException.BROKEN_ON_TAPE ? nfsstat.NFSERR_IO : nfsstat.NFSERR_LAYOUTTRYLATER;
+            throw new ChimeraNFSException(status, e.getMessage());
+        } catch (InterruptedException e) {
 	    _ioMessages.remove(stateid);
             throw new ChimeraNFSException(nfsstat.NFSERR_LAYOUTTRYLATER,
                     e.getMessage());

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
@@ -144,7 +144,7 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
                 throw (ChimeraNFSException)t;
             }
             int status = nfsstat.NFSERR_IO;
-            if (t instanceof CacheException ) {
+            if ((t instanceof CacheException) && ((CacheException)t).getRc() != CacheException.BROKEN_ON_TAPE) {
                 status = nfsstat.NFSERR_DELAY;
             }
             throw new ChimeraNFSException(status, t.getMessage());


### PR DESCRIPTION
currently we return NFSERR_LAYOUTTRYLATER and client
tries later. Stop infinite loop as we cant get file
anyway.

Acked-by: Gerd Behrmann
Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit ef2091a9130cc0206e2534685b34ea5d6abe5590)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
