### PR TITLE
pool: Fix bug in migration module upgrade logic

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
@@ -310,12 +310,12 @@ public class MigrationModuleServer
                                               record.expire(),
                                               false);
                     }
+                    finished(null);
                     break;
                 default:
                     finished(new CacheException("Cannot update file in state " + state));
-
+                    break;
                 }
-                finished(null);
             } catch (IOException e) {
                 finished(new DiskErrorCacheException("I/O error during checksum calculation: " + e.getMessage()));
             } catch (InterruptedException e) {


### PR DESCRIPTION
When attempting to upgrade non-precious and non-cached files (e.g. a file
marked broken), the receiving end of the migration module would answer to the
request twice: First with a failure and then with a success. Message ordering
will usually make sure that the failure reply is the one being used, but if for
some reason the second reply gets used, the effect would be that the migration
is considered successful when in fact it failed.

Target: trunk
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7858/
(cherry picked from commit 6f888e9f7f9217846d0ac28cb2ff0923276827c0)