### PR TITLE
pool: Fix typo that breaks pool.mover.ftp.allow-incoming-connections

### DIFF
--- a/skel/share/services/pool.batch
+++ b/skel/share/services/pool.batch
@@ -90,7 +90,7 @@ create org.dcache.cells.UniversalSpringCell "${pool.cell.name}" \
     "!PoolDefaults classpath:org/dcache/pool/classic/pool.xml \
     -export=${pool.cell.export} -cellClass=Pool -profiles=healthcheck-${pool.enable.repository-check} \
     -setupClass=pool -setupFile=\"${pool.path}/setup\" \
-    -ftpProxyPassive=\"${pool.mover.ftp.allow-incomming-connections}\" \
+    -ftpProxyPassive=\"${pool.mover.ftp.allow-incoming-connections}\" \
     -allowMmap=\"${pool.mover.ftp.mmap}\" \
     -messageExecutor=messageThreadPool \
     -waitForFiles=\"${pool.wait-for-files}\" \


### PR DESCRIPTION
Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7596/
(cherry picked from commit 455ee761660d7e2aa1ddcb08043a30da897034c4)
