### PR TITLE
srm: Fix deadlock like bug

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/RemoveFileCompanion.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/RemoveFileCompanion.java
@@ -80,6 +80,7 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.Subject;
 
 import java.util.EnumSet;
+import java.util.concurrent.Executor;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
@@ -127,14 +128,15 @@ public class RemoveFileCompanion
                                   String path,
                                   RemoveFileCallback callbacks,
                                   CellStub pnfsStub,
-                                  CellEndpoint endpoint)
+                                  CellEndpoint endpoint,
+                                  Executor executor)
     {
         RemoveFileCompanion companion =
             new RemoveFileCompanion(subject, path, callbacks, endpoint);
         PnfsDeleteEntryMessage message =
             new PnfsDeleteEntryMessage(path, EnumSet.of(LINK, REGULAR));
         message.setSubject(subject);
-        CellStub.addCallback(pnfsStub.send(message), companion, MoreExecutors.sameThreadExecutor());
+        CellStub.addCallback(pnfsStub.send(message), companion, executor);
     }
 
     @Override

--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/SrmReleaseSpaceCompanion.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/SrmReleaseSpaceCompanion.java
@@ -74,6 +74,7 @@ import javax.security.auth.Subject;
 
 import java.sql.SQLException;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 
 import diskCacheV111.services.space.SpaceException;
 import diskCacheV111.services.space.message.Release;
@@ -137,7 +138,8 @@ public final class SrmReleaseSpaceCompanion
             String spaceToken,
             Long spaceToReleaseInBytes,
             SrmReleaseSpaceCallback callback,
-            CellStub spaceManagerStub)
+            CellStub spaceManagerStub,
+            Executor executor)
     {
         LOGGER.trace("SrmReleaseSpaceCompanion.releaseSpace({}, token {}, spaceToReleaseInBytes {})",
                 subject.getPrincipals(), spaceToken, spaceToReleaseInBytes);
@@ -146,7 +148,7 @@ public final class SrmReleaseSpaceCompanion
             SrmReleaseSpaceCompanion companion = new SrmReleaseSpaceCompanion(callback);
             Release release = new Release(token, spaceToReleaseInBytes);
             release.setSubject(subject);
-            CellStub.addCallback(spaceManagerStub.send(release), companion, MoreExecutors.sameThreadExecutor());
+            CellStub.addCallback(spaceManagerStub.send(release), companion, executor);
         } catch (NumberFormatException e) {
             callback.invalidRequest("No such space");
         }

--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/SrmReserveSpaceCompanion.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/SrmReserveSpaceCompanion.java
@@ -72,6 +72,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.security.auth.Subject;
 
+import java.util.concurrent.Executor;
+
 import diskCacheV111.services.space.NoFreeSpaceException;
 import diskCacheV111.services.space.SpaceException;
 import diskCacheV111.services.space.message.Reserve;
@@ -142,7 +144,8 @@ public final class SrmReserveSpaceCompanion
             String accessLatencyString,
             String description,
             SrmReserveSpaceCallback callback,
-            CellStub spaceManagerStub)
+            CellStub spaceManagerStub,
+            Executor executor)
     {
         LOGGER.trace(" SrmReserveSpaceCompanion.reserveSpace({} for {} bytes, access lat.={} retention pol.={} lifetime={})",
                 subject.getPrincipals(), sizeInBytes, accessLatencyString, retentionPolicyString, spaceReservationLifetime);
@@ -177,7 +180,7 @@ public final class SrmReserveSpaceCompanion
                         spaceReservationLifetime,
                         description);
         reserve.setSubject(subject);
-        CellStub.addCallback(spaceManagerStub.send(reserve), companion, MoreExecutors.sameThreadExecutor());
+        CellStub.addCallback(spaceManagerStub.send(reserve), companion, executor);
     }
 }
 

--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/UnpinCompanion.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/UnpinCompanion.java
@@ -74,6 +74,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.security.auth.Subject;
 
+import java.util.concurrent.Executor;
+
 import diskCacheV111.util.PnfsId;
 
 import org.dcache.cells.AbstractMessageCallback;
@@ -131,7 +133,8 @@ public class UnpinCompanion
     public static ListenableFuture<String> unpinFile(Subject subject,
                                                      PnfsId pnfsId,
                                                      long pinId,
-                                                     CellStub pinManagerStub)
+                                                     CellStub pinManagerStub,
+                                                     Executor executor)
     {
         _log.info("UnpinCompanion.unpinFile({})", pnfsId);
         UnpinCompanion companion = new UnpinCompanion(pnfsId);
@@ -139,14 +142,15 @@ public class UnpinCompanion
             new PinManagerUnpinMessage(pnfsId);
         msg.setPinId(pinId);
         msg.setSubject(subject);
-        CellStub.addCallback(pinManagerStub.send(msg), companion, MoreExecutors.sameThreadExecutor());
+        CellStub.addCallback(pinManagerStub.send(msg), companion, executor);
         return companion.future;
     }
 
     public static ListenableFuture<String> unpinFileBySrmRequestId(Subject subject,
                                                                    PnfsId pnfsId,
                                                                    String requestToken,
-                                                                   CellStub pinManagerStub)
+                                                                   CellStub pinManagerStub,
+                                                                   Executor executor)
     {
         _log.info("UnpinCompanion.unpinFile({})", pnfsId);
         UnpinCompanion companion = new UnpinCompanion(pnfsId);
@@ -154,20 +158,21 @@ public class UnpinCompanion
             new PinManagerUnpinMessage(pnfsId);
         msg.setRequestId(requestToken);
         msg.setSubject(subject);
-        CellStub.addCallback(pinManagerStub.send(msg), companion, MoreExecutors.sameThreadExecutor());
+        CellStub.addCallback(pinManagerStub.send(msg), companion, executor);
         return companion.future;
     }
 
     public static ListenableFuture<String> unpinFile(Subject subject,
                                                      PnfsId pnfsId,
-                                                     CellStub pinManagerStub)
+                                                     CellStub pinManagerStub,
+                                                     Executor executor)
     {
         _log.info("UnpinCompanion.unpinFile({}", pnfsId);
         UnpinCompanion companion = new UnpinCompanion(pnfsId);
         PinManagerUnpinMessage msg =
             new PinManagerUnpinMessage(pnfsId);
         msg.setSubject(subject);
-        CellStub.addCallback(pinManagerStub.send(msg), companion, MoreExecutors.sameThreadExecutor());
+        CellStub.addCallback(pinManagerStub.send(msg), companion, executor);
         return companion.future;
     }
 }

--- a/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/srm/srm.xml
@@ -179,9 +179,13 @@
   <bean id="storage" class="diskCacheV111.srm.dcache.Storage">
     <description>dCache plugin for SRM</description>
     <property name="executor">
-        <bean class="java.util.concurrent.Executors"
-              factory-method="newCachedThreadPool"
-              destroy-method="shutdown"/>
+        <bean class="org.dcache.util.CDCExecutorServiceDecorator"
+              destroy-method="shutdown">
+                <constructor-arg>
+                    <bean class="java.util.concurrent.Executors"
+                          factory-method="newCachedThreadPool"/>
+                </constructor-arg>
+        </bean>
     </property>
     <property name="directoryListSource" ref="list-handler"/>
     <property name="loginBrokerStub" ref="login-broker-stub"/>


### PR DESCRIPTION
The CellStub refactoring led to more things being executor on the message
delivery thread, the point being to reduce the number of threads messages have
to hop through to reach the real destination. In this SRM this has however lead
to a deadlock like situation during file upload: If the file is aborted by
the client while the upload directory is prepared, the SRM will issue an abort
once the callback from the creation of the upload directory comes back. The
abort will send a message to the pnfs manager from the message delivery thread,
which blocks the entire cell - until the abort times out (so not a true
deadlock).

The proper fix is more elaborate: Eventually I would like all the SRM callbacks
to execute on the request scheduler's executor. This requires quite some more
refactoring, which obviously isn't applicable to stable branches. Hence the
present patch simply puts those callbacks back on a dedicated thread pool -
similar to the old behaviour.

Target: trunk
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7292/
(cherry picked from commit 0dfc80eac4703acd629c667e1feaf895812b557d)
