### PR TITLE
Fix valueSpec help parser

### DIFF
--- a/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
+++ b/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
@@ -20,7 +20,6 @@ package dmg.util.command;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
-import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Multimap;
 
@@ -84,7 +83,7 @@ public abstract class TextHelpPrinter implements AnnotatedCommandHelpPrinter
     protected String valuespec(String valuespec)
     {
         StringBuilder out = new StringBuilder();
-        for (String s : Splitter.on(VALUESPEC_SEPARATOR).split(valuespec)) {
+        for (String s : VALUESPEC_SEPARATOR.split(valuespec, 0)) {
             switch (s) {
             case "[":
             case "]":


### PR DESCRIPTION
Turns out that Guava's splitter doesn't work with patterns that split between
characters. Causes problems with for instance 'UID:[GID]'.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
(cherry picked from commit ea9bffa7d63865381f16df16392e595356ef5b7e)