### PR TITLE
nfs: do not use CDC as try-with-resource

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -416,7 +416,8 @@ public class NFSv41Door extends AbstractCellComponent implements
             throws IOException {
 
         FsInode inode = _fileFileSystemProvider.inodeFromBytes(nfsInode.getFileId());
-        try(CDC cdc = CDC.reset(_cellName, _domainName)) {
+        CDC cdc = CDC.reset(_cellName, _domainName);
+        try {
             NDC.push(inode.toString());
             NDC.push(context.getRpcCall().getTransport().getRemoteSocketAddress().toString());
             deviceid4 deviceid;
@@ -480,6 +481,8 @@ public class NFSv41Door extends AbstractCellComponent implements
 	    cleanStateAndKillMover(stateid);
             throw new ChimeraNFSException(nfsstat.NFSERR_LAYOUTTRYLATER,
                     e.getMessage());
+        } finally {
+            cdc.close();
         }
 
     }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
@@ -38,7 +38,8 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
     public void process(CompoundContext context, nfs_resop4 result) {
         final READ4res res = result.opread;
 
-        try (CDC ignored = new CDC()) {
+        CDC cdc = CDC.reset(proxyIoFactory.getCellName(), proxyIoFactory.getCellDomainName());
+        try {
 	    NDC.push(context.getRpcCall().getTransport().getRemoteSocketAddress().toString());
             Inode inode = context.currentInode();
             if (!context.getFs().hasIOLayout(inode)) {
@@ -105,6 +106,8 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
         }catch(Exception e) {
             _log.error("DSREAD: ", e);
             res.status = nfsstat.NFSERR_SERVERFAULT;
+        } finally {
+            cdc.close();
         }
     }
 }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
@@ -41,7 +41,8 @@ public class ProxyIoWRITE extends AbstractNFSv4Operation {
     public void process(CompoundContext context, nfs_resop4 result) {
         final WRITE4res res = result.opwrite;
 
-        try (CDC ignored = new CDC()) {
+        CDC cdc = CDC.reset(proxyIoFactory.getCellName(), proxyIoFactory.getCellDomainName());
+        try {
 	    NDC.push(context.getRpcCall().getTransport().getRemoteSocketAddress().toString());
             Inode inode = context.currentInode();
             /**
@@ -114,6 +115,8 @@ public class ProxyIoWRITE extends AbstractNFSv4Operation {
         }catch(Exception e) {
             _log.error("DSWRITE: ", e);
             res.status = nfsstat.NFSERR_SERVERFAULT;
+        } finally {
+            cdc.close();
         }
     }
 }


### PR DESCRIPTION
in a cunstruction like:

  try (CDC ignored = new CDC()) {
     ....
  } catch (Exception e) {
    log.error(e);
  }

the catch block will not have a correct context.
Use try-catch-finally instead.

Acked-by: Gerd Behrmann
Target: master, 2.9, 2.8, 2.7
Require-book: no
Require-notes: no
(cherry picked from commit c34be640f9aaa59a93048fd5ef16ef7af652c8ca)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
