### PR TITLE
Fix/2.2/pinstaged1

### DIFF
--- a/modules/dcache/src/test/java/org/dcache/pinmanager/PinManagerTests.java
+++ b/modules/dcache/src/test/java/org/dcache/pinmanager/PinManagerTests.java
@@ -54,6 +54,7 @@ public class PinManagerTests
         attributes.setPnfsId(pnfsId);
         attributes.setStorageInfo(STORAGE_INFO);
         attributes.setLocations(Collections.singleton(POOL1));
+        attributes.setSize(0L);
         return attributes;
     }
 


### PR DESCRIPTION
Fixes unit test regression introduced in 0eb17558d13723f5926dc5639ce1c8686bb2ba3d Since file size is required attribute it has to be specified

RB: https://rb.dcache.org/r/7057/
Acked-by: Paul Millar 
Target: 2.2 
Require-book: no 
Require-notes: no 
