### PR TITLE
poolmanager: Suppress stack trace in case of unmatch units

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -2016,6 +2016,11 @@ public class RequestContainerV5
                _log.warn(err);
                setError(130, err);
                return RT_ERROR;
+           } catch (IllegalArgumentException e) {
+               String err = "Read pool selection failed:" + e.getMessage();
+               _log.error(err);
+               setError(130, err);
+               return RT_ERROR;
            } catch (RuntimeException e) {
                _log.error("Read pool selection failed", e);
                setError(130, "Read pool selection failed: " + e.toString());
@@ -2078,6 +2083,10 @@ public class RequestContainerV5
                 setError(128, e.getMessage());
                 _log.error("[p2p] {}", e.toString());
                 return RT_ERROR;
+            } catch (IllegalArgumentException e) {
+                setError(128, e.getMessage());
+                _log.error("[p2p] {}", e.getMessage());
+                return RT_ERROR;
             } catch (RuntimeException e) {
                 setError(128, e.getMessage());
                 _log.error("[p2p] contact support@dcache.org", e);
@@ -2132,6 +2141,10 @@ public class RequestContainerV5
             } catch (NoRouteToCellException e) {
                 setError(128, e.getMessage());
                 _log.error("[stage] {}", e.toString());
+                return RT_ERROR;
+            } catch (IllegalArgumentException e) {
+                setError(128, e.getMessage());
+                _log.error("[stage] {}", e.getMessage());
                 return RT_ERROR;
             } catch (RuntimeException e) {
                 setError(128, e.getMessage());


### PR DESCRIPTION
The patch suppresses stack traces like the following:

03 Aug 2014 06:40:09 (PoolManager) [door:NFS-fax-dcap-proxy@faxDomain:1407040808696 NFS-fax-dcap-proxy PoolMgrSelectReadPool 0000D36F8581AC7043118452477B188E6EC1] Read pool selection failed
java.lang.IllegalArgumentException: Unit not matched : 0:0:0:0:0:0:0:1
        at diskCacheV111.poolManager.PoolSelectionUnitV2.match(PoolSelectionUnitV2.java:545) ~[dcache-core-2.9.6.jar:2.9.6]
        at diskCacheV111.poolManager.PoolMonitorV5$PnfsFileLocation.selectReadPool(PoolMonitorV5.java:234) ~[dcache-core-2.9.6.jar:2.9.6]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.askIfAvailable(RequestContainerV5.java:2008) [dcache-core-2.9.6.jar:2.9.6]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.stateEngine(RequestContainerV5.java:1488) [dcache-core-2.9.6.jar:2.9.6]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.stateLoop(RequestContainerV5.java:1266) [dcache-core-2.9.6.jar:2.9.6]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.access$2300(RequestContainerV5.java:691) [dcache-core-2.9.6.jar:2.9.6]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler$RunEngine.run(RequestContainerV5.java:1197) [dcache-core-2.9.6.jar:2.9.6]
        at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) [dcache-core-2.9.6.jar:2.9.6]
        at org.dcache.util.CDCExecutorServiceDecorator$1.run(CDCExecutorServiceDecorator.java:104) [dcache-core-2.9.6.jar:2.9.6]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_65]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_65]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_65]

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7194/
(cherry picked from commit 1adf0d0b7cb9c262ab9b07009c53d35b58a6fe65)
