### PR TITLE
srm: Restore estimated wait time update

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/ContainerRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/ContainerRequest.java
@@ -155,6 +155,7 @@ public abstract class ContainerRequest<R extends FileRequest<?>> extends Request
          super(user ,
          requestCredentalId,
          max_number_of_retries,
+         max_update_period,
          lifetime,
          description,
          client_host);
@@ -333,6 +334,7 @@ public abstract class ContainerRequest<R extends FileRequest<?>> extends Request
         // we can rely on the fact that
         // once file request reach their final state, this state does not change
         // so the combined logic
+        updateRetryDeltaTime();
         RequestStatus rs = new RequestStatus();
         rs.requestId = getRequestNum();
         rs.errorMessage = getLastJobChange().getDescription();

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Request.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Request.java
@@ -114,12 +114,14 @@ public abstract class Request extends Job {
     public Request(SRMUser user,
     Long requestCredentalId,
     int max_number_of_retries,
+    long max_update_period,
     long lifetime,
     @Nullable String description,
     String client_host
         ) {
         super(lifetime,max_number_of_retries);
         this.credentialId = requestCredentalId;
+        this.max_update_period = max_update_period;
         this.description = description;
         this.client_host = client_host;
         this.user = user;
@@ -177,7 +179,20 @@ public abstract class Request extends Job {
 
     /** general srm server configuration settings */
     private transient Configuration configuration;
+
+
+
+
     private final Long credentialId;
+
+
+
+    protected int cyclicUpdateCounter;
+
+    protected long max_update_period = 10*60*60;
+
+
+
 
     /*
      * public constructors
@@ -303,6 +318,37 @@ public abstract class Request extends Job {
         try {
             retryDeltaTime = 1;
             should_updateretryDeltaTime = false;
+        } finally {
+            wunlock();
+        }
+    }
+
+    /**
+     * updateRetryDeltaTime is called every time user gets RequestStatus
+     * so the next time user waits longer (up to MAX_RETRY_TIME secs)
+     * if nothing has been happening for a while
+     * The algoritm of incrising retryDeltaTime is absolutely arbitrary
+     */
+
+    protected void updateRetryDeltaTime() {
+        wlock();
+        try {
+            if (should_updateretryDeltaTime && cyclicUpdateCounter == 0) {
+
+                if(retryDeltaTime <100) {
+                    retryDeltaTime +=3;
+                }
+                else if(retryDeltaTime <300) {
+                    retryDeltaTime +=6;
+                }
+                else {
+                    retryDeltaTime *= 2;
+                }
+                if (retryDeltaTime > max_update_period) {
+                    retryDeltaTime = (int) max_update_period;
+                }
+            }
+            cyclicUpdateCounter = (cyclicUpdateCounter+1)%5;
         } finally {
             wunlock();
         }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
@@ -131,6 +131,7 @@ public final class ReserveSpaceRequest extends Request {
               super(user,
               requestCredentalId,
               maxNumberOfRetries,
+              0,
               lifetime,
               description,
               clienthost);


### PR DESCRIPTION
Commit 5211277 removed some "dead wood" (as the patch description called
it), but it turns out that some of the wood wasn't quite dead - just old.

Since we all grow older, this patch brings justice to the old trees and
restores the polling backoff that used to be part of the SRM. Clients will
once again reduce the polling frequency for requests that seem to take
a long time.

Target: trunk
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi arossi@fnal.gov
Patch: https://rb.dcache.org/r/7175/
(cherry picked from commit c99aa7b18214d079dfe75e78d55794ecd46eb7d9)

Conflicts:
    modules/srm-server/src/main/java/org/dcache/srm/request/ContainerRequest.java
