### PR TITLE
(2.11) datanucleus: use persistence units

### DIFF
--- a/modules/dcache-webadmin/src/main/resources/META-INF/persistence.xml
+++ b/modules/dcache-webadmin/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
+                        http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+                        version="1.0">
+
+    <persistence-unit name="WebAlarmsXML">
+      <mapping-file>org/dcache/alarms/dao/package.jdo</mapping-file>
+    </persistence-unit>
+
+    <persistence-unit name="WebAlarmsRDBMS">
+      <mapping-file>org/dcache/alarms/dao/package.jdo</mapping-file>
+    </persistence-unit>
+</persistence>
+

--- a/modules/dcache-webadmin/src/main/webapp/WEB-INF/WebAdminInterface.xml
+++ b/modules/dcache-webadmin/src/main/webapp/WEB-INF/WebAdminInterface.xml
@@ -361,6 +361,7 @@
             <description>Database persistence manager</description>
             <constructor-arg>
                 <util:properties location="file:${httpd.alarms.db.config.path}" local-override="true">
+                    <prop key="datanucleus.PersistenceUnitName">WebAlarmsRDBMS</prop>
                     <prop key="datanucleus.connectionPoolingType">None</prop>
                 </util:properties>
             </constructor-arg>
@@ -378,6 +379,7 @@
             <description>Database persistence manager</description>
             <constructor-arg>
                 <util:properties location="file:${httpd.alarms.db.config.path}" local-override="true">
+                    <prop key="datanucleus.PersistenceUnitName">WebAlarmsXML</prop>
                     <prop key="datanucleus.ConnectionURL">${httpd.alarms.db.url}</prop>
                 </util:properties>
             </constructor-arg>

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -244,6 +244,7 @@ public abstract class TransferManager extends AbstractCell
     {
         // FIXME: Close connection pool and pmf
         Properties properties = new Properties();
+        properties.setProperty("datanucleus.PersistenceUnitName", "TransferManager");
         properties.setProperty("javax.jdo.option.DetachAllOnCommit", "true");
         properties.setProperty("javax.jdo.option.Optimistic", "true");
         properties.setProperty("javax.jdo.option.NontransactionalRead", "true");

--- a/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryAppender.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryAppender.java
@@ -470,11 +470,13 @@ public final class LogEntryAppender extends AppenderBase<ILoggingEvent> {
 
         if (url.startsWith("xml:")) {
             initializeXmlFile(xmlPath);
+            properties.setProperty("datanucleus.PersistenceUnitName", "AlarmsXML");
             properties.setProperty("datanucleus.ConnectionURL", url);
         } else if (url.startsWith("jdbc:")) {
             HikariConfig config = new HikariConfig();
             config.setDataSource(new DriverManagerDataSource(url, user, password));
             dataSource = new HikariDataSource(config);
+            properties.setProperty("datanucleus.PersistenceUnitName", "AlarmsRDBMS");
             properties.setProperty("datanucleus.connectionPoolingType", "None");
         }
 

--- a/modules/dcache/src/main/resources/META-INF/persistence.xml
+++ b/modules/dcache/src/main/resources/META-INF/persistence.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd" version="1.0">
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
+                        http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+                        version="1.0">
 
     <persistence-unit name="PinManager">
       <mapping-file>org/dcache/pinmanager/model/package.jdo</mapping-file>
@@ -10,5 +12,20 @@
       </properties>
     </persistence-unit>
 
+    <persistence-unit name="AlarmsXML">
+      <mapping-file>org/dcache/alarms/dao/package.jdo</mapping-file>
+    </persistence-unit>
+
+    <persistence-unit name="AlarmsRDBMS">
+      <mapping-file>org/dcache/alarms/dao/package.jdo</mapping-file>
+    </persistence-unit>
+
+    <persistence-unit name="Billing">
+      <mapping-file>org/dcache/services/billing/db/data/package.jdo</mapping-file>
+    </persistence-unit>
+
+    <persistence-unit name="TransferManager">
+      <mapping-file>diskCacheV111/services/package.jdo</mapping-file>
+    </persistence-unit>
 </persistence>
 

--- a/modules/dcache/src/main/resources/org/dcache/services/billing/cells/billing.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/cells/billing.xml
@@ -63,6 +63,7 @@
           <description>Database persistence manager</description>
           <constructor-arg>
               <util:properties location="${billing.db.config.path}" local-override="true">
+                  <prop key="datanucleus.PersistenceUnitName">Billing</prop>
                   <prop key="datanucleus.connectionPoolingType">None</prop>
               </util:properties>
           </constructor-arg>

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -260,7 +260,7 @@ alarms.db.datanucleus-properties.path=${alarms.dir}/datanucleus.properties
 
 # ---- JDBC Url
 #
-(immutable)alarms.db.url-when-type-is-off=
+(immutable)alarms.db.url-when-type-is-off=off
 (immutable)alarms.db.url-when-type-is-xml=xml:file:${alarms.db.xml.path}
 (immutable)alarms.db.url-when-type-is-rdbms=jdbc:${alarms.db.rdbms.type}://${alarms.db.host}/${alarms.db.name}
 (forbidden)alarms.store.db.url=Use alarms.db.url


### PR DESCRIPTION
Based on the 2.11 release notes, a patch to embed the alarms service in dCacheDomain of system-test
was committed. The release notes claimed that there no longer was a requirement to run it in a separate domain.

Embedding it however broke the tests because the EnhancementHelper.registerClass() call for the XML database (alarms)
rejects other classes using the datastore identity, even though not destined for storage in that database.

The issue here, to quote the author of the code, is as follows:

"JDO comes with an auto-notify feature that will inform ALL interested parties when an enhanced class is loaded (so they can load up metadata for it). Since you have multiple PMF's then the MetaDataManager of each PMF are informed and they try to load it (since it is simply an enhanced class - can be used with any persistence environment that supports JDO). Since one PMF is for XML and it only accepts particular metadata then it rejects that class (for that MetaDataManager) by exception. DN 4.1 code simply logs a warning (instead of exception) that the class is not available for that PMF (so the user can fix their metadata if they want it to be available there)."

For fuller discussion, see http://www.datanucleus.org/servlet/forum/viewthread_thread,7815.

While an update to 4.1 will remove the failure, the better solution is the one we have adopted:
the suggested partitioning of all enhanced classes by persistence units (already used for the pinmanager).

Also makes the 'off' url for alarms a non-empty string; otherwise an NPE occurs during injection.

Target:  2.11
Patch: https://rb.dcache.org/r/7517
Require-book: no
Require-notes: yes
Acked-by: Gerd

RELEASE NOTES:  Fixes error when alarms XML database and TransferManager share the same domain.
