### PR TITLE
pool: Fix ISE in CacheEntryImpl#toString

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheEntryImpl.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.StorageInfo;
 
+import org.dcache.namespace.FileAttribute;
 import org.dcache.pool.repository.CacheEntry;
 import org.dcache.pool.repository.EntryState;
 import org.dcache.pool.repository.MetaDataRecord;
@@ -136,10 +137,11 @@ public class CacheEntryImpl implements CacheEntry
         sb.append("L(0)[").append(_linkCount).append("]");
         sb.append("> ");
 
-        StorageInfo info = _fileAttributes.getStorageInfo();
         sb.append(_size);
         sb.append(" si={")
-            .append(info == null ? "<unknown>" : info.getStorageClass())
+            .append(_fileAttributes.isDefined(FileAttribute.STORAGEINFO)
+                            ? _fileAttributes.getStorageInfo().getStorageClass()
+                            : "<unknown>")
             .append("}");
         return sb.toString();
     }


### PR DESCRIPTION
Fixes

18 Sep 2014 12:57:38 (pdc_kth_se_034) [admin] Uncaught exception in thread sweeper-free
java.lang.IllegalStateException: Attribute is not defined: STORAGEINFO
        at org.dcache.vehicles.FileAttributes.guard(FileAttributes.java:150) ~[dcache-core-2.8.4.jar:2.8.4]
        at org.dcache.vehicles.FileAttributes.getStorageInfo(FileAttributes.java:296) ~[dcache-core-2.8.4.jar:2.8.4]
        at org.dcache.pool.repository.v5.CacheEntryImpl.toString(CacheEntryImpl.java:139) ~[dcache-core-2.8.4.jar:2.8.4]
        at java.lang.String.valueOf(String.java:2854) ~[na:1.7.0_51]
        at java.lang.StringBuilder.append(StringBuilder.java:128) ~[na:1.7.0_51]
        at org.dcache.pool.classic.SpaceSweeper2.reclaim(SpaceSweeper2.java:335) ~[dcache-core-2.8.4.jar:2.8.4]
        at org.dcache.pool.classic.SpaceSweeper2.access$000(SpaceSweeper2.java:39) ~[dcache-core-2.8.4.jar:2.8.4]
        at org.dcache.pool.classic.SpaceSweeper2$1.run(SpaceSweeper2.java:209) ~[dcache-core-2.8.4.jar:2.8.4]
Waiting for data... (interrupt to abort)

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7368/
(cherry picked from commit c91e19508b7c32999c8ffc90ada0f1235ccf2dfc)

Conflicts:
    modules/dcache/src/main/java/org/dcache/vehicles/FileAttributes.java

(cherry picked from commit 841db65d86618b62a1d7172741c11069a7280fdb)
