### PR TITLE
Don't use legacy properties

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -158,7 +158,7 @@
       <property name="srmHandler" ref="srm-handler"/>
       <property name="pnfsStub" ref="pnfs-stub"/>
       <property name="remoteTransferHandler" ref="remote-transfer-handler"/>
-      <property name="rootPath" value="${webdavRootPath}"/>
+      <property name="rootPath" value="${webdav.root}"/>
   </bean>
 
 

--- a/skel/share/services/billing.batch
+++ b/skel/share/services/billing.batch
@@ -4,7 +4,7 @@ onerror shutdown
 
 check -strong billing.cell.name
 check -strong billing.cell.export
-check -strong billingLogsDir
+check -strong billing.text.dir
 check -strong billing.enable.text
 check -strong billing.enable.db
 check -strong billing.service.poolmanager

--- a/skel/share/services/topo.batch
+++ b/skel/share/services/topo.batch
@@ -55,4 +55,4 @@ define env topo-none.exe end
   exec env topo-cells.exe
 end
 
-exec env topo-${broker.scheme}.exe
+exec env topo-${dcache.broker.scheme}.exe

--- a/skel/share/services/xrootd.batch
+++ b/skel/share/services/xrootd.batch
@@ -32,7 +32,7 @@ check -strong xrootd.service.loginbroker.family
 
 check -strong xrootd.mover.timeout
 check -strong xrootd.mover.timeout.unit
-check -strong xrootd.mover.queue
+check xrootd.mover.queue
 check -strong xrootd.plugins
 check -strong xrootd.authz.user
 check -strong xrootd.authz.read-paths


### PR DESCRIPTION
Fixes a couple of places that still relied on old property names.

Target: trunk
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi arossi@fnal.gov
Patch: https://rb.dcache.org/r/7167/
(cherry picked from commit ce761048c861c0bff59e927247c90d35cf1a8239)
