### PR TITLE
(2.10) webadmin: restore missing components to respect jquery script opt...

### DIFF
--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.html
@@ -47,6 +47,19 @@
                 type="submit"
                 wicket:id="deselectAllButton"
                 wicket:message="value:deselectAllButton" />
+            <br><br>
+            <wicket:message key="poolAdmin.quickfind"></wicket:message>
+            &nbsp;
+            <input
+                    type="text"
+                    class="quickfind"/>
+            &nbsp;
+            <input
+                    type="button"
+                    value="Clear Filters"
+                    class="cleanfilters"/>
+            <div class="clear"></div>
+            <br>
             <table class="sortable">
                 <thead>
                     <tr>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.properties
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.properties
@@ -11,6 +11,7 @@ poolAdmin.pooldomain=Domain
 poolAdmin.poolresponse=Response
 poolAdmin.cutoffMessage=... rest is cut off - full display only for a single pool
 poolAdminForm.commandText.Required=Enter a command to send
+poolAdmin.quickfind=Quick Find:
 error.noPoolGroups=Could not get poolgroups - is the Info service running?
 error.noSelection=Select at least one pool
 error.failed=failed

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.html
@@ -25,6 +25,19 @@
                 style="position: absolute; visibility: show; left: 25px; top: -100px; z-index: +1"
                 onmouseover="overdiv='1';"
                 onmouseout="overdiv='0'; setTimeout('hideBox()',2000)"></div>
+            <br>
+            <wicket:message key="PoolGroupView.quickfind"></wicket:message>
+            &nbsp;
+            <input
+                    type="text"
+                    class="quickfind"/>
+            &nbsp;
+            <input
+                    type="button"
+                    value="Clear Filters"
+                    class="cleanfilters"/>
+            <div class="clear"></div>
+            <br>
             <table class="sortable">
                 <thead>
                     <tr>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.properties
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.properties
@@ -5,6 +5,7 @@ PoolGroupView.poolGroup.header=Poolgroup
 PoolGroupView.total.header=Total space/MiB
 PoolGroupView.free.header=Free space/MiB
 PoolGroupView.precious.header=Precious space/MiB
+PoolGroupView.quickfind=Quick Find:
 cellViewMessage=Cell View
 spaceUsageMessage=Space Usage
 moverViewMessage=Request Queues

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.html
@@ -17,6 +17,19 @@
             <wicket:message key="header1"></wicket:message>
         </h1>
         <span wicket:id="feedback" />
+        <br>
+        <wicket:message key="linkGroupView.quickfind"></wicket:message>
+        &nbsp;
+        <input
+            type="text"
+            class="quickfind"/>
+        &nbsp;
+        <input
+            type="button"
+            value="Clear Filters"
+            class="cleanfilters"/>
+        <div class="clear"></div>
+        <br>
         <table class="sortable">
             <thead>
                 <tr>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.properties
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.properties
@@ -8,4 +8,5 @@ linkGroupView.availableSpace.header=Available/MiB
 linkGroupView.reservedSpace.header=Reserved/MiB
 linkGroupView.freeSpace.header=Free/MiB
 linkGroupView.totalSpace.header=Total/MiB
+linkGroupView.quickfind=Quick Find:
 error.getTokenInfoFailed=Retrieval of Linkgroups failed\u0020

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.html
@@ -17,6 +17,19 @@
             <wicket:message key="header1"></wicket:message>
         </h1>
         <span wicket:id="feedback" />
+        <br>
+        <wicket:message key="TapeTransferQueue.quickfind"></wicket:message>
+        &nbsp;
+        <input
+            type="text"
+            class="quickfind"/>
+        &nbsp;
+        <input
+            type="button"
+            value="Clear Filters"
+            class="cleanfilters"/>
+        <div class="clear"></div>
+        <br>
         <table class="sortable">
             <thead>
                 <tr>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.properties
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.properties
@@ -7,4 +7,5 @@ TapeTransferQueue.started.header=Started
 TapeTransferQueue.clients.header=Clients
 TapeTransferQueue.retries.header=Retries
 TapeTransferQueue.status.header=Status
+TapeTransferQueue.quickfind=Quick Find:
 error.getRestoresFailed=failed to retrieve restores

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poollist/PoolListPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poollist/PoolListPanel.html
@@ -12,6 +12,18 @@
 </head>
 <body>
     <wicket:panel>
+        <wicket:message key="PoolPanel.quickfind"></wicket:message>
+        &nbsp;
+        <input
+                type="text"
+                class="quickfind"/>
+        &nbsp;
+        <input
+                type="button"
+                value="Clear Filters"
+                class="cleanfilters"/>
+        <div class="clear"></div>
+        <br>
         <table class="sortable">
             <thead>
                 <tr>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poollist/PoolListPanel.properties
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poollist/PoolListPanel.properties
@@ -5,3 +5,4 @@ PoolPanel.poolMode.header=Pool Mode
 PoolPanel.total.header=Total space/MiB
 PoolPanel.free.header=Free space/MiB
 PoolPanel.precious.header=Precious space/MiB
+PoolPanel.quickfind=Quick Find:


### PR DESCRIPTION
...ions

The filterboxes and sorting on most tables are controlled by two
jquery libraries and a special script added to the page header.
The script has options which assume the presence not only of
a sortable table, but also of two components controlling the
filters (aside from the individual filter boxes at the head of
each column).

The extra components were inadvertently suppressed in the markup
of several pages.  Their absence blocks the filtering from
working (typing return in the filter box basically freezes
the cursor).

The quickest solution (which also preserves uniformity)
was to restore the missing components to the pages
and panels which require them.

Target: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran

RELEASE NOTES:  Restores missing markup which was blocking
the proper functioning of table filtering.