### PR TITLE
dcap: do not call toString() on error object

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -960,11 +960,7 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
         }
 
         protected void sendReply( String tag , Message msg ){
-
-            sendReply( tag ,
-            msg.getReturnCode() ,
-            msg.getErrorObject().toString() ) ;
-
+            sendReply( tag, msg.getReturnCode(), String.valueOf(msg.getErrorObject()) ) ;
         }
 
         protected void addUs()


### PR DESCRIPTION
use String.valueOf() to handle null object as well.

Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit 8f63805207506d60a8469f1ccebf8b737f25df9f)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>