### PR TITLE
httpd: Fix pcells compatibility

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/Args.java
+++ b/modules/common/src/main/java/org/dcache/util/Args.java
@@ -1,15 +1,18 @@
 package org.dcache.util;
 
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -53,6 +56,11 @@ public class Args implements Serializable
     }
 
     public Args(String[] args)
+    {
+        this(asList(args));
+    }
+
+    public Args(Iterable<String> args)
     {
         Scanner scanner = new Scanner();
         for (String arg : args) {
@@ -329,7 +337,14 @@ public class Args implements Serializable
             s.append("-- ");
         }
 
-        Joiner.on(' ').appendTo(s, _arguments);
+        Joiner.on(' ').appendTo(s, Iterables.transform(_arguments, new Function<String, CharSequence>()
+        {
+            @Override
+            public CharSequence apply(String s)
+            {
+                return quote(s);
+            }
+        }));
 
         return s.toString();
     }

--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -787,34 +788,34 @@ public class TransferObserverV1
         StringBuilder sb  = new StringBuilder();
 
         for (IoEntry io : ioList) {
-            sb.append(io._ioDoorInfo.getCellName()).append(" ").
-                append(io._ioDoorInfo.getDomainName()).append(" ");
-            sb.append(io._ioDoorEntry.getSerialId()).append(" ");
-            sb.append(io._ioDoorInfo.getProtocolFamily()).append("-").
-                append(io._ioDoorInfo.getProtocolVersion()).append(" ");
-            sb.append(io._ioDoorInfo.getOwner()).append(" ").
-                append(io._ioDoorInfo.getProcess()).append(" ");
-            sb.append(io._ioDoorEntry.getPnfsId()).append(" ").
-                append(io._ioDoorEntry.getPool()).append(" ").
-                append(io._ioDoorEntry.getReplyHost()).append(" ").
-                append(io._ioDoorEntry.getStatus()).append(" ").
-                append((now -io._ioDoorEntry.getWaitingSince())).append(" ");
+            List<String> args = new ArrayList<>();
+            args.add(io._ioDoorInfo.getCellName());
+            args.add(io._ioDoorInfo.getDomainName());
+            args.add(String.valueOf(io._ioDoorEntry.getSerialId()));
+            args.add(io._ioDoorInfo.getProtocolFamily() + "-" + io._ioDoorInfo.getProtocolVersion());
+            args.add(io._ioDoorInfo.getOwner());
+            args.add(io._ioDoorInfo.getProcess());
+            args.add(Objects.toString(io._ioDoorEntry.getPnfsId(), ""));
+            args.add(io._ioDoorEntry.getPool());
+            args.add(io._ioDoorEntry.getReplyHost());
+            args.add(io._ioDoorEntry.getStatus());
+            args.add(String.valueOf(now - io._ioDoorEntry.getWaitingSince()));
 
-            if (io._ioJobInfo == null) {
-                sb.append("No-Mover-Found");
+            IoJobInfo mover = io._ioJobInfo;
+            if (mover == null) {
+                args.add("No-mover()-Found");
             } else {
-                sb.append(io._ioJobInfo.getStatus()).append(" ");
-                if (io._ioJobInfo.getStartTime() > 0L) {
-                    long transferTime     = io._ioJobInfo.getTransferTime();
-                    long bytesTransferred = io._ioJobInfo.getBytesTransferred();
-                    sb.append(transferTime).append(" ").
-                        append(bytesTransferred).append(" ").
-                        append( transferTime > 0 ? ( (double)bytesTransferred/(double)transferTime ) : 0 ).
-                        append(" ");
-                    sb.append((now-io._ioJobInfo.getStartTime())).append(" ");
+                args.add(mover.getStatus());
+                if (mover.getStartTime() > 0L) {
+                    long transferTime     = mover.getTransferTime();
+                    long bytesTransferred = mover.getBytesTransferred();
+                    args.add(String.valueOf(transferTime));
+                    args.add(String.valueOf(bytesTransferred));
+                    args.add(String.valueOf(transferTime > 0 ? ((double) bytesTransferred / (double) transferTime) : 0));
+                    args.add(String.valueOf(now - mover.getStartTime()));
                 }
             }
-            sb.append("\n");
+            sb.append(new Args(args)).append('\n');
         }
         return sb.toString();
     }


### PR DESCRIPTION
Ensures that the status field is quoted - otherwise pcells breaks when
the field contains a space.

Requires an update to pcells too.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8018/
(cherry picked from commit 5749145423350047c998d3f6d458cb2a01369cde)