### PR TITLE
chimera: prevent attempts to remove '.' and '..'

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -264,6 +264,10 @@ class FsSqlDriver {
 
     void remove(Connection dbConnection, FsInode parent, String name) throws ChimeraFsException, SQLException {
 
+        if (name.equals("..") || name.equals(".")) {
+            throw new InvalidNameChimeraException("bad name: '" + name + "'");
+        }
+
         FsInode inode = inodeOf(dbConnection, parent, name);
         if (inode == null || inode.type() != FsInodeType.INODE) {
             throw new FileNotFoundHimeraFsException("Not a file.");

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -1058,4 +1058,25 @@ public class BasicTest extends ChimeraTestCaseHelper {
         }
         fail("No checksums");
     }
+
+    @Test(expected = InvalidNameChimeraException.class)
+    public void testDeleteDot() throws Exception {
+
+        FsInode base = _rootInode.mkdir("dir1");
+        base.remove(".");
+    }
+
+    @Test(expected = InvalidNameChimeraException.class)
+    public void testDeleteDotAtEnd() throws Exception {
+
+        FsInode base = _rootInode.mkdir("dir1");
+        _fs.remove("/dir1/.");
+    }
+
+    @Test(expected = InvalidNameChimeraException.class)
+    public void testDeleteDotDot() throws Exception {
+
+        FsInode base = _rootInode.mkdir("dir1");
+        base.remove("..");
+    }
 }


### PR DESCRIPTION
we have in place checks for NFS, but not for the
other protocols.

Acked-by: Paul MIllar
Target: master, 2.11 ..  2.6
Require-book: no
Require-notes: no
(cherry picked from commit 8685d9a44881004f276c3f11bbe764c2f53953e8)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
