### PR TITLE
billing plots: use 'transferred' rather than 'size' for bytes

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/data/TransferredEntry.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/data/TransferredEntry.java
@@ -59,6 +59,8 @@ documents or software obtained from this server.
  */
 package org.dcache.services.billing.db.data;
 
+import java.util.Map;
+
 import org.dcache.services.billing.histograms.data.IHistogramData;
 
 /**
@@ -66,6 +68,9 @@ import org.dcache.services.billing.histograms.data.IHistogramData;
  */
 public abstract class TransferredEntry extends SizeEntry implements IHistogramData {
     private static final long serialVersionUID = -3981596987619899105L;
+
+    public static final String TRANSFERRED = "transferred";
+
     protected Long transferred = 0L;
 
     public Long getTransferred() {
@@ -74,5 +79,12 @@ public abstract class TransferredEntry extends SizeEntry implements IHistogramDa
 
     public void setTransferred(Long transferred) {
         this.transferred = transferred;
+    }
+
+    @Override
+    public Map<String, Double> data() {
+        Map<String, Double> dataMap = super.data();
+        dataMap.put(TRANSFERRED, transferred.doubleValue());
+        return dataMap;
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/histograms/data/JDOTimeFrameHistogramDataService.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/histograms/data/JDOTimeFrameHistogramDataService.java
@@ -85,6 +85,7 @@ import org.dcache.services.billing.db.data.HitsHourly;
 import org.dcache.services.billing.db.data.MissesHourly;
 import org.dcache.services.billing.db.data.PoolToPoolTransfersDaily;
 import org.dcache.services.billing.db.data.PoolToPoolTransfersHourly;
+import org.dcache.services.billing.db.data.TransferredEntry;
 import org.dcache.services.billing.histograms.TimeFrame;
 import org.dcache.services.billing.histograms.TimeFrame.BinType;
 import org.dcache.services.billing.histograms.data.TimeFrameHistogramData.HistogramDataType;
@@ -147,7 +148,7 @@ public final class JDOTimeFrameHistogramDataService implements
         }
         histogram[0].setData(plotData);
         histogram[0].setDfactor(GB);
-        histogram[0].setField(SizeEntry.SIZE);
+        histogram[0].setField(TransferredEntry.TRANSFERRED);
         return histogram;
     }
 
@@ -297,7 +298,7 @@ public final class JDOTimeFrameHistogramDataService implements
                             timeFrame);
         }
         histogram[0].setData(plotData);
-        histogram[0].setField(SizeEntry.SIZE);
+        histogram[0].setField(TransferredEntry.TRANSFERRED);
         histogram[0].setDfactor(GB);
         return histogram;
     }

--- a/modules/dcache/src/main/resources/org/dcache/services/billing/plot/jaida.properties
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/plot/jaida.properties
@@ -38,8 +38,8 @@ time.description.YEARLY=365 days since
 
 # histogram labels
 label.x.axis=Time
-label.y.axis.gbytes.hourly=Gbytes/hour
-label.y.axis.gbytes.daily=Gbytes/day
+label.y.axis.gbytes.hourly=GiB/hour
+label.y.axis.gbytes.daily=GiB/day
 label.y.axis.transfers.hourly=Transfers/hour
 label.y.axis.transfers.daily=Transfers/day
 label.y.axis.connection.time=Duration (secs)


### PR DESCRIPTION
This bug has gone
undiscovered. The plotting for dCache
bytes read and written has been accessing aggregate table
values for fullsize rather than transfersize. While this
is OK for writes, reads will not be correctly represented
(we found this on our CMS Tier1 dcache, where
it was off by a factor of 10).

RELEASE NOTES:

```
Fixes a bug in the billing plots causing incorrect values for dCache bytes read.
```

Target: 2.7
Require-book: no
Require-notes: yes
Acked-by: Dmitry
Patch: https://rb.dcache.org/r/7290
Committed: master@7680a0156a1af5b5479af7b4472c2385117cc711
