### PR TITLE
admin: Restore pcells compatibility

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/services/space/Space.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/services/space/Space.java
@@ -113,10 +113,9 @@ public class Space implements Serializable {
         sb.append("accessLatency:").append(accessLatency.toString()).append(' ');
         sb.append("linkGroupId:").append(linkGroupId).append(' ');
         sb.append("size:").append(sizeInBytes).append(' ');
-        sb.append("created:").append((new Date(creationTime))).append(' ');
-        if (expirationTime != null) {
-            sb.append("expiration:").append(new Date(expirationTime).toString()).append(' ');
-        }
+        sb.append("created:").append(new Date(creationTime)).append(' ');
+        sb.append("lifetime:").append(expirationTime == null ? -1 : expirationTime - creationTime).append("ms ");
+        sb.append("expiration:").append(expirationTime == null ? "NEVER" : new Date(expirationTime)).append(' ');
         sb.append("description:").append(description).append(' ');
         sb.append("state:").append(state).append(' ');
         sb.append("used:").append(usedSizeInBytes).append(' ');

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/PcellsCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/PcellsCommand.java
@@ -11,15 +11,24 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import diskCacheV111.admin.UserAdminShell;
+import diskCacheV111.services.space.LinkGroup;
+import diskCacheV111.services.space.Space;
+import diskCacheV111.services.space.message.GetLinkGroupsMessage;
+import diskCacheV111.services.space.message.GetSpaceTokensMessage;
+import diskCacheV111.util.CacheException;
 import diskCacheV111.util.TimeoutCacheException;
 
 import dmg.cells.applets.login.DomainObjectFrame;
 import dmg.cells.nucleus.CellEndpoint;
+import dmg.cells.nucleus.CellPath;
 import dmg.util.CommandException;
+
+import org.dcache.cells.CellStub;
 
 public class PcellsCommand implements Command, Runnable
 {
@@ -27,6 +36,7 @@ public class PcellsCommand implements Command, Runnable
             LoggerFactory.getLogger(PcellsCommand.class);
 
     private final CellEndpoint _endpoint;
+    private final CellStub _stub;
     private UserAdminShell _userAdminShell;
     private InputStream _in;
     private ExitCallback _exitCallback;
@@ -38,6 +48,7 @@ public class PcellsCommand implements Command, Runnable
     public PcellsCommand(CellEndpoint endpoint)
     {
         _endpoint = endpoint;
+        _stub = new CellStub(_endpoint);
     }
 
     @Override
@@ -106,7 +117,19 @@ public class PcellsCommand implements Command, Runnable
                             if (frame.getDestination() == null) {
                                 result = _userAdminShell.executeCommand(frame.getPayload().toString());
                             } else {
-                                result = _userAdminShell.executeCommand(frame.getDestination(), frame.getPayload());
+                                switch (frame.getDestination()) {
+                                case "SrmSpaceManager":
+                                    if (frame.getPayload().equals("ls -l")) {
+                                        result = listSpaceReservations();
+                                    } else {
+                                        result = _userAdminShell.executeCommand("SrmSpaceManager", frame.getPayload());
+                                    }
+                                    break;
+
+                                default:
+                                    result = _userAdminShell.executeCommand(frame.getDestination(), frame.getPayload());
+                                    break;
+                                }
                             }
                         } catch (CommandException e) {
                             result = e;
@@ -140,5 +163,37 @@ public class PcellsCommand implements Command, Runnable
         } finally {
             _exitCallback.onExit(0);
         }
+    }
+
+    private String listSpaceReservations() throws CacheException, InterruptedException
+    {
+        /* Query information from space manager. */
+        CellPath spaceManager = new CellPath("SrmSpaceManager");
+        Collection<Space> spaces = _stub.sendAndWait(spaceManager, new GetSpaceTokensMessage()).getSpaceTokenSet();
+        Collection<LinkGroup> groups = _stub.sendAndWait(spaceManager, new GetLinkGroupsMessage()).getLinkGroups();
+
+        /* Build pcells compatible list. */
+        StringBuilder out = new StringBuilder();
+
+        out.append("Reservations:\n");
+        for (Space space : spaces) {
+            out.append(space).append('\n');
+        }
+        out.append("total number of reservations: ").append(spaces.size()).append('\n');
+        out.append("total number of bytes reserved: ")
+                .append(spaces.stream().mapToLong(Space::getSizeInBytes).sum()).append('\n');
+
+        out.append("\nLinkGroups:\n");
+        for (LinkGroup group : groups) {
+            out.append(group).append('\n');
+        }
+        out.append("total number of linkGroups: ").
+                append(groups.size()).append('\n');
+        out.append("total number of bytes reservable: ").
+                append(groups.stream().mapToLong(LinkGroup::getAvailableSpace).sum()).append('\n');
+        out.append("total number of bytes reserved  : ").
+                append(groups.stream().mapToLong(LinkGroup::getReservedSpace).sum()).append('\n');
+
+        return out.toString();
     }
 }


### PR DESCRIPTION
pcells submits an "ls -l" command to "SrmSpaceManager" to learn about
link groups and space reservations. That command is not supported
since 2.10.

This patch restores compatibility by implementing a translation in
the pcells subsystem of admin from the internal binary messages and
the textual format expected by pcells.

In the current patch the space manager name is still hard-coded, but
a future patch will resolve that too.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7994/
(cherry picked from commit 7ec4fdeaa7ea364bf4abfd380f1f8ab88f2c40a3)