### PR TITLE
xrootd: Add billing entry on delete

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -49,6 +49,7 @@ import diskCacheV111.util.FileLocality;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
+import diskCacheV111.vehicles.DoorRequestInfoMessage;
 import diskCacheV111.vehicles.DoorTransferFinishedMessage;
 import diskCacheV111.vehicles.IoDoorEntry;
 import diskCacheV111.vehicles.IoDoorInfo;
@@ -63,6 +64,8 @@ import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.cells.services.login.LoginManagerChildrenInfo;
 
 import org.dcache.acl.enums.AccessType;
+import org.dcache.auth.Origin;
+import org.dcache.auth.Subjects;
 import org.dcache.cells.CellStub;
 import org.dcache.cells.MessageCallback;
 import org.dcache.namespace.ACLPermissionHandler;
@@ -470,6 +473,25 @@ public class XrootdDoor
 
         Set<FileType> allowedSet = EnumSet.of(FileType.REGULAR);
         pnfsHandler.deletePnfsEntry(path.toString(), allowedSet);
+        sendRemoveInfoToBilling(path, subject);
+    }
+
+    private void sendRemoveInfoToBilling(FsPath path, Subject subject)
+    {
+        try {
+            DoorRequestInfoMessage infoRemove =
+                    new DoorRequestInfoMessage(getCellAddress().toString(), "remove");
+            infoRemove.setSubject(subject);
+            infoRemove.setPath(path);
+            Origin origin = Subjects.getOrigin(subject);
+            if (origin != null) {
+                infoRemove.setClient(origin.getAddress().getHostAddress());
+            }
+            _billingStub.notify(infoRemove);
+        } catch (NoRouteToCellException e) {
+            _log.error("Cannot send remove message to billing: {}",
+                       e.getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
In contrast to other doors, the xrootd door failed to generate billing
notifications on file deletion. This patch resolves this issue.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7190/
(cherry picked from commit 3425431abcf5457c26e94b21e415b35fbcb7cd78)
