### PR TITLE
nfs: cleanup CDC related mess

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoMdsOpFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoMdsOpFactory.java
@@ -1,6 +1,5 @@
 package org.dcache.chimera.nfsv41.door.proxy;
 
-import dmg.cells.nucleus.CDC;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
 import org.dcache.nfs.v4.NFSv4OperationFactory;
 import org.dcache.nfs.v4.xdr.nfs_argop4;
@@ -13,29 +12,23 @@ public class ProxyIoMdsOpFactory implements NFSv4OperationFactory {
 
     private final ProxyIoFactory _proxyIoFactory;
     private final NFSv4OperationFactory _inner;
-    private final String _cellName;
-    private final String _cellDomain;
 
-    public ProxyIoMdsOpFactory(String cellName, String cellDomain, ProxyIoFactory proxyIoFactory, NFSv4OperationFactory inner) {
-        _cellName = cellName;
-        _cellDomain = cellDomain;
+    public ProxyIoMdsOpFactory(ProxyIoFactory proxyIoFactory, NFSv4OperationFactory inner) {
         _proxyIoFactory = proxyIoFactory;
         _inner = inner;
     }
 
     @Override
     public AbstractNFSv4Operation getOperation(nfs_argop4 op) {
-        try (CDC ignored = CDC.reset(_cellName, _cellDomain)) {
-            switch (op.argop) {
-                case nfs_opnum4.OP_READ:
-                    return new ProxyIoREAD(op, _proxyIoFactory);
-                case nfs_opnum4.OP_WRITE:
-                    return new ProxyIoWRITE(op, _proxyIoFactory);
-                case nfs_opnum4.OP_CLOSE:
-                    return new ProxyIoClose(op);
-                default:
-                    return _inner.getOperation(op);
-            }
+        switch (op.argop) {
+            case nfs_opnum4.OP_READ:
+                return new ProxyIoREAD(op, _proxyIoFactory);
+            case nfs_opnum4.OP_WRITE:
+                return new ProxyIoWRITE(op, _proxyIoFactory);
+            case nfs_opnum4.OP_CLOSE:
+                return new ProxyIoClose(op);
+            default:
+                return _inner.getOperation(op);
         }
     }
 


### PR DESCRIPTION
or create a new one

As NFS door runs as a single cell, we don't need to
create a new context for each request. Nevertheless,
we clean session information when transfer class is used.

Acked-by: Gerd Behrmann
Target: master, 2.12
Require-book: no
Require-notes: no
(cherry picked from commit bd49037db2cfd2f5a91b2279224b39e299e293de)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>