### PR TITLE
webdav: Fix reported content length for partial GETs

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
@@ -254,6 +254,18 @@ public class DcacheResponseHandler extends AbstractWrappingResponseHandler
             Range range) throws NotAuthorizedException, BadRequestException,
             NotFoundException
     {
+        Long contentLength = resource.getContentLength();
+        /* [RFC 2616, section 14.35.1]
+         *
+         * "If the last-byte-pos value is absent, or if the value is greater than or equal to the
+         * current length of the entity-body, last-byte-pos is taken to be equal to one less than
+         * the current length of the entity- body in bytes."
+         *
+         * Milton ought to do this, but it doesn't.
+         */
+        if (contentLength != null && range.getFinish() != null && range.getFinish() >= contentLength) {
+            range = new Range(range.getStart(), contentLength - 1);
+        }
         super.respondPartialContent(resource, response, request, params, range);
         rfc3230(resource, response);
     }


### PR DESCRIPTION
When a client requests a byte range beyond the end of the file,
Milton fails to take the file length into account. The consequence
is that we claim to provide a longer body than we do and that
the reported entity length in the Content-Range header is wrong.

This patch resolves the issue by fixing the range in our
custom response handler.

Resolves a compatibility issue with ARC.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Paul Millar paul.millar@desy.de
Patch: https://rb.dcache.org/r/7615/
(cherry picked from commit e4d8b607bfa91acf689dcbc35362852d1c7a649c)
