### PR TITLE
admin: Avoid line breaks when not connection from a TTY

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
@@ -162,7 +162,7 @@ public class ConsoleReaderCommand implements Command, Runnable {
     }
 
     private void runAsciiMode() throws IOException {
-        Ansi.setEnabled(_useColors);
+        Ansi.setEnabled(_console.getTerminal().isAnsiSupported() && _useColors);
         while (true) {
             String prompt = Ansi.ansi().bold().a(_userAdminShell.getPrompt()).boldOff().toString();
             Object result;
@@ -278,7 +278,7 @@ public class ConsoleReaderCommand implements Command, Runnable {
         {
             super(true);
             _env = env;
-            setAnsiSupported(true);
+            setAnsiSupported(env.getEnv().get(Environment.ENV_TERM) != null);
             setEchoEnabled(false);
         }
 
@@ -291,11 +291,13 @@ public class ConsoleReaderCommand implements Command, Runnable {
                      * even when it got no local TTY.
                      */
                     int i = Integer.parseInt(h);
-                    return i == 0 ? Integer.MAX_VALUE : i;
+                    if (i > 0) {
+                        return i;
+                    }
                 } catch(NumberFormatException ignored) {
                 }
             }
-            return super.getHeight();
+            return Integer.MAX_VALUE;
         }
 
         @Override
@@ -307,11 +309,13 @@ public class ConsoleReaderCommand implements Command, Runnable {
                      * even when it got no local TTY.
                      */
                     int i = Integer.parseInt(w);
-                    return i == 0 ? Integer.MAX_VALUE : i;
+                    if (i > 0) {
+                        return i;
+                    }
                 } catch(NumberFormatException ignored) {
                 }
             }
-            return super.getWidth();
+            return Integer.MAX_VALUE;
         }
     }
 


### PR DESCRIPTION
The legacy shell is used both interactively and from scripts. After the upgrade
to jline 2, the 80 character default terminal width use when the client did not
allocate a pseudo TTY causes unintended line feeds to be inserted into the output.

This patch fixes this problem and also disables the use of any ANSI sequences
when the client does not provide a TTY.

It was tempting to define the terminal for a non-tty session as not supported
in jline, causing it to disable most of its features, but this would also have
suppressed echoing the commands to the output. Although that would have been
the correct thing to do when using the shell in a pipe, we have always echoed
the command and it is likely that existing scripts rely on this.

Target: trunk
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8122/