### PR TITLE
nfs: do not use CDC as try-with-resource

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -383,9 +383,10 @@ public class NFSv41Door extends AbstractCellComponent implements
             throws IOException {
 
         FsInode inode = _fileFileSystemProvider.inodeFromBytes(nfsInode.getFileId());
-        try(CDC cdc = CDC.reset(_cellName, _domainName)) {
-            NDC.push("pnfsid=" + inode);
-            NDC.push("client=" + context.getRpcCall().getTransport().getRemoteSocketAddress());
+        CDC cdc = CDC.reset(_cellName, _domainName);
+        try {
+            NDC.push(inode.toString());
+            NDC.push(context.getRpcCall().getTransport().getRemoteSocketAddress().toString());
             deviceid4 deviceid;
             if (inode.type() != FsInodeType.INODE || inode.getLevel() != 0) {
                 /*
@@ -440,6 +441,8 @@ public class NFSv41Door extends AbstractCellComponent implements
 	    _ioMessages.remove(stateid);
             throw new ChimeraNFSException(nfsstat.NFSERR_LAYOUTTRYLATER,
                     e.getMessage());
+        } finally {
+            cdc.close();
         }
 
     }

--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
@@ -50,7 +50,8 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
     public void process(CompoundContext context, nfs_resop4 result) {
         final READ4res res = result.opread;
 
-        try (CDC ignored = new CDC()) {
+        CDC cdc = CDC.reset(proxyIoFactory.getCellName(), proxyIoFactory.getCellDomainName());
+        try {
 	    NDC.push(context.getRpcCall().getTransport().getRemoteSocketAddress().toString());
             Inode inode = context.currentInode();
             if (!context.getFs().hasIOLayout(inode)) {
@@ -109,6 +110,8 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
         }catch(Exception e) {
             _log.error("DSREAD: ", e);
             res.status = nfsstat.NFSERR_SERVERFAULT;
+        } finally {
+            cdc.close();
         }
     }
 


### PR DESCRIPTION
in a cunstruction like:

  try (CDC ignored = new CDC()) {
     ....
  } catch (Exception e) {
    log.error(e);
  }

the catch block will not have a correct context.
Use try-catch-finally instead.

Acked-by: Gerd Behrmann
Target: master, 2.9, 2.8, 2.7
Require-book: no
Require-notes: no
(cherry picked from commit c34be640f9aaa59a93048fd5ef16ef7af652c8ca)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
