### PR TITLE
srm: Avoid loading the same job multiple times

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -1007,12 +1007,7 @@ public abstract class Job  {
 
         @Override
         public String toString() {
-            StringBuilder sb = new StringBuilder();
-            sb.append("JobHistory[");
-            sb.append(new Date(transitionTime)).append(',');
-            sb.append(state).append(',');
-            sb.append(description).append(']');
-            return sb.toString();
+            return "JobHistory[" + new Date(transitionTime) + ',' + state + ',' + description + ']';
         }
 
         public synchronized boolean isSaved() {

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
@@ -530,7 +530,7 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
                     TRANSITIONTIME);
             jh.setSaved();
             l.add(jh);
-            logger.debug("found JobHistory: {}", jh.toString());
+            logger.debug("found JobHistory: {}", jh);
 
         } while (set.next());
         statement.close();
@@ -603,8 +603,7 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
             public J mapRow(ResultSet rs, int rowNum) throws SQLException
             {
                 J job = getJob(rs.getStatement().getConnection(), rs);
-                logger.debug("==========> deserialization from database of job id {}", job.getId());
-                logger.debug("==========> jobs submitter id is {}", job.getSubmitterId());
+                logger.debug("==========> deserialized job with id {}", job.getId());
                 return job;
             }
         }));


### PR DESCRIPTION
Restore from the database is suppossed to be fairly ordered: First the file
requests are read and added to an in-memory store and then the container
requests are read and an aggregation of the file requests is formed.

Unfortunately while reading the file requests, a debug log statement calls
Job#getSubmitterId which triggers an unexpected load of the container request.
This severily messes up restore from the database.

The patch removes this log statement. It also reduces some of the overhead of
loading the job history.

Target: trunk
Request: 2.8
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6820/
(cherry picked from commit cabc9b7573d55042fad0b6669ebbfc79b11a4a12)
