### PR TITLE
pool: Fix pool entry reconstruction

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
@@ -58,11 +58,11 @@ public class ConsistentStore
     private final static String UPDATE_SIZE_MSG =
         "Recovering: Setting size of %1$s in name space to %2$d.";
     private final static String UPDATE_ACCESS_LATENCY_MSG =
-        "Recovering: Setting access latency of %1$s in name space to %2$d.";
+        "Recovering: Setting access latency of %1$s in name space to %2$s.";
     private final static String UPDATE_RETENTION_POLICY_MSG =
-        "Recovering: Setting retention policy of %1$s in name space to %2$d.";
+        "Recovering: Setting retention policy of %1$s in name space to %2$s.";
     private final static String UPDATE_CHECKSUM_MSG =
-        "Recovering: Setting checksum of %1$s in name space to %2$d.";
+        "Recovering: Setting checksum of %1$s in name space to %2$s.";
     private final static String MARKED_MSG =
         "Recovering: Marked %1$s as %2$s.";
     private final static String REMOVING_REDUNDANT_META_DATA =


### PR DESCRIPTION
A recent fix to pool entry reconstruction introduced another bug that
would cause pool startup to fail. The cause is a type mismatch in
the formatting of the error message.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/7984/
(cherry picked from commit 51ff1041383ad851b3737bf57e0ffb561755e571)