### PR TITLE
chimera: create missing index i_dirs_iparent

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-1.8.0.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-1.8.0.xml
@@ -574,6 +574,17 @@
         </createIndex>
     </changeSet>
 
+    <changeSet author="tigran" id="1.1">
+        <preConditions>
+            <not>
+                <indexExists indexName="i_dirs_ipnfsid"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="i_dirs_ipnfsid" tableName="t_dirs" unique="false">
+            <column name="ipnfsid"/>
+        </createIndex>
+    </changeSet>
+
     <changeSet author="tigran" id="2">
         <!--
             populate db if empty


### PR DESCRIPTION
speedups remove operation

Acked-by: Albert Rossi
Acked-by: Paul Millar
Target: master, 2.6, 2.7, 2.8, 2.9, 2.10
Require-book: no
Require-notes: yes
(cherry picked from commit 1db22cf0d017933b64da167c52fe5248ca901733)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
