### PR TITLE
cell: Prevent interpreter stack overflow from killing the domain

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
@@ -1739,6 +1739,8 @@ public class      CellShell
             }
 
             return args.hasOption("nooutput") ? "" : out.toString();
+        } catch (StackOverflowError e) {
+            throw new CommandExitException("Stack overflow", 2, e);
         } catch (FileNotFoundException e) {
             throw new CommandException(66, e.getMessage(), e);
         } catch (IOException e) {


### PR DESCRIPTION
This no longer causes a dCache crash:

cd System
define env x
exec env x
.
exec env x

Now it simply outputs an error message stating that a stack overflow
happened. Before it caused the domain to restart.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7352/
(cherry picked from commit 8378b5e01dc2a439706f91dbb618d7c76cea5c84)
