### PR TITLE
webdav: Fix return code on DELETE of absent file

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/SecurityFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/SecurityFilter.java
@@ -56,7 +56,7 @@ import org.dcache.auth.attributes.RootDirectory;
 public class SecurityFilter implements Filter
 {
     private final Logger _log = LoggerFactory.getLogger(SecurityFilter.class);
-    private static final String X509_CERTIFICATE_ATTRIBUTE =
+    public static final String X509_CERTIFICATE_ATTRIBUTE =
         "javax.servlet.request.X509Certificate";
 
     private String _realm;

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/X509AuthenticationHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/X509AuthenticationHandler.java
@@ -1,0 +1,90 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2014 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.webdav;
+
+import io.milton.http.AuthenticationHandler;
+import io.milton.http.Request;
+import io.milton.resource.Resource;
+import io.milton.servlet.ServletRequest;
+import org.globus.gsi.bc.BouncyCastleUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import diskCacheV111.srm.dcache.DCacheAuthorization;
+
+/**
+ * Supports authentication from X509 client certificates.
+ *
+ * No actual authentication is performed as that happens during the SSL handshake. The presence
+ * of a client certificate is however detected and the DN of the client certificate is passed
+ * on as a user name.
+ *
+ * Some logic in Milton relies on knowing whether a request is anonymous or authenticated and this
+ * handler allows sessions that were authenticated using an SSL client certificate to be
+ * treated as authenticated by Milton.
+ */
+public class X509AuthenticationHandler implements AuthenticationHandler
+{
+    private static final Logger logger = LoggerFactory.getLogger(DCacheAuthorization.class);
+
+    @Override
+    public boolean supports(Resource r, Request request)
+    {
+        Object chain = ServletRequest.getRequest().getAttribute(SecurityFilter.X509_CERTIFICATE_ATTRIBUTE);
+        return (chain != null);
+    }
+
+    @Override
+    public Object authenticate(Resource resource, Request request)
+    {
+        try {
+            X509Certificate[] chain =
+                    (X509Certificate[]) ServletRequest.getRequest().getAttribute(
+                            SecurityFilter.X509_CERTIFICATE_ATTRIBUTE);
+            String dn = BouncyCastleUtil.getIdentity(BouncyCastleUtil.getIdentityCertificate(chain));
+            return resource.authenticate(dn, null);
+        } catch (CertificateException e) {
+            logger.warn("Failed to extract DN from certificate chain: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public void appendChallenges(Resource resource, Request request, List<String> challenges)
+    {
+        // don't issue challenges
+    }
+
+    @Override
+    public boolean isCompatible(Resource resource, Request request)
+    {
+        // never issue challenges
+        return false;
+    }
+
+    @Override
+    public boolean credentialsPresent(Request request)
+    {
+        Object chain = ServletRequest.getRequest().getAttribute(SecurityFilter.X509_CERTIFICATE_ATTRIBUTE);
+        return chain != null;
+    }
+}

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -149,6 +149,11 @@
         <property name="buffering" value="never"/>
         <property name="staticContentPath" value="${webdav.static-content.location}"/>
         <property name="templateResource" value="${webdav.templates.html}"/>
+        <property name="extraAuthenticationHandlers">
+            <list>
+                <bean class="org.dcache.webdav.X509AuthenticationHandler"/>
+            </list>
+        </property>
     </bean>
 
     <bean id="handlers" class="org.eclipse.jetty.server.handler.HandlerList">


### PR DESCRIPTION
Due to compatibility concerns with MS Office 2010, Milton in some
cases turns a 404 reply into 401. Atlas noticed this and complained.

Milton only does this for anonymous requests, however when using client
certificates, from the point of view of Milton the session is anonymous
as no HTTP level authentication was performed.

This patch adds an X509AuthenticationHandler for Milton. It doesn't
actually do any authentication, but it is sufficient to let Milton
discover that the request has been authenticated and return the
correct error code.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7614/
(cherry picked from commit d273f7e696ec24075c88f45d88efc630f3c6b9ed)
