### PR TITLE
srm: fix race condition if stop is called too soon after start

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -213,16 +213,22 @@ public final class Scheduler
         addScheduler(id, this);
     }
 
-    public synchronized void start() throws IllegalStateException
+    public void start() throws IllegalStateException
     {
-        checkState(!running, "Scheduler is running.");
-        running = true;
+        synchronized (this) {
+            checkState(!running, "Scheduler is running.");
+            running = true;
+        }
         workSupplyService.startAsync().awaitRunning();
     }
 
-    public synchronized void stop()
+    public void stop()
     {
-        running = false;
+        synchronized (this) {
+            checkState(running, "Scheduler is not running.");
+            running = false;
+        }
+
         workSupplyService.stopAsync().awaitTerminated();
         retryTimer.cancel();
         pooledExecutor.shutdownNow();


### PR DESCRIPTION
The WorkSupplyService fetches information that is protected by
the Scheduler monitor.  If the stop method is called while the
WorkSupplyService is not resting then the thread calling stop
enters the Scheduler monitor and waits for the WorkSupplyService
service to end, resulting in a deadlock.

This patch fixes this by moving the WorkSupplyService activation
and deactivation so it happens outside the Scheduler monitor.

Target: master
Acked-by: Dmitry Litvintsev
Patch: http://rb.dcache.org/r/6750/
Request: 2.8
