### PR TITLE
nfs4:  shutdown state handler on destroy

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -302,6 +302,9 @@ public class NFSv41Door extends AbstractCellComponent implements
     public void destroy() throws IOException {
         _loginBrokerHandler.stop();
         _rpcService.stop();
+        if (_nfs4 != null) {
+            _nfs4.getStateHandler().shutdown();
+        }
         if(_proxyIoFactory != null) {
             _proxyIoFactory.cleanUp();
         }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -85,6 +85,7 @@ public class NfsTransferService extends AbstractCellComponent
 
     public void shutdown() throws IOException {
         _nfsIO.shutdown();
+        _nfsIO.getNFSServer().getStateHandler().shutdown();
     }
 
     @Override


### PR DESCRIPTION
for graceful dcache shutdown

Target: master, 2.10
Acked-By: Paul Millar
Require-book: no
Require-notes: no
(cherry picked from commit 55eb29f3f3038325f60e187d34c20546580f6c03)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
