### PR TITLE
pool: Fix race condition that leads to orphaned files

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/FileNotInCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/FileNotInCacheException.java
@@ -1,5 +1,9 @@
 package diskCacheV111.util ;
 
+/**
+ * Thrown when attempting to access a replica that doesn't exist
+ * in the repository.
+ */
 public class FileNotInCacheException extends CacheException {
 
     private static final long serialVersionUID = 7790043638464132679L;

--- a/modules/dcache/src/main/java/diskCacheV111/util/LockedCacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/LockedCacheException.java
@@ -1,5 +1,8 @@
 package diskCacheV111.util;
 
+/**
+ * Thrown when accessing a locked resource.
+ */
 public class LockedCacheException extends CacheException
 {
     private static final long serialVersionUID = 3557655138424508092L;

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/Repository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/Repository.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileInCacheException;
 import diskCacheV111.util.FileNotInCacheException;
+import diskCacheV111.util.LockedCacheException;
 import diskCacheV111.util.PnfsId;
 
 import org.dcache.pool.FaultListener;
@@ -96,8 +97,8 @@ public interface Repository
      * @param flags options that influence how the entry is opened
      * @return IO descriptor
      * @throws InterruptedException if thread was interrupted
-     * @throws FileNotInCacheException if file not found or in a state
-     * in which it cannot be opened
+     * @throws FileNotInCacheException if file not found
+     * @throws LockedCacheException if in a state in which it cannot be opened
      * @throws CacheException in case of other errors
      */
     ReplicaDescriptor openEntry(PnfsId id, Set<OpenFlags> flags)

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -23,6 +23,7 @@ import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.util.FileInCacheException;
 import diskCacheV111.util.FileNotInCacheException;
+import diskCacheV111.util.LockedCacheException;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.util.UnitInteger;
@@ -475,10 +476,6 @@ public class CacheRepositoryV5
     public ReplicaDescriptor openEntry(PnfsId id, Set<OpenFlags> flags)
         throws CacheException, InterruptedException
     {
-        /* TODO: Refine the exceptions. Throwing FileNotInCacheException
-         * implies that one could create the entry, however this is not
-         * the case for broken or incomplete files.
-         */
         assertInitialized();
 
         try {
@@ -486,18 +483,16 @@ public class CacheRepositoryV5
 
             MetaDataRecord entry = getMetaDataRecord(id);
             synchronized (entry) {
-                /* REVISIT: Is using FileNotInCacheException appropriate?
-                 */
                 switch (entry.getState()) {
                 case NEW:
                 case FROM_CLIENT:
                 case FROM_STORE:
                 case FROM_POOL:
-                    throw new FileNotInCacheException("File is incomplete");
+                    throw new LockedCacheException("File is incomplete");
                 case BROKEN:
-                    throw new FileNotInCacheException("File is broken");
+                    throw new LockedCacheException("File is broken");
                 case DESTROYED:
-                    throw new FileNotInCacheException("File has been removed");
+                    throw new LockedCacheException("File has been removed");
                 case PRECIOUS:
                 case CACHED:
                 case REMOVED:


### PR DESCRIPTION
Using FileNotInCacheException cause the chimera registration to be cleared.
Clearly we don't want this when the file is actually in the pool and just
happens to be in a state in which it isn't accessible.

This patch changes the exception to LockedCacheException.

This is an alternative to patch: https://rb.dcache.org/r/5801

Target: trunk
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Request: 2.2
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7103/
(cherry picked from commit ade506eb0c921bdeb4284d42e7c247794b3e5d1a)
