### PR TITLE
srm-client: Report file level errors

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/Report.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/Report.java
@@ -11,6 +11,7 @@ import org.globus.util.GlobusURL;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.PrintStream;
 
 /**
  *
@@ -160,15 +161,27 @@ public class Report {
     }
 
     public void dumpReport() {
-        if(reportFile != null) {
-            try {
-                FileWriter fw = new FileWriter(reportFile);
+        if (reportFile != null) {
+            try (FileWriter fw = new FileWriter(reportFile)) {
                 fw.write(toString());
-                fw.close();
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
+        }
+    }
+
+    public void reportErrors(PrintStream out) {
+        for (int i = 0; i < length; ++i) {
+            if (rc [i] != 0) {
+                out.append(from[i].getURL());
+                if (to[i] != from[i]) {
+                    out.append(" -> ");
+                    out.append(to[i].getURL());
+                }
+                out.append(": ");
+                out.append(error[i].replace('\n', ' '));
+            }
+            out.println();
         }
     }
 

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMBringOnlineClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMBringOnlineClientV2.java
@@ -382,8 +382,8 @@ public class SRMBringOnlineClientV2 extends SRMClient implements Runnable {
             say(e.toString());
         } finally {
             report.dumpReport();
-            if(!report.everythingAllRight()){
-                System.err.println("srm bring online of at least one file failed or not completed");
+            if (!report.everythingAllRight()){
+                report.reportErrors(System.err);
                 System.exit(1);
             }
 

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV1.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV1.java
@@ -276,7 +276,7 @@ public class SRMCopyClientV1 extends SRMClient implements Runnable {
         finally {
             report.dumpReport();
             if(!report.everythingAllRight()){
-                System.err.println("srm copy of at least one file failed or not completed");
+                report.reportErrors(System.err);
                 System.exit(1);
             }
         }

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
@@ -428,7 +428,7 @@ public class SRMCopyClientV2 extends SRMClient implements Runnable {
         } finally {
             report.dumpReport();
             if(!report.everythingAllRight()){
-                System.err.println("srm copy of at least one file failed or not completed");
+                report.reportErrors(System.err);
             }
         }
     }

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV1.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV1.java
@@ -271,7 +271,7 @@ public class SRMGetClientV1 extends SRMClient implements Runnable {
             }
             report.dumpReport();
             if(!report.everythingAllRight()){
-                System.err.println("srm copy of at least one file failed or not completed");
+                report.reportErrors(System.err);
                 System.exit(1);
             }
         }

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV2.java
@@ -417,7 +417,7 @@ public class SRMGetClientV2 extends SRMClient implements Runnable {
             }
             report.dumpReport();
             if(!report.everythingAllRight()){
-                System.err.println("srm copy of at least one file failed or not completed");
+                report.reportErrors(System.err);
             }
         }
     }

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMPutClientV1.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMPutClientV1.java
@@ -299,7 +299,7 @@ public class SRMPutClientV1 extends SRMClient implements Runnable {
             }
             report.dumpReport();
             if(!report.everythingAllRight()){
-                System.err.println("srm copy of at least one file failed or not completed");
+                report.reportErrors(System.err);
                 System.exit(1);
             }
         }

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMSimpleCopyClient.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMSimpleCopyClient.java
@@ -109,7 +109,7 @@ public class SRMSimpleCopyClient extends SRMClient {
         copier.waitCompletion();
         report.dumpReport();
         if(!report.everythingAllRight()){
-            System.err.println("srm copy of at least one file failed or not completed");
+            report.reportErrors(System.err);
             System.exit(1);
         }
     }

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMStageClientV1.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMStageClientV1.java
@@ -223,7 +223,7 @@ public class SRMStageClientV1 extends SRMClient implements Runnable {
             report.dumpReport();
             if(!report.everythingAllRight()){
                 //This means that some failure occurred while staging file onto dCache
-                System.err.println("srm stage of at least one file failed or not completed");
+                report.reportErrors(System.err);
                 System.exit(1);
             }
         }


### PR DESCRIPTION
Our srm client in many places simply reports a generic error message
rather than the file level message. This patch resolves this by
reporting an error for each failed file.

Target: trunk
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7406/
(cherry picked from commit 042531c1fbd45666c41225a4d4e9a082d8f7a455)
