### PR TITLE
srm: Fix listing of failed, done and cancelled jobs

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseRequestStorage.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/sql/DatabaseRequestStorage.java
@@ -209,19 +209,19 @@ public abstract class DatabaseRequestStorage extends DatabaseJobStorage implemen
 
     public Set<Long> getLatestDoneRequestIds(int maxNum)  throws SQLException {
         return getJobIdsByCondition("STATE ="+State.DONE.getStateId()+
-                " ORDERED BY ID"+
+                " ORDER BY ID"+
                 " LIMIT "+maxNum+" ");
     }
 
     public Set<Long> getLatestFailedRequestIds(int maxNum)  throws SQLException {
-        return getJobIdsByCondition("STATE !="+State.FAILED.getStateId()+
-                " ORDERED BY ID"+
+        return getJobIdsByCondition("STATE ="+State.FAILED.getStateId()+
+                " ORDER BY ID"+
                 " LIMIT "+maxNum+" ");
     }
 
     public Set<Long> getLatestCanceledRequestIds(int maxNum)  throws SQLException {
-        return getJobIdsByCondition("STATE != "+State.CANCELED.getStateId()+
-                " ORDERED BY ID"+
+        return getJobIdsByCondition("STATE = "+State.CANCELED.getStateId()+
+                " ORDER BY ID"+
                 " LIMIT "+maxNum+" ");
     }
 


### PR DESCRIPTION
Both the condition and the ORDER BY clause of the SQL query were
faulty.

The faulty expression can be traced all the way back to 2007 - isn't
that wonderful?

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Christian Bernardt christian.bernardt@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7350/
(cherry picked from commit 05e5f62d21d71457393fed011021a31fec353e16)

Conflicts:
    modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
