### PR TITLE
libs: update to nfs4j-0.8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -802,7 +802,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.8.4</version>
+            <version>0.8.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
a bugfix release:

Changelog for nfs4j-0.8.4..nfs4j-0.8.5
    * [7c02112] nfsv4: leave the synchronized block when disposing a client
    * [52d7520] nfs: localhost must have an explicit export entry
    * [ef7b065] nfs: fix sorting of export entries

Acked-by:
Target: 2.10, 2.9