### PR TITLE
spacemanager: Fix NPE in listing space reservations

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerCommandLineInterface.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerCommandLineInterface.java
@@ -497,7 +497,9 @@ public class SpaceManagerCommandLineInterface implements CellCommandListener
 
     private String toOwner(String voGroup, String voRole)
     {
-        if (voGroup.charAt(0) != '/' || voRole == null || voRole.equals("*")) {
+        if (voGroup == null) {
+            return null;
+        } else if (voGroup.charAt(0) != '/' || voRole == null || voRole.equals("*")) {
             return voGroup;
         } else {
             return voGroup + "/Role=" + voRole;
@@ -652,8 +654,8 @@ public class SpaceManagerCommandLineInterface implements CellCommandListener
     }
 
     @Command(name = "reserve space", hint = "create space reservation",
-             description = "A space reservation has a size, an access latency, a retention policy, " +
-                     "and an owner. It may have a description, and a lifetime. If the lifetime " +
+             description = "A space reservation has a size, an access latency, and a retention policy. " +
+                     "It may have a description, a lifetime, and an owner. If the lifetime " +
                      "is exceeded, the reservation expires and the files in it are released. " +
                      "The owner is only used to authorize creation of the reservation in the " +
                      "link group, and to authorize the release of the reservation - it is " +


### PR DESCRIPTION
Reservations without an owner would trigger an NPE.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Acked-by: Karsten Schwank <karsten.schwank@desy.de>
Patch: https://rb.dcache.org/r/7846/
(cherry picked from commit c275812ccbb62e7b400b48ea1685102f7b54bd08)