### PR TITLE
pool: Extend nearline storage SPI with path and custom error codes

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/FlushRequest.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/FlushRequest.java
@@ -17,6 +17,8 @@
  */
 package org.dcache.pool.nearline.spi;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 import java.io.File;
 import java.net.URI;
 import java.util.Set;
@@ -44,4 +46,19 @@ public interface FlushRequest extends NearlineRequest<Set<URI>>
      * @return Attributes of the file
      */
     FileAttributes getFileAttributes();
+
+    /**
+     * Signals that the request is being activated and returns the path of the file.
+     *
+     * Similar to <code>activate</code>, but in addition to marking the request as
+     * active, this method resolves the path of the file. Resolving the path of a
+     * file is relatively expensive, which is why <code>activate</code> doesn't do
+     * it. If a file has several hard-links, only one of the paths is returned.
+     *
+     * @return An asynchronous reply indicating when to proceed with processing
+     *         the request. The activation may fail and a NearlineStorage must
+     *         fail the entire request by calling {@code failed} with the exception
+     *         returned by the future. The result carries the path of the file.
+     */
+    ListenableFuture<String> activateWithPath();
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/NearlineRequest.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/NearlineRequest.java
@@ -91,6 +91,26 @@ public interface NearlineRequest<T>
     void failed(Exception cause);
 
     /**
+     * Signals that the request has failed.
+     *
+     * Identical to calling <code>failed(new CacheException(rc, msg))</code>, but avoids
+     * the dependency on that specific exception type.
+     *
+     * Summary of return codes:
+     *
+     * Return Code      Meaning                 Behaviour for PUT FILE    Behaviour for GET FILE
+     * 30 <= rc < 40    User defined            Deactivates request       Reports problem to poolmanager
+     * 41	            No space left on device	Pool retries              Disables pool and reports problem to poolmanager
+     * 42               Disk read I/O error     Pool retries              Disables pool and reports problem to poolmanager
+     * 43               Disk write I/O error    Pool retries              Disables pool and reports problem to poolmanager
+     * other            -                       Pool retries              Reports problem to poolmanager
+     *
+     * @param rc Return code
+     * @param msg Error message
+     */
+    void failed(int rc, String msg);
+
+    /**
      * Signals that the request has completed successfully.
      *
      * @param result The result of the request


### PR DESCRIPTION
A request from Triumf indicates that a nearline storage may want to access the
path of a file. On initial write to a pool, the path is present in the
StorageInfo, but there is no guarantee that the path survives when the file is
replicated. This patch adds an alternative method to activate flush requests,
which returns resolves the path of the file.

Discussion with Triumf also revealed a challenge in reporting errors to the
pool: An implementation would need to rely on our CacheException to inject
specific error codes. This class is however not part of the SPI. This patch
adds a second failed method that accepts a return code and an error message.

The patch is backwards compatible and can be safely merged to stable versions.

Target: trunk
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7743/
(cherry picked from commit 1a2dc42e93ff36fdac3f912dc3ba553cb7faddab)