### PR TITLE
gplazma: Fix JVM implementation dependency in unit test

### DIFF
--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/loader/cli/ListCommand.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/loader/cli/ListCommand.java
@@ -1,5 +1,7 @@
 package org.dcache.gplazma.loader.cli;
 
+import com.google.common.collect.Ordering;
+
 import java.io.PrintStream;
 
 import org.dcache.gplazma.loader.PluginMetadata;
@@ -53,7 +55,7 @@ public class ListCommand implements Command {
             boolean firstAlias = true;
             StringBuilder sb = new StringBuilder();
             sb.append( shortestName);
-            for( String name : plugin.getPluginNames()) {
+            for( String name : Ordering.natural().sortedCopy(plugin.getPluginNames())) {
                 if( name.equals( shortestName)) {
                     continue;
                 }
@@ -83,7 +85,7 @@ public class ListCommand implements Command {
             StringBuilder sb = new StringBuilder();
             sb.append( "    Name: ");
             boolean isFirstName = true;
-            for( String name : plugin.getPluginNames()) {
+            for( String name : Ordering.natural().sortedCopy(plugin.getPluginNames())) {
                 if( !isFirstName) {
                     sb.append( ",");
                 }


### PR DESCRIPTION
The ListCommand outputs plugins in hash table order - this ordering is
implementation dependent, which in turn causes the
ListCommandTests.testDetailedList unit test to fail with some JVMs (eg Oracle
JDK 8).

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7196/
(cherry picked from commit c0a68c5a29d48d06dcb10ead9261aadeac074c6d)
