### PR TITLE
Internalize common strings in StorageInfo

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
@@ -102,11 +102,11 @@ public class ChimeraEnstoreStorageInfoExtractor extends ChimeraHsmStorageInfoExt
             for (String line: OSMTemplate) {
                 StringTokenizer st = new StringTokenizer(line);
                 if (st.countTokens() >= 2) {
-                    hash.put(st.nextToken(), st.nextToken());
+                    hash.put(st.nextToken().intern(), st.nextToken());
                 }
             }
-            String sg = getFirstLine(group).or("none");
-            String ff = getFirstLine(family).or("none");
+            String sg = getFirstLine(group).transform(internString()).or("none");
+            String ff = getFirstLine(family).transform(internString()).or("none");
             EnstoreStorageInfo info = new EnstoreStorageInfo(sg,ff);
             info.addKeys(hash);
             return info;
@@ -119,4 +119,5 @@ public class ChimeraEnstoreStorageInfoExtractor extends ChimeraHsmStorageInfoExt
     private static boolean isEncoded(String s) throws UnsupportedEncodingException {
         return !s.equals(UriUtils.decode(s,"UTF-8"));
     }
+
 }

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
@@ -1,9 +1,12 @@
 package org.dcache.chimera.namespace;
 
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.URI;
@@ -173,12 +176,12 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
             // overwrite hsm type with hsmInstance tag
             Optional<String> hsmInstance = getFirstLine(dirInode.getTag("hsmInstance"));
             if (hsmInstance.isPresent()) {
-                info.setHsm(hsmInstance.get());
+                info.setHsm(hsmInstance.get().intern());
             }
 
             Optional<String> cacheClass = getFirstLine(dirInode.getTag("cacheClass"));
             if (cacheClass.isPresent()) {
-                info.setCacheClass(cacheClass.get());
+                info.setCacheClass(cacheClass.get().intern());
             }
 
             Optional<String> spaceToken = getFirstLine(dirInode.getTag("WriteToken"));
@@ -248,4 +251,18 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
         }
         return Optional.absent();
     }
+
+    protected Function<String,String> internString()
+    {
+        return new Function<String, String>()
+        {
+            @Nullable
+            @Override
+            public String apply(@Nullable String s)
+            {
+                return s.intern();
+            }
+        };
+    }
+
 }

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraOsmStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraOsmStorageInfoExtractor.java
@@ -88,7 +88,7 @@ public class ChimeraOsmStorageInfoExtractor extends ChimeraHsmStorageInfoExtract
                     if (st.countTokens() < 2) {
                         continue;
                     }
-                    hash.put(st.nextToken(), st.nextToken());
+                    hash.put(st.nextToken().intern(), st.nextToken());
                 }
                 store = hash.get("StoreName");
                 if (store == null) {
@@ -97,7 +97,7 @@ public class ChimeraOsmStorageInfoExtractor extends ChimeraHsmStorageInfoExtract
             }
 
             ImmutableList<String> sGroup = dirInode.getTag("sGroup");
-            String group = getFirstLine(sGroup).orNull();
+            String group = getFirstLine(sGroup).transform(internString()).orNull();
             OSMStorageInfo info = new OSMStorageInfo(store, group);
             info.addKeys(hash);
             return info;

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/GenericStorageInfo.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/GenericStorageInfo.java
@@ -1,8 +1,6 @@
 package diskCacheV111.vehicles;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -18,8 +16,6 @@ import diskCacheV111.util.RetentionPolicy;
 public class GenericStorageInfo
     implements StorageInfo
 {
-    private static Logger _logger = LoggerFactory.getLogger( GenericStorageInfo.class);
-
     private static final long serialVersionUID = 2089636591513548893L;
 
     /*
@@ -31,8 +27,8 @@ public class GenericStorageInfo
     @Deprecated
     private RetentionPolicy _retentionPolicy = StorageInfo.DEFAULT_RETENTION_POLICY;
 
-    private HashMap<String, String> _keyHash = new HashMap<>();
-    private ArrayList<URI> _locations = new ArrayList<>();
+    private Map<String, String> _keyHash = new HashMap<>();
+    private List<URI> _locations = new ArrayList<>();
     private boolean _setHsm;
     private boolean _setStorageClass;
     private boolean _setBitFileId;
@@ -368,8 +364,8 @@ public class GenericStorageInfo
     {
         try {
             GenericStorageInfo copy = (GenericStorageInfo) super.clone();
-            copy._keyHash = (HashMap<String,String>) copy._keyHash.clone();
-            copy._locations = (ArrayList<URI>) copy._locations.clone();
+            copy._keyHash = new HashMap<>(_keyHash);
+            copy._locations = new ArrayList<>(_locations);
             return copy;
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException("Failed to clone storage info: " +
@@ -439,4 +435,25 @@ public class GenericStorageInfo
         _fileSize = fileSize;
     }
 
+    private void readObject(java.io.ObjectInputStream stream)
+            throws IOException, ClassNotFoundException
+    {
+        stream.defaultReadObject();
+        if (_keyHash != null) {
+            Map<String,String> map = new HashMap<>();
+            for (Map.Entry<String, String> entry : _keyHash.entrySet()) {
+                map.put(entry.getKey().intern(), entry.getValue());
+            }
+            _keyHash = map;
+        }
+        if (_storageClass != null) {
+            _storageClass = _storageClass.intern();
+        }
+        if (_cacheClass != null) {
+            _cacheClass = _cacheClass.intern();
+        }
+        if (_hsm != null) {
+            _hsm = _hsm.intern();
+        }
+    }
 }


### PR DESCRIPTION
Several strings in StorageInfo are very common, such as hsm names,
storage class and keys for the flags. This patch internalizes these,
both when generating the StorageInfo in chimera and when deserializing
them. This reduces memory consumption in components that hold many
StorageInfo instances in memory.

I avoided Java 8 constructs to allow this to be backported.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7646/
(cherry picked from commit a032759dd9a71a6a3a88c27fa7562b51c16888d8)