### PR TITLE
dcap: ensure that we remove session on DoorTransferFinishedMessage

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -2369,41 +2369,43 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
         public synchronized void
         doorTransferArrived( DoorTransferFinishedMessage reply ){
 
-            if( reply.getReturnCode() == 0 ){
+            try {
+                if( reply.getReturnCode() == 0 ){
 
-                long filesize = reply.getFileAttributes().getSize() ;
-                _log.info("doorTransferArrived : fs={};strict={};m={}", filesize, _strictSize, _ioMode);
-                if( _strictSize && ( filesize > 0L ) && (_ioMode.contains("w")) ){
+                    long filesize = reply.getFileAttributes().getSize() ;
+                    _log.info("doorTransferArrived : fs={};strict={};m={}", filesize, _strictSize, _ioMode);
+                    if( _strictSize && ( filesize > 0L ) && (_ioMode.contains("w")) ){
 
-                    for( int count = 0 ; count < 10 ; count++  ){
-                        try{
-                            long fs = _pnfs.getFileAttributes(_fileAttributes.getPnfsId(), EnumSet.of(SIZE)).getSize();
-                            _log.info("doorTransferArrived : Size of {}: {}",
-                                      _fileAttributes.getPnfsId(), fs);
-                            if( fs > 0L ) {
-                                break;
+                        for( int count = 0 ; count < 10 ; count++  ){
+                            try{
+                                long fs = _pnfs.getFileAttributes(_fileAttributes.getPnfsId(), EnumSet.of(SIZE)).getSize();
+                                _log.info("doorTransferArrived : Size of {}: {}",
+                                          _fileAttributes.getPnfsId(), fs);
+                                if( fs > 0L ) {
+                                    break;
+                                }
+                            }catch(Exception ee ){
+                                _log.error("Problem getting storage info (check) for {}: {}", _fileAttributes.getPnfsId(), ee);
                             }
-                        }catch(Exception ee ){
-                            _log.error("Problem getting storage info (check) for {}: {}", _fileAttributes.getPnfsId(), ee);
-                        }
-                        try{
-                            Thread.sleep(10000L);
-                        }catch(InterruptedException ie ){
-                            break ;
+                            try{
+                                Thread.sleep(10000L);
+                            }catch(InterruptedException ie ){
+                                break ;
+                            }
                         }
                     }
+                    sendReply( "doorTransferArrived" , 0 , "" ) ;
+                }else{
+                    sendReply( "doorTransferArrived" , reply ) ;
                 }
-                sendReply( "doorTransferArrived" , 0 , "" ) ;
-            }else{
-                sendReply( "doorTransferArrived" , reply ) ;
+            }finally {
+                /*
+                 * mover is already gone
+                 */
+                _moverId = null;
+                removeUs() ;
+                setStatus( "<done>" ) ;
             }
-
-            /*
-             * mover is already gone
-             */
-            _moverId = null;
-            removeUs() ;
-            setStatus( "<done>" ) ;
         }
         @Override
         public String toString(){ return "io ["+_pool+"] "+super.toString() ; }


### PR DESCRIPTION
does not fix, but ensure that we do cleanup in case of:

java.lang.NullPointerException: null
        at diskCacheV111.doors.DCapDoorInterpreterV3$SessionHandler.sendReply(DCapDoorInterpreterV3.java:963) ~[dcach
e-dcap-2.8.4.jar:2.8.4]
        at diskCacheV111.doors.DCapDoorInterpreterV3$IoHandler.doorTransferArrived(DCapDoorInterpreterV3.java:2398) ~
[dcache-dcap-2.8.4.jar:2.8.4]
        at diskCacheV111.doors.DCapDoorInterpreterV3.messageArrived(DCapDoorInterpreterV3.java:2695) ~[dcache-dcap-2.
8.4.jar:2.8.4]
        at diskCacheV111.doors.DCapDoor.messageArrived(DCapDoor.java:354) ~[dcache-dcap-2.8.4.jar:2.8.4]
        at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:994) ~[cells-2.8.4.jar:2.8.4]
        at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.innerRun(CellNucleus.java:1070) ~[cells-2.8.4.jar:2.8.4]
        at dmg.cells.nucleus.CellNucleus$AbstractNucleusTask.run(CellNucleus.java:975) ~[cells-2.8.4.jar:2.8.4]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_55]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_55]
        at dmg.cells.nucleus.CellNucleus$1.run(CellNucleus.java:687) [cells-2.8.4.jar:2.8.4]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_55]
21 May 2014 04:42:04 (DCap-dcache-door-cms19-<unknown>-57629) [] Uncaught exception in thread DCap-dcache-door-cms19-
<unknown>-57629-0

kills active transfers page with accumulated transfers

Acked-by: Paul Millar
Target: master, 2.8, 2.9, 2.7, 2.6
Require-book: no
Require-notes: no
(cherry picked from commit 2f2badb6a9ceb931d4522dac2355ad30f86e8faa)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
