### PR TITLE
(2.6) dcache-webadmin: change Jetty setting so .war is not unpacked

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/HttpServiceCell.java
@@ -141,7 +141,7 @@ public class HttpServiceCell extends AbstractCell implements EnvironmentAware {
                     + "   class              <fullClassName> <...>\n"
                     + "   context            [options] <context> or  <contextNameStart>*\n"
                     + "                       options : -overwrite=<alias> -onError=<alias>\n"
-                    + "   webapp             <webappsContext> <webappsPath> <tempUnpackDir> <...> \n"
+                    + "   webapp             <webappsContext> <webappsPath> <...> \n"
                     + "   redirect           <forward-to-context>\n"
                     + "   predefined alias : <home>    =  default for http://host:port/ \n"
                     + "                      <default> =  default for any type or error \n";

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/util/AliasEntry.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/util/AliasEntry.java
@@ -89,7 +89,6 @@ public class AliasEntry {
     public static final String TYPE_BAD_CONFIG = "badconfig";
     public static final String CELL_ENDPOINT = "serviceCellEndpoint";
     public static final String CELL_NUCLEUS = "serviceCellNucleus";
-    public static final String OPT_UNPACK_DIR = "tempUnpackDir";
 
     public static AliasEntry createEntry(Args args, HttpServiceCell cell)
                     throws Exception {
@@ -186,17 +185,13 @@ public class AliasEntry {
     private static Handler createWebAppContext(String alias, String webappsPath,
                     Args args, HttpServiceCell cell) throws Exception {
             final String context = "/" + alias;
-            final String tmp = args.getOpt(OPT_UNPACK_DIR);
 
             final File war = new File(webappsPath, context + ".war");
-            final File tmpDir = new File(tmp, alias);
 
             final WebAppContext webappContext = new WebAppContext();
             webappContext.setDefaultsDescriptor(cell.getDefaultWebappsXml());
             webappContext.setContextPath(context);
             webappContext.setWar(war.getAbsolutePath());
-            webappContext.setExtractWAR(true);
-            webappContext.setTempDirectory(tmpDir);
             webappContext.setConfigurationClasses(configClasses);
 
             /*

--- a/modules/fhs/src/main/assembly/filter.properties
+++ b/modules/fhs/src/main/assembly/filter.properties
@@ -84,4 +84,3 @@ dcache.paths.ssh-keys=${dcache.paths.etc}/admin
 dcache.pid.dir=/var/run
 dcache.paths.lock.file=/var/run/subsys/dcache
 dcache.paths.alarms=/var/lib/dcache/alarms
-dcache.paths.unpack=/var/lib/dcache/httpd

--- a/modules/system-test/src/main/assembly/filter.properties
+++ b/modules/system-test/src/main/assembly/filter.properties
@@ -105,4 +105,3 @@ dcache.paths.ssh-keys=${dcache.paths.etc}/admin
 dcache.pid.dir=${dcache.home}/var/run
 dcache.paths.lock.file=
 dcache.paths.alarms=${dcache.home}/var/alarms
-dcache.paths.unpack=${dcache.home}/var/httpd

--- a/modules/tar/src/main/assembly/filter.properties
+++ b/modules/tar/src/main/assembly/filter.properties
@@ -104,4 +104,3 @@ dcache.paths.ssh-keys=${dcache.paths.etc}/admin
 dcache.pid.dir=${dcache.home}/var/run
 dcache.paths.lock.file=
 dcache.paths.alarms=${dcache.home}/var/alarms
-dcache.paths.unpack=${dcache.home}/var/httpd

--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -64,7 +64,7 @@ webadminWebappsPath=${dcache.paths.classes}/webapps
 #
 #   Specifies the path where the war file is unpacked into
 #
-webadminWarunpackdir=@dcache.paths.unpack@
+(obsolete)webadminWarunpackdir=webadmin .war is no longer extracted
 
 #
 #   This Name will be displayed on some of the webpages as Header

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -69,7 +69,6 @@ define context webadmin.exe endDefine
      -srmSpaceManagerEnabled=${srmSpaceManagerEnabled} \
      -collectorTimeout=${collectorTimeout} \
      -transfersCollectorUpdate=${transfersCollectorUpdate} \
-     -tempUnpackDir=${webadminWarunpackdir} \
      -billingCell=${billing} \
      -generatePlots=${plotBillingData} \
      -profiles=plotting-${billingToDb} \


### PR DESCRIPTION
See http://rt.dcache.org/Ticket/Display.html?id=8489.

When upgrading from 2.6 to 2.10, there is a potential
for the webadmin directory timestamps to be more recent
than the timestamp of the /usr/share/dcache/classes/webapps/webadmin.war
file, which then causes Jetty to ignore the new war
and use the old directory. This subsequently provokes
jndi issues because the new httpd.batch file does not
pass through properties that the webadmin spring file
expects to find in the naming and directory interface.

The simplest solution is to turn off unpacking.

While the specific issue reported in the ticket does not
occur in 2.6, the conversion to non-extraction was requested
for this branch as well, to prevent further possible
timestamp issues on the update of the .war.

Note that https://rb.dcache.org/r/7436/ does this for master.

Target: 2.6
Acked-by: Gerd
Require-book: no
Require-notes: yes

RELEASE NOTES:  The webadmin.war found in /usr/share/dcache/classes/webapps
is no longer unpacked (by default, /var/lib/dcache/httpd).  This
avoids potential conflicts between versions when update installs are run.
