### PR TITLE
srm: fix NPE when checking delegated credential

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/RequestCredential.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/RequestCredential.java
@@ -209,8 +209,8 @@ public class RequestCredential
     public synchronized void keepBestDelegatedCredential(GSSCredential credential)
             throws GSSException
     {
-        if (credential != null && this.delegatedCredential == null ||
-                expiryDateFor(credential) > this.delegatedCredentialExpiration) {
+        if (credential != null && (this.delegatedCredential == null ||
+                expiryDateFor(credential) > this.delegatedCredentialExpiration)) {
             updateCredential(credential);
         }
     }


### PR DESCRIPTION
The SRM keeps "the best" delegated credential, if the user supplies one.
If the user doesn't delegate a credential then the current code throws
a NPE.  This is fixed with this patch.

Target: master
Request: 2.10
Requires-notes: no
Requires-book: no
Acked-by: Tigran Mkrtchyan
Patch: https://rb.dcache.org/r/7147/
