### PR TITLE
srm: Fix asynchroneous job storage leak

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
@@ -465,9 +465,9 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
 
 
     @Override
-    public void saveJob(final Job job, boolean saveifmonitoringisdesabled) throws DataAccessException
+    public void saveJob(final Job job, boolean force) throws DataAccessException
     {
-        if (!saveifmonitoringisdesabled && !logHistory) {
+        if (!force && !logHistory) {
             return;
         }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/CanonicalizingJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/CanonicalizingJobStorage.java
@@ -105,13 +105,13 @@ public class CanonicalizingJobStorage<J extends Job> implements JobStorage<J>
     }
 
     @Override
-    public void saveJob(J job, boolean saveIfMonitoringDisabled) throws DataAccessException
+    public void saveJob(J job, boolean force) throws DataAccessException
     {
         Job other = map.putIfAbsent(job.getId(), job);
         if (other != null && other != job) {
             throw new IllegalStateException("Duplicate job #" + job.getId());
         }
-        storage.saveJob(job, saveIfMonitoringDisabled);
+        storage.saveJob(job, force);
     }
 
     @Override

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/FinalStateOnlyJobStorageDecorator.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/FinalStateOnlyJobStorageDecorator.java
@@ -47,9 +47,9 @@ public class FinalStateOnlyJobStorageDecorator<J extends Job> implements JobStor
     }
 
     @Override
-    public void saveJob(J job, boolean saveIfMonitoringDisabled) throws DataAccessException {
+    public void saveJob(J job, boolean force) throws DataAccessException {
         if(job.getState().isFinal()) {
-            jobStorage.saveJob(job,saveIfMonitoringDisabled);
+            jobStorage.saveJob(job, force);
         }
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/JobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/JobStorage.java
@@ -94,11 +94,11 @@ public interface JobStorage<J extends Job> {
     /**
      *
      * @param job Job to save
-     * @param saveIfMonitoringDisabled if this is false and monitoring jdbc login
+     * @param force if this is false and monitoring jdbc login
      *         disabled, this operation will be ignored
      * @throws SQLException
      */
-    void saveJob(J job, boolean saveIfMonitoringDisabled)
+    void saveJob(J job, boolean force)
             throws DataAccessException;
 
     boolean isJdbcLogRequestHistoryInDBEnabled();

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/NoopJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/NoopJobStorage.java
@@ -41,7 +41,7 @@ public class NoopJobStorage<J extends Job> implements JobStorage<J> {
     }
 
     @Override
-    public void saveJob(J job, boolean saveIfMonitoringDisabled) {
+    public void saveJob(J job, boolean force) {
     }
 
     @Override

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 
 import org.dcache.srm.request.Job;
 
@@ -126,9 +125,9 @@ public class SharedMemoryCacheJobStorage<J extends Job> implements JobStorage<J>
     }
 
     @Override
-    public void saveJob(J job, boolean saveIfMonitoringDisabled) throws DataAccessException
+    public void saveJob(J job, boolean force) throws DataAccessException
     {
-        storage.saveJob(job, saveIfMonitoringDisabled);
+        storage.saveJob(job, force);
         sharedMemoryCache.update(job);
         updateExpirationSet(job);
     }

--- a/modules/srm-server/src/test/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorageTest.java
+++ b/modules/srm-server/src/test/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorageTest.java
@@ -1,0 +1,120 @@
+package org.dcache.srm.scheduler;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import org.dcache.srm.request.Job;
+
+import static org.mockito.Mockito.*;
+
+public class AsynchronousSaveJobStorageTest
+{
+    private JobStorage<Job> storage;
+    private List<Runnable> tasks;
+    private AsynchronousSaveJobStorage<Job> asyncStorage;
+    private Job job;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        storage = mock(JobStorage.class);
+        job = mock(Job.class);
+        tasks = new ArrayList<>();
+        asyncStorage = new AsynchronousSaveJobStorage<>(storage, new ListExecutor(tasks));
+    }
+
+    @Test
+    public void whenRequestHistoryLoggingIsDisabledAndSavingWithForceThenActualSaveIsWithForce() throws Exception
+    {
+        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(false);
+        asyncStorage.saveJob(job, true);
+        runTasks();
+        verify(storage).saveJob(job, true);
+    }
+
+    @Test
+    public void whenRequestHistoryLoggingIsEnabledAndSavingWithForceThenActualSaveIsWithForce() throws Exception
+    {
+        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
+        asyncStorage.saveJob(job, true);
+        runTasks();
+        verify(storage).saveJob(job, true);
+    }
+
+    @Test
+    public void whenRequestHistoryLoggingIsEnabledAndSavingWithoutForceThenActualSaveIsWithoutForce() throws Exception
+    {
+        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
+        asyncStorage.saveJob(job, false);
+        runTasks();
+        verify(storage).saveJob(job, false);
+    }
+
+    @Test
+    public void whenSavingTwiceWithoutForceThenActualSaveIsOnceWithoutForce() throws Exception
+    {
+        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
+        asyncStorage.saveJob(job, false);
+        asyncStorage.saveJob(job, false);
+        runTasks();
+        verify(storage).saveJob(job, false);
+    }
+
+    @Test
+    public void whenSavingTwiceWithForceThenActualSaveIsOnceWithForce() throws Exception
+    {
+        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
+        asyncStorage.saveJob(job, true);
+        asyncStorage.saveJob(job, true);
+        runTasks();
+        verify(storage).saveJob(job, true);
+    }
+
+    @Test
+    public void whenSavingTwiceWithAndWithoutForceThenActualSaveIsOnceWithForce() throws Exception
+    {
+        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
+        asyncStorage.saveJob(job, true);
+        asyncStorage.saveJob(job, false);
+        runTasks();
+        verify(storage).saveJob(job, true);
+    }
+
+    @Test
+    public void whenSavingTwiceWithoutAndWithForceThenActualSaveIsOnceWithForce() throws Exception
+    {
+        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
+        asyncStorage.saveJob(job, false);
+        asyncStorage.saveJob(job, true);
+        runTasks();
+        verify(storage).saveJob(job, true);
+    }
+
+    private void runTasks()
+    {
+        for (Runnable task : tasks) {
+            task.run();
+        }
+    }
+
+    private static class ListExecutor implements Executor
+    {
+        private final List<Runnable> tasks;
+
+        private ListExecutor(List<Runnable> tasks)
+        {
+            this.tasks = tasks;
+        }
+
+        @Override
+        public void execute(
+                Runnable command)
+        {
+            tasks.add(command);
+        }
+    }
+}


### PR DESCRIPTION
The asynchroneous job storage fails to preserve the force flag when
collapsing several save calls. In case srm.persistence.enable.history
is false (the default), this could lead to incomplete data in the
database. This in case could lead to incomplete cleanup of upload
directories after an SRM restart.

The patch also renames the boolean parameter to something that I find
less confusing.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7307/
(cherry picked from commit 98f21155a8927aae68a2619c3738bb31f0110fa1)
