### PR TITLE
Fix CacheException references in error messages

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/CacheExceptionFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/util/CacheExceptionFactory.java
@@ -102,10 +102,13 @@ public class CacheExceptionFactory {
     public static CacheException exceptionOf(Message message)
     {
         Object error = message.getErrorObject();
-        if (error != null && error.getClass() == CacheException.class) {
+        if (!(error instanceof CacheException)) {
+            return exceptionOf(message.getReturnCode(), Objects.toString(error, null));
+        }
+        if (error.getClass() == CacheException.class) {
             CacheException ce = (CacheException) error;
             return exceptionOf(ce.getRc(), ce.getMessage(), ce.getCause());
         }
-        return exceptionOf(message.getReturnCode(), Objects.toString(error, null));
+        return (CacheException) error;
     }
 }


### PR DESCRIPTION
A regression in CacheExceptionFactory results in CacheException#toString
form to be included as the message of another CacheException. The
intention of the code was that sub-classes of CacheException do not
get wrapped, but the code was flawed.

Target: trunk
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7267/
(cherry picked from commit 3c6b4fa394248d55fa572f6130468e6b386ccd72)
