### PR TITLE
dcache: Make cell communication use the correct timeout

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/cells/CellStub.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/CellStub.java
@@ -430,7 +430,7 @@ public class CellStub
         if (_retryOnNoRouteToCell) {
             _endpoint.sendMessageWithRetryOnNoRouteToCell(envelope, future, MoreExecutors.sameThreadExecutor(), timeout);
         } else {
-            _endpoint.sendMessage(envelope, future, MoreExecutors.sameThreadExecutor(), getTimeoutInMillis());
+            _endpoint.sendMessage(envelope, future, MoreExecutors.sameThreadExecutor(), timeout);
         }
         return future;
     }


### PR DESCRIPTION
In one case, CellStub used the CellStub timeout rather than the timeout
given as an argument to the send method.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8100/
(cherry picked from commit b052229653002e8679ae326a4ef74b54fd767b74)