### PR TITLE
pool: ignore duplicated mover kill requests

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SimpleIoScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SimpleIoScheduler.java
@@ -435,6 +435,10 @@ public class SimpleIoScheduler implements IoScheduler, Runnable {
 
         public synchronized void kill()
         {
+            if (_state == CANCELED || _state == DONE) {
+                return;
+            }
+
             if (_cancellable != null) {
                 _cancellable.cancel();
             } else {


### PR DESCRIPTION
if mover for whatever reason get stuck in post processing
(checksumming, for example), then door can send yet another
kill request. Ignore kill requests if mover in a CANCELED or DONE
state.

observer on DESY instance a pool with 10121 threads calculating a checksum
for the same mover.

Acked-by: paul Millar
Target: master, 2.12, 2.11, 2.10
Require-notes: yes
Require-book: no
(cherry picked from commit 78a06ec7e2a7f76a7477ab4d8acf307756b78ef0)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>