### PR TITLE
srm: Enable legacy GSI close by default

### DIFF
--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -155,7 +155,6 @@ webdav.net.internal=127.0.0.1
 [dCacheDomain/srm]
 srm.net.host=localhost
 srm.persistence.enable.history=true
-srm.enable.legacy-close=true
 
 [dCacheDomain/nfs]
 nfs.version=3,4.1

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -234,7 +234,7 @@ srm.limits.jetty.threads.queued.max = 500
 # sending a close notification first. This should be enabled if compatibility
 # with these clients is required.
 #
-(one-of?true|false)srm.enable.legacy-close=false
+(one-of?true|false)srm.enable.legacy-close=true
 
 # ---- Parameters for schedulable SRM requests
 #


### PR DESCRIPTION
We have only recently released a client for close works, so it is
wise to enable legacy close by default.

Target: trunk
Request: 2.11
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7452/
(cherry picked from commit a8c0c7e79ca1bc2b778223f4272d17633049c1d4)
