### PR TITLE
doors: Fix race condition that causes NPE in webadmin

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -296,7 +296,10 @@ public class LoginManager
     {
         boolean binary = args.hasOption("binary");
         if (binary) {
-            String[] list = _children.keySet().toArray(new String[_children.size()]);
+            /* Important: Do not try to allocate a sized array as _children may be
+             * updated in between creating the array and copying the keys.
+             */
+            String[] list = _children.keySet().toArray(new String[0]);
             return new LoginManagerChildrenInfo(getCellName(), getCellDomainName(), list);
         } else {
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Fixes

java.lang.NullPointerException: null
      at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:213) ~[guava-17.0.jar:na]
      at dmg.cells.nucleus.CellAddressCore.<init>(CellAddressCore.java:68) ~[cells-2.10.20.jar:2.10.20]
      at org.dcache.webadmin.model.dataaccess.communication.collectors.ActiveTransfersCollector.getMovers(ActiveTransfersCollector.java:104) ~[classes/:na]
      at org.dcache.webadmin.model.dataaccess.communication.collectors.ActiveTransfersCollector.call(ActiveTransfersCollector.java:57) ~[classes/:na]
      at org.dcache.webadmin.model.dataaccess.communication.collectors.ActiveTransfersCollector.call(ActiveTransfersCollector.java:34) ~[classes/:na]
      at org.dcache.util.backoff.BackoffController.call(BackoffController.java:95) ~[dcache-common-2.10.20.jar:2.10.20]
      at org.dcache.webadmin.model.dataaccess.communication.collectors.Collector.run(Collector.java:65) ~[classes/:na]
      at java.lang.Thread.run(Thread.java:745) ~[na:1.7.0_67]

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8704
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/8098/
(cherry picked from commit 33e81db85f2b17cce9d78d97217599c50b62474f)