### PR TITLE
(2.8) dcache-webadmin: change Jetty setting so .war is not unpacked

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
@@ -58,11 +58,6 @@ public class HttpServiceCell extends CommandInterpreter
     private String webappResourceUrl;
 
     /**
-     * Where the war should be unpacked
-     */
-    private String tmpUnpackDir;
-
-    /**
      * Enablement of secure connection (HTTPS)
      */
     private boolean authenticated;
@@ -233,10 +228,6 @@ public class HttpServiceCell extends CommandInterpreter
         return server;
     }
 
-    public String getTmpUnpackDir() {
-        return tmpUnpackDir;
-    }
-
     public boolean getAuthenticated() {
         return authenticated;
     }
@@ -304,11 +295,6 @@ public class HttpServiceCell extends CommandInterpreter
     @Required
     public void setKeystorePassword(String keystorePassword) {
         this.keystorePassword = keystorePassword;
-    }
-
-    @Required
-    public void setTmpUnpackDir(String tmpUnpackDir) {
-        this.tmpUnpackDir = tmpUnpackDir;
     }
 
     @Required

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/util/AliasEntry.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/util/AliasEntry.java
@@ -190,14 +190,12 @@ public class AliasEntry {
         Map<String, Object> env = cell.getEnvironment();
 
         File war = new File(webappsPath, context + ".war");
-        File tmpDir = new File(cell.getTmpUnpackDir(), alias);
 
         WebAppContext webappContext = new WebAppContext();
         webappContext.setDefaultsDescriptor(cell.getDefaultWebappsXml());
         webappContext.setContextPath(context);
         webappContext.setWar(war.getAbsolutePath());
-        webappContext.setExtractWAR(true);
-        webappContext.setTempDirectory(tmpDir);
+        webappContext.setExtractWAR(false);
         webappContext.setConfigurationClasses(configClasses);
 
         /*

--- a/modules/dcache/src/main/resources/org/dcache/services/httpd/httpd.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/httpd/httpd.xml
@@ -18,7 +18,6 @@
     <bean id="serviceCell" class="org.dcache.services.httpd.HttpServiceCell"
         init-method="initialize" destroy-method="cleanUp">
         <property name="webappResourceUrl" value="${httpd.container.default-webapp}"/>
-        <property name="tmpUnpackDir" value="${httpd.container.webapps.tmp-dir}"/>
         <property name="authenticated" value="${httpd.enable.authn}"/>
         <property name="host" value="#{ '${httpd.net.listen}'.equals('any') ? null : '${httpd.net.listen}' }"/>
         <property name="httpPort" value="${httpd.net.port}"/>

--- a/packages/fhs/src/main/assembly/filter.properties
+++ b/packages/fhs/src/main/assembly/filter.properties
@@ -73,7 +73,6 @@ dcache.paths.billing=/var/lib/dcache/billing
 dcache.paths.statistics=/var/lib/dcache/statistics
 dcache.paths.star.state=/var/lib/dcache/star
 dcache.paths.star.spool=/var/spool/dcache/star
-dcache.paths.unpack=/var/lib/dcache/httpd
 webdav.static-content.dir.local=/var/lib/dcache/webdav/local
 httpd.static-content.plots=/var/lib/dcache/plots
 dcache.user=dcache

--- a/packages/system-test/src/main/assembly/filter.properties
+++ b/packages/system-test/src/main/assembly/filter.properties
@@ -94,7 +94,6 @@ dcache.paths.billing=${dcache.home}/var/billing
 dcache.paths.statistics=${dcache.home}/var/statistics
 dcache.paths.star.state=${dcache.home}/var/star
 dcache.paths.star.spool=${dcache.home}/var/spool/star
-dcache.paths.unpack=${dcache.home}/var/httpd
 webdav.static-content.dir.local=${dcache.home}/var/webdav/local
 httpd.static-content.plots=${dcache.home}/var/plots
 dcache.user=

--- a/packages/tar/src/main/assembly/filter.properties
+++ b/packages/tar/src/main/assembly/filter.properties
@@ -93,7 +93,6 @@ dcache.paths.billing=${dcache.home}/var/billing
 dcache.paths.statistics=${dcache.home}/var/statistics
 dcache.paths.star.state=${dcache.home}/var/star
 dcache.paths.star.spool=${dcache.home}/var/spool/star
-dcache.paths.unpack=${dcache.home}/var/httpd
 webdav.static-content.dir.local=${dcache.home}/var/webdav/local
 httpd.static-content.plots=${dcache.home}/var/plots
 dcache.user=

--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -129,8 +129,8 @@ httpd.container.webapps.dir=${webadminWebappsPath}
 #
 #     Specifies the path where the war files are unpacked
 #
-(deprecated)webadminWarunpackdir=${dcache.paths.unpack}
-httpd.container.webapps.tmp-dir=${webadminWarunpackdir}
+(obsolete)webadminWarunpackdir = No longer used (webadmin war is not unpacked)
+(obsolete)httpd.container.webapps.tmp-dir = No longer used (webadmin war is not unpacked)
 
 #
 #     Name will be displayed on some of the webpages as header

--- a/skel/share/defaults/paths.properties
+++ b/skel/share/defaults/paths.properties
@@ -27,7 +27,6 @@ dcache.paths.billing=@dcache.paths.billing@
 dcache.paths.statistics=@dcache.paths.statistics@
 dcache.paths.plugins=@dcache.paths.plugins@
 dcache.paths.setup=@dcache.paths.setup@
-dcache.paths.unpack=@dcache.paths.unpack@
 dcache.paths.classpath=${dcache.java.classpath}:${dcache.paths.classes}/\*
 (deprecated)dcache.paths.ssh-keys=${dcache.paths.etc}/admin
 dcache.paths.admin=${dcache.paths.ssh-keys}

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -34,7 +34,6 @@ check -strong httpd.limits.idle-time.unit
 check -strong httpd.limits.threads
 check -strong httpd.container.default-webapp
 check -strong httpd.container.webapps.dir
-check -strong httpd.container.webapps.tmp-dir
 check httpd.html.dcache-instance-name
 
 check -strong httpd.service.pool.timeout


### PR DESCRIPTION
See http://rt.dcache.org/Ticket/Display.html?id=8489.

When upgrading from 2.6 to 2.10, there is a potential
for the webadmin directory timestamps to be more recent
than the timestamp of the /usr/share/dcache/classes/webapps/webadmin.war
file, which then causes Jetty to ignore the new war
and use the old directory. This subsequently provokes
jndi issues because the new httpd.batch file does not
pass through properties that the webadmin spring file
expects to find in the naming and directory interface.

The simplest solution is to turn off unpacking in
versions subsequent to 2.6.

Note that https://rb.dcache.org/r/7436/ does this for master.

Testing:

Installed 2.6.  Then updated to master (this patch) over it,
leaving the old webadmin directory intact.  Httpd confirmed
to start without issues, navigation through pages is normal.

Target: 2.8
Request: 2.7
Acked-by: Gerd
Require-book: no
Require-notes: yes

RELEASE NOTES:  The webadmin.war found in /usr/share/dcache/classes/webapps
is no longer unpacked (by default, /var/lib/dcache/httpd).  This
avoids potential conflicts between versions when update installs are run.
