### PR TITLE
javatunnel: use connected socket to discover local inet address

### DIFF
--- a/modules/javatunnel/src/main/java/javatunnel/GssTunnel.java
+++ b/modules/javatunnel/src/main/java/javatunnel/GssTunnel.java
@@ -148,7 +148,7 @@ class GssTunnel extends TunnelConverter {
             _context.requestMutualAuth(true);
 
             if( _useChannelBinding ) {
-                 ChannelBinding cb = new ChannelBinding(socket.getInetAddress(), InetAddress.getLocalHost(), null);
+                 ChannelBinding cb = new ChannelBinding(socket.getInetAddress(), socket.getLocalAddress(), null);
             	_context.setChannelBinding(cb);
             }
 
@@ -186,8 +186,8 @@ class GssTunnel extends TunnelConverter {
             Socket  socket = (Socket)addon;
 
             if(_useChannelBinding) {
-            	ChannelBinding cb = new ChannelBinding(socket.getInetAddress(),   InetAddress.getLocalHost(), null);
-            	_context.setChannelBinding(cb);
+                ChannelBinding cb = new ChannelBinding(socket.getInetAddress(),   socket.getLocalAddress(), null);
+                _context.setChannelBinding(cb);
             }
 
             while(  !_context.isEstablished() ) {


### PR DESCRIPTION
the InetAddress.getLocalHost() depends on local dns/hostname configuration

Ticket: #8698
Target: master, 2.12, 2.11, 2.10
Acked-by: Gerd Behrmann
(cherry picked from commit 7271794e88ea9a01603e36832d568a59b61f9f90)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>