### PR TITLE
libs: update to jglobus-2.0.6-rc7.d

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <version.jetty>8.1.13.v20130916</version.jetty>
         <version.wicket>6.9.1</version.wicket>
         <version.xrootd4j>1.3.3</version.xrootd4j>
-        <version.jglobus>2.0.6-rc6.d</version.jglobus>
+        <version.jglobus>2.0.6-rc7.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
Changelog for v2.0.6-rc6.d..v2.0.6-rc7.d
    \* [7e2d73d] Signal end-of-stream when remote sends a CLOSE notification
    \* [d636727] Enable TLS 1.2 clients

Acked-by: Paul Millar
Target: master, 2.10, 2.9, 2.8, 2.7, 2.6
Require-book: no
Require-notes: no
(cherry picked from commit 7d5cb72264ca12d7629343299f145050ab05b902)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
