### PR TITLE
webdav: Make threading and TCP connection limits configurable

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -274,17 +274,42 @@
         <constructor-arg value="${webdav.authn.ciphers}"/>
     </bean>
 
+    <bean id="thread-pool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"
+          init-method="start" destroy-method="stop">
+        <description>Thread pool used by Jetty for request processing</description>
+        <property name="maxIdleTimeMs"
+                  value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
+                     ${webdav.limits.threads.idle-time},
+                     '${webdav.limits.threads.idle-time.unit}')}" />
+        <property name="maxThreads" value="${webdav.limits.threads.max}"/>
+        <property name="minThreads" value="${webdav.limits.threads.min}"/>
+        <property name="name" value="jetty-srm"/>
+        <property name="maxQueued" value="${webdav.limits.queue-length}"/>
+    </bean>
+
     <beans profile="connector-http">
       <bean id="jetty" class="org.eclipse.jetty.server.Server"
 	    init-method="start" destroy-method="stop">
 	  <description>Embedded HTTP server</description>
 
+      <property name="gracefulShutdown" value="${webdav.limits.graceful-shutdown}"/>
+      <property name="threadPool" ref="thread-pool"/>
 	  <property name="connectors">
 	      <list>
 		  <bean class="org.eclipse.jetty.server.nio.SelectChannelConnector">
 		      <property name="port" value="${webdav.net.port}"/>
 		      <property name="host" value="#{ '${webdav.net.listen}'.equals('any') ? null : '${webdav.net.listen}' }"/>
-		  </bean>
+              <property name="acceptors" value="${webdav.limits.acceptors}"/>
+              <property name="maxIdleTime"
+                        value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
+                     ${webdav.limits.idle-time},
+                     '${webdav.limits.idle-time.unit}')}" />
+              <property name="lowResourceMaxIdleTime"
+                        value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
+                     ${webdav.limits.low-resource-idle-time},
+                     '${webdav.limits.low-resource-idle-time.unit}')}" />
+              <property name="acceptQueueSize" value="${webdav.limits.backlog}"/>
+          </bean>
 	      </list>
 	  </property>
 
@@ -299,6 +324,7 @@
 	    init-method="start" destroy-method="stop">
 	  <description>Embedded HTTPS server</description>
 
+      <property name="threadPool" ref="thread-pool"/>
 	  <property name="connectors">
 	      <list>
 		  <ref bean="https-connector"/>
@@ -315,16 +341,26 @@
 	    class="org.eclipse.jetty.server.ssl.SslSelectChannelConnector">
           <description>HTTPS connector from Jetty</description>
 
-	  <property name="port" value="${webdav.net.port}"/>
-	  <property name="host" value="#{ '${webdav.net.listen}'.equals('any') ? null : '${webdav.net.listen}' }"/>
-	  <property name="keystore" value="${webdav.authn.keystore}"/>
-	  <property name="keystoreType" value="PKCS12"/>
-	  <property name="password" value="${webdav.authn.keystore.password}"/>
-	  <property name="truststore" value="${webdav.authn.truststore}"/>
-	  <property name="trustPassword" value="${webdav.authn.truststore.password}"/>
-	  <property name="wantClientAuth" value="${webdav.authn.accept-client-cert}"/>
-	  <property name="needClientAuth" value="${webdav.authn.require-client-cert}"/>
-      <property name="excludeCipherSuites" ref="banned-ciphers"/>
+          <property name="port" value="${webdav.net.port}"/>
+          <property name="host" value="#{ '${webdav.net.listen}'.equals('any') ? null : '${webdav.net.listen}' }"/>
+          <property name="keystore" value="${webdav.authn.keystore}"/>
+          <property name="keystoreType" value="PKCS12"/>
+          <property name="password" value="${webdav.authn.keystore.password}"/>
+          <property name="truststore" value="${webdav.authn.truststore}"/>
+          <property name="trustPassword" value="${webdav.authn.truststore.password}"/>
+          <property name="wantClientAuth" value="${webdav.authn.accept-client-cert}"/>
+          <property name="needClientAuth" value="${webdav.authn.require-client-cert}"/>
+          <property name="excludeCipherSuites" ref="banned-ciphers"/>
+          <property name="acceptors" value="${webdav.limits.acceptors}"/>
+          <property name="maxIdleTime"
+                    value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
+                     ${webdav.limits.idle-time},
+                     '${webdav.limits.idle-time.unit}')}" />
+          <property name="lowResourceMaxIdleTime"
+                    value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
+                     ${webdav.limits.low-resource-idle-time},
+                     '${webdav.limits.low-resource-idle-time.unit}')}" />
+          <property name="acceptQueueSize" value="${webdav.limits.backlog}"/>
       </bean>
   </beans>
 
@@ -334,22 +370,36 @@
       <bean id="https-connector" class="org.dcache.util.JettyGSIConnector">
           <description>HTTPS connector using jGlobus</description>
 
-	  <property name="port" value="${webdav.net.port}"/>
-	  <property name="host" value="#{ '${webdav.net.listen}'.equals('any') ? null : '${webdav.net.listen}' }"/>
-	  <property name="hostCertificatePath" value="${webdav.authn.hostcert.cert}"/>
-	  <property name="hostKeyPath" value="${webdav.authn.hostcert.key}"/>
-	  <property name="caCertificatePath" value="${webdav.authn.capath}"/>
-	  <property name="autoFlush" value="true"/>
-	  <property name="encrypt" value="true"/>
-      <property name="requireClientAuth" value="${webdav.authn.require-client-cert}"/>
-      <property name="acceptNoClientCerts"
-                 value="#{ '${webdav.authn.accept-client-cert}' == 'false' }"/>
-	  <property name="gssMode" value="SSL"/>
-	  <property name="hostCertRefreshInterval" value="${webdav.authn.hostcert.refresh}"/>
-	  <property name="hostCertRefreshIntervalUnit" value="${webdav.authn.hostcert.refresh.unit}"/>
-	  <property name="trustAnchorRefreshInterval" value="${webdav.authn.capath.refresh}"/>
-      <property name="trustAnchorRefreshIntervalUnit" value="${webdav.authn.capath.refresh.unit}"/>
-      <property name="excludeCipherSuites" ref="banned-ciphers"/>
+          <property name="port" value="${webdav.net.port}"/>
+          <property name="host" value="#{ '${webdav.net.listen}'.equals('any') ? null : '${webdav.net.listen}' }"/>
+          <property name="hostCertificatePath" value="${webdav.authn.hostcert.cert}"/>
+          <property name="hostKeyPath" value="${webdav.authn.hostcert.key}"/>
+          <property name="caCertificatePath" value="${webdav.authn.capath}"/>
+          <property name="autoFlush" value="true"/>
+          <property name="encrypt" value="true"/>
+          <property name="requireClientAuth" value="${webdav.authn.require-client-cert}"/>
+          <property name="acceptNoClientCerts"
+                     value="#{ '${webdav.authn.accept-client-cert}' == 'false' }"/>
+          <property name="gssMode" value="SSL"/>
+          <property name="hostCertRefreshInterval" value="${webdav.authn.hostcert.refresh}"/>
+          <property name="hostCertRefreshIntervalUnit" value="${webdav.authn.hostcert.refresh.unit}"/>
+          <property name="trustAnchorRefreshInterval" value="${webdav.authn.capath.refresh}"/>
+          <property name="trustAnchorRefreshIntervalUnit" value="${webdav.authn.capath.refresh.unit}"/>
+          <property name="excludeCipherSuites" ref="banned-ciphers"/>
+          <property name="acceptors" value="${webdav.limits.acceptors}"/>
+          <property name="maxIdleTime"
+                    value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
+                     ${webdav.limits.idle-time},
+                     '${webdav.limits.idle-time.unit}')}" />
+          <property name="lowResourceMaxIdleTime"
+                    value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
+                     ${webdav.limits.low-resource-idle-time},
+                     '${webdav.limits.low-resource-idle-time.unit}')}" />
+          <property name="acceptQueueSize" value="${webdav.limits.backlog}"/>
+          <property name="handshakeTimeout"
+                    value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
+                     ${webdav.limits.handshake-time},
+                     '${webdav.limits.handshake-time.unit}')}" />
       </bean>
   </beans>
 

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -422,6 +422,99 @@ webdav.authn.capath=${dcache.authn.capath}
 webdav.authn.capath.refresh=${dcache.authn.capath.refresh}
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.authn.capath.refresh.unit})webdav.authn.capath.refresh.unit=${dcache.authn.capath.refresh.unit}
 
+# ---- Threads that accept TCP connections
+#
+# The number of threads that accept and dispatch new client connections.
+# Except under very high connection rates, a single thread should be
+# sufficient.
+#
+webdav.limits.acceptors=1
+
+# ---- Time before an idle connection is closed
+#
+# An idle connection is one on which no data is transferred.
+#
+# Note that a connection may appear idle because the WebDAV door is blocked
+# on other operations on dCache, such as waiting for a file to stage from
+# tape, or waiting for a mover to start. It is advisable that this timeout
+# is not lower than the individual timeouts configured for talking to other
+# dCache services.
+#
+webdav.limits.idle-time=300
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
+webdav.limits.idle-time.unit=SECONDS
+
+# ---- Time before an idle TCP connection is closed during high load
+#
+# An idle connection is one on which no data is transferred. The door
+# is considered under high load when all request processing threads
+# are busy.
+#
+# Under high load, new connections will be configured with this timeout
+# rather than the timeout defined by webdav.limits.idle-time. Currently,
+# existing connections are not affected, although this may change in
+# the future.
+#
+webdav.limits.low-resource-idle-time=30
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
+webdav.limits.low-resource-idle-time.unit=SECONDS
+
+# --- Handshake timeout
+#
+# SSL handshake timeout. Only supported by the https-jglobus protocol
+# implementation. If a socket read takes more than this time during
+# the SSL handshake, the connection is broken.
+#
+webdav.limits.handshake-time=10
+(one-of?MILLISECONDS|SECONDS|MINUTES)\
+webdav.limits.handshake-time.unit=SECONDS
+
+# ---- TCP backlog
+#
+# Maximum number of TCP connections queued for accept. If the acceptor
+# threads cannot keep up, up to this number of connections are queued
+# before new connections are rejected.
+webdav.limits.backlog=1024
+
+# ---- Maximum number of threads used for request processing
+#
+# Whenever a client submits a request, the request is processed by a thread.
+# This setting controls the maximum number of such threads.
+#
+webdav.limits.threads.max=500
+
+# ---- Minimum number of threads used for request processing
+#
+# Request processing threads that have been idle for a while are terminated.
+# This setting controls a minimum number of threads to keep alive even
+# when idle.
+webdav.limits.threads.min=1
+
+# ---- Time before an idle request processing thread is terminated
+webdav.limits.threads.idle-time=60
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
+webdav.limits.threads.idle-time.unit=SECONDS
+
+# ---- Maximum number of queued requests
+#
+# Once the limit is reached no new connections will be accepted;
+# instead, the operating system will queue them in the TCP backlog.
+# Once the TCP backlog is filled, the operating system will reject
+# further TCP connections.
+#
+webdav.limits.queue-length=500
+
+# ---- Shutdown timeout
+#
+# During shutdown no new connections will be accepted. Existing
+# connections will be given this much time to complete the
+# request, after which the connections are forcefully broken.
+#
+webdav.limits.graceful-shutdown=2
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
+webdav.limits.graceful-shutdown.unit=SECONDS
+
+
 #  ---- Location for static content
 #
 #   The WebDAV door provides HTML renderings of directories and error

--- a/skel/share/services/webdav.batch
+++ b/skel/share/services/webdav.batch
@@ -53,6 +53,22 @@ check -strong webdav.service.missing-files.timeout
 check -strong webdav.service.missing-files.timeout.unit
 check -strong webdav.enable.missing-files
 
+check -strong webdav.limits.acceptors
+check -strong webdav.limits.idle-time
+check -strong webdav.limits.idle-time.unit
+check -strong webdav.limits.low-resource-idle-time
+check -strong webdav.limits.low-resource-idle-time.unit
+check -strong webdav.limits.handshake-time
+check -strong webdav.limits.handshake-time.unit
+check -strong webdav.limits.backlog
+check -strong webdav.limits.threads.max
+check -strong webdav.limits.threads.min
+check -strong webdav.limits.threads.idle-time
+check -strong webdav.limits.threads.idle-time.unit
+check -strong webdav.limits.queue-length
+check -strong webdav.limits.graceful-shutdown
+check -strong webdav.limits.graceful-shutdown.unit
+
 check webdav.net.internal
 check webdav.mover.queue
 check webdav.authn.ciphers


### PR DESCRIPTION
With the increase use of our webdav door, we see a need to tune
certain aspects of the webdav door that are currently hardcoded.

This patch exposes those aspects to the configuration.

Since I suspect that other sites will run into similar problems,
I suggest merging this into dCache 2.10.

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Albert Rossi arossi@fnal.gov
Patch: https://rb.dcache.org/r/7173/
(cherry picked from commit 797b966b4723b12f033d2c516d41fc292926a25f)
