### PR TITLE
srm: Force save jobs when adding information needed for cancellation

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
@@ -503,7 +503,7 @@ public final class BringOnlineFileRequest extends FileRequest<BringOnlineRequest
         try {
             future.checkedGet(60, TimeUnit.SECONDS);
             setPinId(null);
-            this.saveJob();
+            saveJob(true);
             return new TReturnStatus(TStatusCode.SRM_SUCCESS, null);
         } catch (TimeoutException e) {
             throw new SRMInternalErrorException("Operation timed out.");

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/CopyFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/CopyFileRequest.java
@@ -596,7 +596,7 @@ public final class CopyFileRequest extends FileRequest<CopyRequest>
                 }
             };
             setTransferId(getStorage().getFromRemoteTURL(getUser(), getSourceTurl(), getDestinationFileId(), getUser(), credential.getId(), extraInfo, copycallbacks));
-            saveJob();
+            saveJob(true);
         } else {
             // transfer id is not null and we are scheduled
             // there was some kind of error during the transfer
@@ -656,7 +656,7 @@ public final class CopyFileRequest extends FileRequest<CopyRequest>
             TheCopyCallbacks copycallbacks = new TheCopyCallbacks(getId());
             setTransferId(getStorage().putToRemoteTURL(getUser(), getSourceSurl(), getDestinationTurl(), getUser(), credential.getId(), extraInfo, copycallbacks));
             setState(State.RUNNINGWITHOUTTHREAD, "Transferring file.");
-            saveJob();
+            saveJob(true);
         } else {
             // transfer id is not null and we are scheduled
             // there was some kind of error durign the transfer
@@ -1034,6 +1034,7 @@ public final class CopyFileRequest extends FileRequest<CopyRequest>
                     if (state == State.ASYNCWAIT) {
                         LOG.debug("PutCallbacks success for file {}", fr.getDestinationSurl());
                         fr.setDestinationFileId(fileId);
+                        fr.saveJob(true);
                         Scheduler scheduler = Scheduler.getScheduler(fr.getSchedulerId());
                         try {
                             scheduler.schedule(fr);

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -756,7 +756,7 @@ public abstract class Job  {
             }
 
             lifetime = now + newLifetimeInMillis - creationTime;
-            saveJob();
+            saveJob(true);
             return newLifetimeInMillis;
         } finally {
             wunlock();

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
@@ -635,6 +635,7 @@ public final class PutFileRequest extends FileRequest<PutRequest> {
                     case ASYNCWAIT:
                         logger.trace("Storage info arrived for file {}.", fr.getSurlString());
                         fr.setFileId(fileId);
+                        fr.saveJob(true);
                         Scheduler<?> scheduler = Scheduler.getScheduler(fr.getSchedulerId());
                         try {
                             scheduler.schedule(fr);


### PR DESCRIPTION
By default the SRM does not save every minor state update to the database. It
is however import that we update the database when information needed to abort
requests become available. These would be upload paths, pin IDs and third party
transfer IDs. This resolves problems with cleaning up upload directories upon
SRM restart.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8155/
(cherry picked from commit a25248f6f4ad2ac952898baaf335310cbf97bfbc)