### PR TITLE
pool: Fix logging in HTTP mover

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/HttpRequestHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpRequestHandler.java
@@ -116,12 +116,12 @@ public class HttpRequestHandler extends IdleStateAwareChannelHandler
             HttpResponseStatus statusCode,
             String message)
     {
-        _logger.info("Sending error {} with message {} to client.",
-                statusCode, message);
-
         if (message == null || message.isEmpty()) {
             message = "An unexpected server error has occurred.";
         }
+
+        _logger.info("Sending error {} with message '{}' to client.",
+                     statusCode, message);
 
         HttpResponse response = new DefaultHttpResponse(HTTP_1_1, statusCode);
         response.headers().add(CONTENT_TYPE, "text/plain; charset=UTF-8");
@@ -147,12 +147,12 @@ public class HttpRequestHandler extends IdleStateAwareChannelHandler
             HttpResponseStatus statusCode,
             String message)
     {
-        _logger.info("Sending error {} with message {} to client.",
-                statusCode, message);
-
         if (message == null || message.isEmpty()) {
             message = "An unexpected server error has occurred.";
         }
+
+        _logger.info("Sending error {} with message '{}' to client.",
+                     statusCode, message);
 
         HttpResponse response = new DefaultHttpResponse(HTTP_1_1, statusCode);
         response.headers().add(CONTENT_TYPE, "text/plain; charset=UTF-8");


### PR DESCRIPTION
Target: trunk
Request: 2.11
Request: 2.10
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7713/
(cherry picked from commit 932fcf07f280a9ef62ccae7b56bf3882582beae8)