### PR TITLE
admin: Restore pcells compatibility

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/Space.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/Space.java
@@ -113,10 +113,9 @@ public class Space implements Serializable {
         sb.append("accessLatency:").append(accessLatency.toString()).append(' ');
         sb.append("linkGroupId:").append(linkGroupId).append(' ');
         sb.append("size:").append(sizeInBytes).append(' ');
-        sb.append("created:").append((new Date(creationTime))).append(' ');
-        if (expirationTime != null) {
-            sb.append("expiration:").append(new Date(expirationTime).toString()).append(' ');
-        }
+        sb.append("created:").append(new Date(creationTime)).append(' ');
+        sb.append("lifetime:").append(expirationTime == null ? -1 : expirationTime - creationTime).append("ms ");
+        sb.append("expiration:").append(expirationTime == null ? "NEVER" : new Date(expirationTime)).append(' ');
         sb.append("description:").append(description).append(' ');
         sb.append("state:").append(state).append(' ');
         sb.append("used:").append(usedSizeInBytes).append(' ');


### PR DESCRIPTION
pcells submits an "ls -l" command to "SrmSpaceManager" to learn about
link groups and space reservations. That command is not supported
since 2.10.

This patch restores compatibility by implementing a translation in
the pcells subsystem of admin from the internal binary messages and
the textual format expected by pcells.

In the current patch the space manager name is still hard-coded, but
a future patch will resolve that too.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7994/
(cherry picked from commit 7ec4fdeaa7ea364bf4abfd380f1f8ab88f2c40a3)
(cherry picked from commit d3b6f42f8231a7156d19954b99268d7402cc7c83)