### PR TITLE
srm: Fix credential store registration

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
@@ -270,7 +270,7 @@ public class SRM {
     @Required
     public void setRequestCredentialStorage(RequestCredentialStorage store)
     {
-        RequestCredential.registerRequestCredentialStorage(requestCredentialStorage);
+        RequestCredential.registerRequestCredentialStorage(store);
         requestCredentialStorage = store;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/RequestCredential.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/RequestCredential.java
@@ -87,6 +87,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.dcache.srm.SRMInvalidRequestException;
 import org.dcache.srm.scheduler.JobIdGeneratorFactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class RequestCredential
 {
     private static final ConcurrentMap<Long, RequestCredential> weakRequestCredentialStorage =
@@ -105,7 +107,7 @@ public class RequestCredential
 
     public static void registerRequestCredentialStorage(RequestCredentialStorage requestCredentialStorage)
     {
-        requestCredentailStorages.add(requestCredentialStorage);
+        requestCredentailStorages.add(checkNotNull(requestCredentialStorage));
     }
 
     public static RequestCredential getRequestCredential(Long requestCredentialId) throws DataAccessException


### PR DESCRIPTION
A regression in 2.10.0 prevents credentials from being reloaded. This regression
results in errors like these:

28 Aug 2014 16:54:25 (c-dCacheDomain-101-102) [] Uncaught exception in thread pool-2-thread-1
java.lang.NullPointerException: null
        at org.dcache.srm.request.RequestCredential.getRequestCredential(RequestCredential.java:120) ~[srm-server-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at org.dcache.srm.request.Request.getCredential(Request.java:226) ~[srm-server-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at org.dcache.srm.request.ContainerRequest.toString(ContainerRequest.java:679) ~[srm-server-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at org.dcache.srm.SRM.listRequest(SRM.java:1183) ~[srm-server-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at diskCacheV111.srm.dcache.SrmCommandLineInterface.ac_ls_$_0_1(SrmCommandLineInterface.java:218) ~[dcache-core-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at sun.reflect.GeneratedMethodAccessor364.invoke(Unknown Source) ~[na:na]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_65]
        at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_65]
        at dmg.util.command.AcCommandExecutor.execute(AcCommandExecutor.java:140) ~[cells-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at org.dcache.util.cli.CommandInterpreter$CommandEntry.execute(CommandInterpreter.java:260) ~[common-cli-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at org.dcache.util.cli.CommandInterpreter.doExecute(CommandInterpreter.java:169) ~[common-cli-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at dmg.cells.nucleus.CellAdapter.doExecute(CellAdapter.java:955) ~[cells-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at org.dcache.util.cli.CommandInterpreter.command(CommandInterpreter.java:155) ~[common-cli-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at dmg.cells.nucleus.CellAdapter.command(CellAdapter.java:184) ~[cells-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at dmg.cells.nucleus.CellAdapter.executeLocalCommand(CellAdapter.java:891) ~[cells-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:817) ~[cells-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.innerRun(CellNucleus.java:1092) ~[cells-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at dmg.cells.nucleus.CellNucleus$AbstractNucleusTask.run(CellNucleus.java:1000) ~[cells-2.10.4-SNAPSHOT.jar:2.10.4-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_65]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_65]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_65]

The regression is fixed by this patch.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.10
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Acked-by: Paul Millar paul.millar@desy.de
(cherry picked from commit 1c149472bb5c7eeb608a580f2c535c4933158006)
