### PR TITLE
nfs-proxy: kill mover on close

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapChannelImpl.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapChannelImpl.java
@@ -32,6 +32,7 @@ public class DcapChannelImpl implements ProxyIoAdapter {
 
     private final SocketChannel _channel;
     private final long _size;
+    private final int _sessionId;
 
     public DcapChannelImpl(InetSocketAddress addr, int session, byte[] challange, long size) throws IOException {
         _channel = SocketChannel.open(addr);
@@ -43,6 +44,12 @@ public class DcapChannelImpl implements ProxyIoAdapter {
         buf.flip();
         writeFully(_channel, buf);
         _size = size;
+        _sessionId = session;
+    }
+
+    @Override
+    public int getSessionId() {
+        return _sessionId;
     }
 
     @Override

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapProxyIoFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapProxyIoFactory.java
@@ -24,7 +24,6 @@ import org.dcache.cells.CellStub;
 import org.dcache.chimera.JdbcFs;
 import org.dcache.commons.util.NDC;
 import org.dcache.nfs.ChimeraNFSException;
-import org.dcache.nfs.nfsstat;
 import org.dcache.nfs.status.DelayException;
 import org.dcache.nfs.status.NfsIoException;
 import org.dcache.nfs.v4.CompoundContext;
@@ -34,6 +33,7 @@ import org.dcache.nfs.v4.StateDisposeListener;
 import org.dcache.nfs.v4.xdr.stateid4;
 import org.dcache.nfs.vfs.Inode;
 import org.dcache.util.RedirectedTransfer;
+import org.dcache.util.Transfer;
 import org.dcache.util.TransferRetryPolicy;
 import org.dcache.xdr.RpcCall;
 import org.jboss.netty.util.internal.ConcurrentHashMap;
@@ -64,7 +64,7 @@ public class DcapProxyIoFactory extends AbstractCell {
 
     private JdbcFs _fileFileSystemProvider;
 
-    private final Cache<stateid4, ProxyIoAdapter> _prioxyIO
+    private final Cache<stateid4, ProxyIoAdapter> _proxyIO
             = CacheBuilder.newBuilder()
             .build();
 
@@ -121,18 +121,25 @@ public class DcapProxyIoFactory extends AbstractCell {
 
         _pendingIO.put(session, transfer);
         transfer.setWrite(isWrite);
-        transfer.selectPoolAndStartMover(_ioQueue, _retryPolicy);
-        PoolPassiveIoFileMessage<byte[]> redirect = transfer.waitForRedirect(NFS_RETRY_PERIOD);
+        try {
 
-        return new DcapChannelImpl(redirect.socketAddress(), session,
-                Base64.byteArrayToBase64(redirect.challange()).getBytes(Charsets.US_ASCII),
-                transfer.getFileAttributes().getSize());
+            transfer.selectPoolAndStartMover(_ioQueue, _retryPolicy);
+            PoolPassiveIoFileMessage<byte[]> redirect = transfer.waitForRedirect(NFS_RETRY_PERIOD);
+
+            return new DcapChannelImpl(redirect.socketAddress(), session,
+                    Base64.byteArrayToBase64(redirect.challange()).getBytes(Charsets.US_ASCII),
+                    transfer.getFileAttributes().getSize());
+        } catch (CacheException | InterruptedException | IOException e) {
+            // remove the pending mover if exists
+            transfer.killMover(0);
+            throw e;
+        }
     }
 
     ProxyIoAdapter getOrCreateProxy(final Inode inode, final stateid4 stateid, final CompoundContext context, final boolean isWrite) throws ChimeraNFSException {
 
         try {
-            ProxyIoAdapter adapter = _prioxyIO.get(stateid,
+            ProxyIoAdapter adapter = _proxyIO.get(stateid,
                     new Callable<ProxyIoAdapter>() {
 
                         @Override
@@ -153,7 +160,12 @@ public class DcapProxyIoFactory extends AbstractCell {
                                 @Override
                                 public void notifyDisposed(NFS4State state) {
                                     tryToClose(adapter);
-                                    _prioxyIO.invalidate(state.stateid());
+                                    Transfer transfer = _pendingIO.remove(adapter.getSessionId());
+                                    if (transfer != null) {
+                                        // kill the mover if it did not started yet (queued)
+                                        transfer.killMover(0);
+                                    }
+                                    _proxyIO.invalidate(state.stateid());
                                 }
                             });
 
@@ -168,7 +180,7 @@ public class DcapProxyIoFactory extends AbstractCell {
             if (t instanceof ChimeraNFSException) {
                 throw (ChimeraNFSException) t;
             }
-            int status = nfsstat.NFSERR_IO;
+
             if ((t instanceof CacheException) && ((CacheException) t).getRc() != CacheException.BROKEN_ON_TAPE) {
                 throw new DelayException();
             }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoAdapter.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoAdapter.java
@@ -39,4 +39,6 @@ public interface ProxyIoAdapter extends Closeable {
      * @return size of the files,  measured in bytes
      */
     long size();
+
+    int getSessionId();
 }


### PR DESCRIPTION
kill the mover on close if we did not have an
established data connection yet.

kill mover if we have failed to get a redirect within a
defined time window

Acked-by: Gerd Behrmann
Target: master, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6
Require-book: no
Require-notes: no
(cherry picked from commit 7c3d400b656b2531c1f19701d7ad96707aa65e89)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
