### PR TITLE
nfs: always reply FILE_SYNC4 on write

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationWRITE.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationWRITE.java
@@ -61,6 +61,17 @@ public class EDSOperationWRITE extends AbstractNFSv4Operation {
             _args.opwrite.data.rewind();
             int bytesWritten = fc.write(_args.opwrite.data, offset);
 
+            /*
+                due to bug in linux commit-through-ds code,
+                we shamelessly always return FILE_SYNC4 without
+                committing.
+
+                RedHat Bugzilla:
+                   https://bugzilla.redhat.com/show_bug.cgi?id=1184394
+            */
+            int stable = stable_how4.FILE_SYNC4;
+            /*
+            FIXME: enable this back as soon as kernel bug is fixed
             int stable = _args.opwrite.stable;
             switch (stable) {
                 case stable_how4.FILE_SYNC4:
@@ -75,6 +86,7 @@ public class EDSOperationWRITE extends AbstractNFSv4Operation {
                 default:
                     throw new BadXdrException();
             }
+            */
 
             res.status = nfsstat.NFS_OK;
             res.resok4 = new WRITE4resok();


### PR DESCRIPTION
the recent change to support different levels of write stability
have triggered a bug in linux kernel, which fixed in kernel
>=3.16, but still exists in RHEL/Debian/Ubuntu.

As long as kernel is not fixed, revert to old behavior.

Redhat-Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1184394
Acked-by: Dmitry Litvintsev
Target: master, 2.11
(cherry picked from commit e601b4bbcb24b4c25cdd3d78bce7b5dc6cafb025)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>