### PR TITLE
srm: Force save when job becomes RQUEUED

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -330,7 +330,7 @@ public abstract class Job  {
                 throw new IllegalStateTransition("Scheduler ID is null");
             }
             stateChanged(oldState);
-            saveJob();
+            saveJob(state == State.RQUEUED);
         } finally {
             wunlock();
         }


### PR DESCRIPTION
The intention was that jobs that are in RQUEUED or READY can survive an SRM
restart, however that doesn't work if we don't save that state to the database.
This job achieves this by forcing the save when the job becomes RQUEUED. We
don't force save it again when it becomes READY as we treat those states the
same on restart.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8156/
(cherry picked from commit de739075d46de11bf40a05195aad00c9801654a0)