### PR TITLE
chimera: fix NPE on '.(parent)()' for root inode

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PARENT.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PARENT.java
@@ -66,7 +66,11 @@ public class FsInode_PARENT extends FsInode {
         Stat ret = super.stat();
         ret.setMode((ret.getMode() & 0000777) | UnixPermission.S_IFREG);
         if (_parent == null) {
-            _parent = _fs.getParentOf(this).toString();
+            FsInode parentInode = _fs.getParentOf(this);
+            if (parentInode == null) {
+                throw new FileNotFoundHimeraFsException();
+            }
+            _parent = parentInode.toString();
         }
 
         if (_parent.equals(this.toString())) {

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -1024,6 +1024,12 @@ public class BasicTest extends ChimeraTestCaseHelper {
         assertEquals(inodeWithOldId, inodeWithNewId);
     }
 
+    @Test(expected = FileNotFoundHimeraFsException.class)
+    public void testGetParentOnRoot() throws Exception {
+        String id = _rootInode.toString();
+        _rootInode.inodeOf(".(parent)(" + id + ")");
+    }
+
     private void assertHasChecksum(Checksum expectedChecksum, FsInode inode) throws Exception {
         for(Checksum checksum: _fs.getInodeChecksums(inode)) {
             if (checksum.equals(expectedChecksum)) {


### PR DESCRIPTION
Acked-by: Albert Rossi
Acked-by: Dmitry Litvintsev
Target: master, 2.10, 2.9, 2.8, 2.7, 2.6
Require-book: no
Require-notes: no
(cherry picked from commit 82879878110e5254ae1314c759a5fc4f26aecf0c)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
