### PR TITLE
chimera-cli: fix chown

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
@@ -221,7 +221,7 @@ public class Shell extends ShellApplication
             FsInode inode = lookup(path);
             inode.setUID(_uid);
             if (_gid != -1) {
-                pwd.setGID(_gid);
+                inode.setGID(_gid);
             }
             return null;
         }


### PR DESCRIPTION
chown updates gid of a current directory instead of required file.

Acked-by: Paul Millar
Target: master, 2.11, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 36ce25267ee2c9aec830e705b77018d9d7e1227b)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
