### PR TITLE
poolmanager: Fix excessive p2p and stage alive checks

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
@@ -60,6 +60,11 @@
       <property name="destination" value="${poolmanager.service.billing}"/>
   </bean>
 
+  <bean id="pool-stub" class="org.dcache.cells.CellStub">
+      <property name="timeout" value="180"/>
+      <property name="timeoutUnit" value="SECONDS"/>
+  </bean>
+
   <bean id="broadcast-stub" class="org.dcache.cells.CellStub">
       <property name="destination" value="${poolmanager.service.broadcast}"/>
   </bean>
@@ -81,6 +86,7 @@
     <property name="pnfsHandler" ref="pnfs"/>
     <property name="hitInfoMessages" value="${poolmanager.enable.cache-hit-message}"/>
     <property name="billing" ref="billing-stub"/>
+    <property name="poolStub" ref="pool-stub"/>
   </bean>
 
   <bean id="rebalance" class="org.dcache.poolmanager.Rebalancer">


### PR DESCRIPTION
Stage and pool to pool requests in pool manager periodically check
whether the request is still alive on the pool. This is done by
listing the requests on the pool and checking whether the PNFS ID
of the file to stage or replicate is in the output.

For pools with many requests (like a stage pool), this will lead
to all requests being listed for every request. Thus O(n*n) entries
are transferred, which leads to problems on pools with many requests.

This patch is meant as an intermediate solution that can be backported
to stable branches. Rather than letting every request query the
list itself, a single thread will now do this collectively for all
requests waiting for a pool to pool transfer or stage.

A more long term solution should involve using a binary API to query
this information from the pool (or possibly let the pool broadcast this
information instead - could be considered together with a refactoring
of the way we collect information about active transfers).

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7177/
(cherry picked from commit f9f9ccdba6dcb0ef02f39c5e8c0678408740e671)
