### PR TITLE
javatunnel: fix array size to decode

### DIFF
--- a/modules/javatunnel/src/main/java/javatunnel/TunnelConverter.java
+++ b/modules/javatunnel/src/main/java/javatunnel/TunnelConverter.java
@@ -57,7 +57,7 @@ class TunnelConverter implements Convertable,UserBindible  {
             throw new IOException("short read: " + total + new String(buf, 0, total));
         }
 
-        return Base64.getDecoder().decode(Arrays.copyOfRange(buf, 4, total - 5));
+        return  Base64.getDecoder().decode(Arrays.copyOfRange(buf, 4, total - 1));
     }
 
     @Override


### PR DESCRIPTION
the arguments to copyOfRange is from-to and not from-len

Acked-by: Gerd Behrmann
Fixes: 99907188034f02dfa598c719b25e767e9dbcfb59
Target: master, 2.12
Require-book: no
Require-notes: no
(cherry picked from commit 6a7006c03cf5474e4b4ae346832719f737d73e7f)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>