### PR TITLE
chimera: Add messages to JdbcFs#move exceptions

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -1755,13 +1755,13 @@ public class JdbcFs implements FileSystemProvider {
 
             Stat destStat = _sqlDriver.stat(dbConnection, destDir);
             if ((destStat.getMode() & UnixPermission.S_IFDIR) == 0) {
-                throw new NotDirChimeraException();
+                throw new NotDirChimeraException(destDir);
             }
 
             FsInode destInode = _sqlDriver.inodeOf(dbConnection, destDir, dest);
             FsInode srcInode = _sqlDriver.inodeOf(dbConnection, srcDir, source);
             if (srcInode == null) {
-                throw new FileNotFoundHimeraFsException();
+                throw new FileNotFoundHimeraFsException(source);
             }
 
             if (destInode != null) {
@@ -1777,7 +1777,7 @@ public class JdbcFs implements FileSystemProvider {
                 * renaming only into existing same type is allowed
                 */
                 if ((statSrc.getMode() & UnixPermission.S_TYPE) != (statDest.getMode() & UnixPermission.S_TYPE)) {
-                    throw new FileExistsChimeraFsException();
+                    throw new FileExistsChimeraFsException(dest);
                 }
 
                 _sqlDriver.remove(dbConnection, destDir, dest);


### PR DESCRIPTION
Otherwise the exceptions will have a null message, which in other
places may lead to rather meaningless error messages being logged.

Target: trunk
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7403/
(cherry picked from commit 65d750447f276b0a45c163edd406e244c41fd49c)

Conflicts:
    modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
