### PR TITLE
poolmanager: Avoid request leak

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -513,23 +513,7 @@ public class RequestContainerV5
        rph.failed(errorNumber,errorString) ;
        return "" ;
     }
-    public static final String hh_rc_destroy = "<pnfsId> # !!!  use with care" ;
-    public String ac_rc_destroy_$_1( Args args )
-    {
 
-       PoolRequestHandler rph;
-
-       synchronized( _handlerHash ){
-          rph = _handlerHash.get(args.argv(0));
-          if( rph == null ) {
-              throw new
-                      IllegalArgumentException("Not found : " + args.argv(0));
-          }
-
-          _handlerHash.remove( args.argv(0) ) ;
-       }
-       return "" ;
-    }
     public static final String hh_rc_ls = " [<regularExpression>] [-w] [-l] # lists pending requests" ;
     public String ac_rc_ls_$_0_1( Args args ){
        StringBuilder sb  = new StringBuilder() ;
@@ -1075,6 +1059,9 @@ public class RequestContainerV5
                     return false;
                 }
                 sendMessage( cellMessage );
+                if( _waitingFor != null ) {
+                    _messageHash.remove(_waitingFor);
+                }
                 _poolMonitor.messageToCostModule( cellMessage ) ;
                 _messageHash.put( _waitingFor = cellMessage.getUOID() , this ) ;
                 _status = "Staging "+_formatter.format(new Date()) ;


### PR DESCRIPTION
When a read pool request waits for a file to be replicated or staged, it
registers a callback for the reply from the pool.

We have observed a situation, in which there were many more entries in the hash
table of callbacks than there were requests. The only code path I could find that
could explain this behaviour is when resubmitting a stage request. I am not
certain when exactly this would happen, but it is the only scenario I can see
how entries in the map could leak.

The patch also removes the 'rc destroy' command. The implementation was incomplete
and dangerous to use.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7179/
(cherry picked from commit abdb8d47fb31af99b539a32369b06d94f5fbe4da)

Conflicts:
    modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
