### PR TITLE
billing: Add file size to request records

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -2157,6 +2157,8 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                                                 _readPoolSelectionContext,
                                                 allowedStates);
                getPoolMessage.setIoQueueName(_ioQueueName );
+
+                _info.setFileSize(_fileAttributes.getSize());
             }
 
             if( _verbose ) {
@@ -2382,6 +2384,9 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                                 break ;
                             }
                         }
+                    }
+                    if (_ioMode.contains("w")) {
+                        _info.setFileSize(filesize);
                     }
                     sendReply( "doorTransferArrived" , 0 , "" ) ;
                 }else{

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -975,6 +975,9 @@ public class Transfer implements Comparable<Transfer>
             msg.setTransaction(getTransaction());
             msg.setClient(_clientAddress.getAddress().getHostAddress());
             msg.setPnfsId(getPnfsId());
+            if (_fileAttributes.isDefined(SIZE)) {
+                msg.setFileSize(_fileAttributes.getSize());
+            }
             msg.setResult(code, error);
             if (_fileAttributes.isDefined(STORAGEINFO)) {
                 msg.setStorageInfo(_fileAttributes.getStorageInfo());


### PR DESCRIPTION
Request records submitted by doors lack the file size (they always
appeared as 0 in billing records). This patch adds the file size for
all protocols except for NFS.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7360/
(cherry picked from commit ef3d069dd73275189543be30160ed29484e7c2ec)
