### PR TITLE
Fix/2.2/rb5425

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/AdjustableSemaphore.java
+++ b/modules/dcache/src/main/java/org/dcache/util/AdjustableSemaphore.java
@@ -1,6 +1,10 @@
 package org.dcache.util;
 
+import com.google.common.base.Preconditions;
+
 import java.util.concurrent.Semaphore;
+
+import static com.google.common.base.Preconditions.*;
 
 /**
  * A simple implementation of an adjustable semaphore.
@@ -43,10 +47,7 @@ final public class AdjustableSemaphore {
      * @param newMax
      */
     public synchronized void setMaxPermits(int newMax) {
-        if (newMax < 1) {
-            throw new IllegalArgumentException("Semaphore size must be at least 1,"
-                    + " was " + newMax);
-        }
+        checkArgument(newMax >= 0);
 
         int delta = newMax - this.maxPermits;
 


### PR DESCRIPTION
Allow to specify 0 as max active mover queue size. Original patch by Gerd. The Fix was 
requested by CMS T1
