### PR TITLE
libs: update to nfs4j-0.7.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -795,7 +795,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.7.7</version>
+            <version>0.7.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
performance improvements

Changelog for nfs4j-0.7.7..nfs4j-0.7.8
    \* [c885cc0] pseudofs: do not check READ_ATTR bit for unix
    \* [787ddaf] avoid extra copy of data buffer in nfs3.read

Target: 2.8, 2.7, 2.6
Require-book: no
Require-notes: no
