### PR TITLE
pool: Fix concurrency settings for script nearline storage

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/BoundedExecutor.java
+++ b/modules/dcache/src/main/java/org/dcache/util/BoundedExecutor.java
@@ -142,12 +142,17 @@ public class BoundedExecutor extends AbstractExecutorService
         }
     }
 
-    public void setMaximumPoolSize(int threads)
+    public void setMaximumPoolSize(int size)
     {
         monitor.enter();
         try {
-            maxThreads = threads;
-            // TODO: If tasks are queued, we could possibly start more threads at this point
+            maxThreads = size;
+
+            int threadsToStart = Math.min(maxThreads - threads, workQueue.size());
+            for (int i = 0; i < threadsToStart; i++) {
+                threads++;
+                executor.execute(worker);
+            }
         } finally {
             monitor.leave();
         }


### PR DESCRIPTION
Adjusting the thread pool size did not have an immediate effect. This
patch resolves the problem.

Target: trunk
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7181/
(cherry picked from commit b89cd06d4d41c0f6b32f7d944a871a913bdb014a)
