### PR TITLE
don't use real example domains for default values

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -489,7 +489,7 @@ dcache.service.copymanager=CopyManager
 #
 #  Your kerberos 5 realm, used by Kerberos dcap and FTP doors
 #
-(deprecated,not-for-services)kerberos.realm=EXAMPLE.ORG
+(deprecated,not-for-services)kerberos.realm=EXAMPLE.INVALID
 (not-for-services)dcache.authn.kerberos.realm=${kerberos.realm}
 
 #  ---- Kerberos key distribution center
@@ -507,7 +507,7 @@ dcache.authn.kerberos.key-distribution-center-list=${kerberos.key-distribution-c
 #  Please copy these files into ${dcache.paths.etc} and modify their
 #  content as appropriate.  The minimum configuration is to change
 #  the principle value, replacing "door.example.org" with the FQDN of
-#  the door and replacing "EXAMPLE.ORG" with the Kerberos Realm.
+#  the door and replacing "EXAMPLE.INVALID" with the Kerberos Realm.
 #
 #  The file jgss.conf is suitable for a domain running a Kerberos FTP
 #  door and jgss_host.conf is suitable for a domain running a Kerberos

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -171,10 +171,10 @@ gplazma.argus.endpoint=https://localhost:8154/authz
 gplazma.kpwd.file=${kpwdFile}
 
 #  ---- NIS server host
-gplazma.nis.server=nisserv.example.org
+gplazma.nis.server=nisserv.example.invalid
 
 #  ---- NIS domain name
-gplazma.nis.domain=example.org
+gplazma.nis.domain=example.invalid
 
 #  ---- JAAS application name
 #
@@ -196,7 +196,7 @@ gplazma.xacml.ca=${dcache.authn.capath}
 #
 
 # LDAP server host
-(deprecated)gplazma.ldap.server = ldap.example.org
+(deprecated)gplazma.ldap.server = ldap.example.invalid
 
 # LDAP server port number
 (deprecated)gplazma.ldap.port = 389

--- a/skel/share/defaults/info-provider.properties
+++ b/skel/share/defaults/info-provider.properties
@@ -37,7 +37,7 @@ info-provider.site-unique-id=EXAMPLESITE-ID
 #   The default value is not valid, so this property must be
 #   configured.
 #
-info-provider.se-unique-id=dcache-srm.example.org
+info-provider.se-unique-id=dcache-srm.example.invalid
 
 #   GlueSEName [1.3, 2.0]: a human understandable name for your SE.
 #   It may contain spaces.  You may leave this empty and a GlueSEName

--- a/skel/share/defaults/missingfiles-semsg.properties
+++ b/skel/share/defaults/missingfiles-semsg.properties
@@ -8,7 +8,7 @@
 #
 #   The hostname of the message broker
 #
-missing-files.plugins.semsg.broker.host = semsg-broker.example.org
+missing-files.plugins.semsg.broker.host = semsg-broker.example.invalid
 #
 #   The TCP port number on which the message broken is listening.
 #


### PR DESCRIPTION
Using RFC 2606 respectively 6761 domain names rather then domains like “cern.ch”
was some improvement already, but the well known reserved domains like
“example.org” are real existing domains and forbidden to be used as dCache uses
them now (see RFC 6761, section 6.5.)
These domains are only allowed within documentation.

Actually, using those domains in a system, will lead to their connected hosts
really being used and may even be a security issue.

In places where a domain name is used for a real configuration value,
RFC 2606/6761 define the “invalid.” TLD for such purposes.
This has the advantages that no correctly configured nameserver will ever
resolve these addresses to anything valid.

• Replace “example.org” with “example.invalid” for all default configuration
  values.
• Even though a Kerberos realm isn’t a domain name per se, replace “EXAMPLE.ORG”
  with “EXAMPLE.INVALID” to clearly indicate that this is an invalid realm.
• Leave “example.org” in place at any documentatory context, unless it directly
  refers to the default value that has been changed now.

On the long term scale, dCache should leave all these options empty per default
and the respective service/functionality should simply refuse to start or block
if an option has not been set manually.

Require-book: no
Require-notes: yes

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>