### PR TITLE
    pools: fix parsing error in HsmRunSystem

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/HsmRunSystem.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/HsmRunSystem.java
@@ -62,16 +62,33 @@ public class HsmRunSystem extends RunSystem
     private String extractPossibleEnstoreIds(String error) {
         StringBuilder ids = new StringBuilder();
 
-        int index = error.indexOf(PNFSID_TAG);
-        if (index >= 0) {
-            index += PNFSID_TAG.length();
-            ids.append(error.substring(index, error.indexOf("&", index)));
+        /*
+         *  FIXME  this method should not really be in this class,
+         *  but in an enstore-specific script utility.
+         *  The check for the end tag is a provisional work-around.
+         *
+         *  NOTE:  I am not sure whether the mere presence of the ampersand
+         *  here denotes an enstore error string or not, so I've left
+         *  each check as self-contained for the moment.
+         */
+        int start = error.indexOf(PNFSID_TAG);
+        if (start >= 0) {
+            start += PNFSID_TAG.length();
+            int end = error.indexOf("&", start);
+            if (end >= 0) {
+                ids.append(PNFSID_TAG)
+                   .append(error.substring(start, end));
+            }
         }
 
-        index = error.indexOf(BFID_TAG);
-        if (index >= 0) {
-            index += BFID_TAG.length();
-            ids.append(error.substring(index, error.indexOf("&", index)));
+        start = error.indexOf(BFID_TAG);
+        if (start >= 0) {
+            start += BFID_TAG.length();
+            int end = error.indexOf("&", start);
+            if (end > 0) {
+                ids.append(BFID_TAG)
+                   .append(error.substring(start, end));
+            }
         }
 
         /*


### PR DESCRIPTION
    Enstore-specific parsing was added (erroneously) to this generic HSM
    utilty.  See:

    7137 alarms: convert definitions into marked alarms (part 1)
    commit 325948d7553c6fecfb73204625cdc30c30c6589c
    Date:   Wed Jul 16 11:28:05 2014 -0500

    When used in other environments, where the ampersand does not serve
    as delimiter token, the end index for the substring sought will be -1,
    and a StringIndexOutOfBoundsException may be thrown.

    This patch offers a provisional fix to the indexing.  However,
    this code eventually needs to be factored out and placed inside
    an Enstore-specific utility class.

    Target:  2.11
    Patch: https://rb.dcache.org/r/8141
    Require-book: no
    Require-notes: yes
    Acked-by: Gerd

    RELEASE NOTES:

    Fixes a potential StringIndexOutOfBoundsException in HsmRunSystem
    when parsing error strings not generated by an enstore-specific
    script