### PR TITLE
rootd,pool: Fix xrootd and http logging context

### DIFF
--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -61,10 +61,13 @@
   </bean>
 
   <bean id="dirlist-timeout-executor"
-        class="java.util.concurrent.Executors"
-        factory-method="newSingleThreadScheduledExecutor"
+        class="org.dcache.util.CDCScheduledExecutorServiceDecorator"
         destroy-method="shutdown">
-    <description>Thread pool for dirlist callback timeouts</description>
+      <description>Thread pool for dirlist callback timeouts</description>
+      <constructor-arg>
+          <bean class="java.util.concurrent.Executors"
+                factory-method="newSingleThreadScheduledExecutor"/>
+      </constructor-arg>
   </bean>
 
   <bean id="request-thread-pool"


### PR DESCRIPTION
Several executors didn't use a CDC resetting executor, causing the CDC
to be from whatever transfer first created the thread.

Target: trunk
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7507/
(cherry picked from commit 2b652204310d8164fbff2a3903c8cedeb1b12986)
