### PR TITLE
common: Fix race condition in AtomicCounter unit test

### DIFF
--- a/modules/common/src/main/java/org/dcache/commons/util/AtomicCounter.java
+++ b/modules/common/src/main/java/org/dcache/commons/util/AtomicCounter.java
@@ -1,5 +1,7 @@
 package org.dcache.commons.util;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.Date;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -21,6 +23,7 @@ public class AtomicCounter
     {
         _lock.lock();
         try {
+            inLock();
             _counter++;
             _updated.signalAll();
         } finally {
@@ -35,6 +38,7 @@ public class AtomicCounter
     {
         _lock.lock();
         try {
+            inLock();
             return _counter;
         } finally {
             _lock.unlock();
@@ -69,9 +73,15 @@ public class AtomicCounter
     {
         _lock.lock();
         try {
+            inLock();
             return _counter != value || _updated.awaitUntil(deadline);
         } finally {
             _lock.unlock();
         }
+    }
+
+    @VisibleForTesting
+    void inLock()
+    {
     }
 }


### PR DESCRIPTION
The patch modifies two unit tests. The first slept, although the
race between the two threads did not lead to failing tests (the
test thus was non-deterministic, but not non-determinate).

The second test could fail on certain interleavings of threads.
This is resolved by hooking into the base class at a specific
point to synchronize the execution of the two threads involved.
This too elliminates the sleep from the test.

Finally, the unit test is moved to the correct package and
Maven module.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: no
Require-book: no
Acked-by: Albert Rossi arossi@fnal.gov
Patch: https://rb.dcache.org/r/7293/
(cherry picked from commit 7175bf09ae69fa76825d603e5d0bd7dfc78a51d4)
