### PR TITLE
pool: Fix pool size health check in case of asynchronous release of space

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/Account.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/Account.java
@@ -17,6 +17,7 @@ public class Account
     private long _precious;
     private long _removable;
     private long _requested;
+    private long _timeOfLastFree;
 
     public synchronized long getTotal()
     {
@@ -48,6 +49,11 @@ public class Account
         return _requested;
     }
 
+    public synchronized long getTimeOfLastFree()
+    {
+        return _timeOfLastFree;
+    }
+
     public synchronized void setTotal(long total)
     {
         if (total < _used) {
@@ -71,6 +77,7 @@ public class Account
 
         notifyAll();
         _used -= space;
+        _timeOfLastFree = System.currentTimeMillis();
     }
 
     /**


### PR DESCRIPTION
We have observed that operating sometimes don't report freed space
right away when deleting files. This was observed on Linux (using ext4
and Mac OS X), but the behaviour can likely be observed on many other
systems.

The pool periodically checks the free space on the pool partition and
compares it with its own internal account of free space. If the partition
does not have enough free space, the pool size is reduced accordingly.

If the operating system does not report free space right after a file
has been deleted, it may happen that the pool's internal account object
has registered free space that isn't yet reported as free by the operating
system. In that case, the periodic health check may falsely reduce the
pool size.

The patch fixes this by introducing a 60 second grace period after
the pool deletes a file. During this period, the pool size health
check is suppressed.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7366/
(cherry picked from commit b7211458b3af38206594a36a72eb87b09ffeeaee)

Conflicts:
    modules/dcache/src/main/java/org/dcache/pool/repository/v5/CheckHealthTask.java
