### PR TITLE
Upgrade to Milton 2.6

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
@@ -241,6 +241,14 @@ public class DcacheResponseHandler extends AbstractWrappingResponseHandler
     }
 
     @Override
+    public void respondPartialContent(GetableResource resource, Response response, Request request, Map<String, String> params, List<Range> ranges)
+            throws NotAuthorizedException, BadRequestException, NotFoundException
+    {
+        super.respondPartialContent(resource, response, request, params, ranges);
+        rfc3230(resource, response);
+    }
+
+    @Override
     public void respondPartialContent(GetableResource resource,
             Response response, Request request, Map<String,String> params,
             Range range) throws NotAuthorizedException, BadRequestException,

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -150,6 +150,7 @@
         <property name="enableExpectContinue" value="false"/>
         <property name="enableCompression" value="false"/>
         <property name="enableFormAuth" value="false"/>
+        <property name="enableCookieAuth" value="false"/>
         <property name="resourceFactory" ref="resource-factory"/>
         <property name="buffering" value="never"/>
         <property name="staticContentPath" value="${webdav.static-content.location}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <target.version>1.7</target.version>
 
         <version.slf4j>1.7.6</version.slf4j>
-        <version.milton>2.3.0.7</version.milton>
+        <version.milton>2.6.3.3</version.milton>
         <version.spring>4.0.3.RELEASE</version.spring>
         <version.aspectj>1.7.4</version.aspectj>
         <version.smc>6.1.0</version.smc>


### PR DESCRIPTION
Appears to be working. Solves the problem where proxied vector reads cause the entire
file to be written to local disk. Instead only the actual data that is to be returned
to the client is buffered. If this is more than 100 KB, that data is buffered on local
disk. The file is deleted after successful return of the data.

There are still problems though: In case of failures reading the data from the pool,
the temporary file is not deleted. The entire file is still downloaded from the pool
to the door (even when only the requested data is buffered), and the multi-range writer
in Milton is extremely inefficient as it processes one byte at a time (it fails to
override the multi-byte write methods).

The new version supports using cookies to remeber when a client has already logged in.
I disabled this feature for now.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7530/
(cherry picked from commit b0f88c5080926e867ca644087a4e75e7c077bf00)

Conflicts:
    pom.xml

(cherry picked from commit a510d8109287fce0b825db266225e935ac2e3919)

Conflicts:
    pom.xml

(cherry picked from commit 27783b3575665704b147e36e8bf4c189efbff6c2)

Conflicts:
    pom.xml
