### PR TITLE
pool: Fix race leading to false positices in pool size health checks

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -965,8 +965,14 @@ public class CacheRepositoryV5
             PnfsId id = entry.getPnfsId();
             if (entry.getLinkCount() == 0 && state == EntryState.REMOVED) {
                 setState(entry, DESTROYED);
-                _account.free(entry.getSize());
                 _store.remove(id);
+
+                /* It is essential to free after we removed the file: This is the opposite
+                 * of what happens during allocation, in which we allocate before writing
+                 * to disk. We rely on never having anything on disk that we haven't accounted
+                 * for in the Account object.
+                 */
+                _account.free(entry.getSize());
             }
         }
     }


### PR DESCRIPTION
The pool would register free space before actually deleting the file
from the file system. Thus for a brief moment, the pool would appear
to have more free space that is available on disk.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7367/
(cherry picked from commit dbd6b7043bca392f4ef5487b5889dadd828fec31)
