### PR TITLE
pool: Avoid memory exhaustion problems on write with xrootd and http

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolNettyServer.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolNettyServer.java
@@ -124,6 +124,11 @@ public class XrootdPoolNettyServer
         public ChannelPipeline getPipeline() throws Exception {
             ChannelPipeline pipeline = pipeline();
 
+            /* The disk executor is an OrderedMemoryAwareThreadPoolExecutor.  It only
+             * knows how to estimate the size of ChannelBuffer, so we cannot place
+             * decoded messages on the queue.
+             */
+            pipeline.addLast("executor", new ExecutionHandler(getDiskExecutor()));
             pipeline.addLast("encoder", new XrootdEncoder());
             pipeline.addLast("decoder", new XrootdDecoder());
             if (_logger.isDebugEnabled()) {
@@ -132,7 +137,6 @@ public class XrootdPoolNettyServer
             }
             pipeline.addLast("handshake",
                              new XrootdHandshakeHandler(XrootdProtocol.DATA_SERVER));
-            pipeline.addLast("executor", new ExecutionHandler(getDiskExecutor()));
             for (ChannelHandlerFactory plugin: _plugins) {
                 pipeline.addLast("plugin:" + plugin.getName(),
                         plugin.createHandler());


### PR DESCRIPTION
The http and xrootd movers use an OrderedMemoryAwayThreadPoolExecutor. This
thread pool limits memory usage per client, however it relies on being able to
estimate the size of the messages in the queue. It knows how to calculate the
size for ChannelBuffer objects, however it doesn't know how to do this for most
other objects. Since we store protocol messages in the queue, the limit doesn't
have the intended effect. The consequence is that a slow disk or full pool can
cause the queue to fill up and trigger OOM.

The patch solves this by moving the ExecutorHandler to the front of the
pipeline such that only ChannelBuffers are stored in the queue.

Target: trunk
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/6796/
(cherry picked from commit 7e6df2048c31c62cbd75b0aac0c1817b048f3faa)
