### PR TITLE
poolmanager: Warn when spacecostfactor is too big

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/WeightedAvailableSpaceSelection.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/WeightedAvailableSpaceSelection.java
@@ -279,7 +279,7 @@ public class WeightedAvailableSpaceSelection implements Serializable
         }
 
         if (sum == Double.POSITIVE_INFINITY) {
-            throw new IllegalStateException("WASS overflow: Space cost factor is too large.");
+            throw new IllegalStateException("WASS overflow: Configured space cost factor (" + spaceCostFactor + ") is too large.");
         }
 
         throw new RuntimeException("Unreachable statement.");


### PR DESCRIPTION
When space cost factor is large, wass may run into a problem caused by
the limited precision of floating point arithmetic. When that happens
the code reaches a statement that was thought to be unreachable.

This patch adds a check that detects the situation and generates
a more suitable error message.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Karsten Schwank karsten.schwank@desy.de
Patch: https://rb.dcache.org/r/7399/
(cherry picked from commit b9b1ecd8ad31662da627d48aaafca367af164032)
