### PR TITLE
Exclude cwd from classpath

### DIFF
--- a/skel/share/lib/services.sh
+++ b/skel/share/lib/services.sh
@@ -157,11 +157,11 @@ printLimitedClassPath() # $1..$n = list of jar files
 
     classes_path="$(getProperty dcache.paths.classes)"
     for name in "$@"; do
-	jar="$(echo $classes_path/$name-*.jar)"
-	classpath="${classpath}:${jar}"
+        jar="$(echo $classes_path/$name-*.jar)"
+        classpath="${classpath}:${jar}"
     done
 
-    echo $classpath
+    echo ${classpath#:}
 }
 
 # Prints the classpath to include plugins for a given domain
@@ -191,7 +191,7 @@ printPluginClassPath() # $1 = domain
         fi
     done
 
-    echo $classpath
+    echo ${classpath%:}
 }
 
 


### PR DESCRIPTION
The way the limited classpath was generated, the empty string could
be included in the classpath. The effect of this was that the current
working directory would become part of the classpath, which in turn
would cause several of our command line tools to pick up logback.xml
from the cwd if present.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7829/
(cherry picked from commit 709432c9cf8e5e4f10bb9c90304e911fa2563e72)

Conflicts:
	skel/share/lib/loadConfig.sh