### PR TITLE
pool: Restore flush and stage stats in info

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -34,6 +34,7 @@ import javax.annotation.PostConstruct;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.channels.CompletionHandler;
@@ -184,6 +185,27 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         repository.addListener(this);
     }
 
+    @Override
+    public void getInfo(PrintWriter pw)
+    {
+        pw.append(" Restore Timeout  : ").print(stageTimeout / 1000L);
+        pw.println(" seconds");
+        pw.append("   Store Timeout  : ").print(flushTimeout / 1000L);
+        pw.println(" seconds");
+        pw.append("  Remove Timeout  : ").print(removeTimeout / 1000L);
+        pw.println(" seconds");
+        pw.println("  Job Queues (active/queued)");
+        pw.append("    to store   ").print(getActiveStoreJobs());
+        pw.append("/").print(getStoreQueueSize());
+        pw.println();
+        pw.append("    from store ").print(getActiveFetchJobs());
+        pw.append("/").print(getFetchQueueSize());
+        pw.println();
+        pw.append("    delete     " + "").print(getActiveRemoveJobs());
+        pw.append("/").print(getRemoveQueueSize());
+        pw.println();
+    }
+
     /**
      * Flushes a set of files to nearline storage.
      *
@@ -252,7 +274,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
 
     public int getActiveFetchJobs()
     {
-        return stageRequests.getCount(AbstractRequest.State.ACTIVE);
+        return stageRequests.getCount(AbstractRequest.State.ACTIVE) + stageRequests.getCount(AbstractRequest.State.CANCELED);
     }
 
     public int getFetchQueueSize()
@@ -262,12 +284,22 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
 
     public int getActiveStoreJobs()
     {
-        return flushRequests.getCount(AbstractRequest.State.ACTIVE);
+        return flushRequests.getCount(AbstractRequest.State.ACTIVE) + flushRequests.getCount(AbstractRequest.State.CANCELED);
     }
 
     public int getStoreQueueSize()
     {
         return flushRequests.getCount(AbstractRequest.State.QUEUED);
+    }
+
+    public int getActiveRemoveJobs()
+    {
+        return removeRequests.getCount(AbstractRequest.State.ACTIVE) + removeRequests.getCount(AbstractRequest.State.CANCELED);
+    }
+
+    public int getRemoveQueueSize()
+    {
+        return removeRequests.getCount(AbstractRequest.State.QUEUED);
     }
 
     @Override


### PR DESCRIPTION
Resolves a regression in which statistics about the number of HSM
requests and HSM timeouts is no longer provided in the info output.

Also fixes a minor bug in how active HSM jobs are counted: A cancelled
task is still active until the driver has ended the job.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7520/
(cherry picked from commit 4162c2be8b263ae8a9716cb2818528f4dc792f4d)
