### PR TITLE
Disallow Java 8

### DIFF
--- a/skel/share/lib/loadConfig.sh
+++ b/skel/share/lib/loadConfig.sh
@@ -56,7 +56,7 @@ isJavaVersionOk()
 {
     version=$($JAVA -version 2>&1)
     case $version in
-        *1.[78]*)
+        *1.[7]*)
             return 0
             ;;
         *)


### PR DESCRIPTION
2.9 and earlier do now work with Java 8.

Target: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: no
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/7712/