### PR TITLE
pool: Avoid interrupting Berkeley DB in migration module server

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
@@ -244,6 +244,11 @@ public class MigrationModuleServer
             return false;
         }
 
+        private synchronized void disableInterrupt()
+        {
+            _updateTask = null;
+        }
+
         protected synchronized void finished(Throwable e)
         {
             PoolMigrationCopyFinishedMessage message =
@@ -293,6 +298,8 @@ public class MigrationModuleServer
                         handle.close();
                     }
                 }
+
+                disableInterrupt();
 
                 EntryState state = _repository.getState(_pnfsId);
                 switch (state) {


### PR DESCRIPTION
Berkeley DB for Java doesn't like thread interrupts, and the pool tries to
never interrupt threads while they update the meta data database. We however
missed at least one case:

17 Nov 2014 11:11:10 (ore_ndgf_org_001) [ore_ndgf_org_002 PoolMigrationCopyReplica 00007D0EC04343684CF6A5F78B289361CD7B] Fault occured in repository: Internal repository error
diskCacheV111.util.CacheException: No transaction is active
        at org.dcache.pool.repository.meta.db.CacheRepositoryEntryImpl.setSticky(CacheRepositoryEntryImpl.java:225) ~[dcache-core-2.10.10.jar:2.10.10]
        at org.dcache.pool.repository.v5.CacheRepositoryV5.setSticky(CacheRepositoryV5.java:890) [dcache-core-2.10.10.jar:2.10.10]
        at org.dcache.pool.repository.v5.CacheRepositoryV5.setSticky(CacheRepositoryV5.java:600) [dcache-core-2.10.10.jar:2.10.10]
        at org.dcache.pool.migration.MigrationModuleServer$Request.run(MigrationModuleServer.java:301) [dcache-core-2.10.10.jar:2.10.10]
        at org.dcache.util.CDCExecutorServiceDecorator$1.run(CDCExecutorServiceDecorator.java:104) [dcache-core-2.10.10.jar:2.10.10]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471) [na:1.7.0_71]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_71]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:178) [na:1.7.0_71]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:292) [na:1.7.0_71]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_71]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_71]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_71]

This patch fixes this problem.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Karsten Schwank karsten.schwank@desy.de
Patch: https://rb.dcache.org/r/7509/
(cherry picked from commit 19d6b127d170c700f1fd77afdfd65846aab1fc0a)
