### PR TITLE
fix WebDAV door logging stacktrace on USERINFO request

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
@@ -55,10 +55,16 @@ public class MiltonHandler
         try (CDC ignored = CDC.reset(_cellName, _domainName)) {
             Transfer.initSession();
             ServletContext context = ContextHandler.getCurrentContext();
-            ServletRequest req = new DcacheServletRequest(request, context);
-            ServletResponse resp = new DcacheServletResponse(response);
-            baseRequest.setHandled(true);
-            _httpManager.process(req, resp);
+            switch (request.getMethod()) {
+            case "USERINFO":
+                response.sendError(501, "Not implemented");
+                break;
+            default:
+                ServletRequest req = new DcacheServletRequest(request, context);
+                ServletResponse resp = new DcacheServletResponse(response);
+                baseRequest.setHandled(true);
+                _httpManager.process(req, resp);
+            }
             response.getOutputStream().flush();
             response.flushBuffer();
         }


### PR DESCRIPTION
Milton does not support the USERINFO request. If such an request arrives
(davfs2 uses it for example) it will produce an IllegalArgumentException
with the message "No enum constant io.milton.http.Request.Method.USERINFO"
that will end up as a StackTrace
in the log and sends back a HTTP response "500 No enum constant
io.milton.http.Request.Method.USERINFO".  Better would be to respond
with "501 Not implemented" and not log the StackTrace.  This patch
solves this issue by checking for the unsupported method before passing
it on to Milton and sending the approprate response.

Ticket:
Acked-by: Gerd
Target: master
Request: 2.11
Request: 2.10
Require-book: no
Require-notes: no
