### PR TITLE
Revert "pool: Make EntryState#DESTROYED deprecated"

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -1264,6 +1264,7 @@ public class PoolV4
 
             case NEW:
             case REMOVED:
+            case DESTROYED:
                 msg.setFailed(101, "File does not exist: " + pnfsId);
                 break;
             }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
@@ -164,6 +164,7 @@ public class SpaceSweeper2
         CacheEntry entry = event.getNewEntry();
         switch (event.getNewState()) {
         case REMOVED:
+        case DESTROYED:
             remove(entry);
             break;
 

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
@@ -156,12 +156,14 @@ public class ConsistentStore
 
             try {
                 /* It is safe to remove FROM_STORE files: We have a
-                 * copy on HSM anyway. Files in REMOVED where about
-                 * to be deleted, so we can finish the job.
+                 * copy on HSM anyway. Files in REMOVED or DESTROYED
+                 * where about to be deleted, so we can finish the
+                 * job.
                  */
                 switch (entry.getState()) {
                 case FROM_STORE:
                 case REMOVED:
+                case DESTROYED:
                     delete(id, file);
                     _log.info(String.format(PARTIAL_FROM_TAPE_MSG, id));
                     return null;

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/EntryState.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/EntryState.java
@@ -10,6 +10,5 @@ public enum EntryState
     CACHED,
     PRECIOUS,
     REMOVED,
-    @Deprecated
-    DESTROYED    // Kept for backwards compatibility with pre-2.12 - drop after next golden + 1
+    DESTROYED;
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
@@ -123,7 +123,7 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
     public synchronized void incrementLinkCount()
     {
         EntryState state = getState();
-        if (state == EntryState.REMOVED) {
+        if (state == EntryState.REMOVED || state == EntryState.DESTROYED) {
             throw new IllegalStateException("Entry is marked as removed");
         }
         _linkCount++;

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v3/entry/CacheRepositoryEntryState.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v3/entry/CacheRepositoryEntryState.java
@@ -108,24 +108,32 @@ public class CacheRepositoryEntryState
             }
             break;
         case CACHED:
-            if (_state == EntryState.REMOVED) {
+            if (_state == EntryState.REMOVED ||
+                _state == EntryState.DESTROYED) {
                 throw new IllegalStateException("Entry is " + _state);
             }
             break;
         case PRECIOUS:
-            if (_state == EntryState.REMOVED) {
+            if (_state == EntryState.REMOVED ||
+                _state == EntryState.DESTROYED) {
                 throw new IllegalStateException("Entry is " + _state);
             }
             break;
         case BROKEN:
-            if (_state == EntryState.REMOVED) {
+            if (_state == EntryState.REMOVED ||
+                _state == EntryState.DESTROYED) {
                 throw new IllegalStateException("Entry is " + _state);
             }
             break;
         case REMOVED:
+            if (_state == EntryState.DESTROYED) {
+                throw new IllegalStateException("Entry is " + _state);
+            }
             break;
-        default:
-            throw new IllegalArgumentException("Invalid state " + state);
+        case DESTROYED:
+            if (_state != EntryState.REMOVED) {
+                throw new IllegalStateException("Entry is " + _state);
+            }
         }
 
         _state = state;
@@ -146,7 +154,7 @@ public class CacheRepositoryEntryState
     public boolean setSticky(String owner, long expire, boolean overwrite)
         throws IllegalStateException, IOException
     {
-        if (_state == EntryState.REMOVED) {
+        if (_state == EntryState.REMOVED || _state == EntryState.DESTROYED) {
             throw new IllegalStateException("Entry in removed state");
         }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheEntryImpl.java
@@ -3,6 +3,7 @@ package org.dcache.pool.repository.v5;
 import java.util.Collection;
 
 import diskCacheV111.util.PnfsId;
+import diskCacheV111.vehicles.StorageInfo;
 
 import org.dcache.namespace.FileAttribute;
 import org.dcache.pool.repository.CacheEntry;
@@ -129,7 +130,7 @@ public class CacheEntryImpl implements CacheEntry
         sb.append("-");
         sb.append("-");
         sb.append((_state == EntryState.REMOVED)     ? "R" : "-");
-        sb.append("-");
+        sb.append((_state == EntryState.DESTROYED)   ? "D" : "-");
         sb.append(isSticky()                         ? "X" : "-");
         sb.append((_state == EntryState.BROKEN)      ? "E" : "-");
         sb.append("-");

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -503,6 +503,7 @@ public class CacheRepositoryV5
                 case BROKEN:
                     throw new LockedCacheException("File is broken");
                 case REMOVED:
+                case DESTROYED:
                     throw new LockedCacheException("File has been removed");
                 case PRECIOUS:
                 case CACHED:
@@ -609,6 +610,7 @@ public class CacheRepositoryV5
                 case FROM_POOL:
                     throw new FileNotInCacheException("File is incomplete");
                 case REMOVED:
+                case DESTROYED:
                     throw new FileNotInCacheException("File has been removed");
                 case BROKEN:
                 case PRECIOUS:
@@ -653,6 +655,7 @@ public class CacheRepositoryV5
                 switch (source) {
                 case NEW:
                 case REMOVED:
+                case DESTROYED:
                     if (state == EntryState.REMOVED) {
                         /* File doesn't exist or is already
                          * deleted. That's all we care about.
@@ -976,6 +979,9 @@ public class CacheRepositoryV5
             EntryState state = entry.getState();
             PnfsId id = entry.getPnfsId();
             if (entry.getLinkCount() == 0 && state == EntryState.REMOVED) {
+                /* Setting the entry to DESTROYED ensures that we only deallocate it once.
+                 */
+                setState(entry, DESTROYED);
                 _store.remove(id);
 
                 /* It is essential to free after we removed the file: This is the opposite

--- a/modules/dcache/src/test/java/org/dcache/tests/repository/RepositorySubsystemTest.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/repository/RepositorySubsystemTest.java
@@ -543,6 +543,18 @@ public class RepositorySubsystemTest
         repository.setState(id1, NEW);
     }
 
+    @Test(expected=IllegalTransitionException.class)
+    public void testSetStateToDestroyed()
+            throws IOException, IllegalTransitionException,
+            CacheException, InterruptedException
+    {
+        repository.init();
+        repository.load();
+        stateChangeEvents.clear();
+
+        repository.setState(id1, DESTROYED);
+    }
+
     @Test(expected=IllegalStateException.class)
     public void testClosedReadHandleClose()
         throws IOException, CacheException, InterruptedException
@@ -634,6 +646,7 @@ public class RepositorySubsystemTest
             {
                 repository.setState(id1, REMOVED);
                 expectStateChangeEvent(id1, PRECIOUS, REMOVED);
+                expectStateChangeEvent(id1, REMOVED, DESTROYED);
                 assertStep("Cache location cleared", 1);
                 assertEquals(repository.getState(id1), NEW);
             }
@@ -668,7 +681,7 @@ public class RepositorySubsystemTest
                 assertNoStateChangeEvent();
                 assertStep("Cache location cleared", 1);
                 handle1.close();
-                assertEquals(repository.getState(id1), NEW);
+                expectStateChangeEvent(id1, REMOVED, DESTROYED);
             }
         };
     }


### PR DESCRIPTION
This reverts commit 980b20cae878d88720c420c0dee39df66c76276b.

The reverted patch introduced an accounting error most easily triggered
when deleting a file while it is being uploaded. In that case the space
allocated for the file is released twice.

Target: trunk
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8003/
(cherry picked from commit eb41f79443eecc6a9511737d7c8be7a1f13511e3)