### PR TITLE
pool: Fix NPE in xrootd mover

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.2.8.v20150217</version.jetty>
         <version.wicket>6.19.0</version.wicket>
-        <version.xrootd4j>2.0.0</version.xrootd4j>
+        <version.xrootd4j>2.0.1</version.xrootd4j>
         <version.jglobus>2.0.6-rc8.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 


### PR DESCRIPTION
The symptom would be errors like these:

10 mar. 2015 11:41:17 (pool_read) [] Failed to mark a promise as failure because it's done already: DefaultChannelPromise@19ca4f35(failure(java.lang.NullPointerException)

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7957/
(cherry picked from commit e0dc3ae5b54ea69dc39cb96ceeaab03d8c64afb2)