### PR TITLE
admin: Fix connection shutdown

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
@@ -86,8 +86,13 @@ public class ConsoleReaderCommand implements Command, Runnable {
 
     @Override
     public void destroy() {
-        if (_pipeThread != null) {
-            _pipeThread.interrupt();
+        Thread thread = _pipeThread;
+        if (thread != null) {
+            thread.interrupt();
+        }
+        thread = _adminShellThread;
+        if (thread != null) {
+            thread.interrupt();
         }
     }
 
@@ -344,7 +349,6 @@ public class ConsoleReaderCommand implements Command, Runnable {
                     _pipedOut.close();
                 } catch (IOException ignored) {
                 }
-                _adminShellThread.interrupt();
             }
         }
     }


### PR DESCRIPTION
It is desirable that the shell completes the last command even when the
input stream shuts down. This patch ensures that the shell thread is not
prematurely interrupted.

Target: trunk
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Christian Bernardt <christian.bernardt@desy.de>
Patch: https://rb.dcache.org/r/8120/
(cherry picked from commit 1ee6afe17e980fe867cdf6f6d16afa4e3e25a0c8)