### PR TITLE
pool: Fix regression causing FTP movers to default to proxy mode

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
@@ -209,9 +209,9 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
 
         if (_cell != null) {
             Args args = _cell.getArgs();
-            if (args.hasOption("ftpProxyPassive")) {
+            if (args.hasOption("ftpAllowIncomingConnections")) {
                 _allowPassivePool =
-                    !Boolean.parseBoolean(args.getOpt("ftpProxyPassive"));
+                        Boolean.parseBoolean(args.getOpt("ftpAllowIncomingConnections"));
             }
 
             if (args.hasOption("gsiftpBlockSize")) {

--- a/skel/share/services/pool.batch
+++ b/skel/share/services/pool.batch
@@ -97,7 +97,7 @@ create org.dcache.cells.UniversalSpringCell "${pool.cell.name}" \
     "!PoolDefaults classpath:org/dcache/pool/classic/pool.xml \
     -export=${pool.cell.export} -cellClass=Pool -profiles=healthcheck-${pool.enable.repository-check} \
     -setupClass=pool -setupFile=\"${pool.path}/setup\" \
-    -ftpProxyPassive=\"${pool.mover.ftp.allow-incoming-connections}\" \
+    -ftpAllowIncomingConnections=\"${pool.mover.ftp.allow-incoming-connections}\" \
     -allowMmap=\"${pool.mover.ftp.mmap}\" \
     -callbackExecutor=callbackThreadPool \
     -messageExecutor=messageThreadPool \


### PR DESCRIPTION
A recent patch fixed a typo that had caused the
pool.mover.ftp.allow-incoming-connections property to be ignored. Fixing the
bug however revealed another bug that causes the interpretation of the property
to be negated. Thus the mover defaulted to proxy mode.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7630/
(cherry picked from commit be20f110ef3d95b5e1d0cbc3140beaa1a50a30ac)

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java

(cherry picked from commit 277f3cfa3af72074867c3c40bd676018e9d52918)