### PR TITLE
cells: Fix message timeout in case of thread pool overflows

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -457,17 +457,43 @@ public class CellNucleus implements ThreadFactory
         // _waitHash can't be used here. Otherwise
         // we will end up in a deadlock (NO LOCKS WHILE CALLING CALLBACKS)
         //
-        for (CellLock lock: expired) {
-            try {
-                CellMessage envelope = lock.getMessage();
-                EventLogger.sendEnd(envelope);
-                lock.getCallback().answerTimedOut(envelope);
-            } catch (RuntimeException e) {
-                /* Don't let a problem in the callback prevent us from
-                 * expiring all messages.
-                 */
-                Thread t = Thread.currentThread();
-                t.getUncaughtExceptionHandler().uncaughtException(t, e);
+        for (final CellLock lock: expired) {
+            try (CDC ignored = lock.getCdc().restore()) {
+                try {
+                    lock.getExecutor().execute(new Runnable()
+                    {
+                        @Override
+                        public void run()
+                        {
+                            CellMessage envelope = lock.getMessage();
+                            try {
+                                lock.getCallback().answerTimedOut(envelope);
+                                EventLogger.sendEnd(envelope);
+                            } catch (RejectedExecutionException e) {
+                                /* May happen when the callback itself tries to schedule the call
+                                 * on an executor. Put the request back and let it time out.
+                                 */
+                                synchronized (_waitHash) {
+                                    _waitHash.put(envelope.getUOID(), lock);
+                                }
+                                LOGGER.warn("Failed to invoke callback: {}", e.toString());
+                            }
+                        }
+                    });
+                } catch (RejectedExecutionException e) {
+                    /* Put it back and deal with it later.
+                     */
+                    synchronized (_waitHash) {
+                        _waitHash.put(lock.getMessage().getUOID(), lock);
+                    }
+                    LOGGER.warn("Failed to invoke callback: {}", e.toString());
+                } catch (RuntimeException e) {
+                    /* Don't let a problem in the callback prevent us from
+                     * expiring all messages.
+                     */
+                    Thread t = Thread.currentThread();
+                    t.getUncaughtExceptionHandler().uncaughtException(t, e);
+                }
             }
         }
 
@@ -505,7 +531,7 @@ public class CellNucleus implements ThreadFactory
     public void sendMessage(CellMessage msg,
                             boolean local,
                             boolean remote,
-                            CellMessageAnswerable callback,
+                            final CellMessageAnswerable callback,
                             Executor executor,
                             long timeout)
         throws SerializationException
@@ -516,27 +542,52 @@ public class CellNucleus implements ThreadFactory
 
         msg.setTtl(timeout);
 
-        EventLogger.sendBegin(this, msg, "callback");
-        UOID uoid = msg.getUOID();
-        boolean success = false;
-        try {
-            CellLock lock = new CellLock(msg, callback, executor, timeout);
-            synchronized (_waitHash) {
-                _waitHash.put(uoid, lock);
-            }
+        final UOID uoid = msg.getUOID();
+        final CellLock lock = new CellLock(msg, callback, executor, timeout);
 
+        EventLogger.sendBegin(this, msg, "callback");
+        synchronized (_waitHash) {
+            _waitHash.put(uoid, lock);
+        }
+        try {
             __cellGlue.sendMessage(this, msg, local, remote);
-            success = true;
-        } catch (NoRouteToCellException e) {
-            if (callback != null) {
-                callback.exceptionArrived(msg, e);
+        } catch (SerializationException e) {
+            synchronized (_waitHash) {
+                _waitHash.remove(uoid);
             }
-        } finally {
-            if (!success) {
+            EventLogger.sendEnd(msg);
+            throw e;
+        } catch (Exception e) {
+            synchronized (_waitHash) {
+                _waitHash.remove(uoid);
+            }
+            try {
+                executor.execute(new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        try {
+                            callback.exceptionArrived(msg, e);
+                            EventLogger.sendEnd(msg);
+                        } catch (RejectedExecutionException e) {
+                            /* May happen when the callback itself tries to schedule the call
+                             * on an executor. Put the request back and let it time out.
+                             */
+                            synchronized (_waitHash) {
+                                _waitHash.put(uoid, lock);
+                            }
+                            LOGGER.error("Failed to invoke callback: {}", e.toString());
+                        }
+                    }
+                });
+            } catch (RejectedExecutionException e1) {
+                /* Put it back and let it time out.
+                 */
                 synchronized (_waitHash) {
-                    _waitHash.remove(uoid);
+                    _waitHash.put(uoid, lock);
                 }
-                EventLogger.sendEnd(msg);
+                LOGGER.error("Failed to invoke callback: {}", e1.toString());
             }
         }
     }
@@ -933,7 +984,8 @@ public class CellNucleus implements ThreadFactory
         }
     }
 
-    public Class<?> loadClass(String className) throws ClassNotFoundException {
+    public Class<?> loadClass(String className) throws ClassNotFoundException
+    {
         return __cellGlue.loadClass(className);
     }
 
@@ -1045,13 +1097,22 @@ public class CellNucleus implements ThreadFactory
                     answer = null;
                 }
 
-                EventLogger.sendEnd(_lock.getMessage());
-                if (obj instanceof Exception) {
-                    callback.
-                            exceptionArrived(_lock.getMessage(), (Exception) obj);
-                } else {
-                    callback.
-                            answerArrived(_lock.getMessage(), answer);
+                CellMessage request = _lock.getMessage();
+                try {
+                    if (obj instanceof Exception) {
+                        callback.exceptionArrived(request, (Exception) obj);
+                    } else {
+                        callback.answerArrived(request, answer);
+                    }
+                    EventLogger.sendEnd(request);
+                } catch (RejectedExecutionException e) {
+                    /* May happen when the callback itself tries to schedule the call
+                     * on an executor. Put the request back and let it time out.
+                     */
+                    synchronized (_waitHash) {
+                        _waitHash.put(request.getUOID(), _lock);
+                    }
+                    LOGGER.error("Failed to invoke callback: {}", e.toString());
                 }
                 LOGGER.trace("addToEventQueue : callback done for : {}", _message);
             }

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -528,7 +528,7 @@ public class CellNucleus implements ThreadFactory
      * @exception SerializationException if the payload object of this
      *            message is not serializable.
      */
-    public void sendMessage(CellMessage msg,
+    public void sendMessage(final CellMessage msg,
                             boolean local,
                             boolean remote,
                             final CellMessageAnswerable callback,
@@ -557,7 +557,7 @@ public class CellNucleus implements ThreadFactory
             }
             EventLogger.sendEnd(msg);
             throw e;
-        } catch (Exception e) {
+        } catch (final Exception e) {
             synchronized (_waitHash) {
                 _waitHash.remove(uoid);
             }


### PR DESCRIPTION
Asynchronous message callbacks may be scheduled on an Executor. This executor
may be bounded, which means it may throw RejectedExecutionException. If we
never call the callback, we risk that there is state in the services that
doesn't get cleaned. Invoking one of the callback methods is thus essential for
dCache.

In one case we already had a solution for this: When unable to inject the task
for calling the delivery of a reply, the request is reinserted into the map
tracking asynchronous requests. Eventually this request will time out and the
timeout callback is called instead. In all other cases the code would not
recover from a RejectedExecutionException and simply log a stack trace.

This patch extends the existing solution to all callback invocations: If the
callback is rejected, the request is reinserted into the map to allow the
timeout callback to be called later (note that the timeout callback itself may
be rejected, in which case the request is put back into the map too).

In several cases the code failed to call the callback on the correct executor.
This has been fixed too. The same goes for restoring the CDC when invoking the
timeout callback.

I did consider whether we could fall back to in-thread execution of the
callback, but since the callback may perform blocking operations, it would be
very dangerous to invoke the callback from outside the correct thread pool.

Since the callback map is unbounded, there is a risk that it could grow very
large. If callbacks kept failing, this patch would increase the risk of the map
growing aggressively. That is however a different problem that could happen in
the old code already - the proper solution for that would be to reject sending
new requests rather than to drop the callbacks.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Request: 2.9
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8585
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7682/
(cherry picked from commit c07c2f6e9ea4fd01352016670c20e5399427599e)