### PR TITLE
cells: Fix event queue counting bug

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -832,50 +832,41 @@ public class CellNucleus implements ThreadFactory
             }
         }
 
-        try {
-            //
-            // we have to cover 2 cases :
-            //   - absolutely asynchronous request
-            //   - asynchronous, but we have a callback to call
-            //
-            final CellMessage msg = ce.getMessage();
-            if (msg != null) {
-                LOGGER.trace("addToEventQueue : message arrived : {}", msg);
-                CellLock lock;
+        CellMessage msg = ce.getMessage();
+        LOGGER.trace("addToEventQueue : message arrived : {}", msg);
 
+        CellLock lock;
+        synchronized (_waitHash) {
+            lock = _waitHash.remove(msg.getLastUOID());
+        }
+
+        if (lock != null) {
+            //
+            // we were waiting for you (sync or async)
+            //
+            LOGGER.trace("addToEventQueue : lock found for : {}", msg);
+            try {
+                _eventQueueSize.incrementAndGet();
+                lock.getExecutor().execute(new CallbackTask(lock, msg));
+            } catch (RejectedExecutionException e) {
+                _eventQueueSize.decrementAndGet();
+                /* Put it back; the timeout handler will eventually take care of it.
+                 */
                 synchronized (_waitHash) {
-                    lock = _waitHash.remove(msg.getLastUOID());
+                    _waitHash.put(msg.getLastUOID(), lock);
                 }
-
-                if (lock != null) {
-                    //
-                    // we were waiting for you (sync or async)
-                    //
-                    LOGGER.trace("addToEventQueue : lock found for : {}", msg);
-                    try {
-                        _eventQueueSize.incrementAndGet();
-                        lock.getExecutor().execute(new CallbackTask(lock, msg));
-                    } catch (RejectedExecutionException e) {
-                        _eventQueueSize.decrementAndGet();
-                        /* Put it back; the timeout handler
-                         * will eventually take care of it.
-                         */
-                        synchronized (_waitHash) {
-                            _waitHash.put(msg.getLastUOID(), lock);
-                        }
-                        throw e;
-                    }
-                    return;
-                }
-            }     // end of : msg != null
-
-            EventLogger.queueBegin(ce);
-            _eventQueueSize.incrementAndGet();
-            _messageExecutor.execute(new DeliverMessageTask(ce));
-        } catch (RejectedExecutionException e) {
-            EventLogger.queueEnd(ce);
-            _eventQueueSize.decrementAndGet();
-            LOGGER.error("Message queue overflow. Dropping {}", ce);
+                LOGGER.error("Message queue overflow. Dropping {}", ce);
+            }
+        } else {
+            try {
+                EventLogger.queueBegin(ce);
+                _eventQueueSize.incrementAndGet();
+                _messageExecutor.execute(new DeliverMessageTask(ce));
+            } catch (RejectedExecutionException e) {
+                EventLogger.queueEnd(ce);
+                _eventQueueSize.decrementAndGet();
+                LOGGER.error("Message queue overflow. Dropping {}", ce);
+            }
         }
     }
 

--- a/modules/cells/src/main/java/dmg/cells/nucleus/MessageEvent.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/MessageEvent.java
@@ -1,30 +1,24 @@
-package dmg.cells.nucleus ;
-  /**
-    *   The message event is the vehicle which is used
-    *   to deliver a message to a cell.
- 
-  *  
-  *
-  * @author Patrick Fuhrmann
-  * @version 0.1, 15 Feb 1998
- 
-    */
-public class MessageEvent extends CellEvent {
-    /**
-      *  The MessageEvent constructor creates a MessageEvent 
-      *  containing the specified CellMessage.
-      */
-    public MessageEvent( CellMessage msg ){
-        super( msg , CellEvent.OTHER_EVENT ) ;
+package dmg.cells.nucleus;
+
+import javax.annotation.Nonnull;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class MessageEvent extends CellEvent
+{
+    public MessageEvent(CellMessage msg)
+    {
+        super(checkNotNull(msg), CellEvent.OTHER_EVENT);
     }
-    /**
-      *  getMessage extracts the CellMessage out of the
-      *  MessageEvent.
-      */
-    public CellMessage getMessage(){
-       return (CellMessage) getSource() ;
+
+    @Nonnull
+    public CellMessage getMessage()
+    {
+        return (CellMessage) getSource();
     }
-    public String toString(){
-      return "MessageEvent(source="+getSource().toString()+")" ;
+
+    public String toString()
+    {
+        return "MessageEvent(source=" + getMessage() + ")";
     }
 }


### PR DESCRIPTION
In case of an RejectedExecutionException thrown when submitting a
task to invoke the message callback, the event counter would have
been decremented twice. The event logging would have been wrong
too.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8067/
(cherry picked from commit abc6e3b9c1901083a8d312a314a5c6a7ea64dd20)
(cherry picked from commit 865e9e555dacd7e08dde4ff77844d9606315ecb8)