### PR TITLE
loginbroker: Restore compatibility with pcells

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerInfo.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerInfo.java
@@ -40,6 +40,8 @@ public class LoginBrokerInfo implements Serializable
     private final String _protocolEngine;
     private final String _root;
     private final List<InetAddress> _addresses;
+    @Deprecated
+    private final String[] _hosts; // Kept for compatibility with pcells
     private final int _port;
     private final double _load;
     private final long _update;
@@ -65,6 +67,10 @@ public class LoginBrokerInfo implements Serializable
         _port = port;
         _load = load;
         _update = updateTime;
+        _hosts = new String[addresses.size()];
+        for (int i = 0; i < addresses.size(); i++) {
+            _hosts[i] = addresses.get(i).getHostAddress();
+        }
         checkArgument(!addresses.isEmpty());
     }
 


### PR DESCRIPTION
Target: trunk
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8001/
(cherry picked from commit 80ddd564ccb239f9fcd629e689c9e04983a20d71)