### PR TITLE
cells: Restore CellExceptionMessage encoding

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellExceptionMessage.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellExceptionMessage.java
@@ -1,19 +1,23 @@
-package dmg.cells.nucleus ;
+package dmg.cells.nucleus;
 
 import java.io.Serializable;
 
-/**
-  *  
-  *
-  * @author Patrick Fuhrmann
-  * @version 0.1, 15 Feb 1998
-  */
-public class CellExceptionMessage extends CellMessage {
+public class CellExceptionMessage extends CellMessage
+{
+    private static final long serialVersionUID = -5819709105553527283L;
 
-  private static final long serialVersionUID = -5819709105553527283L;
-  public CellExceptionMessage( CellPath addr , Serializable msg ){
-     super( addr , msg ) ;
-  }
-  
-  
+    public CellExceptionMessage(CellPath addr, Serializable msg)
+    {
+        super(addr, msg);
+    }
+
+    private CellExceptionMessage()
+    {
+    }
+
+    @Override
+    protected CellMessage cloneWithoutFields()
+    {
+        return new CellExceptionMessage();
+    }
 }


### PR DESCRIPTION
Some years ago we modified the cell message encoding/decoding to copy the
message rather than convert in place. Since then the CellExceptionMessage type
has been lost as it would be encoded and decoded as regular CellMessage. The
CellExceptionMessage type is important as it is used to distinguish message
delivery problems from service problems - thus we can avoid that a
no-route-to-cell exception bounces back and forth.

This patch restores the original encoding of CellExceptionMessage encoding.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8034/
(cherry picked from commit 829aa732576386d221e25f2c5a0a6c2b0caaad23)