### PR TITLE
loginmanager: Associate ScheduledExecutor with the cell's thread group

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -186,7 +186,7 @@ public class LoginManager
                     .build();
             _version = new CellVersion(Version.of(_loginCellFactory));
 
-            _scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+            _scheduledExecutor = Executors.newSingleThreadScheduledExecutor(_nucleus);
 
             String loginBroker = _args.getOpt("loginBroker");
             if (loginBroker != null) {


### PR DESCRIPTION
Would lead to log messages to be associated with the wrong cell. Also
caused issues during shutdown.

Target: trunk
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7382/
(cherry picked from commit d6754d5112c1a2324e66c3ee8965466881ced8fe)
