### PR TITLE
check-config: fix warning for deprecated properties

### DIFF
--- a/modules/dcache/src/test/java/org/dcache/util/ConfigurationPropertiesTests.java
+++ b/modules/dcache/src/test/java/org/dcache/util/ConfigurationPropertiesTests.java
@@ -223,17 +223,6 @@ public class ConfigurationPropertiesTests {
     }
 
     @Test
-    public void testDeprecatedForwardSynonymPropertyPut() {
-        _properties.put( DEPRECATED_PROPERTY_W_FORWARD_SYNONYM_NAME, "some value");
-        assertEquals(1, _log.size());
-        assertEquals(Level.WARN, _log.get(0).getLevel());
-        assertEquals("Property " + DEPRECATED_PROPERTY_W_FORWARD_SYNONYM_NAME +
-                     ": use \"" + SIMPLE_PROPERTY_NAME + "\" instead; support for " +
-                     DEPRECATED_PROPERTY_W_FORWARD_SYNONYM_NAME + " will be removed in the future",
-                     _log.get(0).getFormattedMessage());
-    }
-
-    @Test
     public void testDeprecatedBackSynonymDefaultPropertyPut() {
         ConfigurationProperties properties = new ConfigurationProperties(_properties);
         properties.put( DEPRECATED_PROPERTY_W_BACK_SYNONYM_NAME, "some value");


### PR DESCRIPTION
check-config attempts to find a synonym for deprecated properties but fails to
take chains of deprecated properties into account. Thus it may end up
suggesting other deprecated properties instead.

The patch addresses this by resolving the synonym recursively. The patch
removes one direction of chaining in the analysis: Previously it would consider
the value of a property to identify a synonym if it is a simple reference to
another property. This type of chaining isn't the proper way to implement
deprecated properties (the new name should have precedence and thus the new
property needs to be defined from the old, not the other way arround). There is
also the risk of introducing false positives as a deprecated property could be
defined in terms of some other, broader, property that isn't actually a
synonym. E.g. a service specific property could have been defined in terms of a
generic dcache.x property, but the dcache.x property isn't a synonym for the
service specific property.

Specifically, this patch resolves problems with the
SpaceManagerReserveSpaceForNonSRMTransfers property.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7639/
(cherry picked from commit d8182a50d31db2112c17fce96be4baa981ef8a0e)