### PR TITLE
admin: Propagate NoRouteToCellException to pcells

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/PcellsCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/PcellsCommand.java
@@ -26,6 +26,7 @@ import diskCacheV111.util.TimeoutCacheException;
 import dmg.cells.applets.login.DomainObjectFrame;
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellPath;
+import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.util.CommandException;
 
 import org.dcache.cells.CellStub;
@@ -139,7 +140,11 @@ public class PcellsCommand implements Command, Runnable
                             } catch (IOException ignored) {
                             }
                         } catch (TimeoutCacheException e) {
-                            result = null;
+                            if (e.getCause() instanceof NoRouteToCellException) {
+                                result = e.getCause();
+                            } else {
+                                result = null;
+                            }
                         } catch (Exception ae) {
                             result = ae;
                         }


### PR DESCRIPTION
In contrast to most places in dCache, pcells distinguishes between a timeout
and a failure to send a message to a cell.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8014/
(cherry picked from commit b4aeea8bf3a6e4e525106fe3ed3bb01fdc672d9a)