### PR TITLE
Validate mover 2.10

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -57,7 +57,6 @@ import org.dcache.chimera.FsInode;
 import org.dcache.chimera.FsInodeType;
 import org.dcache.chimera.JdbcFs;
 import org.dcache.chimera.nfsv41.door.proxy.DcapProxyIoFactory;
-import org.dcache.chimera.nfsv41.door.proxy.ProxyIoAdapter;
 import org.dcache.chimera.nfsv41.door.proxy.ProxyIoMdsOpFactory;
 import org.dcache.chimera.nfsv41.mover.NFS4ProtocolInfo;
 import org.dcache.commons.stats.RequestExecutionTimeGauges;
@@ -67,6 +66,7 @@ import org.dcache.nfs.ExportFile;
 import org.dcache.nfs.status.DelayException;
 import org.dcache.nfs.status.LayoutTryLaterException;
 import org.dcache.nfs.status.NfsIoException;
+import org.dcache.nfs.status.BadStateidException;
 import org.dcache.nfs.v3.MountServer;
 import org.dcache.nfs.v3.NfsServerV3;
 import org.dcache.nfs.v3.xdr.mount_prot;
@@ -99,6 +99,7 @@ import org.dcache.util.RedirectedTransfer;
 import org.dcache.util.Transfer;
 import org.dcache.util.TransferRetryPolicy;
 import org.dcache.utils.Bytes;
+import org.dcache.vehicles.DoorValidateMoverMessage;
 import org.dcache.xdr.OncRpcException;
 import org.dcache.xdr.OncRpcProgram;
 import org.dcache.xdr.OncRpcSvc;
@@ -371,6 +372,24 @@ public class NFSv41Door extends AbstractCellComponent implements
                 transfer.notifyBilling(transferFinishedMessage.getReturnCode(), "");
                 _vfs.invalidateStatCache(transfer.getInode());
         }
+    }
+
+    public DoorValidateMoverMessage messageArrived(DoorValidateMoverMessage<org.dcache.chimera.nfs.v4.xdr.stateid4> message) {
+        org.dcache.chimera.nfs.v4.xdr.stateid4 legacyStateid = message.getChallenge();
+        stateid4 stateid = new stateid4(legacyStateid.other, legacyStateid.seqid.value);
+
+        boolean isValid = false;
+        try {
+            NFS4Client nfsClient = _nfs4.getStateHandler().getClientIdByStateId(stateid);
+            // will throw exception if state does not exists
+            nfsClient.state(stateid);
+            isValid = true;
+        } catch (BadStateidException e) {
+        } catch (ChimeraNFSException e) {
+            _log.warn("Unexpected NFS exception: {}", e.getMessage() );
+        }
+        message.setIsValid(isValid);
+        return message;
     }
 
     private int nextDeviceID() {

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapProxyIoFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapProxyIoFactory.java
@@ -26,6 +26,8 @@ import org.dcache.chimera.JdbcFs;
 import org.dcache.commons.util.NDC;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.nfsstat;
+import org.dcache.nfs.status.DelayException;
+import org.dcache.nfs.status.NfsIoException;
 import org.dcache.nfs.v4.CompoundContext;
 import org.dcache.nfs.v4.NFS4Client;
 import org.dcache.nfs.v4.NFS4State;
@@ -188,9 +190,9 @@ public class DcapProxyIoFactory extends AbstractCell {
 
             int status = nfsstat.NFSERR_IO;
             if ((t instanceof CacheException) && ((CacheException) t).getRc() != CacheException.BROKEN_ON_TAPE) {
-                status = nfsstat.NFSERR_DELAY;
+                throw new DelayException();
             }
-            throw new ChimeraNFSException(status, t.getMessage());
+            throw new NfsIoException();
         }
     }
 

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoREAD.java
@@ -11,6 +11,7 @@ import dmg.cells.nucleus.CDC;
 import org.dcache.commons.util.NDC;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.nfsstat;
+import org.dcache.nfs.status.AccessException;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
 import org.dcache.nfs.v4.CompoundContext;
 import org.dcache.nfs.v4.OperationREAD;
@@ -63,7 +64,7 @@ public class ProxyIoREAD extends AbstractNFSv4Operation {
 		 * As there was no open, we have to check  permissions.
 		 */
 		if (context.getFs().access(inode, nfs4_prot.ACCESS4_READ) == 0) {
-		    throw new ChimeraNFSException(nfsstat.NFSERR_ACCESS, "Permission denied.");
+		    throw new AccessException();
 		}
 
 		/*

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
@@ -11,6 +11,7 @@ import dmg.cells.nucleus.CDC;
 import org.dcache.commons.util.NDC;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.nfsstat;
+import org.dcache.nfs.status.AccessException;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
 import org.dcache.nfs.v4.CompoundContext;
 import org.dcache.nfs.v4.OperationWRITE;
@@ -67,7 +68,7 @@ public class ProxyIoWRITE extends AbstractNFSv4Operation {
 		 * As there was no open, we have to check  permissions.
 		 */
 		if (context.getFs().access(inode, nfs4_prot.ACCESS4_MODIFY | nfs4_prot.ACCESS4_EXTEND ) == 0) {
-		    throw new ChimeraNFSException(nfsstat.NFSERR_ACCESS, "Permission denied.");
+		    throw new AccessException();
 		}
 
 		/*

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.nfsstat;
+import org.dcache.nfs.status.BadStateidException;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
 import org.dcache.nfs.v4.CompoundContext;
 import org.dcache.nfs.v4.xdr.READ4res;
@@ -41,8 +42,7 @@ public class EDSOperationREAD extends AbstractNFSv4Operation {
 
             NfsMover mover = _activeIO.get(_args.opread.stateid);
             if(mover == null) {
-                throw new ChimeraNFSException(nfsstat.NFSERR_BAD_STATEID,
-                        "No mover associated with given stateid");
+                throw new BadStateidException("No mover associated with given stateid");
             }
             mover.attachSession(context.getSession());
 

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationWRITE.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationWRITE.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.nfsstat;
+import org.dcache.nfs.status.BadStateidException;
+import org.dcache.nfs.status.PermException;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
 import org.dcache.nfs.v4.CompoundContext;
 import org.dcache.nfs.v4.xdr.WRITE4res;
@@ -45,13 +47,12 @@ public class EDSOperationWRITE extends AbstractNFSv4Operation {
 
             NfsMover mover = _activeIO.get( _args.opwrite.stateid);
             if (mover == null) {
-                throw new ChimeraNFSException(nfsstat.NFSERR_BAD_STATEID,
-                        "No mover associated with given stateid");
+                throw new BadStateidException("No mover associated with given stateid");
             }
 
             mover.attachSession(context.getSession());
             if( mover.getIoMode() != IoMode.WRITE ) {
-                throw new ChimeraNFSException(nfsstat.NFSERR_PERM, "an attempt to write without IO mode enabled");
+                throw new PermException("an attempt to write without IO mode enabled");
             }
 
             long offset = _args.opwrite.offset.value;

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
@@ -203,10 +203,10 @@ public class NFSv4MoverHandler {
             oncRpcSvcBuilder.withGssSessionManager(gss);
         }
 
-	_rpcService = oncRpcSvcBuilder.build();
-	final Map<OncRpcProgram, RpcDispatchable> programs = new HashMap<>();
-	programs.put(new OncRpcProgram(nfs4_prot.NFS4_PROGRAM, nfs4_prot.NFS_V4), _embededDS);
-	_rpcService.setPrograms(programs);
+        final Map<OncRpcProgram, RpcDispatchable> programs = new HashMap<>();
+        programs.put(new OncRpcProgram(nfs4_prot.NFS4_PROGRAM, nfs4_prot.NFS_V4), _embededDS);
+        _rpcService = oncRpcSvcBuilder.build();
+        _rpcService.setPrograms(programs);
         _rpcService.start();
     }
 

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -107,7 +107,7 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
      * the {@link CompletionHandler#failed(Throwable, A)} method will be called.
      * @param error error to report, or {@code null} on success
      */
-    private void disable(Throwable error) {
+    void disable(Throwable error) {
         _nfsIO.remove(NfsMover.this);
         detachSession();
         try {
@@ -154,7 +154,11 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
 
         @Override
         protected void dispose() {
-            disable(new InterruptedException("Killing mover due to client inactivity"));
+            detachSession();
         }
+    }
+
+    public synchronized boolean hasSession() {
+        return (_session != null);
     }
 }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMoverValidationCallback.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMoverValidationCallback.java
@@ -1,0 +1,55 @@
+package org.dcache.chimera.nfsv41.mover;
+
+import diskCacheV111.util.CacheException;
+import dmg.cells.nucleus.CellPath;
+import java.lang.ref.WeakReference;
+import org.dcache.cells.AbstractMessageCallback;
+import org.dcache.chimera.nfs.v4.xdr.stateid4;
+import org.dcache.vehicles.DoorValidateMoverMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@code DoorValidateMoverMessage} callback handler for NFS transfer service.
+ */
+public class NfsMoverValidationCallback extends AbstractMessageCallback<DoorValidateMoverMessage<org.dcache.chimera.nfs.v4.xdr.stateid4>> {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(NfsMoverValidationCallback.class);
+    /**
+     * A weak reference to the mover. If mover will be killed by some
+     * other path (admin command or from the door), then we can simply
+     * forget about it.
+     */
+    private final WeakReference<NfsMover> moverRef;
+
+    public NfsMoverValidationCallback(NfsMover mover) {
+        moverRef = new WeakReference<>(mover);
+    }
+
+    @Override
+    public void success(DoorValidateMoverMessage<stateid4> message) {
+        if (!message.isIsValid()) {
+            kill();
+        }
+    }
+
+    @Override
+    public void failure(int rc, Object error) {
+        // effective NOP, as we can't safely decide to kill the mover
+        LOGGER.info("Failed to send validation requests: {} ({})", error, rc);
+    }
+
+    @Override
+    public void noroute(CellPath path) {
+        // door is dead. All states (movers) are invalid.
+        kill();
+    }
+
+    private void kill() {
+        NfsMover mover = moverRef.get();
+        if (mover != null) {
+            LOGGER.info("Killing abandoned mover: {}", mover);
+            mover.disable(new CacheException(CacheException.THIRD_PARTY_TRANSFER_FAILED, "Abandoned mover"));
+        }
+    }
+}

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -22,7 +22,6 @@ import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellPath;
 import dmg.cells.nucleus.NoRouteToCellException;
 import java.net.Inet4Address;
-import java.util.Arrays;
 
 import org.dcache.cells.CellStub;
 import org.dcache.commons.stats.RequestExecutionTimeGauges;
@@ -70,7 +69,8 @@ public class NfsTransferService extends AbstractCellComponent
             portRange = new PortRange(0);
         }
 
-        _nfsIO = new NFSv4MoverHandler(portRange, _withGss, getCellName());
+        _door = new CellStub(getCellEndpoint());
+        _nfsIO = new NFSv4MoverHandler(portRange, _withGss, getCellName(), _door, _bootVerifier);
         _localSocketAddresses = localSocketAddresses(NetworkUtils.getLocalAddresses(), _nfsIO.getLocalAddress().getPort());
 
         /*
@@ -84,8 +84,6 @@ public class NfsTransferService extends AbstractCellComponent
             }
         }
         _sortMultipathList = ipv4Count > 1;
-
-        _door = new CellStub(getCellEndpoint());
     }
 
     @Required

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -193,7 +193,7 @@ public class NfsTransferService extends AbstractCellComponent
     public String ac_nfs_sessions(Args args) {
 
        StringBuilder sb = new StringBuilder();
-        for (NFS4Client client : _nfsIO.getNFSServer().getClients()) {
+        for (NFS4Client client : _nfsIO.getNFSServer().getStateHandler().getClients()) {
             sb.append(client).append('\n');
             for (NFSv41Session session : client.sessions()) {
                 sb.append("  ")

--- a/modules/dcache/src/main/java/org/dcache/vehicles/DoorValidateMoverMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/vehicles/DoorValidateMoverMessage.java
@@ -1,0 +1,89 @@
+package org.dcache.vehicles;
+
+import diskCacheV111.util.PnfsId;
+import diskCacheV111.vehicles.Message;
+import java.io.Serializable;
+
+/**
+ *
+ * A from a pool to the door to validate validate a mover. The pool provides
+ * <tt>moverId</tt>, <tt>pnfsId</tt> and <tt>challenge</tt> to identify itself a door.
+ *
+ * NOTICE: the message provide a vehicle for moverId, but current mover implementation
+ * does not provides such information.
+ *
+ * @param <T> the type of challenge used by this message
+ * @since 2.12
+ */
+public class DoorValidateMoverMessage<T extends Serializable>  extends Message {
+
+    private static final long serialVersionUID = -2105249651572604794L;
+
+    private final T _challenge;
+    private final int _moverId;
+    private final long _verifier;
+    private final PnfsId _pnfsId;
+
+    private boolean _isValid;
+
+    /**
+     * Construct a new <tt>DoorValidateMoverMessage</tt> for a given mover.
+     * The <tt>verifier</tt> field the to allow client to detect pool restarts.
+     *
+     * @param moverId pool specific identifier of the mover or -1 if unknown
+     * @param pnfsId the pnfsid of the file which mover serves
+     * @param verifier pool restart verifier
+     * @param challenge an opaque, protocol specific data which identifies the transfer
+     */
+    public DoorValidateMoverMessage(int moverId, PnfsId pnfsId, long verifier, T challenge) {
+        _moverId = moverId;
+        _verifier = verifier;
+        _challenge = challenge;
+        _pnfsId = pnfsId;
+    }
+
+    /**
+     * Returns true if mover is valid.
+     * @return true if mover is valid.
+     */
+    public boolean isIsValid() {
+        return _isValid;
+    }
+
+    /**
+     * Get <tt>challenge</tt> provided by mover to validate.
+     * @return challenge to validate.
+     */
+    public T getChallenge() {
+        return _challenge;
+    }
+
+    /**
+     * Get moverid which have triggered the validation.
+     * @return moverid
+     */
+    public int getMoverId() {
+        return _moverId;
+    }
+
+    /**
+     * Get verifier to detect pool restarts. Typically pool's startup time.
+     * @return pool restart verifier.
+     */
+    public long getVerifier() {
+        return _verifier;
+    }
+
+    /**
+     * Return <tt>PnfsId</tt> of a file associated with the mover.
+     * @return pnfsid of the file
+     */
+    public PnfsId getPnfsId() {
+        return _pnfsId;
+    }
+
+    public void setIsValid(boolean isValid) {
+        _isValid = isValid;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -802,7 +802,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.8.6</version>
+            <version>0.9.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
This pool request contains two major changes:

 - update on nfs library to one which used in 2.11
 - update mover validation logic