### PR TITLE
webdav: work-around race-condition in StringTemplate library

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -109,6 +109,8 @@ public class DcacheResourceFactory
         EnumSet.of(TYPE, PNFSID, CREATION_TIME, MODIFICATION_TIME, SIZE,
                    MODE, OWNER, OWNER_GROUP);
 
+    private static final String HTML_TEMPLATE_NAME = "page";
+
     // Additional attributes needed for PROPFIND requests; e.g., to supply
     // values for properties.
     private static final Set<FileAttribute> PROPFIND_ATTRIBUTES =
@@ -459,6 +461,16 @@ public class DcacheResourceFactory
     {
         _listingGroup = new STGroupFile(resource.getURL(), "UTF-8", '$', '$');
         _listingGroup.setListener(new Slf4jSTErrorListener(_log));
+
+        /* StringTemplate has lazy initialisation, but this is very racey and
+         * can break StringTemplate altogether:
+         *
+         *     https://github.com/antlr/stringtemplate4/issues/61
+         *
+         * here we force initialisation to work-around this.
+         */
+        _listingGroup.getInstanceOf(HTML_TEMPLATE_NAME);
+
     }
 
     /**
@@ -783,7 +795,7 @@ public class DcacheResourceFactory
         String requestPath = new URI(request.getAbsoluteUrl()).getPath();
         String[] base =
             Iterables.toArray(PATH_SPLITTER.split(requestPath), String.class);
-        final ST t = _listingGroup.getInstanceOf("page");
+        final ST t = _listingGroup.getInstanceOf(HTML_TEMPLATE_NAME);
         t.add("path", asList(UrlPathWrapper.forPaths(base)));
         t.add("static", _staticContentPath);
         t.add("subject", new SubjectWrapper(getSubject()));

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
@@ -49,6 +49,8 @@ public class DcacheResponseHandler extends AbstractWrappingResponseHandler
     private final static Logger log =
         LoggerFactory.getLogger(DcacheResponseHandler.class);
 
+    private static final String HTML_TEMPLATE_NAME = "errorpage";
+
     private final static Splitter PATH_SPLITTER =
         Splitter.on('/').omitEmptyStrings();
 
@@ -82,6 +84,15 @@ public class DcacheResponseHandler extends AbstractWrappingResponseHandler
     {
         _templateGroup = new STGroupFile(resource.getURL(), "UTF-8", '$', '$');
         _templateGroup.setListener(new Slf4jSTErrorListener(log));
+
+        /* StringTemplate has lazy initialisation, but this is very racey and
+         * can break StringTemplate altogether:
+         *
+         *     https://github.com/antlr/stringtemplate4/issues/61
+         *
+         * here we force initialisation to work-around this.
+         */
+        _templateGroup.getInstanceOf(HTML_TEMPLATE_NAME);
     }
 
     /**
@@ -169,7 +180,7 @@ public class DcacheResponseHandler extends AbstractWrappingResponseHandler
         String[] base =
             Iterables.toArray(PATH_SPLITTER.split(path), String.class);
 
-        ST template = _templateGroup.getInstanceOf("errorpage");
+        ST template = _templateGroup.getInstanceOf(HTML_TEMPLATE_NAME);
 
         template.add("path", UrlPathWrapper.forPaths(base));
         template.add("base", UrlPathWrapper.forEmptyPath());


### PR DESCRIPTION
StringTemplate has a lazy-load for parsing the template file.  It
turns out that this is very racy, with at least two race-conditions.

Once race-condition has the effect that if two threads attempt to
fetch a template at about the same time with the template file not
loaded then the template being requested by the second thread (the one
that lost the race, so not loading the template file) will be never be
available.

Since dCache uses STGroupFile object to render only one template, this
means that if two threads attempt to fetch the template close enough
together then the template is never available and null is returned.
Because of another problem, this triggers a NPE.

A symptom of this problem is that dCache (> 2.6) will log a single
entry

   "redefinition of template <name>"

where <name> is the template that is no longer available.

The work-around is to force the loading and parsing the template file
by the thread creating the cell.  This removes the race-condition and
the file is loaded correctly.

There is another race-condition that results in multiple threads
attempting to load and parse the file.  This will result in dCache
logging a line like:

   "redefinition of template <name>"

for each template and for each additional thread that attempts to load
the file. While noisy, this should only happen (if at all) for "a
while" after initialising and does not affect the correctness of the
rendered response.

Target: master
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Bug-report: http://rt.dcache.org/Ticket/Display.html?id=8315
Bug-report: (private correspondance with DESY people)
Patch: http://rb.dcache.org/r/6986/
Acked-by: Gerd Behrmann
