### PR TITLE
poolmanager: Fix 'request clumping limit reached' failures

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -96,7 +96,7 @@ public class RequestContainerV5
     private String      _warningPath   = "billing" ;
     private long        _retryTimer    = 15 * 60 * 1000 ;
 
-    private int         _maxRequestClumping = 1 ;
+    private int         _maxRequestClumping = 20;
 
     private String      _onError       = "suspend" ;
     private int         _maxRetries    = 3 ;
@@ -1776,14 +1776,12 @@ public class RequestContainerV5
                     // it is essential that we are not within any other
                     // lock when trying to get the handlerHash lock.
                     //
-                    synchronized( _handlerHash ){
-                       if( answerRequest( _maxRequestClumping ) ){
-                            setError(CacheException.RESOURCE,
-                                     "Request clumping limit reached");
-                            nextStep(RequestState.ST_DONE, CONTINUE);
-                       }else{
-                           _handlerHash.remove( _name ) ;
-                       }
+                    synchronized (_handlerHash) {
+                        _handlerHash.remove(_name);
+                    }
+                    while (answerRequest(_maxRequestClumping)) {
+                        setError(CacheException.OUT_OF_DATE,
+                                 "Request clumping limit reached");
                     }
                  }
 


### PR DESCRIPTION
Pool manager has an incomplete feature in which a read pool selection is at
most used for a certain number of requests. This limit is hard coded to one,
meaning that as soon as two clients ask for the same file, the second will
receive an error. For some protocols the door silently retries. For other
protocols, the error is propagated to the client.

This patch changes the behaviour in two ways:

The limit is raised to 20, meaning up to 20 clients will receive the same pool
selection. The reason not to put this to infinity is because we still want to
trigger load based replication. 20 is an arbitrary number, that reduces the
risk of triggering the clumping warning, while also protecting against starting
too many movers on a single pool without pool manager getting a chance to
intervene.

The error code is changed from one indicating an out of resource problem to
one that simply indicates that the request is out of date - the latter causes
the door to refresh information about the file and resubmit the pool selection.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7184/
Patch: https://rb.dcache.org/r/7180/
(cherry picked from commit 38e3ac367a6ac7696bed1b863388830dfe46194c)
