### PR TITLE
dcap: fix interaction with Spacemanager

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -2282,6 +2282,7 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
             }
 
             poolMessage.setId( _sessionId ) ;
+            poolMessage.setSubject(_subject);
 
             // current request is a initiator for the pool request
             // we need this to trace back pool billing information


### PR DESCRIPTION
we have to set subject in message to pool as well, as
space manager processes PoolAcceptFileMessage as well.

Ticket: #8456
Acked-by: Dmitry Litvintsev
Target: master, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 22230c4e1b851891e6f874e00f526d8c2c9bf752)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
