### PR TITLE
billing: Improve error message on failur to parse date arguments

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/text/Indexer.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/text/Indexer.java
@@ -154,8 +154,16 @@ public class Indexer
                     SORTED_FILE_TREE_TRAVERSER
                             .preOrderTraversal(dir);
             if (args.hasOption("since") || args.hasOption("until")) {
-                Date since = args.hasOption("since") ? LOCALE_DATE_FORMAT.get().parse(args.getOption("since")) : new Date(0);
-                Date until = args.hasOption("until") ? LOCALE_DATE_FORMAT.get().parse(args.getOption("until")) : new Date();
+                Date since;
+                Date until;
+                try {
+                    since = args.hasOption("since") ? LOCALE_DATE_FORMAT.get().parse(args.getOption("since")) : new Date(0);
+                    until = args.hasOption("until") ? LOCALE_DATE_FORMAT.get().parse(args.getOption("until")) : new Date();
+                } catch (ParseException e) {
+                    throw new ParseException(e.getMessage() + ". Expected format is " +
+                                                     ((SimpleDateFormat) LOCALE_DATE_FORMAT.get()).toLocalizedPattern() + '.',
+                                             e.getErrorOffset());
+                }
                 filesWithPossibleMatch =
                         filesWithPossibleMatch.filter(inRange(since, until));
             }
@@ -702,10 +710,14 @@ public class Indexer
 
         try {
             new Indexer(new Args(arguments));
-        } catch (IllegalArgumentException | ParseException e) {
+        } catch (IllegalArgumentException e) {
             System.err.println(e.getMessage());
             System.err.println();
             help(System.err);
+            System.exit(1);
+        } catch (ParseException e) {
+            System.err.println(e.getMessage());
+            System.err.println();
             System.exit(1);
         } catch (IOException | URISyntaxException | ClassNotFoundException e) {
             System.err.println(e);


### PR DESCRIPTION
Target: trunk
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Karsten Schwank karsten.schwank@desy.de
Patch: https://rb.dcache.org/r/7359/
(cherry picked from commit ea8b501786bff2c6bbaf026d0603e54d1923875a)
