### PR TITLE
spacemanager: Fix race condition leading to leaked files

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -700,7 +700,14 @@ public final class SpaceManagerService
         private void transferFinished(DoorTransferFinishedMessage finished)
                 throws DataAccessException
         {
-                transferFinished(finished.getPnfsId(), finished.getFileAttributes().getSize());
+        if (finished.getReturnCode() == CacheException.FILE_NOT_FOUND) {
+            /* File is gone from name space, but we may never receive a notification
+             * from cleaner if the file location didn't get registered first.
+             */
+            fileRemoved(finished.getPnfsId());
+        } else {
+            transferFinished(finished.getPnfsId(), finished.getFileAttributes().getSize());
+        }
         }
 
         @Transactional


### PR DESCRIPTION
If a file is deleted while being uploaded, the pool will receive a failure from
pnfs manager when attempting to register the file. The pool will delete the
replica in response to this error.

Space manager on the other hand always moves a file from TRANSFERRING to STORED
upon DoorTransferFinished. This is because the decision to delete a file upon
upload failure depends on the door. Howeve in the above scenario the pool
actually did delete the file and the cleaner nevers sends delete notifications
since the replica was not registered when the file was deleted. The consequence
is a leaked file.

This patch partially fixes the problem: It is an easy fix for a common scenario,
but there are other races left. Those will not be fixable without some bigger
changes.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8110/
(cherry picked from commit cf0f5d2ee1212e0841df820b96ea53ce8ff611f6)