### PR TITLE
httpd: Use service specific property for list of login brokers

### DIFF
--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -6,6 +6,13 @@
 httpd.cell.name=httpd
 
 #
+#    Optional config file for configurig the httpd
+#    service. If present, it is executed as a batch
+#    file as part of the httpd cell startup.
+#
+httpd.setup=${dcache.paths.etc}/httpd.conf
+
+#
 #     Mirrored properties
 #
 httpd.service.billing=${dcache.service.billing}

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -9,9 +9,8 @@
 onerror shutdown
 check -strong httpd.net.listen
 check -strong httpd.net.port
-check -strong dcache.paths.config
-check -strong dcache.paths.etc
 check -strong httpd.cell.name
+check -strong httpd.setup
 check -strong httpd.enable.authn
 check -strong httpd.enable.alarm-cleaner
 check -strong httpd.enable.plots.pool-queue
@@ -233,14 +232,6 @@ User-agent: *
 Disallow: /
 endDefine
 
-# Any of the above defaults can be redefined in etc/httpd.conf
-####################################################################
-
-onerror continue
-test -f ${dcache.paths.etc}/httpd.conf
-exec file:${dcache.paths.etc}/httpd.conf -ifok
-onerror shutdown
-
 # Transfer observer collects information about active transfers
 ####################################################################
 
@@ -251,7 +242,7 @@ endDefine
 
 create diskCacheV111.cells.TransferObserverV1 TransferObserver \
               "default \
-               -loginBroker=${dcache.service.loginbroker} \
+               -loginBroker=${httpd.service.loginbroker} \
                -update=60"
 
 
@@ -271,8 +262,17 @@ create diskCacheV111.cells.WebCollectorV3 collector \
     "PnfsManager \
      PoolManager \
      gPlazma \
-     -loginBroker=${dcache.service.loginbroker} \
+     -loginBroker=${httpd.service.loginbroker} \
      -replyObject"
+
+# Any of the above defaults can be redefined in etc/httpd.conf
+####################################################################
+
+onerror continue
+test -f ${httpd.setup}
+exec file:${httpd.setup} -ifok
+onerror shutdown
+
 
 # The http service cell provides the web interface
 #


### PR DESCRIPTION
Part of the httpd service used dcache.service.loginbroker rather
than httpd.service.loginbroker. This patch resolves the issue.

The patch introduces httpd.setup to define the setup file of the
httpd service, thus making the reference to the file explicit in
the configuration.

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7266/
(cherry picked from commit 69de830289824943d7800931312fbecdd4923f05)
