### PR TITLE
loginbroker: Fix login broker registration retry

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/LoginBrokerHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/util/LoginBrokerHandler.java
@@ -38,6 +38,11 @@ public class LoginBrokerHandler
     private final static Logger _log =
         LoggerFactory.getLogger(LoginBrokerHandler.class);
 
+    enum UpdateMode
+    {
+        EAGER, NORMAL
+    }
+
     private static final long EAGER_UPDATE_TIME = SECONDS.toMillis(1);
 
     private String[] _loginBrokers;
@@ -46,8 +51,8 @@ public class LoginBrokerHandler
     private String _protocolEngine;
     private long   _brokerUpdateTime = MINUTES.toMillis(5);
     private TimeUnit _brokerUpdateTimeUnit = MILLISECONDS;
-    private long _currentBrokerUpdateTime = EAGER_UPDATE_TIME;
     private double _brokerUpdateThreshold = 0.1;
+    private UpdateMode _currentUpdateMode = UpdateMode.NORMAL;
     private LoadProvider _load = new FixedLoad(0.0);
     private String[] _hosts;
     private int _port;
@@ -103,30 +108,18 @@ public class LoginBrokerHandler
         info.setPort(_port);
         info.setLoad(_load.getLoad());
 
-        normalUpdates();
+        UpdateMode newUpdateMode = UpdateMode.NORMAL;
         for (String loginBroker: _loginBrokers) {
             try {
                 sendMessage(new CellMessage(new CellPath(loginBroker), info));
             } catch (NoRouteToCellException e) {
-                _log.error("Failed to send update to {}", loginBroker);
-                eagerUpdates();
+                _log.warn("Failed to send update to {}", loginBroker);
+                newUpdateMode = UpdateMode.EAGER;
             }
         }
-    }
 
-    private void eagerUpdates()
-    {
-        if (_currentBrokerUpdateTime != EAGER_UPDATE_TIME) {
-            _currentBrokerUpdateTime = EAGER_UPDATE_TIME;
-            rescheduleTask();
-        }
-    }
-
-    private void normalUpdates()
-    {
-        long millis = _brokerUpdateTimeUnit.toMillis(_brokerUpdateTime);
-        if (_currentBrokerUpdateTime != millis) {
-            _currentBrokerUpdateTime = millis;
+        if (_currentUpdateMode != newUpdateMode) {
+            _currentUpdateMode = newUpdateMode;
             rescheduleTask();
         }
     }
@@ -323,7 +316,15 @@ public class LoginBrokerHandler
                     sendUpdate();
                 }
             };
-        _task = _executor.scheduleWithFixedDelay(command, 0, _currentBrokerUpdateTime, MILLISECONDS);
+        switch (_currentUpdateMode) {
+        case EAGER:
+            _task = _executor.scheduleWithFixedDelay(command, EAGER_UPDATE_TIME, EAGER_UPDATE_TIME, MILLISECONDS);
+            break;
+
+        case NORMAL:
+            _task = _executor.scheduleWithFixedDelay(command, 0, _brokerUpdateTime, _brokerUpdateTimeUnit);
+            break;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes a problem in which doors would log "Failed to send update to LoginBroker"
in a busy retry loop when unable to register with LoginBroker. This typically
happens during shutdown.

The intention of the code was to switch to an eager retry loop with a one
second sleep between retries, however the code switches the update period to
'normal' update before attempting to send an update and then switches back to
'eager' mode. Changing the scheduling time causes the task to be rescheduled,
but rescheduling schedules a new update with an initial delay of zero, thus
causing an immediate retry. Thus failure to deliver an update initiates a
tight retry loop without any delays.

Also fixes a bug in which the 'lb set update' command was not respected.

Target: trunk
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: http://rb.dcache.org/r/6787/
(cherry picked from commit 6cbd994e7a2e68d34543cc461467e37ac6a2bb6b)
