### PR TITLE
srm: Fix set max ready get command

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
@@ -1305,7 +1305,7 @@ public class SRM {
     public void setGetMaxReadyJobs(int value)
     {
         configuration.setGetMaxReadyJobs(value);
-        schedulers.setMaxReadyJobs(GetRequest.class, value);
+        schedulers.setMaxReadyJobs(GetFileRequest.class, value);
     }
 
     public void setBringOnlineMaxReadyJobs(int value)


### PR DESCRIPTION
A regression in 2.9.0 caused the 'set max ready get' command of the
SRM to break. The regression is fixed by this patch.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.10
Request: 2.9
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7228/
(cherry picked from commit 3c9e3fb8ada286592ae505cbcd43860c9b3b0ce9)

Conflicts:
    modules/srm-server/src/main/java/org/dcache/srm/SRM.java
