### PR TITLE
pool: add Io mode into mover's status line

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -265,6 +265,7 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends Mover<P>> 
     {
         StringBuilder sb = new StringBuilder();
         sb.append(getFileAttributes().getPnfsId());
+        sb.append(" IoMode=").append(getIoMode());
         sb.append(" h={").append(getStatus()).append("} bytes=").append(getBytesTransferred()).append(
                 " time/sec=").append(getTransferTime() / 1000L).append(" LM=");
         long lastTransferTime = getLastTransferred();


### PR DESCRIPTION
we got a request from our admins to add READ/WRITE info
to the output of 'mover ls'.

Acked-by: Gerd Behrmann
Target: master, 2.10, 2.11
Require-book: no
Require-notes: yes
(cherry picked from commit 7f61122516e42f3901dd03f6676057599869c1b0)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
