### PR TITLE
pool: Extend nearline storage SPI with path and custom error codes

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -60,6 +60,7 @@ import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.util.FileInCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
+import diskCacheV111.util.FsPath;
 import diskCacheV111.util.HsmLocationExtractorFactory;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
@@ -94,6 +95,7 @@ import org.dcache.pool.repository.StateChangeEvent;
 import org.dcache.pool.repository.StateChangeListener;
 import org.dcache.pool.repository.StickyChangeEvent;
 import org.dcache.pool.repository.StickyRecord;
+import org.dcache.util.CacheExceptionFactory;
 import org.dcache.util.Checksum;
 import org.dcache.vehicles.FileAttributes;
 
@@ -439,6 +441,13 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             }
         }
 
+        public void failed(int rc, String msg)
+        {
+            failed(CacheExceptionFactory.exceptionOf(rc, msg));
+        }
+
+        public abstract void failed(Exception cause);
+
         @Override
         public String toString()
         {
@@ -708,6 +717,13 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         }
 
         @Override
+        public ListenableFuture<String> activateWithPath()
+        {
+            LOGGER.debug("Activating flush of {}.", getFileAttributes().getPnfsId());
+            return register(Futures.transform(super.activate(), new PreFlushWithPathFunction(), executor));
+        }
+
+        @Override
         public String toString()
         {
             return super.toString() + ' ' + getFileAttributes().getPnfsId();
@@ -861,6 +877,22 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             flushRequests.removeAndCallback(pnfsId, cause);
         }
 
+        private void removeFile(PnfsId pnfsId)
+        {
+            try {
+                repository.setState(pnfsId, EntryState.REMOVED);
+            } catch (CacheException f) {
+                LOGGER.error("File not found in name space, but failed to remove {}: {}",
+                             pnfsId, f.getMessage());
+            } catch (InterruptedException f) {
+                LOGGER.warn("File not found in name space, but failed to remove {}: {}",
+                            pnfsId, f);
+            } catch (IllegalTransitionException f) {
+                LOGGER.warn("File not found in name space, but failed to remove {}: {}",
+                            pnfsId, f.getMessage());
+            }
+        }
+
         private class PreFlushFunction implements AsyncFunction<Void, Void>
         {
             @Override
@@ -874,30 +906,47 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
                 } catch (FileNotFoundCacheException e) {
                     // Remove file asynchronously to prevent request cancellation from
                     // interrupting the state update.
-                    executor.execute(
-                            new Runnable()
-                            {
-                                @Override
-                                public void run()
-                                {
-                                    try {
-                                        repository.setState(pnfsId, EntryState.REMOVED);
-                                    } catch (CacheException f) {
-                                        LOGGER.error("File not found in name space, but failed to remove {}: {}",
-                                                     pnfsId, f.getMessage());
-                                    } catch (InterruptedException f) {
-                                        LOGGER.warn("File not found in name space, but failed to remove {}: {}",
-                                                    pnfsId, f);
-                                    } catch (IllegalTransitionException f) {
-                                        LOGGER.warn("File not found in name space, but failed to remove {}: {}",
-                                                    pnfsId, f.getMessage());
-                                    }
-                                }
-                            });
+                    executor.execute(new Runnable()
+                    {
+                        @Override
+                        public void run()
+                        {
+                            removeFile(pnfsId);
+                        }
+                    });
                     throw new FileNotFoundCacheException("File not found in name space during pre-flush check.", e);
                 }
                 checksumModule.enforcePreFlushPolicy(descriptor);
                 return Futures.immediateFuture(null);
+            }
+        }
+
+        private class PreFlushWithPathFunction implements AsyncFunction<Void, String>
+        {
+            @Override
+            public ListenableFuture<String> apply(Void ignored)
+                    throws CacheException, InterruptedException, NoSuchAlgorithmException, IOException
+            {
+                final PnfsId pnfsId = descriptor.getFileAttributes().getPnfsId();
+                LOGGER.debug("Checking if {} still exists.", pnfsId);
+                FsPath path;
+                try {
+                    path = pnfs.getPathByPnfsId(pnfsId);
+                } catch (FileNotFoundCacheException e) {
+                    // Remove file asynchronously to prevent request cancellation from
+                    // interrupting the state update.
+                    executor.execute(new Runnable()
+                    {
+                        @Override
+                        public void run()
+                        {
+                            removeFile(pnfsId);
+                        }
+                    });
+                    throw new FileNotFoundCacheException("File not found in name space during pre-flush check.", e);
+                }
+                checksumModule.enforcePreFlushPolicy(descriptor);
+                return Futures.immediateFuture(path.toString());
             }
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/FlushRequest.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/FlushRequest.java
@@ -17,6 +17,8 @@
  */
 package org.dcache.pool.nearline.spi;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 import java.io.File;
 import java.net.URI;
 import java.util.Set;
@@ -44,4 +46,19 @@ public interface FlushRequest extends NearlineRequest<Set<URI>>
      * @return Attributes of the file
      */
     FileAttributes getFileAttributes();
+
+    /**
+     * Signals that the request is being activated and returns the path of the file.
+     *
+     * Similar to <code>activate</code>, but in addition to marking the request as
+     * active, this method resolves the path of the file. Resolving the path of a
+     * file is relatively expensive, which is why <code>activate</code> doesn't do
+     * it. If a file has several hard-links, only one of the paths is returned.
+     *
+     * @return An asynchronous reply indicating when to proceed with processing
+     *         the request. The activation may fail and a NearlineStorage must
+     *         fail the entire request by calling {@code failed} with the exception
+     *         returned by the future. The result carries the path of the file.
+     */
+    ListenableFuture<String> activateWithPath();
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/NearlineRequest.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/NearlineRequest.java
@@ -91,6 +91,26 @@ public interface NearlineRequest<T>
     void failed(Exception cause);
 
     /**
+     * Signals that the request has failed.
+     *
+     * Identical to calling <code>failed(new CacheException(rc, msg))</code>, but avoids
+     * the dependency on that specific exception type.
+     *
+     * Summary of return codes:
+     *
+     * Return Code      Meaning                 Behaviour for PUT FILE    Behaviour for GET FILE
+     * 30 <= rc < 40    User defined            Deactivates request       Reports problem to poolmanager
+     * 41	            No space left on device	Pool retries              Disables pool and reports problem to poolmanager
+     * 42               Disk read I/O error     Pool retries              Disables pool and reports problem to poolmanager
+     * 43               Disk write I/O error    Pool retries              Disables pool and reports problem to poolmanager
+     * other            -                       Pool retries              Reports problem to poolmanager
+     *
+     * @param rc Return code
+     * @param msg Error message
+     */
+    void failed(int rc, String msg);
+
+    /**
      * Signals that the request has completed successfully.
      *
      * @param result The result of the request


### PR DESCRIPTION
A request from Triumf indicates that a nearline storage may want to access the
path of a file. On initial write to a pool, the path is present in the
StorageInfo, but there is no guarantee that the path survives when the file is
replicated. This patch adds an alternative method to activate flush requests,
which returns resolves the path of the file.

Discussion with Triumf also revealed a challenge in reporting errors to the
pool: An implementation would need to rely on our CacheException to inject
specific error codes. This class is however not part of the SPI. This patch
adds a second failed method that accepts a return code and an error message.

The patch is backwards compatible and can be safely merged to stable versions.

Target: trunk
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7743/
(cherry picked from commit 1a2dc42e93ff36fdac3f912dc3ba553cb7faddab)