### PR TITLE
deb: Add python-psycopg2 as a recommended dependency

### DIFF
--- a/pkgs/deb/server/control.template
+++ b/pkgs/deb/server/control.template
@@ -8,7 +8,7 @@ Standards-Version: 3.9.0
 Package: @PackageName@
 Depends: ssh-client, adduser, ssl-cert
 Conflicts: dcache-server
-Recommends: libxml2-utils
+Recommends: libxml2-utils, python-psycopg2
 Architecture: all
 Suggests: ruby
 Description: distributed mass storage system


### PR DESCRIPTION
Needed by dcache-star.

Target: trunk
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7091/
(cherry picked from commit efa2de674ac1ca5aa1b18d0aba186ee98c4ead22)
