### PR TITLE
cleaner: Fix class cast exception

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
@@ -50,6 +50,7 @@ import org.dcache.services.hsmcleaner.RequestTracker;
 import org.dcache.services.hsmcleaner.Sink;
 import org.dcache.util.Args;
 import org.dcache.util.BroadcastRegistrationTask;
+import org.dcache.util.CacheExceptionFactory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -476,12 +477,14 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
                                                 new PoolRemoveFilesMessage(poolName, removeList)));
             if (msg.getReturnCode() == 0) {
                 removeFiles(poolName, removeList);
-            } else {
+            } else if (msg.getReturnCode() == 1 && msg.getErrorObject() instanceof String[]) {
                 Set<String> notRemoved =
                         new HashSet<>(Arrays.asList((String[]) msg.getErrorObject()));
                 List<String> removed = new ArrayList<>(removeList);
                 removed.removeAll(notRemoved);
                 removeFiles(poolName, removed);
+            } else {
+                throw CacheExceptionFactory.exceptionOf(msg);
             }
         } catch (CacheException e) {
             _log.warn("Failed to remove files from {}: {}", poolName, e.getMessage());


### PR DESCRIPTION
Fixes the following bug:

19 Mar 2015 10:16:57 (cleaner) [] Bug detected
java.lang.ClassCastException: java.lang.String cannot be cast to [Ljava.lang.String;
        at org.dcache.chimera.namespace.ChimeraCleaner.sendRemoveToPoolCleaner(ChimeraCleaner.java:482) ~[dcache-chimera-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.chimera.namespace.ChimeraCleaner.access$100(ChimeraCleaner.java:64) ~[dcache-chimera-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.chimera.namespace.ChimeraCleaner$5.processRow(ChimeraCleaner.java:535) ~[dcache-chimera-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.springframework.jdbc.core.JdbcTemplate$RowCallbackHandlerResultSetExtractor.extractData(JdbcTemplate.java:1607) ~[spring-jdbc-4.1.5.RELEASE.jar:4.1.5.RELEASE
]
        at org.springframework.jdbc.core.JdbcTemplate$1.doInPreparedStatement(JdbcTemplate.java:708) ~[spring-jdbc-4.1.5.RELEASE.jar:4.1.5.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:644) ~[spring-jdbc-4.1.5.RELEASE.jar:4.1.5.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:695) ~[spring-jdbc-4.1.5.RELEASE.jar:4.1.5.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:727) ~[spring-jdbc-4.1.5.RELEASE.jar:4.1.5.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:752) ~[spring-jdbc-4.1.5.RELEASE.jar:4.1.5.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:762) ~[spring-jdbc-4.1.5.RELEASE.jar:4.1.5.RELEASE]
        at org.dcache.chimera.namespace.ChimeraCleaner.cleanPoolComplete(ChimeraCleaner.java:522) ~[dcache-chimera-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.chimera.namespace.ChimeraCleaner.runDelete(ChimeraCleaner.java:454) ~[dcache-chimera-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.chimera.namespace.ChimeraCleaner.run(ChimeraCleaner.java:357) ~[dcache-chimera-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_31]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_31]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_31]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_31]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_31]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_31]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_31]

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Albert Rossi <arossi@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7988/
(cherry picked from commit 1c2beb7c3e2e3de48a73893ca86a171e19e48d76)