### PR TITLE
pool: reorder ip addresses returned to NFS client

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Required;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.nio.channels.CompletionHandler;
 import java.util.List;
 
@@ -20,6 +21,8 @@ import dmg.cells.nucleus.AbstractCellComponent;
 import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellPath;
 import dmg.cells.nucleus.NoRouteToCellException;
+import java.net.Inet4Address;
+import java.util.Arrays;
 
 import org.dcache.cells.CellStub;
 import org.dcache.commons.stats.RequestExecutionTimeGauges;
@@ -55,6 +58,7 @@ public class NfsTransferService extends AbstractCellComponent
     private PostTransferService _postTransferService;
     private FaultListener _faultListener;
     private final long _bootVerifier = System.currentTimeMillis();
+    private boolean _sortMultipathList;
 
     public void init() throws IOException, GSSException, OncRpcException {
 
@@ -67,8 +71,19 @@ public class NfsTransferService extends AbstractCellComponent
         }
 
         _nfsIO = new NFSv4MoverHandler(portRange, _withGss, getCellName());
-        _localSocketAddresses =
-                localSocketAddresses(NetworkUtils.getLocalAddresses(), _nfsIO.getLocalAddress().getPort());
+        _localSocketAddresses = localSocketAddresses(NetworkUtils.getLocalAddresses(), _nfsIO.getLocalAddress().getPort());
+
+        /*
+         * we assume, that client's can't handle multipath list correctly
+         * if data server has multiple IPv4 addresses. (RHEL6 and clones)
+         */
+        int ipv4Count = 0;
+        for (InetSocketAddress addr : _localSocketAddresses) {
+            if (addr.getAddress() instanceof Inet4Address) {
+                ipv4Count++;
+            }
+        }
+        _sortMultipathList = ipv4Count > 1;
 
         _door = new CellStub(getCellEndpoint());
     }
@@ -101,8 +116,9 @@ public class NfsTransferService extends AbstractCellComponent
 
             CellPath directDoorPath = new CellPath(mover.getPathToDoor().getDestinationAddress());
             final org.dcache.chimera.nfs.v4.xdr.stateid4 legacyStateId = mover.getProtocolInfo().stateId();
+            final InetSocketAddress[] localSocketAddresses = localSocketAddresses(mover);
             _door.notify(directDoorPath,
-                         new PoolPassiveIoFileMessage<>(getCellName(), _localSocketAddresses, legacyStateId,
+                         new PoolPassiveIoFileMessage<>(getCellName(), localSocketAddresses, legacyStateId,
                                                         _bootVerifier));
 
             /* An NFS mover doesn't complete until it is cancelled (the door sends a mover kill
@@ -113,7 +129,7 @@ public class NfsTransferService extends AbstractCellComponent
             _faultListener.faultOccurred(new FaultEvent("repository", FaultAction.DISABLED,
                     e.getMessage(), e));
             completionHandler.failed(e, null);
-        } catch (NoRouteToCellException e) {
+        } catch (NoRouteToCellException | SocketException e) {
             completionHandler.failed(e, null);
         }
         return null;
@@ -135,6 +151,24 @@ public class NfsTransferService extends AbstractCellComponent
             i++;
         }
         return socketAddresses;
+    }
+
+    private InetSocketAddress[] localSocketAddresses(NfsMover mover) throws SocketException {
+
+        InetSocketAddress[] addressesToUse;
+        if (_sortMultipathList) {
+            addressesToUse = new InetSocketAddress[_localSocketAddresses.length + 1];
+            System.arraycopy(_localSocketAddresses, 0, addressesToUse, 1, _localSocketAddresses.length);
+
+            InetSocketAddress preferredInterface = new InetSocketAddress(
+                    NetworkUtils.getLocalAddress(mover.getProtocolInfo().getSocketAddress().getAddress()),
+                    _nfsIO.getLocalAddress().getPort());
+            addressesToUse[0] = preferredInterface;
+        } else {
+            addressesToUse = _localSocketAddresses;
+        }
+
+        return addressesToUse;
     }
 
     public final static String fh_nfs_stats =


### PR DESCRIPTION
according to NFS spec pool client can select a best matching IP
address from the list available IP addresses of the pool.

Nevertheless, current client implementation in RHEL-6 takes first
one from the list and, some times, makes a wrong choice for mutihomed
pools.

This change will put 'expected correct' interface as a first element
of the returned list.

Ticket: #8404
Acked-by: Gerd Behrmann
Target: master, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6
Require-book: no
Require-notes: no
(cherry picked from commit 7c43c2ad6a6d6209625ee78d6745a5f8c531d7a3)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
