### PR TITLE
(2.6) webadmin: fix select/deselect all on PoolUsage and ActiveTransfers

### DIFF
--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfers.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfers.java
@@ -45,7 +45,7 @@ public class ActiveTransfers extends BasePage {
             @Override
             protected void setSelectionForAll(Boolean selected) {
                 for (SelectableWrapper<ActiveTransfersBean> wrapper: _transfers) {
-                    wrapper.setSelected(true);
+                    wrapper.setSelected(selected);
                 }
             }
         };

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
@@ -107,7 +107,7 @@ public class PoolList extends BasePage {
                 @Override
                 protected void setSelectionForAll(Boolean selected) {
                     for (PoolSpaceBean bean: _poolBeans) {
-                        bean.setSelected(true);
+                        bean.setSelected(selected);
                     }
                 }
             };


### PR DESCRIPTION
Bug in code which forces true where it should be using the
method parameter makes deselect all button behave like select all
on these two pages.

Target:  2.6
Require-book: no
Require-notes: yes
Acked-by:  Gerd

RELEASE NOTES:  Fixes bug preventing deselect button on PoolUsage and ActiveTransfers pages from working.