### PR TITLE
alarms: Fix checksum alarm filter.

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
@@ -425,9 +425,6 @@ public class ChecksumScanner
                     }
                 } catch (FileCorruptedCacheException e) {
                     _badCount++;
-                    /* This can now be configured as an alarm by using
-                     * the org.dcache.alarms.logback.AlarmDefinitionFilter
-                     */
                     _log.error("Marking {} as BROKEN: {}", id, e.getMessage());
                     try {
                         _repository.setState(id, EntryState.BROKEN);

--- a/skel/var/alarms/alarm-definitions.xml
+++ b/skel/var/alarms/alarm-definitions.xml
@@ -94,7 +94,7 @@
     <alarmType>
         <logger>org.dcache.pool.classic.ChecksumScanner</logger>
         <type>CHECKSUM</type>
-        <regex>Checksum mismatch detected for (.+) - marking as BROKEN</regex>
+        <regex>Marking (.+) as BROKEN</regex>
         <level>ERROR</level>
         <severity>MODERATE</severity>
         <includeInKey>group1 type host service domain</includeInKey>


### PR DESCRIPTION
The filter provided for checksum alarms generated by the pool scrubber
is out of sync with the actual logging statement in the scrubber.

This patch fixes the regex for the filter to match.

Target: 2.8
Require-book: no
Require-notes: yes
Acked-by: Karsten
Acked-by: Paul

RELEASE NOTES

Fixes a bug present since April 2013 (but up to now undiscovered by us) preventing
reporting of checksum alarms from the pool scrubber.
