### PR TITLE
(2.11) dcache-webadmin: eliminate clojure dependency

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/BasePage.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/BasePage.java
@@ -105,7 +105,9 @@ public abstract class BasePage extends WebPage {
                         .getJavaScriptLibrarySettings()
                         .getJQueryReference()));
         response.render(JavaScriptHeaderItem.forUrl("js/infobox.js"));
-    }
+	response.render(JavaScriptHeaderItem.forScript("CLOSURE_NO_DEPS = true;",
+                        "nodeps"));  
+  }
 
     protected Form<?> getAutoRefreshingForm(String name) {
         return getAutoRefreshingForm(name, 1, TimeUnit.MINUTES);


### PR DESCRIPTION
Get rid of stack trace reporting error.  deps.js is
unused.

Target: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Requires-book: no
Requires-notes: yes
Acked-by:  Paul

RELEASE NOTES:  Removes erroneous dependency on deps.js library which was causing an error to be reported.
