### PR TITLE
(2.6) webadmin: repair css and js dependencies

### DIFF
--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/pages/basepage/BasePage.html
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/pages/basepage/BasePage.html
@@ -11,6 +11,9 @@
         <script type="text/javascript" src="js/jquery.min.js"></script>
         <script type="text/javascript" src="js/jquery.tablesorter.min.js"></script>
         <script type="text/javascript">
+           CLOSURE_NO_DEPS = true;
+        </script>
+        <script type="text/javascript">
             $(document).ready(function() {
                 $('.sortable').tablesorter();
                 // Initialise Plugin

--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/pages/poollist/PoolList.css
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/pages/poollist/PoolList.css
@@ -1,0 +1,9 @@
+@CHARSET "UTF-8";
+
+table {
+    width: 100%;
+}
+
+td {
+    text-align: center;
+}

--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/CheckPanel.html
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/CheckPanel.html
@@ -1,6 +1,4 @@
 <html>
-<wicket:head>
-</wicket:head>
 <body>
 	<wicket:panel>
 	    <span wicket:id="label"></span>

--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/DisplayPanel.html
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/DisplayPanel.html
@@ -1,12 +1,4 @@
 <html>
-<head>
-<title><wicket:message key="tableTitle"></wicket:message></title>
-<wicket:head>
-	<wicket:link>
-		<link href="Alarms.css" rel="stylesheet" type="text/css" />
-	</wicket:link>
-</wicket:head>
-</head>
 <body>
 	<wicket:panel>
 		<h1>

--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/ErrorPanel.html
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/ErrorPanel.html
@@ -1,12 +1,4 @@
 <html>
-<head>
-<title><wicket:message key="tableTitle"></wicket:message></title>
-<wicket:head>
-	<wicket:link>
-		<link href="Alarms.css" rel="stylesheet" type="text/css" />
-	</wicket:link>
-</wicket:head>
-</head>
 <body>
 	<wicket:panel>
 		<h2>

--- a/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
+++ b/modules/webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
@@ -1,13 +1,4 @@
 <html>
-<head>
-<title><wicket:message key="queryTitle"></wicket:message>
-</title>
-<wicket:head>
-	<wicket:link>
-		<link href="Alarms.css" rel="stylesheet" type="text/css" />
-	</wicket:link>
-</wicket:head>
-</head>
 <body>
 	<wicket:panel>
 	    <h3>


### PR DESCRIPTION
Two minor dependencies are fixed:  a missing .css file is restored,
and CLOJURE is told to ignore the deps.js library.

Target: 2.6
Requires-book: no
Requires-notes: no
Acked-by:  Paul
