### PR TITLE
spacemanager: Get rid of access latency and retention policy defaults

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/LinkGroup.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/LinkGroup.java
@@ -5,6 +5,8 @@ import com.google.common.base.Function;
 import java.io.Serializable;
 import java.util.Date;
 
+import diskCacheV111.util.AccessLatency;
+import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.util.VOInfo;
 
 public class LinkGroup implements Serializable{
@@ -137,6 +139,19 @@ public class LinkGroup implements Serializable{
 
     public long getAvailableSpace() {
         return availableSpace;
+    }
+
+    public boolean isAllowed(AccessLatency al)
+    {
+        return (al == AccessLatency.NEARLINE && isNearlineAllowed()) ||
+                (al == AccessLatency.ONLINE && isOnlineAllowed());
+    }
+
+    public boolean isAllowed(RetentionPolicy rp)
+    {
+        return (rp == RetentionPolicy.CUSTODIAL && isCustodialAllowed()) ||
+                (rp == RetentionPolicy.REPLICA && isReplicaAllowed()) ||
+                (rp == RetentionPolicy.OUTPUT && isOutputAllowed());
     }
 
     public static final Function<LinkGroup, Long> getId =

--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerDatabase.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerDatabase.java
@@ -70,16 +70,8 @@ public interface SpaceManagerDatabase
 
     LinkGroup getLinkGroupByName(String name) throws DataAccessException;
 
-    List<Long> findLinkGroupIds(long sizeInBytes,
-                                String voGroup,
-                                String voRole,
-                                AccessLatency al,
-                                RetentionPolicy rp,
-                                long lastUpdateTime)
-            throws DataAccessException;
-
     List<LinkGroup> findLinkGroups(long sizeInBytes,
-                                   AccessLatency al,
+                                   @Nullable AccessLatency al,
                                    RetentionPolicy rp,
                                    long lastUpdateTime)
             throws DataAccessException;

--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/message/Reserve.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/message/Reserve.java
@@ -9,9 +9,13 @@
 
 package diskCacheV111.services.space.message;
 
+import javax.annotation.Nonnull;
+
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.vehicles.Message;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 
 /**
@@ -21,15 +25,12 @@ import diskCacheV111.vehicles.Message;
 public class Reserve extends Message{
     private static final long serialVersionUID = 8295404238593418916L;
     private long spaceToken;
-    private long sizeInBytes;
-    private RetentionPolicy retentionPolicy;
-    private AccessLatency accessLatency;
-    private long lifetime;
+    private final long sizeInBytes;
+    private final RetentionPolicy retentionPolicy;
+    private final AccessLatency accessLatency;
+    private final long lifetime;
     private long expirationTime;
-    private String description;
-    /** Creates a new instance of Reserve */
-    public Reserve() {
-    }
+    private final String description;
 
     public Reserve(
             long sizeInBytes,
@@ -40,7 +41,7 @@ public class Reserve extends Message{
         this.sizeInBytes = sizeInBytes;
         this.lifetime = lifetime;
         this.accessLatency = accessLatency;
-        this.retentionPolicy = retentionPolicy;
+        this.retentionPolicy = checkNotNull(retentionPolicy);
         this.description = description;
         setReplyRequired(true);
     }
@@ -57,32 +58,17 @@ public class Reserve extends Message{
         return sizeInBytes;
     }
 
-    public void setSizeInBytes(long sizeInBytes) {
-        this.sizeInBytes = sizeInBytes;
-    }
-
+    @Nonnull
     public RetentionPolicy getRetentionPolicy() {
         return retentionPolicy;
-    }
-
-    public void setRetentionPolicy(RetentionPolicy retentionPolicy) {
-        this.retentionPolicy = retentionPolicy;
     }
 
     public AccessLatency getAccessLatency() {
         return accessLatency;
     }
 
-    public void setAccessLatency(AccessLatency accessLatency) {
-        this.accessLatency = accessLatency;
-    }
-
     public long getLifetime() {
         return lifetime;
-    }
-
-    public void setLifetime(long lifetime) {
-        this.lifetime = lifetime;
     }
 
     public long getExpirationTime() {
@@ -95,9 +81,5 @@ public class Reserve extends Message{
 
     public String getDescription() {
         return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
     }
 }

--- a/modules/dcache-spacemanager/src/main/resources/diskCacheV111/services/space/spacemanager.xml
+++ b/modules/dcache-spacemanager/src/main/resources/diskCacheV111/services/space/spacemanager.xml
@@ -107,8 +107,6 @@
 
   <bean id="cli" class="diskCacheV111.services.space.SpaceManagerCommandLineInterface">
     <property name="database" ref="database"/>
-    <property name="defaultRetentionPolicy" value="#{T(diskCacheV111.util.RetentionPolicy).getRetentionPolicy('${spacemanager.default-retention-policy}')}" />
-    <property name="defaultAccessLatency" value="#{T(diskCacheV111.util.AccessLatency).getAccessLatency('${spacemanager.default-access-latency}')}" />
     <property name="linkGroupLoader" ref="linkgroup-loader"/>
     <property name="pnfs" ref="pnfs"/>
     <property name="executor" ref="executor"/>
@@ -133,7 +131,6 @@
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
                      ${spacemanager.expire-space-reservation.period},
                      '${spacemanager.expire-space-reservation.period.unit}')}" />
-    <property name="defaultAccessLatency" value="#{T(diskCacheV111.util.AccessLatency).getAccessLatency('${spacemanager.default-access-latency}')}" />
     <property name="allowUnreservedUploadsToLinkGroups" value="${spacemanager.enable.unreserved-uploads-to-linkgroups}" />
     <property name="shouldDeleteStoredFileRecord" value="false" />
     <property name="shouldReturnFlushedSpaceToReservation" value="true" />

--- a/skel/share/defaults/spacemanager.properties
+++ b/skel/share/defaults/spacemanager.properties
@@ -27,16 +27,6 @@ spacemanager.cell.name=SrmSpaceManager
 #  using their fully qualified cell address.
 (one-of?true|false)spacemanager.cell.export=true
 
-#  ---- Default access latency
-#
-#   Default access latency used if space reservation request does not
-#   specify one.
-#
-(forbidden)DefaultAccessLatencyForSpaceReservation = Use spacemanager.default-access-latency
-(one-of?ONLINE|NEARLINE)spacemanager.default-access-latency = NEARLINE
-
-(one-of?CUSTODIAL|REPLICA|OUTPUT)spacemanager.default-retention-policy = CUSTODIAL
-
 # ---- Allow uploads to link groups outside of space reservation
 #
 #   If set to false, uploads using links in a link group are only possible by
@@ -141,3 +131,8 @@ spacemanager.db.schema.auto=${dcache.db.schema.auto}
 
 # Liquibase schema definition
 spacemanager.db.schema.changelog=diskCacheV111/services/space/db/spacemanager.changelog-master.xml
+
+
+(obsolete)DefaultAccessLatencyForSpaceReservation = No longer used
+(obsolete)spacemanager.default-access-latency = No longer used
+(obsolete)spacemanager.default-retention-policy = No longer used

--- a/skel/share/services/spacemanager.batch
+++ b/skel/share/services/spacemanager.batch
@@ -13,7 +13,6 @@ check -strong spacemanager.db.password
 check -strong spacemanager.db.connections.idle
 check -strong spacemanager.db.connections.max
 check -strong spacemanager.limits.threads
-check -strong spacemanager.default-access-latency
 check -strong spacemanager.enable.unreserved-uploads-to-linkgroups
 check spacemanager.authz.link-group-file-name
 check -strong spacemanager.enable.space-reservation


### PR DESCRIPTION
I recently got contacted by KIT about the differences between the AL/RP
defaults in space manager and pnfs manager. It became clear that the
documentation in our property files wasn't clear enough about the difference.

While looking at this, it became clear that there was no need for defaults in
space manager. The defaults where used in two places: When creating
reservations through the command line interface and when creating reservations
through SRM. In the former case we can just as well make the al and rp options
required, forcing the admin to be explicit about the desired al and rp. In the
latter case, the SRM declares retention policy a required parameter (so we
don't need a default), but access latency is optional. However, rather than
limiting the access latency to a single site default, it makes much more sense
to let the retention policy steer the link group selection and then see which
options we have for access latency. Most likely the retention policy is enough
to limit the choice to a single link group and most likely only a single access
latency is possible for that case. This avoids the need for a default and
even makes the code more intelligent.

When reserving through the SRM withoug an explicit access latency, the code
prefer ONLINE for REPLICA reservations, and NEARLINE for CUSTODIAL reservations,
but falls back to whatever the link group allows.

For reservations through the command line (admin shell), the code has been
simplified: There is no point in a complicated query to the database when the
command invocation already specified the link group to use. All we need to do
is to verify the parameters. This also allows us to provide better error
messages. The patch makes one change to authorization for admin created
reservations: Previously the owner (the FQAN or user allowed to release the
reservation) had to be among the list of principals authorized to create
reservations in the link group. There is however no reason for this
restriction. Indeed, this limitation prevented useful scenarios, e.g. allowing
user made or implicit reservations in a link group, but block release of the
reservation by setting the owner to an admin.

The patch also gets rid of some dead code in the SpaceManagerService and
simplifies the logic for reserving space.

I request backport to 2.10 as the presence of the defaults in space manager has
caused confusion for those upgrading.

Target: trunk
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Dmitry Litvintsev litvinse@fnal.gov
Patch: https://rb.dcache.org/r/7538/
(cherry picked from commit 9094d68dc8fac928dc50287498c28ef6c230a664)
