### PR TITLE
libs: update jglobus to 2.0.6-rc8.d

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <version.jetty>8.1.13.v20130916</version.jetty>
         <version.wicket>6.9.1</version.wicket>
         <version.xrootd4j>1.3.3</version.xrootd4j>
-        <version.jglobus>2.0.6-rc7.d</version.jglobus>
+        <version.jglobus>2.0.6-rc8.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
Changelog for v2.0.6-rc7.d..2.0.6-rc8.d
    \* [35fe1c1] Only cache CA's signing policy as not found after searching all
    \* [3ae5c04] Avoid memory leak and stale information when scanning directorie

Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit 7085fa21c3a2137c94984999ba046bb5ad59df02)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
