### PR TITLE
srm: Fix race condition in listing

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/vehicles/PnfsListDirectoryMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/vehicles/PnfsListDirectoryMessage.java
@@ -28,20 +28,22 @@ public class PnfsListDirectoryMessage extends PnfsMessage
 {
     private static final long serialVersionUID = -5774904472984157638L;
 
-    public final Glob _pattern;
-    public final Integer _lower;
-    public final Integer _upper;
-    public final BoundType _lowerBoundType;
-    public final BoundType _upperBoundType;
-    public final UUID _uuid = UUID.randomUUID();
-    public final Set<FileAttribute> _requestedAttributes;
-    public Collection<DirectoryEntry> _entries =
+    private final Glob _pattern;
+    private final Integer _lower;
+    private final Integer _upper;
+    private final BoundType _lowerBoundType;
+    private final BoundType _upperBoundType;
+    private final UUID _uuid = UUID.randomUUID();
+    private final Set<FileAttribute> _requestedAttributes;
+    private Collection<DirectoryEntry> _entries =
         CollectionFactory.newArrayList();
 
     /**
-     * The last message has the following field set to true.
+     * The last message has the following field set to true and a non-zero
+     * message count;
      */
-    public boolean _isFinal = true;
+    private boolean _isFinal;
+    private int _messageCount;
 
     /**
      * Constructs a new message.
@@ -123,14 +125,27 @@ public class PnfsListDirectoryMessage extends PnfsMessage
         _entries.clear();
     }
 
-    public void setFinal(boolean isFinal)
+    @Override
+    public void setSucceeded()
     {
-        _isFinal = isFinal;
+        super.setSucceeded();
+        _isFinal = true;
+    }
+
+    public void setSucceeded(int messageCount)
+    {
+        setSucceeded();
+        _messageCount = messageCount;
     }
 
     public boolean isFinal()
     {
         return _isFinal;
+    }
+
+    public int getMessageCount()
+    {
+        return _messageCount;
     }
 
     @Override

--- a/modules/dcache/src/test/java/org/dcache/auth/RemoteNameSpaceProviderTests.java
+++ b/modules/dcache/src/test/java/org/dcache/auth/RemoteNameSpaceProviderTests.java
@@ -16,7 +16,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
 import diskCacheV111.util.CacheException;
@@ -756,8 +755,8 @@ public class RemoteNameSpaceProviderTests
 
         for(int i = 0; i < replies.length; i++) {
             Collection<DirectoryEntry> entries = replies [i];
-            boolean isLast = i == replies.length -1;
-            CellMessage reply = buildListReply(request, entries, isLast);
+            boolean isLast = i == (replies.length - 1);
+            CellMessage reply = buildListReply(request, entries, isLast, replies.length);
 
             messages.add((PnfsListDirectoryMessage) reply.getMessageObject());
         }
@@ -767,14 +766,16 @@ public class RemoteNameSpaceProviderTests
 
 
     private static CellMessage buildListReply(CellMessage request,
-            final Collection<DirectoryEntry> entries, final boolean isLast)
+            final Collection<DirectoryEntry> entries, final boolean isLast, final int cnt)
     {
         return buildReply(request, new Modifier<PnfsListDirectoryMessage>(){
             @Override
             public void modify(PnfsListDirectoryMessage reply)
             {
                 reply.setEntries(entries);
-                reply.setFinal(isLast);
+                if (isLast) {
+                    reply.setSucceeded(cnt);
+                }
             }
         }, SUCCESSFUL);
     }

--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -35,6 +35,7 @@ ssh1.paths.history=${system-test.home}/var/admin/history
 [dCacheDomain/pnfsmanager]
 pnfsmanager.default-retention-policy=REPLICA
 pnfsmanager.default-access-latency=ONLINE
+pnfsmanager.limits.list-chunk-size=5
 
 [dCacheDomain/poolmanager]
 poolmanager.enable.cache-hit-message=true


### PR DESCRIPTION
The ListDirectoryHandler only worked if replies arrived in sequence
and sequentially. For singe threaded cells this worked fine, however
srm now uses multithreaded message delivery and thus listing broke.

The fix updates the handler to deal with concurrent and out of order
reply delivery.

Target: trunk
Request: 2.9
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6946/
(cherry picked from commit 942035ad08e781006a7fa87201ab35f3eba7d502)
