### PR TITLE
pool, xrootd: Upgrade to Netty 4.0.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.0.25.Final</version>
+                <version>4.0.26.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.grizzly</groupId>


### PR DESCRIPTION
Mostly bug fixes, see change at https://github.com/netty/netty/issues?q=milestone%3A4.0.26.Final

Target: trunk
Require-notes: no
Require-book: no
Request: 2.12
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7958/
(cherry picked from commit 62bdfa0c1cf458da015cf74cd0958505b4cec3f0)