### PR TITLE
pool: Preserve HSM option ordering

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -100,8 +101,8 @@ public class HsmSet
     {
         private final String _type;
         private final String _instance;
-        private final Map<String,String> _currentAttributes = new HashMap<>();
-        private final Map<String,String> _newAttributes = new HashMap<>();
+        private final Map<String,String> _currentAttributes = new LinkedHashMap<>();
+        private final Map<String,String> _newAttributes = new LinkedHashMap<>();
         private final NearlineStorageProvider _provider;
         private final NearlineStorage _nearlineStorage;
 


### PR DESCRIPTION
Although the script should not care about the order, it might. Also,
it is nicer to see the options in the order you put them rather than
how they got hashed.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Christian Bernardt christian.bernardt@desy.de
Patch: https://rb.dcache.org/r/7621/
(cherry picked from commit 1bb519f0a6be84bbbace8157d9e5f585ffe473f3)
