### PR TITLE
pnfsmanager,doors: Add user relative upload directories

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/SecurityFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/SecurityFilter.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -307,13 +308,13 @@ public class SecurityFilter implements Filter
         return _rootPath.toString();
     }
 
-    public void setUploadPath(String uploadPath)
+    public void setUploadPath(File uploadPath)
     {
-        this._uploadPath = isNullOrEmpty(uploadPath) ? null : new FsPath(uploadPath);
+        this._uploadPath = uploadPath.isAbsolute() ? new FsPath(uploadPath.getPath()) : null;
     }
 
-    public String getUploadPath()
+    public File getUploadPath()
     {
-        return Objects.toString(_uploadPath, null);
+        return (_uploadPath == null) ? null : new File(_uploadPath.toString());
     }
 }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/NettyXrootdServer.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/NettyXrootdServer.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -136,14 +137,14 @@ public class NettyXrootdServer
         return Objects.toString(_rootPath, null);
     }
 
-    public void setUploadPath(String uploadPath)
+    public void setUploadPath(File uploadPath)
     {
-        this._uploadPath = (isNullOrEmpty(uploadPath) ? null : new FsPath(uploadPath));
+        this._uploadPath = uploadPath.isAbsolute() ? new FsPath(uploadPath.getPath()) : null;
     }
 
-    public String getUploadPath()
+    public File getUploadPath()
     {
-        return Objects.toString(_uploadPath, null);
+        return (_uploadPath == null) ? null : new File(_uploadPath.toString());
     }
 
     public void init()

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/AbstractNameSpaceProvider.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/AbstractNameSpaceProvider.java
@@ -145,8 +145,8 @@ public class AbstractNameSpaceProvider
     }
 
     @Override
-    public FsPath createUploadPath(Subject subject, FsPath path, int uid, int gid, int mode,
-                                   Long size,
+    public FsPath createUploadPath(Subject subject, FsPath path, FsPath rootPath,
+                                   int uid, int gid, int mode, Long size,
                                    AccessLatency al, RetentionPolicy rp, String spaceToken,
                                    Set<CreateOption> options) throws CacheException
     {

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/NameSpaceProvider.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/NameSpaceProvider.java
@@ -225,6 +225,7 @@ public interface NameSpaceProvider
      *
      * @param subject the subject of user who invoked this method
      * @param path the path of the file to upload
+     * @param rootPath  a base path relative to which the upload directory may optionally be created
      * @param uid the UID of new file or -1 for default
      * @param gid the GID of new file or -1 for default
      * @param mode the permission mask of the new entry or -1 for default
@@ -235,7 +236,7 @@ public interface NameSpaceProvider
      * @param options options specifying how the path should be created
      * @return A temporary upload path that must eventually be committed or cancelled
      */
-    FsPath createUploadPath(Subject subject, FsPath path, int uid, int gid, int mode,
+    FsPath createUploadPath(Subject subject, FsPath path, FsPath rootPath, int uid, int gid, int mode,
                             Long size, AccessLatency al, RetentionPolicy rp, String spaceToken,
                             Set<CreateOption> options)
             throws CacheException;

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -1124,6 +1124,7 @@ public class PnfsManagerV3
         try {
             FsPath uploadPath = _nameSpaceProvider.createUploadPath(message.getSubject(),
                                                                     message.getPath(),
+                                                                    message.getRootPath(),
                                                                     message.getUid(),
                                                                     message.getGid(),
                                                                     message.getMode(),

--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/DcacheUser.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/DcacheUser.java
@@ -17,12 +17,15 @@
  */
 package diskCacheV111.srm.dcache;
 
+import javax.annotation.Nonnull;
 import javax.security.auth.Subject;
 
 import diskCacheV111.util.FsPath;
 
 import org.dcache.auth.Subjects;
 import org.dcache.srm.SRMUser;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * SRMUser adaptor for Subjects.
@@ -37,9 +40,9 @@ public class DcacheUser implements SRMUser
     public DcacheUser(long id, Subject subject, boolean isReadOnly, FsPath root)
     {
         this.id = id;
-        this.subject = subject;
+        this.subject = checkNotNull(subject);
         this.isReadOnly = isReadOnly;
-        this.root = root;
+        this.root = checkNotNull(root);
     }
 
     @Override
@@ -60,11 +63,13 @@ public class DcacheUser implements SRMUser
         return this.isReadOnly;
     }
 
+    @Nonnull
     public Subject getSubject()
     {
         return subject;
     }
 
+    @Nonnull
     public FsPath getRoot()
     {
         return root;

--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -759,22 +759,14 @@ public final class Storage
         }
     }
 
-    private boolean verifyUserPathIsRootSubpath(FsPath absolutePath, SRMUser user) {
-        if (absolutePath == null) {
+    private boolean verifyUserPathIsRootSubpath(FsPath absolutePath, SRMUser user)
+    {
+        FsPath user_root = ((DcacheUser) user).getRoot();
+        _log.trace("getTurl() user root is {}", user_root);
+        if (!absolutePath.startsWith(user_root)) {
+            _log.warn("verifyUserPathIsInTheRoot error: user's path {} is not subpath of the user's root {}",
+                    absolutePath, user_root);
             return false;
-        }
-        FsPath user_root = null;
-        if (user != null) {
-            DcacheUser duser = (DcacheUser) user;
-            user_root = duser.getRoot();
-        }
-        if (user_root!= null) {
-            _log.trace("getTurl() user root is {}", user_root);
-            if (!absolutePath.startsWith(user_root)) {
-                _log.warn("verifyUserPathIsInTheRoot error: user's path {} is not subpath of the user's root {}",
-                        absolutePath, user_root);
-                return false;
-            }
         }
         return true;
     }
@@ -1034,7 +1026,7 @@ public final class Storage
                 options.add(CreateOption.CREATE_PARENTS);
             }
             PnfsCreateUploadPath msg =
-                    new PnfsCreateUploadPath(subject, fullPath,
+                    new PnfsCreateUploadPath(subject, fullPath, ((DcacheUser) user).getRoot(),
                                              uid, gid, NameSpaceProvider.DEFAULT, size,
                                              al, rp, spaceToken,
                                              options);
@@ -2537,6 +2529,7 @@ public final class Storage
      * Given a path relative to the root path, this method returns a
      * full PNFS path.
      */
+    @Nonnull
     private FsPath getPath(String path)
     {
         return new FsPath(new FsPath(config.getSrm_root()), new FsPath(path));
@@ -2545,6 +2538,7 @@ public final class Storage
     /**
      * Given a surl, this method returns a full PNFS path.
      */
+    @Nonnull
     private FsPath getPath(URI surl)
         throws SRMInvalidPathException
     {

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsCreateUploadPath.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsCreateUploadPath.java
@@ -52,9 +52,10 @@ public class PnfsCreateUploadPath extends PnfsMessage
     private final RetentionPolicy retentionPolicy;
     private final String spaceToken;
     private final Set<CreateOption> options;
+    private final String rootPath;
     private String uploadPath;
 
-    public PnfsCreateUploadPath(Subject subject, FsPath path, int uid, int gid, int mode, Long size,
+    public PnfsCreateUploadPath(Subject subject, FsPath path, FsPath rootPath, int uid, int gid, int mode, Long size,
                                 AccessLatency accessLatency, RetentionPolicy retentionPolicy, String spaceToken,
                                 Set<CreateOption> options)
     {
@@ -66,6 +67,7 @@ public class PnfsCreateUploadPath extends PnfsMessage
         this.retentionPolicy = retentionPolicy;
         this.spaceToken = spaceToken;
         this.options = options;
+        this.rootPath = rootPath.toString();
         setSubject(subject);
         setPnfsPath(path.toString());
         setReplyRequired(true);
@@ -116,9 +118,14 @@ public class PnfsCreateUploadPath extends PnfsMessage
         return new FsPath(getPnfsPath());
     }
 
+    public FsPath getRootPath()
+    {
+        return (rootPath == null) ? new FsPath() : new FsPath(rootPath);
+    }
+
     public FsPath getUploadPath()
     {
-        return uploadPath == null ? null : new FsPath(uploadPath);
+        return (uploadPath == null) ? null : new FsPath(uploadPath);
     }
 
     public void setUploadPath(FsPath uploadPath)

--- a/modules/dcache/src/main/java/org/dcache/auth/LoginReply.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/LoginReply.java
@@ -1,5 +1,6 @@
 package org.dcache.auth;
 
+import javax.annotation.Nonnull;
 import javax.security.auth.Subject;
 
 import java.util.Arrays;
@@ -7,6 +8,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.dcache.auth.attributes.LoginAttribute;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Immutable encapsulation of a login result as provided by a
@@ -27,13 +30,14 @@ public class LoginReply
 
     public LoginReply(Subject subject, Set<LoginAttribute> attributes)
     {
-        _subject = subject;
-        _attributes = attributes;
+        _subject = checkNotNull(subject);
+        _attributes = checkNotNull(attributes);
     }
 
     /**
      * Returns the Subject of this LoginReply.
      */
+    @Nonnull
     public Subject getSubject()
     {
         return _subject;
@@ -48,6 +52,7 @@ public class LoginReply
      * login attributes Set. Any modification to the returned Set
      * affects the internal login attributes Set as well.
      */
+    @Nonnull
     public Set<LoginAttribute> getLoginAttributes()
     {
         return _attributes;
@@ -62,6 +67,7 @@ public class LoginReply
      * each method invocation. Modifications to the returned Set will
      * not affect the internal login attributes Set.
      */
+    @Nonnull
     public <T extends LoginAttribute> Set<T> getLoginAttributes(Class<T> type)
     {
         Set<T> result = new HashSet<>();

--- a/modules/dcache/src/main/java/org/dcache/auth/RemoteNameSpaceProvider.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/RemoteNameSpaceProvider.java
@@ -205,12 +205,12 @@ public class RemoteNameSpaceProvider implements NameSpaceProvider
     }
 
     @Override
-    public FsPath createUploadPath(Subject subject, FsPath path, int uid, int gid, int mode,
+    public FsPath createUploadPath(Subject subject, FsPath path, FsPath rootPath, int uid, int gid, int mode,
                                    Long size, AccessLatency al, RetentionPolicy rp, String spaceToken,
                                    Set<CreateOption> options)
             throws CacheException
     {
-        PnfsCreateUploadPath msg = new PnfsCreateUploadPath(subject, path,
+        PnfsCreateUploadPath msg = new PnfsCreateUploadPath(subject, path, rootPath,
                                                             uid, gid, mode, size,
                                                             al, rp, spaceToken,
                                                             options);

--- a/modules/dcache/src/main/java/org/dcache/services/login/LoginMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/services/login/LoginMessage.java
@@ -9,6 +9,8 @@ import diskCacheV111.vehicles.Message;
 
 import org.dcache.auth.attributes.LoginAttribute;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Requests a login by a login cell.
  */
@@ -48,10 +50,7 @@ public class LoginMessage extends Message
 
     public void setLoginAttributes(Set<LoginAttribute> loginAttributes)
     {
-        if (loginAttributes == null) {
-            throw new NullPointerException();
-        }
-        _loginAttributes = loginAttributes;
+        _loginAttributes = checkNotNull(loginAttributes);
     }
 
     public Set<LoginAttribute> getLoginAttributes()

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -663,12 +663,52 @@ dcache.authn.ciphers=${dcache.security.ciphers}
 #   permission mask 711.  The directory is created automatically if it does not
 #   exist and must be accessible through all doors used for SRM uploading.
 #
-#   The two primary reasons for changing this path is to
+#   If this property is set to an absolute path, it is interpreted as an absolute
+#   path in dCache's name space. If this directory is not exposed by a door, that
+#   door cannot be used for upload by SRM. This would happen if a non-default root
+#   directory has been defined for a door, or if a non-default root directory
+#   has been defined for users.
 #
-#     - avoid naming conflicts, and
-#     - when only part of the name space is exported through doors, e.g. if
-#       all doors are rooted at /pnfs/example.org/data, then it makes sense
-#       to change this setting to /pnfs/example.org/data/upload.
+#   There are three ways to resolve this problem:
+#
+#   - Change dcache.upload-directory to a directory that is within a part of
+#     the name space exposed by all doors needed for SRM and for all accounts
+#     using SRM. E.g. if
+#
+#           /pnfs/example.org/data
+#
+#     is the root of all your doors and all your accounts, then setting
+#
+#           dcache.upload-directory = /pnfs/example.org/data/upload
+#
+#     is the best solution. This needs to be done for pnfsmanager and all
+#     doors.
+#
+#     If accounts have individual root directories, then this solution may not
+#     be suitable.
+#
+#   - Add additional FTP doors for the SRM configured with
+#
+#        ftp.root = /
+#
+#     or
+#
+#        ftp.root = ${ftp.authz.upload-directory}
+#
+#     This will expose the upload directory and SRM will automatically
+#     prefer these for uploads. This could be done in the same domain as
+#     existing doors using a non-standard TCP port.
+#
+#   - Defined a relative upload directory. If this property is defined to
+#     a relative path, it is interpreted relative to the account's root
+#     directory. It will thus appear in the name space exposed by the FTP
+#     door. There are two downsides to this:
+#
+#       * The upload directory may conflict with user files and directories.
+#
+#       * There will be several upload directories scattered throughout the
+#         name space. This may make it more difficult to clean up in case
+#         dCache fails to remove temporary upload directories.
 #
 dcache.upload-directory=/upload
 

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -59,6 +59,9 @@ ftp.authz.readonly.kerberos=false
 #   by gPlazma). The upload directory is an exception to this rule. The directory
 #   is typically used by SRM for uploading files.
 #
+#   If the property is defined to a relative path, it is interpreted relative to
+#   the account's root directory.
+#
 ftp.authz.upload-directory=${dcache.upload-directory}
 
 #  ---- Root path of FTP door

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -278,6 +278,9 @@ webdav.root=${webdavRootPath}
 #   by gPlazma). The upload directory is an exception to this rule. The directory
 #   is typically used by SRM for uploading files.
 #
+#   If the property is defined to a relative path, it is interpreted relative to
+#   the account's root directory.
+#
 webdav.authz.upload-directory=${dcache.upload-directory}
 
 #  ---- Paths which are accessible through WebDAV

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -175,6 +175,9 @@ xrootd.authz.user=${xrootdUser}
 #   by gPlazma). The upload directory is an exception to this rule. The directory
 #   is typically used by SRM for uploading files.
 #
+#   If the property is defined to a relative path, it is interpreted relative to
+#   the account's root directory.
+#
 xrootd.authz.upload-directory=${dcache.upload-directory}
 
 


### PR DESCRIPTION
This patch adds user relative upload directories. If dcache.user-directory
is defined to a relative path, it is now interpreted relative to the
account's root directory. This works around the problem that there may
not be a common directory accessible through all accounts. Rather than
adding extra FTP doors, this patch allows extra upload directories to
be created.

The downside is that the upload directories may clash with other items
in the users directory. Also, the user could bypass the access limitations
(if he got write permission to the parent of the upload directory).
Finally, the sysadmin has several directories to check for orphaned
temporary upload directories.

All doors and pnfsmanager needs to be updated for the change to be effective.
If the feature is not used, then there is no limitation on upgrades.

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7328/
(cherry picked from commit 2976ef12952b86800f91bc8740577eff385997ee)
