### PR TITLE
nfs-proxy: kill mover if we get a timeout on redirect

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapProxyIoFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapProxyIoFactory.java
@@ -101,11 +101,16 @@ public class DcapProxyIoFactory extends AbstractCell {
 
         _pendingIO.put(session, transfer);
         transfer.selectPoolAndStartMover(_ioQueue, _retryPolicy);
-        PoolPassiveIoFileMessage<byte[]> redirect = transfer.waitForRedirect(NFS_RETRY_PERIOD);
+        try {
+            PoolPassiveIoFileMessage<byte[]> redirect = transfer.waitForRedirect(NFS_RETRY_PERIOD);
 
-        return new DcapChannelImpl(redirect.socketAddress(), session,
-                Base64.byteArrayToBase64(redirect.challange()).getBytes(Charsets.US_ASCII),
-                transfer.getFileAttributes().getSize());
+            return new DcapChannelImpl(redirect.socketAddress(), session,
+                    Base64.byteArrayToBase64(redirect.challange()).getBytes(Charsets.US_ASCII),
+                    transfer.getFileAttributes().getSize());
+        } catch (CacheException | InterruptedException | IOException e) {
+            transfer.killMover(0);
+            throw e;
+        }
     }
 
     public void startAdapter() throws InterruptedException, ExecutionException {


### PR DESCRIPTION
a lite version of 7c3d400b656b2531c1f19701d7ad96707aa65e89

Ticket: #8525
Acked-by:
Target: 2.6
Require-book: no
Require-notes: no
