### PR TITLE
pinmanager: Don't log stack trace when unable to fetch pool monitor

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pinmanager/UnpinProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/UnpinProcessor.java
@@ -4,6 +4,7 @@ import com.google.common.base.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.remoting.RemoteConnectFailureException;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.jdo.JDOException;
@@ -63,6 +64,8 @@ public class UnpinProcessor implements Runnable
         } catch (JDOException | DataAccessException e) {
             _logger.error("Database failure while unpinning: {}",
                           e.getMessage());
+        } catch (RemoteConnectFailureException e) {
+            _logger.error("Remote connection failure while unpinning: {)", e.getMessage());
         } catch (RuntimeException e) {
             _logger.error("Unexpected failure while unpinning", e);
         } finally {


### PR DESCRIPTION
Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8049/
(cherry picked from commit 23078cf5317b4782b1663e8c8b5ff6d9a8c11b59)