### PR TITLE
pool: update NFS transfer service to validate inactive movers

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
@@ -1,5 +1,6 @@
 package org.dcache.chimera.nfsv41.mover;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.ietf.jgss.GSSException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,12 +14,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.PnfsId;
 
 import org.dcache.auth.Subjects;
+import org.dcache.cells.CellStub;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
 import org.dcache.nfs.v4.NFSServerV41;
+import org.dcache.nfs.v4.NFSv4Defaults;
 import org.dcache.nfs.v4.NFSv4OperationFactory;
 import org.dcache.nfs.v4.OperationBIND_CONN_TO_SESSION;
 import org.dcache.nfs.v4.OperationCREATE_SESSION;
@@ -46,6 +52,7 @@ import org.dcache.nfs.vfs.VirtualFileSystem;
 import org.dcache.nfs.vfs.AclCheckable;
 import org.dcache.pool.movers.IoMode;
 import org.dcache.util.PortRange;
+import org.dcache.vehicles.DoorValidateMoverMessage;
 import org.dcache.xdr.IpProtocolType;
 import org.dcache.xdr.OncRpcProgram;
 import org.dcache.xdr.OncRpcSvc;
@@ -188,7 +195,20 @@ public class NFSv4MoverHandler {
     private final Map<PnfsId, NfsMover> _activeWrites = new ConcurrentHashMap<>();
     private final NFSServerV41 _embededDS;
 
-    public NFSv4MoverHandler(PortRange portRange, boolean withGss, String serverId)
+    /**
+     * A CellStub for communication with doors.
+     */
+    private final CellStub _door;
+
+    /**
+     * A time window in millis during which we accept idle movers.
+     */
+    private final static long IDLE_PERIOD = TimeUnit.SECONDS.toMillis(NFSv4Defaults.NFS4_LEASE_TIME * 5);
+
+    private final ScheduledExecutorService _cleanerExecutor;
+    private final long _bootVerifier;
+
+    public NFSv4MoverHandler(PortRange portRange, boolean withGss, String serverId, CellStub door, long bootVerifier)
             throws IOException , GSSException, OncRpcException {
 
         _embededDS = new NFSServerV41(_operationFactory, null, _fs, new SimpleIdMap(), null);
@@ -216,6 +236,14 @@ public class NFSv4MoverHandler {
         _rpcService = oncRpcSvcBuilder.build();
         _rpcService.setPrograms(programs);
         _rpcService.start();
+        _door = door;
+        _bootVerifier = bootVerifier;
+        _cleanerExecutor = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder()
+                .setNameFormat("NFS mover validationthread")
+                .build()
+        );
+        _cleanerExecutor.scheduleAtFixedRate(new MoverValidator(), IDLE_PERIOD, IDLE_PERIOD, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -293,9 +321,28 @@ public class NFSv4MoverHandler {
 
     public void shutdown() throws IOException {
         _rpcService.stop();
+        _cleanerExecutor.shutdown();
     }
 
     NFSServerV41 getNFSServer() {
         return _embededDS;
+    }
+
+    class MoverValidator implements Runnable {
+
+        @Override
+        public void run() {
+            long now = System.currentTimeMillis();
+            for(NfsMover mover: _activeIO.values()) {
+                if (!mover.hasSession() && (now - mover.getLastTransferred() > IDLE_PERIOD)) {
+                    _log.debug("Verifing inactive mover {}", mover);
+                    final org.dcache.chimera.nfs.v4.xdr.stateid4 legacyStateId = mover.getProtocolInfo().stateId();
+                    CellStub.addCallback(_door.send(mover.getPathToDoor(),
+                            new DoorValidateMoverMessage<>(-1, mover.getFileAttributes().getPnfsId(), _bootVerifier, legacyStateId)),
+                            new NfsMoverValidationCallback(mover),
+                            _cleanerExecutor);
+                }
+            }
+        }
     }
 }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -115,7 +115,7 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
      * the {@link CompletionHandler#failed(Throwable, A)} method will be called.
      * @param error error to report, or {@code null} on success
      */
-    private void disable(Throwable error) {
+    void disable(Throwable error) {
         _nfsIO.remove(NfsMover.this);
         detachSession();
         try {
@@ -162,7 +162,7 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
 
         @Override
         protected void dispose() {
-            disable(new InterruptedException("Killing mover due to client inactivity"));
+            detachSession();
         }
     }
 
@@ -174,5 +174,9 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
 
     public verifier4 getBootVerifier() {
         return _bootVerifier;
+    }
+
+    public synchronized boolean hasSession() {
+        return (_session != null);
     }
 }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMoverValidationCallback.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMoverValidationCallback.java
@@ -1,0 +1,55 @@
+package org.dcache.chimera.nfsv41.mover;
+
+import diskCacheV111.util.CacheException;
+import dmg.cells.nucleus.CellPath;
+import java.lang.ref.WeakReference;
+import org.dcache.cells.AbstractMessageCallback;
+import org.dcache.chimera.nfs.v4.xdr.stateid4;
+import org.dcache.vehicles.DoorValidateMoverMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@code DoorValidateMoverMessage} callback handler for NFS transfer service.
+ */
+public class NfsMoverValidationCallback extends AbstractMessageCallback<DoorValidateMoverMessage<org.dcache.chimera.nfs.v4.xdr.stateid4>> {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(NfsMoverValidationCallback.class);
+    /**
+     * A weak reference to the mover. If mover will be killed by some
+     * other path (admin command or from the door), then we can simply
+     * forget about it.
+     */
+    private final WeakReference<NfsMover> moverRef;
+
+    public NfsMoverValidationCallback(NfsMover mover) {
+        moverRef = new WeakReference<>(mover);
+    }
+
+    @Override
+    public void success(DoorValidateMoverMessage<stateid4> message) {
+        if (!message.isIsValid()) {
+            kill();
+        }
+    }
+
+    @Override
+    public void failure(int rc, Object error) {
+        // effective NOP, as we can't safely decide to kill the mover
+        LOGGER.info("Failed to send validation requests: {} ({})", error, rc);
+    }
+
+    @Override
+    public void noroute(CellPath path) {
+        // door is dead. All states (movers) are invalid.
+        kill();
+    }
+
+    private void kill() {
+        NfsMover mover = moverRef.get();
+        if (mover != null) {
+            LOGGER.info("Killing abandoned mover: {}", mover);
+            mover.disable(new CacheException(CacheException.THIRD_PARTY_TRANSFER_FAILED, "Abandoned mover"));
+        }
+    }
+}

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -23,7 +23,6 @@ import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellPath;
 import dmg.cells.nucleus.NoRouteToCellException;
 import java.net.Inet4Address;
-import java.util.Arrays;
 
 import org.dcache.cells.CellStub;
 import org.dcache.commons.stats.RequestExecutionTimeGauges;
@@ -76,7 +75,8 @@ public class NfsTransferService extends AbstractCellComponent
             portRange = new PortRange(0);
         }
 
-        _nfsIO = new NFSv4MoverHandler(portRange, _withGss, getCellName());
+        _door = new CellStub(getCellEndpoint());
+        _nfsIO = new NFSv4MoverHandler(portRange, _withGss, getCellName(), _door, _bootVerifier);
         _localSocketAddresses = localSocketAddresses(NetworkUtils.getLocalAddresses(), _nfsIO.getLocalAddress().getPort());
 
         /*
@@ -90,8 +90,6 @@ public class NfsTransferService extends AbstractCellComponent
             }
         }
         _sortMultipathList = ipv4Count > 1;
-
-        _door = new CellStub(getCellEndpoint());
     }
 
     @Required

--- a/modules/dcache/src/main/java/org/dcache/vehicles/DoorValidateMoverMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/vehicles/DoorValidateMoverMessage.java
@@ -1,0 +1,89 @@
+package org.dcache.vehicles;
+
+import diskCacheV111.util.PnfsId;
+import diskCacheV111.vehicles.Message;
+import java.io.Serializable;
+
+/**
+ *
+ * A from a pool to the door to validate validate a mover. The pool provides
+ * <tt>moverId</tt>, <tt>pnfsId</tt> and <tt>challenge</tt> to identify itself a door.
+ *
+ * NOTICE: the message provide a vehicle for moverId, but current mover implementation
+ * does not provides such information.
+ *
+ * @param <T> the type of challenge used by this message
+ * @since 2.12
+ */
+public class DoorValidateMoverMessage<T extends Serializable>  extends Message {
+
+    private static final long serialVersionUID = -2105249651572604794L;
+
+    private final T _challenge;
+    private final int _moverId;
+    private final long _verifier;
+    private final PnfsId _pnfsId;
+
+    private boolean _isValid;
+
+    /**
+     * Construct a new <tt>DoorValidateMoverMessage</tt> for a given mover.
+     * The <tt>verifier</tt> field the to allow client to detect pool restarts.
+     *
+     * @param moverId pool specific identifier of the mover or -1 if unknown
+     * @param pnfsId the pnfsid of the file which mover serves
+     * @param verifier pool restart verifier
+     * @param challenge an opaque, protocol specific data which identifies the transfer
+     */
+    public DoorValidateMoverMessage(int moverId, PnfsId pnfsId, long verifier, T challenge) {
+        _moverId = moverId;
+        _verifier = verifier;
+        _challenge = challenge;
+        _pnfsId = pnfsId;
+    }
+
+    /**
+     * Returns true if mover is valid.
+     * @return true if mover is valid.
+     */
+    public boolean isIsValid() {
+        return _isValid;
+    }
+
+    /**
+     * Get <tt>challenge</tt> provided by mover to validate.
+     * @return challenge to validate.
+     */
+    public T getChallenge() {
+        return _challenge;
+    }
+
+    /**
+     * Get moverid which have triggered the validation.
+     * @return moverid
+     */
+    public int getMoverId() {
+        return _moverId;
+    }
+
+    /**
+     * Get verifier to detect pool restarts. Typically pool's startup time.
+     * @return pool restart verifier.
+     */
+    public long getVerifier() {
+        return _verifier;
+    }
+
+    /**
+     * Return <tt>PnfsId</tt> of a file associated with the mover.
+     * @return pnfsid of the file
+     */
+    public PnfsId getPnfsId() {
+        return _pnfsId;
+    }
+
+    public void setIsValid(boolean isValid) {
+        _isValid = isValid;
+    }
+
+}


### PR DESCRIPTION
The NFS protocol provides a mechanism to detect dead client. In dCache,
this functionality implemented by binding mover to a nfs session on a first
IO operation. When a pool detects expired session, the corresponding mover
is terminated.

While this mechanism works in most situations, there are at least two conner
cases which must be covered:
  a) client never connects to a pool and, as a result, mover is not bound to
    a nfs session. In such situations, we will observe NFS movers, with
    zero bytes transfered size, which never get accessed.

  b) due to network errors the client my loose the connection to the pool,
  but still maintain its state with a door.  In such situation, client will assume
  that mover still exists and will attempt to use. Nevertheless, the pool may already
  killed the corresponding mover, and reject IO request with NFSERR_BAD_STATEID .
  By receiving NFSERR_BAD_STATEID the client will issue a new OPEN requests, but
  won't ask for new mover. This will endup into an infinite pool, pool will not accept
  this transfers.

To cover this conditions, the nfs transfer service is update to change his behavior.
The mover still get associated with a nfs session, but not killed when session expires.
In case of session expires, mover get decoupled from a session, but stays active.
A special task periodically scans for movers without sessions as queries corresponding
door for a validity. A mover get killed only if door does not held a valid open-state.

The change introduces a new message, which is generic enough to be used by other protocols
as well.

Acked-by: Gerd Behrmann
Target: master
(cherry picked from commit feea8e9f17069ac8f3806e6293a7e961957f2d90)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>