### PR TITLE
poolmanager,pool: Fix precision underflow in WASS

### DIFF
--- a/modules/dcache/src/test/java/org/dcache/poolmanager/WeightedAvailableSpaceSelectionTest.java
+++ b/modules/dcache/src/test/java/org/dcache/poolmanager/WeightedAvailableSpaceSelectionTest.java
@@ -1,10 +1,17 @@
 package org.dcache.poolmanager;
 
+import com.google.common.base.Functions;
 import org.junit.Test;
+
+import java.util.Collections;
 
 import diskCacheV111.pools.PoolCostInfo;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.*;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class WeightedAvailableSpaceSelectionTest
 {
@@ -59,5 +66,43 @@ public class WeightedAvailableSpaceSelectionTest
     public void testLruOneWeekHalflifeOneWeekLessThanGap()
     {
         checkAvailable(0, 1000000, 500000, 0.5, (7 * 24 * 3600), 1500000);
+    }
+
+    @Test
+    public void testLargeLoad()
+    {
+        PoolCostInfo info = new PoolCostInfo("pool");
+        info.setSpaceUsage(100000000, 100000000, 0, 0);
+        info.getSpaceInfo().setParameter(0, 1000);
+        info.setMoverCostFactor(0.5);
+        info.addExtendedMoverQueueSizes("movers", 3000, 3000, 0, 0, 3000);
+        PoolCostInfo selected =
+                wass.selectByAvailableSpace(singletonList(info), 1000,
+                                            Functions.<PoolCostInfo>identity());
+        assertThat(selected, is(info));
+    }
+
+    @Test
+    public void testIdleFullPoolDoesNotAffectLoadNormalization()
+    {
+        PoolCostInfo busy = new PoolCostInfo("pool1");
+        busy.setSpaceUsage(100000000, 100000000, 0, 0);
+        busy.getSpaceInfo().setParameter(0, 1000);
+        busy.setMoverCostFactor(0.5);
+        busy.addExtendedMoverQueueSizes("movers", 3000, 3000, 0, 0, 3000);
+        PoolCostInfo veryBusy = new PoolCostInfo("pool2");
+        veryBusy.setSpaceUsage(100000000, 100000000, 0, 0);
+        veryBusy.getSpaceInfo().setParameter(0, 1000);
+        veryBusy.setMoverCostFactor(0.5);
+        veryBusy.addExtendedMoverQueueSizes("movers", 6000, 6000, 0, 0, 6000);
+        PoolCostInfo full = new PoolCostInfo("pool3");
+        full.setSpaceUsage(100000000, 0, 100000000, 0);
+        full.getSpaceInfo().setParameter(0, 1000);
+        full.setMoverCostFactor(0.5);
+        full.addExtendedMoverQueueSizes("movers", 0, 3000, 0, 0, 0);
+        PoolCostInfo selected =
+                wass.selectByAvailableSpace(asList(full, busy, veryBusy), 1000,
+                                            Functions.<PoolCostInfo>identity());
+        assertThat(selected, is(busy));
     }
 }


### PR DESCRIPTION
Fixes a problem in which a large number of writers on a pool (such as what you
would see on a tape read pool) would cause the scale of a double to underflow,
causing the weigthed acailable space to become zero.  If all pools have such
high load, no pool would be availble for selection and pool manager would
report that no pool is available for staging.

The fix uses the fact that only the relative weighted available space is
relevant. Since the weighted space is calculated by dividing unweighted space
with two to the power of the load, we can subtract a constant from the load of
all pools and maintain the relative available space of each pool. The patch
first finds the lowest load of all non-full pools in the selection and
subtracts that from the load of all pools, thus normalizing the calculation.

Other pools may have even high load, still causing the precision of a double to
be insufficient, however the likelihood of selection such a pool is virtuallt
zero anyway, so this barely affects the write distribution. The normalization
does however ensure that at least one pool does not underflow (assuming
non-full pools exist at all) and thus that a pool can be selected.

Target: trunk
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Dmitry Litvtinsev litvinse@fnal.gov
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7993
(cherry picked from commit 80ade65b1a6399b443512fc5c12f929c276eb630)
