### PR TITLE
pool: Fix lock problems in xrootd and http movers

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannel.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannel.java
@@ -80,9 +80,9 @@ public class MoverChannel<T extends ProtocolInfo> implements RepositoryChannel
 
     /**
      * The number of bytes reserved in the space allocator. Only
-     * accessed while the monitor lock is held.
+     * updated while the monitor lock is held.
      */
-    private long _reserved;
+    private volatile long _reserved;
 
     public MoverChannel(Mover<T> mover, RepositoryChannel channel)
     {
@@ -162,7 +162,7 @@ public class MoverChannel<T extends ProtocolInfo> implements RepositoryChannel
     }
 
     @Override
-    public synchronized int read(ByteBuffer buffer, long position) throws IOException {
+    public int read(ByteBuffer buffer, long position) throws IOException {
         try {
             int bytes = _channel.read(buffer, position);
             _bytesTransferred.getAndAdd(bytes);
@@ -301,7 +301,7 @@ public class MoverChannel<T extends ProtocolInfo> implements RepositoryChannel
         return _lastTransferred.get();
     }
 
-    public synchronized long getAllocated() {
+    public long getAllocated() {
         return _reserved;
     }
 


### PR DESCRIPTION
When the pool is full, a blocking preallocate call could block
simple 'mover ls' queries and thus cause the entire pool to appear
unresponsive.

Target: trunk
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/6795/
(cherry picked from commit a5b01e4a15f473c8c7c02205cbc1d4ee01151e04)
