### PR TITLE
spacemanager: Don't log stack-trace on AL/RP/Reservation conflict

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -3236,7 +3236,10 @@ public abstract class AbstractFtpDoorV1
                 transfer.abort(452, "File is unavailable", e);
                 break;
             case CacheException.INVALID_ARGS:
-                transfer.abort(501, "Invalid request: " + e.getMessage(), e);
+                transfer.abort(500, "Invalid request: " + e.getMessage(), e);
+                break;
+            case CacheException.RESOURCE:
+                transfer.abort(452, "Insufficient resources: " + e.getMessage(), e);
                 break;
             default:
                 transfer.abort(451, "Operation failed: " + e.getMessage(), e);
@@ -3363,7 +3366,10 @@ public abstract class AbstractFtpDoorV1
                 transfer.abort(452, "No write pool available", e);
                 break;
             case CacheException.INVALID_ARGS:
-                transfer.abort(501, "Invalid request: " + e.getMessage(), e);
+                transfer.abort(500, "Invalid request: " + e.getMessage(), e);
+                break;
+            case CacheException.RESOURCE:
+                transfer.abort(452, "Insufficient resources: " + e.getMessage(), e);
                 break;
             default:
                 transfer.abort(451, "Operation failed: " + e.getMessage(), e);

--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -467,7 +467,7 @@ public final class SpaceManagerService
             } catch (NoFreeSpaceException e) {
                 message.setFailedConditionally(CacheException.RESOURCE, e);
             } catch (SpaceException e) {
-                message.setFailedConditionally(CacheException.DEFAULT_ERROR_CODE, e);
+                message.setFailedConditionally(CacheException.INVALID_ARGS, e);
             } catch (IllegalArgumentException e) {
                 LOGGER.error("Message processing failed: {}", e.getMessage(), e);
                 message.setFailedConditionally(CacheException.INVALID_ARGS, e.getMessage());
@@ -920,12 +920,12 @@ public final class SpaceManagerService
                 if (!fileAttributes.isDefined(FileAttribute.ACCESS_LATENCY)) {
                     fileAttributes.setAccessLatency(space.getAccessLatency());
                 } else if (fileAttributes.getAccessLatency() != space.getAccessLatency()) {
-                    throw new IllegalArgumentException("Access latency conflicts with access latency defined by space reservation.");
+                    throw new SpaceException("Access latency conflicts with access latency defined by space reservation.");
                 }
                 if (!fileAttributes.isDefined(FileAttribute.RETENTION_POLICY)) {
                     fileAttributes.setRetentionPolicy(space.getRetentionPolicy());
                 } else if (fileAttributes.getRetentionPolicy() != space.getRetentionPolicy()) {
-                    throw new IllegalArgumentException("Retention policy conflicts with retention policy defined by space reservation.");
+                    throw new SpaceException("Retention policy conflicts with retention policy defined by space reservation.");
                 }
 
                 if (space.getDescription() != null) {


### PR DESCRIPTION
Space manager rejects requests where AL/RP conflicts with the selected
reservation. These errors were internally thrown as IllegalArgumentException,
which are logged with a stack trace. Since this error condition is not a bug,
this patch changes the error to use a SpaceException.

SpaceException used to be propagated as a generic error with the default error
code, which doors usually report as transient errors. Yet all but one
SpaceException are permanent errors. Thus the patch changes these to be
propagated as INVALID_ARGS (indicating that the request parameters could not be
accepted).

FTP door propagates INVALID_ARGS as a syntax error, which is wrong as an
internal service rejecting message arguments does not imply that the FTP
command syntax was wrong (such errors should have been detected in the door).
Thus this patch changes the FTP error code for INVALID_ARGS from 501 to the
generic 500.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7930/
(cherry picked from commit dd4be9c16a04e37022cc4c249a657fe84c7ea495)