### PR TITLE
spacemanager: Lower default for number of threads

### DIFF
--- a/skel/share/defaults/spacemanager.properties
+++ b/skel/share/defaults/spacemanager.properties
@@ -93,9 +93,11 @@ spacemanager.service.poolmanager.timeout=300
 # ---- Number of concurrent threads used by space manager
 #
 # Each thread will likely obtain a connection to the database, meaning the thread limit
-# and the database connection limit should be in the same ballpark.
+# and the database connection limit should be in the same ballpark. It is best to keep
+# the connection limit a little higher than the number of threads, as there are a few
+# periodic background tasks consuming connections too.
 #
-spacemanager.limits.threads=30
+spacemanager.limits.threads=20
 
 # ---- Whether space manager is enabled
 #


### PR DESCRIPTION
IN2P3 reported the following failure:

04 Mar 2015 20:41:12 (SrmSpaceManager) [] Link group update failed: org.springframework.transaction.CannotCreateTransactionException: Could not open JDBC Connection for transaction; nested exception is java.sql.SQLException: Timeout of 30000ms encountered waiting for connection.
org.springframework.transaction.CannotCreateTransactionException: Could not open JDBC Connection for transaction; nested exception is java.sql.SQLException: Timeout of 30000ms encountered waiting for connection.

The previous default was to have as many threads as the database connection
limit.  This did not leave any room for background updates, so this patch
lowers the number of processing threads. I chose to lower the number of threads
rather than increase the number of connections, as space manager processing is
database bound, and 30 threads hammering the database is likely too much (with
Chimera we often use 12). Many threads increases the liklyhood of transaction
conflicts.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Requsst: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7928/
(cherry picked from commit 8c0cd4e1c96a3086cb08270246d7fde0a2e13e5a)