### PR TITLE
When space cost factor is large, wass may run into a problem caused by the limited precision of floating point arithmetic. When that happens the code reaches a statement that was thought to be unreachable.

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/WassPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/WassPartition.java
@@ -307,6 +307,10 @@ public class WassPartition extends ClassicPartition
             }
         }
 
+        if (sum == Double.POSITIVE_INFINITY) {
+            throw new IllegalStateException("WASS overflow: Configured space cost factor (" + _spaceCostFactor + ") is too large.");
+        }
+
         throw new RuntimeException("Unreachable statement");
     }
 


### PR DESCRIPTION
This patch adds a check that detects the situation and generates
a more suitable error message.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Karsten Schwank karsten.schwank@desy.de
Patch: https://rb.dcache.org/r/7399
