### PR TITLE
libs: update to nfs4j-0.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -806,7 +806,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.9.1</version>
+            <version>0.9.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
performance improvements

Changelog for nfs4j-0.9.1..nfs4j-0.9.2
    \* [9951033] pseudofs: do not check READ_ATTR bit for unix
    \* [c16ed50] avoid extra copy of data buffer in nfs3.read

Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit d7c410890dd6a1c5965d22a0790b69b82c0a6915)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
