### PR TITLE
spacemanager: Change release authorization for unowned reservations

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SimpleSpaceManagerAuthorizationPolicy.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SimpleSpaceManagerAuthorizationPolicy.java
@@ -11,10 +11,6 @@ import org.dcache.auth.FQAN;
 import org.dcache.auth.FQANPrincipal;
 import org.dcache.auth.Subjects;
 
-/**
- *
- * @author timur
- */
 public class SimpleSpaceManagerAuthorizationPolicy
         implements SpaceManagerAuthorizationPolicy {
 	private static Logger logger =
@@ -26,23 +22,19 @@ public class SimpleSpaceManagerAuthorizationPolicy
         String spaceGroup = space.getVoGroup();
         String spaceRole  = space.getVoRole();
 
-        if (spaceGroup == null && spaceRole != null) {
-            logger.debug("Space {} has no owner and can be released by anybody", space);
-            return;
-        }
-        if (spaceGroup != null && spaceGroup.equals(Subjects.getUserName(subject)) && spaceRole == null) {
-            logger.debug("Subject with user name {} has permission to release space {}",
-                    Subjects.getUserName(subject), space);
-            return;
-        }
-
-        for (FQANPrincipal principal : subject.getPrincipals(FQANPrincipal.class)) {
-            FQAN fqan = principal.getFqan();
-            if ((spaceGroup == null || spaceGroup.equals(fqan.getGroup())) &&
-                    (spaceRole == null || spaceRole.equals(fqan.getRole()))) {
-                logger.debug("Subject with fqan {} has permission to release space {}",
-                        fqan, space);
+        if (spaceGroup != null) {
+            if (spaceRole == null && spaceGroup.equals(Subjects.getUserName(subject))) {
+                logger.debug("Subject with user name {} has permission to release space {}",
+                             Subjects.getUserName(subject), space);
                 return;
+            }
+            for (FQANPrincipal principal : subject.getPrincipals(FQANPrincipal.class)) {
+                FQAN fqan = principal.getFqan();
+                if (spaceGroup.equals(fqan.getGroup()) && (spaceRole == null || spaceRole.equals(fqan.getRole()))) {
+                    logger.debug("Subject with fqan {} has permission to release space {}",
+                                 fqan, space);
+                    return;
+                }
             }
         }
 

--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerCommandLineInterface.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerCommandLineInterface.java
@@ -655,9 +655,9 @@ public class SpaceManagerCommandLineInterface implements CellCommandListener
              description = "A space reservation has a size, an access latency, a retention policy, " +
                      "and an owner. It may have a description, and a lifetime. If the lifetime " +
                      "is exceeded, the reservation expires and the files in it are released. " +
-                     "The owner is only used to authorize creation of the reservation in the " +
-                     "link group, and to authorize the release of the reservation - it is " +
-                     "not used to authorize uploads to the reservation.\n\n" +
+                     "The owner is only used to authorize the release of the reservation - it is " +
+                     "not used to authorize uploads to the reservation. Reservations without an owner " +
+                     "can only be administratively released.\n\n" +
 
                      "Space reservations are created in link groups. The link group authorizes " +
                      "reservations. The owner of the reservation as well as its file type " +


### PR DESCRIPTION
Reservations without an owner currently are releasable by everybody.
It is unlikely that anybody would ever want a reservation that anybody
can release. Given that not having an owner is the default in the
reserve space command, out current interpretation is a bit dangerous.

This patch changes it such that unowner reservations are not releasable
by anybody - i.e. only the admin can release them (or they can expire).

Target: trunk
Require-notes: yes
Require-book: yes
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7847/
(cherry picked from commit 9ca71b56bbd41dd3864b467d209d0fa7a4b42c26)