### PR TITLE
nfs-proxy: modify ProxyIOAdapter interface

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIoFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIoFactory.java
@@ -104,7 +104,7 @@ public class NfsProxyIoFactory implements ProxyIoFactory {
         deviceid4 dsId = fileLayoutSegment.nfl_deviceid;
         device_addr4 deviceAddr = deviceManager.getDeviceInfo(context, dsId);
         nfsv4_1_file_layout_ds_addr4 nfs4DeviceAddr = GetDeviceListStub.decodeFileDevice(deviceAddr.da_addr_body);
-        // we assume that only device points only to one server
+        // we assume that device points only to one server
         for(netaddr4 na: nfs4DeviceAddr.nflda_multipath_ds_list[0].value) {
             if (na.na_r_netid.equals("tcp") || na.na_r_netid.equals("tcp6") ) {
                 InetSocketAddress poolAddress = InetSocketAddresses.forUaddrString(na.na_r_addr);

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoAdapter.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoAdapter.java
@@ -3,6 +3,7 @@ package org.dcache.chimera.nfsv41.door.proxy;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import org.dcache.nfs.vfs.VirtualFileSystem;
 
 /**
  *
@@ -16,11 +17,10 @@ public interface ProxyIoAdapter extends Closeable {
      * @param dst The buffer into which bytes are to be transferred
      * @param position The file position at which the transfer is to begin; must
      * be non-negative
-     * @return The number of bytes read, possibly zero, or -1 if the given
-     * position is greater than or equal to the file's current size
+     * @return {@link ReadResult}
      * @throws IOException
      */
-    int read(ByteBuffer dst, long position) throws IOException;
+    ReadResult read(ByteBuffer dst, long position) throws IOException;
 
     /**
      * Writes a sequence of bytes to this channel from the given buffer,
@@ -29,16 +29,38 @@ public interface ProxyIoAdapter extends Closeable {
      * @param src The buffer from which bytes are to be transferred
      * @param position The file position at which the transfer is to begin; must
      * be non-negative
-     * @return The number of bytes written, possibly zero
+     * @return {@link VirtualFileSystem.WriteResult}
      * @throws IOException
      */
-    int write(ByteBuffer src, long position) throws IOException;
-
-    /**
-     * Returns the size of the file access by this adapter.
-     * @return size of the files,  measured in bytes
-     */
-    long size();
+    VirtualFileSystem.WriteResult write(ByteBuffer src, long position) throws IOException;
 
     int getSessionId();
+
+    // FIXME: move into generic NFS code
+    public static class ReadResult {
+
+        private final int bytesRead;
+        private final boolean isEof;
+
+        public ReadResult(int bytesRead, boolean isEof) {
+            this.bytesRead = bytesRead;
+            this.isEof = isEof;
+        }
+
+        /**
+         * Get number of bytes read.
+         * @return number of bytes
+         */
+        public int getBytesRead() {
+            return bytesRead;
+        }
+
+        /**
+         * Indicated is EOF reached
+         * @return true, iff EOF reached.
+         */
+        public boolean isEof() {
+            return isEof;
+        }
+    }
 }


### PR DESCRIPTION
read and write requests return ReadResult and WriteResult to
provide not only a number of transfered bytes but as well
corresponding medatada, like stable write flag or EOF marker.

removed getSize() method.

Target: master
Acked-by: Paul Millar
Require-notes: no
Require-book: no
(cherry picked from commit 7703d69a3a82204c55d7e6f02ef9cea16bd0ea08)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>