### PR TITLE
srm: Mark srm.enable.space-reservation.implicit forbidden

### DIFF
--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -1258,8 +1258,8 @@ srm.authn.ciphers=${srm.security.ciphers}
 #
 (obsolete)srmIgnoreClientProtocolOrder = Use srm.protocols.preferred instead (set to gsiftp,gsidcap to achieve the same effect)
 (obsolete)srm.db.driver=The property is not needed with JDBC 4 drivers
-(obsolete)srmImplicitSpaceManagerEnabled = Configure space manager to allow unreserved uploads instead
-(obsolete)srm.enable.space-reservation.implicit = Configure space manager to allow unreserved uploads instead
+(forbidden)srmImplicitSpaceManagerEnabled = Configure space manager to allow unreserved uploads instead
+(forbidden)srm.enable.space-reservation.implicit = Configure space manager to allow unreserved uploads instead
 (obsolete)srmSpaceReservationStrict = No longer needed
 (obsolete)srm.enable.space-reservation.strict = No longer needed
 


### PR DESCRIPTION
When upgrading, sites that used to enable implicit space reservation in SRM
must enable the equivalent option in space manager. To force this change, this
patch marks the old properties as forbidden.

Target: 2.10
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7402/
(cherry picked from commit ec26c94df25ff352763b34a816dddb5750677b4b)
