### PR TITLE
bootloader: Don't fail on missing cell name

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/boot/Domain.java
+++ b/modules/dcache/src/main/java/org/dcache/boot/Domain.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.util.StatusPrinter;
+import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.FileSystemResource;
@@ -64,7 +65,7 @@ public class Domain
         List<String> cells = new ArrayList<>();
         for (ConfigurationProperties service: _services) {
             String cellName = Properties.getCellName(service);
-            if (cellName != null) {
+            if (!Strings.isNullOrEmpty(cellName)) {
                 cells.add(cellName);
             }
         }

--- a/modules/dcache/src/main/java/org/dcache/boot/PythonOracleLayoutPrinter.java
+++ b/modules/dcache/src/main/java/org/dcache/boot/PythonOracleLayoutPrinter.java
@@ -1,5 +1,7 @@
 package org.dcache.boot;
 
+import com.google.common.base.Strings;
+
 import java.io.PrintStream;
 
 import org.dcache.util.ConfigurationProperties;
@@ -155,7 +157,7 @@ public class PythonOracleLayoutPrinter implements LayoutPrinter
 
             for(ConfigurationProperties service : domain.getServices()) {
                 String name = Properties.getCellName(service);
-                if(name != null) {
+                if (!Strings.isNullOrEmpty(name)) {
                     out.println("'" + markup(name) + "' : {");
                     printProperties(indent, service, domain.properties());
                     indent.println("},");

--- a/modules/dcache/src/main/java/org/dcache/boot/ShellOracleLayoutPrinter.java
+++ b/modules/dcache/src/main/java/org/dcache/boot/ShellOracleLayoutPrinter.java
@@ -1,5 +1,7 @@
 package org.dcache.boot;
 
+import com.google.common.base.Strings;
+
 import java.io.PrintStream;
 
 import org.dcache.util.ConfigurationProperties;
@@ -41,7 +43,7 @@ public class ShellOracleLayoutPrinter implements LayoutPrinter {
             out.println("          ;;"); // Fall through
             for (ConfigurationProperties service: domain.getServices()) {
                 String cellName = Properties.getCellName(service);
-                if (cellName != null) {
+                if (!Strings.isNullOrEmpty(cellName)) {
                     out.append("        ").append(quoteForCase(cellName)).println(")");
                     compile(out, "          ", service, domain.properties());
                     out.println("          ;;");


### PR DESCRIPTION
If a pool name isn't defined in the configuration, the dCache fails due
to failure to parse the shell oracle.

This patch addresses this problem. check-config doesn't report the error
as there is nothing in the definition of a service that requires it
to start a cell and thus we cannot complain about lack of a cell name.
The pool will however report the lack of a name during startup.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7641/
(cherry picked from commit da7ba8202c268807ef06c778ff0e9cf2bb0e5f54)