### PR TITLE
chimera: protect list initialization from FS inconsistencies

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/DirectoryStreamHelper.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/DirectoryStreamHelper.java
@@ -19,8 +19,12 @@ package org.dcache.chimera;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DirectoryStreamHelper {
+
+    private static final Logger _log = LoggerFactory.getLogger(DirectoryStreamHelper.class);
 
     /**
      * Convert directory stream into a {@link List}.
@@ -34,7 +38,8 @@ public class DirectoryStreamHelper {
 
         int estimatedListSize = inode.statCache().getNlink();
         if (estimatedListSize < 0) {
-            throw new RuntimeException("Invalid nlink count for directory: " + inode);
+            _log.error("Invalid nlink count for directory {}", inode);
+            directoryList = new ArrayList<>();
         } else {
             directoryList = new ArrayList<>(estimatedListSize);
         }

--- a/modules/chimera/src/test/java/org/dcache/chimera/DirectoryStreamHelperTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/DirectoryStreamHelperTest.java
@@ -16,20 +16,17 @@
  */
 package org.dcache.chimera;
 
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
-
 import org.dcache.chimera.posix.Stat;
-
-import static org.mockito.BDDMockito.given;
+import org.junit.Test;
 import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.given;
 
 public class DirectoryStreamHelperTest {
 
-    @Test(expected=RuntimeException.class)
+    @Test
     public void testNegativeNlink() throws ChimeraFsException, IOException {
 
         FsInode inode = mock(FsInode.class);


### PR DESCRIPTION
we observe that in some situations nlink count get out of
sync. As this is a bug by itself, protect directory listing
from from invalid initial capacity initialization.

Acked-by: Karsten Schwank
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit d325d16e29e7454f3ecc916c0b54a42feb6903ee)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
