### PR TITLE
info-provider: fix capitalisation of SRM in ControlProtocol

### DIFF
--- a/skel/share/info-provider/glue-1.3-defn.xml
+++ b/skel/share/info-provider/glue-1.3-defn.xml
@@ -1289,7 +1289,8 @@
     </map>
 
     <map name="door-family-to-ctrl-proto-type">
-      <sub match="srm_v2" replace-with="SRM"/>
+      <!-- The ControlProtocolType must be upper-case -->
+      <sub match="srm" replace-with="SRM"/>
     </map>
 
 


### PR DESCRIPTION
The glue ControlProtocol has a Type field that describes what kind
of protocol is being published; or SRM, this value should be 'SRM'.
Commit 9eab932c altered the capitalisation to 'srm', which is
picked up as an error.

This patch restores the published value to SRM.  It also removes a
mapping since all supported versions of dCache have an SRM family
of either 'SRM' or 'srm'.

Target: master
Patch: http://rb.dcache.org/r/6892/
Acked-by: Tigran Mkrtchyan
Request: 2.8
Request: 2.7
