### PR TITLE
srm: Fix scheduling period for expiration task

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
@@ -10,8 +10,11 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.dcache.srm.request.Job;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Canonicalizing and caching job storage decorator suitable for Terracotta.
@@ -73,7 +76,7 @@ public class SharedMemoryCacheJobStorage<J extends Job> implements JobStorage<J>
         for (J job : storage.getActiveJobs()) {
             canonicalize(job);
         }
-        timer.schedule(new ExpirationTask(), 10, 60);
+        timer.schedule(new ExpirationTask(), SECONDS.toMillis(10), SECONDS.toMillis(60));
     }
 
     @Override


### PR DESCRIPTION
I believe the intention was to schedule the task every 60 seconds, not every
60 milliseconds.

Target: trunk
Request: 2.8
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: http://rb.dcache.org/r/6816/
(cherry picked from commit 8d4b4bd7adf6f85989d21a4b3a7c71f1ea987f3c)
