### PR TITLE
srm: Fix reporting of infinite space lifetime

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
@@ -288,7 +288,7 @@ public final class ReserveSpaceRequest extends Request {
             response.setSpaceToken(getSpaceToken());
             response.setSizeOfTotalReservedSpace(new UnsignedLong(sizeInBytes) );
             response.setSizeOfGuaranteedReservedSpace(new UnsignedLong(sizeInBytes));
-            response.setLifetimeOfReservedSpace((int)(spaceReservationLifetime/1000L));
+            response.setLifetimeOfReservedSpace((int)((spaceReservationLifetime) == -1 ? -1 : TimeUnit.MILLISECONDS.toSeconds(spaceReservationLifetime)));
             return response;
         } finally {
             runlock();
@@ -306,7 +306,7 @@ public final class ReserveSpaceRequest extends Request {
             response.setSpaceToken(getSpaceToken());
             response.setSizeOfTotalReservedSpace(new UnsignedLong(sizeInBytes) );
             response.setSizeOfGuaranteedReservedSpace(new UnsignedLong(sizeInBytes));
-            response.setLifetimeOfReservedSpace((int)(spaceReservationLifetime/1000L));
+            response.setLifetimeOfReservedSpace((int)((spaceReservationLifetime) == -1 ? -1 : TimeUnit.MILLISECONDS.toSeconds(spaceReservationLifetime)));
             return response;
         } finally {
             runlock();


### PR DESCRIPTION
A lifetime of -1 indidicates that the space has an infinite lifetime. This
needs to be taken into account when converting between seconds and milli-
seconds.

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7269/
(cherry picked from commit 3273e4ac85c2e0c22cbf9d1299beecd89806c0e8)
