### PR TITLE
pool: Prevent interruption of replica deletion during HSM flush

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -752,20 +752,30 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             public ListenableFuture<Void> apply(Void ignored)
                     throws CacheException, InterruptedException, NoSuchAlgorithmException, IOException
             {
-                PnfsId pnfsId = descriptor.getFileAttributes().getPnfsId();
+                final PnfsId pnfsId = descriptor.getFileAttributes().getPnfsId();
                 LOGGER.debug("Checking if {} still exists.", pnfsId);
                 try {
                     pnfs.getFileAttributes(pnfsId, EnumSet.noneOf(FileAttribute.class));
                 } catch (FileNotFoundCacheException e) {
-                    try {
-                        repository.setState(pnfsId, EntryState.REMOVED);
-                        LOGGER.info("File not found in name space; removed {}.", pnfsId);
-                    } catch (CacheException f) {
-                        LOGGER.error("File not found in name space, but failed to remove {}: {}", pnfsId,
-                                     f.getMessage());
-                    } catch (InterruptedException | IllegalTransitionException f) {
-                        LOGGER.error("File not found in name space, but failed to remove {}: {}", pnfsId, f);
-                    }
+                    // Remove file asynchronously to prevent request cancellation from
+                    // interrupting the state update.
+                    executor.execute(
+                            new Runnable()
+                            {
+                                @Override
+                                public void run()
+                                {
+                                    try {
+                                        repository.setState(pnfsId, EntryState.REMOVED);
+                                        LOGGER.info("File not found in name space; removed {}.", pnfsId);
+                                    } catch (CacheException f) {
+                                        LOGGER.error("File not found in name space, but failed to remove {}: {}", pnfsId,
+                                                     f.getMessage());
+                                    } catch (InterruptedException | IllegalTransitionException f) {
+                                        LOGGER.error("File not found in name space, but failed to remove {}: {}", pnfsId, f);
+                                    }
+                                }
+                            });
                     throw e;
                 }
                 checksumModule.enforcePreFlushPolicy(descriptor);


### PR DESCRIPTION
Target: trunk
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7335/
(cherry picked from commit be918388ba1fb1899b2e2409ed8d9a4361cb3d07)
