### PR TITLE
allow DCAP configuration to be set per flavour

### DIFF
--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -68,10 +68,10 @@ dcap.authz.staging=${dcache.authz.staging}
 # Whether a dcap client is allowed to override which mover queue on
 # the pool is used to schedule a request.
 (one-of?true|false|${dcap.authz.mover-queue-overwrite.${dcap.authn.protocol}})dcap.authz.mover-queue-overwrite=${dcap.authz.mover-queue-overwrite.${dcap.authn.protocol}}
-(immutable)dcap.authz.mover-queue-overwrite.plain=${dcap.authz.mover-queue-overwrite-when-${dcapIoQueueOverwrite}}
-(immutable)dcap.authz.mover-queue-overwrite.auth=${dcap.authz.mover-queue-overwrite-when-${dcapIoQueueOverwrite}}
-(immutable)dcap.authz.mover-queue-overwrite.gsi=${dcap.authz.mover-queue-overwrite-when-${gsidcapIoQueueOverwrite}}
-(immutable)dcap.authz.mover-queue-overwrite.kerberos=${dcap.authz.mover-queue-overwrite-when-${kerberosdcapIoQueueOverwrite}}
+dcap.authz.mover-queue-overwrite.plain=${dcap.authz.mover-queue-overwrite-when-${dcapIoQueueOverwrite}}
+dcap.authz.mover-queue-overwrite.auth=${dcap.authz.mover-queue-overwrite-when-${dcapIoQueueOverwrite}}
+dcap.authz.mover-queue-overwrite.gsi=${dcap.authz.mover-queue-overwrite-when-${gsidcapIoQueueOverwrite}}
+dcap.authz.mover-queue-overwrite.kerberos=${dcap.authz.mover-queue-overwrite-when-${kerberosdcapIoQueueOverwrite}}
 (immutable)dcap.authz.mover-queue-overwrite-when-allowed=true
 (immutable)dcap.authz.mover-queue-overwrite-when-denied=false
 (deprecated,one-of?allowed|denied)dcapIoQueueOverwrite=denied
@@ -94,20 +94,20 @@ dcap.net.listen=${dcache.net.listen}
 
 # Pool mover queue to use for transfers by this door
 dcap.mover.queue=${dcap.mover.queue.${dcap.authn.protocol}}
-(immutable)dcap.mover.queue.plain=${dcapIoQueue}
-(immutable)dcap.mover.queue.auth=${dcapIoQueue}
-(immutable)dcap.mover.queue.gsi=${gsidcapIoQueue}
-(immutable)dcap.mover.queue.kerberos=${kerberosdcapIoQueue}
+dcap.mover.queue.plain=${dcapIoQueue}
+dcap.mover.queue.auth=${dcapIoQueue}
+dcap.mover.queue.gsi=${gsidcapIoQueue}
+dcap.mover.queue.kerberos=${kerberosdcapIoQueue}
 (deprecated)dcapIoQueue=
 (deprecated)gsidcapIoQueue=
 (deprecated)kerberosdcapIoQueue=
 
 # Maximum number of concurrent DCAP transfers on this door
 dcap.limits.clients=${dcap.limits.clients.${dcap.authn.protocol}}
-(immutable)dcap.limits.clients.plain=${dcapMaxLogin}
-(immutable)dcap.limits.clients.auth=${dcapMaxLogin}
-(immutable)dcap.limits.clients.gsi=${gsidcapMaxLogin}
-(immutable)dcap.limits.clients.kerberos=${kerberosdcapMaxLogin}
+dcap.limits.clients.plain=${dcapMaxLogin}
+dcap.limits.clients.auth=${dcapMaxLogin}
+dcap.limits.clients.gsi=${gsidcapMaxLogin}
+dcap.limits.clients.kerberos=${kerberosdcapMaxLogin}
 (deprecated)dcapMaxLogin=1500
 (deprecated)gsidcapMaxLogin=1500
 (deprecated)kerberosdcapMaxLogin=1500


### PR DESCRIPTION
Currently, the defaults file forbid to set per-protocol-flavour options for
“dcap.authz.mover-queue-overwrite”, “dcap.mover.queue” and
“dcap.limits.clients”.

I do not see any good reason why this shouldn’t be allowed, actually this is
highly desired, since admins for example want to default all their mover queues
for GSI DCAP to “gsidcap” while all others should perhaps default to “dcap”.
When those options are marked immutable, an admin can’t set e.g. site-wide
defaults in dcache.conf.

• Drop the “immutable” flag for those DCAP per-protocol-flavour options where
  it seems approppriate.

Require-book: no
Require-notes: yes

Signed-off-by: Christoph Anton Mitterer mail@christoph.anton.mitterer.name
