### PR TITLE
cells: fix IAE in 'show pinboard'

### DIFF
--- a/modules/cells/src/main/java/dmg/util/Pinboard.java
+++ b/modules/cells/src/main/java/dmg/util/Pinboard.java
@@ -41,7 +41,8 @@ public class Pinboard
 
     public synchronized void dump(StringBuilder sb, int last)
     {
-        dump(sb, Iterables.skip(_entries, _entries.size() - last));
+        int skip = Math.max(0, _entries.size() - last);
+        dump(sb, Iterables.skip(_entries, skip));
     }
 
     public synchronized void dump(File file) throws IOException
@@ -51,7 +52,8 @@ public class Pinboard
 
     public synchronized void dump(File file, int last) throws IOException
     {
-        dump(file, Iterables.skip(_entries, _entries.size() - last));
+        int skip = Math.max(0, _entries.size() - last);
+        dump(file, Iterables.skip(_entries, skip));
     }
 
     private void dump(StringBuilder sb, Iterable<PinEntry> entries)


### PR DESCRIPTION
we get IllegalArgumentException if number of entries in the pinboard
less that we have to skip:

java.lang.IllegalArgumentException: number to skip cannot be negative
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:125) ~[guava-17.0.jar:na]
    at com.google.common.collect.Iterables.skip(Iterables.java:846) ~[guava-17.0.jar:na]
    at dmg.util.Pinboard.dump(Pinboard.java:44) ~[cells-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
    at dmg.cells.nucleus.CellAdapter$ShowPinboardCommand.call(CellAdapter.java:676) ~[cells-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
    at dmg.cells.nucleus.CellAdapter$ShowPinboardCommand.call(CellAdapter.java:657) ~[cells-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
    at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:128) ~[common-cli-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
    at org.dcache.util.cli.CommandInterpreter$CommandEntry.execute(CommandInterpreter.java:260) ~[common-cli-2.11.0-SNAPSHOT.jar:2.11.0-SN

Acked-by: Gerd Behrmann
Target: master, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 788b56c0c2a93b69639ae35eca020795a09c6ecf)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
