### PR TITLE
2.10: Upgrade HikariCP to 2.0.1

### DIFF
--- a/modules/acl/pom.xml
+++ b/modules/acl/pom.xml
@@ -24,7 +24,7 @@
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
+      <artifactId>HikariCP-java6</artifactId>
     </dependency>
     <dependency>
       <groupId>org.dcache</groupId>

--- a/modules/dcache-chimera/pom.xml
+++ b/modules/dcache-chimera/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
+      <artifactId>HikariCP-java6</artifactId>
     </dependency>
     <dependency>
         <groupId>org.postgresql</groupId>

--- a/modules/dcache/pom.xml
+++ b/modules/dcache/pom.xml
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
+      <artifactId>HikariCP-java6</artifactId>
     </dependency>
     <dependency>
         <groupId>org.postgresql</groupId>

--- a/modules/srm-server/pom.xml
+++ b/modules/srm-server/pom.xml
@@ -104,7 +104,7 @@
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
+      <artifactId>HikariCP-java6</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -300,8 +300,8 @@
             </dependency>
             <dependency>
                 <groupId>com.zaxxer</groupId>
-                <artifactId>HikariCP</artifactId>
-                <version>1.3.9</version>
+                <artifactId>HikariCP-java6</artifactId>
+                <version>2.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>

--- a/skel/bin/chimera
+++ b/skel/bin/chimera
@@ -6,7 +6,7 @@ lib="$(getProperty dcache.paths.share.lib)"
 . ${lib}/utils.sh
 . ${lib}/services.sh
 
-classpath=$(printLimitedClassPath chimera HikariCP javassist \
+classpath=$(printLimitedClassPath chimera HikariCP-java6 javassist \
     guava jline common-cli dcache-common acl dcache-chimera \
     slf4j-api logback-classic logback-core logback-console-config \
     $(getProperty chimera.db.jar))


### PR DESCRIPTION
IN2P3 reported the following failure:

04 Mar 2015 20:42:12 (SrmSpaceManager) [door:gridftp-ccdcatli013-81197@gridftp-ccdcatli013Domain:1425495819459 gridftp-ccdcatli013-81197 PoolAcceptFile 000078810A3673A644A286B0EFC8D4C69356] Internal accounting inconsistency, totalConnections=-1
java.lang.Exception: null
	at com.zaxxer.hikari.pool.HikariPool.closeConnection(HikariPool.java:268) [HikariCP-1.3.9.jar:na]
	at com.zaxxer.hikari.pool.HikariPool.releaseConnection(HikariPool.java:210) [HikariCP-1.3.9.jar:na]
	at com.zaxxer.hikari.proxy.ConnectionProxy.close(ConnectionProxy.java:313) [HikariCP-1.3.9.jar:na]
	at org.springframework.jdbc.datasource.DataSourceUtils.doCloseConnection(DataSourceUtils.java:341) [spring-jdbc-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at org.springframework.jdbc.datasource.DataSourceUtils.doReleaseConnection(DataSourceUtils.java:328) [spring-jdbc-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at org.springframework.jdbc.datasource.DataSourceUtils.releaseConnection(DataSourceUtils.java:294) [spring-jdbc-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at org.springframework.jdbc.datasource.DataSourceTransactionManager.doCleanupAfterCompletion(DataSourceTransactionManager.java:326) [spring-jdbc-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.cleanupAfterCompletion(AbstractPlatformTransactionManager.java:1012) [spring-tx-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.processRollback(AbstractPlatformTransactionManager.java:879) [spring-tx-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.rollback(AbstractPlatformTransactionManager.java:826) [spring-tx-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.completeTransactionAfterThrowing(TransactionAspectSupport.java:496) [spring-tx-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:266) [spring-tx-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96c(AbstractTransactionAspect.aj:63) [spring-aspects-4.0.5.RELEASE.jar:4.0.5.RELEASE]
	at diskCacheV111.services.space.SpaceManagerService.processMessageTransactionally(SpaceManagerService.java:488) [dcache-core-2.10.18.jar:2.10.18]
	at diskCacheV111.services.space.SpaceManagerService.processMessage(SpaceManagerService.java:452) [dcache-core-2.10.18.jar:2.10.18]
	at diskCacheV111.services.space.SpaceManagerService.access$000(SpaceManagerService.java:107) [dcache-core-2.10.18.jar:2.10.18]
	at diskCacheV111.services.space.SpaceManagerService$2.run(SpaceManagerService.java:413) [dcache-core-2.10.18.jar:2.10.18]
	at org.dcache.util.CDCExecutorServiceDecorator$1.run(CDCExecutorServiceDecorator.java:104) [dcache-core-2.10.18.jar:2.10.18]
	at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:211) [dcache-core-2.10.18.jar:2.10.18]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_51]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_51]
	at java.lang.Thread.run(Thread.java:744) [na:1.7.0_51]

This looks like the following HikariCP bug: https://github.com/brettwooldridge/HikariCP/issues/128

This patch upgrades HikariCP to version 2.0.1, the same version we use in 2.11.

Target: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>