### PR TITLE
spacemanager: Minor simplification to link group updates

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/JdbcSpaceManagerDatabase.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/JdbcSpaceManagerDatabase.java
@@ -307,15 +307,11 @@ public class JdbcSpaceManagerDatabase extends JdbcDaoSupport implements SpaceMan
     {
         long id;
         try {
-            LinkGroup group =
-                    getJdbcTemplate().queryForObject(
-                            "SELECT * FROM " + LINKGROUP_TABLE + " WHERE  name = ? FOR UPDATE",
-                            linkGroupMapper,
-                            linkGroupName);
-            id = group.getId();
+            /* FOR UPDATE to avoid lock upgrade below */
+            id = getJdbcTemplate().queryForObject("SELECT id FROM " + LINKGROUP_TABLE + " WHERE name = ? FOR UPDATE", Long.class, linkGroupName);
             getJdbcTemplate().update(
                     "UPDATE " + LINKGROUP_TABLE + " SET availableSpaceInBytes=?-reservedSpaceInBytes,lastUpdateTime=?,onlineAllowed=?,nearlineAllowed=?,"
-                            + "replicaAllowed=?,outputAllowed=?,custodialAllowed=? WHERE  id = ?",
+                            + "replicaAllowed=?,outputAllowed=?,custodialAllowed=? WHERE id = ?",
                     freeSpace,
                     updateTime,
                     (onlineAllowed ? 1 : 0),


### PR DESCRIPTION
There is no reason to read the entire link group record when
all we need is the ID - in particular this change avoids reading
the authorzation records from the vo table.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7931/
(cherry picked from commit 4217f3f9636667d00607d5a95792d8125f3a1404)

Conflicts:
	modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/JdbcSpaceManagerDatabase.java

(cherry picked from commit f820942fa347d79f8a90b2e55fe7b92bb355173d)