### PR TITLE
srm: Fix listing of failed, done and cancelled jobs

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
@@ -594,23 +594,23 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
     public Set<Long> getLatestDoneJobIds(int maxNum) throws DataAccessException
     {
         return getJobIdsByCondition("STATE =" + State.DONE.getStateId() +
-                " ORDERED BY ID DESC" +
+                " ORDER BY ID DESC" +
                 " LIMIT " + maxNum + " ");
     }
 
     @Override
     public Set<Long> getLatestFailedJobIds(int maxNum) throws DataAccessException
     {
-        return getJobIdsByCondition("STATE !="+State.FAILED.getStateId()+
-                " ORDERED BY ID DESC"+
+        return getJobIdsByCondition("STATE ="+State.FAILED.getStateId()+
+                " ORDER BY ID DESC"+
                 " LIMIT "+maxNum+" ");
     }
 
     @Override
     public Set<Long> getLatestCanceledJobIds(int maxNum) throws DataAccessException
     {
-        return getJobIdsByCondition("STATE != "+State.CANCELED.getStateId()+
-                " ORDERED BY ID DESC"+
+        return getJobIdsByCondition("STATE = "+State.CANCELED.getStateId()+
+                " ORDER BY ID DESC"+
                 " LIMIT "+maxNum+" ");
     }
 


### PR DESCRIPTION
Both the condition and the ORDER BY clause of the SQL query were
faulty.

The faulty expression can be traced all the way back to 2007 - isn't
that wonderful?

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Christian Bernardt christian.bernardt@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7350/
(cherry picked from commit 05e5f62d21d71457393fed011021a31fec353e16)
