### PR TITLE
admin: Propopage NPE to user

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -1391,7 +1391,8 @@ public class UserAdminShell
            Throwables.propagateIfInstanceOf(cause, NoRouteToCellException.class);
            Throwables.propagateIfInstanceOf(cause, CacheException.class);
            Throwables.propagateIfInstanceOf(cause, CommandException.class);
-           throw new CacheException(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, cause.getMessage(), cause);
+           Throwables.propagateIfPossible(cause);
+           throw new CacheException(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, cause.toString(), cause);
        }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
@@ -232,7 +232,7 @@ public class ConsoleReaderCommand implements Command, Runnable {
                         " located this message in log file and send an email" +
                         " to support@dcache.org with this line and the" +
                         " following stack-trace", str);
-                _logger.warn((String)result, e);
+                _logger.error((String)result, e);
             } catch (Exception e) {
                 result = e.getMessage();
                 if(result == null) {


### PR DESCRIPTION
I ran into a bug in migration module that caused an NPE to be thrown. Unfortunately
the admin shell return no message at all. This was because the exception was wrapped
in a CacheException with an empty message string.

This patch addresses this problem at several levels: Unexpected exceptions are
now wrapped with message being Throwable#toString (given that we don't know which
except is being wrapped it is reasonable to include the exception type in the error
message), RuntimeExceptions and Errors are propagated unwrapped, and the log output
in admin is increased from warning to error.

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7361/
(cherry picked from commit 201685dd5f91ab924a0e632e6ebc8ea77ab200b6)
