### PR TITLE
commons: fix TimeUtils nanos to duration string conversion

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/TimeUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/TimeUtils.java
@@ -98,15 +98,15 @@ public class TimeUtils
                 units.compareTo(MILLISECONDS) <= 0) {
             sb.append(durationInMillis).append(' ').
                     append(unitsFormat.get(MILLISECONDS));
-        } else if (duration < MINUTES.toMillis(2) &&
+        } else if (durationInMillis < MINUTES.toMillis(2) &&
                 units.compareTo(SECONDS) <= 0) {
             sb.append(units.toSeconds(duration)).append(' ').
                     append(unitsFormat.get(SECONDS));
-        } else if (duration < HOURS.toMillis(2) &&
+        } else if (durationInMillis < HOURS.toMillis(2) &&
                 units.compareTo(MINUTES) <= 0) {
             sb.append(units.toMinutes(duration)).append(' ').
                     append(unitsFormat.get(MINUTES));
-        } else if (duration < DAYS.toMillis(2) &&
+        } else if (durationInMillis < DAYS.toMillis(2) &&
                 units.compareTo(HOURS) <= 0) {
             sb.append(units.toHours(duration)).append(' ').
                     append(unitsFormat.get(HOURS));

--- a/modules/common/src/test/java/org/dcache/util/TimeUtilsTest.java
+++ b/modules/common/src/test/java/org/dcache/util/TimeUtilsTest.java
@@ -1,0 +1,58 @@
+package org.dcache.util;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+public class TimeUtilsTest {
+
+    @Test
+    public void testDurationOfNanos() {
+
+        CharSequence cs = TimeUtils.duration(13, TimeUnit.NANOSECONDS, TimeUtils.TimeUnitFormat.SHORT);
+        assertEquals(cs.toString(), "13 ns");
+    }
+
+    @Test
+    public void testDurationOfSeconds() {
+
+        CharSequence cs = TimeUtils.duration(13, TimeUnit.SECONDS, TimeUtils.TimeUnitFormat.SHORT);
+        assertEquals(cs.toString(), "13 s" );
+    }
+
+    @Test
+    public void testDurationOfMin() {
+
+        CharSequence cs = TimeUtils.duration(13, TimeUnit.MINUTES, TimeUtils.TimeUnitFormat.SHORT);
+        assertEquals(cs.toString(), "13 min");
+    }
+
+    @Test
+    public void testDurationOfHours() {
+
+        CharSequence cs = TimeUtils.duration(13, TimeUnit.HOURS, TimeUtils.TimeUnitFormat.SHORT);
+        assertEquals(cs.toString(), "13 hours");
+    }
+
+    @Test
+    public void testDurationOfDays() {
+
+        CharSequence cs = TimeUtils.duration(13, TimeUnit.DAYS, TimeUtils.TimeUnitFormat.SHORT);
+        assertEquals(cs.toString(), "13 days");
+    }
+
+    @Test
+    public void testDurationFromNanos() {
+        long duration = TimeUnit.SECONDS.toNanos(13);
+        CharSequence cs = TimeUtils.duration(duration, TimeUnit.NANOSECONDS, TimeUtils.TimeUnitFormat.SHORT);
+        assertEquals(cs.toString(), "13 s");
+    }
+
+    @Test
+    public void testDurationFromNanosToDays() {
+        long duration = TimeUnit.DAYS.toNanos(13);
+        CharSequence cs = TimeUtils.duration(duration, TimeUnit.NANOSECONDS, TimeUtils.TimeUnitFormat.SHORT);
+        assertEquals(cs.toString(), "13 days");
+    }
+}


### PR DESCRIPTION
Ached-by: Karsten Schwank
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit ae63e2ed2657066599a09280737a07f56e7e1760)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
