### PR TITLE
ftp: Fix root path validation for upload directory

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1399,15 +1399,20 @@ public abstract class AbstractFtpDoorV1
             }
         }
         FsPath doorRootPath;
+        String cwd;
         if (_root == null) {
             doorRootPath = userRootPath;
+            cwd = userHomePath.toString();
         } else {
             doorRootPath = new FsPath(_root);
-            if (!userRootPath.startsWith(doorRootPath) && (_uploadPath == null || !_uploadPath.startsWith(doorRootPath))) {
+            if (userRootPath.startsWith(doorRootPath)) {
+                cwd = doorRootPath.relativize(new FsPath(userRootPath, userHomePath)).toString();
+            } else if (_uploadPath != null && _uploadPath.startsWith(doorRootPath)) {
+                cwd = doorRootPath.relativize(_uploadPath).toString();
+            } else {
                 throw new PermissionDeniedCacheException("User's files are not visible through this FTP service.");
             }
         }
-        String cwd = doorRootPath.relativize(new FsPath(userRootPath, userHomePath)).toString();
 
         _pnfs = new PnfsHandler(new CellStub(_cellEndpoint, new CellPath(_pnfsManager), _pnfsTimeout, _pnfsTimeoutUnit));
         _pnfs.setSubject(mappedSubject);


### PR DESCRIPTION
The ftp door can be configured to use a static root rather than the user's
root path. If the static root is not a prefix of the user's root directory,
the door should only allow access to the upload directory. The logic that
enforces this was broken, resulting in such upload attempts failing.

Target: trunk
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Karsten Schwank karsten.schwank@desy.de
Patch: https://rb.dcache.org/r/7347/
(cherry picked from commit 1321d431e155f11cf1d2e3665f3ac3265ddc9de8)
