### PR TITLE
cells: Refine TTL discard message

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
@@ -1,5 +1,6 @@
 package dmg.cells.nucleus;
 
+import com.google.common.base.Ascii;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -800,8 +801,9 @@ public class   CellAdapter extends CommandInterpreter
 
             if (msg.isFinalDestination()) {
                 if (!msg.isReply() && msg.getLocalAge() > msg.getAdjustedTtl()) {
-                    _log.warn("Discarding " + obj.getClass().getSimpleName() +
-                                      " because its time to live has been exceeded.");
+                    _log.warn("Discarding {} because its age of {} ms exceeds its time to live of {} ms.",
+                              (obj instanceof CharSequence) ? '\'' + Ascii.truncate((CharSequence) obj, 50, "...") + '\'' : obj.getClass().getSimpleName(),
+                              msg.getLocalAge(), msg.getAdjustedTtl());
                     return;
                 }
 


### PR DESCRIPTION
A recent addition has added automatic discard of messages when their TTL is
exceeded. dCache logs a warning when this happens. Our admins have noted that
in particular for String messages, the warning is not particularly useful, as
only the message type is logged.

Since String messages are already a special case in dCache, I think it makes
sense to also log when they are discarded in a special way. This patch logs the
(possibly truncated) content of the string.

The patch also adds the message age and ttl to the log message.

Given how minor the change is and given that the log message was recently
introduced and may trigger support requests, I request that this change is
backported.

Target: trunk
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7503/
(cherry picked from commit fa36eb22260be4eaeed138f27408cd4d54fd1ee9)
