### PR TITLE
chimera: Fix creation time flag in ls command

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
@@ -341,7 +341,7 @@ public class Shell extends ShellApplication
                 case "mtime":
                     time = stat.getMTime();
                     break;
-                case "created":
+                case "create":
                     time = stat.getCrTime();
                     break;
                 default:


### PR DESCRIPTION
The ls command of the chimera CLI fails to interpret the creation time
flag correctly.

Target: trunk
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7268/
(cherry picked from commit 70d414e72c91b40fd914d9f069d17860643ba68f)
