### PR TITLE
pnfsmanager: Controlled shutdown of processing threads

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellMessage.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellMessage.java
@@ -130,7 +130,7 @@ public boolean equals( Object obj ){
     }
   }
 
-    private CellMessage()
+    public CellMessage()
     {
         _mode = DUMMY_MODE;
         _messageStream = null;

--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -19,7 +19,7 @@
     </bean>
 
   <bean id="pnfs-manager" class="diskCacheV111.namespace.PnfsManagerV3"
-        init-method="init">
+        init-method="init" destroy-method="shutdown">
       <description>Request processor</description>
       <property name="threads" value="${pnfsmanager.limits.threads-per-group}"/>
       <property name="threadGroups" value="${pnfsmanager.limits.thread-groups}"/>

--- a/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/PnfsManagerTest.java
+++ b/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/PnfsManagerTest.java
@@ -132,7 +132,6 @@ public class PnfsManagerTest
 
         _fs.setTag(baseInode, "sGroup",sGroupTagData, 0, sGroupTagData.length);
         _fs.setTag(baseInode, "OSMTemplate",osmTemplateTagData, 0, osmTemplateTagData.length);
-
     }
 
     @Test
@@ -543,6 +542,7 @@ public class PnfsManagerTest
     @After
     public void tearDown() throws Exception
     {
+        _pnfsManager.shutdown();
         _fs.close();
         _conn.createStatement().execute("SHUTDOWN;");
         _conn.close();


### PR DESCRIPTION
PNFS manager's processing threads currently rely on cells automatically killing
threads with an interrupt if the cell fails to shut them down.  This presents
two problems: One is that it makes cell shutdown slower (unfortunate, but not
critical); the other is that it means the processing threads run after the
database connection pool has been closed (worse as it causes partial processing
of requests and quite some noise in the logs).

This patch reworks the PNFS manager shutdown to explicitly shut down the
processing threads. Queued requests are rejected by returning a
NoRouteToCellException to the requestor. The currently being processed requests
are allowed to finish (although they only get half a second to do so).

Target: trunk
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7383/
(cherry picked from commit 6919e2645f844f1681f9181ad0272b34f6ead547)
