### PR TITLE
pool: Fix ISE in 'rep ls'

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -18,6 +18,8 @@ import dmg.util.Args;
 import dmg.util.Formats;
 
 import org.dcache.cells.CellCommandListener;
+import org.dcache.namespace.FileAttribute;
+import org.dcache.vehicles.FileAttributes;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -173,10 +175,11 @@ public class RepositoryInterpreter
                         for (PnfsId id: _repository) {
                             try {
                                 CacheEntry entry = _repository.getEntry(id);
-                                StorageInfo info = entry.getFileAttributes().getStorageInfo();
-                                if (info == null) {
+                                FileAttributes fileAttributes = entry.getFileAttributes();
+                                if (!fileAttributes.isDefined(FileAttribute.STORAGEINFO)) {
                                     continue;
                                 }
+                                StorageInfo info = fileAttributes.getStorageInfo();
                                 String sc = info.getStorageClass()
                                     + "@" + info.getHsm();
 


### PR DESCRIPTION
Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7369/
(cherry picked from commit f743599fc7cc72d7a3b88fda030d088df2096bd0)

Conflicts:
    modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java

(cherry picked from commit d99e691b8da3b4ce5db24fc3a454b479bb2bf02d)

Conflicts:
    modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
