### PR TITLE
pool: Update xrootd properties to reflect changes to Netty 4

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -347,7 +347,7 @@
       <property name="postTransferService" ref="post-transfer-service"/>
       <property name="checksumModule" ref="csm"/>
       <property name="faultListener" ref="pool"/>
-      <property name="threads" value="${pool.mover.xrootd.disk-threads}"/>
+      <property name="threads" value="${pool.mover.xrootd.threads}"/>
       <property name="clientIdleTimeout" value="${pool.mover.xrootd.timeout.idle}"/>
       <property name="clientIdleTimeoutUnit" value="${pool.mover.xrootd.timeout.idle.unit}"/>
       <property name="connectTimeout" value="${pool.mover.xrootd.timeout.connect}"/>

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -193,28 +193,8 @@ pool.mover.ftp.read-ahead = 16777216
 
 #  ---- Thread pool size for xrootd disk IO threads
 (forbidden)xrootdMoverDiskThreads = Use pool.mover.xrootd.disk-threads
-pool.mover.xrootd.disk-threads = 20
-
-#  ---- Thread pool size for xrootd socket IO threads.
-#
-#   If unset the number of CPU cores in the host is used as a default.
-#
-(forbidden)xrootdMoverSocketThreads = Use pool.mover.xrootd.socket-threads
-pool.mover.xrootd.socket-threads =
-
-#  ---- Amount of memory to use for buffering per xrootd connection
-#
-#   Specified in bytes.
-#
-(forbidden)xrootdMoverMaxMemoryPerConnection = Use pool.mover.xrootd.memory-per-connection
-pool.mover.xrootd.memory-per-connection = 16777216
-
-#  ---- Total amount of memory to use for buffering for xrootd connections
-#
-#   Specified in bytes.
-#
-(forbidden)xrootdMoverMaxMemory = Use pool.mover.xrootd.memory
-pool.mover.xrootd.memory = 67108864
+(deprecated)pool.mover.xrootd.disk-threads = 20
+pool.mover.xrootd.threads = ${pool.mover.xrootd.disk-threads}
 
 #  ---- Maximum size of an xrootd frame
 #
@@ -380,12 +360,16 @@ pool.destination.replicate.ip=
 #
 (immutable)pool.net.ports.tcp=${dcache.net.wan.port.min}-${dcache.net.wan.port.max} ${dcache.net.lan.port.min}-${dcache.net.lan.port.max}
 
-
-
+# Obsolete properties
 (forbidden)httpMoverSocketThreads = See pool.mover.http.threads
 (forbidden)pool.mover.http.socket-threads = See pool.mover.http.threads
-(obsolete)httpMoverConnectionMaxMemory = No longer used
+(forbidden)httpMoverConnectionMaxMemory = No longer used
 (obsolete)pool.mover.http.memory-per-connection = No longer used
-(obsolete)httpMoverMaxMemory = No longer used
+(forbidden)httpMoverMaxMemory = No longer used
 (obsolete)pool.mover.http.memory = No longer used
-
+(forbidden)xrootdMoverSocketThreads = See pool.mover.xrootd.threads
+(forbidden)pool.mover.xrootd.socket-threads = See pool.mover.xrootd.threads
+(forbidden)xrootdMoverMaxMemoryPerConnection = No longer used
+(obsolete)pool.mover.xrootd.memory-per-connection = No longer used
+(forbidden)xrootdMoverMaxMemory = No longer used
+(obsolete)pool.mover.xrootd.memory = No longer used

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -195,3 +195,10 @@ xrootd.mover.timeout = 180000
 #   Document which TCP ports are opened
 #
 (immutable)xrootd.net.ports.tcp = ${xrootd.net.port}
+
+# Obsolete properties
+(forbidden)xrootdMaxTotalMemorySize = No longer used
+(obsolete)xrootd.max-total-memory-size = No longer used
+(forbidden)xrootdMaxChannelMemorySize = No longer used
+(obsolete)xrootd.max-channel-memory-size = No longer used
+

--- a/skel/share/services/pool.batch
+++ b/skel/share/services/pool.batch
@@ -21,9 +21,7 @@ check -strong pool.plugins.sweeper
 check -strong pool.mover.ftp.allow-incoming-connections
 check -strong pool.mover.ftp.mmap
 check -strong pool.mover.ftp.read-ahead
-check -strong pool.mover.xrootd.disk-threads
-check -strong pool.mover.xrootd.memory-per-connection
-check -strong pool.mover.xrootd.memory
+check -strong pool.mover.xrootd.threads
 check -strong pool.mover.xrootd.timeout.idle
 check -strong pool.mover.xrootd.timeout.idle.unit
 check -strong pool.mover.xrootd.timeout.connect


### PR DESCRIPTION
When reviewing the changes in 2.12, I noticed that we forgot to apply the
property changes related to Netty 4 to the xrootd mover. I also noticed that in
the xrootd door properties were lost rather than marked obsolete.

This patch resolves those issues.

Target: trunk
Require-notes: yes
Require-book: yes
Request: 2.12
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7912/
(cherry picked from commit f2ad4d64baa7d7fd7597c4c5eadd63a75b5eeafb)