### PR TITLE
libs: move to nfs4j-0.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -806,7 +806,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.9.3</version>
+            <version>0.9.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
bugfix release:

Changelog for nfs4j-0.9.3..nfs4j-0.9.4
    * [ad79972] nfsv4: leave the synchronized block when disposing a client
    * [ec0f5c2] nfs: add pnfs/nopnfs export option
    * [4394b72] nfs: localhost must have an explicit export entry
    * [571116c] nfs: fix sorting of export entries

Acked-by: Paul Millar
Target: master, 2.11
Require-book: no
Require-notes: no
(cherry picked from commit 77e28cdcd545292354105295ee9f54661a5a45a9)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>