### PR TITLE
srm: Use more sensible default values

### DIFF
--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -178,7 +178,7 @@ srm.limits.jetty-connector.low-resource.max.idle-time.unit=MILLISECONDS
 
 # ---- TCP backlog for SRM connections
 (forbidden)srmJettyConnectorBackLog = Use srm.limits.jetty-connector.backlog
-srm.limits.jetty-connector.backlog = 1024
+srm.limits.jetty-connector.backlog = 2048
 
 # ---- Maximum number of threads used for SRM request processing
 #
@@ -207,7 +207,7 @@ srm.limits.jetty.threads.max = 500
 srm.limits.jetty.threads.min = 10
 
 
-# ---- Milliseconds before an idle requst processing thread is terminated
+# ---- Milliseconds before an idle request processing thread is terminated
 (forbidden)srmJettyThreadsMaxIdleTime = Use srm.limits.jetty.idle-time.max
 srm.limits.jetty.threads.idle-time.max = 30000
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
@@ -318,7 +318,7 @@ srm.limits.jetty.threads.queued.max = 500
 # Another difference is that for bulk requests, the webserver thread is bound
 # to the entire request, while the scheduler threads process individual SURLs.
 #
-srm.request.threads = 250
+srm.request.threads = 12
 
 (forbidden)srmGetReqThreadPoolSize = Use srm.request.get.threads
 srm.request.get.threads = ${srm.request.threads}
@@ -333,7 +333,7 @@ srm.request.put.threads = ${srm.request.threads}
 srm.request.copy.threads = ${srm.request.copy.max-inprogress}
 
 (forbidden)srmLsRequestThreadPoolSize = Use srm.request.ls.threads
-srm.request.ls.threads = ${srm.request.threads}
+srm.request.ls.threads = ${srm.request.ls.max-inprogress}
 
 (forbidden)srmReserveReqThreadPoolSize = Use srm.request.reserve-space.threads
 srm.request.reserve-space.threads = ${srm.request.threads}
@@ -348,7 +348,7 @@ srm.request.reserve-space.threads = ${srm.request.threads}
 # requests in one of the following states: SRM_REQUEST_QUEUED,
 # SRM_REQUEST_INPROGRESS, SRM_FILE_PINNED and SRM_SPACE_AVAILABLE.
 #
-srm.request.max-requests = 10000
+srm.request.max-requests = 50000
 srm.request.get.max-requests = ${srm.request.max-requests}
 srm.request.bring-online.max-requests = ${srm.request.max-requests}
 srm.request.put.max-requests = ${srm.request.max-requests}
@@ -401,7 +401,7 @@ srm.request.reserve-space.max-inprogress = 10
 # the settings of the transfermanagers service.
 #
 (forbidden)srm.request.max-ready-requests = Use srm.request.max-transfers
-srm.request.max-transfers=2000
+srm.request.max-transfers=50000
 
 (forbidden)srmGetReqMaxReadyRequests = Use srm.request.get.max-transfers
 (forbidden)srm.request.get.max-ready-requests = Use srm.request.get.max-transfers
@@ -672,7 +672,7 @@ srm.persistence.reserve-space.keep-history-period.unit=${srm.persistence.keep-hi
 # --- How frequently to remove old requests from the database.
 #
 (forbidden)srmExpiredRequestRemovalPeriod = Use srm.persistence.remove-expired-period
-srm.persistence.remove-expired-period = 60
+srm.persistence.remove-expired-period = 600
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
 srm.persistence.remove-expired-period.unit=SECONDS
 
@@ -831,7 +831,7 @@ srm.persistence.reserve-space.enable.store-transient-state = ${srm.persistence.e
 # streamed. Once heap limit is reached, the SRM will auto-restart.
 #
 (forbidden)srmLsMaxNumberOfEntries = Use srm.limits.ls.entries
-srm.limits.ls.entries = 1000
+srm.limits.ls.entries = 10000
 
 # ---- List recursion depth
 #
@@ -899,7 +899,7 @@ srm.service.pnfsmanager=${dcache.service.pnfsmanager}
 
 # Timeout for pnfsmanager requests
 (forbidden)srmPnfsTimeout = Use srm.service.pnfsmanager.timeout
-srm.service.pnfsmanager.timeout = 300
+srm.service.pnfsmanager.timeout = 120
 (one-of?MILLISECONDS|\
 	SECONDS|\
 	MINUTES|\
@@ -935,7 +935,7 @@ srm.service.gplazma.cache.timeout.unit=SECONDS
 srm.service.spacemanager=${dcache.service.spacemanager}
 
 # Timeout for spacemanager requests
-srm.service.spacemanager.timeout=180
+srm.service.spacemanager.timeout=30
 (one-of?MILLISECONDS|\
 	SECONDS|\
 	MINUTES|\
@@ -1180,14 +1180,14 @@ srm.limits.jetty.graceful-shutdown.unit=MILLISECONDS
 # Comma separated list of protocols that will not be used even if both
 # client and server support it.
 #
-srm.protocols.disallowed.get = ${srm.service.loginbroker.family}
+srm.protocols.disallowed.get = file,${srm.service.loginbroker.family}
 
 # ----- Disallowed protocols for put requests
 #
 # Comma separated list of protocols that will not be used even if both
 # client and server support it.
 #
-srm.protocols.disallowed.put = http,${srm.service.loginbroker.family}
+srm.protocols.disallowed.put = http,file,${srm.service.loginbroker.family}
 
 # ----- Preferred transfer protocols
 #
@@ -1220,7 +1220,7 @@ srm.protocols.loginbroker.period.unit=MILLISECONDS
 
 # ---- Login broker lookup timeout after which a request is retried (seconds)
 (forbidden)srm.lookup.timeout = Use srm.protocols.loginbroker.timeout
-srm.protocols.loginbroker.timeout = 300
+srm.protocols.loginbroker.timeout = 20
 (one-of?MILLISECONDS|\
 	SECONDS|\
 	MINUTES|\


### PR DESCRIPTION
Based on recent reports, it is clear that too many sites rely on
defaults that are not sensible for most of our customers. This
patch adjusts those defaults.

-srm.limits.jetty-connector.backlog = 1024
+srm.limits.jetty-connector.backlog = 2048

To avoid rejected connections upon request bursts (particular
relevant for VOs that use SRM from worker nodes). An even higher
backlog may be relevant, but 2048 appears to be the default limit
in the Linux kernel.

It is generally better to have a connection queue in the backlog
that in Jetty: If the client decides to disconnect, we haven't
spent resources on authentication nor have we created any SRM
request on behalf of the client.

-srm.request.threads = 250
+srm.request.threads = 12

With the exception of copy and ls (for which this setting does not
apply), request processing is asynchronous. There is no need for 250
threads for that.

-srm.request.ls.threads = ${srm.request.threads}
+srm.request.ls.threads = ${srm.request.ls.max-in-progress}

Make the default match the documentation (ls is processed
in a blocking fashion, so we need a thread for each in progress
request).

-srm.request.max-requests = 10000
+srm.request.max-requests = 50000

It would be nice if we could control the load on dCache by stearing
the number of TURLs, but most users check out TURLs ahead of time
or forget to release the TURLs. Thus the number of requests allowed
has to be much higher than the expected number of concurrent transfers.
We should probably have per request type defaults, but I don't want
to change that in a stable release.

This also brings the max requests in line with the max transfers
below. Thus by default we do not withhold any TURLs (although we
still limit the total number of requests - beyond that the client
will receive an error).

-srm.request.max-transfers=2000
+srm.request.max-transfers=50000

Same argument as above.

-srm.persistence.remove-expired-period = 60
+srm.persistence.remove-expired-period = 600

We keep requests for 10 days by default. There is no reason to stress
the database with delete requests every 60 seconds.

-srm.limits.ls.entries = 1000
+srm.limits.ls.entries = 10000

The point of having a limit is to avoid building too large SOAP
replies in memory. It should not be a problem to build a reply
with 10000 entries on modern systems.

-srm.service.pnfsmanager.timeout = 300
+srm.service.pnfsmanager.timeout = 120

Too large timeouts mean that the SRM will take longer to recover from errors
and will appear unresponsive when it is actually another component that is
to blame. I chose 2 minutes as many clients time out after about that much
time. A pnfs manager that has not responded withing 2 minutes is likely in
trouble.

-srm.service.spacemanager.timeout=180
+srm.service.spacemanager.timeout=30

Same argument, but space manage queries are simpler than name space queries
and a timeout is less critical. If space manager didn't respond within 30
seconds, then there is something wrong with it.

-srm.protocols.disallowed.get = ${srm.service.loginbroker.family}
+srm.protocols.disallowed.get = file,${srm.service.loginbroker.family}

Using SRM to negotiate NFS transfers is a perfectly valid use case. However
it requires more than just starting an NFS door: The name space needs to
be carefully mounted on the client nodes, aligning the path with Chimera.
It is far more common that sites accidentally expose file when starting
an NFS door and shooting themselves in the foot than sites actually wanting
to use file with SRM. Thus we block file by default and require the admin
to manually allow it (making it a deliberate choice).OB

-srm.protocols.disallowed.put = http,${srm.service.loginbroker.family}
+srm.protocols.disallowed.put = http,file,${srm.service.loginbroker.family}

Same argument.

 # ---- Login broker lookup timeout after which a request is retried (seconds)
 (forbidden)srm.lookup.timeout = Use srm.protocols.loginbroker.timeout
-srm.protocols.loginbroker.timeout = 300
+srm.protocols.loginbroker.timeout = 20

Similar to above. If loginbroker fails to respond within 20 seconds, something
is wrong.

Since we observe problems at sites with our current defaults, I request this
to be backported to stable branches.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7979/
(cherry picked from commit da69ddab82d03fd2cc7a22f93610f5267db9279c)