### PR TITLE
pnfsmanager: Fix upload to space token that conflicts with AL and RP tags

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -1181,14 +1181,20 @@ public class ChimeraNameSpaceProvider
              * the upload directory.
              */
             Map<String, byte[]> tags = Maps.newHashMap(parentOfPath.getTags());
+            if (spaceToken != null) {
+                tags.put(TAG_WRITE_TOKEN, spaceToken.getBytes(Charsets.UTF_8));
+
+                /* If client provides space token to upload to, the access latency and
+                 * retention policy tags of the upload directory must be disregarded.
+                 */
+                tags.remove(TAG_ACCESS_LATENCY);
+                tags.remove(TAG_RETENTION_POLICY);
+            }
             if (al != null) {
                 tags.put(TAG_ACCESS_LATENCY, al.toString().getBytes(Charsets.UTF_8));
             }
             if (rp != null) {
                 tags.put(TAG_RETENTION_POLICY, rp.toString().getBytes(Charsets.UTF_8));
-            }
-            if (spaceToken != null) {
-                tags.put(TAG_WRITE_TOKEN, spaceToken.getBytes(Charsets.UTF_8));
             }
             if (size != null) {
                 tags.put(TAG_EXPECTED_SIZE, size.toString().getBytes(Charsets.UTF_8));


### PR DESCRIPTION
According to the SRM spec, when an SRM client uploads to a space token, any
access latency (AL) and retention policy (RP) it specifies must match the
token. If no AL or RP is specified, the AL and RP of the token is used as is.

In dCache we have tags to specify the default AL and RP for a directory. These
two features currently clash such that when a client uploads to a space token,
but doesn't specify AL and RP, the AL and RP from the tags are picked up. If
these do not match the space token, the upload will fail. This is clearly
not desirable.

This patch resolves the problem: When creating the temporary upload directory,
the AL and RP tags from the target directory are only copied if the client did
not specify a space token. The existing AL and RP extractor code already has a
check that if a WriteToken tag is specified, the extractor will *not* fall back
to the system wide defaults. Thus when a WriteToken tag is present and no AL
and RP tags are present, then AL and RP are left as null and space manager will
inject the proper values from the reservation.

If the client specifies neither space token, AL or RP, the directory tags will
be used. If a directory specifies both WriteToken and
AccessLatency/RetentionPolicy tags, then these have to be consistent. If the
directory conains a WriteToken tag and the client specifies AL/RP, then the
client specified values have to be consistent with the WriteToken tag.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.11
Request: 2.10
Request: 2.9
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7867/
(cherry picked from commit b30bd03712f0bcaf3922582552ead3dc216ede5a)