### PR TITLE
doors: Add pnfs ID to billing remove entries

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -1367,11 +1367,12 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                 //
                 // we are not called if the pnfs request failed.
                 //
-                String path = _message.getPnfsPath();
                 if (_fileAttributes.getFileType() != DIR) {
-                    _pnfs.deletePnfsEntry(path);
+                    String path = _message.getPnfsPath();
+                    PnfsId pnfsId = _fileAttributes.getPnfsId();
+                    _pnfs.deletePnfsEntry(pnfsId, path);
                     sendReply("fileAttributesAvailable", 0, "");
-                    sendRemoveInfoToBilling(path);
+                    sendRemoveInfoToBilling(_fileAttributes, path);
                 } else {
                     sendReply("fileAttributesAvailable", 17, "Path is a Directory", "EISDIR");
                 }
@@ -1382,14 +1383,17 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
             }
         }
 
-        private void sendRemoveInfoToBilling(String path)
+        private void sendRemoveInfoToBilling(FileAttributes attributes, String path)
         {
             CellInfo cellInfo = _cell.getCellInfo();
             DoorRequestInfoMessage infoRemove =
                 new DoorRequestInfoMessage(cellInfo.getCellName() + "@"
                                            + cellInfo.getDomainName(), "remove");
             infoRemove.setSubject(_subject);
+            infoRemove.setPnfsId(attributes.getPnfsId());
+            infoRemove.setFileSize(attributes.getSize());
             infoRemove.setPath(path);
+            infoRemove.setClient(_clientAddress.getHostAddress());
 
             postToBilling(infoRemove);
         }

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -141,6 +141,7 @@ import diskCacheV111.util.NotDirCacheException;
 import diskCacheV111.util.NotFileCacheException;
 import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
+import diskCacheV111.util.PnfsId;
 import diskCacheV111.util.TimeoutCacheException;
 import diskCacheV111.vehicles.DoorRequestInfoMessage;
 import diskCacheV111.vehicles.DoorTransferFinishedMessage;
@@ -1889,10 +1890,10 @@ public abstract class AbstractFtpDoorV1
 
         FsPath path = absolutePath(arg);
         try {
-            _pnfs.deletePnfsEntry(path.toString(),
-                                  EnumSet.of(FileType.REGULAR, FileType.LINK));
+            PnfsId pnfsId =
+                    _pnfs.deletePnfsEntry(path.toString(), EnumSet.of(FileType.REGULAR, FileType.LINK));
             reply("250 OK");
-            sendRemoveInfoToBilling(path);
+            sendRemoveInfoToBilling(pnfsId, path);
         }
         catch (PermissionDeniedCacheException e) {
             throw new FTPCommandException(550,"Permission denied");
@@ -4209,12 +4210,13 @@ public abstract class AbstractFtpDoorV1
         }
     }
 
-    private void sendRemoveInfoToBilling(FsPath path) {
+    private void sendRemoveInfoToBilling(PnfsId pnfsId, FsPath path) {
         try {
             DoorRequestInfoMessage infoRemove =
                 new DoorRequestInfoMessage(_cellAddress.toString(), "remove");
             infoRemove.setSubject(_subject);
             infoRemove.setPath(path);
+            infoRemove.setPnfsId(pnfsId);
             infoRemove.setClient(_clientDataAddress.getAddress().getHostAddress());
 
             _billingStub.notify(infoRemove);

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/RemoveFileCompanion.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/RemoveFileCompanion.java
@@ -93,6 +93,7 @@ import dmg.cells.nucleus.CellMessage;
 import dmg.cells.nucleus.CellPath;
 import dmg.cells.nucleus.NoRouteToCellException;
 
+import org.dcache.auth.Subjects;
 import org.dcache.cells.AbstractMessageCallback;
 import org.dcache.cells.CellStub;
 import org.dcache.srm.RemoveFileCallback;
@@ -196,6 +197,7 @@ public class RemoveFileCompanion
             msg.setSubject(_subject);
             msg.setPath(_path);
             msg.setPnfsId(pnfsid);
+            msg.setClient(Subjects.getOrigin(_subject).getAddress().getHostAddress());
 
             _endpoint.sendMessage(new CellMessage(BILLING_PATH, msg));
         } catch (NoRouteToCellException e) {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheFileResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheFileResource.java
@@ -178,7 +178,7 @@ public class DcacheFileResource
         throws NotAuthorizedException, ConflictException, BadRequestException
     {
         try {
-            _factory.deleteFile(_attributes.getPnfsId(), _path);
+            _factory.deleteFile(_attributes, _path);
         } catch (PermissionDeniedCacheException e) {
             throw new NotAuthorizedException(this);
         } catch (CacheException e) {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -849,16 +849,15 @@ public class DcacheResourceFactory
     /**
      * Deletes a file.
      */
-    public void deleteFile(PnfsId pnfsid, FsPath path)
+    public void deleteFile(FileAttributes attributes, FsPath path)
         throws CacheException
     {
         PnfsHandler pnfs = new PnfsHandler(_pnfs, getSubject());
-        pnfs.deletePnfsEntry(pnfsid, path.toString(),
-                EnumSet.of(REGULAR, LINK));
-        sendRemoveInfoToBilling(path);
+        pnfs.deletePnfsEntry(attributes.getPnfsId(), path.toString(), EnumSet.of(REGULAR, LINK));
+        sendRemoveInfoToBilling(attributes, path);
     }
 
-    private void sendRemoveInfoToBilling(FsPath path)
+    private void sendRemoveInfoToBilling(FileAttributes attributes, FsPath path)
     {
         try {
             DoorRequestInfoMessage infoRemove =
@@ -866,6 +865,8 @@ public class DcacheResourceFactory
             Subject subject = getSubject();
             infoRemove.setSubject(subject);
             infoRemove.setPath(path);
+            infoRemove.setPnfsId(attributes.getPnfsId());
+            infoRemove.setFileSize(attributes.getSize());
             infoRemove.setClient(Subjects.getOrigin(subject).getAddress().getHostAddress());
             _billingStub.notify(infoRemove);
         } catch (NoRouteToCellException e) {

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -49,6 +49,7 @@ import diskCacheV111.util.FileLocality;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
+import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.DoorRequestInfoMessage;
 import diskCacheV111.vehicles.DoorTransferFinishedMessage;
 import diskCacheV111.vehicles.IoDoorEntry;
@@ -472,17 +473,18 @@ public class XrootdDoor
         }
 
         Set<FileType> allowedSet = EnumSet.of(FileType.REGULAR);
-        pnfsHandler.deletePnfsEntry(path.toString(), allowedSet);
-        sendRemoveInfoToBilling(path, subject);
+        PnfsId pnfsId = pnfsHandler.deletePnfsEntry(path.toString(), allowedSet);
+        sendRemoveInfoToBilling(pnfsId, path, subject);
     }
 
-    private void sendRemoveInfoToBilling(FsPath path, Subject subject)
+    private void sendRemoveInfoToBilling(PnfsId pnfsId, FsPath path, Subject subject)
     {
         try {
             DoorRequestInfoMessage infoRemove =
                     new DoorRequestInfoMessage(getCellAddress().toString(), "remove");
             infoRemove.setSubject(subject);
             infoRemove.setPath(path);
+            infoRemove.setPnfsId(pnfsId);
             Origin origin = Subjects.getOrigin(subject);
             if (origin != null) {
                 infoRemove.setClient(origin.getAddress().getHostAddress());

--- a/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
@@ -339,15 +339,15 @@ public class PnfsHandler
             return pnfsRequest(new PnfsGetParentMessage(pnfsId)).getParent();
     }
 
-    public void deletePnfsEntry(String path) throws CacheException
+    public PnfsId deletePnfsEntry(String path) throws CacheException
     {
-        deletePnfsEntry(null, path);
+        return deletePnfsEntry(path, EnumSet.allOf(FileType.class));
     }
 
-    public void deletePnfsEntry(String path, Set<FileType> allowed)
+    public PnfsId deletePnfsEntry(String path, Set<FileType> allowed)
         throws CacheException
     {
-        deletePnfsEntry(null, path, allowed);
+        return pnfsRequest(new PnfsDeleteEntryMessage(null, path, allowed)).getPnfsId();
     }
 
     public void deletePnfsEntry(PnfsId pnfsid)  throws CacheException


### PR DESCRIPTION
Doors reform billing when files are deleted, but many only included the path.
Since the path is ambiguous, this patch adds PnfsId to those notifications. In
a few cases we even have the file size available and add that too. The client
IP address is also added.

Please advice whether this should be backported to 2.10.

Target: trunk
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7476/
(cherry picked from commit 6a750afd1044aba4471dbffcbee81d11d28a5270)
