### PR TITLE
pool: Fix pool selection bugs in migration module

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/PoolSelectionStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/PoolSelectionStrategy.java
@@ -1,5 +1,7 @@
 package org.dcache.pool.migration;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 import diskCacheV111.vehicles.PoolManagerPoolInformation;
@@ -9,5 +11,6 @@ import diskCacheV111.vehicles.PoolManagerPoolInformation;
  */
 public interface PoolSelectionStrategy
 {
+    @Nullable
     PoolManagerPoolInformation select(List<PoolManagerPoolInformation> pools);
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
@@ -207,10 +207,14 @@ public class Task
     {
         List<PoolManagerPoolInformation> pools =
             _definition.poolList.getPools();
-        if (pools.isEmpty()) {
-            throw new NoSuchElementException("No pools available");
+        PoolManagerPoolInformation pool = _definition.selectionStrategy.select(pools);
+        if (pool == null) {
+            if (pools.isEmpty()) {
+                throw new NoSuchElementException("No pools available.");
+            }
+            throw new NoSuchElementException("All target pools are full.");
         }
-        return new CellPath(_definition.selectionStrategy.select(pools).getName());
+        return new CellPath(pool.getName());
     }
 
 


### PR DESCRIPTION
There were two bugs in migration module:
- Random pool selection would select pools even when they are full.
- Proportional pool selection would trigger a NPE as it would return
  null when all pools are full.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7362/
(cherry picked from commit 55de0de55cc6940f6204dee68e29ec24a13c75d3)

Conflicts:
    modules/dcache/src/main/java/org/dcache/pool/migration/Task.java

(cherry picked from commit d85629dfba3027144ae0664d84120e2d0ce4bd92)
