### PR TITLE
pool: Fix and align pool meta data recovery with current pnfs manager

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
@@ -13,11 +13,13 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 
+import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.util.FileInCacheException;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
+import diskCacheV111.util.RetentionPolicy;
 
 import org.dcache.namespace.FileAttribute;
 import org.dcache.pool.classic.ChecksumModule;
@@ -45,24 +47,34 @@ public class ConsistentStore
     private final static String RECOVERING_MSG =
         "Recovering %1$s...";
     private final static String MISSING_MSG =
-        "Recovering: Reconstructing meta data for %1$s";
+        "Recovering: Reconstructing meta data for %1$s.";
     private final static String PARTIAL_FROM_TAPE_MSG =
-        "Recovering: Removed %1$s because it was not fully staged";
+        "Recovering: Removed %1$s because it was not fully staged.";
     private final static String FETCHED_STORAGE_INFO_FOR_1$S_FROM_PNFS =
-        "Recovering: Fetched storage info for %1$s from PNFS";
+        "Recovering: Fetched storage info for %1$s from name space.";
     private final static String FILE_NOT_FOUND_MSG =
-        "Recovering: Removed %1$s because name space entry was deleted";
+        "Recovering: Removed %1$s because name space entry was deleted.";
     private final static String UPDATE_SIZE_MSG =
-        "Recovering: Setting size of %1$s in PNFS to %2$d";
+        "Recovering: Setting size of %1$s in name space to %2$d.";
+    private final static String UPDATE_ACCESS_LATENCY_MSG =
+        "Recovering: Setting access latency of %1$s in name space to %2$d.";
+    private final static String UPDATE_RETENTION_POLICY_MSG =
+        "Recovering: Setting retention policy of %1$s in name space to %2$d.";
+    private final static String UPDATE_CHECKSUM_MSG =
+        "Recovering: Setting checksum of %1$s in name space to %2$d.";
     private final static String MARKED_MSG =
-        "Recovering: Marked %1$s as %2$s";
+        "Recovering: Marked %1$s as %2$s.";
     private final static String REMOVING_REDUNDANT_META_DATA =
-        "Removing redundant meta data for %s";
+        "Removing redundant meta data for %s.";
 
     private final static String BAD_MSG =
-        "Marked %1$s bad: %2$s";
+        "Marked %1$s bad: %2$s.";
     private final static String BAD_SIZE_MSG =
         "File size mismatch for %1$s. Expected %2$d bytes, but found %3$d bytes.";
+    private final static String MISSING_ACCESS_LATENCY =
+        "Missing access latency for %1$s.";
+    private final static String MISSING_RETENTION_POLICY =
+        "Missing retention policy for %1$s.";
 
     private final EnumSet<FileAttribute> REQUIRED_ATTRIBUTES =
             EnumSet.of(STORAGEINFO, ACCESS_LATENCY, RETENTION_POLICY, SIZE, CHECKSUM);
@@ -212,8 +224,7 @@ public class ConsistentStore
                }
 
                _log.warn(String.format(FETCHED_STORAGE_INFO_FOR_1$S_FROM_PNFS, id));
-               FileAttributes fileAttributes = _pnfsHandler.getFileAttributes(id, REQUIRED_ATTRIBUTES);
-               entry.setFileAttributes(fileAttributes);
+               FileAttributes attributesInNameSpace = _pnfsHandler.getFileAttributes(id, REQUIRED_ATTRIBUTES);
 
                 /* If the intended file size is known, then compare it
                  * to the actual file size on disk. Fail in case of a
@@ -222,14 +233,15 @@ public class ConsistentStore
                  * may thus safe some time for incomplete files.
                  */
                 long length = entry.getDataFile().length();
-                if ((state != EntryState.FROM_CLIENT || fileAttributes.isDefined(FileAttribute.SIZE) && fileAttributes.getSize() != 0)
-                    && fileAttributes.getSize() != length) {
-                    throw new CacheException(String.format(BAD_SIZE_MSG, id, fileAttributes.getSize(), length));
+                if (attributesInNameSpace.isDefined(FileAttribute.SIZE)
+                    && (state != EntryState.FROM_CLIENT || attributesInNameSpace.getSize() != 0)
+                    && attributesInNameSpace.getSize() != length) {
+                    throw new CacheException(String.format(BAD_SIZE_MSG, id, attributesInNameSpace.getSize(), length));
                 }
 
                 /* Verify checksum. Will fail if there is a mismatch.
                  */
-                Iterable<Checksum> expectedChecksums = fileAttributes.getChecksums();
+                Iterable<Checksum> expectedChecksums = attributesInNameSpace.getChecksumsIfPresent().or(Collections.<Checksum>emptySet());
                 Iterable<Checksum> actualChecksums;
                 if (_checksumModule != null &&
                         (_checksumModule.hasPolicy(ChecksumModule.PolicyFlag.ON_WRITE) ||
@@ -245,36 +257,72 @@ public class ConsistentStore
                 FileAttributes attributesToUpdate = new FileAttributes();
                 attributesToUpdate.setLocations(Collections.singleton(_poolName));
 
+
                 /* If file size was not registered in the name space, we now replay the registration just as it would happen
                  * in WriteHandleImpl. This includes initializing access latency, retention policy, and checksums.
                  */
-                if (state == EntryState.FROM_CLIENT && (fileAttributes.isUndefined(FileAttribute.SIZE) || fileAttributes.getSize() == 0)) {
-                    attributesToUpdate.setSize(length);
-                    attributesToUpdate.setAccessLatency(fileAttributes.getAccessLatency());
-                    attributesToUpdate.setRetentionPolicy(fileAttributes.getRetentionPolicy());
+                if (state == EntryState.FROM_CLIENT) {
+                    if (attributesInNameSpace.isUndefined(ACCESS_LATENCY)) {
+                        /* Access latency must have been injected by space manager, so we hope we still
+                         * got it stored on the pool.
+                         */
+                        FileAttributes attributesOnPool = entry.getFileAttributes();
+                        if (attributesOnPool.isUndefined(ACCESS_LATENCY)) {
+                            throw new CacheException(String.format(MISSING_ACCESS_LATENCY, id));
+                        }
+
+                        AccessLatency accessLatency = attributesOnPool.getAccessLatency();
+                        attributesToUpdate.setAccessLatency(accessLatency);
+                        attributesInNameSpace.setAccessLatency(accessLatency);
+
+                        _log.warn(String.format(UPDATE_ACCESS_LATENCY_MSG, id, accessLatency));
+                    }
+                    if (attributesInNameSpace.isUndefined(RETENTION_POLICY)) {
+                        /* Retention policy must have been injected by space manager, so we hope we still
+                         * got it stored on the pool.
+                         */
+                        FileAttributes attributesOnPool = entry.getFileAttributes();
+                        if (attributesOnPool.isUndefined(RETENTION_POLICY)) {
+                            throw new CacheException(String.format(MISSING_RETENTION_POLICY, id));
+                        }
+
+                        RetentionPolicy retentionPolicy = attributesInNameSpace.getRetentionPolicy();
+                        attributesToUpdate.setRetentionPolicy(retentionPolicy);
+                        attributesInNameSpace.setRetentionPolicy(retentionPolicy);
+
+                        _log.warn(String.format(UPDATE_RETENTION_POLICY_MSG, id, retentionPolicy));
+                    }
+                    if (attributesInNameSpace.isUndefined(SIZE) || attributesInNameSpace.getSize() == 0) {
+                        attributesToUpdate.setSize(length);
+                        attributesInNameSpace.setSize(length);
+
+                        _log.warn(String.format(UPDATE_SIZE_MSG, id, length));
+                    }
                     if (!isEmpty(actualChecksums)) {
                         attributesToUpdate.setChecksums(Sets.newHashSet(actualChecksums));
-                        fileAttributes.setChecksums(Sets.newHashSet(concat(expectedChecksums, actualChecksums)));
+                        attributesInNameSpace.setChecksums(
+                                Sets.newHashSet(concat(expectedChecksums, actualChecksums)));
+                        _log.warn(String.format(UPDATE_CHECKSUM_MSG, id, actualChecksums));
                     }
-                    fileAttributes.setSize(length);
-                    entry.setFileAttributes(fileAttributes);
-
-                    _log.warn(String.format(UPDATE_SIZE_MSG, id, length));
                 }
 
-                /* Update file size, location, access_latency and
-                 * retention_policy within namespace (pnfs or chimera).
+                /* Update file size, location, checksum, access_latency and
+                 * retention_policy within namespace.
                  */
                 _pnfsHandler.setFileAttributes(id, attributesToUpdate);
+
+                /* Update the pool meta data.
+                 */
+                entry.setFileAttributes(attributesInNameSpace);
 
                 /* If not already precious or cached, we move the entry to
                  * the target state of a newly uploaded file.
                  */
                 if (state != EntryState.CACHED && state != EntryState.PRECIOUS) {
                     EntryState targetState =
-                        _replicaStatePolicy.getTargetState(fileAttributes);
+                        _replicaStatePolicy.getTargetState(attributesInNameSpace);
                     List<StickyRecord> stickyRecords =
-                        _replicaStatePolicy.getStickyRecords(fileAttributes);
+                        _replicaStatePolicy.getStickyRecords(attributesInNameSpace);
 
                     for (StickyRecord record: stickyRecords) {
                         entry.setSticky(record.owner(), record.expire(), false);
@@ -283,6 +331,7 @@ public class ConsistentStore
                     entry.setState(targetState);
                     _log.warn(String.format(MARKED_MSG, id, targetState));
                 }
+
                 return entry;
     }
 

--- a/modules/dcache/src/test/java/org/dcache/pool/repository/ConsistentStoreTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/repository/ConsistentStoreTest.java
@@ -10,10 +10,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 
+import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
+import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.vehicles.OSMStorageInfo;
 import diskCacheV111.vehicles.StorageInfo;
 import diskCacheV111.vehicles.StorageInfos;
@@ -59,25 +61,24 @@ public class ConsistentStoreTest
         _fileStore.shutdown();
     }
 
-    private static StorageInfo createStorageInfo(long size)
+    private static FileAttributes createFileAttributes(PnfsId pnfsId)
         throws URISyntaxException
     {
         StorageInfo info = new OSMStorageInfo("h1", "rawd");
         info.addLocation(new URI("osm://mystore/?store=mystore&group=mygroup&bdid=1"));
-        info.setLegacySize(size);
-        return info;
-    }
-
-    private static FileAttributes
-        fileAttributes(PnfsId pnfsId, StorageInfo info)
-    {
         FileAttributes attributes = new FileAttributes();
-        attributes.setSize(info.getLegacySize());
-        attributes.setAccessLatency(info.getLegacyAccessLatency());
-        attributes.setRetentionPolicy(info.getLegacyRetentionPolicy());
-        attributes.setChecksums(Collections.<Checksum>emptySet());
         attributes.setPnfsId(pnfsId);
         attributes.setStorageInfo(info);
+        attributes.setAccessLatency(AccessLatency.NEARLINE);
+        attributes.setRetentionPolicy(RetentionPolicy.CUSTODIAL);
+        return attributes;
+    }
+
+    private static FileAttributes createFileAttributes(PnfsId pnfsId, long size)
+        throws URISyntaxException
+    {
+        FileAttributes attributes = createFileAttributes(pnfsId);
+        attributes.setSize(size);
         return attributes;
     }
 
@@ -87,14 +88,11 @@ public class ConsistentStoreTest
         _fileStore.add(pnfsId).setSize(17);
     }
 
-    private void givenMetaDataStoreHas(PnfsId pnfsId, EntryState state,
-                                              StorageInfo info)
+    private void givenMetaDataStoreHas(EntryState state, FileAttributes attributes)
         throws DuplicateEntryException, CacheException
     {
-        MetaDataRecord entry = _metaDataStore.create(pnfsId);
+        MetaDataRecord entry = _metaDataStore.create(attributes.getPnfsId());
         entry.setState(state);
-        FileAttributes attributes = StorageInfos.injectInto(info, new FileAttributes());
-        attributes.setPnfsId(pnfsId);
         entry.setFileAttributes(attributes);
     }
 
@@ -107,12 +105,11 @@ public class ConsistentStoreTest
 
         // and given the meta data indicates a different size, but is
         // otherwise in a valid non-transient state
-        StorageInfo info = createStorageInfo(20);
-        givenMetaDataStoreHas(PNFSID, CACHED, info);
+        FileAttributes info = createFileAttributes(PNFSID, 20);
+        givenMetaDataStoreHas(CACHED, info);
 
         // and given that the name space provides the same storage info
-        given(_pnfs.getFileAttributes(eq(PNFSID), Mockito.anySet()))
-            .willReturn(fileAttributes(PNFSID, info));
+        given(_pnfs.getFileAttributes(eq(PNFSID), Mockito.anySet())).willReturn(info);
 
         // when reading the meta data record
         MetaDataRecord record = _consistentStore.get(PNFSID);
@@ -138,19 +135,17 @@ public class ConsistentStoreTest
         givenStoreHasFileOfSize(PNFSID, 17);
 
         // and given the replica is an incomplete upload
-        StorageInfo info = createStorageInfo(0);
-        givenMetaDataStoreHas(PNFSID, FROM_CLIENT, info);
+        FileAttributes info = createFileAttributes(PNFSID);
+        givenMetaDataStoreHas(FROM_CLIENT, info);
 
         // and given the name space entry exists without any size
-        given(_pnfs.getFileAttributes(eq(PNFSID), Mockito.anySet()))
-            .willReturn(fileAttributes(PNFSID, info));
+        given(_pnfs.getFileAttributes(eq(PNFSID), Mockito.anySet())).willReturn(info);
 
         // when reading the meta data record
         MetaDataRecord record = _consistentStore.get(PNFSID);
 
-        // then the correct size is set in storage info
-        assertThat(_metaDataStore.get(PNFSID).getFileAttributes().getSize(),
-                   is(17L));
+        // then the correct size is set in file attributes info
+        assertThat(_metaDataStore.get(PNFSID).getFileAttributes().getSize(), is(17L));
 
         // and the correct file size and location is registered in
         // the name space
@@ -172,8 +167,8 @@ public class ConsistentStoreTest
         givenStoreHasFileOfSize(PNFSID, 17);
 
         // and given the replica is in an incomplete upload
-        StorageInfo info = createStorageInfo(0);
-        givenMetaDataStoreHas(PNFSID, FROM_CLIENT, info);
+        FileAttributes info = createFileAttributes(PNFSID, 0);
+        givenMetaDataStoreHas(FROM_CLIENT, info);
 
         // and given the name space entry does not exist
         given(_pnfs.getFileAttributes(eq(PNFSID), Mockito.anySet()))
@@ -237,12 +232,11 @@ public class ConsistentStoreTest
         givenStoreHasFileOfSize(PNFSID, 17);
 
         // and given the replica is marked broken
-        StorageInfo info = createStorageInfo(0);
-        givenMetaDataStoreHas(PNFSID, BROKEN, info);
+        FileAttributes info = createFileAttributes(PNFSID);
+        givenMetaDataStoreHas(BROKEN, info);
 
         // and given the name space entry exists without any size
-        given(_pnfs.getFileAttributes(eq(PNFSID), Mockito.anySet()))
-                .willReturn(fileAttributes(PNFSID, info));
+        given(_pnfs.getFileAttributes(eq(PNFSID), Mockito.anySet())).willReturn(info);
 
         // when reading the meta data record
         MetaDataRecord record = _consistentStore.get(PNFSID);
@@ -273,8 +267,8 @@ public class ConsistentStoreTest
         // and given the replica meta data indicates the file was
         // being restored from tape and has is supposed to have a
         // different file size,
-        StorageInfo info = createStorageInfo(20);
-        givenMetaDataStoreHas(PNFSID, FROM_STORE, info);
+        FileAttributes info = createFileAttributes(PNFSID, 20);
+        givenMetaDataStoreHas(FROM_STORE, info);
 
         // when reading the meta data record
         MetaDataRecord record = _consistentStore.get(PNFSID);
@@ -302,9 +296,8 @@ public class ConsistentStoreTest
         givenStoreHasFileOfSize(PNFSID, 17);
 
         // and given the name space entry reports a different size
-        StorageInfo info = createStorageInfo(20);
-        given(_pnfs.getFileAttributes(eq(PNFSID), Mockito.anySet()))
-            .willReturn(fileAttributes(PNFSID, info));
+        FileAttributes info = createFileAttributes(PNFSID, 20);
+        given(_pnfs.getFileAttributes(eq(PNFSID), Mockito.anySet())).willReturn(info);
 
         // when reading the meta data record
         MetaDataRecord record = _consistentStore.get(PNFSID);
@@ -325,7 +318,7 @@ public class ConsistentStoreTest
         givenStoreHasFileOfSize(PNFSID, 17);
 
         // and given the replica has intact meta data
-        givenMetaDataStoreHas(PNFSID, CACHED, createStorageInfo(17));
+        givenMetaDataStoreHas(CACHED, createFileAttributes(PNFSID, 17));
 
         // when reading the meta data record
         MetaDataRecord record = _consistentStore.get(PNFSID);


### PR DESCRIPTION
Paul, please double check the changes as I had to adjust the patch
compared to master.


Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7974/
(cherry picked from commit 451c567673591a6a42b5c304bc812d791317e474)
(cherry picked from commit a43d7a0c5e1e279ade66beee8c8c0456aec6f5e4)