### PR TITLE
pool: Improve xrootd error message on missing UUID

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -225,13 +225,13 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
             UUID uuid = getUuid(msg.getOpaque());
             if (uuid == null) {
                 _log.warn("Request contains no UUID: {}", msg);
-                return redirectToDoor(ctx, event, msg);
+                throw new XrootdException(kXR_NotAuthorized, "Request lacks the " + UUID_PREFIX + " property.");
             }
 
             MoverChannel<XrootdProtocolInfo> file = _server.open(uuid, false);
             if (file == null) {
                 _log.warn("No mover found for {}", msg);
-                return redirectToDoor(ctx, event, msg);
+                throw new XrootdException(kXR_NotAuthorized, UUID_PREFIX + " is no longer valid.");
             }
 
             try {


### PR DESCRIPTION
The existing error when the client doesn't present a valid UUID is misleading
as it usually states that the open request is not supported when it reallity
the request is not authorized due to the lack of the token.

This patch improves the error message and return code.

Target: trunk
Request: 2.10
Request: 2.11
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7515/
(cherry picked from commit 12d5aedef13860d3b875fcf135fa02ca2f4a59dc)
