### PR TITLE
pool: Fix meta data reconstruction

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
@@ -307,7 +307,7 @@ public class ConsistentStore
                             throw new CacheException(message);
                         }
 
-                        RetentionPolicy retentionPolicy = attributesInNameSpace.getRetentionPolicy();
+                        RetentionPolicy retentionPolicy = attributesOnPool.getRetentionPolicy();
                         attributesToUpdate.setRetentionPolicy(retentionPolicy);
                         attributesInNameSpace.setRetentionPolicy(retentionPolicy);
 


### PR DESCRIPTION
Another fix to a bug fix. Fixes:

java.lang.IllegalStateException: Attribute is not defined: RETENTION_POLICY
       at org.dcache.vehicles.FileAttributes.guard(FileAttributes.java:152) ~[dcache-core-2.11.14.jar:2.11.14]
       at org.dcache.vehicles.FileAttributes.getRetentionPolicy(FileAttributes.java:285) ~[dcache-core-2.11.14.jar:2.11.14]
       at org.dcache.pool.repository.ConsistentStore.rebuildEntry(ConsistentStore.java:310) ~[dcache-core-2.11.14.jar:2.11.14]
       at org.dcache.pool.repository.ConsistentStore.get(ConsistentStore.java:172) ~[dcache-core-2.11.14.jar:2.11.14]
       at org.dcache.pool.repository.MetaDataCache$Monitor.get(MetaDataCache.java:98) ~[dcache-core-2.11.14.jar:2.11.14]
       at org.dcache.pool.repository.MetaDataCache$Monitor.access$400(MetaDataCache.java:80) ~[dcache-core-2.11.14.jar:2.11.14]
       at org.dcache.pool.repository.MetaDataCache.get(MetaDataCache.java:167) ~[dcache-core-2.11.14.jar:2.11.14]
       at org.dcache.pool.repository.v5.CacheRepositoryV5.readMetaDataRecord(CacheRepositoryV5.java:931)
~[dcache-core-2.11.14.jar:2.11.14]
       at org.dcache.pool.repository.v5.CacheRepositoryV5.load(CacheRepositoryV5.java:349) ~[dcache-core-2.11.14.jar:2.11.14]
       at org.dcache.pool.classic.PoolV4$1.run(PoolV4.java:467) ~[dcache-core-2.11.14.jar:2.11.14]

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8058/
(cherry picked from commit 4922f33f2a44ee47cfbae0eb5ccf3d13b08938f5)