### PR TITLE
alarms:  fix regex for checksum alarm

### DIFF
--- a/skel/var/alarms/alarm-definitions.xml
+++ b/skel/var/alarms/alarm-definitions.xml
@@ -94,9 +94,9 @@
     <alarmType>
         <logger>org.dcache.pool.classic.ChecksumScanner</logger>
         <type>CHECKSUM</type>
-        <regex>Marking (.+) as BROKEN</regex>
+        <regex>Marking ([0-9A-F]+{24}) as BROKEN</regex>
         <level>ERROR</level>
-        <severity>MODERATE</severity>
+        <severity>HIGH</severity>
         <includeInKey>group1 type host service domain</includeInKey>
     </alarmType>
 </definitions>


### PR DESCRIPTION
The alarm definition for CHECKSUM uses the regex

Marking (.+) as BROKEN.

Unfortunately this matches both the error emitted by
the ChecksumScanner

 _log.error("Marking {} as BROKEN: {}", id, e.getMessage());

as well as the broken file message from WriteHandleImpl:

 _log.warn("Marking pool entry as BROKEN");

The latter should not produce an alarm.

The regex for the CHECKSUM alarm has been made more specific
in order to exclude matching the latter logging statement.

Note that the changes to alarms in 2.11 render this
patch unnecessary for 2.11 or master.

Target: 2.10
Request: 2.9
Request: 2.8
Reqeust: 2.7
Reqeust: 2.6
Acked-by: Dmitry
Require-notes: no
Require-book: no
