### PR TITLE
ftp: fix invalid default for ftp.authz.readonly property

### DIFF
--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -48,10 +48,10 @@ ftp.authz.staging=${dcache.authz.staging}
 #  The ftp.authz.readonly property controls whether an FTP door will allow
 #  users to upload files, delete files or otherwise modify dCache's
 #  contents.
-ftp.authz.readonly=ftp.authz.readonly.${ftp.authn.protocol}
-ftp.authz.readonly.plain=true
-ftp.authz.readonly.gsi=false
-ftp.authz.readonly.kerberos=false
+(one-of?true|false|${ftp.authz.readonly.${ftp.authn.protocol}})ftp.authz.readonly=${ftp.authz.readonly.${ftp.authn.protocol}}
+(one-of?true|false)ftp.authz.readonly.plain=true
+(one-of?true|false)ftp.authz.readonly.gsi=false
+(one-of?true|false)ftp.authz.readonly.kerberos=false
 
 #  ---- Upload directory
 #


### PR DESCRIPTION
ftp.authz.readonly is by default set to the string
ftp.authz.readonly.$\{ftp.authz.readonly\} instead of the value of the
so property of that name. This causes the ftp.authz.readonly.plain, etc.
properties to be ignored in the readonly=true case, because the fallback
seems to be "false", thus causing a potential security issue.
This patch fixes this by assigning the evaluated value to the property
instead.

Ticket: 8610
Acked-by: Paul
Target: 2.11
Require-book: no
Require-notes: yes