### PR TITLE
nfs-proxy: remove proxy adapter on IO errors

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapProxyIoFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapProxyIoFactory.java
@@ -194,6 +194,13 @@ public class DcapProxyIoFactory extends AbstractCell {
         }
     }
 
+    void shutdownAdapter(stateid4 stateid) {
+        ProxyIoAdapter adapter = _proxyIO.getIfPresent(stateid);
+        if (adapter != null) {
+            _proxyIO.invalidate(stateid);
+            tryToClose(adapter);
+        }
+    }
     @Override
     public void getInfo(PrintWriter pw) {
 	pw.println("  Known proxy adapters (proxy-io):");

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
@@ -102,6 +102,7 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
             _log.debug(he.getMessage());
         }catch(IOException ioe) {
             _log.error("DSREAD: ", ioe);
+            proxyIoFactory.shutdownAdapter(_args.opread.stateid);
             res.status = nfsstat.NFSERR_IO;
         }catch(Exception e) {
             _log.error("DSREAD: ", e);

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
@@ -111,6 +111,7 @@ public class ProxyIoWRITE extends AbstractNFSv4Operation {
             _log.debug(he.getMessage());
         }catch(IOException ioe) {
             _log.error("DSWRITE: {}", ioe.getMessage());
+            proxyIoFactory.shutdownAdapter(_args.opwrite.stateid);
             res.status = nfsstat.NFSERR_IO;
         }catch(Exception e) {
             _log.error("DSWRITE: ", e);


### PR DESCRIPTION
If we lost connection to pool, then makes no sense to
keep adapter which always returns IO error

Ticket: #8607
Acked-by: Karsten Schwank
Target: master, 2.11, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 88daff7ffba72b80699e7d7f373e2c58510fd1da)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>