### PR TITLE
srm-client: Output file level errors for sync requests

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
@@ -261,9 +261,19 @@ public class SRMCopyClientV2 extends SRMClient implements Runnable {
             if ( rs == null) {
                 throw new IOException(" null TReturnStatus ");
             }
-            if (RequestStatusTool.isFailedRequestStatus(rs)) {
-                throw new IOException("srmCopy submission failed, unexpected or failed return status : "+
-                        rs.getStatusCode()+" explanation="+rs.getExplanation());
+            TStatusCode statusCode = rs.getStatusCode();
+            if(statusCode == null) {
+                throw new IOException(" null status code");
+            }
+            if (RequestStatusTool.isFailedRequestStatus(rs) &&
+                    (statusCode != TStatusCode.SRM_FAILURE || resp.getArrayOfFileStatuses() == null)) {
+                String explanation = rs.getExplanation();
+                if (explanation != null) {
+                    throw new IOException("srmCopy submission failed, unexpected or failed status : " +
+                                                  statusCode + " explanation= " + explanation);
+                } else {
+                    throw new IOException("srmCopy submission failed, unexpected or failed status : " + statusCode);
+                }
             }
             if(resp.getArrayOfFileStatuses() == null) {
                 throw new IOException("srmCopy submission failed, arrayOfFileStatuses is null, status code :"+
@@ -382,7 +392,7 @@ public class SRMCopyClientV2 extends SRMClient implements Runnable {
                 if ( status == null ) {
                     throw new IOException(" null return status");
                 }
-                TStatusCode statusCode = status.getStatusCode();
+                statusCode = status.getStatusCode();
                 if(statusCode == null) {
                     throw new IOException(" null status code");
                 }

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV2.java
@@ -229,9 +229,16 @@ public class SRMGetClientV2 extends SRMClient implements Runnable {
             if(statusCode == null) {
                 throw new IOException(" null status code");
             }
-            if(RequestStatusTool.isFailedRequestStatus(status)){
-                throw new IOException("srmPrepareToGet submission failed, unexpected or failed status : "+
-                        statusCode+" explanation="+status.getExplanation());
+            if(RequestStatusTool.isFailedRequestStatus(status) &&
+                    (statusCode != TStatusCode.SRM_FAILURE || response.getArrayOfFileStatuses() == null)) {
+                String explanation = status.getExplanation();
+                if (explanation != null){
+                    throw new IOException("srmPrepareToGet submission failed, unexpected or failed status : " +
+                                                  statusCode + " explanation= " + explanation);
+                } else {
+                    throw new IOException(
+                            "srmPrepareToGet submission failed, unexpected or failed status : " + statusCode);
+                }
             }
             requestToken = response.getRequestToken();
             dsay(" srm returned requestToken = "+requestToken);

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMPutClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMPutClientV2.java
@@ -261,8 +261,9 @@ public class SRMPutClientV2 extends SRMClient implements Runnable {
             if(statusCode == null) {
                 throw new IOException(" null status code");
             }
-            String explanation = status.getExplanation();
-            if(RequestStatusTool.isFailedRequestStatus(status)){
+            if(RequestStatusTool.isFailedRequestStatus(status) &&
+                    (statusCode != TStatusCode.SRM_FAILURE || response.getArrayOfFileStatuses() == null)) {
+                String explanation = status.getExplanation();
                 if(explanation != null){
                     throw new IOException("srmPrepareToPut submission failed, unexpected or failed status : "+ statusCode+" explanation= "+explanation);
                 }else{


### PR DESCRIPTION
srm clients fail to output file level error information if the initial srmPrepareToPut,
srmPrepareToGet or srmCopy request fails. This would be the common way for synchroneous
process to fail. Originally these requests were always asynchronous and this problem
was not visible to the client.

This patch fixes this for srmCopy, srmPrepareToGet and srmPrepareToPut.

Without the patch one could observe:

Gerds-MacBook-Pro:dcache-git behrmann$ srmcp file:////bin/bash srm://localhost/private/test2
srm copy of at least one file failed or not completed
srm client error:
java.io.IOException: srmPrepareToPut submission failed, unexpected or failed status : SRM_FAILURE explanation= File requests have failed.

with the patch one now gets:

Gerds-MacBook-Pro:dcache-git behrmann$ srmcp file:////bin/bash srm://localhost/private/test2
Fri Oct 10 13:35:55 CEST 2014: retrieval of surl srm://localhost/private/test2 failed, status = SRM_AUTHORIZATION_FAILURE explanation=Access denied: /private/test2
srm copy of at least one file failed or not completed

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Christian Bernardt christian.bernardt@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7349/
(cherry picked from commit d88a98be54eaa96a71b3b7ad9348c6067151976c)
