### PR TITLE
spacemanager: Fix various error recovery scenarios

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -252,9 +252,12 @@ public final class SpaceManagerService
         {
                 LOGGER.trace("expireSpaceReservations()...");
 
-                /* Remove file reservations for files no longer in the name space. Under normal
-                 * circumstances this should never be necessary, but since notifications from
-                 * PnfsManager about deleted files may be lost, we need to recover in some way.
+                /* Recover files from lost notifications. Space manager receives notifications
+                 * on file transfer finishing (DoorTransferFinished), name space deletion
+                 * (PnfsDeleteEntryNotification), pool location cleaning (PoolRemoveFiles),
+                 * and flush (PoolFileFlushed). These notifications are however lossy, and we
+                 * need to recover from lost messages in some way.
+                 *
                  * We ought to do this with any kind of file reservation, but that would be rather
                  * expensive. This code is currently limited to reservations in the TRANSFERRING
                  * state: It is easy to miss the notification for such files if space manager
@@ -266,21 +269,35 @@ public final class SpaceManagerService
                 final int maximumNumberFilesToLoadAtOnce = 1000;
                 for (File file: db.get(oldTransfers, maximumNumberFilesToLoadAtOnce)) {
                     try {
-                        if (!isRegularFile(file)) {
+                        EnumSet<FileAttribute> attributes =
+                                EnumSet.of(FileAttribute.TYPE,
+                                           FileAttribute.SIZE,
+                                           FileAttribute.LOCATIONS,
+                                           FileAttribute.STORAGEINFO,
+                                           FileAttribute.ACCESS_LATENCY);
+                        FileAttributes fileAttributes = pnfs.getFileAttributes(file.getPnfsId(), attributes);
+                        if (fileAttributes.getFileType() != FileType.REGULAR) {
                             db.removeFile(file.getId());
+                        } else if (fileAttributes.getStorageInfo().isStored()) {
+                            boolean isRemovable = !fileAttributes.getAccessLatency().equals(AccessLatency.ONLINE);
+                            fileFlushed(file.getPnfsId(), fileAttributes.getSize(), isRemovable);
+                        } else if (!fileAttributes.getLocations().isEmpty()) {
+                            transferFinished(file.getPnfsId(), fileAttributes.getSize());
                         }
+                    } catch (FileNotFoundCacheException e) {
+                        db.removeFile(file.getId());
                     } catch (TransientDataAccessException e) {
-                            LOGGER.warn("Transient data access failure while deleting expired file {}: {}",
-                                         file, e.getMessage());
+                        LOGGER.warn("Transient data access failure while deleting expired file {}: {}",
+                                    file, e.getMessage());
                     } catch (DataAccessException e) {
-                            LOGGER.error("Data access failure while deleting expired file {}: {}",
-                                         file, e.getMessage());
-                            break;
+                        LOGGER.error("Data access failure while deleting expired file {}: {}",
+                                     file, e.getMessage());
+                        break;
                     } catch (TimeoutCacheException e) {
-                            LOGGER.error("Failed to delete file {}: {}", file.getPnfsId(), e.getMessage());
-                            break;
+                        LOGGER.error("Failed to lookup file {} in name space: {}", file.getPnfsId(), e.getMessage());
+                        break;
                     } catch (CacheException e) {
-                            LOGGER.error("Failed to delete file {}: {}", file.getPnfsId(), e.getMessage());
+                        LOGGER.error("Failed to lookup file {} in name space: {}", file.getPnfsId(), e.getMessage());
                     }
                 }
 
@@ -296,16 +313,6 @@ public final class SpaceManagerService
                 db.remove(db.spaces()
                                   .whereStateIsIn(SpaceState.EXPIRED, SpaceState.RELEASED)
                                   .thatHaveNoFiles());
-        }
-
-        private boolean isRegularFile(File file) throws CacheException
-        {
-                try {
-                        FileAttributes fileAttributes = pnfs.getFileAttributes(file.getPnfsId(), EnumSet.of(FileAttribute.TYPE));
-                        return (fileAttributes.getFileType() == FileType.REGULAR);
-                } catch (FileNotFoundCacheException e) {
-                        return false;
-                }
         }
 
         private void getValidSpaceTokens(GetSpaceTokensMessage msg) throws DataAccessException {
@@ -667,11 +674,14 @@ public final class SpaceManagerService
         private void transferFinished(DoorTransferFinishedMessage finished)
                 throws DataAccessException
         {
-                boolean weDeleteStoredFileRecord = shouldDeleteStoredFileRecord;
-                PnfsId pnfsId = finished.getPnfsId();
-                long size = finished.getFileAttributes().getSize();
-                boolean success = finished.getReturnCode() == 0;
-                LOGGER.trace("transferFinished({},{})", pnfsId, success);
+                transferFinished(finished.getPnfsId(), finished.getFileAttributes().getSize());
+        }
+
+        @Transactional
+        private void transferFinished(PnfsId pnfsId, long size)
+                throws DataAccessException
+        {
+                LOGGER.trace("transferFinished({})", pnfsId);
                 File f;
                 try {
                         f = db.selectFileForUpdate(pnfsId);
@@ -681,81 +691,57 @@ public final class SpaceManagerService
                                      e.getMessage());
                         return;
                 }
-                long spaceId = f.getSpaceId();
-                if(f.getState() == FileState.TRANSFERRING) {
-                        if(success) {
-                                if(shouldReturnFlushedSpaceToReservation && weDeleteStoredFileRecord) {
-                                        RetentionPolicy rp = db.getSpace(spaceId).getRetentionPolicy();
-                                        if(rp.equals(RetentionPolicy.CUSTODIAL)) {
-                                                //we do not delete it here, since the
-                                                // file will get flushed and we will need
-                                                // to account for that
-                                                weDeleteStoredFileRecord = false;
-                                        }
-                                }
-                                if(weDeleteStoredFileRecord) {
-                                        LOGGER.trace("file transferred, deleting file record");
-                                        db.removeFile(f.getId());
-                                }
-                                else {
-                                        f.setSizeInBytes(size);
-                                        f.setState(FileState.STORED);
-                                        db.updateFile(f);
-                                }
-                        }
-                        else {
-                            db.removeFile(f.getId());
-
-                            /* TODO: If we also created the reservation, we should
-                             * release it at this point, but at the moment we cannot
-                             * know who created it. It will eventually expire
-                             * automatically.
-                             */
-                        }
-                }
-                else {
+                if (f.getState() != FileState.TRANSFERRING) {
                         LOGGER.trace("transferFinished({}): file state={}",
                                      pnfsId, f.getState());
+                } else if (shouldDeleteStoredFileRecord) {
+                        LOGGER.trace("file transferred, deleting file record");
+                        db.removeFile(f.getId());
+                } else {
+                        f.setSizeInBytes(size);
+                        f.setState(FileState.STORED);
+                        db.updateFile(f);
                 }
         }
 
-    private void  fileFlushed(PoolFileFlushedMessage fileFlushed) throws DataAccessException
+        private void fileFlushed(PoolFileFlushedMessage fileFlushed)
+                throws DataAccessException
         {
-                if(!shouldReturnFlushedSpaceToReservation) {
-                        return;
-                }
-                PnfsId pnfsId = fileFlushed.getPnfsId();
-                LOGGER.trace("fileFlushed({})", pnfsId);
                 FileAttributes fileAttributes = fileFlushed.getFileAttributes();
-                AccessLatency ac = fileAttributes.getAccessLatency();
-                if (ac.equals(AccessLatency.ONLINE)) {
-                        LOGGER.trace("File Access latency is ONLINE " +
-                                             "fileFlushed does nothing");
+                boolean isRemovable = !fileAttributes.getAccessLatency().equals(AccessLatency.ONLINE);
+                fileFlushed(fileFlushed.getPnfsId(), fileAttributes.getSize(), isRemovable);
+        }
+
+        @Transactional
+        private void fileFlushed(PnfsId pnfsId, long size, boolean isRemovable)
+                throws DataAccessException
+        {
+                LOGGER.trace("fileFlushed({})", pnfsId);
+                File f;
+                try {
+                        f = db.selectFileForUpdate(pnfsId);
+                } catch (EmptyResultDataAccessException e) {
+                        LOGGER.trace("failed to find file {}: {}", pnfsId, e.getMessage());
                         return;
                 }
-                long size = fileAttributes.getSize();
-                try {
-                        File f = db.selectFileForUpdate(pnfsId);
-                        if(f.getState() == FileState.STORED) {
-                                if(shouldDeleteStoredFileRecord) {
-                                        LOGGER.trace("returnSpaceToReservation, " +
-                                                             "deleting file record");
-                                        db.removeFile(f.getId());
-                                }
-                                else {
-                                        f.setSizeInBytes(size);
-                                        f.setState(FileState.FLUSHED);
-                                        db.updateFile(f);
-                                }
+                if (shouldDeleteStoredFileRecord) {
+                        /* A file must have been stored for it to be flushed. If we didn't do
+                         * it during DoorTransferFinished, we do it now.
+                         */
+                        db.removeFile(f.getId());
+                } else if (f.getState() != FileState.FLUSHED) {
+                        if (shouldReturnFlushedSpaceToReservation && isRemovable) {
+                                f.setSizeInBytes(size);
+                                f.setState(FileState.FLUSHED);
+                                db.updateFile(f);
+                        } else if (f.getState() == FileState.TRANSFERRING) {
+                                /* A file must have been stored for it to be flushed. If we didn't do
+                                 * it during DoorTransferFinished, we do it now.
+                                 */
+                                f.setSizeInBytes(size);
+                                f.setState(FileState.STORED);
+                                db.updateFile(f);
                         }
-                        else {
-                                LOGGER.trace("returnSpaceToReservation({}): " +
-                                                     "file state={}", pnfsId, f.getState());
-                        }
-
-                }
-                catch (EmptyResultDataAccessException e) {
-                    /* if this file is not in srmspacefile table, silently quit */
                 }
         }
 
@@ -1021,8 +1007,8 @@ public final class SpaceManagerService
         {
             try {
                 File f = db.selectFileForUpdate(msg.getPnfsId());
-                LOGGER.trace("Marking file as deleted {}", f);
-                if (f.getState() == FileState.FLUSHED) {
+                if (f.getState() != FileState.STORED) {
+                    LOGGER.trace("Deleting file reservation {}", f);
                     db.removeFile(f.getId());
                 }
             } catch (EmptyResultDataAccessException ignored) {


### PR DESCRIPTION
The patch fixes several related issues in space manager:
- The code used to delete a file reservation when the mover reported
  a failure. However whether such a file is actually deleted depends
  on what the door does. If the door deletes it, the space manager
  will be notified and the file can be deleted at that point.
  
  The special case that exists is if the mover failure was caused by the
  pool being unable to register the location in the name space. When
  such a file is deleted it would only get a name space delete notification,
  and no pool remove file notification. To account for this case, the
  pool leaves a file for which the mover reported an error in the
  transferring state. If the name space entry is deleted, such an entry
  is removed. If the file is not deleted, the other fixes of this
  patch will address it eventually.
- The code used to assume that a file that was in transferring
  would either get a DoorTransferFinished notification or be deleted.
  There is however no guarantee that this happens for non-srm uploads,
  such as when the door doesn't delete on failed upload. The client
  may even think the transfer is successfull if no control channel is
  used (eg http and xrootd). Such a file is perfectly readable, but
  stayed in transferring in space manager.
  
  This patch addresses this problem by extending the background check
  of files that have stayed in transferring for more than 24 hours:
  rather than just deleting reservations for deleted files, the code
  now also detects flushed and completed files and updates the reservation
  accordingly.
- The patch changes how we react to notifications that a name space entry
  is deleted: Before, we deleted the reservation if the file was marked
  flushed. For other states we assumed we would eventually get a pool
  remove file notification: However if the pool failed to register the
  location, we will never get such a notification. This scenario is
  quite likely if the name space entry is deleted during upload.
  
  The patch addresses this problem by deleting a transferring reservation on
  the name space delete notification. The downside is that we have some
  space allocated for the file on the pool that isn't explicitly linked
  to a reservation in space manager, but since the name space entry got
  deleted, the file on the pool will soon get deleted too.
- The patch also refines how we react to notifications for flushed files: if the
  reservation was in transferring, it is now considered complete.  Before the
  flush notification was simply ignored. This could both happen for lost
  DoorTransferFinished notification, of if the flush notification managed to
  overtake the DoorTransferFinished notification (unlikely).

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: yes
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: https://rb.dcache.org/r/7519/
(cherry picked from commit c59f61eb89d04948f7e8172b15cbd8288778533c)
