### PR TITLE
srm: Introduce max pool period property

### DIFF
--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -287,55 +287,46 @@
               value="${srm.enable.recursive-directory-creation}"/>
     <property name="advisoryDelete" value="${srm.enable.advisory-delete}"/>
 
-    <property name="getMaxNumOfRetries"
-              value="${srm.request.get.retries}"/>
-    <property name="getRetryTimeout"
+    <property name="getMaxPollPeriod"
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
-                     ${srm.request.get.retry-timeout},
-                     '${srm.request.get.retry-timeout.unit}')}" />
+                     ${srm.request.get.max-poll-period},
+                     '${srm.request.get.max-poll-period.unit}')}" />
     <property name="getSwitchToAsynchronousModeDelay"
               value="#{T(org.dcache.commons.util.Strings).parseTime(
                      '${srm.request.get.switch-to-async-mode-delay}',
                      '${srm.request.get.switch-to-async-mode-delay.unit}')}"/>
-    <property name="bringOnlineMaxNumOfRetries"
-              value="${srm.request.bring-online.retries}"/>
-    <property name="bringOnlineRetryTimeout"
+    <property name="bringOnlineMaxPollPeriod"
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
-                     ${srm.request.bring-online.retry-timeout},
-                     '${srm.request.bring-online.retry-timeout.unit}')}" />
+                     ${srm.request.bring-online.max-poll-period},
+                     '${srm.request.bring-online.max-poll-period.unit}')}" />
     <property name="bringOnlineSwitchToAsynchronousModeDelay"
               value="#{T(org.dcache.commons.util.Strings).parseTime(
                      '${srm.request.bring-online.switch-to-async-mode-delay}',
                      '${srm.request.bring-online.switch-to-async-mode-delay.unit}')}"/>
-    <property name="lsMaxNumOfRetries"
-              value="${srm.request.ls.retries}"/>
-    <property name="lsRetryTimeout"
+    <property name="lsMaxPollPeriod"
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
-                     ${srm.request.ls.retry-timeout},
-                     '${srm.request.ls.retry-timeout.unit}')}" />
+                     ${srm.request.ls.max-poll-period},
+                     '${srm.request.ls.max-poll-period.unit}')}" />
     <property name="lsSwitchToAsynchronousModeDelay"
               value="#{T(org.dcache.commons.util.Strings).parseTime(
                      '${srm.request.ls.switch-to-async-mode-delay}',
                      '${srm.request.ls.switch-to-async-mode-delay.unit}')}"/>
-    <property name="putMaxNumOfRetries" value="${srm.request.put.retries}"/>
-    <property name="putRetryTimeout"
+    <property name="putMaxPollPeriod"
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
-                     ${srm.request.put.retry-timeout},
-                     '${srm.request.put.retry-timeout.unit}')}" />
+                     ${srm.request.put.max-poll-period},
+                     '${srm.request.put.max-poll-period.unit}')}" />
     <property name="putSwitchToAsynchronousModeDelay"
               value="#{T(org.dcache.commons.util.Strings).parseTime(
                      '${srm.request.put.switch-to-async-mode-delay}',
                      '${srm.request.put.switch-to-async-mode-delay.unit}')}"/>
-    <property name="copyMaxNumOfRetries" value="${srm.request.copy.retries}"/>
-    <property name="copyRetryTimeout"
+    <property name="copyMaxPollPeriod"
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
-                     ${srm.request.copy.retry-timeout},
-                     '${srm.request.copy.retry-timeout.unit}')}" />
-    <property name="reserveSpaceMaxNumOfRetries" value="${srm.request.reserve-space.retries}"/>
-    <property name="reserveSpaceRetryTimeout"
+                     ${srm.request.copy.max-poll-period},
+                     '${srm.request.copy.max-poll-period.unit}')}" />
+    <property name="reserveSpaceMaxPollPeriod"
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
-                     ${srm.request.reserve-space.retry-timeout},
-                     '${srm.request.reserve-space.retry-timeout.unit}')}" />
+                     ${srm.request.reserve-space.max-poll-period},
+                     '${srm.request.reserve-space.max-poll-period.unit}')}" />
 
     <property name="maxQueuedJdbcTasksNum"
               value="${srm.limits.db.queue}"/>

--- a/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
@@ -73,7 +73,6 @@ documents or software obtained from this server.
  */
 package org.dcache.srm;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -593,7 +592,7 @@ public class SRM {
                     to_urls,
                     null, // no space reservation in v1
                     lifetime,
-                    configuration.getCopyRetryTimeout(),
+                    configuration.getCopyMaxPollPeriod(),
                     SRMProtocol.V1_1,
                     TFileStorageType.PERMANENT,
                     null,
@@ -662,7 +661,7 @@ public class SRM {
             GetRequest r =
                     new GetRequest(user, uris, protocols,
                             configuration.getGetLifetime(),
-                            configuration.getGetRetryTimeout(),
+                            configuration.getGetMaxPollPeriod(),
                             null,
                             client_host);
             schedule(r);
@@ -879,7 +878,7 @@ public class SRM {
             // create a new put request
             PutRequest r = new PutRequest(user, dests_urls, sizes,
                     wantPerm, protocols, configuration.getPutLifetime(),
-                    configuration.getPutRetryTimeout(),
+                    configuration.getPutMaxPollPeriod(),
                     clientHost,
                     null,
                     null,

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmBringOnline.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmBringOnline.java
@@ -100,7 +100,7 @@ public class SrmBringOnline
                         protocols,
                         requestTime,
                         desiredLifetimeInSeconds,
-                        configuration.getGetRetryTimeout(),
+                        configuration.getBringOnlineMaxPollPeriod(),
                         request.getUserRequestDescription(),
                         clientHost);
         try (JDC ignored = r.applyJdc()) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmCopy.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmCopy.java
@@ -115,7 +115,7 @@ public class SrmCopy implements CredentialAwareHandler
                 to_urls,
                 spaceToken,
                 lifetime,
-                configuration.getCopyRetryTimeout(),
+                configuration.getCopyMaxPollPeriod(),
                 SRMProtocol.V2_1,  // Revisit: v2.1?
                 request.getTargetFileStorageType(),
                 targetRetentionPolicy,

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmLs.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmLs.java
@@ -77,7 +77,7 @@ public class SrmLs
         LsRequest r = new LsRequest(user,
                 surls,
                 TimeUnit.HOURS.toMillis(1),
-                configuration.getLsRetryTimeout(),
+                configuration.getLsMaxPollPeriod(),
                 clientHost,
                 count,
                 offset,

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToGet.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToGet.java
@@ -106,7 +106,7 @@ public class SrmPrepareToGet
                         surls,
                         protocols,
                         lifetime,
-                        configuration.getGetRetryTimeout(),
+                        configuration.getGetMaxPollPeriod(),
                         request.getUserRequestDescription(),
                         clientHost);
         try (JDC ignored = r.applyJdc()) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToPut.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToPut.java
@@ -148,7 +148,7 @@ public class SrmPrepareToPut
                         wantPermanent,
                         protocols,
                         lifetime,
-                        configuration.getGetRetryTimeout(),
+                        configuration.getPutMaxPollPeriod(),
                         clientHost,
                         spaceToken,
                         retentionPolicy,

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmReserveSpace.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmReserveSpace.java
@@ -88,6 +88,7 @@ public class SrmReserveSpace
                     new ReserveSpaceRequest(
                             user,
                             requestLifetime,
+                            configuration.getReserveSpaceMaxPollPeriod(),
                             size.longValue(),
                             lifetime,
                             retentionPolicy,

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
@@ -130,13 +130,14 @@ public final class ReserveSpaceRequest extends Request {
     public ReserveSpaceRequest(
             SRMUser user,
             long lifetime,
+            long max_update_period,
             long sizeInBytes ,
             long spaceReservationLifetime,
             TRetentionPolicy retentionPolicy,
             TAccessLatency accessLatency,
             String description,
             String clienthost) {
-        super(user, 0, lifetime, description, clienthost);
+        super(user, max_update_period, lifetime, description, clienthost);
 
         this.sizeInBytes = sizeInBytes ;
         this.retentionPolicy = retentionPolicy;
@@ -162,6 +163,7 @@ public final class ReserveSpaceRequest extends Request {
             int numberOfRetries,
             long lastStateTransitionTime,
             JobHistory[] jobHistoryArray,
+            int retryDeltaTime,
             long sizeInBytes,
             long spaceReservationLifetime,
             String spaceToken,
@@ -182,7 +184,7 @@ public final class ReserveSpaceRequest extends Request {
                 numberOfRetries,
                 lastStateTransitionTime,
                 jobHistoryArray,//VVV
-                0,
+                retryDeltaTime,
                 false,
                 description,
                 clienthost,

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/ReserveSpaceRequestStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/ReserveSpaceRequestStorage.java
@@ -225,6 +225,7 @@ public class ReserveSpaceRequestStorage extends DatabaseRequestStorage<ReserveSp
             NUMOFRETR,
             LASTSTATETRANSITIONTIME,
             jobHistoryArray,
+            RETRYDELTATIME,
                 SIZEINBYTES,
                 RESERVATIONLIFETIME,
                 SPACETOKEN,

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -1028,6 +1028,7 @@ public class Scheduler <T extends Job>
         formatter.column2("Total requests (max " + getMaxRequests() + ")", getTotalRequests());
         formatter.format("\n");
         formatter.format("    In progress per user soft limit : %d requests\n", maxRunningByOwner);
+        formatter.format("    Maximum number of retries       : %d\n", maxNumberOfRetries);
         formatter.format("    Retry timeout                   : %d ms\n", retryTimeout);
         formatter.format("    Retry limit                     : %d retries\n", maxNumberOfRetries);
     }

--- a/modules/srm-server/src/main/java/org/dcache/srm/unixfs/Configuration.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/unixfs/Configuration.java
@@ -36,6 +36,8 @@ public class Configuration extends org.dcache.srm.util.Configuration
     private int getReadyQueueSize=1000;
     private int getMaxReadyJobs=60;
     private int getMaxRunningBySameOwner=10;
+    private int getMaxNumOfRetries = 10;
+    private long getRetryTimeout = 60000;
 
     private int lsReqTQueueSize=1000;
     private int lsThreadPoolSize=30;
@@ -43,6 +45,8 @@ public class Configuration extends org.dcache.srm.util.Configuration
     private int lsReadyQueueSize=1000;
     private int lsMaxReadyJobs=60;
     private int lsMaxRunningBySameOwner=10;
+    private int lsMaxNumOfRetries = 10;
+    private long lsRetryTimeout = 60000;
 
     private int bringOnlineReqTQueueSize=1000;
     private int bringOnlineThreadPoolSize=30;
@@ -50,6 +54,8 @@ public class Configuration extends org.dcache.srm.util.Configuration
     private int bringOnlineReadyQueueSize=1000;
     private int bringOnlineMaxReadyJobs=60;
     private int bringOnlineMaxRunningBySameOwner=10;
+    private int bringOnlineMaxNumOfRetries = 10;
+    private long bringOnlineRetryTimeout = 60000;
 
     private int putReqTQueueSize=1000;
     private int putThreadPoolSize=30;
@@ -57,11 +63,15 @@ public class Configuration extends org.dcache.srm.util.Configuration
     private int putReadyQueueSize=1000;
     private int putMaxReadyJobs=60;
     private int putMaxRunningBySameOwner=10;
+    private int putMaxNumOfRetries = 10;
+    private long putRetryTimeout = 60000;
 
     private int copyReqTQueueSize=1000;
     private int copyThreadPoolSize=30;
     private int copyMaxWaitingRequests=1000;
     private int copyMaxRunningBySameOwner=10;
+    private int copyMaxNumOfRetries = 10;
+    private long copyRetryTimeout = 60000;
 
     private int reserveSpaceReqTQueueSize=1000;
     private int reserveSpaceThreadPoolSize=30;
@@ -69,6 +79,8 @@ public class Configuration extends org.dcache.srm.util.Configuration
     private int reserveSpaceReadyQueueSize=1000;
     private int reserveSpaceMaxReadyJobs=60;
     private int reserveSpaceMaxRunningBySameOwner=10;
+    private int reserveSpaceMaxNumOfRetries = 10;
+    private long reserveSpaceRetryTimeout = 60000;
 
     public Configuration()
     {

--- a/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
@@ -149,27 +149,21 @@ public class Configuration {
 
     // scheduler parameters
 
-    protected int getMaxNumOfRetries=10;
-    protected long getRetryTimeout=60000;
+    protected long getMaxPollPeriod =60000;
     private long getSwitchToAsynchronousModeDelay = 0;
 
-    protected int lsMaxNumOfRetries=10;
-    protected long lsRetryTimeout=60000;
+    protected long lsMaxPollPeriod =60000;
     private long lsSwitchToAsynchronousModeDelay = 0;
 
-    protected long bringOnlineRetryTimeout=60000;
-    protected int bringOnlineMaxNumOfRetries=10;
+    protected long bringOnlineMaxPollPeriod =60000;
     private long bringOnlineSwitchToAsynchronousModeDelay = 0;
 
-    protected int putMaxNumOfRetries=10;
-    protected long putRetryTimeout=60000;
+    protected long putMaxPollPeriod =60000;
     private long putSwitchToAsynchronousModeDelay = 0;
 
-    protected int reserveSpaceMaxNumOfRetries=10;
-    protected long reserveSpaceRetryTimeout=60000;
+    protected long reserveSpaceMaxPollPeriod =60000;
 
-    protected int copyMaxNumOfRetries=10;
-    protected long copyRetryTimeout=60000;
+    protected long copyMaxPollPeriod =60000;
 
 
     protected long getLifetime = 24*60*60*1000;
@@ -507,37 +501,31 @@ public class Configuration {
         sb.append("\n\tuseDcapForSrmCopy=").append(this.useDcapForSrmCopy);
         sb.append("\n\tuseFtpForSrmCopy=").append(this.useFtpForSrmCopy);
         sb.append("\n\t\t *** GetRequests Parameters **");
-        sb.append("\n\t\t request Lifetime in miliseconds =").append(this.getLifetime);
-        sb.append("\n\t\t maximum number of retries = ").append(this.getMaxNumOfRetries);
-        sb.append("\n\t\t retry timeout in miliseconds =").append(this.getRetryTimeout);
+        sb.append("\n\t\t request Lifetime in milliseconds =").append(this.getLifetime);
+        sb.append("\n\t\t max poll period in milliseconds =").append(this.getMaxPollPeriod);
         sb.append("\n\t\t switch to async mode delay=").append(timeToString(this.getSwitchToAsynchronousModeDelay));
 
         sb.append("\n\t\t *** BringOnlineRequests Parameters **");
-        sb.append("\n\t\t request Lifetime in miliseconds =").append(this.bringOnlineLifetime);
-        sb.append("\n\t\t maximum number of retries = ").append(this.bringOnlineMaxNumOfRetries);
-        sb.append("\n\t\t retry timeout in miliseconds =").append(this.bringOnlineRetryTimeout);
+        sb.append("\n\t\t request Lifetime in milliseconds =").append(this.bringOnlineLifetime);
+        sb.append("\n\t\t max poll period in milliseconds =").append(this.bringOnlineMaxPollPeriod);
         sb.append("\n\t\t switch to async mode delay=").append(timeToString(this.bringOnlineSwitchToAsynchronousModeDelay));
 
         sb.append("\n\t\t *** LsRequests Parameters **");
-        sb.append("\n\t\t maximum number of retries = ").append(this.lsMaxNumOfRetries);
-        sb.append("\n\t\t retry timeout in miliseconds =").append(this.lsRetryTimeout);
+        sb.append("\n\t\t max poll period in milliseconds =").append(this.lsMaxPollPeriod);
         sb.append("\n\t\t switch to async mode delay=").append(timeToString(this.lsSwitchToAsynchronousModeDelay));
 
         sb.append("\n\t\t *** PutRequests Parameters **");
-        sb.append("\n\t\t request Lifetime in miliseconds =").append(this.putLifetime);
-        sb.append("\n\t\t maximum number of retries = ").append(this.putMaxNumOfRetries);
-        sb.append("\n\t\t retry timeout in miliseconds =").append(this.putRetryTimeout);
+        sb.append("\n\t\t request Lifetime in milliseconds =").append(this.putLifetime);
+        sb.append("\n\t\t max poll period in milliseconds =").append(this.putMaxPollPeriod);
         sb.append("\n\t\t switch to async mode delay=").append(timeToString(this.putSwitchToAsynchronousModeDelay));
 
         sb.append("\n\t\t *** ReserveSpaceRequests Parameters **");
-        sb.append("\n\t\t request Lifetime in miliseconds =").append(this.reserveSpaceLifetime);
-        sb.append("\n\t\t maximum number of retries = ").append(this.reserveSpaceMaxNumOfRetries);
-        sb.append("\n\t\t retry timeout in miliseconds =").append(this.reserveSpaceRetryTimeout);
+        sb.append("\n\t\t request Lifetime in milliseconds =").append(this.reserveSpaceLifetime);
+        sb.append("\n\t\t max poll period in milliseconds =").append(this.reserveSpaceMaxPollPeriod);
 
         sb.append("\n\t\t *** CopyRequests Parameters **");
-        sb.append("\n\t\t request Lifetime in miliseconds =").append(this.copyLifetime);
-        sb.append("\n\t\t maximum number of retries = ").append(this.copyMaxNumOfRetries);
-        sb.append("\n\t\t retry timeout in miliseconds =").append(this.copyRetryTimeout);
+        sb.append("\n\t\t request Lifetime in milliseconds =").append(this.copyLifetime);
+        sb.append("\n\t\t max poll period in milliseconds =").append(this.copyMaxPollPeriod);
 
         databaseParameters.values().forEach(sb::append);
 
@@ -760,131 +748,67 @@ public class Configuration {
     }
 
     /**
-     * Getter for property getMaxNumOfRetries.
-     * @return Value of property getMaxNumOfRetries.
+     * Getter for property getMaxPollPeriod.
+     * @return Value of property getMaxPollPeriod.
      */
-    public int getGetMaxNumOfRetries() {
-        return getMaxNumOfRetries;
+    public long getGetMaxPollPeriod() {
+        return getMaxPollPeriod;
     }
 
     /**
-     * Setter for property getMaxNumOfRetries.
-     * @param getMaxNumOfRetries New value of property getMaxNumOfRetries.
+     * Setter for property getMaxPollPeriod.
+     * @param getMaxPollPeriod New value of property getMaxPollPeriod.
      */
-    public void setGetMaxNumOfRetries(int getMaxNumOfRetries) {
-        this.getMaxNumOfRetries = getMaxNumOfRetries;
+    public void setGetMaxPollPeriod(long getMaxPollPeriod) {
+        this.getMaxPollPeriod = getMaxPollPeriod;
     }
 
     /**
-     * Getter for property getRetryTimeout.
-     * @return Value of property getRetryTimeout.
+     * Getter for property putMaxPollPeriod.
+     * @return Value of property putMaxPollPeriod.
      */
-    public long getGetRetryTimeout() {
-        return getRetryTimeout;
+    public long getPutMaxPollPeriod() {
+        return putMaxPollPeriod;
     }
 
     /**
-     * Setter for property getRetryTimeout.
-     * @param getRetryTimeout New value of property getRetryTimeout.
+     * Setter for property putMaxPollPeriod.
+     * @param putMaxPollPeriod New value of property putMaxPollPeriod.
      */
-    public void setGetRetryTimeout(long getRetryTimeout) {
-        this.getRetryTimeout = getRetryTimeout;
+    public void setPutMaxPollPeriod(long putMaxPollPeriod) {
+        this.putMaxPollPeriod = putMaxPollPeriod;
     }
 
     /**
-     * Getter for property putMaxNumOfRetries.
-     * @return Value of property putMaxNumOfRetries.
+     * Getter for property copyMaxPollPeriod.
+     * @return Value of property copyMaxPollPeriod.
      */
-    public int getPutMaxNumOfRetries() {
-        return putMaxNumOfRetries;
+    public long getCopyMaxPollPeriod() {
+        return copyMaxPollPeriod;
     }
 
     /**
-     * Setter for property putMaxNumOfRetries.
-     * @param putMaxNumOfRetries New value of property putMaxNumOfRetries.
+     * Setter for property copyMaxPollPeriod.
+     * @param copyMaxPollPeriod New value of property copyMaxPollPeriod.
      */
-    public void setPutMaxNumOfRetries(int putMaxNumOfRetries) {
-        this.putMaxNumOfRetries = putMaxNumOfRetries;
+    public void setCopyMaxPollPeriod(long copyMaxPollPeriod) {
+        this.copyMaxPollPeriod = copyMaxPollPeriod;
     }
 
     /**
-     * Getter for property putRetryTimeout.
-     * @return Value of property putRetryTimeout.
+     * Getter for property reserveSpaceMaxPollPeriod.
+     * @return Value of property reserveSpaceMaxPollPeriod.
      */
-    public long getPutRetryTimeout() {
-        return putRetryTimeout;
+    public long getReserveSpaceMaxPollPeriod() {
+        return reserveSpaceMaxPollPeriod;
     }
 
     /**
-     * Setter for property putRetryTimeout.
-     * @param putRetryTimeout New value of property putRetryTimeout.
+     * Setter for property reserveSpaceMaxPollPeriod.
+     * @param reserveSpaceMaxPollPeriod New value of property reserveSpaceMaxPollPeriod.
      */
-    public void setPutRetryTimeout(long putRetryTimeout) {
-        this.putRetryTimeout = putRetryTimeout;
-    }
-
-    /**
-     * Getter for property copyMaxNumOfRetries.
-     * @return Value of property copyMaxNumOfRetries.
-     */
-    public int getCopyMaxNumOfRetries() {
-        return copyMaxNumOfRetries;
-    }
-
-    /**
-     * Setter for property copyMaxNumOfRetries.
-     * @param copyMaxNumOfRetries New value of property copyMaxNumOfRetries.
-     */
-    public void setCopyMaxNumOfRetries(int copyMaxNumOfRetries) {
-        this.copyMaxNumOfRetries = copyMaxNumOfRetries;
-    }
-
-    /**
-     * Getter for property copyRetryTimeout.
-     * @return Value of property copyRetryTimeout.
-     */
-    public long getCopyRetryTimeout() {
-        return copyRetryTimeout;
-    }
-
-    /**
-     * Setter for property copyRetryTimeout.
-     * @param copyRetryTimeout New value of property copyRetryTimeout.
-     */
-    public void setCopyRetryTimeout(long copyRetryTimeout) {
-        this.copyRetryTimeout = copyRetryTimeout;
-    }
-
-    /**
-     * Getter for property reserveSpaceMaxNumOfRetries.
-     * @return Value of property reserveSpaceMaxNumOfRetries.
-     */
-    public int getReserveSpaceMaxNumOfRetries() {
-        return reserveSpaceMaxNumOfRetries;
-    }
-
-    /**
-     * Setter for property reserveSpaceMaxNumOfRetries.
-     * @param reserveSpaceMaxNumOfRetries New value of property reserveSpaceMaxNumOfRetries.
-     */
-    public void setReserveSpaceMaxNumOfRetries(int reserveSpaceMaxNumOfRetries) {
-        this.reserveSpaceMaxNumOfRetries = reserveSpaceMaxNumOfRetries;
-    }
-
-    /**
-     * Getter for property reserveSpaceRetryTimeout.
-     * @return Value of property reserveSpaceRetryTimeout.
-     */
-    public long getReserveSpaceRetryTimeout() {
-        return reserveSpaceRetryTimeout;
-    }
-
-    /**
-     * Setter for property reserveSpaceRetryTimeout.
-     * @param reserveSpaceRetryTimeout New value of property reserveSpaceRetryTimeout.
-     */
-    public void setReserveSpaceRetryTimeout(long reserveSpaceRetryTimeout) {
-        this.reserveSpaceRetryTimeout = reserveSpaceRetryTimeout;
+    public void setReserveSpaceMaxPollPeriod(long reserveSpaceMaxPollPeriod) {
+        this.reserveSpaceMaxPollPeriod = reserveSpaceMaxPollPeriod;
     }
 
     /**
@@ -1070,20 +994,12 @@ public class Configuration {
         this.srmUserPersistenceManager = srmUserPersistenceManager;
     }
 
-    public int getBringOnlineMaxNumOfRetries() {
-        return bringOnlineMaxNumOfRetries;
+    public long getBringOnlineMaxPollPeriod() {
+        return bringOnlineMaxPollPeriod;
     }
 
-    public void setBringOnlineMaxNumOfRetries(int bringOnlineMaxNumOfRetries) {
-        this.bringOnlineMaxNumOfRetries = bringOnlineMaxNumOfRetries;
-    }
-
-    public long getBringOnlineRetryTimeout() {
-        return bringOnlineRetryTimeout;
-    }
-
-    public void setBringOnlineRetryTimeout(long bringOnlineRetryTimeout) {
-        this.bringOnlineRetryTimeout = bringOnlineRetryTimeout;
+    public void setBringOnlineMaxPollPeriod(long bringOnlineMaxPollPeriod) {
+        this.bringOnlineMaxPollPeriod = bringOnlineMaxPollPeriod;
     }
 
     public long getBringOnlineLifetime() {
@@ -1102,20 +1018,12 @@ public class Configuration {
         this.bringOnlinePriorityPolicyPlugin = bringOnlinePriorityPolicyPlugin;
     }
 
-    public int getLsMaxNumOfRetries() {
-        return lsMaxNumOfRetries;
+    public long getLsMaxPollPeriod() {
+        return lsMaxPollPeriod;
     }
 
-    public void setLsMaxNumOfRetries(int lsMaxNumOfRetries) {
-        this.lsMaxNumOfRetries = lsMaxNumOfRetries;
-    }
-
-    public long getLsRetryTimeout() {
-        return lsRetryTimeout;
-    }
-
-    public void setLsRetryTimeout(long lsRetryTimeout) {
-        this.lsRetryTimeout = lsRetryTimeout;
+    public void setLsMaxPollPeriod(long lsMaxPollPeriod) {
+        this.lsMaxPollPeriod = lsMaxPollPeriod;
     }
 
     public String getLsPriorityPolicyPlugin() {

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -561,6 +561,41 @@ srm.request.ls.switch-to-async-mode-delay = ${srm.request.switch-to-async-mode-d
 	${srm.request.switch-to-async-mode-delay.unit})\
 srm.request.ls.switch-to-async-mode-delay.unit=${srm.request.switch-to-async-mode-delay.unit}
 
+# ---- Maximum advertised poll period for asynchronous requests
+#
+# Once a schedulable SRM request switches to asynchronous processing (see srm.request.switch-to-async-mode-delay),
+# the SRM servers advertises a polling period to the client. The server gradually increases the period every
+# time the client polls for the result. This setting places an upper bound on this poll period.
+#
+# An SRM client is free to ignore the advertised poll period.
+#
+srm.request.max-poll-period = 60
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
+srm.request.max-poll-period.unit = SECONDS
+
+srm.request.get.max-poll-period = ${srm.request.max-poll-period}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${srm.request.max-poll-period.unit})\
+srm.request.get.max-poll-period.unit = ${srm.request.max-poll-period.unit}
+
+srm.request.put.max-poll-period = ${srm.request.max-poll-period}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${srm.request.max-poll-period.unit})\
+srm.request.put.max-poll-period.unit = ${srm.request.max-poll-period.unit}
+
+srm.request.bring-online.max-poll-period = ${srm.request.max-poll-period}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${srm.request.max-poll-period.unit})\
+srm.request.bring-online.max-poll-period.unit = ${srm.request.max-poll-period.unit}
+
+srm.request.ls.max-poll-period = ${srm.request.max-poll-period}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${srm.request.max-poll-period.unit})\
+srm.request.ls.max-poll-period.unit = ${srm.request.max-poll-period.unit}
+
+srm.request.reserve-space.max-poll-period = ${srm.request.max-poll-period}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${srm.request.max-poll-period.unit})\
+srm.request.reserve-space.max-poll-period.unit = ${srm.request.max-poll-period.unit}
+
+srm.request.copy.max-poll-period = ${srm.request.max-poll-period}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${srm.request.max-poll-period.unit})\
+srm.request.copy.max-poll-period.unit = ${srm.request.max-poll-period.unit}
 
 # ---- Persistence of requests
 #

--- a/skel/share/services/srm.batch
+++ b/skel/share/services/srm.batch
@@ -74,6 +74,8 @@ check -strong srm.request.bring-online.retry-timeout.unit
 check -strong srm.request.bring-online.max-by-same-user
 check -strong srm.request.bring-online.switch-to-async-mode-delay
 check -strong srm.request.bring-online.switch-to-async-mode-delay.unit
+check -strong srm.request.bring-online.max-poll-period
+check -strong srm.request.bring-online.max-poll-period.unit
 check -strong srm.persistence.bring-online.enable
 check -strong srm.persistence.bring-online.enable.clean-pending-on-restart
 check -strong srm.persistence.bring-online.enable.store-transient-state
@@ -92,6 +94,8 @@ check -strong srm.request.copy.retries
 check -strong srm.request.copy.retry-timeout
 check -strong srm.request.copy.retry-timeout.unit
 check -strong srm.request.copy.max-by-same-user
+check -strong srm.request.copy.max-poll-period
+check -strong srm.request.copy.max-poll-period.unit
 check -strong srm.persistence.copy.enable
 check -strong srm.persistence.copy.enable.clean-pending-on-restart
 check -strong srm.persistence.copy.enable.store-transient-state
@@ -113,6 +117,8 @@ check -strong srm.request.get.retry-timeout.unit
 check -strong srm.request.get.max-by-same-user
 check -strong srm.request.get.switch-to-async-mode-delay
 check -strong srm.request.get.switch-to-async-mode-delay.unit
+check -strong srm.request.get.max-poll-period
+check -strong srm.request.get.max-poll-period.unit
 check -strong srm.persistence.get.enable
 check -strong srm.persistence.get.enable.clean-pending-on-restart
 check -strong srm.persistence.get.enable.store-transient-state
@@ -133,6 +139,8 @@ check -strong srm.request.ls.retry-timeout.unit
 check -strong srm.request.ls.max-by-same-user
 check -strong srm.request.ls.switch-to-async-mode-delay
 check -strong srm.request.ls.switch-to-async-mode-delay.unit
+check -strong srm.request.ls.max-poll-period
+check -strong srm.request.ls.max-poll-period.unit
 check -strong srm.persistence.ls.enable
 check -strong srm.persistence.ls.enable.clean-pending-on-restart
 check -strong srm.persistence.ls.enable.store-transient-state
@@ -154,6 +162,8 @@ check -strong srm.request.put.retry-timeout.unit
 check -strong srm.request.put.max-by-same-user
 check -strong srm.request.put.switch-to-async-mode-delay
 check -strong srm.request.put.switch-to-async-mode-delay.unit
+check -strong srm.request.put.max-poll-period
+check -strong srm.request.put.max-poll-period.unit
 check -strong srm.persistence.put.enable
 check -strong srm.persistence.put.enable.clean-pending-on-restart
 check -strong srm.persistence.put.enable.store-transient-state
@@ -172,6 +182,8 @@ check -strong srm.request.reserve-space.retries
 check -strong srm.request.reserve-space.retry-timeout
 check -strong srm.request.reserve-space.retry-timeout.unit
 check -strong srm.request.reserve-space.max-by-same-user
+check -strong srm.request.reserve-space.max-poll-period
+check -strong srm.request.reserve-space.max-poll-period.unit
 check -strong srm.persistence.reserve-space.enable
 check -strong srm.persistence.reserve-space.enable.clean-pending-on-restart
 check -strong srm.persistence.reserve-space.enable.store-transient-state


### PR DESCRIPTION
The SRM overloaded the meaning of the retry period property to be used
for both the documented retry period on internal failure and the undocumented
maximum client poll period.

This patch introduces a maximum polling period property to detangle these
two unrelated concepts. The patch also refactors a few related properties that
no longer belong in the Configuration class.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7978/
(cherry picked from commit 695c433eedd93363b079eba21b8bce9b50cd4c70)