### PR TITLE
poolmanager: Fix full pool detection for WASS

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/WassPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/WassPartition.java
@@ -190,17 +190,20 @@ public class WassPartition extends ClassicPartition
     {
         long free = space.getFreeSpace();
         long gap = space.getGap();
+
+        /* If the pool cannot hold the file without eating into the gap, the
+         * pool is considered full.
+         */
+        if (free + space.getRemovableSpace() - filesize <= gap) {
+            return 0;
+        }
+
         double removable = getAvailableRemovable(space);
 
         /* The amount of available space on a pool is the sum of
          * whatever is free and decayed removable space.
          */
-        double available = free + removable;
-
-        /* If available space is less than the gap then the pool is
-         * considered full.
-         */
-        return (available - filesize > gap) ? available : 0;
+        return free + removable;
     }
 
     /**


### PR DESCRIPTION
When a file cannot fit within the free plus removable space without
crossing the pool gap, a pool is considered full. WASS erroneously
used the decayed removable space in this check. This meant that
if all pools had very fresh files, they could all be considered
full even though there are plenty of removable files. This patch
changes the check to consider all removable space of a pool. The
decayed removable space is only used when weighting the random
selection.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8390
Require-notes: yes
Require-book: no
Acked-by: Christian Bernardt christian.bernardt@desy.de
Patch: https://rb.dcache.org/r/7531/
(cherry picked from commit 42e31b5f935af4f3220aa29f2e51e8ea2c0bd146)

Conflicts:
    modules/dcache/src/main/java/org/dcache/poolmanager/WeightedAvailableSpaceSelection.java
    modules/dcache/src/test/java/org/dcache/poolmanager/WeightedAvailableSpaceSelectionTest.java
