### PR TITLE
spacemanager: Suppress transient deadlock resolution errors

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.RecoverableDataAccessException;
 import org.springframework.dao.TransientDataAccessException;
@@ -444,21 +445,24 @@ public final class SpaceManagerService
         {
             try {
                 boolean isSuccessful = false;
-                for (int attempts = 0; !isSuccessful; attempts++) {
+                int attempts = 0;
+                while (!isSuccessful) {
                     try {
                         if (message instanceof PoolRemoveFilesMessage) {
                             // fileRemoved does its own transaction management
                             fileRemoved((PoolRemoveFilesMessage) message);
-                        }
-                        else {
+                        } else {
                             processMessageTransactionally(message);
                         }
                         isSuccessful = true;
+                    } catch (DeadlockLoserDataAccessException e) {
+                        LOGGER.debug("Transaction lost deadlock race and will be retried: {}", e.toString());
                     } catch (TransientDataAccessException | RecoverableDataAccessException e) {
                         if (attempts >= 3) {
                             throw e;
                         }
                         LOGGER.warn("Retriable data access error: {}", e.toString());
+                        attempts++;
                     }
                 }
             } catch (SpaceAuthorizationException e) {


### PR DESCRIPTION
When having non-trivial concurrent transactions, it is not unusual that
these transactions may conflict and cause deadlocks. An RDBMS will detect
such deadlocks and role back one or more of the involved transactions
to allow the rest to complete. An application is supposed to retry such
a failed transaction.

Space manager does catch and retry such transient failures. At the time
I didn't know which transient failures to expect, so I limited it to three
retries and added log output on each. After we have run the new space
manager in production, I see that DeadlockLoserDataAccessException happens
during load. This exception is absolutely expected from the RDBMS and
indiciates that the present transaction lost in conflicting updates and
has to be retried. The RDBMS should ensure that there is progress (ie
no livelock in which all transactions always fail and are retried), so
it is safe to retry such a failed transaction until it succeeds.

Therefore this patch removes the retry limit for this failure and also
lowers the log output to debug.

I will as a separate activity investigate whether some of the observed
deadlocks are avoidable (using normal deadlock prevention techniques)
and thus improve throughput.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Require-notes: yes
Require-book: no
Acked-by: Karsten Schwank karsten.schwank@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7371/
(cherry picked from commit 31dfdba81ebb393faf884915e3b7437f4fa7771e)
