### PR TITLE
pom: update to nfs4j-0.7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -795,7 +795,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
Changelog for nfs4j-0.7.6..nfs4j-0.7.7
    \* [94db02f] calculate index in the FsExport constructor

Target: 2.8, 2.7, 2.6
Require-book: no
Require-notes: no
