### PR TITLE
pool: Fix file deletion

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryState.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryState.java
@@ -49,6 +49,7 @@ public class CacheRepositoryEntryState implements Serializable
             _error = true;
             break;
         case REMOVED:
+        case DESTROYED:
             _removed = true;
             break;
         default:


### PR DESCRIPTION
Fixes a regression introduced when reverting the patch that removed the
DESTROYED state:

23 Mar 2015 18:44:25 (atlas_hpc2n_umu_se_w02) [door:GFTP-rizzo-AAUR9heL18g GFTP-rizzo-AAUR9heL18g PoolAcceptFile 0000E68D9F05F14B46F5A5E4593ABE8A8CE8] Transfer failed in post-processing. Please report this bug to support@dcache.org.
java.lang.IllegalArgumentException: null
        at org.dcache.pool.repository.meta.db.CacheRepositoryEntryState.<init>(CacheRepositoryEntryState.java:55) ~[dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.pool.repository.meta.db.CacheRepositoryEntryImpl.storeState(CacheRepositoryEntryImpl.java:286) ~[dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.pool.repository.meta.db.CacheRepositoryEntryImpl.setState(CacheRepositoryEntryImpl.java:215) ~[dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.pool.repository.v5.CacheRepositoryV5.setState(CacheRepositoryV5.java:864) ~[dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.pool.repository.v5.CacheRepositoryV5.destroyWhenRemovedAndUnused(CacheRepositoryV5.java:984) ~[dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.pool.repository.v5.CacheRepositoryV5.setState(CacheRepositoryV5.java:889) ~[dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.pool.repository.v5.WriteHandleImpl.fail(WriteHandleImpl.java:406) ~[dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.pool.repository.v5.WriteHandleImpl.close(WriteHandleImpl.java:429) ~[dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.pool.classic.DefaultPostTransferService$1.run(DefaultPostTransferService.java:107) ~[dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) [dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at org.dcache.util.CDCExecutorServiceDecorator$1.run(CDCExecutorServiceDecorator.java:104) [dcache-core-2.12.3-SNAPSHOT.jar:2.12.3-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_40]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_40]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_40]

Target: trunk
Request: 2.12
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8010/
(cherry picked from commit ff6b86c69b3ca0b04dbcc661bd6ac9f7526749de)