### PR TITLE
poolmanager: Shut down request container thread pool during shutdown

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
@@ -69,7 +69,8 @@
       <property name="destination" value="${poolmanager.service.broadcast}"/>
   </bean>
 
-  <bean id="rc-pool" class="org.dcache.util.CDCExecutorServiceDecorator">
+  <bean id="rc-pool" class="org.dcache.util.CDCExecutorServiceDecorator"
+          destroy-method="shutdownNow">
       <constructor-arg>
           <bean class="diskCacheV111.poolManager.RequestContainerExecutor"/>
       </constructor-arg>


### PR DESCRIPTION
Target: trunk
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7376/
(cherry picked from commit e9595f5da4a0adec702222c5404a5b29a97ac2a0)
