### PR TITLE
pool: Report correct client IP to billing for passive FTP transfers

### DIFF
--- a/modules/dcache-ftp/src/main/java/diskCacheV111/vehicles/GFtpProtocolInfo.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/vehicles/GFtpProtocolInfo.java
@@ -285,6 +285,10 @@ public class GFtpProtocolInfo implements IpProtocolInfo {
         return _protocolFamily;
     }
 
+    public void setSocketAddress(InetSocketAddress address) {
+        _addr = address;
+    }
+
     @Override
     public InetSocketAddress getSocketAddress() {
         return _addr;

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/data/Mode.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/data/Mode.java
@@ -9,8 +9,12 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.UnresolvedAddressException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.dcache.pool.repository.RepositoryChannel;
 
@@ -62,6 +66,9 @@ public abstract class Mode extends AbstractMultiplexerListener
 
     /** Number of connections that have been closed. */
     protected int               _closed;
+
+    /** Remote addresses of data channels connected by this class. */
+    private final Set<InetSocketAddress> _remoteAddresses = new HashSet<>();
 
     /** Constructs a new mode for outgoing connections. */
     public Mode(Role role, RepositoryChannel file, ConnectionMonitor monitor)
@@ -154,6 +161,12 @@ public abstract class Mode extends AbstractMultiplexerListener
     public long getSize()
     {
         return _size;
+    }
+
+    /** Returns the remote addresses the mode connected with. */
+    public Collection<InetSocketAddress> getRemoteAddresses()
+    {
+        return Collections.unmodifiableCollection(_remoteAddresses);
     }
 
     /**
@@ -358,6 +371,7 @@ public abstract class Mode extends AbstractMultiplexerListener
             Socket socket = channel.socket();
             _opened++;
             multiplexer.say("Opened " + socket);
+            _remoteAddresses.add((InetSocketAddress) socket.getRemoteSocketAddress());
             channel.configureBlocking(false);
             if (_bufferSize > 0) {
                 channel.socket().setSendBufferSize(_bufferSize);
@@ -386,6 +400,7 @@ public abstract class Mode extends AbstractMultiplexerListener
                 Socket socket = channel.socket();
                 _opened++;
                 multiplexer.say("Opened " + socket);
+                _remoteAddresses.add((InetSocketAddress) socket.getRemoteSocketAddress());
                 newConnection(multiplexer, channel);
             }
         } catch (IOException e) {

--- a/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
@@ -1,5 +1,6 @@
 package org.dcache.pool.movers;
 
+import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -587,6 +588,10 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
              */
             gftpProtocolInfo.setBytesTransferred(getBytesTransferred());
             gftpProtocolInfo.setTransferTime(getTransferTime());
+            if (passive) {
+                gftpProtocolInfo.setSocketAddress(
+                        Iterables.getFirst(mode.getRemoteAddresses(), gftpProtocolInfo.getSocketAddress()));
+            }
         }
     }
 


### PR DESCRIPTION
The pool incorrectly reported the FTP proxy address of the FTP door
even when a direct connection between the client and the pool was
established.

I am undecided how far back to fix this. Please advice.

Target: trunk
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: http://rb.dcache.org/r/6940/
(cherry picked from commit 7e6e2ef7a8ad506293fc440cc1354eeed9c2607a)
