### PR TITLE
ftp: fix CKSM command for files with white-space

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -2213,15 +2213,15 @@ public abstract class AbstractFtpDoorV1
     {
         checkLoggedIn();
 
-        String[] st = arg.split("\\s+");
-        if (st.length != 4) {
+        List<String> st = Splitter.on(' ').limit(4).splitToList(arg);
+        if (st.size() != 4) {
             reply("500 Unsupported CKSM command operands");
             return;
         }
-        String algo = st[0];
-        String offset = st[1];
-        String length = st[2];
-        String path = st[3];
+        String algo = st.get(0);
+        String offset = st.get(1);
+        String length = st.get(2);
+        String path = st.get(3);
 
         long offsetL;
         long lengthL;


### PR DESCRIPTION
The CKSM command allows a client to request the checksum of a
file.  It assumes that the path contains no whitespace and fails
any request where this isn't true.

This patch fixes this.

Target: master
Patch: http://rb.dcache.org/r/6853/
Acked-by: Gerd Behrmann
Request: 2.8
Request: 2.7
Request: 2.6
