### PR TITLE
admin: Fix command completion

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/HelpCompletor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/HelpCompletor.java
@@ -1,5 +1,6 @@
 package diskCacheV111.admin ;
 
+import com.google.common.base.CharMatcher;
 import jline.Completor;
 
 import java.util.ArrayList;
@@ -24,17 +25,8 @@ public class HelpCompletor implements Completor
 
     protected String scan(String line)
     {
-        StringBuilder completion = new StringBuilder();
-        loop:
-        for (String s: line.split(" ")) {
-            if (s.startsWith("#")) {
-                break;
-            }
-            if (!s.contains("[") && !s.contains("<") && !s.contains("|") && !s.startsWith("-")) {
-                completion.append(s).append(" ");
-            }
-        }
-        return completion.toString();
+        int i = CharMatcher.anyOf("#[]<>|-").indexIn(line);
+        return (i == -1) ? line : line.substring(0, i);
     }
 
     @Override


### PR DESCRIPTION
The completor parses the help output. This failed for commands using
white space in placeholders.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8051/
(cherry picked from commit bedd48573e300f5318a00fdf88321678f4940769)
(cherry picked from commit 380206dfdab4defbbae9031a3d436532acaefe98)