### PR TITLE
pkg: fix solaris packaging

### DIFF
--- a/packages/fhs/pom.xml
+++ b/packages/fhs/pom.xml
@@ -304,5 +304,90 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>pkg</id>
+
+            <properties>
+                <build.id>1</build.id>
+                <local.version />
+                <build.number>${build.id}${local.version}</build.number>
+
+                <Timestamp>${maven.build.timestamp}</Timestamp>
+                <Version>${pkg.version}</Version>
+                <Release>${build.number}</Release>
+
+                <maven.build.timestamp.format>EEE MMM dd yyyy</maven.build.timestamp.format>
+            </properties>
+
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>regex-property</id>
+                                <goals>
+                                    <goal>regex-property</goal>
+                                </goals>
+                                <configuration>
+                                    <name>pkg.version</name>
+                                    <value>${project.version}</value>
+                                    <regex>-</regex>
+                                    <replacement/>
+                                    <failIfNoMatch>false</failIfNoMatch>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>pkg</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>src/main/assembly/pkg.xml</descriptor>
+                                    </descriptors>
+                                    <outputDirectory>${fhs.outputDirectory}</outputDirectory>
+                                    <finalName>${fhs.finalName}</finalName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>sh</executable>
+                            <workingDirectory>${project.build.directory}/${fhs.finalName}</workingDirectory>
+                            <arguments>
+                              <argument>${project.basedir}/src/main/solaris/mk-sol-pkg.sh</argument>
+                              <argument>${project.build.directory}/solaris-pkg</argument>
+                              <argument>${project.build.directory}</argument>
+                              <argument>${pkg.version}-${build.number}</argument>
+                              <argument>dcache</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/packages/fhs/src/main/assembly/pkg.xml
+++ b/packages/fhs/src/main/assembly/pkg.xml
@@ -1,0 +1,15 @@
+<assembly>
+  <id>pkg</id>
+  <formats>
+    <format>directory</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <files>
+    <file>
+      <source>src/main/solaris/pkginfo.template</source>
+      <outputDirectory></outputDirectory>
+      <destName>pkginfo</destName>
+      <filtered>true</filtered>
+    </file>
+  </files>
+</assembly>

--- a/packages/fhs/src/main/solaris/mk-sol-pkg.sh
+++ b/packages/fhs/src/main/solaris/mk-sol-pkg.sh
@@ -1,12 +1,9 @@
 #!/bin/sh
 
-BINDIR=$1
-BUILDDIR=$2
-DISTDIR=$3
-VERSION=$4
-NAME=$5
-
-cd ${BINDIR}
+BUILDDIR=$1
+DISTDIR=$2
+VERSION=$3
+NAME=$4
 
 echo 'i pkginfo' > prototype
 find . | grep -v '^./prototype$' | grep -v '^./pkginfo$' | pkgproto \

--- a/packages/fhs/src/main/solaris/pkginfo.template
+++ b/packages/fhs/src/main/solaris/pkginfo.template
@@ -1,10 +1,10 @@
 PKG="dCache"
 NAME="dCache Server"
 ARCH="all"
-VERSION="@VERSION@"
+VERSION="@Version@-@Release@"
 CATEGORY="application"
-VENDOR="@VENDOR@"
+VENDOR="dCache.ORG"
 EMAIL="support@dcache.org"
-PSTAMP="@VENDOR@"
+PSTAMP="@Timestamp@"
 BASEDIR=/
 CLASSES="none"


### PR DESCRIPTION
added new profile to build solaris package:

$ mvn package -am -pl packages/fhs -P pkg

This is the old package format, but still supported by
Oracle Solaris 11.

Target: master, 2.8, 2.7
Acked-by: Paul Millar
Require-book: no
Require-notes: yes
(cherry picked from commit 46027137d70a6626763df92f428146e47b62a456)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
