### PR TITLE
dcap: Fix typo that causes GSI and auth dcap to use the wrong port

### DIFF
--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -75,8 +75,8 @@ dcap.authz.staging=${dcache.authz.staging}
 # TCP port to listen to
 dcap.net.port=${dcap.net.port.${dcap.authn.protocol}}
 dcap.net.port.plain=22125
-dcap.net.port.auth=22128
-dcap.net.port.gsi=22129
+dcap.net.port.gsi=22128
+dcap.net.port.auth=22129
 dcap.net.port.kerberos=22725
 (forbidden)dCapPort = Use dcap.net.port
 (forbidden)dCapGsiPort = Use dcap.net.port


### PR DESCRIPTION
Target: trunk
Request: 2.11
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7707/
(cherry picked from commit 893381a7d3a431c17c4c65da8be65a9e882a6a6a)