### PR TITLE
info: Fix HashMap ordering assumption in unit test

### DIFF
--- a/modules/dcache/src/test/java/org/dcache/services/info/base/TestStateExhibitor.java
+++ b/modules/dcache/src/test/java/org/dcache/services/info/base/TestStateExhibitor.java
@@ -1,5 +1,6 @@
 package org.dcache.services.info.base;
 
+import com.google.common.collect.Ordering;
 import org.junit.Assert;
 
 import java.util.HashMap;
@@ -125,9 +126,8 @@ public class TestStateExhibitor implements StateExhibitor, Cloneable {
 
             visitor.visitCompositePreDescend( ourPath, visitMetadata);
 
-            for( Map.Entry<String, Node> entry : _children.entrySet()) {
-                String childName = entry.getKey();
-                Node child = entry.getValue();
+            for (String childName : Ordering.natural().sortedCopy(_children.keySet())) {
+                Node child = _children.get(childName);
 
                 StatePath childPath = (ourPath == null)
                         ? new StatePath( childName)


### PR DESCRIPTION
The unit test assumes a particular serialized form of the state tree
nodes, which isn't guaranteed when iterating over a HashMap. This causes
the unit tests to fail with some JDKs, in particular JDK 8.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7198/
(cherry picked from commit 14797ddac174e77e1aabf2a1873e5878d3d311f2)
