### PR TITLE
LocationManager: Use fqdn instead of hostname

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
@@ -999,11 +999,11 @@ public class LocationManager extends CellAdapter {
          CellMessage   msg = getThisMessage() ;
          String portString = args.argv(1) ;
 
-         try{
-             _registered  = InetAddress.getLocalHost().getHostName()+":"+portString ;
-         }catch( UnknownHostException uhe ){
-             _log.warn("Couldn't resolve hostname : "+uhe);
-             return null ;
+         try {
+             _registered = InetAddress.getLocalHost().getCanonicalHostName() + ":" + portString;
+         } catch (UnknownHostException uhe) {
+             _log.warn("Couldn't resolve hostname: " + uhe);
+             return null;
          }
 
          String request = "listeningOn "+getCellDomainName()+" "+_registered ;
@@ -1236,7 +1236,7 @@ public class LocationManager extends CellAdapter {
               // we are a server and a client
               //
               port = Integer.parseInt( _args.argv(0) );
-              host = InetAddress.getByName("localhost") ;
+              host = InetAddress.getLoopbackAddress();
               _server = new Server( port , _args ) ;
               _log.info("Server Setup Done") ;
            }else{


### PR DESCRIPTION
LocationManager uses the hostname of the local host to determine
the listening endpoint. This may not always be enough.
This patch changes the behavior to use the canonical hostname.

Also, it replaces a getByName("localhost") by getLoopbackAddress()

Ticket: 8388
Acked-by:
Target: master
Request: 2.11
Request: 2.10
Require-book: no
Require-notes: yes