### PR TITLE
chimera: query for inode generation on readdir

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/DirectoryStreamImpl.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/DirectoryStreamImpl.java
@@ -102,10 +102,12 @@ public class DirectoryStreamImpl implements DirectoryStreamB<HimeraDirectoryEntr
             stat.setGid(_listResultSet.getInt("igid"));
             stat.setMode(_listResultSet.getInt("imode") | _listResultSet.getInt("itype"));
             stat.setNlink(_listResultSet.getInt("inlink"));
+            stat.setGeneration(_listResultSet.getInt("igeneration"));
             FsInode inode = new FsInode(_parent.getFs(), _listResultSet.getString("ipnfsid"));
             inode.setParent(_parent);
             stat.setIno((int) inode.id());
             stat.setDev(17);
+            stat.setRdev(13);
 
             inode.setStatCache(stat);
             _hasPendingElement = false;

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -233,7 +233,7 @@ class FsSqlDriver {
         return list;
     }
     private static final String sqlListDirFull = "SELECT "
-            + "t_inodes.ipnfsid, t_dirs.iname, t_inodes.isize,t_inodes.inlink,t_inodes.imode,t_inodes.itype,t_inodes.iuid,t_inodes.igid,t_inodes.iatime,t_inodes.ictime,t_inodes.imtime  "
+            + "t_inodes.ipnfsid, t_dirs.iname, t_inodes.isize,t_inodes.inlink,t_inodes.imode,t_inodes.itype,t_inodes.iuid,t_inodes.igid,t_inodes.iatime,t_inodes.ictime,t_inodes.imtime,t_inodes.igeneration  "
             + "FROM t_inodes, t_dirs WHERE iparent=? AND t_inodes.ipnfsid = t_dirs.ipnfsid";
 
     /**
@@ -389,6 +389,7 @@ class FsSqlDriver {
                 ret.setNlink(statResult.getInt("inlink"));
                 ret.setIno((int) inode.id());
                 ret.setDev(17);
+                ret.setRdev(13);
             }
 
         } finally {

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -1030,6 +1030,22 @@ public class BasicTest extends ChimeraTestCaseHelper {
         _rootInode.inodeOf(".(parent)(" + id + ")");
     }
 
+    @Test
+    public void testGenerationOnReaddir() throws Exception {
+        FsInode inode = _rootInode.mkdir("junit");
+        inode.setUID(1); // to bump generation
+        try (DirectoryStreamB<HimeraDirectoryEntry> dirStream = _fs.newDirectoryStream(_rootInode)) {
+
+            for (HimeraDirectoryEntry entry : dirStream) {
+                if (entry.getName().equals("junit") && entry.getStat().getGeneration() == 1) {
+                    return;
+                }
+            }
+
+            fail();
+        }
+    }
+
     private void assertHasChecksum(Checksum expectedChecksum, FsInode inode) throws Exception {
         for(Checksum checksum: _fs.getInodeChecksums(inode)) {
             if (checksum.equals(expectedChecksum)) {


### PR DESCRIPTION
keep nfs client cache more consistent.
add missing rdev field.

Acked-by: Paul Millar
Target: master, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 86f6f6b8da0e0350408301f32bd8746c8e52656b)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
