### PR TITLE
loginmanager: Fix leak caused by absent child limit

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -165,7 +165,6 @@ public class LoginManager
             if (_maxLogin < 0) {
                 LOGGER.info("Maximum login feature disabled");
             } else {
-                _nucleus.addCellEventListener(new LoginEventListener());
                 LOGGER.info("Maximum logins set to: {}", _maxLogin);
             }
 
@@ -211,6 +210,8 @@ public class LoginManager
             } else {
                 _loginBrokerHandler = null;
             }
+
+            _nucleus.addCellEventListener(new LoginEventListener());
 
             _listenThread = new ListenThread(listenPort);
 
@@ -869,24 +870,22 @@ public class LoginManager
                 }
 
                 Object cell = _loginCellFactory.newCell(engine, userName);
-                if (_maxLogin > -1) {
-                    try {
-                        Method m = cell.getClass().getMethod("getCellName");
-                        String cellName = (String) m.invoke(cell);
-                        LOGGER.info("Invoked cell name : {}", cellName);
-                        if (_children.putIfAbsent(cellName, cell) == DEAD_CELL) {
-                            /*  while cell may be already gone do following trick:
-                             *  if put return an old cell, then it's a dead cell and we
-                             *  have to remove it. Dead cell is inserted by cleanup procedure:
-                             *  if a remove for non existing cells issued, then cells is dead, and
-                             *  we put it into _children.
-                             */
-                            _children.remove(cellName, DEAD_CELL);
-                        }
-                        loadChanged();
-                    } catch (IllegalAccessException | IllegalArgumentException | NoSuchMethodException | SecurityException | InvocationTargetException ee) {
-                        LOGGER.warn("Can't determine child name", ee);
+                try {
+                    Method m = cell.getClass().getMethod("getCellName");
+                    String cellName = (String) m.invoke(cell);
+                    LOGGER.info("Invoked cell name : {}", cellName);
+                    if (_children.putIfAbsent(cellName, cell) == DEAD_CELL) {
+                        /*  while cell may be already gone do following trick:
+                         *  if put return an old cell, then it's a dead cell and we
+                         *  have to remove it. Dead cell is inserted by cleanup procedure:
+                         *  if a remove for non existing cells issued, then cells is dead, and
+                         *  we put it into _children.
+                         */
+                        _children.remove(cellName, DEAD_CELL);
                     }
+                    loadChanged();
+                } catch (IllegalAccessException | IllegalArgumentException | NoSuchMethodException | SecurityException | InvocationTargetException ee) {
+                    LOGGER.warn("Can't determine child name", ee);
                 }
                 _loginCounter.incrementAndGet();
 


### PR DESCRIPTION
A regression in 2.8 causes the door to not track child removal if the
connection limit is set to -1. This causes the door to eventually run out of
memory.

Rather than just restoring the pre-2.8 logic, the patch causes the login
manager to track children regardless of the limit. Even when the child count
isn't needed and even when the list of children isn't published to a login
broker, there are other features in the login manager that rely on it (such as
keep alive).

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8570
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7585
(cherry picked from commit a80006497e5d2dd41c9908703e0dfc11be01393a)
