### PR TITLE
Fix NPE in cell initialization

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/network/ExampleSocket.java
+++ b/modules/cells/src/main/java/dmg/cells/network/ExampleSocket.java
@@ -39,6 +39,7 @@ public class ExampleSocket implements Cell, Runnable {
    public ExampleSocket( String cellName , Socket socket ){
 
       _nucleus = new CellNucleus( this , cellName ) ;
+      _nucleus.start();
       _nucleus.export() ;
 
       _worker = _nucleus.newThread( this , "I/O Engine" ) ;

--- a/modules/cells/src/main/java/dmg/cells/network/GNLCell.java
+++ b/modules/cells/src/main/java/dmg/cells/network/GNLCell.java
@@ -84,6 +84,7 @@ public class GNLCell implements Cell, Runnable  {
   private void _GNLCell( String name , String cellClass , int port ){
 
        _nucleus    = new CellNucleus( this , name ) ;
+       _nucleus.start();
        _cellName   = name ;
        _cellClass  = cellClass ;
        _listenPort = port ;

--- a/modules/cells/src/main/java/dmg/cells/network/ReflectionTunnel.java
+++ b/modules/cells/src/main/java/dmg/cells/network/ReflectionTunnel.java
@@ -39,7 +39,7 @@ public class ReflectionTunnel implements Cell,
    {
 
       _nucleus  = new CellNucleus( this , cellName ) ;
-
+      _nucleus.start();
    }
 
    @Override

--- a/modules/cells/src/main/java/dmg/cells/network/RetryTunnel.java
+++ b/modules/cells/src/main/java/dmg/cells/network/RetryTunnel.java
@@ -103,6 +103,7 @@ public class RetryTunnel implements Cell,
       _mode     = "Accepted" ;
       _socket   = socket ;
       _nucleus  = new CellNucleus( this , cellName ) ;
+      _nucleus.start();
 
       _engine   = new StateThread( this ) ;
       _engine.start() ;
@@ -135,6 +136,7 @@ public class RetryTunnel implements Cell,
       _port    = port ;
 
       _nucleus = new CellNucleus( this , cellName ) ;
+      _nucleus.start();
 
       _engine   = new StateThread( this ) ;
       _engine.start() ;
@@ -148,6 +150,7 @@ public class RetryTunnel implements Cell,
       _port    = port ;
 
       _nucleus = new CellNucleus( this , cellName ) ;
+      _nucleus.start();
 
       _engine   = new StateThread( this ) ;
       _engine.start() ;

--- a/modules/cells/src/main/java/dmg/cells/network/SimpleTunnel.java
+++ b/modules/cells/src/main/java/dmg/cells/network/SimpleTunnel.java
@@ -78,6 +78,7 @@ public class SimpleTunnel implements Cell, Runnable, CellTunnel {
       _socket  = new Socket( address , port ) ;
       _mode    = "Connection" ;
       _nucleus = new CellNucleus( this , cellName ) ;
+      _nucleus.start();
 
       _connectorThread = _nucleus.newThread( this , "Connector" ) ;
       _connectorThread.start() ;
@@ -88,6 +89,7 @@ public class SimpleTunnel implements Cell, Runnable, CellTunnel {
 
       _mode    = "Acception" ;
       _nucleus = new CellNucleus( this , cellName ) ;
+      _nucleus.start();
 
 
       _socket  = socket ;

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
@@ -128,6 +128,7 @@ public class   CellAdapter
 
         _args      = args;
         _nucleus   = new CellNucleus(this, cellName, cellType);
+        _nucleus.start();
         _autoSetup = cellName + "Setup";
 
         if ((_args.argc() > 0) &&

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -33,6 +33,9 @@ import dmg.util.Pinboard;
 import dmg.util.logback.FilterThresholds;
 import dmg.util.logback.RootFilterThresholds;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 /**
  *
  *
@@ -57,7 +60,7 @@ public class CellNucleus implements ThreadFactory
     private final  Cell      _cell;
     private final  Date      _creationTime   = new Date();
 
-    private        int       _state          = INITIAL;
+    private final AtomicInteger _state = new AtomicInteger(INITIAL);
 
     //  have to be synchronized map
     private final  Map<UOID, CellLock> _waitHash = new HashMap<>();
@@ -151,13 +154,6 @@ public class CellNucleus implements ThreadFactory
                         0L, TimeUnit.MILLISECONDS,
                         new LinkedBlockingQueue<Runnable>(),
                         this);
-
-        _state = ACTIVE;
-
-        //
-        // make ourself known to the world
-        //
-        __cellGlue.addCell(_cellName, this);
 
         LOGGER.info("Created {}", name);
     }
@@ -266,7 +262,7 @@ public class CellNucleus implements ThreadFactory
         info.setCellClass(_cellClass);
         try {
             info.setEventQueueSize(getEventQueueSize());
-            info.setState(_state);
+            info.setState(_state.get());
             info.setThreadCount(_threads.activeCount());
         } catch(Exception e) {
             info.setEventQueueSize(0);
@@ -334,9 +330,10 @@ public class CellNucleus implements ThreadFactory
      */
     public synchronized void setMessageExecutor(ExecutorService executor)
     {
-        if (executor == null) {
-            throw new IllegalArgumentException("null is not allowed");
-        }
+        checkNotNull(executor);
+        int state = _state.get();
+        checkState(state != REMOVING && state != DEAD);
+
         if (_isPrivateMessageExecutor) {
             _messageExecutor.shutdown();
         }
@@ -830,12 +827,22 @@ public class CellNucleus implements ThreadFactory
         }
     }
 
+    public void start()
+    {
+        checkState(_state.compareAndSet(INITIAL, ACTIVE));
+
+        //
+        // make ourself known to the world
+        //
+        __cellGlue.addCell(_cellName, this);
+    }
+
     void shutdown(KillEvent event)
     {
         LOGGER.trace("Received {}", event);
 
         try (CDC ignored = CDC.reset(CellNucleus.this)) {
-            _state = REMOVING;
+            checkState(_state.compareAndSet(INITIAL, REMOVING) || _state.compareAndSet(ACTIVE, REMOVING));
             addToEventQueue(LAST_MESSAGE_EVENT);
             try {
                 _cell.prepareRemoval(event);
@@ -864,7 +871,7 @@ public class CellNucleus implements ThreadFactory
                 LOGGER.warn("Interrupted while waiting for threads");
             }
             __cellGlue.destroy(CellNucleus.this);
-            _state = DEAD;
+            _state.set(DEAD);
         }
     }
 

--- a/modules/cells/src/main/java/dmg/cells/services/BootstrapStore.java
+++ b/modules/cells/src/main/java/dmg/cells/services/BootstrapStore.java
@@ -49,6 +49,7 @@ public class BootstrapStore implements Cell {
       _storeBase = args.argv(0) ;
 
       _nucleus   = new CellNucleus( this , cellName ) ;
+      _nucleus.start();
    }
    public String toString(){
       return  _nucleus.getCellDomainName()+


### PR DESCRIPTION
Cells block delivery of messages until they have been started. Prior to being
started the message is returned to the sender. The code however suffers from a
race resulting in the following exception:

17 nov. 2014 15:01:17 (SrmSpaceManager) [] Uncaught exception in thread SrmSpaceManager-0
java.lang.NullPointerException: null
        at dmg.cells.nucleus.CellAdapter.getCellName(CellAdapter.java:325) ~[cells-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:784) ~[cells-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.innerRun(CellNucleus.java:1095) ~[cells-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at dmg.cells.nucleus.CellNucleus$AbstractNucleusTask.run(CellNucleus.java:1005) ~[cells-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_25]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_25]
        at dmg.cells.nucleus.CellNucleus$3.run(CellNucleus.java:696) [cells-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_25]

The cause is the classic problem of leaking a reference to an object in its
constructor. In this case CellNucleus registers itself with CellGlue inside
its constructor, meaning that others may deliver messages to it even before
the final nucleus member in CellAdapter has been initialized.

This minimal patch moves the CellGlue registration into a new CellNucleus#start
method. The method is called right after the constructor returns. The patch
is kept small to allow it to be backported, however a subsequent patch for trunk
will change the code further to not start the CellNucleus until the cell has
been started, thus solving the problem of early message delivery.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Karsten Schwank karsten.schwank@desy.de
Patch: https://rb.dcache.org/r/7511/
(cherry picked from commit 019e10e1eef0469e447e4a80bde1a8e708ae2de3)

Conflicts:
    modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java

(cherry picked from commit 6762e044e43066fd82d2835a6d344d044a68b513)

Conflicts:
    modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
