### PR TITLE
libs: update to nfs4j-0.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -806,7 +806,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.9.4</version>
+            <version>0.9.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
bugfix release

fixed NPE and improves logging

hangelog for nfs4j-0.9.4..nfs4j-0.9.5
    * [96adafb] [maven-release-plugin] prepare for next development iteration
    * [3bc1678] libs: update to oncrpc4j-2.3.2
    * [e544ad6] chimera-vfs: convert FileNotFoundHimeraException into StaleException
    * [33ed6f6] nfs4: log faulty clients
    * [9d12409] nfs4: log badstateid exceptions
    * [d96f0a9] libs: update to oncrpc4j-2.3.3
    * [5799b60] nfs4: set session into request context after lease validation
    * [47e2c8f] nfs4: fix synchronization of lease time
    * [3905689] [maven-release-plugin] prepare release nfs4j-0.9.5

Acked-by:
Target: 2.11, 2.10
Require-book: no
Require-notes: yes