### PR TITLE
(2.9) gitignore additions for IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@
 /plugins/**/*.iml
 /.idea/
 
+## Once again, the above expressions are not working (SL 6).
+## the following are sufficient, as with the Eclipse
+## exclusions.
+.idea/
+*.iml
 
 ## Ignore Mac generated files, wherever they are
 .DS_Store


### PR DESCRIPTION
The current .gitignore exclusions were not working (SL6).

The additional ones fix it.

Target: 2.9
Acked-by: Tigran
Require-book: no
Require-notes: no