### PR TITLE
spacemanager: Log unexpected exceptions

### DIFF
--- a/modules/cells/src/main/java/dmg/util/command/DelayedCommand.java
+++ b/modules/cells/src/main/java/dmg/util/command/DelayedCommand.java
@@ -1,11 +1,18 @@
 package dmg.util.command;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 
 import dmg.cells.nucleus.DelayedReply;
 import dmg.cells.nucleus.Reply;
+import dmg.util.CommandPanicException;
+
+import org.dcache.util.ReflectionUtils;
 
 /**
  * Abstract base class for annotated commands for executing the command
@@ -25,6 +32,7 @@ public abstract class DelayedCommand<T extends Serializable>
             new Thread(command).start();
         }
     };
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelayedCommand.class);
 
     private final Executor executor;
 
@@ -54,6 +62,15 @@ public abstract class DelayedCommand<T extends Serializable>
         try {
             result = execute();
         } catch (Exception e) {
+            try {
+                Method method = ReflectionUtils.getAnyMethod(getClass(), "execute");
+                if (!ReflectionUtils.hasDeclaredException(method, e)) {
+                    LOGGER.error("Command failed due to a bug, please contact support@dcache.org.", e);
+                    e = new CommandPanicException("Command failed: " + e.toString(),  e);
+                }
+            } catch (NoSuchMethodException suppressed) {
+                e.addSuppressed(suppressed);
+            }
             result = e;
         }
         reply(result);

--- a/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
+++ b/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
@@ -36,6 +36,7 @@ import dmg.util.command.Option;
 import dmg.util.command.PlainHelpPrinter;
 
 import org.dcache.util.Args;
+import org.dcache.util.ReflectionUtils;
 
 import static com.google.common.collect.Iterables.*;
 import static java.util.Arrays.asList;
@@ -135,15 +136,8 @@ public class AnnotatedCommandExecutor implements CommandExecutor
                  * those declared to be thrown by the method as
                  * bugs and propagate them.
                  */
-                boolean declared = false;
                 Method method = command.getClass().getMethod("call");
-                for (Class<?> clazz: method.getExceptionTypes()) {
-                    if (clazz.isAssignableFrom(e.getClass())) {
-                        declared = true;
-                    }
-                }
-
-                if (!declared) {
+                if (!ReflectionUtils.hasDeclaredException(method, e)) {
                     throw new CommandPanicException("Command failed: " + e.toString(),  e);
                 }
                 throw new CommandThrowableException(


### PR DESCRIPTION
Undeclared exceptions thrown by shell commands are usually logged as bugs
and rethrown as CommandPanicExceptions, however that doesn't apply to
DelayedCommands. This patch resolve the problem.

DelayedCommands are mostly used by space manager.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.11
Request: 2.10
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/7844/
(cherry picked from commit f47beea74650075c8778fa09148979a95d534061)

Conflicts:
	modules/cells/src/main/java/dmg/util/command/DelayedCommand.java