### PR TITLE
(2.6) webadmin: alternative to tidy up login link in UserPanel

### DIFF
--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/BasePage.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/BasePage.java
@@ -41,7 +41,7 @@ public class BasePage extends WebPage {
         setTitle(getStringResource("title"));
         add(new Label("pageTitle", new PropertyModel<String>(this, "_title")));
         add(new HeaderPanel("headerPanel"));
-        add(new UserPanel("userPanel", this));
+        add(new UserPanel("userPanel"));
         BasicNavigationPanel navigation = new BasicNavigationPanel("navigationPanel",
                                 this.getClass());
         add(navigation);

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/login/LogIn.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/pages/login/LogIn.java
@@ -1,6 +1,6 @@
 package org.dcache.webadmin.view.pages.login;
 
-import org.apache.wicket.Page;
+import org.apache.wicket.PageReference;
 import org.apache.wicket.Session;
 import org.apache.wicket.authentication.IAuthenticationStrategy;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -14,9 +14,7 @@ import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.protocol.http.servlet.ServletWebRequest;
 import org.apache.wicket.protocol.https.RequireHttps;
-import org.apache.wicket.request.RequestHandlerStack.ReplaceHandlerException;
 import org.apache.wicket.request.cycle.RequestCycle;
-import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +28,15 @@ import org.dcache.webadmin.view.beans.LogInBean;
 import org.dcache.webadmin.view.beans.UserBean;
 import org.dcache.webadmin.view.beans.WebAdminInterfaceSession;
 import org.dcache.webadmin.view.pages.basepage.BasePage;
-import org.dcache.webadmin.view.panels.userpanel.UserPanel;
 import org.dcache.webadmin.view.util.DefaultFocusBehaviour;
 
+/**
+ * Contains all the page construction and logic for servicing a login
+ * request, but may be extended to return to a referring page
+ * by overriding the #getReferrer() method.
+ *
+ * @author arossi
+ */
 @RequireHttps
 public class LogIn extends BasePage {
 
@@ -40,8 +44,6 @@ public class LogIn extends BasePage {
         = "javax.servlet.request.X509Certificate";
     private static final Logger _log = LoggerFactory.getLogger(LogIn.class);
     private static final long serialVersionUID = 8902191632839916396L;
-
-    private Class<? extends Page> returnPage;
 
     private class LogInForm extends StatelessForm {
 
@@ -63,7 +65,7 @@ public class LogIn extends BasePage {
                     if (!isSignedIn()) {
                         signInWithCert(getLogInService());
                     }
-                    setGoOnPage();
+                    goToPage();
                 } catch (IllegalArgumentException ex) {
                     error(getStringResource("noCertError"));
                     _log.debug("no certificate provided");
@@ -95,7 +97,7 @@ public class LogIn extends BasePage {
                     if (!isSignedIn()) {
                         signIn(_logInModel, strategy);
                     }
-                    setGoOnPage();
+                    goToPage();
                 } catch (LogInServiceException ex) {
                     strategy.remove();
                     String cause = "unknown";
@@ -144,49 +146,6 @@ public class LogIn extends BasePage {
             return getWebadminSession().isSignedIn();
         }
 
-        /**
-         * There seems to be an unresolved issue in the way the base url
-         * is determined for the originating page.  It seems that if the
-         * RestartResponseAtInterceptPageException is thrown
-         * from within a subcomponent of the page, the url
-         * reflects in its query part that subcomponent, and
-         * consequently on redirect after intercept, Wicket attempts
-         * to return to it, generating an Access Denied Page.
-         * <p>
-         * At present I see no other way of maintaining proper intercept-
-         * redirect behavior except via a workaround which defeats
-         * the exception handling mechanism by setting the response page,
-         * determined via the constructor.  Panels using the
-         * intercept exception (for example, {@link UserPanel}) should
-         * set the first page parameter to be the originating page
-         * class name.
-         * <p>
-         * This behavior has been present since Wicket 1.5.
-         * See <a href="http://apache-wicket.1842946.n4.nabble.com/RestartResponseAtInterceptPageException-problem-in-1-5-td4255020.html">RestartAtIntercept problem</a>.
-         */
-         private void setGoOnPage() {
-             /*
-             * If login has been called because the user was not yet logged in,
-              * then continue to the original destination, otherwise to the Home
-             * page.
-              */
-            try {
-                continueToOriginalDestination();
-            } catch (ReplaceHandlerException e) {
-                /*
-                 * Note that #continueToOriginalDestination should use
-                 * this exception to return to the calling page, with
-                 * no exception thrown if this page was not invoked
-                 * as an intercept page.  Hence catching this exception
-                 * is technically incorrect behavior, according to the
-                 * Wicket specification.  But see the documentation
-                 * to this method.
-                 */
-            }
-
-            setResponsePage(returnPage);
-        }
-
         private void signIn(LogInBean model, IAuthenticationStrategy strategy)
                         throws LogInServiceException {
             String username;
@@ -217,15 +176,32 @@ public class LogIn extends BasePage {
         }
     }
 
-    public LogIn() {
-        super();
-        this.returnPage = getApplication().getHomePage();
+    /**
+     *   Can be overridden to return a reference.
+     */
+    protected PageReference getReferrer() {
+        return null;
     }
 
-    public LogIn(PageParameters pageParameters) throws ClassNotFoundException {
-        super(pageParameters);
-        this.returnPage = (Class<? extends Page>)BasePage.class.getClassLoader()
-                           .loadClass(pageParameters.get(0).toString());
+    protected void goToPage() {
+        /*
+         * Covers the redirect from admin-authz page, noop in other cases
+         */
+        continueToOriginalDestination();
+
+        PageReference ref = getReferrer();
+        if (ref != null) {
+            /*
+             * Covers the user-clicking a the "Login" button.
+             * This must be done first.
+             */
+            setResponsePage(ref.getPage());
+        } else {
+            /*
+             * Covers case when user somehow jumps to login page directly
+             */
+            setResponsePage(getWebadminApplication().getHomePage());
+        }
     }
 
     protected void initialize() {

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/userpanel/UserPanel.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/panels/userpanel/UserPanel.java
@@ -1,17 +1,15 @@
 package org.dcache.webadmin.view.panels.userpanel;
 
-import org.apache.wicket.RestartResponseAtInterceptPageException;
 import org.apache.wicket.Session;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.Link;
 import org.apache.wicket.model.PropertyModel;
-import org.apache.wicket.request.mapper.parameter.PageParameters;
 
 import org.dcache.webadmin.view.beans.WebAdminInterfaceSession;
 import org.dcache.webadmin.view.pages.basepage.BasePage;
 import org.dcache.webadmin.view.pages.dcacheservices.DCacheServices;
-import org.dcache.webadmin.view.pages.login.LogIn;
 import org.dcache.webadmin.view.panels.basepanel.BasePanel;
+import org.dcache.webadmin.view.util.LogInLink;
 
 /**
  *
@@ -23,14 +21,10 @@ import org.dcache.webadmin.view.panels.basepanel.BasePanel;
  * @author tanja
  */
 public class UserPanel extends BasePanel {
-
     private static final long serialVersionUID = -4419358909048041100L;
 
-    public UserPanel(String id, BasePage basePage) {
+    public UserPanel(String id) {
         super(id);
-
-        final PageParameters parameters = new PageParameters();
-        parameters.set(0, basePage.getClass().getName());
 
         add(new Label("username", new PropertyModel(this, "session.userName")));
         add(new Link("logout") {
@@ -51,21 +45,14 @@ public class UserPanel extends BasePanel {
             }
         });
 
-        add(new Link("login") {
+        add(new LogInLink("login") {
 
-            private static final long serialVersionUID = -1031589310010810063L;
-
-            @Override
-            public void onClick() {
-                throw new RestartResponseAtInterceptPageException(LogIn.class,
-                                                                  parameters);
-            }
+            private static final long serialVersionUID = 6704578675572299011L;
 
             @Override
             public boolean isVisible() {
                 return !((WebAdminInterfaceSession) Session.get()).isSignedIn();
             }
         });
-
     }
 }

--- a/modules/webadmin/src/main/java/org/dcache/webadmin/view/util/LogInLink.java
+++ b/modules/webadmin/src/main/java/org/dcache/webadmin/view/util/LogInLink.java
@@ -1,0 +1,95 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.webadmin.view.util;
+
+import org.apache.wicket.PageReference;
+import org.apache.wicket.markup.html.link.Link;
+
+import org.dcache.webadmin.view.pages.login.LogIn;
+
+/**
+ * A link which sends the user to a login page which
+ * returns to the page on which this link is found.
+ * Overrides the LogIn page getReferrer() to return the current page reference
+ * instead of relying on the redirect exception control flow
+ * that is meant for intercepting links to authenticated pages.
+ *
+ * @author arossi
+ */
+public class LogInLink extends Link {
+    private static final long serialVersionUID = -7690463969366711208L;
+
+    public LogInLink(String id) {
+        super(id);
+    }
+
+    @Override
+    public void onClick() {
+        final PageReference responseRef = getPage().getPageReference();
+        setResponsePage(new LogIn() {
+            private static final long serialVersionUID = -7249427372922482262L;
+
+            @Override
+            protected PageReference getReferrer() {
+                return responseRef;
+            }
+        });
+    }
+}


### PR DESCRIPTION
Replace a kludgy fix for the case when intercept redirect to
the LogIn page is initiated from a panel rather than a page.

Wicket has a built-in control flow pattern for handling
"intercept" pages.  What one does is to use a redirectToInterceptPage
method which brings you to the intermediate page (here, LogIn);
when the page has completed its work, a call to continueToOriginalDestination
is made.  If this page is an intercept, an exception will be
thrown which is handled by a redirect handler, returning you
to the original page via the URL known to the embedded exception
object.  If the page was not called via intercept, then that
call simply returns, and a response page should be set (here
home).

This is all well and good when the redirectToInterceptPage is
initiated inside a Page; but if the component initiating it is
a Panel or a Form, the URL contains an additional query part
indicating the component listener.  Unfortunately, a redirect
using a URL with a Panel listener produces an AccessDenied error.
This is usually benign (if one does back in the browser, one
notes that one is properly logged in, though not on the
page desired).

The original workaround for this in the code was ugly, because
it defeated the exception flow.  It also introduced a bug
where the redirect to login did not proceed to the desired
page if the user had to provide a password, so the solution
was ultimately incorrect.

(see patches 7481, 7462, 7451, 6987 for further elucidation)

The solution offered by this patch was a compromise which
uses the "Hollywood" pattern rather than defeat
the exception-flow.

Target: 2.6
Require-book: no
Require-notes: yes
Acked-by: Paul

RELEASE NOTES:  Fixes minor bugs resulting in (a) an "unauthorized access"
error (when the login button in the bird panel is used) and (b)
a redirect to the home page rather than return to the original page after
successful login to an admin page via the login panel presented when
the user does not have a certificate or is not an admin user.