### PR TITLE
srm: Log common misconfiguration preventing upload

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
@@ -411,8 +411,7 @@ public final class GetFileRequest extends FileRequest<GetRequest> {
                 }
                 return;
             } catch (SRMException e) {
-                String error = "cannot obtain turl for file:" + e.getMessage();
-                logger.error(error);
+                String error = "Cannot obtain TURL for file: " + e.getMessage();
                 try {
                     setState(State.FAILED,error);
                 } catch (IllegalStateTransition ist) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
@@ -358,29 +358,6 @@ public final class PutFileRequest extends FileRequest<PutRequest> {
                     }
                 }
 
-
-                addDebugHistoryEvent("selecting transfer protocol");
-                // if we can not read this path for some reason
-                //(not in ftp root for example) this will throw exception
-                // we do not care about the return value yet
-                PutRequest request = getContainerRequest();
-                String[] supportedProts = getStorage().supportedPutProtocols();
-                boolean found_supp_prot=false;
-                String[] requestProtocols = request.getProtocols();
-                mark1:
-                for(String supportedProtocol:supportedProts) {
-                    for(String requestProtocol:requestProtocols) {
-                        if(supportedProtocol.equals(requestProtocol)) {
-                            found_supp_prot = true;
-                            break mark1;
-                        }
-                    }
-                }
-
-                if(!found_supp_prot) {
-                    throw new FatalJobFailure("transfer protocols not supported");
-                }
-
                 setState(State.ASYNCWAIT, "Doing name space lookup.");
                 CheckedFuture<String, ? extends SRMException> future =
                         getStorage().prepareToPut(
@@ -409,8 +386,7 @@ public final class PutFileRequest extends FileRequest<PutRequest> {
                 }
                 return;
             } catch (SRMException e) {
-                String error = "cannot obtain turl for file:" + e.getMessage();
-                logger.error(error);
+                String error = "Cannot obtain TURL for file: " + e.getMessage();
                 try {
                     setState(State.FAILED, error);
                 } catch (IllegalStateTransition ist) {


### PR DESCRIPTION
Whether a transfer protocol is supported is checked in several places:
- At the request level (per requirement in the SRM spec)
- At the TURL computation level (as that's where we know the final path)
- In PutFileRequest (redundantly)

The redundant check in PutFileRequest is removed. The logging for
failed TURL computation is removed - this information is already
registered as a state transition on the job. A new log message is
added that logs common misconfiguration in which the path being
accessed isn't exposed by any of the doors supporting the requested
protocol. This would typically be the upload directory.

Such a misconfiguration now logs:

10 sep. 2014 23:46:18 (SRM-Gerds-MacBook-Pro) [hMA:1:srm2:prepareToPut:-2147482647:-2147482646] No door for [gsiftp] provides access to /upload/eefaa8f5-ea76-460e-b172-57ea8c69eb5f/a.

Target: trunk
Require-notes: yes
Require-book: yes
Request: 2.10
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7294/
(cherry picked from commit 1ab18b97742effc9c706a296512dd3e21af18475)
