### PR TITLE
The gPlazma cache used by NFS and SRM caches both positive and negative replies. Unfortunately it also caches failures to communicate with gPlazma. This means that a transient timeout would be cached too, thus increasing the effect of the transient error.

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/login/CachingLoginStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/services/login/CachingLoginStrategy.java
@@ -1,5 +1,6 @@
 package org.dcache.services.login;
 
+import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -10,14 +11,17 @@ import javax.security.auth.Subject;
 
 import java.security.Principal;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.CacheException;
 import dmg.util.Args;
+import diskCacheV111.util.TimeoutCacheException;
+
+import dmg.cells.nucleus.CellCommandListener;
 
 import org.dcache.auth.LoginReply;
 import org.dcache.auth.LoginStrategy;
-import dmg.cells.nucleus.CellCommandListener;
 
 /**
  * Caching implementation of {@link LoginStrategy}.
@@ -71,26 +75,44 @@ public class CachingLoginStrategy implements LoginStrategy, CellCommandListener 
 
     @Override
     public LoginReply login(Subject subject) throws CacheException {
-        return _loginCache.getUnchecked(subject).checkedGet();
+        try {
+            return _loginCache.get(subject).checkedGet();
+        } catch (ExecutionException e) {
+            Throwables.propagateIfPossible(e.getCause(), CacheException.class);
+            throw new RuntimeException(e.getCause());
+        }
     }
 
     @Override
     public Principal map(Principal principal) throws CacheException {
-        return _forwardCache.getUnchecked(principal).checkedGet();
+        try {
+            return _forwardCache.get(principal).checkedGet();
+        } catch (ExecutionException e) {
+            Throwables.propagateIfPossible(e.getCause(), CacheException.class);
+            throw new RuntimeException(e.getCause());
+        }
     }
 
     @Override
     public Set<Principal> reverseMap(Principal principal) throws CacheException {
-        return _reverseCache.getUnchecked(principal).checkedGet();
+        try {
+            return _reverseCache.get(principal).checkedGet();
+        } catch (ExecutionException e) {
+            Throwables.propagateIfPossible(e.getCause(), CacheException.class);
+            throw new RuntimeException(e.getCause());
+        }
     }
 
     private class ForwardFetcher extends CacheLoader<Principal, CheckedFuture<Principal, CacheException>> {
 
         @Override
-        public CheckedFuture<Principal, CacheException> load(Principal f) {
+        public CheckedFuture<Principal, CacheException> load(Principal f) throws TimeoutCacheException
+        {
             try {
                 Principal p = _inner.map(f);
                 return Futures.immediateCheckedFuture(p);
+            } catch (TimeoutCacheException e) {
+                throw e;
             } catch (CacheException e) {
                 return Futures.immediateFailedCheckedFuture(e);
             }
@@ -100,10 +122,13 @@ public class CachingLoginStrategy implements LoginStrategy, CellCommandListener 
     private class ReverseFetcher extends CacheLoader<Principal, CheckedFuture<Set<Principal>, CacheException>> {
 
         @Override
-        public CheckedFuture<Set<Principal>, CacheException> load(Principal f) {
+        public CheckedFuture<Set<Principal>, CacheException> load(Principal f) throws TimeoutCacheException
+        {
             try {
                 Set<Principal> s = _inner.reverseMap(f);
                 return  Futures.immediateCheckedFuture(s);
+            } catch (TimeoutCacheException e) {
+                throw e;
             } catch (CacheException e) {
                 return Futures.immediateFailedCheckedFuture(e);
             }
@@ -113,10 +138,13 @@ public class CachingLoginStrategy implements LoginStrategy, CellCommandListener 
     private class LoginFetcher extends CacheLoader<Subject, CheckedFuture<LoginReply, CacheException>> {
 
         @Override
-        public CheckedFuture<LoginReply, CacheException> load(Subject f) {
+        public CheckedFuture<LoginReply, CacheException> load(Subject f) throws TimeoutCacheException
+        {
             try {
                 LoginReply s = _inner.login(f);
                 return Futures.immediateCheckedFuture(s);
+            } catch (TimeoutCacheException e) {
+                throw e;
             } catch (CacheException e) {
                 return Futures.immediateFailedCheckedFuture(e);
             }


### PR DESCRIPTION
This patch resolves this problem by not caching timeouts (which include failure
to communicate with gPlazma).

Other errors are still cached - the correctness of this is debatable when
gPlazma does not distinguish between transient and permanent errors.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Committed: 43ecb8c5ffac90014cf339560ca8f4640584c4bd
Acked-by: Albert Rossi arossi@fnal.gov
Patch: https://rb.dcache.org/r/7332
(cherry picked from commit 6bfdfa83d5b51c8601bd30d5de262ae032b14da8)

Conflicts:
    modules/dcache/src/main/java/org/dcache/services/login/CachingLoginStrategy.java
