### PR TITLE
billing: Make indexer case insensitive

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/text/BillingParserBuilder.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/text/BillingParserBuilder.java
@@ -272,7 +272,7 @@ public class BillingParserBuilder
         if (pos < format.length()) {
             regex.append(Pattern.quote(format.substring(pos)));
         }
-        return Pattern.compile(regex.toString());
+        return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);
     }
 
     /**


### PR DESCRIPTION
The billing indexer turns the billing output patterns into regular expressions
and uses those when parsing billing files. Literal text in the pattern are
translated to literal text in the regular expression.

Unfortunately, at some point we altered the capitalization of 'Unknown' in the
output pattern. This causes the billing indexer to fail to match older billing
files.

The patch changes the pattern to case insensitive matching. The generated bloom
filter is still case sensitive.

It is recomended that existing indexes are reindexed using the
'/usr/sbin/dcache-billing-indexer -all' command.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.8
Request: 2.7
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/6798/
(cherry picked from commit ca3f2447a8a4f2658dd37d94efced5e68f691b78)
