### PR TITLE
srm: Fix calculation of total number of requests

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -477,7 +477,7 @@ public class Scheduler <T extends Job>
 
     private int getTotalRequests()
     {
-        return getTotalTQueued() + getTotalInprogress() + getTotalRQueued();
+        return getTotalTQueued() + getTotalInprogress() + getTotalRQueued() + getTotalReady();
     }
 
     private int getTotalInprogress()


### PR DESCRIPTION
The SRM has a configurable limit for the number of requests of a given type.
This patch fixes the problem that the calculated total does not include jobs in
the ready state. The previous behaviour is contrary to what we have documented
and contrary to the report the SRM generates as part of the info command:

--- scheduler-get (Scheduler for GET operations) ---
    Queued ............................     0     [TQueued]
    Waiting for CPU ..........     0              [PriorityTQueued]
    Running (max 250) ........     0              [Running]
    Running without thread ...     0              [RunningWithoutThread]
    Waiting for callback .....     0              [AsyncWait]
    In progress (max 1000) ...   SUM >>     0
    Queued for retry ..................     0     [RetryWait]
    Queued for transfer ...............     0     [RQueued]
    Waiting for transfer (max 15000) ..   441     [Ready]
    ------------------------------------------
    Total requests (max 20000) ........     0

    In progress per user soft limit : 100 requests
    Retry timeout                   : 60000 ms
    Retry limit                     : 10 retries

Note how the 441 ready jobs were not counted against the total.

Target: trunk
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7711/
(cherry picked from commit e1f3d69966c1e30e12f08c90f6783df376d31989)