### PR TITLE
pool: Fix race condition that leads to orphaned files

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/FileNotInCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/FileNotInCacheException.java
@@ -1,5 +1,9 @@
 package diskCacheV111.util ;
 
+/**
+ * Thrown when attempting to access a replica that doesn't exist
+ * in the repository.
+ */
 public class FileNotInCacheException extends CacheException {
 
     private static final long serialVersionUID = 7790043638464132679L;

--- a/modules/dcache/src/main/java/diskCacheV111/util/LockedCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/LockedCacheException.java
@@ -1,5 +1,8 @@
 package diskCacheV111.util;
 
+/**
+ * Thrown when accessing a locked resource.
+ */
 public class LockedCacheException extends CacheException
 {
     static final long serialVersionUID = 3557655138424508092L;

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/Repository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/Repository.java
@@ -1,19 +1,17 @@
 package org.dcache.pool.repository;
 
-import diskCacheV111.util.PnfsId;
-import diskCacheV111.util.FileInCacheException;
-import diskCacheV111.util.FileNotInCacheException;
-import diskCacheV111.util.CacheException;
-import diskCacheV111.vehicles.StorageInfo;
-
-import org.dcache.pool.repository.v3.RepositoryException;
-import org.dcache.pool.FaultListener;
-
 import java.io.IOException;
-import java.io.FileNotFoundException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileInCacheException;
+import diskCacheV111.util.FileNotInCacheException;
+import diskCacheV111.util.LockedCacheException;
+import diskCacheV111.util.PnfsId;
+import diskCacheV111.vehicles.StorageInfo;
+
+import org.dcache.pool.FaultListener;
 
 public interface Repository
     extends Iterable<PnfsId>
@@ -86,16 +84,12 @@ public interface Repository
      * entry from being deleted. Notice that an open read handle does
      * not prevent state changes.
      *
-     * TODO: Refine the exceptions. Throwing FileNotInCacheException
-     * implies that one could create the entry, however this is not
-     * the case for broken or incomplet files.
-     *
      * @param id the PNFS ID of the entry to open
      * @param flags options that influence how the file is opened
      * @return IO descriptor
      * @throws InterruptedException if thread was interrupted
-     * @throws FileNotInCacheException if file not found or in a state
-     * in which it cannot be opened
+     * @throws FileNotInCacheException if file not found
+     * @throws LockedCacheException if in a state in which it cannot be opened
      * @throws CacheException in case of other errors
      */
     ReplicaDescriptor openEntry(PnfsId id, Set<OpenFlags> flags)


### PR DESCRIPTION
Using FileNotInCacheException cause the chimera registration to be cleared.
Clearly we don't want this when the file is actually in the pool and just
happens to be in a state in which it isn't accessible.

This patch changes the exception to LockedCacheException.

This is an alternative to patch: https://rb.dcache.org/r/5801

Target: trunk
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7103/
(cherry picked from commit ade506eb0c921bdeb4284d42e7c247794b3e5d1a)

Conflicts:
    modules/dcache/src/main/java/org/dcache/pool/repository/Repository.java
    modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
