### PR TITLE
dcap: Fix regression in published protocol family

### DIFF
--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -120,7 +120,11 @@ dcap.service.loginbroker.update-period=${dcache.service.loginbroker.update-perio
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.service.loginbroker.update-period.unit})\
   dcap.service.loginbroker.update-period.unit=${dcache.service.loginbroker.update-period.unit}
 dcap.service.loginbroker.update-threshold=${dcache.service.loginbroker.update-threshold}
-dcap.service.loginbroker.family=dcap
+dcap.service.loginbroker.family=${dcap.service.loginbroker.family.${dcap.authn.protocol}}
+dcap.service.loginbroker.family.plain=dcap
+dcap.service.loginbroker.family.auth=dcap
+dcap.service.loginbroker.family.gsi=gsidcap
+dcap.service.loginbroker.family.kerberos=dcap
 dcap.service.loginbroker.version=1.3.0
 
 # Cell address of pnfsmanager service


### PR DESCRIPTION
Prior to 2.7, gsidcap was published as gsidcap and the SRM used this
as the protocol name when negotiating the transfer protocol. 2.7
always publishes 'dcap', which is a regression compared to 2.6.

This patch resolves the problem.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Require-notes: yes
Require-book: no
Reported-by: Yvan Calas yvan.calas@cc.in2p3.fr
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7587/
(cherry picked from commit f0d4e8f53ef87dc26f895c74b8a9eb89f585dfa2)
