### PR TITLE
Maintain CDC of threads in decorated thread pool

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/CDCExecutorServiceDecorator.java
+++ b/modules/dcache/src/main/java/org/dcache/util/CDCExecutorServiceDecorator.java
@@ -102,8 +102,6 @@ public class CDCExecutorServiceDecorator<E extends ExecutorService> extends Forw
             {
                 try (CDC ignored = cdc.restore()) {
                     task.run();
-                } finally {
-                    CDC.clear();
                 }
             }
         };


### PR DESCRIPTION
CDCExecutorServiceDecorator injects the CDC of the calling thread into the
thread executing the task. Upon completion the CDC is however cleared rather
than just reset. The consequence is that if the wrapped executor is used
outside the decorator, then the threads loose their cell association.

This patch resolves this problem.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.11
Request: 2.10
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/7845/
(cherry picked from commit ee39ee15f6fd1f98ead764ac4ca96c705e85f496)