### PR TITLE
webadmin: remove redundant head element in alarms panel html

### DIFF
--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/CheckPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/CheckPanel.html
@@ -1,6 +1,4 @@
 <html>
-<wicket:head>
-</wicket:head>
 <body>
     <wicket:panel>
         <span wicket:id="label"></span>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/DisplayPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/DisplayPanel.html
@@ -1,15 +1,4 @@
 <html>
-<head>
-<title><wicket:message key="tableTitle"></wicket:message></title>
-<wicket:head>
-    <wicket:link>
-        <link
-            href="Alarms.css"
-            rel="stylesheet"
-            type="text/css" />
-    </wicket:link>
-</wicket:head>
-</head>
 <body>
     <wicket:panel>
         <h1>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/ErrorPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/ErrorPanel.html
@@ -1,15 +1,4 @@
 <html>
-<head>
-<title><wicket:message key="tableTitle"></wicket:message></title>
-<wicket:head>
-    <wicket:link>
-        <link
-            href="Alarms.css"
-            rel="stylesheet"
-            type="text/css" />
-    </wicket:link>
-</wicket:head>
-</head>
 <body>
     <wicket:panel>
         <h2>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
@@ -1,15 +1,4 @@
 <html>
-<head>
-<title><wicket:message key="queryTitle"></wicket:message></title>
-<wicket:head>
-    <wicket:link>
-        <link
-            href="Alarms.css"
-            rel="stylesheet"
-            type="text/css" />
-    </wicket:link>
-</wicket:head>
-</head>
 <body>
     <wicket:panel>
         <h3>


### PR DESCRIPTION
Not necessary, should have been removed numerous versions ago.

Target: master
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Acked-by: Paul
Require-book: no
Require-notes: no
