### PR TITLE
nfs: mark unused nfs.db.host property as forbidden

### DIFF
--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -120,7 +120,7 @@ nfs.service.billing=${dcache.service.billing}
 #
 # Database related settings
 #
-nfs.db.host=${chimera.db.host}
+(forbidden)nfs.db.host= Use nfs.db.url
 nfs.db.name=${chimera.db.name}
 nfs.db.user=${chimera.db.user}
 nfs.db.password=${chimera.db.password}


### PR DESCRIPTION
The nfs.db.host property exists in the nfs.properties files
but it is not used anywhere.
It was probably introduced during the merge of nfs3 and nfs41.

To avoid confusion about the usage of this property this patch
marks it as forbidden and refers the user to nfs.db.url instead.

Ticket: http://rt.dcache.org/Ticket/Display.html?id=8465
Acked-by:
Target: master
Request: 2.10
Require-book: no
Require-notes: no
