### PR TITLE
pnfsmanager: Check file type before overwrite

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -1120,7 +1120,8 @@ public class ChimeraNameSpaceProvider
              */
             try {
                 ExtendedInode inodeOfPath = parentOfPath.inodeOf(path.getName());
-                if (!options.contains(CreateOption.OVERWRITE_EXISTING)) {
+                if (!options.contains(CreateOption.OVERWRITE_EXISTING) ||
+                        (inodeOfPath.statCache().getMode() & UnixPermission.S_TYPE) != UnixPermission.S_IFREG) {
                     throw new FileExistsCacheException("File exists: " + path);
                 }
                 /* User must be authorized to delete existing file.


### PR DESCRIPTION
When preparing a file for upload for the SRM, pnfsmanager fails to check the
file type of any existing file with the same path. The upload eventually fails
during srmPutDone because Chimera refuses to move the file, but this failure
ought to happen during srmPrepareToPut. This patch resolves this problem.

Target: trunk
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7407/
(cherry picked from commit 84c8587315c1f80012e422955403bfd9374c1b7f)
