### PR TITLE
bugfix: fix reverseMap not throwing NoSuchPrincipalExceptions

### DIFF
--- a/modules/gplazma2-ldap/src/main/scala/org/dcache/gplazma/plugins/Ldap.scala
+++ b/modules/gplazma2-ldap/src/main/scala/org/dcache/gplazma/plugins/Ldap.scala
@@ -197,33 +197,38 @@ class Ldap(properties : Properties) extends GPlazmaIdentityPlugin with GPlazmaSe
     })
   }
 
-  def reverseMap(principal: Principal) = new java.util.HashSet[Principal](
-    WrapAsJava.asJavaCollection((
-    try {
-      val id: String = principal.getName
-      principal match {
-        case _: GidPrincipal =>
-          reverseMapSearchGroup(id).map((searchResult) => {
-            new GroupNamePrincipal(
-              searchResult.getAttributes.get(Ldap.COMMON_NAME_ATTRIBUTE)
-            )
-          })
-        case _: UidPrincipal =>
-          reverseMapSearchUser(id).map((searchResult) => {
-              new UserNamePrincipal(
-                searchResult.getAttributes.get(Ldap.USER_ID_ATTRIBUTE)
-              )
-            })
-        case _ => Nil
-      }
-    }
-    catch {
-      case e: NamingException => {
-        log.debug("Failed to get reverse mapping: {}", e.toString)
-        Nil
-      }
-    }
-  ).toSet[Principal]))
+  def reverseMap(principal: Principal) = {
+    new java.util.HashSet[Principal](
+      WrapAsJava.asJavaCollection((
+        try {
+          val id: String = principal.getName
+          principal match {
+            case _: GidPrincipal =>
+              reverseMapSearchGroup(id).map((searchResult) => {
+                new GroupNamePrincipal(
+                  searchResult.getAttributes.get(Ldap.COMMON_NAME_ATTRIBUTE)
+                )
+              })
+            case _: UidPrincipal =>
+              reverseMapSearchUser(id).map((searchResult) => {
+                new UserNamePrincipal(
+                  searchResult.getAttributes.get(Ldap.USER_ID_ATTRIBUTE)
+                )
+              })
+            case _ => Nil
+          }
+        }
+        catch {
+          case e: NamingException => {
+            log.debug("Failed to get reverse mapping: {}", e.toString)
+            Nil
+          }
+        }
+        ).toSet[Principal]) match {
+        case mapping if mapping.isEmpty => throw new NoSuchPrincipalException("No reverse mapping")
+        case mapping => mapping
+      })
+  }
 
   private def reverseMapSearchUser(id: String) = JEnumerationWrapper {
     retryWithNewContextOnException( () => {

--- a/modules/gplazma2-ldap/src/test/scala/org/dcache/gplazma/plugins/LdapPluginTest.scala
+++ b/modules/gplazma2-ldap/src/test/scala/org/dcache/gplazma/plugins/LdapPluginTest.scala
@@ -76,16 +76,22 @@ class LdapPluginTest extends FlatSpec with Matchers {
     set.isInstanceOf[java.io.Serializable] should be (true)
   }
 
-  it should "return an empty Set for an non existent Uid" in {
-    ldapPlugin.reverseMap(new UidPrincipal("666")) should be ('empty)
+  it should "throw an NoSuchPrincipalException for a non existent Uid" in {
+
+    intercept[NoSuchPrincipalException] {
+      ldapPlugin.reverseMap(new UidPrincipal("666"))
+    }
   }
 
   it should "return a Set containing a GroupNamePrincipal for an existing Gid" in {
     ldapPlugin.reverseMap(new GidPrincipal("3752", true)) should contain (new GroupNamePrincipal("htw-berlin"))
   }
 
-  it should "return an empty Set for a non existent Gid" in {
-    ldapPlugin.reverseMap(new GidPrincipal("51000", true)) should be ('empty)
+  it should "throw a NoSuchPrincipalException for a non existent Gid" in {
+
+    intercept[NoSuchPrincipalException] {
+      ldapPlugin.reverseMap(new GidPrincipal("51000", true))
+    }
   }
 
   "session" should "return the user's home and root directory, and the access rights" in {


### PR DESCRIPTION
Instead of throwing a NoSuchPrincipalException on failed reverse
mappings the Ldap plugin would just return an empty set.
This fixed this misbehaviour.

Ticket: http://rt.dcache.org/Ticket/Display.html?id=8422
Acked-by: Paul
Target: trunk
Target: 2.7
Target: 2.8
Target: 2.9
Target: 2.10
Require-book: no
Require-notes: yes
