### PR TITLE
chimera: handle NULL field of directory tags

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -1603,8 +1603,11 @@ class FsSqlDriver {
                 while (rs.next()) {
                     try (InputStream in = rs.getBinaryStream("ivalue")) {
                         byte[] data = new byte[Ints.saturatedCast(rs.getLong("isize"))];
-                        ByteStreams.readFully(in, data);
-                        tags.put(rs.getString("itagname"), data);
+                        // we get null if filed id NULL, e.g not set
+                        if (in != null) {
+                            ByteStreams.readFully(in, data);
+                            tags.put(rs.getString("itagname"), data);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
if tag exists but empty we get a NullPointerException:

15 Jan 2015 15:22:01 (PnfsManager) [dcache-photon35-05 PnfsGetFileAttributes 0000E8718A3F3169474C92626C718FBC10B4] Error while retrieving file attributes: null
java.lang.NullPointerException: null
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:213) ~[guava-17.0.jar:na]
	at com.google.common.io.ByteStreams.read(ByteStreams.java:917) ~[guava-17.0.jar:na]
	at com.google.common.io.ByteStreams.readFully(ByteStreams.java:785) ~[guava-17.0.jar:na]
	at com.google.common.io.ByteStreams.readFully(ByteStreams.java:766) ~[guava-17.0.jar:na]
	at org.dcache.chimera.FsSqlDriver.getAllTags(FsSqlDriver.java:1606) ~[chimera-2.11.5.jar:2.11.5]
	at org.dcache.chimera.JdbcFs.getAllTags(JdbcFs.java:2017) ~[chimera-2.11.5.jar:2.11.5]
	at org.dcache.chimera.namespace.ExtendedInode.getTags(ExtendedInode.java:150) ~[dcache-chimera-2.11.5.jar:2.11.5]
	at org.dcache.chimera.namespace.ExtendedInode.getTag(ExtendedInode.java:158) ~[dcache-chimera-2.11.5.jar:2.11.5]
	at org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor.getDirStorageInfo(ChimeraOsmStorageInfoExtractor.java:84) ~[dcache-chimera-2.11.5.jar:2.11.5]
	at org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor.getFileStorageInfo(ChimeraOsmStorageInfoExtractor.java:45) ~[dcache-chimera-2.11.5.jar:2.11.5]
	at org.dcache.chimera.namespace.ChimeraHsmStorageInfoExtractor.getStorageInfo(ChimeraHsmStorageInfoExtractor.java:168) ~[dcache-chimera-2.11.5.jar:2.11.5]
	at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.getFileAttributes(ChimeraNameSpaceProvider.java:765) ~[dcache-chimera-2.11.5.jar:2.11.5]
	at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.getFileAttributes(ChimeraNameSpaceProvider.java:783) ~[dcache-chimera-2.11.5.jar:2.11.5]
	at diskCacheV111.namespace.PnfsManagerV3.getFileAttributes(PnfsManagerV3.java:1986) [dcache-core-2.11.5.jar:2.11.5]
	at diskCacheV111.namespace.PnfsManagerV3.processPnfsMessage(PnfsManagerV3.java:1753) [dcache-core-2.11.5.jar:2.11.5]
	at diskCacheV111.namespace.PnfsManagerV3$ProcessThread.run(PnfsManagerV3.java:1564) [dcache-core-2.11.5.jar:2.11.5]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_72]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_72]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_72]

Observed at DESY after upgrade from 2.7+

Acked-by: Albert Rossi
Target: master, 2.11, 2.10, 2.9
Require-book: no
Require-notes: no
(cherry picked from commit 39a1931baa44a13afa80ebe6a5594872ac6176f3)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>