### PR TITLE
cells: remove System time dependency in unit-test

### DIFF
--- a/modules/dcache-jms/src/main/java/org/dcache/cells/CellNameServiceRegistry.java
+++ b/modules/dcache-jms/src/main/java/org/dcache/cells/CellNameServiceRegistry.java
@@ -53,7 +53,7 @@ public class CellNameServiceRegistry
 
     public Collection<String> getDomains()
     {
-        long now = System.currentTimeMillis();
+        long now = currentTimeMillis();
         Collection<String> domains = new ArrayList<>();
         for (String domainName: _domains.keySet()) {
             if (isValid(now, domainName)) {
@@ -66,7 +66,7 @@ public class CellNameServiceRegistry
     public String getDomain(String cell)
     {
         String domain = _cells.get(cell);
-        if (domain != null && isValid(System.currentTimeMillis(), domain)) {
+        if (domain != null && isValid(currentTimeMillis(), domain)) {
             return domain;
         }
         return null;
@@ -99,7 +99,7 @@ public class CellNameServiceRegistry
         _domains.put(domainName, cells);
 
         /* Schedule new timeout */
-        _timeouts.put(domainName, System.currentTimeMillis() + timeout);
+        _timeouts.put(domainName, currentTimeMillis() + timeout);
     }
 
     /* Registration messages follow the format
@@ -167,5 +167,13 @@ public class CellNameServiceRegistry
     public CellInfo getCellInfo(CellInfo info)
     {
         return info;
+    }
+
+    /**
+     * Hook to allow unit-testing
+     */
+    protected long currentTimeMillis()
+    {
+        return System.currentTimeMillis();
     }
 }

--- a/modules/dcache-jms/src/test/java/org/dcache/cells/CellNameServiceRegistryTests.java
+++ b/modules/dcache-jms/src/test/java/org/dcache/cells/CellNameServiceRegistryTests.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -36,11 +37,19 @@ public class CellNameServiceRegistryTests {
 
     public static final String UNKNOWN_CELL = "unknown-cell";
 
+    long _currentTimeMillis;
     CellNameServiceRegistry _registry;
 
     @Before
     public void setup() {
-        _registry = new CellNameServiceRegistry();
+        _currentTimeMillis = System.currentTimeMillis();
+        _registry = new CellNameServiceRegistry() {
+            @Override
+            protected long currentTimeMillis()
+            {
+                return _currentTimeMillis;
+            }
+        };
         simulateDomainRegistration(DOMAIN_1, 60000, DOMAIN_1_CELLS);
         simulateDomainRegistration(DOMAIN_2, 60000, DOMAIN_2_CELLS);
     }
@@ -76,8 +85,7 @@ public class CellNameServiceRegistryTests {
         String expiringDomain = "new-domain";
         String expiringDomainsCell = "well-known";
         simulateDomainRegistration(expiringDomain, 1, expiringDomainsCell);
-
-        Thread.sleep(2);
+        _currentTimeMillis += 2;
 
         assertNull(_registry.getDomain(expiringDomainsCell));
 


### PR DESCRIPTION
The CellNameServiceRegistryTests class provides unit-tests for the
CellNameServiceReigstry.  One of these tests verifies that expired
well-known cells registration is removed successfully, leaving the
existing cells intact.

This patch refacts CellNameServiceRegistry slighly to allow a
subclass to adjust its concept of time.  This is used to provide a
reliable simulated flow of time in the unit-tests, removing the
need for a sleep statement.

Target: master
Patch: https://rb.dcache.org/r/7090/
Acked-by: Tigran Mkrtchyan
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
