### PR TITLE
chimera: do not maintain time-based cached value of FsStat

### DIFF
--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -173,6 +173,8 @@
         <property name="maxEntries" value="${nfs.namespace-cache.size}" />
         <property name="lifeTime" value="${nfs.namespace-cache.time}" />
         <property name="timeUnit" value="${nfs.namespace-cache.time.unit}" />
+        <property name="fsStatLifeTime" value="${nfs.fs-stat-cache.time}" />
+        <property name="fsStatTimeUnit" value="${nfs.fs-stat-cache.time.unit}" />
     </bean>
 
     <beans  profile="portmap-true">

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -157,6 +157,13 @@ nfs.db.connections.idle = 1
 #
 # Each cached entry takes 120 bytes of additional memory
 nfs.namespace-cache.time = 3
-nfs.namespace-cache.time.unit = SECONDS
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)nfs.namespace-cache.time.unit = SECONDS
 nfs.namespace-cache.size = 0
 
+# FS stat cache update interval. This variable controls frequency of
+# aggregate queries to underlying db back-end when reporting
+# total size and total number of files in namespace (e.g. when executing
+# 'df' command). Depending on database implementation, the aggregate queries
+# could be costly (PostgreSQL is one such implementation).
+nfs.fs-stat-cache.time = 3600
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)nfs.fs-stat-cache.time.unit = SECONDS


### PR DESCRIPTION
NFS server by itself can cache the results of fsstat.
JdbcFs sill keeps a cached result, but it updated on demand.
Nevertheless, as this is a time consuming operation,
start an extra thread to perform the update. As long as update
is still in the progress, the last value is returned.

The update part takes care that only one thread is started in parallel.

Introduce two new properties:

nfs.fs-stat-cache.time
nfs.fs-stat-cache.time.unit

which will turn on caching in the nfs server.

Acked-by: Gerd Behrmann
Acked-by: Dmitry Litvintsev
Target: master
Target: 2.12, 2.11, 2.10 in the future
Require-book: no
Require-notes: yes
(cherry picked from commit f1f765da379a15dc9462e218771a5b4807841d4d)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>