### PR TITLE
nfs4: do not log stacktrace on IO errors

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
@@ -109,7 +109,7 @@ public class ProxyIoWRITE extends AbstractNFSv4Operation {
             res.status = he.getStatus();
             _log.debug(he.getMessage());
         }catch(IOException ioe) {
-            _log.error("DSWRITE: ", ioe);
+            _log.error("DSWRITE: {}", ioe.getMessage());
             res.status = nfsstat.NFSERR_IO;
         }catch(Exception e) {
             _log.error("DSWRITE: ", e);


### PR DESCRIPTION
there are no reasons to log  full stack trace on IO errors

Acked-by: Paul Millar
Target: master, 2.9
(cherry picked from commit 193cba946cdf5235035379f24b4735ec91627645)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
