### PR TITLE
srm: Fix incomplete restore of "ready queued" jobs

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -286,6 +286,7 @@ public final class Scheduler <T extends Job>
             switch (job.getState()) {
             case RQUEUED:
                 increaseNumberOfReadyQueued(job);
+                readyQueue(job);
                 break;
 
             case READY:
@@ -930,7 +931,6 @@ public final class Scheduler <T extends Job>
                     job.wlock();
                     try {
                         if (job.getState() == State.RUNNING) {
-                            // put blocks if ready queue is full
                             job.setState(State.RQUEUED, "Putting on a \"Ready\" Queue.");
                             if (!readyQueue(job)) {
                                 LOGGER.warn("All ready slots are taken and ready queue is full.");


### PR DESCRIPTION
When restoring jobs in the RQUEUED state, they are counted as a ready-queued
job, but the code fails to add them to the actual ready queue. As a consequence
such jobs do not appear in the output when listing the queue, and the queue
length and the count are different.

This patch resolves this issue. It is unknown for how long this bug has existed,
but until version 2.9 we didn't attempt to restore RQUEUED jobs and the bug
doesn't matter before that release.

Target: trunk
Request: 2.10
Reqeuest: 2.9
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7230/
(cherry picked from commit d5b5f7849f4d596bf272eccaa9661317aba193b7)
