### PR TITLE
Fix serialization of cache class in FileAttributes

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -1043,7 +1043,7 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
             _attributes = EnumSet.of(OWNER, OWNER_GROUP, MODE, TYPE, SIZE,
                     CREATION_TIME, ACCESS_TIME, MODIFICATION_TIME, PNFSID);
             if (!metaDataOnly) {
-                _attributes.add(STORAGEINFO);
+                _attributes.addAll(PoolMgrSelectReadPoolMsg.getRequiredAttributes());
             }
 
             String tmp = args.getOpt("timeout");

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PoolMgrGetPoolMsg.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PoolMgrGetPoolMsg.java
@@ -1,10 +1,7 @@
-// $Id: PoolMgrGetPoolMsg.java,v 1.3 2004-11-05 12:07:19 tigran Exp $
-
 package diskCacheV111.vehicles;
 
 import javax.annotation.Nonnull;
 
-import java.util.Collection;
 import java.util.EnumSet;
 
 import diskCacheV111.util.PnfsId;
@@ -15,10 +12,7 @@ import org.dcache.namespace.FileAttribute;
 import org.dcache.vehicles.FileAttributes;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.dcache.namespace.FileAttribute.HSM;
-import static org.dcache.namespace.FileAttribute.PNFSID;
-import static org.dcache.namespace.FileAttribute.STORAGECLASS;
-import static org.dcache.namespace.FileAttribute.STORAGEINFO;
+import static org.dcache.namespace.FileAttribute.*;
 
 public class PoolMgrGetPoolMsg extends PoolManagerMessage
 {
@@ -30,7 +24,7 @@ public class PoolMgrGetPoolMsg extends PoolManagerMessage
 
     public PoolMgrGetPoolMsg(FileAttributes fileAttributes)
     {
-        checkArgument(fileAttributes.getDefinedAttributes().containsAll(getRequiredAttributes()), "Required attributes are missing");
+        checkArgument(fileAttributes.isDefined(getRequiredAttributes()), "Required attributes are missing.");
 
 	_fileAttributes = fileAttributes;
 	setReplyRequired(true);
@@ -87,7 +81,7 @@ public class PoolMgrGetPoolMsg extends PoolManagerMessage
         }
     }
 
-    public static Collection<FileAttribute> getRequiredAttributes()
+    public static EnumSet<FileAttribute> getRequiredAttributes()
     {
         return EnumSet.of(PNFSID, STORAGEINFO, STORAGECLASS, HSM);
     }

--- a/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/FileAttributes.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/FileAttributes.java
@@ -509,8 +509,11 @@ public class FileAttributes implements Serializable {
     private void writeObject(ObjectOutputStream stream)
             throws IOException
     {
-        _definedAttributes.remove(CACHECLASS); // For compatibility with pre-2.12 - remove after next golden
+        boolean wasCacheClassDefined = _definedAttributes.remove(CACHECLASS); // For compatibility with pre-2.12 - remove after next golden
         stream.defaultWriteObject();
+        if (wasCacheClassDefined) {
+            _definedAttributes.add(CACHECLASS);
+        }
     }
 
     private void readObject(ObjectInputStream stream)

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
@@ -56,8 +56,6 @@ public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg
                                     Context context)
     {
         this(fileAttributes, protocolInfo, context, RequestContainerV5.allStates);
-        checkArgument(fileAttributes.isDefined(getRequiredAttributes()),
-                "Required attributes are missing");
     }
 
     /**
@@ -72,6 +70,7 @@ public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg
                                     EnumSet<RequestContainerV5.RequestState> allowedStates)
     {
         super(fileAttributes, protocolInfo, allowedStates);
+        checkArgument(fileAttributes.isDefined(getRequiredAttributes()), "Required attributes are missing.");
         _context = (context == null) ? new Context() : context;
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerPinMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerPinMessage.java
@@ -1,6 +1,5 @@
 package org.dcache.pinmanager;
 
-import java.util.Collection;
 import java.util.Date;
 import java.util.EnumSet;
 
@@ -33,11 +32,8 @@ public class PinManagerPinMessage extends Message
                                 String requestId,
                                 long lifetime)
     {
-        checkNotNull(fileAttributes);
-        checkNotNull(protocolInfo);
-
-        _fileAttributes = fileAttributes;
-        _protocolInfo = protocolInfo;
+        _fileAttributes = checkNotNull(fileAttributes);
+        _protocolInfo = checkNotNull(protocolInfo);
         _requestId = requestId;
         _lifetime = lifetime;
     }
@@ -69,7 +65,7 @@ public class PinManagerPinMessage extends Message
 
     public void setFileAttributes(FileAttributes attributes)
     {
-        _fileAttributes = attributes;
+        _fileAttributes = checkNotNull(attributes);
     }
 
     public ProtocolInfo getProtocolInfo()
@@ -121,9 +117,9 @@ public class PinManagerPinMessage extends Message
             _protocolInfo + "," + _lifetime + "]";
     }
 
-    public static Collection<FileAttribute> getRequiredAttributes()
+    public static EnumSet<FileAttribute> getRequiredAttributes()
     {
-        Collection<FileAttribute> attributes = EnumSet.of(PNFSID);
+        EnumSet<FileAttribute> attributes = EnumSet.of(PNFSID);
         attributes.addAll(PoolMgrSelectReadPoolMsg.getRequiredAttributes());
         return attributes;
     }

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
@@ -25,7 +25,6 @@ import diskCacheV111.util.FileNotOnlineCacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.PoolMgrSelectReadPoolMsg;
 import diskCacheV111.vehicles.PoolSetStickyMessage;
-import diskCacheV111.vehicles.StorageInfo;
 
 import dmg.cells.nucleus.CellAddressCore;
 import dmg.cells.nucleus.CellPath;
@@ -91,9 +90,6 @@ public class PinRequestProcessor
      * account for clock drift.
      */
     private final static long CLOCK_DRIFT_MARGIN = MINUTES.toMillis(30);
-
-    private final static Set<FileAttribute> REQUIRED_ATTRIBUTES =
-        PoolMgrSelectReadPoolMsg.getRequiredAttributes();
 
     private ScheduledExecutorService _scheduledExecutor;
     private Executor _executor;
@@ -201,7 +197,7 @@ public class PinRequestProcessor
 
         PinTask task = createTask(message, reply);
         if (task != null) {
-            if (!task.getFileAttributes().isDefined(REQUIRED_ATTRIBUTES)) {
+            if (!task.getFileAttributes().isDefined(PoolMgrSelectReadPoolMsg.getRequiredAttributes())) {
                 rereadNameSpaceEntry(task);
             } else {
                 selectReadPool(task);


### PR DESCRIPTION
To maintain backwards compatibility, cache class serialization is treated in a
special way. As a side effect, serializing FileAttributes clears it CACHECLASS
attribute when being serialized, thus after sending FileAttributes to another
cell, the original object is corrupted. This leads to the following error:

16 Mar 2015 10:26:16 (PoolManager) [Jrs:11946394:srm2:bringOnline:-1776876581:-1776876578 PinManager PoolMgrSelectReadPool 0000FD7EE4F955D0440B936D7B605C89FAAD] [stage] contact support@dcache.org
java.lang.IllegalStateException: Attribute is not defined: CACHECLASS
        at org.dcache.vehicles.FileAttributes.guard(FileAttributes.java:171) ~[dcache-vehicles-2.12.0.jar:2.12.0]
        at org.dcache.vehicles.FileAttributes.getCacheClass(FileAttributes.java:457) ~[dcache-vehicles-2.12.0.jar:2.12.0]
        at diskCacheV111.poolManager.PoolSelectionUnitV2.match(PoolSelectionUnitV2.java:440) ~[dcache-core-2.12.0.jar:2.12.0]
        at diskCacheV111.poolManager.PoolMonitorV5$PnfsFileLocation.match(PoolMonitorV5.java:143) ~[dcache-core-2.12.0.jar:2.12.0]
        at diskCacheV111.poolManager.PoolMonitorV5$PnfsFileLocation.selectStagePool(PoolMonitorV5.java:366) ~[dcache-core-2.12.0.jar:2.12.0]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.askForStaging(RequestContainerV5.java:2005) [dcache-core-2.12.0.jar:2.12.0]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.stateEngine(RequestContainerV5.java:1561) [dcache-core-2.12.0.jar:2.12.0]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.stateLoop(RequestContainerV5.java:1147) [dcache-core-2.12.0.jar:2.12.0]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.access$1700(RequestContainerV5.java:689) [dcache-core-2.12.0.jar:2.12.0]
        at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler$RunEngine.run(RequestContainerV5.java:1078) [dcache-core-2.12.0.jar:2.12.0]
        at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) [dcache-core-2.12.0.jar:2.12.0]
        at org.dcache.util.CDCExecutorServiceDecorator$1.run(CDCExecutorServiceDecorator.java:104) [dcache-core-2.12.0.jar:2.12.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_31]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_31]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_31]

The patch makes minor adjustments to required attribute handling in related
parts of the code (done to exclude other sources of the same problem).

Target: trunk
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7974/
(cherry picked from commit 8f7e08c6d0594031fda2d3cccfd5527be9aebc97)