### PR TITLE
srm: Restore estimated wait time update

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/ContainerRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/ContainerRequest.java
@@ -99,18 +99,8 @@ import org.dcache.srm.v2_2.TRequestSummary;
 import org.dcache.srm.v2_2.TRequestType;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
-import org.dcache.util.TimeUtils;
 
 import static org.dcache.srm.handler.ReturnStatuses.*;
-
-import org.dcache.srm.scheduler.IllegalStateTransition;
-import org.dcache.srm.scheduler.State;
-import org.dcache.srm.util.RequestStatusTool;
-import org.dcache.srm.v2_2.TRequestSummary;
-import org.dcache.srm.v2_2.TRequestType;
-import org.dcache.srm.v2_2.TReturnStatus;
-import org.dcache.srm.v2_2.TStatusCode;
-import org.dcache.util.TimeUtils;
 
 import static org.dcache.util.TimeUtils.relativeTimestamp;
 
@@ -167,6 +157,7 @@ public abstract class ContainerRequest<R extends FileRequest<?>> extends Request
          super(user ,
          requestCredentalId,
          max_number_of_retries,
+         max_update_period,
          lifetime,
          description,
          client_host);
@@ -345,6 +336,7 @@ public abstract class ContainerRequest<R extends FileRequest<?>> extends Request
         // we can rely on the fact that
         // once file request reach their final state, this state does not change
         // so the combined logic
+        updateRetryDeltaTime();
         RequestStatus rs = new RequestStatus();
         rs.requestId = getRequestNum();
         rs.errorMessage = getLastJobChange().getDescription();

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
@@ -141,6 +141,7 @@ public final class ReserveSpaceRequest extends Request {
               super(user,
               requestCredentalId,
               maxNumberOfRetries,
+              0,
               lifetime,
               description,
               clienthost);


### PR DESCRIPTION
Commit 5211277 removed some "dead wood" (as the patch description called
it), but it turns out that some of the wood wasn't quite dead - just old.

Since we all grow older, this patch brings justice to the old trees and
restores the polling backoff that used to be part of the SRM. Clients will
once again reduce the polling frequency for requests that seem to take
a long time.

Target: trunk
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi arossi@fnal.gov
Patch: https://rb.dcache.org/r/7175/
(cherry picked from commit c99aa7b18214d079dfe75e78d55794ecd46eb7d9)
