### PR TITLE
srm,dcap: Use configured vomsdir and capath

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
@@ -218,6 +218,8 @@
                      '${srm.limits.external-copy-script.timeout.unit}')}" />
     <property name="srmHost" value="${srm.net.host}"/>
     <property name="srmHostsAsArray" value="${srm.net.local-hosts}"/>
+    <property name="caCertificatePath" value="${srm.authn.capath}"/>
+    <property name="vomsdir" value="${srm.authn.vomsdir}"/>
     <property name="sizeOfSingleRemoveBatch"
               value="${srm.limits.remove-batch-size}"/>
     <property name="maxNumberOfLsEntries"
@@ -683,11 +685,13 @@
 
 
   <bean id="gridsite-credential-store"
-	class="org.dcache.gridsite.SrmCredentialStore">
+        class="org.dcache.gridsite.SrmCredentialStore">
       <description>Bridge between GridSite- and SRM- credential storage</description>
 
       <property name="requestCredentialStorage"
 		value="#{srm.requestCredentialStorage}"/>
+      <property name="caCertificatePath" value="${srm.authn.capath}"/>
+      <property name="vomsdir" value="${srm.authn.vomsdir}"/>
   </bean>
 
   <bean id="gridsite-credential-delegation-factory"

--- a/modules/gplazma2-voms/src/main/java/org/dcache/gplazma/plugins/VomsPlugin.java
+++ b/modules/gplazma2-voms/src/main/java/org/dcache/gplazma/plugins/VomsPlugin.java
@@ -40,8 +40,7 @@ public class VomsPlugin implements GPlazmaAuthenticationPlugin {
         checkArgument(caDir != null, "Undefined property: " + VOMSDIR);
         checkArgument(vomsDir != null, "Undefined property: " + CADIR);
 
-        _pkiVerifier = GSSUtils.getPkiVerifier(vomsDir, caDir,
-                        MDC.getCopyOfContextMap());
+        _pkiVerifier = GSSUtils.getPkiVerifier(vomsDir, caDir);
     }
 
     @Override

--- a/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
+++ b/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
@@ -297,8 +297,7 @@ public final class XACMLPlugin implements GPlazmaAuthenticationPlugin {
         String caDir = properties.getProperty(CADIR);
         String vomsDir = properties.getProperty(VOMSDIR);
 
-        _pkiVerifier = GSSUtils.getPkiVerifier(vomsDir, caDir,
-                                                MDC.getCopyOfContextMap());
+        _pkiVerifier = GSSUtils.getPkiVerifier(vomsDir, caDir);
 
 
         /*

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
@@ -41,6 +41,20 @@ import static org.dcache.gridsite.Utilities.assertThat;
 public class SrmCredentialStore implements CredentialStore
 {
     private RequestCredentialStorage _store;
+    private String caDir;
+    private String vomsDir;
+
+    @Required
+    public void setCaCertificatePath(String caDir)
+    {
+        this.caDir = caDir;
+    }
+
+    @Required
+    public void setVomsdir(String vomsDir)
+    {
+        this.vomsDir = vomsDir;
+    }
 
     @Required
     public void setRequestCredentialStorage(RequestCredentialStorage store)
@@ -62,7 +76,7 @@ public class SrmCredentialStore implements CredentialStore
             throws DelegationException
     {
         try {
-            Iterable<String> fqans = GSSUtils.getFQANsFromGSSCredential(credential);
+            Iterable<String> fqans = GSSUtils.getFQANsFromGSSCredential(vomsDir, caDir, credential);
             String primaryFqan = Iterables.getFirst(fqans, null);
 
             RequestCredential srmCredential = new RequestCredential(nameFromId(id),

--- a/modules/srm-server/src/main/java/org/dcache/srm/server/SRMServerV1.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/server/SRMServerV1.java
@@ -19,11 +19,13 @@ import org.dcache.srm.util.JDC;
 
 public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
 
-   public Logger log;
-   private SrmAuthorizer srmAuth;
-   private final SRM srm;
-   private final RequestCounters<String> srmServerCounters;
-   private final RequestExecutionTimeGauges<String> srmServerGauges;
+    private final String vomsDir;
+    private final String caDir;
+    private final Logger log;
+    private final SrmAuthorizer srmAuth;
+    private final SRM srm;
+    private final RequestCounters<String> srmServerCounters;
+    private final RequestExecutionTimeGauges<String> srmServerGauges;
 
     public SRMServerV1() throws java.rmi.RemoteException {
        try
@@ -39,6 +41,8 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
                     config.isClientDNSLookup());
              srmServerCounters = srm.getSrmServerV1Counters();
              srmServerGauges = srm.getSrmServerV1Gauges();
+             vomsDir = config.getVomsdir();
+             caDir = config.getCaCertificatePath();
        } catch (Exception e) {
            throw new java.rmi.RemoteException("exception",e);
        }
@@ -67,7 +71,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
 
           try {
               userCred = srmAuth.getUserCredentials();
-              Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+              Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
               String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -110,7 +114,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
           org.dcache.srm.request.RequestCredential requestCredential;
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -154,7 +158,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
           org.dcache.srm.request.RequestCredential requestCredential;
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -200,7 +204,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
 
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -229,7 +233,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
           org.dcache.srm.request.RequestCredential requestCredential;
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("SRMServerV1.pin() : role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -259,7 +263,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
           org.dcache.srm.request.RequestCredential requestCredential;
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -289,7 +293,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
           org.dcache.srm.request.RequestCredential requestCredential;
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -329,7 +333,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
           org.dcache.srm.request.RequestCredential requestCredential;
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -371,7 +375,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
           org.dcache.srm.request.RequestCredential requestCredential;
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -414,7 +418,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
 
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -455,7 +459,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
 
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -496,7 +500,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
 
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -536,7 +540,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
           org.dcache.srm.request.RequestCredential requestCredential;
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);
@@ -576,7 +580,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
 
           try {
              userCred = srmAuth.getUserCredentials();
-             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext((ExtendedGSSContext) userCred.context);
+             Iterable<String> roles = SrmAuthorizer.getFQANsFromContext(vomsDir, caDir, (ExtendedGSSContext) userCred.context);
              String role = Iterables.getFirst(roles, null);
               log.debug("SRMServerV1.getProtocols() : role is "+role);
               requestCredential = srmAuth.getRequestCredential(userCred,role);

--- a/modules/srm-server/src/main/java/org/dcache/srm/server/SrmAuthorizer.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/server/SrmAuthorizer.java
@@ -1,12 +1,3 @@
-/**
- * SrmAuthorizer.java
- *
- * Authors:  LH - Leo Heska
- *
- * History:
- *    2005/07/22 LH Extracted from SrmSoapBindingImpl.java
- */
-
 /*
 COPYRIGHT STATUS:
 Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
@@ -74,7 +65,6 @@ exporting documents or software obtained from this server.
 package org.dcache.srm.server;
 
 import org.apache.axis.MessageContext;
-import org.glite.voms.PKIVerifier;
 import org.globus.gsi.gssapi.auth.AuthorizationException;
 import org.gridforum.jgss.ExtendedGSSContext;
 import org.ietf.jgss.GSSContext;
@@ -87,7 +77,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Collection;
 
 import org.dcache.auth.util.GSSUtils;
 import org.dcache.srm.SRMAuthorization;
@@ -238,11 +227,11 @@ public class SrmAuthorizer
         }
     }
 
-    static Iterable<String> getFQANsFromContext(ExtendedGSSContext gssContext)
+    static Iterable<String> getFQANsFromContext(String vomsDir, String caDir, ExtendedGSSContext gssContext)
             throws SRMAuthorizationException
     {
         try {
-            return GSSUtils.getFQANsFromGSSContext(gssContext);
+            return GSSUtils.getFQANsFromGSSContext(vomsDir, caDir, gssContext);
         } catch (AuthorizationException ae) {
             log.error("Could not extract FQANs from context",ae);
             throw new SRMAuthorizationException("Could not extract FQANs from context " + ae.getMessage());

--- a/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
@@ -260,6 +260,8 @@ public class Configuration {
 
     private Map<String,DatabaseParameters> databaseParameters =
         new HashMap<>();
+    private String caCertificatePath;
+    private String vomsdir;
 
     /** Creates a new instance of Configuration */
     public Configuration() {
@@ -2283,6 +2285,26 @@ public class Configuration {
 
     public DatabaseParameters getDatabaseParameters(String name) {
         return databaseParameters.get(name);
+    }
+
+    public void setCaCertificatePath(String caCertificatePath)
+    {
+        this.caCertificatePath = caCertificatePath;
+    }
+
+    public String getCaCertificatePath()
+    {
+        return caCertificatePath;
+    }
+
+    public void setVomsdir(String vomsdir)
+    {
+        this.vomsdir = vomsdir;
+    }
+
+    public String getVomsdir()
+    {
+        return vomsdir;
     }
 
     public class DatabaseParameters

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -1038,6 +1038,9 @@ srm.authn.capath.refresh=${dcache.authn.capath.refresh}
 	${dcache.authn.capath.refresh.unit})\
 srm.authn.capath.refresh.unit=${dcache.authn.capath.refresh.unit}
 
+# Path to vomsdir directory
+srm.authn.vomsdir=${dcache.authn.vomsdir}
+
 # ---- Directory for delegated proxy certificates
 #
 # This is the directory in which the delegated user credentials will

--- a/skel/share/services/srm.batch
+++ b/skel/share/services/srm.batch
@@ -18,6 +18,7 @@ check -strong srm.net.host
 check -strong srm.net.local-hosts
 check srm.net.listen
 
+check -strong srm.authn.vomsdir
 check -strong srm.authn.capath
 check -strong srm.authn.capath.refresh
 check -strong srm.authn.capath.refresh.unit


### PR DESCRIPTION
The code for extracting vomsdir and the capath from certificates ignored the
configured paths. The code also created internal refresh threads with the wrong
diagnostic context.

Introduces srm.authn.vomsdir.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.10
Request: 2.9
(cherry picked from commit 7f39db9755cd151cbce2ac38f6ecdea3df5c40d3)

Conflicts:
    modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
