### PR TITLE
libs: update to nfs4j-0.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -795,7 +795,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.7.8</version>
+            <version>0.7.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
bufgix release:
Changelog for nfs4j-0.7.8..nfs4j-0.7.9
    * [ac7c01a] nfsv4: release file state only after successful LayoutReturn
    * [02de71b] nfsv4: leave the synchronized block when disposing a client
    * [3fa6701] nfs: fix sorting of export entries

Acked-by:
Target: master
Require-book: no
Require-notes: no