### PR TITLE
acl: add heuristic to detect acl format

### DIFF
--- a/modules/acl/src/main/java/org/dcache/acl/parser/ACEParser.java
+++ b/modules/acl/src/main/java/org/dcache/acl/parser/ACEParser.java
@@ -57,6 +57,10 @@ public class ACEParser {
             throw new IllegalArgumentException("ace_spec ends with \"" + SEPARATOR + "\"");
         }
 
+        if (ace_spec.contains(":+") || ace_spec.contains(":-")) {
+            return parseAdmACE(ace_spec);
+        }
+
         String[] split = ace_spec.split(SEPARATOR);
         if ( split == null ) {
             throw new IllegalArgumentException("ace_spec can't be splitted.");


### PR DESCRIPTION
there are two ways to define acl:

USER:7:rlwfx:o:ALLOW:FFFF
and
USER:7:i+rlwfx:o:FFFF

make ACE#parse() smart enouth to detect that.

Ticket: #8424
Acked-by: Karsten Schwank
Target: master, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit f2e9dedd7052e9bbf1a6caea1f1b35b2586af801)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
