### PR TITLE
srm: fix deserialise of TExtraInfo

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/CopyFileRequestStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/CopyFileRequestStorage.java
@@ -91,7 +91,7 @@ public class CopyFileRequestStorage extends DatabaseFileRequestStorage<CopyFileR
     private static ImmutableMap<String,String> deserialiseMap(String serialised)
     {
         ImmutableMap.Builder builder = new ImmutableMap.Builder<>();
-        for (Map.Entry<String,String> entry : Splitter.on(',').
+        for (Map.Entry<String,String> entry : Splitter.on(',').omitEmptyStrings().
                 withKeyValueSeparator('=').split(serialised).entrySet()) {
             try {
                 builder.put(URLDecoder.decode(entry.getKey(), "UTF-8"),


### PR DESCRIPTION
The SRM saves the content of TExtraInfo for COPY requests, but fails
to deserialise it correctly if the user supplied no TExtraInfo.
This patch fixes that.

Target: master
Request: 2.10
Requires-book: no
Requires-notes: no
Acked-by: Tigran Mkrtchyan
Patch: https://rb.dcache.org/r/7147/
