### PR TITLE
pool: Resolve high memory usage and other issues in sweeper

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -301,6 +301,7 @@ public class RepositoryInterpreter
                 @Override
                 public void run()
                 {
+                    int cnt = 0;
                     for (PnfsId id: _repository) {
                         try {
                             CacheEntry entry = _repository.getEntry(id);
@@ -312,19 +313,20 @@ public class RepositoryInterpreter
                             String sc = info.getStorageClass();
                             if (sc.equals(storageClassName)) {
                                 _repository.setState(id, EntryState.REMOVED);
+                                cnt++;
                             }
-                        } catch (FileNotInCacheException e) {
+                        } catch (FileNotInCacheException ignored) {
                             // File was deleted - no problem
-                        } catch (IllegalTransitionException e) {
+                        } catch (IllegalTransitionException ignored) {
                             // File is transient - no problem
                         } catch (CacheException e) {
-                            _log.error("File removal failed: " + e.getMessage());
+                            _log.error("Failed to delete {}: {}", id, e.getMessage());
                         } catch (InterruptedException e) {
-                            _log.warn("File removal was interrupted: " +
-                                      e.getMessage());
+                            _log.warn("File removal was interrupted.");
                             break;
                         }
                     }
+                    _log.info("'rep rmclass {}' removed {} files.", storageClassName, cnt);
                 }
             }, "rmclass").start();
         return "Backgrounded";


### PR DESCRIPTION
Space sweeper while reclaiming loads the meta data entry of the
files it will remove. This consumes a lot of memory, in particular
when the entire pool is purged, causing OOM in the worst case.

This patch resolves this issue. The patch also resolves an issue
with the 'sweeper ls' command which would block the message thread.

Finally, log messages indicating the end of long running operations
in sweeper and for 'rep rmclass' have been added. This allows the
admin to detect when these operations have finished. Other log messages
have been refined too, including lowering the log level of several
messages.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7195/
(cherry picked from commit 467ad69ceaa2d5f7cdb4dd8ce21f36015381bdf4)

Conflicts:
    modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java

(cherry picked from commit 8aaa6da3e174714e6f0433a12a598d62bf7bc7f2)
