### PR TITLE
alarms: Detach alarms appender on shutdown

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryServer.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryServer.java
@@ -111,13 +111,17 @@ public final class LogEntryServer implements LifeCycle {
         server.start();
     }
 
+    @Override
     public void stop() {
         if (started.getAndSet(false)) {
             server.close();
+            Logger root = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+            root.detachAppender(appender);
             appender.stop();
         }
     }
 
+    @Override
     public boolean isStarted() {
         return started.get();
     }


### PR DESCRIPTION
Otherwise alarms may be attemped to be logged to a datasource that is
already shut down - this causes hanging shutdown issues, in particular
when alarms shares a domain with other services.

Target: trunk
Request: 2.11
Require-notes: yes
Require-book: no
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7553/
(cherry picked from commit 765e6bf470c55d24f8d3576a53946e89395065f9)
