### PR TITLE
webdav,srm: Do not manage life cycle of Jetty thread pool

### DIFF
--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -602,8 +602,8 @@
     <property name="srm" ref="srm"/>
   </bean>
 
-  <bean id="thread-pool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"
-        init-method="start" destroy-method="stop">
+  <bean id="thread-pool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+      <!-- Note that Jetty manages the lifecycle of this thread pool -->
       <description>Thread pool used by Jetty for request processing</description>
 
       <constructor-arg value="${srm.limits.jetty.threads.max}"/>

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -272,8 +272,8 @@
         <constructor-arg value="${webdav.authn.ciphers}"/>
     </bean>
 
-    <bean id="thread-pool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"
-          init-method="start" destroy-method="stop">
+    <bean id="thread-pool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+        <!-- Note that Jetty manages the lifecycle of this thread pool -->
         <description>Thread pool used by Jetty for request processing</description>
 
         <constructor-arg value="${webdav.limits.threads.max}"/>


### PR DESCRIPTION
Jetty does that itself.

Target: trunk
Request: 2.11
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7422/
(cherry picked from commit c57a0ae9d3e90ec6c9e790c8450c0bc5c551c88e)
