### PR TITLE
pool: Fix read corruption in HTTP mover

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/ReusableChunkedNioFile.java
+++ b/modules/dcache/src/main/java/org/dcache/http/ReusableChunkedNioFile.java
@@ -92,7 +92,7 @@ public class ReusableChunkedNioFile implements ChunkedInput<ByteBuf>
     {
         long offset = _offset;
 
-        if (_offset >= _endOffset) {
+        if (offset >= _endOffset) {
             return null;
         }
 
@@ -100,24 +100,17 @@ public class ReusableChunkedNioFile implements ChunkedInput<ByteBuf>
         byte [] chunkArray = new byte[chunkSize];
 
         ByteBuffer chunk = ByteBuffer.wrap(chunkArray);
-        int readBytes = 0;
 
-        while (true) {
-            /* use call that does not change the channel's position */
-            int localReadBytes = _channel.read(chunk, _offset);
-
-            if (localReadBytes < 0) {
+        while (chunk.hasRemaining()) {
+            /* use position independent thread safe call */
+            int bytes = _channel.read(chunk, offset);
+            if (bytes < 0) {
                 break;
             }
-
-            readBytes += localReadBytes;
-
-            if (readBytes == chunkSize) {
-                break;
-            }
+            offset += bytes;
         }
 
-        _offset += readBytes;
+        _offset = offset;
 
         return Unpooled.wrappedBuffer(chunkArray);
     }


### PR DESCRIPTION
The offset isn't updated in the loop. This means that if the OS doesn't read
the requested amount of data, the same bytes would be reread. It is unlikekly
that the OS for a file opened in blocking mode would not read all the data we
requested, so the impact is probably low.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7968/
(cherry picked from commit b896fd53580ff6aa04ef33514362d46bfa653406)