### PR TITLE
srm: Fix loading of jobs during restart

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/FinalStateOnlyJobStorageDecorator.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/FinalStateOnlyJobStorageDecorator.java
@@ -4,7 +4,6 @@ import org.springframework.dao.DataAccessException;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collections;
 import java.util.Set;
 
 import org.dcache.srm.request.Job;
@@ -80,7 +79,7 @@ public class FinalStateOnlyJobStorageDecorator<J extends Job> implements JobStor
     @Override
     public Set<J> getActiveJobs()
     {
-        return Collections.emptySet();
+        return jobStorage.getActiveJobs();
     }
 
     @Override


### PR DESCRIPTION
In 2.12 we changed the semantics of
srm.persistence.enable.store-transient-state.  As a consequence,
FinalStateOnlyJobStorageDecorator may store jobs in non-final states if the
update is forced. Thus the implementation of getActiveJobs() is wrong, since
there may be non-final jobs in the database. The observable symptom was that
with our default configuration, jobs would not be loaded back after a restart.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8154/
(cherry picked from commit f9e32e5cb433b2175b8659374fd8d7ab53d9367b)