### PR TITLE
cells: Improve pinboard

### DIFF
--- a/modules/cells/src/main/java/dmg/util/Pinboard.java
+++ b/modules/cells/src/main/java/dmg/util/Pinboard.java
@@ -1,74 +1,86 @@
-package dmg.util ;
+package dmg.util;
 
+import com.google.common.collect.EvictingQueue;
+import com.google.common.collect.Iterables;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.Vector;
+import java.util.Queue;
 
-public class Pinboard {
-
-    private static final ThreadLocal<DateFormat> _df =
+public class Pinboard
+{
+    private static final ThreadLocal<DateFormat> TIMESTAMP_FORMAT =
             new ThreadLocal<DateFormat>()
             {
                 @Override
                 protected DateFormat initialValue()
                 {
-                    return new SimpleDateFormat("hh.mm.ss ");
+                    return DateFormat.getTimeInstance();
                 }
             };
 
-   private final List<PinEntry>       _pin = new Vector<>() ;
-   private final int          _size;
-   private class PinEntry {
-      private String _message ;
-      private Date   _date ;
-      public PinEntry( String message ){
-         _message = message ;
-         _date = new Date() ;
-      }
-      public String toString(){
-         return _df.get().format(_date)+" "+_message ;
-      }
-   }
-   public Pinboard(){
-      this( 20 ) ;
-   }
-   public Pinboard( int size ){
-      _size = size ;
-   }
-   public synchronized void pin( String note ){
-      _pin.add( new PinEntry( note ) ) ;
-      if( _pin.size() > _size ) {
-          _pin.remove(0);
-      }
-   }
-   public synchronized void dump( StringBuilder sb ){
-       dump( sb , _size ) ;
-   }
-   public synchronized void dump( StringBuilder sb , int last ){
-       int i = _pin.size() - last + 1 ;
-       for( i =i<0?0:i ; i < _pin.size() ; i++) {
-           sb.append(_pin.get(i).toString()).append("\n");
-       }
-   }
-   public synchronized void dump( File file ) throws IOException {
-       dump( file , _size ) ;
-   }
-   public synchronized void dump( File file , int last ) throws IOException {
-       int i =  _pin.size() - last + 1 ;
+    private final Queue<PinEntry> _entries;
 
-       PrintWriter pw = new PrintWriter( new FileWriter( file ) ) ;
-       for( i =i<0?0:i ; i < _pin.size() ; i++) {
-           pw.println(_pin.get(i).toString());
-       }
-       pw.close() ;
+    public Pinboard(int size)
+    {
+        _entries = EvictingQueue.create(size);
+    }
 
-   }
+    public synchronized void pin(String note)
+    {
+        _entries.add(new PinEntry(note));
+    }
 
+    public synchronized void dump(StringBuilder sb)
+    {
+        dump(sb, _entries);
+    }
+
+    public synchronized void dump(StringBuilder sb, int last)
+    {
+        dump(sb, Iterables.skip(_entries, _entries.size() - last));
+    }
+
+    public synchronized void dump(File file) throws IOException
+    {
+        dump(file, _entries);
+    }
+
+    public synchronized void dump(File file, int last) throws IOException
+    {
+        dump(file, Iterables.skip(_entries, _entries.size() - last));
+    }
+
+    private void dump(StringBuilder sb, Iterable<PinEntry> entries)
+    {
+        DateFormat format = TIMESTAMP_FORMAT.get();
+        for (PinEntry entry : entries) {
+            sb.append(format.format(entry.timestamp)).append(' ').append(entry.message).append('\n');
+        }
+    }
+
+    private void dump(File file, Iterable<PinEntry> entries) throws IOException
+    {
+        DateFormat format = TIMESTAMP_FORMAT.get();
+        try (PrintWriter pw = new PrintWriter(new FileWriter(file))) {
+            for (PinEntry entry : entries) {
+                pw.append(format.format(entry.timestamp)).append(' ').println(entry.message);
+            }
+        }
+    }
+
+    private static class PinEntry
+    {
+        final String message;
+        final long timestamp;
+
+        public PinEntry(String message)
+        {
+            this.message = message;
+            this.timestamp = System.currentTimeMillis();
+        }
+    }
 }


### PR DESCRIPTION
- Changes the time format to use the local time format (rather than
  hard-coding a 12 hour format with no indication wheter it is am or pm).
- Uses a circular buffer rather than an array to keep the log - removing
  the oldest entry from an array is rather expensive as the entire array
  has to be copied. This change reduce the CPU overhead of the pinboard.
  This also reduces a potential contention point between threads of a cell
  all writing to the pinboard.
- Reduces the memory foot print and CPU overhead of creating a
  pinboard entry (static inner and no Date instance stored in a field).

Target: trunk
Require-notes: yes
Require-book: yes
Request: 2.10
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7220/
(cherry picked from commit 00d25349d08cc24671be69d8e42b90ed7893ad1b)
