### PR TITLE
xrootd: Propagate mover errors to dCache

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/vehicles/XrootdProtocolInfo.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/vehicles/XrootdProtocolInfo.java
@@ -1,6 +1,9 @@
 package org.dcache.vehicles;
 
+import com.google.common.collect.Sets;
+
 import java.net.InetSocketAddress;
+import java.util.EnumSet;
 import java.util.UUID;
 
 import diskCacheV111.util.PnfsId;
@@ -8,120 +11,121 @@ import diskCacheV111.vehicles.IpProtocolInfo;
 
 import dmg.cells.nucleus.CellPath;
 
+import static java.util.Arrays.asList;
+
 public class XrootdProtocolInfo implements IpProtocolInfo {
 
-	private static final long serialVersionUID = -7070947404762513894L;
+    private static final long serialVersionUID = -7070947404762513894L;
 
-	private String _name;
+    public enum Flags
+    {
+        POSC
+    }
 
-	private int _minor;
+    private final String _name;
 
-	private int _major;
+    private final int _minor;
 
-        private InetSocketAddress _clientSocketAddress;
+    private final int _major;
 
-	private CellPath _pathToDoor;
+    private final InetSocketAddress _clientSocketAddress;
 
-	private PnfsId _pnfsId;
+    private final CellPath _pathToDoor;
 
-	private int _xrootdFileHandle;
+    private final PnfsId _pnfsId;
 
-	private String _path;
+    private final int _xrootdFileHandle;
 
-	private UUID _uuid;
+    private String _path;
 
-	private InetSocketAddress _doorAddress;
+    private final UUID _uuid;
 
-	public XrootdProtocolInfo(String protocol,  int major,int minor,
-		InetSocketAddress clientAddress, CellPath pathToDoor, PnfsId pnfsID,
-			int xrootdFileHandle, UUID uuid,
-			InetSocketAddress doorAddress) {
+    private final InetSocketAddress _doorAddress;
 
-		_name = protocol;
-		_minor = minor;
-		_major = major;
-                _clientSocketAddress = clientAddress;
-		_pathToDoor = pathToDoor;
-		_pnfsId = pnfsID;
-		_xrootdFileHandle = xrootdFileHandle;
-		_uuid = uuid;
-		_doorAddress = doorAddress;
-	}
+    private final EnumSet<Flags> _flags;
 
-	@Override
-        public String getProtocol() {
-		return _name;
-	}
+    public XrootdProtocolInfo(String protocol,  int major,int minor,
+        InetSocketAddress clientAddress, CellPath pathToDoor, PnfsId pnfsID,
+            int xrootdFileHandle, UUID uuid,
+            InetSocketAddress doorAddress, Flags... flags)
+    {
+        _name = protocol;
+        _minor = minor;
+        _major = major;
+        _clientSocketAddress = clientAddress;
+        _pathToDoor = pathToDoor;
+        _pnfsId = pnfsID;
+        _xrootdFileHandle = xrootdFileHandle;
+        _uuid = uuid;
+        _doorAddress = doorAddress;
+        _flags = Sets.newEnumSet(asList(flags), Flags.class);
+    }
 
-	@Override
-        public int getMinorVersion() {
-		return _minor;
-	}
+    @Override
+    public String getProtocol() {
+        return _name;
+    }
 
-	@Override
-        public int getMajorVersion() {
-		return _major;
-	}
+    @Override
+    public int getMinorVersion() {
+        return _minor;
+    }
 
-	@Override
-        public String getVersionString() {
-		return _name + "-" + _major + "." + _minor;
-	}
+    @Override
+    public int getMajorVersion() {
+        return _major;
+    }
 
-        @Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder();
-		sb.append(getVersionString());
-                sb.append(':');
-                sb.append(_clientSocketAddress.getAddress().getHostAddress());
-		sb.append(":").append(_clientSocketAddress.getPort());
+    @Override
+    public String getVersionString() {
+        return _name + "-" + _major + "." + _minor;
+    }
 
-		return sb.toString();
-	}
+    @Override
+    public String toString()
+    {
+        return getVersionString() + ':' + _clientSocketAddress.getAddress().getHostAddress() + ":" + _clientSocketAddress.getPort();
+    }
 
-	public CellPath getXrootdDoorCellPath() {
-		return _pathToDoor;
-	}
+    public CellPath getXrootdDoorCellPath() {
+        return _pathToDoor;
+    }
 
-	public void setXrootdDoorCellPath(CellPath toDoor) {
-		_pathToDoor = toDoor;
-	}
+    public PnfsId getPnfsId() {
+        return _pnfsId;
+    }
 
-	public PnfsId getPnfsId() {
-		return _pnfsId;
-	}
+    public int getXrootdFileHandle() {
+        return _xrootdFileHandle;
+    }
 
-	public int getXrootdFileHandle() {
-		return _xrootdFileHandle;
-	}
+    public UUID getUUID() {
+        return _uuid;
+    }
 
-	public boolean isFileCheckRequired() {
-//		we do it the fast way. The PoolMgr will not check whether a file is really on the pool where
-//		it is supposed to be. This saves one message.
-		return false;
-	}
+    public InetSocketAddress getDoorAddress() {
+        return _doorAddress;
+    }
 
-	public UUID getUUID() {
-		return _uuid;
-	}
+    public void setPath(String path)
+    {
+        _path = path;
+    }
 
-	public InetSocketAddress getDoorAddress() {
-		return _doorAddress;
-	}
+    public String getPath()
+    {
+        return _path;
+    }
 
-	public void setPath(String path)
-	{
-		_path = path;
-	}
+    @Override
+    public InetSocketAddress getSocketAddress()
+    {
+        return _clientSocketAddress;
+    }
 
-	public String getPath()
-	{
-		return _path;
-	}
-
-        @Override
-        public InetSocketAddress getSocketAddress()
-        {
-            return _clientSocketAddress;
-        }
+    public EnumSet<Flags> getFlags()
+    {
+        // Check null for backwards compatibility with 2.11
+        return (_flags == null) ? EnumSet.noneOf(Flags.class) : _flags;
+    }
 }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/FileDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/FileDescriptor.java
@@ -45,4 +45,9 @@ public interface FileDescriptor
      * Returns the FileChannel of this descriptor.
      */
     MoverChannel<XrootdProtocolInfo> getChannel();
+
+    /**
+     * Whether the file was opened with kXR_posc.
+     */
+    boolean isPersistOnSuccessfulClose();
 }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/ReadDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/ReadDescriptor.java
@@ -56,5 +56,11 @@ public class ReadDescriptor implements FileDescriptor
     {
         return _channel;
     }
+
+    @Override
+    public boolean isPersistOnSuccessfulClose()
+    {
+        return false;
+    }
 }
 

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/WriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/WriteDescriptor.java
@@ -13,9 +13,12 @@ import org.dcache.xrootd.protocol.messages.WriteRequest;
  */
 public class WriteDescriptor extends ReadDescriptor
 {
-    public WriteDescriptor(MoverChannel<XrootdProtocolInfo> channel)
+    private boolean posc;
+
+    public WriteDescriptor(MoverChannel<XrootdProtocolInfo> channel, boolean posc)
     {
         super(channel);
+        this.posc = posc;
     }
 
     @Override
@@ -35,5 +38,11 @@ public class WriteDescriptor extends ReadDescriptor
                 position += _channel.write(buffer, position);
             }
         }
+    }
+
+    @Override
+    public boolean isPersistOnSuccessfulClose()
+    {
+        return posc;
     }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/CacheException.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/CacheException.java
@@ -32,8 +32,9 @@ public class CacheException extends Exception
     public final static int FILESIZE_UNKNOWN = 10003;
 
     /**
-     * File size or checksum in name space does not match actual size or checksum of
-     * the data file.
+     * The data file is corrupted. Typically this is detected because file size or checksum in
+     * name space does not match actual size or checksum of the data file, but other means of
+     * detecting corrupted files may exist for some protocols.
      */
     public final static int FILE_CORRUPTED = 10004;
 

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -205,7 +205,7 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends Mover<P>> 
                     setTransferStatus(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e.getMessage());
                 } catch (CacheException e) {
                     LOGGER.error("Transfer failed: {}", e.getMessage());
-                    setTransferStatus(e.getRc(), "Internal problem: " + e.getMessage());
+                    setTransferStatus(e.getRc(), e.getMessage());
                 } catch (InterruptedIOException | InterruptedException e) {
                     LOGGER.error("Transfer was forcefully killed");
                     setTransferStatus(CacheException.DEFAULT_ERROR_CODE, "Transfer was forcefully killed");


### PR DESCRIPTION
The patch ensures that failures to close a file or unexpected exceptions
are propagated to the pool and logged in billing. Before this patch, xrootd
transfers were always registered as succesful in billing.

The precise error depends on whether the file was opened with the POSC flag
(Persist On Successful Close) or not. If it was, the file is known to be corrupt
from the point of the view of the client and FileCorruptedCacheException is
reported. If not, a generic error is reported.

The current implementation does not actually delete the file on POSC failures.
This is left for a future patch.

The XrootdProtocolInfo is extended with a flag to inject POSC semantics
independent of whether the client specified this flag. This may be used
in doors to enable a POSC-on-default feature mimicking a similar feature
in the SLAC xrootd implementation. This feature is however not supported
by the door yet.

The patch adds logic to disconnect the client when a server side failure
is triggered. Previously this failure was only logged and the error was
ignored.

Backport to 2.10 is requested because the current behaviour fails to log
errors in billing.

Target: trunk
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Karsten Schwank karsten.schwank@desy.d
Patch: https://rb.dcache.org/r/7499/
(cherry picked from commit a6ef4b7080281546ff3f6281bd2101733bb2ebae)

Conflicts:
    modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
