### PR TITLE
admin: Avoid division by zero when the client reports a zero sized terminal

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
@@ -282,7 +282,11 @@ public class ConsoleReaderCommand implements Command, Runnable {
             String h = _env.getEnv().get(Environment.ENV_LINES);
             if (h != null) {
                 try {
-                    return Integer.parseInt(h);
+                    /* The SSH client may report 0 if forced to allocate a pseudo TTY
+                     * even when it got no local TTY.
+                     */
+                    int i = Integer.parseInt(h);
+                    return i == 0 ? Integer.MAX_VALUE : i;
                 } catch(NumberFormatException ignored) {
                 }
             }
@@ -294,7 +298,11 @@ public class ConsoleReaderCommand implements Command, Runnable {
             String w = _env.getEnv().get(Environment.ENV_COLUMNS);
             if (w != null) {
                 try {
-                    return Integer.parseInt(w);
+                    /* The SSH client may report 0 if forced to allocate a pseudo TTY
+                     * even when it got no local TTY.
+                     */
+                    int i = Integer.parseInt(w);
+                    return i == 0 ? Integer.MAX_VALUE : i;
                 } catch(NumberFormatException ignored) {
                 }
             }


### PR DESCRIPTION
The jline error generates an arithemtic error when faced with a terminal
of width 0. The ssh client reports such a width when forced to allocate
a pseudo TTY without having a TTY (i.e. when using the -t -t options with
redirected stdin).

This patch avoids the error by reinterpreting the 0 width/height as meaning
an arbitrarily large terminal (i.e. no line breaks etc).

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8121/
(cherry picked from commit 085c335446b9efeab9120a322ee0ba8b574f0577)