### PR TITLE
dcap: Initialize CDC session

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoor.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoor.java
@@ -24,6 +24,7 @@ import dmg.util.StreamEngine;
 
 import org.dcache.auth.Subjects;
 import org.dcache.util.Args;
+import org.dcache.util.Transfer;
 
 /**
   * @author Patrick Fuhrmann
@@ -127,6 +128,9 @@ public class      DCapDoor
             //
             // check for lock
             //
+
+            Transfer.initSession();
+
             _log.info( "Checking DCap lock" ) ;
             try{
                while( true ){


### PR DESCRIPTION
There may be room for improvement here, as dcap itself has a session field
that could be useful to incorporate. I don't know the semantics of that
field well enough to use it though.

In the meantime, this patch ensures that the CDC session is initialized
using the same format as used by other doors.

Target: trunk
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7418/
(cherry picked from commit e862fcd47f86160795c7700f8f9aba77cdfc1399)
