### PR TITLE
pool: Partially fix interface selection for FTP mover

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/NetworkUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/NetworkUtils.java
@@ -161,12 +161,39 @@ public abstract class NetworkUtils {
     public static InetAddress getLocalAddress(InetAddress intendedDestination)
             throws SocketException
     {
-        return getLocalAddress(intendedDestination, getProtocolFamily(intendedDestination));
+        InetAddress localAddress = getLocalAddress(intendedDestination, getProtocolFamily(intendedDestination));
+        if (localAddress == null) {
+            if (FAKED_ADDRESS) {
+                localAddress =  LOCAL_INET_ADDRESSES.get(0);
+            } else {
+                try (DatagramSocket socket = new DatagramSocket()) {
+                    socket.connect(intendedDestination, RANDOM_PORT);
+                    localAddress = socket.getLocalAddress();
+
+                    /* The following is a workaround for Java bugs on Mac OS X and
+                     * Windows XP, see eg http://goo.gl/ENXkD
+                     */
+                    if (localAddress.isAnyLocalAddress()) {
+                        if (intendedDestination.isLoopbackAddress()) {
+                            localAddress = InetAddress.getLoopbackAddress();
+                        } else {
+                            try {
+                                localAddress = InetAddress.getLocalHost();
+                            } catch (UnknownHostException e) {
+                                localAddress = LOCAL_INET_ADDRESSES.get(0);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return localAddress;
     }
 
     /**
      * Like getLocalAddress(InetAddress), but return an addresses from the given protocolFamily on
-     * the network interface that would be used to reach the destination.
+     * the network interface that would be used to reach the destination. Returns null if the
+     * interface doesn't support the protocol family.
      */
     public static InetAddress getLocalAddress(InetAddress intendedDestination, ProtocolFamily protocolFamily)
             throws SocketException
@@ -206,10 +233,10 @@ public abstract class NetworkUtils {
                             (!address.isLoopbackAddress() || intendedDestination.isLoopbackAddress()) &&
                             (!address.isSiteLocalAddress() || intendedDestination.isSiteLocalAddress()) &&
                             (!address.isLinkLocalAddress() || intendedDestination.isLinkLocalAddress())) {
-                        localAddress = address;
-                        break;
+                        return address;
                     }
                 }
+                return null;
             }
             return localAddress;
         }


### PR DESCRIPTION
The FTP mover tries to select an interface with the correct
protocol family and falls back to proxy mode if not possible.
Unfortunately the NetworkUtils utility class fails to return
null in case no suitable interface could be found.

On the other hand, the original protocol family less version
of the NetworkUtils method fails to handle null values.

This patch fixes the former to return null if the protocol
family could not be match, and fixes the latter by falling
back to ignoring the protocol family. The latter is likely
wrong, but it restore the previous functionality and resolves
the problem that existing callers of that method do not
handle a null return value.

There are plenty of issues with this piece of code. This
patch only sets out to fix the one.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Request: 2.9
Acked-by: Paul Millar paul.millar@desy.de
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Patch: https://rb.dcache.org/r/7597/
(cherry picked from commit b3b24bc378db9552170e66e70fb58aa5cb70f5f9)
