### PR TITLE
srm: Increase default database queue

### DIFF
--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -1160,7 +1160,7 @@ srm.limits.db.threads=${srmJdbcExecutionThreadNum}
 # the execution of SRM requests. The setting controls the maximum
 # length of the queue.
 #
-(deprecated)srmMaxNumberOfJdbcTasksInQueue=1000
+(deprecated)srmMaxNumberOfJdbcTasksInQueue=10000
 srm.limits.db.queue=${srmMaxNumberOfJdbcTasksInQueue}
 
 # ---- srmClientDNSLookup


### PR DESCRIPTION
When receiving bulk requests, such as bulk stage requests, we temporarily
insert a large number of database updates in the queue. Thus the queue limit
should be large enough to encompass these bulk requests to avoid overflow.

This patch increases the default to 10000 as 1000 is usually too low for
our sites.

This patch is only for 2.10 as 2.11 introduced a throttling mechanism.

Target: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7980/