### PR TITLE
(2.6) webadmin: fix exit login in billing refresh loop

### DIFF
--- a/modules/webadmin/src/main/java/org/dcache/webadmin/controller/IBillingService.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/controller/IBillingService.java
@@ -61,6 +61,10 @@ package org.dcache.webadmin.controller;
 
 import java.io.File;
 
+import javax.naming.ServiceUnavailableException;
+
+import dmg.cells.nucleus.NoRouteToCellException;
+
 /**
  * Provides plot images to billing page.
  *
@@ -83,5 +87,5 @@ public interface IBillingService {
 
     void initialize();
 
-    void refresh();
+    void refresh() throws NoRouteToCellException, ServiceUnavailableException;
 }


### PR DESCRIPTION
Currently the thread which refreshes the billing plots
will exit if it encounters an unspecified error from
the billing service. But this behavior does not
take into account slow start-up of domains (i.e.,
the billing service may not be there yet but will
be eventually).

The patch fixes the logic to treat NoRouteToCell
exceptions differently by waiting for a short time
and retrying.

Testing done: On deployed service without billing,
and then with billing booted.

Target: 2.6
Patch: https://rb.dcache.org/r/7306
Acked-by: Gerd
Committed: b315fc0e4c5fdde59d926dea43706079b4957b8f
Require-note: yes
Require-book: no

RELEASE NOTES:
Fixes a bug where a simple timeout (NoRouteToCell) causes an
exit from the billing service refresh loop requiring a restart
of the domain in order to reconnect.
