### PR TITLE
poolmanager: Fix infinite loop in lru partition type

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/LruPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/LruPartition.java
@@ -115,7 +115,11 @@ public class LruPartition extends Partition
                     oldest = pool;
                 }
             }
-        } while (!lastAccessed.replace(oldest.getName(), current, next()));
+            /* Repeat until we manage update the entry without concurrent
+             * modification.
+             */
+        } while (current < 0 && lastAccessed.putIfAbsent(oldest.getName(), next()) != null ||
+                current >= 0 && !lastAccessed.replace(oldest.getName(), current, next()));
         return oldest;
     }
 


### PR DESCRIPTION
Target: trunk
Require-notes: yes
Require-book: no
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6938/
(cherry picked from commit 6750fd426d7e60da7332453a28bfbc88d228274e)
