### PR TITLE
pool: Respect LAN port range for internal srmcp transfers

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/DCapClientProtocol_1.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/DCapClientProtocol_1.java
@@ -32,6 +32,7 @@ import dmg.cells.nucleus.CellPath;
 import org.dcache.pool.repository.Allocator;
 import org.dcache.pool.repository.RepositoryChannel;
 import org.dcache.util.NetworkUtils;
+import org.dcache.util.PortRange;
 import org.dcache.vehicles.FileAttributes;
 
 public class DCapClientProtocol_1 implements MoverProtocol
@@ -94,16 +95,16 @@ public class DCapClientProtocol_1 implements MoverProtocol
         say(" runIO() RemoteGsiftpTranferManager cellpath="+cellpath);
 
         ServerSocket serverSocket;
-        try
-            {
-                serverSocket = new ServerSocket(0,1);
-            }
-        catch(IOException ioe)
-            {
-                esay("exception while trying to create a server socket : "+ioe);
-                throw ioe;
-            }
-        int port = serverSocket.getLocalPort();
+        int port;
+        try {
+            String dcachePorts = System.getProperty("org.dcache.net.tcp.portrange");
+            PortRange portRange = (dcachePorts != null) ? PortRange.valueOf(dcachePorts) : new PortRange(0);
+            serverSocket = new ServerSocket();
+            port = portRange.bind(serverSocket, 1);
+        } catch(IOException ioe) {
+            esay("exception while trying to create a server socket : "+ioe);
+            throw ioe;
+        }
 
         InetAddress localAddress = NetworkUtils.getLocalAddress(dcapClient.getSocketAddress().getAddress());
 


### PR DESCRIPTION
When copying files internally within the same dCache using server side srmCopy,
the actual transfer is done through DCAP. The mover implementing this did not
respect the LAN port range. This patch resolves that problem.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: yes
Acked-by: Karsten Schwank karsten.schwank@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7348/
(cherry picked from commit f7fc29d8eaec1e3a1cd39e3c61e72cf0dfce65bd)
