### PR TITLE
cell: Declassify eval failure as a bug

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
@@ -25,6 +25,7 @@ import diskCacheV111.admin.UserAdminShell;
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.cells.nucleus.SerializationException;
+import dmg.util.CommandEvaluationException;
 import dmg.util.CommandException;
 import dmg.util.CommandExitException;
 import dmg.util.CommandPanicException;
@@ -182,33 +183,32 @@ public class ConsoleReaderCommand implements Command, Runnable {
                     }
                 }
                 result = _userAdminShell.executeCommand(str);
-            } catch (CommandSyntaxException e) {
-                result = e.getMessage()
-                + " Please enter \'help\' to see all commands that can be used.";
             } catch (IllegalArgumentException e) {
                 result = e.getMessage()
                 + " (Please check the spelling of your command or your config file(s)!)";
-            } catch (CommandExitException e) {
-                break;
             } catch (SerializationException e) {
                 result =
                     "There is a bug here, please report to support@dcache.org";
                 _logger.error("This must be a bug, please report to "
-                        + "support@dcache.org: {}" + e.getMessage());
+                        + "support@dcache.org: {}", e.getMessage());
+            } catch (CommandSyntaxException e) {
+                result = e.getMessage()
+                        + " Please enter \'help\' to see all commands that can be used.";
+            } catch (CommandEvaluationException e) {
+                result = e.getMessage();
+            } catch (CommandExitException e) {
+                break;
+            } catch (CommandPanicException e) {
+                _logger.warn("Something went wrong during the remote "
+                                     + "execution of the command: {}",
+                             e.getTargetException());
+                break;
+            } catch (CommandThrowableException e) {
+                _logger.warn("Something went wrong during the remote "
+                                     + "execution of the command: {}",
+                             e.getTargetException());
+                break;
             } catch (CommandException e) {
-                if (e instanceof CommandPanicException) {
-                    _logger.warn("Something went wrong during the remote "
-                            + "execution of the command: {}"
-                            + ((CommandPanicException) e).getTargetException());
-                    return;
-                }
-                if (e instanceof CommandThrowableException) {
-                    _logger.warn("Something went wrong during the remote "
-                            + "execution of the command: {}"
-                            + ((CommandThrowableException) e)
-                            .getTargetException());
-                    return;
-                }
                 result =
                     "There is a bug here, please report to support@dcache.org: "
                     + e.getMessage();


### PR DESCRIPTION
Currently, this is claimed to be a bug:

[Gerds-MacBook-Pro.local](System) admin > eval sdsd
There is a bug here, please report to support@dcache.org: (3) Eval Result : sdsd

After applying this patch, we get:

[Gerds-MacBook-Pro.local](System) admin > eval sds
(3) Eval Result : sds

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7353/
(cherry picked from commit a85817f89123d0b9ec18e805ef7ce6e9cd360631)

Conflicts:
    modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
