### PR TITLE
libs: pull grizzly-framework-2.3.12 for nfs4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
             <dependency>
                 <groupId>org.glassfish.grizzly</groupId>
                 <artifactId>grizzly-framework</artifactId>
-                <version>2.3.5</version>
+                <version>2.3.12</version>
             </dependency>
             <dependency>
                 <groupId>com.sleepycat</groupId>


### PR DESCRIPTION
the latest version of nfs4j depends on grizzly-framework-2.3.12