### PR TITLE
xrootd: Add access-log plugin

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandler.java
@@ -1,0 +1,292 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2014 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.xrootd.plugins;
+
+import org.jboss.netty.channel.ChannelEvent;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelHandler;
+import org.slf4j.Logger;
+
+import javax.security.auth.Subject;
+
+import java.net.InetSocketAddress;
+import java.security.Principal;
+
+import dmg.cells.nucleus.CDC;
+
+import org.dcache.auth.GidPrincipal;
+import org.dcache.auth.LoginReply;
+import org.dcache.auth.Subjects;
+import org.dcache.auth.UidPrincipal;
+import org.dcache.util.NetLoggerBuilder;
+import org.dcache.xrootd.door.LoginEvent;
+import org.dcache.xrootd.protocol.XrootdProtocol;
+import org.dcache.xrootd.protocol.messages.AbstractResponseMessage;
+import org.dcache.xrootd.protocol.messages.ErrorResponse;
+import org.dcache.xrootd.protocol.messages.LocateRequest;
+import org.dcache.xrootd.protocol.messages.MkDirRequest;
+import org.dcache.xrootd.protocol.messages.MvRequest;
+import org.dcache.xrootd.protocol.messages.OpenRequest;
+import org.dcache.xrootd.protocol.messages.PathRequest;
+import org.dcache.xrootd.protocol.messages.PrepareRequest;
+import org.dcache.xrootd.protocol.messages.ReadRequest;
+import org.dcache.xrootd.protocol.messages.ReadVRequest;
+import org.dcache.xrootd.protocol.messages.SetRequest;
+import org.dcache.xrootd.protocol.messages.StatxRequest;
+import org.dcache.xrootd.protocol.messages.WriteRequest;
+import org.dcache.xrootd.protocol.messages.XrootdRequest;
+
+import static org.dcache.util.NetLoggerBuilder.Level.DEBUG;
+import static org.dcache.util.NetLoggerBuilder.Level.ERROR;
+import static org.dcache.util.NetLoggerBuilder.Level.INFO;
+import static org.dcache.xrootd.protocol.XrootdProtocol.*;
+
+public class AccessLogHandler extends SimpleChannelHandler
+{
+    private final Logger logger;
+
+    public AccessLogHandler(Logger logger)
+    {
+        this.logger = logger;
+    }
+
+    @Override
+    public void handleUpstream(ChannelHandlerContext ctx, ChannelEvent e) throws Exception
+    {
+        if (e instanceof LoginEvent) {
+            LoginReply loginReply = ((LoginEvent) e).getLoginReply();
+            Subject subject = loginReply.getSubject();
+            NetLoggerBuilder log = new NetLoggerBuilder(INFO, "org.dcache.xrootd.login").omitNullValues();
+            log.add("session", CDC.getSession());
+            log.add("dn", Subjects.getDn(subject));
+            log.add("user", getUser(subject));
+            log.toLogger(logger);
+        }
+        super.handleUpstream(ctx, e);
+    }
+
+    @Override
+    public void channelConnected(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception
+    {
+        NetLoggerBuilder log = new NetLoggerBuilder(INFO, "org.dcache.xrootd.connection.start").omitNullValues();
+        log.add("session", CDC.getSession());
+        log.add("host.remote", getAddress((InetSocketAddress) e.getChannel().getRemoteAddress()));
+        log.add("host.local", getAddress((InetSocketAddress) e.getChannel().getLocalAddress()));
+        log.toLogger(logger);
+        super.channelConnected(ctx, e);
+    }
+
+    @Override
+    public void channelDisconnected(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception
+    {
+        NetLoggerBuilder log = new NetLoggerBuilder(INFO, "org.dcache.xrootd.connection.end").omitNullValues();
+        log.add("session", CDC.getSession());
+        log.toLogger(logger);
+        super.channelDisconnected(ctx, e);
+    }
+
+    @Override
+    public void writeRequested(ChannelHandlerContext ctx, MessageEvent e) throws Exception
+    {
+        Object msg = e.getMessage();
+        if (msg instanceof AbstractResponseMessage && logger.isErrorEnabled()) {
+            AbstractResponseMessage response = (AbstractResponseMessage) msg;
+            XrootdRequest request = response.getRequest();
+
+            NetLoggerBuilder.Level level;
+            if (response instanceof ErrorResponse) {
+                level = ERROR;
+            } else if (request instanceof WriteRequest || request instanceof ReadRequest || request instanceof ReadVRequest) {
+                level = DEBUG;
+            } else {
+                level = INFO;
+            }
+
+            if (level == ERROR || level == INFO && logger.isInfoEnabled() || level == DEBUG && logger.isDebugEnabled()) {
+                NetLoggerBuilder log = new NetLoggerBuilder(level, "org.dcache.xrootd.request").omitNullValues();
+                log.add("session", CDC.getSession());
+                log.add("request", getRequestId(request));
+
+                if (request instanceof PathRequest) {
+                    log.add("path", ((PathRequest) request).getPath());
+                    if (request instanceof OpenRequest) {
+                        log.add("mode", "0" + Integer.toOctalString(((OpenRequest) request).getUMask()));
+                        log.add("options", "0x" + Integer.toHexString(((OpenRequest) request).getOptions()));
+                    } else if (request instanceof LocateRequest) {
+                        log.add("options", "0x" + Integer.toHexString(((LocateRequest) request).getOptions()));
+                    } else if (request instanceof MkDirRequest) {
+                        log.add("options", "0x" + Integer.toHexString(((MkDirRequest) request).getOptions()));
+                    }
+                } else if (request instanceof MvRequest) {
+                    log.add("source", ((MvRequest) request).getSourcePath());
+                    log.add("target", ((MvRequest) request).getTargetPath());
+                } else if (request instanceof PrepareRequest) {
+                    log.add("options", "0x" + Integer.toHexString(((PrepareRequest) request).getOptions()));
+                    if (((PrepareRequest) request).getPathList().length == 1) {
+                        log.add("path", ((PrepareRequest) request).getPathList()[0]);
+                    } else {
+                        log.add("files", ((PrepareRequest) request).getPathList().length);
+                    }
+                } else if (request instanceof StatxRequest) {
+                    if (((StatxRequest) request).getPaths().length == 1) {
+                        log.add("path", ((StatxRequest) request).getPaths()[0]);
+                    } else {
+                        log.add("files", ((StatxRequest) request).getPaths().length);
+                    }
+                } else if (request instanceof SetRequest) {
+                    final String APPID_PREFIX = "appid ";
+                    final int APPID_PREFIX_LENGTH = APPID_PREFIX.length();
+                    final int APPID_MSG_LENGTH = 80;
+                    String data = ((SetRequest) request).getData();
+                    if (data.startsWith(APPID_PREFIX)) {
+                        log.add("appid", data.substring(APPID_PREFIX_LENGTH,
+                                                        Math.min(APPID_PREFIX_LENGTH + APPID_MSG_LENGTH,
+                                                                 data.length())));
+                    }
+                }
+
+                log.add("response", getStatusCode(response));
+                if (response instanceof ErrorResponse) {
+                    log.add("error.code", ((ErrorResponse) response).getErrorNumber());
+                    log.add("error.msg", ((ErrorResponse) response).getErrorMessage());
+                }
+
+                log.toLogger(logger);
+            }
+        }
+
+        super.writeRequested(ctx, e);
+    }
+
+    private static String getStatusCode(AbstractResponseMessage response)
+    {
+        short status = response.getBuffer().getShort(2);
+        switch (status) {
+        case XrootdProtocol.kXR_authmore:
+            return "authmore";
+        case XrootdProtocol.kXR_error:
+            return "error";
+        case XrootdProtocol.kXR_ok:
+            return "ok";
+        case XrootdProtocol.kXR_oksofar:
+            return "oksofar";
+        case XrootdProtocol.kXR_redirect:
+            return "redirect";
+        case XrootdProtocol.kXR_wait:
+            return "wait";
+        case XrootdProtocol.kXR_waitresp:
+            return "waitresp";
+        default:
+            return String.valueOf(status);
+        }
+    }
+
+    private static String getRequestId(XrootdRequest request)
+    {
+        switch (request.getRequestId()) {
+        case kXR_auth:
+            return "auth";
+        case kXR_login:
+            return "login";
+        case kXR_open:
+            return "open";
+        case kXR_stat:
+            return "stat";
+        case kXR_statx:
+            return "statx";
+        case kXR_read:
+            return "read";
+        case kXR_readv:
+            return "readv";
+        case kXR_write:
+            return "write";
+        case kXR_sync:
+            return "sync";
+        case kXR_close:
+            return "close";
+        case kXR_protocol:
+            return "protocol";
+        case kXR_rm:
+            return "rm";
+        case kXR_rmdir:
+            return "rmdir";
+        case kXR_mkdir:
+            return "mkdir";
+        case kXR_mv:
+            return "mv";
+        case kXR_dirlist:
+            return "dirlist";
+        case kXR_prepare:
+            return "prepare";
+        case kXR_locate :
+            return "locate";
+        case kXR_query :
+            return "query";
+        case kXR_set :
+            return "set";
+        default:
+            return String.valueOf(request.getRequestId());
+        }
+    }
+
+    private static CharSequence getUser(Subject subject)
+    {
+        Long uid = null;
+        Long gid = null;
+        boolean hasSecondaryGid = false;
+        for (Principal principal : subject.getPrincipals()) {
+            if (principal instanceof UidPrincipal) {
+                if (((UidPrincipal) principal).getUid() == 0) {
+                    return "root";
+                }
+                uid = ((UidPrincipal) principal).getUid();
+            } else if (principal instanceof GidPrincipal) {
+                if (((GidPrincipal) principal).isPrimaryGroup()) {
+                    gid = ((GidPrincipal) principal).getGid();
+                } else {
+                    hasSecondaryGid = true;
+                }
+            }
+        }
+        if (uid == null) {
+            return "nobody";
+        }
+        StringBuilder s = new StringBuilder();
+        s.append(uid).append(':');
+        if (gid != null) {
+            s.append(gid).append(',');
+        }
+        if (hasSecondaryGid) {
+            for (Principal principal : subject.getPrincipals()) {
+                if (principal instanceof GidPrincipal) {
+                    if (!((GidPrincipal) principal).isPrimaryGroup()) {
+                        s.append(((GidPrincipal) principal).getGid()).append(',');
+                    }
+                }
+            }
+        }
+        return s.subSequence(0, s.length() - 1);
+    }
+
+    private static String getAddress(InetSocketAddress addr)
+    {
+        return addr.getAddress().getHostAddress() + ":" + addr.getPort();
+    }
+}

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandlerFactory.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandlerFactory.java
@@ -1,0 +1,45 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2014 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.xrootd.plugins;
+
+import org.jboss.netty.channel.ChannelHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AccessLogHandlerFactory implements ChannelHandlerFactory
+{
+    private final Logger accessLogger = LoggerFactory.getLogger("org.dcache.access.xrootd");
+
+    @Override
+    public String getName()
+    {
+        return AccessLogHandlerProvider.NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Generates an access log";
+    }
+
+    @Override
+    public ChannelHandler createHandler()
+    {
+        return new AccessLogHandler(accessLogger);
+    }
+}

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandlerProvider.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandlerProvider.java
@@ -1,0 +1,31 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2014 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.xrootd.plugins;
+
+import java.util.Properties;
+
+public class AccessLogHandlerProvider implements ChannelHandlerProvider
+{
+    public static final String NAME = "access-log";
+
+    @Override
+    public ChannelHandlerFactory createFactory(String plugin, Properties properties) throws Exception
+    {
+        return plugin.equals(NAME) ? new AccessLogHandlerFactory() : null;
+    }
+}

--- a/modules/dcache-xrootd/src/main/resources/META-INF/services/org.dcache.xrootd.plugins.ChannelHandlerProvider
+++ b/modules/dcache-xrootd/src/main/resources/META-INF/services/org.dcache.xrootd.plugins.ChannelHandlerProvider
@@ -1,0 +1,1 @@
+org.dcache.xrootd.plugins.AccessLogHandlerProvider

--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -122,7 +122,7 @@ xrootd.authz.write-paths=/
 [dCacheDomain/xrootd]
 xrootd.cell.name=Xrootd-gsi-${host.name}
 xrootd.net.port=1095
-xrootd.plugins=gplazma:gsi
+xrootd.plugins=gplazma:gsi,access-log
 xrootd.authz.write-paths=/
 
 [dCacheDomain/webdav]

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.2.2.v20140723</version.jetty>
         <version.wicket>6.16.0</version.wicket>
-        <version.xrootd4j>1.3.5</version.xrootd4j>
+        <version.xrootd4j>1.3.6</version.xrootd4j>
         <version.jglobus>2.0.6-rc7.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -228,12 +228,16 @@ pool.mover.xrootd.frame-size = 2097152
 #   Comma separated list of plugins to inject into the xrootd
 #   request processing chain.
 #
-#   dCache ships with a few authentication and authorization plugins:
+#   dCache ships with a few plugins:
 #
 #    authn:gsi  - any xrootd request to the door will use a key-exchange
 #                 process to identify the end-user (pool only).
 #
 #    authz:alice-token - ALICE token based authorization plugin.
+#
+#    access-log - generates a dCache style access log using the NetLogger
+#                 format. Read and write requests are logged at debug
+#                 level to avoid generating too many log messages.
 #
 #   No plugins are required. If an authentication plugin is
 #   specified, then note that the subject will *not* be mapped by

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -118,10 +118,10 @@ xrootd.authz.write-paths =
 
 #  ---- Xrootd plugins
 #
-#   Comma seperated list of plugins to inject into the xrootd
+#   Comma separated list of plugins to inject into the xrootd
 #   request processing chain.
 #
-#   dCache ships with a few authentication and authorization plugins:
+#   dCache ships with a few plugins:
 #
 #    gplazma:none - no authentication is performed; user identity is
 #                   set to ${xrootd.authz.user} (door only).
@@ -131,6 +131,9 @@ xrootd.authz.write-paths =
 #
 #    authz:alice-token - ALICE token based authorization plugin.
 #
+#    access-log - generates a dCache style access log using the NetLogger
+#                 format.
+#
 #   A gplazma:* authentication plugin is required; use
 #   gplazma:none if no authentication is desired. Authorization plugins
 #   have to be placed after the authentication plugin.
@@ -139,6 +142,10 @@ xrootd.authz.write-paths =
 #   directory of dCache and specifying the plugin name here. Note that
 #   third party authentication plugins have to be loaded with
 #   gplazma:<plugin>.
+#
+#   Placement of the access-log is significant, as other plugins may alter
+#   the request. To include login events in the access log, the access-log
+#   plugin must be placed after the gplazma:* authentication plugin.
 #
 xrootd.plugins=gplazma:none,authz:none
 
@@ -151,9 +158,9 @@ xrootd.plugins=gplazma:none,authz:none
 #   The authorization controlled by this parameter is different from
 #   the authorization performed by the authorization plugin: The
 #   authorization plugin validates the requests themselves
-#   indepedently of the file which is accessed. E.g. the token based
+#   independently of the file which is accessed. E.g. the token based
 #   authorization verifies that the request contains a
-#   cryptopgrahically signed token from a trusted source.
+#   cryptographically signed token from a trusted source.
 #
 #   Once the request is authorized it is subject to further
 #   authorization by other components in dCache, e.g. PnfsManager or


### PR DESCRIPTION
Allows xrootd doors to generate an access log similar to those of SRM, FTP and WebDAV
doors. May optionally be used on pools too.

In contrast to 2.12, the plugin is not enabled by default.

Target: trunk
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Karsten Schwank karsten.schwank@desy.de
Patch: https://rb.dcache.org/r/7442/
(cherry picked from commit 25250c09e8288b18ee4a0a569676a9a9db51e3b1)
