### PR TITLE
pool: Fix shutdown of nearline storage subsystem

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,6 +52,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -124,6 +126,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
     private long stageTimeout;
     private long flushTimeout;
     private long removeTimeout;
+    private ScheduledFuture<?> timeoutFuture;
 
     @Required
     public void setScheduledExecutor(ScheduledExecutorService executor)
@@ -176,9 +179,44 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
     @PostConstruct
     public void init()
     {
-        scheduledExecutor.scheduleWithFixedDelay(new TimeoutTask(), 30, 30, TimeUnit.SECONDS);
+        timeoutFuture = scheduledExecutor.scheduleWithFixedDelay(new TimeoutTask(), 30, 30, TimeUnit.SECONDS);
         repository.addListener(this);
     }
+
+    @Override
+    public void beforeStop()
+    {
+        /* Marks the containers as being shut down and cancels all requests, but
+         * doesn't wait for termination.
+         */
+        flushRequests.shutdown();
+        stageRequests.shutdown();
+        removeRequests.shutdown();
+    }
+
+    @PreDestroy
+    public void shutdown() throws InterruptedException
+    {
+        flushRequests.shutdown();
+        stageRequests.shutdown();
+        removeRequests.shutdown();
+
+        if (timeoutFuture != null) {
+            timeoutFuture.cancel(false);
+        }
+        repository.removeListener(this);
+
+        /* Waits for all requests to have finished. This is blocking to avoid that the
+         * repository gets closed nearline storage requests have had a chance to finish.
+         */
+        long deadline = System.currentTimeMillis() + 3000;
+        if (flushRequests.awaitTermination(deadline - System.currentTimeMillis(), TimeUnit.MILLISECONDS)) {
+            if (stageRequests.awaitTermination(deadline - System.currentTimeMillis(), TimeUnit.MILLISECONDS)) {
+                removeRequests.awaitTermination(deadline - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+            }
+        }
+    }
+
 
     @Override
     public void getInfo(PrintWriter pw)
@@ -347,7 +385,6 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             this.storage = storage;
         }
 
-        // Implements NearlineRequest#activate
         public UUID getId()
         {
             return uuid;
@@ -360,11 +397,15 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
 
         protected synchronized <T> ListenableFuture<T> register(ListenableFuture<T> future)
         {
-            // TODO: What if we are already cancelled?
-            asyncTasks.add(future);
+            if (state.get() == State.CANCELED) {
+                future.cancel(true);
+            } else {
+                asyncTasks.add(future);
+            }
             return future;
         }
 
+        // Implements NearlineRequest#activate
         public ListenableFuture<Void> activate()
         {
             if (!state.compareAndSet(State.QUEUED, State.ACTIVE)) {
@@ -429,6 +470,10 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
     {
         private final Map<K, R> requests = new HashMap<>();
 
+        private int count;
+
+        private boolean isShutdown;
+
         public synchronized void addAll(NearlineStorage storage,
                                         Iterable<F> files,
                                         CompletionHandler<Void,K> callback)
@@ -438,12 +483,17 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
                 K key = extractKey(file);
                 R request = requests.get(key);
                 if (request == null) {
+                    if (isShutdown) {
+                        callback.failed(new CacheException("Nearline storage has been shut down."), key);
+                        continue;
+                    }
                     try {
                         request = checkNotNull(createRequest(storage, file));
                     } catch (Exception e) {
                         callback.failed(e, key);
                         continue;
                     }
+                    count++;
                     requests.put(key, request);
                     newRequests.add(request);
                 }
@@ -460,14 +510,42 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             }
         }
 
-        public synchronized void cancelOldRequests(long timeout)
+        public synchronized void cancelRequests(long age)
         {
             long now = System.currentTimeMillis();
             for (R request : requests.values()) {
-                if (now - request.getCreatedAt() > timeout) {
+                if (now - request.getCreatedAt() >= age) {
                     request.cancel();
                 }
             }
+        }
+
+        /**
+         * Shuts down the container, preventing new requests from being added and cancels
+         * all existing requests.
+         */
+        public synchronized void shutdown()
+        {
+            isShutdown = true;
+            notifyAll();
+            cancelRequests(0);
+        }
+
+        /**
+         * Waits for the container to terminate. It is terminated when it has been shut down and
+         * all requests have finished.
+         */
+        public synchronized boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException
+        {
+            long deadline = System.currentTimeMillis() + unit.toMillis(timeout);
+            while (!isShutdown || count > 0) {
+                long to = deadline - System.currentTimeMillis();
+                if (to <= 0) {
+                    return false;
+                }
+                wait(to);
+            }
+            return true;
         }
 
         public synchronized int getCount(AbstractRequest.State state)
@@ -507,7 +585,12 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         private synchronized Iterable<CompletionHandler<Void,K>> remove(K key)
         {
             R actualRequest = requests.remove(key);
-            return (actualRequest != null) ? actualRequest.callbacks() : Collections.<CompletionHandler<Void,K>>emptyList();
+            if (actualRequest == null) {
+                return Collections.<CompletionHandler<Void, K>>emptyList();
+            }
+            count--;
+            notifyAll();
+            return actualRequest.callbacks();
         }
 
         /** Returns a key identifying the request for a particular replica. */
@@ -1188,9 +1271,9 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         @Override
         public void run()
         {
-            flushRequests.cancelOldRequests(flushTimeout);
-            stageRequests.cancelOldRequests(stageTimeout);
-            removeRequests.cancelOldRequests(removeTimeout);
+            flushRequests.cancelRequests(flushTimeout);
+            stageRequests.cancelRequests(stageTimeout);
+            removeRequests.cancelRequests(removeTimeout);
         }
     }
 }


### PR DESCRIPTION
Ensures proper shutdown of the nearline storage subsystem. There is an
existing shutdown call to every nearline storage instance initiated
by the HsmSet class, however this is
- asynchronous
- has no dependency to the repository

This means there is no guarantee that requests get cancelled before
the repository is closed. This leads to errors like these when shutting
down a pool with acive stage requests:

04 dec. 2014 00:02:32 (pool_read) [admin d7ab5ce2-4ff7-4cfa-883e-3bfb41a5c313] Uncaught exception in thread pool-48-thread-1
java.lang.IllegalStateException: Can't open a cursor Database was closed.
        at com.sleepycat.je.Database.checkOpen(Database.java:2200) ~[je-6.1.5.jar:6.1.5]
        at com.sleepycat.je.Database.openCursor(Database.java:824) ~[je-6.1.5.jar:6.1.5]
        at com.sleepycat.collections.CurrentTransaction.openCursor(CurrentTransaction.java:415) ~[je-6.1.5.jar:6.1.5]
        at com.sleepycat.collections.MyRangeCursor.openCursor(MyRangeCursor.java:53) ~[je-6.1.5.jar:6.1.5]
        at com.sleepycat.collections.MyRangeCursor.<init>(MyRangeCursor.java:29) ~[je-6.1.5.jar:6.1.5]
        at com.sleepycat.collections.DataCursor.init(DataCursor.java:170) ~[je-6.1.5.jar:6.1.5]
        at com.sleepycat.collections.DataCursor.<init>(DataCursor.java:58) ~[je-6.1.5.jar:6.1.5]
        at com.sleepycat.collections.StoredContainer.putKeyValue(StoredContainer.java:319) ~[je-6.1.5.jar:6.1.5]
        at com.sleepycat.collections.StoredMap.put(StoredMap.java:279) ~[je-6.1.5.jar:6.1.5]
        at org.dcache.pool.repository.meta.db.CacheRepositoryEntryImpl.storeStateIfDirty(CacheRepositoryEntryImpl.java:270) ~[dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.pool.repository.meta.db.CacheRepositoryEntryImpl.setState(CacheRepositoryEntryImpl.java:190) ~[dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.pool.repository.v5.CacheRepositoryV5.setState(CacheRepositoryV5.java:853) ~[dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.pool.repository.v5.WriteHandleImpl.fail(WriteHandleImpl.java:406) ~[dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.pool.repository.v5.WriteHandleImpl.close(WriteHandleImpl.java:429) ~[dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.pool.nearline.NearlineStorageHandler$StageRequestImpl.done(NearlineStorageHandler.java:955) ~[dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.pool.nearline.NearlineStorageHandler$StageRequestImpl.failed(NearlineStorageHandler.java:918) ~[dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.pool.nearline.AbstractBlockingNearlineStorage$Task.processRequest(AbstractBlockingNearlineStorage.java:268) ~[dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.pool.nearline.AbstractBlockingNearlineStorage$Task.run(AbstractBlockingNearlineStorage.java:242) ~[dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.util.CDCExecutorServiceDecorator$1.run(CDCExecutorServiceDecorator.java:104) [dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:211) [dcache-core-2.12.0-SNAPSHOT.jar:2.12.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_25]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_25]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_25]

I considered whether one should update CacheRepositoryV5 to close all open
descriptors on shutdown, but that would be rather bad: If the descriptor
is closed, there is nothing prevent the nearline storage from still writing
the file.

Instead the nearline storage now properly cancel all requests and also
enforces that no new requests are enqueued once the nearline storage was
shut down. This is done with a two step procedure, first initiating
cancellation followed by a blocking call waiting for requests to terminate
(with a timeout).

We could also simply have represed the above error and relied on pool
startup verification to delete the file, but I think it is cleaner
to properly cancel the requests.

The patch also fixes a race in request cancellation (there was an open
todo comment in the code).

The desired of avoid coarse grained locking unfortunately makes the code
quite a bit more complicated.

Target: trunk
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7573/
