### PR TITLE
delegation-shell: generate delegated credential of correct type

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/DelegationShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/DelegationShell.java
@@ -593,8 +593,8 @@ public class DelegationShell extends ShellApplication
                     BouncyCastleCertProcessingFactory.getDefault();
 
             return factory.createProxyCertificate(proxy.getCertificateChain()[0],
-                    proxy.getPrivateKey(), pubKey, lifetime,
-                    CertificateType.GSI_4_INDEPENDENT_PROXY, null, null);
+                    proxy.getPrivateKey(), pubKey, lifetime, proxy.getProxyType(),
+                    null, null);
         }
 
         private Iterable<X509Certificate> concat(X509Certificate certificate,


### PR DESCRIPTION
There are several types of proxy credential.  Currently the delegation shell generates
a fixed type.

In practise, the chain of proxy certificates must be of the same type or some services
will reject the chain.

This patch updates the delegation client so it generates a certificate of the same
type as the most recent (top-most) proxy certificate.

Target: master
Patch: https://rb.dcache.org/r/7112/
Acked-by: Gerd Behrmann
Request: 2.9
