### PR TITLE
srm,webdav,httpd: Log SSL handshake failures

### DIFF
--- a/modules/dcache/src/main/aspect/org/dcache/util/aspects/LogSSLHandshakeExceptionAspect.aj
+++ b/modules/dcache/src/main/aspect/org/dcache/util/aspects/LogSSLHandshakeExceptionAspect.aj
@@ -1,0 +1,21 @@
+package org.dcache.util.aspects;
+
+import org.eclipse.jetty.server.HttpConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import java.net.InetSocketAddress;
+
+public aspect LogSSLHandshakeExceptionAspect
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpConnection.class);
+
+    before(HttpConnection c, Exception e) : withincode(void HttpConnection.onFillable()) && this(c) && handler(Exception) && args(e) {
+        if (e instanceof SSLHandshakeException) {
+            InetSocketAddress remoteAddress = c.getEndPoint().getRemoteAddress();
+            LOGGER.warn("SSL handshake with {}:{} failed: {}", remoteAddress.getAddress().getHostAddress(), remoteAddress.getPort(), e.getMessage());
+        }
+    }
+}

--- a/modules/dcache/src/main/resources/META-INF/aop.xml
+++ b/modules/dcache/src/main/resources/META-INF/aop.xml
@@ -5,10 +5,12 @@
         <include within="diskCacheV111.services.space.*"/>
         <include within="org.dcache.pinmanager.*"/>
         <include within="org.dcache.util.aspects.*"/>
+        <include within="org.eclipse.jetty.server.HttpConnection"/>
     </weaver>
 
     <aspects>
         <exclude within="org.springframework.transaction.aspectj.AnnotationTransactionAspect"/>
         <aspect name="org.dcache.util.aspects.PerInstanceAnnotationTransactionAspect"/>
+        <aspect name="org.dcache.util.aspects.LogSSLHandshakeExceptionAspect"/>
     </aspects>
 </aspectj>


### PR DESCRIPTION
Will log SSL failures, such as when clients try to use disabled features. Eg:

28 nov. 2014 10:21:53 (SRM-Gerds-MacBook-Pro-5) [] SSL handshake with localhost/127.0.0.1:62713 failed: SSLv2Hello is disabled

Target: trunk
Request: 2.11
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7539/
(cherry picked from commit 3f52dce613e1f76efe119da11a8fab18e711b2d8)
