### PR TITLE
nfs: fix NPE on door reboot

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -293,7 +293,15 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         org.dcache.chimera.nfs.v4.xdr.stateid4 legacyStateid = message.challange();
         NfsTransfer transfer = _ioMessages.get(new stateid4(legacyStateid.other, legacyStateid.seqid.value));
-        transfer.redirect(device);
+        /*
+         * We got a notification for a transfer which was not
+         * started by us.
+         *
+         * Door reboot.
+         */
+        if(transfer != null) {
+            transfer.redirect(device);
+        }
     }
 
     public void messageArrived(DoorTransferFinishedMessage transferFinishedMessage) {


### PR DESCRIPTION
handle PoolPassiveIoFileMessage message comming from a pool
even if door did not initialize it. Happend on door restarts
during heavy IO load.

Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit e4f8fc5c9528e40ca7e27083c6ae92a38d5a9de0)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
