### PR TITLE
billing: Add billing format for PoolHitInfoMessage

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolHitInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolHitInfoMessage.java
@@ -1,6 +1,8 @@
 // $Id: PoolHitInfoMessage.java,v 1.3 2006-04-06 23:26:47 podstvkv Exp $
 package diskCacheV111.vehicles ;
 
+import org.stringtemplate.v4.ST;
+
 import diskCacheV111.util.PnfsId;
 
 public class PoolHitInfoMessage extends PnfsFileInfoMessage {
@@ -42,5 +44,13 @@ public class PoolHitInfoMessage extends PnfsFileInfoMessage {
 			_fileCached+" {"+
 			_protocolInfo+"} "+
 			getResult() ;
+    }
+
+    @Override
+    public void fillTemplate(ST template)
+    {
+        super.fillTemplate(template);
+        template.add("protocol", _protocolInfo);
+        template.add("cached", _fileCached);
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/text/BillingParserBuilder.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/text/BillingParserBuilder.java
@@ -218,6 +218,7 @@ public class BillingParserBuilder
                 case "gid":
                     regex.append("-?\\d+");
                     break;
+                case "cached":
                 case "created":
                     regex.append("(true|false)");
                     break;

--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -145,6 +145,14 @@ billing.text.dir=${billingLogsDir}
 #   No additional attributes.
 #
 #
+# Message: PoolHitInfoMessage
+#
+#   Attribute       Type         Description
+#   ---------       ----         -----------
+#   protocol        ProtocolInfo Protocol related information
+#   cached          Boolean      Whether file was already online
+#
+#
 # Type: Date
 # ----------
 #
@@ -164,7 +172,7 @@ billing.text.dir=${billingLogsDir}
 #   protocol       String            Protocol name (as used in pool manager)
 #   minorVersion   Integer           Minor version of protocol
 #   majorVersion   Integer           Major version of protocol
-#   socketAddresss InetSocketAddress IP address and port of client
+#   socketAddress  InetSocketAddress IP address and port of client
 #
 # Type: StorageInfo
 # -----------------
@@ -236,6 +244,12 @@ billing.text.format.door-request-info-message=${billing.format.DoorRequestInfoMe
 #
 (deprecated)billing.format.StorageInfoMessage=$date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transferTime$ $queuingTime$ {$rc$:"$message$"}
 billing.text.format.storage-info-message=${billing.format.StorageInfoMessage}
+
+#  ---- PoolHitInfoMessage
+#
+#    Submitted by pool manager on pool selection
+#
+billing.text.format.pool-hit-info-message = $date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $cached$ {$protocol$} {$rc$:"$message$"}
 
 #  -----------------------------------------------------------------------
 #     Store billing data in database


### PR DESCRIPTION
Otherwise the Indexer is unable to parse these billing entries and then
appear as empty records in the json and yaml output.

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7355/
(cherry picked from commit bdd5989455aad094bece9f38e98d13cea3db0172)
