### PR TITLE
srm: Fix race condition in srmPrepareToGet

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToGet.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToGet.java
@@ -97,9 +97,11 @@ public class SrmPrepareToGet
         String[] supportedProtocols = storage.supportedGetProtocols();
         URI[] surls = getSurls(request);
 
-        boolean isAnyProtocolSupported = any(asList(protocols), in(asList(supportedProtocols)));
-        if (!isAnyProtocolSupported) {
-            throw new SRMNotSupportedException("Protocol(s) not supported: " + Arrays.toString(protocols));
+        if (protocols != null && protocols.length > 0) {
+            boolean isAnyProtocolSupported = any(asList(protocols), in(asList(supportedProtocols)));
+            if (!isAnyProtocolSupported) {
+                throw new SRMNotSupportedException("Protocol(s) not supported: " + Arrays.toString(protocols));
+            }
         }
 
         GetRequest r =


### PR DESCRIPTION
There is a race condition in the pin call in which the callback happens
while the request is still in state RUNNING, but the main run method
already broke off to the branch that will switch the request to ASYNCWAIT.
In that case the request will not get rescheduled, meaning it will
stay in ASYNCWAIT with no further action until it expires or is aborted.

The patch fixes the problem and also updates the bring online implementation
to match the prepare to get logic. In particular that also means that
protocol support is checked for the entire request and not on a per file
level.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7176
(cherry picked from commit 8d1ce5367cc28f8b9e910a4a5c05dfaba49ee087)
