### PR TITLE
dcache-pnfs: fix sping xml to initialize cacheLocationProvider

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/namespace/pnfsmanager-pnfs+companion.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/namespace/pnfsmanager-pnfs+companion.xml
@@ -25,6 +25,7 @@
       <property name="directoryListLimit" value="${directoryListLimit}"/>
       <property name="permissionHandler" ref="permission-handler"/>
       <property name="nameSpaceProvider" ref="name-space-provider"/>
+      <property name="cacheLocationProvider" ref="cache-location-provider"/>
       <property name="queueMaxSize" value="${queueMaxSize}"/>
   </bean>
 

--- a/modules/dcache/src/main/resources/diskCacheV111/namespace/pnfsmanager-pnfs.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/namespace/pnfsmanager-pnfs.xml
@@ -25,6 +25,7 @@
       <property name="directoryListLimit" value="${directoryListLimit}"/>
       <property name="permissionHandler" ref="permission-handler"/>
       <property name="nameSpaceProvider" ref="name-space-provider"/>
+      <property name="cacheLocationProvider" ref="basic-provider"/>
       <property name="queueMaxSize" value="${queueMaxSize}"/>
   </bean>
 


### PR DESCRIPTION
Ticket: #8329
Target: 2.2
Require-book: no
Require-notes: no
