### PR TITLE
scripts: fix host-credential generation

### DIFF
--- a/packages/system-test/src/main/skel/bin/hostCredentials
+++ b/packages/system-test/src/main/skel/bin/hostCredentials
@@ -127,7 +127,7 @@ if [ ! "$clean$install$generate" = "1" ]; then
     exit 1
 fi
 
-function clean_dot_globus
+clean_dot_globus()
 {
     rm -f $HOST_CRED_STORE/dcache-systemtest-host*.pem
 
@@ -145,7 +145,7 @@ if [ "$clean" = "1" ]; then
     exit 0
 fi
 
-function list_potential_subjaltname()
+list_potential_subjaltname()
 {
     echo localhost
     if [ "$only_localhost" != 1 ]; then
@@ -154,13 +154,13 @@ function list_potential_subjaltname()
     fi
 }
 
-function cleanup_ca_dir()
+cleanup_ca_dir()
 {
     rm -rf $CA_DIR
 }
 
 if [ "$generate" = "1" ]; then
-    CA_DIR=$(mktemp -d)
+    CA_DIR=$(mktemp -d tmp.XXXXXXXXXX)
 
     trap cleanup_ca_dir EXIT
 
@@ -283,8 +283,8 @@ fi
 
 
 # Add any missing trust in user's trust-store
-
 mkdir -p $OUR_TRUST_STORE
+mkdir -p $USER_TRUST_STORE
 
 for file in $TARGET_TRUST_STORE/*; do
     name=$(basename $file)


### PR DESCRIPTION
The system-test includes a script for generating a host
credential.  It currently contains BASH-isms and Debian-isms,
which this patch fixes.

Target: master
Request: 2.8
Request: 2.7
Patch: http://rb.dcache.org/r/6908/
Acked-by: Gerd Behrmann
