### PR TITLE
srm: Fix restore of bring-online requests on restart

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -1119,6 +1119,8 @@ public abstract class Job  {
                 return;
             }
 
+            setScheduler(scheduler.getId(), scheduler.getTimestamp());
+
             switch (state) {
             // Pending jobs were never worked on before the SRM restart; we
             // simply schedule them now.


### PR DESCRIPTION
A regression introduced in 2.10.0 prevents the SRM from starting
when active bring-online requests are found in the SRM database.
The problem is that the scheduler timestamp isn't updated when
restoring jobs. This patch resolves the issue.

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7224/
(cherry picked from commit b3e9b74570779f3a94f464c74984208b2b59512e)
