### PR TITLE
(2.11) jetty: update webdefault.xml to adhere to new specification

### DIFF
--- a/modules/dcache/src/main/resources/javax/servlet/resources/web-app_3_1.xsd
+++ b/modules/dcache/src/main/resources/javax/servlet/resources/web-app_3_1.xsd
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.1">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[[
+      This is the XML Schema for the Servlet 3.1 deployment descriptor.
+      The deployment descriptor must be named "WEB-INF/web.xml" in the
+      web application's war file.  All Servlet deployment descriptors
+      must indicate the web application schema by using the Java EE
+      namespace:
+      
+      http://xmlns.jcp.org/xml/ns/javaee 
+      
+      and by indicating the version of the schema by 
+      using the version element as shown below: 
+      
+      <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="3.1"> 
+      ...
+      </web-app>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Java EE
+      namespace with the following location:
+      
+      http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Java EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="web-common_3_1.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="web-app"
+               type="javaee:web-appType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The web-app element is the root of the deployment
+        descriptor for a web application.  Note that the sub-elements
+        of this element can be in the arbitrary order. Because of
+        that, the multiplicity of the elements of distributable,
+        session-config, welcome-file-list, jsp-config, login-config,
+        and locale-encoding-mapping-list was changed from "?" to "*"
+        in this schema.  However, the deployment descriptor instance
+        file must not contain multiple elements of session-config,
+        jsp-config, and login-config. When there are multiple elements of
+        welcome-file-list or locale-encoding-mapping-list, the container
+        must concatenate the element contents.  The multiple occurence
+        of the element distributable is redundant and the container
+        treats that case exactly in the same way when there is only
+        one distributable. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="web-common-servlet-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The servlet element contains the name of a servlet.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:servlet"/>
+      <xsd:field xpath="javaee:servlet-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-filter-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The filter element contains the name of a filter.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:filter"/>
+      <xsd:field xpath="javaee:filter-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-local-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-local-ref-name element contains the name of an EJB
+          reference. The EJB reference is an entry in the web
+          application's environment and is relative to the
+          java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:ejb-local-ref"/>
+      <xsd:field xpath="javaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an EJB
+          reference. The EJB reference is an entry in the web
+          application's environment and is relative to the
+          java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:ejb-ref"/>
+      <xsd:field xpath="javaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:resource-env-ref"/>
+      <xsd:field xpath="javaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the name of
+          a message destination reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:message-destination-ref"/>
+      <xsd:field xpath="javaee:message-destination-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.  The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:resource-ref"/>
+      <xsd:field xpath="javaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of a web
+          application's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name
+          must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:env-entry"/>
+      <xsd:field xpath="javaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:key name="web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          A role-name-key is specified to allow the references
+          from the security-role-refs.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:security-role"/>
+      <xsd:field xpath="javaee:role-name"/>
+    </xsd:key>
+    <xsd:keyref name="web-common-role-name-references"
+                refer="javaee:web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The keyref indicates the references from
+          security-role-ref to a specified role-name.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:servlet/javaee:security-role-ref"/>
+      <xsd:field xpath="javaee:role-link"/>
+    </xsd:keyref>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="web-appType">
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="module-name"
+                   type="javaee:string"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:web-commonType"/>
+      <xsd:element name="deny-uncovered-http-methods"
+                   type="javaee:emptyType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When specified, this element causes uncovered http methods
+            to be denied. For every url-pattern that is the target of a 
+            security-constrant, this element causes all HTTP methods that
+            are NOT covered (by a security constraint) at the url-pattern
+            to be denied.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="absolute-ordering"
+                   type="javaee:absoluteOrderingType"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="javaee:web-common-attributes"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="absoluteOrderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Please see section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="name"
+                   type="javaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="javaee:ordering-othersType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/modules/dcache/src/main/resources/org/dcache/admin/webadmin/jettycell/resources/webdefault.xml
+++ b/modules/dcache/src/main/resources/org/dcache/admin/webadmin/jettycell/resources/webdefault.xml
@@ -18,11 +18,12 @@
 <!--                                                                       -->
 <!-- ===================================================================== -->
 <web-app
-   xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                       javax/servlet/resources/web-app_3_1.xsd"
    metadata-complete="true"
-   version="2.5">
+   version="3.1">
 
   <description>
     Default web.xml file.
@@ -393,11 +394,18 @@
 
   <security-constraint>
     <web-resource-collection>
-      <web-resource-name>Disable TRACE</web-resource-name>
-      <url-pattern>/</url-pattern>
-      <http-method>TRACE</http-method>
+        <web-resource-name>Disable TRACE</web-resource-name>
+        <url-pattern>/</url-pattern>
+        <http-method>TRACE</http-method>
     </web-resource-collection>
     <auth-constraint/>
   </security-constraint>
+  <security-constraint>
+    <web-resource-collection>
+        <web-resource-name>Enable everything but TRACE</web-resource-name>
+        <url-pattern>/</url-pattern>
+        <http-method-omission>TRACE</http-method-omission>
+    </web-resource-collection>
+ </security-constraint>
 
 </web-app>


### PR DESCRIPTION
The current xml stanza concerning security constraints does
not observe the new requirement that all HTTP methods be
specified.

This patch updates the xml namespace to point to the newer xsd,
and adds the missing omission stanza.

Testing:

Before application of patch, the following type of warning appears in the log:

05 Nov 2014 11:45:13 (httpd) [] ServletContext@o.e.j.w.WebAppContext@1db9683d{/webadmin,file:/var/lib/dcache/httpd/webadmin/webapp/,STARTING}{/webadmin.war} has uncovered http methods for path: /

The patch silences this warning.

Target: master
Patch: https://rb.dcache.org/r/7488
Request: 2.11
Acked-by: Paul
Require-notes: no
Require-book: no
