### PR TITLE
ssh2: close file stream when reading authorized_keys file

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -31,6 +31,7 @@ import diskCacheV111.util.PermissionDeniedCacheException;
 import org.dcache.auth.*;
 
 import static java.util.stream.Collectors.toList;
+import java.util.stream.Stream;
 import static org.dcache.util.Files.checkFile;
 
 /**
@@ -249,9 +250,12 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
                     userName, key);
             try {
                 AuthorizedKeyParser decoder = new AuthorizedKeyParser();
-                List<String> keyLines = java.nio.file.Files.lines(_authorizedKeyList.toPath())
+                List<String> keyLines;
+                try(Stream<String> fileStream = java.nio.file.Files.lines(_authorizedKeyList.toPath())) {
+                    keyLines = fileStream
                         .filter(l -> !l.isEmpty() && !l.matches(" *#.*"))
                         .collect(toList());
+                }
 
                 for (String keyLine : keyLines) {
                     PublicKey decodedKey = decoder.decodePublicKey(keyLine);


### PR DESCRIPTION
a file backended streams must be closed to avoid file descriptor leak.

acked-by: Albert Rossi
Ticket:  #8632
Target: master, 2.12
Require-notes: no
Require-book: no
(cherry picked from commit 60dd0947135d5faabc2139f84b49b53aab1ed6e4)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>