### PR TITLE
srm,webadmin,httpd: Upgrade to Jetty 9.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <version.aspectj>1.8.2</version.aspectj>
         <version.smc>6.3.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
-        <version.jetty>9.2.2.v20140723</version.jetty>
+        <version.jetty>9.2.4.v20141103</version.jetty>
         <version.wicket>6.16.0</version.wicket>
         <version.xrootd4j>1.3.6</version.xrootd4j>
         <version.jglobus>2.0.6-rc8.d</version.jglobus>


### PR DESCRIPTION
I hope this upgrade fixes the following problem:

05 Nov 2014 12:00:10 (SRM-bunsen) [] Commit failed
java.lang.IllegalStateException: Closed with pending callback org.eclipse.jetty.server.HttpConnection$SendCallback@6e3b2c00[CLOSED][i=ResponseInfo{HTTP/1.1 200 null,-1,false},cb=org.eclipse.jetty.server.HttpChannel$CommitCallback@6ec5ec89]
        at org.eclipse.jetty.util.IteratingCallback.close(IteratingCallback.java:397) [jetty-util-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpConnection.onClose(HttpConnection.java:429) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.io.ssl.SslConnection.onClose(SslConnection.java:157) [jetty-io-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.io.SelectorManager.connectionClosed(SelectorManager.java:277) [jetty-io-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.io.SelectorManager$ManagedSelector.destroyEndPoint(SelectorManager.java:690) [jetty-io-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.io.SelectChannelEndPoint.close(SelectChannelEndPoint.java:169) [jetty-io-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.io.ChannelEndPoint.shutdownOutput(ChannelEndPoint.java:92) [jetty-io-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.flush(SslConnection.java:740) [jetty-io-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.io.WriteFlusher.write(WriteFlusher.java:337) [jetty-io-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.io.AbstractEndPoint.write(AbstractEndPoint.java:128) [jetty-io-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpConnection$SendCallback.process(HttpConnection.java:637) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.util.IteratingCallback.processIterations(IteratingCallback.java:233) [jetty-util-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:193) [jetty-util-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpConnection.send(HttpConnection.java:448) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpChannel.sendResponse(HttpChannel.java:740) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpChannel.write(HttpChannel.java:778) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpOutput.write(HttpOutput.java:131) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpOutput.write(HttpOutput.java:124) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpOutput.flush(HttpOutput.java:226) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at sun.nio.cs.StreamEncoder.implFlush(StreamEncoder.java:297) [na:1.7.0_71]
        at sun.nio.cs.StreamEncoder.flush(StreamEncoder.java:141) [na:1.7.0_71]
        at java.io.OutputStreamWriter.flush(OutputStreamWriter.java:229) [na:1.7.0_71]
        at java.io.PrintWriter.flush(PrintWriter.java:320) [na:1.7.0_71]
        at java.io.BufferedWriter.flush(BufferedWriter.java:254) [na:1.7.0_71]
        at org.apache.axis.SOAPPart.writeTo(SOAPPart.java:270) [axis-1.4.jar:na]
        at org.apache.axis.Message.writeTo_aroundBody0(Message.java:539) [axis-1.4.jar:na]
        at org.apache.axis.Message$AjcClosure1.run(Message.java:1) [axis-1.4.jar:na]
        at org.dcache.srm.aspects.EofExceptionAspect.ajc$around$org_dcache_srm_aspects_EofExceptionAspect$1$69ec417cproceed(EofExceptionAspect.aj:39) [srm-server-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
        at org.dcache.srm.aspects.EofExceptionAspect.ajc$around$org_dcache_srm_aspects_EofExceptionAspect$1$69ec417c(EofExceptionAspect.aj:41) [srm-server-2.11.0-SNAPSHOT.jar:2.11.0-SNAPSHOT]
        at org.apache.axis.Message.writeTo(Message.java:539) [axis-1.4.jar:na]
        at org.apache.axis.transport.http.AxisServlet.sendResponse(AxisServlet.java:902) [axis-1.4.jar:na]
        at org.apache.axis.transport.http.AxisServlet.doPost(AxisServlet.java:777) [axis-1.4.jar:na]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:707) [javax.servlet-api-3.1.0.jar:3.1.0]
        at org.apache.axis.transport.http.AxisServletBase.service(AxisServletBase.java:327) [axis-1.4.jar:na]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) [javax.servlet-api-3.1.0.jar:3.1.0]
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:769) [jetty-servlet-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585) [jetty-servlet-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577) [jetty-security-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1125) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515) [jetty-servlet-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1059) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:52) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.Server.handle(Server.java:485) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:290) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:248) [jetty-server-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540) [jetty-io-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:606) [jetty-util-9.2.2.v20140723.jar:9.2.2.v20140723]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:535) [jetty-util-9.2.2.v20140723.jar:9.2.2.v20140723]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_71]

At leat the specific code path leading to the above exception no longer
exists in v9.2.4.

Target: trunk
Request: 2.11
Require-notes: no
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7454/
(cherry picked from commit e2d9435e3829936ad40e5ec7ce4ee2dff5549918)
