### PR TITLE
libs: update to nfs4j-0.8.5

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -250,14 +250,15 @@ public class NFSv41Door extends AbstractCellComponent implements
         _cellName = getCellName();
         _domainName = getCellDomainName();
 
-        _rpcService = new OncRpcSvcBuilder()
+        OncRpcSvcBuilder oncRpcSvcBuilder = new OncRpcSvcBuilder()
                 .withPort(_port)
                 .withTCP()
-                .withAutoPublish()
-                .build();
+                .withWorkerThreadIoStrategy()
+                .withAutoPublish();
         if (_enableRpcsecGss) {
-            _rpcService.setGssSessionManager(new GssSessionManager(_idMapper));
+            oncRpcSvcBuilder.withGssSessionManager(new GssSessionManager(_idMapper));
         }
+        _rpcService = oncRpcSvcBuilder.build();
 
         _vfs = new VfsCache(new ChimeraVfs(_fileFileSystemProvider, _idMapper), _vfsCacheConfig);
 

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
@@ -184,29 +184,29 @@ public class NFSv4MoverHandler {
             throws IOException , GSSException, OncRpcException {
 
         _embededDS = new NFSServerV41(_operationFactory, null, _fs, new SimpleIdMap(), null);
-        _rpcService = new OncRpcSvcBuilder()
+        OncRpcSvcBuilder oncRpcSvcBuilder = new OncRpcSvcBuilder()
                 .withMinPort(portRange.getLower())
                 .withMaxPort(portRange.getUpper())
                 .withTCP()
                 .withoutAutoPublish()
-                .withWorkerThreadIoStrategy()
-                .build();
+                .withWorkerThreadIoStrategy();
 
-        final Map<OncRpcProgram, RpcDispatchable> programs = new HashMap<>();
-        programs.put(new OncRpcProgram(nfs4_prot.NFS4_PROGRAM, nfs4_prot.NFS_V4), _embededDS);
-        _rpcService.setPrograms(programs);
-
-        if(withGss) {
+        if (withGss) {
             RpcLoginService rpcLoginService = new RpcLoginService() {
-
                 @Override
                 public Subject login(Principal principal) {
                     return Subjects.NOBODY;
                 }
             };
             GssSessionManager gss = new GssSessionManager(rpcLoginService);
-            _rpcService.setGssSessionManager(gss);
+            oncRpcSvcBuilder.withGssSessionManager(gss);
         }
+
+        _rpcService = oncRpcSvcBuilder.build();
+
+        final Map<OncRpcProgram, RpcDispatchable> programs = new HashMap<>();
+        programs.put(new OncRpcProgram(nfs4_prot.NFS4_PROGRAM, nfs4_prot.NFS_V4), _embededDS);
+        _rpcService.setPrograms(programs);
         _rpcService.start();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -799,7 +799,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.8.3</version>
+            <version>0.8.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
a bugfix release:

Changelog for nfs4j-0.8.4..nfs4j-0.8.5
    * [7c02112] nfsv4: leave the synchronized block when disposing a client
    * [52d7520] nfs: localhost must have an explicit export entry
    * [ef7b065] nfs: fix sorting of export entries

Acked-by:
Target: 2.10, 2.9