### PR TITLE
pool: Make migration task cancellation more robust

### DIFF
--- a/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
+++ b/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
@@ -474,8 +474,8 @@ Entry
 Cancelling
 Entry
 {
-        cancelCopy();
         startTimer(ctxt.getTaskDeadTimeout());
+        cancelCopy();
 }
 Exit
 {


### PR DESCRIPTION
A recent bug as a side effect caused task cancellation to fail
because cancelCopy threw an NPE. As a result the task got stuck
in this state. This patch moves the timeout initiation to be the
first action when entering the Cancelling state. That way the task
would eventually have timed out.

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi arossi@fnal.gov
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7364/
(cherry picked from commit 336ce076164187b5acc41afa255ba03956f81885)
