### PR TITLE
admin: Restore timeout semantics for pcells compatibility

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/PcellsCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/PcellsCommand.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import diskCacheV111.admin.UserAdminShell;
+import diskCacheV111.util.TimeoutCacheException;
 
 import dmg.cells.applets.login.DomainObjectFrame;
 import dmg.cells.nucleus.CellEndpoint;
@@ -114,6 +115,8 @@ public class PcellsCommand implements Command, Runnable
                                 in.close();
                             } catch (IOException ignored) {
                             }
+                        } catch (TimeoutCacheException e) {
+                            result = null;
                         } catch (Exception ae) {
                             result = ae;
                         }


### PR DESCRIPTION
pcells relies on the classic cells behaviour of returning null
if a request timed out. This patch restores the classic behaviour.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8002/
(cherry picked from commit 6db9956a9e89e4b96524dcd4c435c34b28c0d384)
(cherry picked from commit 344cde7fb16702cbd3c6dba12aa5f8c398ede1f3)