### PR TITLE
Suppress nfs' file protocol from being published

### DIFF
--- a/skel/share/info-provider/glue-1.3-defn.xml
+++ b/skel/share/info-provider/glue-1.3-defn.xml
@@ -77,6 +77,11 @@
               <lookup path="d:protocol/d:metric[@name='family']"/>
             </suppress>
 
+            <!-- Don't publish any nfs doors -->
+            <suppress test="file">
+              <lookup path="d:protocol/d:metric[@name='family']"/>
+            </suppress>
+
             <!-- Uncomment the next section to suppress publishing gsidcap -->
 <!--
             <suppress test="gsidcap">


### PR DESCRIPTION
The dcache-info-provider publishes all doors as endpoints by default. A
couple of doors are already configured to be excluded from this, but the
nfs door isn't and causes an file://xyz/ endpoint to be published.

Ticket: 8365
Acked-by: Paul
Target: master
Request: 2.7
Require-book: no
Require-notes: yes
