### PR TITLE
dcache-webadmin: change output field of cell admin page to monospace fon...

### DIFF
--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/celladmin/CellAdmin.css
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/celladmin/CellAdmin.css
@@ -10,3 +10,7 @@ p {
     background: #d2dddd;
     padding: 15px;
 }
+
+.output {
+    font-family: "Lucida Console", Monaco, monospace
+}

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/celladmin/CellAdmin.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/celladmin/CellAdmin.html
@@ -35,7 +35,9 @@
                 <span wicket:id="cellAdmin.receiver"></span>
             </h2>
             <br />
-            <span wicket:id="cellAdmin.cellresponsevalue"></span>
+            <div class="output">
+                <span wicket:id="cellAdmin.cellresponsevalue"></span>
+            </div>
         </form>
     </wicket:extend>
 </body>


### PR DESCRIPTION
...t

Many of the dCache services format the output into columns and that only works with a mono space font.

Target: master
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Gerd
Acked-by: Paul
Require-notes: no
Require-book: no
