### PR TITLE
srm: Allow the SRM to take action upon cleaned requests

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
@@ -232,7 +232,7 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
     }
 
     @Override
-    public void onSrmRestart(Scheduler scheduler)
+    public void onSrmRestart(Scheduler scheduler, boolean shouldFailJobs)
     {
         // Nothing to do.
     }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
@@ -223,7 +223,7 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
     }
 
     @Override
-    public void onSrmRestart(Scheduler scheduler)
+    public void onSrmRestart(Scheduler scheduler, boolean shouldFailJobs)
     {
         // Nothing to do.
     }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -74,6 +74,7 @@ import javax.annotation.Nonnull;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1106,7 +1107,7 @@ public abstract class Job  {
      * some JobStorage (such as a DatabaseJobStorage) and the job is in a
      * non-final state.
      */
-    public void onSrmRestart(Scheduler scheduler)
+    public void onSrmRestart(Scheduler scheduler, boolean shouldFailJobs)
     {
         wlock();
         try {
@@ -1114,8 +1115,13 @@ public abstract class Job  {
                 return;
             }
 
+            if (shouldFailJobs) {
+                setState(State.FAILED, "Aborted due to SRM service restart.");
+                return;
+            }
+
             if (getRemainingLifetime() == 0) {
-                setState(State.FAILED, "Expired during SRM service restart");
+                setState(State.FAILED, "Expired during SRM service restart.");
                 return;
             }
 
@@ -1168,6 +1174,6 @@ public abstract class Job  {
             throws IllegalStateTransition
     {
         // By default, simply fail such requests.
-        setState(State.FAILED, "Aborted due to SRM service restart");
+        setState(State.FAILED, "Aborted due to SRM service restart.");
     }
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/LsRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/LsRequest.java
@@ -164,7 +164,7 @@ public final class LsRequest extends ContainerRequest<LsFileRequest> {
         }
 
         @Override
-        public void onSrmRestart(Scheduler scheduler)
+        public void onSrmRestart(Scheduler scheduler, boolean shouldFailJobs)
         {
             // Nothing to do.
         }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/PutRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/PutRequest.java
@@ -240,7 +240,7 @@ public final class PutRequest extends ContainerRequest<PutFileRequest> {
     }
 
     @Override
-    public void onSrmRestart(Scheduler scheduler)
+    public void onSrmRestart(Scheduler scheduler, boolean shouldFailJobs)
     {
         // Nothing to do.
     }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/BringOnlineRequestStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/BringOnlineRequestStorage.java
@@ -156,9 +156,9 @@ public class BringOnlineRequestStorage extends DatabaseContainerRequestStorage<B
     }
 
     @Override
-    protected void dbInit(boolean clean) throws DataAccessException
+    protected void dbInit() throws DataAccessException
     {
-            super.dbInit(clean);
+            super.dbInit();
             if (droppedOldTable) {
                     dropTable(getProtocolsTableName());
             }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseFileRequestStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseFileRequestStorage.java
@@ -30,9 +30,9 @@ public abstract class DatabaseFileRequestStorage<F extends FileRequest<?>> exten
     }
 
     @Override
-    protected void dbInit(boolean clean) throws DataAccessException
+    protected void dbInit() throws DataAccessException
     {
-           super.dbInit(clean);
+           super.dbInit();
            String columns[] = {
 		    "REQUESTID"};
 	   createIndex(columns, getTableName().toLowerCase());

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
@@ -157,7 +157,7 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
         this.jdbcTemplate = new JdbcTemplate(configuration.getDataSource());
         this.transactionTemplate = new TransactionTemplate(configuration.getTransactionManager());
 
-        dbInit(configuration.isCleanPendingRequestsOnRestart());
+        dbInit();
     }
 
     @Override
@@ -221,7 +221,7 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
         return getTableName().toLowerCase()+"history";
     }
 
-    protected void dbInit(boolean clean)
+    protected void dbInit()
             throws DataAccessException
     {
         createTable(srmStateTableName, createStateTable);
@@ -232,7 +232,7 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
                 " CONSTRAINT fk_"+tableName+"_ST FOREIGN KEY (STATE) REFERENCES "+
                 srmStateTableName +" (ID) "+
                 " )";
-        createTable(tableName,createStatement,true,clean);
+        createTable(tableName,createStatement,true);
         String historyTableName = getHistoryTableName();
         if (droppedOldTable) {
             dropTable(historyTableName);
@@ -676,10 +676,10 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
     protected void createTable(String tableName, String createStatement)
             throws DataAccessException
     {
-        createTable(tableName, createStatement,false,false);
+        createTable(tableName, createStatement,false);
     }
 
-    protected void createTable(final String tableName, final String createStatement, final boolean verify, final boolean clean)
+    protected void createTable(final String tableName, final String createStatement, final boolean verify)
             throws DataAccessException
     {
             jdbcTemplate.execute(new ConnectionCallback<Void>()
@@ -723,24 +723,6 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
                                     logger.debug("executing statement: {}", createStatement);
                                     s.executeUpdate(createStatement);
                                 }
-                            }
-                        }
-                        if (clean) {
-                            String sqlStatementString = "UPDATE " + getTableName() +
-                                    " SET STATE=" + State.DONE.getStateId() +
-                                    " WHERE STATE=" + State.READY.getStateId();
-                            try (Statement s = con.createStatement()) {
-                                logger.debug("executing statement: {}", sqlStatementString);
-                                s.executeUpdate(sqlStatementString);
-                            }
-                            sqlStatementString = "UPDATE " + getTableName() +
-                                    " SET STATE=" + State.FAILED.getStateId() +
-                                    " WHERE STATE !=" + State.FAILED.getStateId() + " AND" +
-                                    " STATE !=" + State.CANCELED.getStateId() + " AND " +
-                                    " STATE !=" + State.DONE.getStateId();
-                            try (Statement s = con.createStatement()) {
-                                logger.debug("executing statement: {}", sqlStatementString);
-                                s.executeUpdate(sqlStatementString);
                             }
                         }
                     }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/GetRequestStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/GetRequestStorage.java
@@ -185,9 +185,9 @@ public class GetRequestStorage extends DatabaseContainerRequestStorage<GetReques
     }
 
     @Override
-    protected void dbInit(boolean clean) throws DataAccessException
+    protected void dbInit() throws DataAccessException
     {
-        super.dbInit(clean);
+        super.dbInit();
 
         String protocolsTableName = getProtocolsTableName().toLowerCase();
         if (droppedOldTable || !validateProtocolsTableSchema(protocolsTableName)) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/PutRequestStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/PutRequestStorage.java
@@ -187,9 +187,9 @@ public class PutRequestStorage extends DatabaseContainerRequestStorage<PutReques
     }
 
     @Override
-    protected void dbInit(boolean clean) throws DataAccessException
+    protected void dbInit() throws DataAccessException
     {
-        super.dbInit(clean);
+        super.dbInit();
 
         String protocolsTableName = getProtocolsTableName().toLowerCase();
         if (droppedOldTable || !validateProtocolsTableSchema(protocolsTableName)) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SchedulerContainer.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SchedulerContainer.java
@@ -104,14 +104,14 @@ public class SchedulerContainer
         return sb;
     }
 
-    public void restoreJobsOnSrmStart(Iterable<? extends Job> activeJobs)
+    public void restoreJobsOnSrmStart(Iterable<? extends Job> activeJobs, boolean shouldFailJobs)
     {
         Scheduler<?> scheduler = null;
 
         for (Job job : activeJobs) {
             scheduler = getScheduler(scheduler, job.getSchedulerType());
             if (scheduler.getId().equals(job.getSchedulerId())) {
-                job.onSrmRestart(scheduler);
+                job.onSrmRestart(scheduler, shouldFailJobs);
             } // else another SRM instance is handling this job
         }
     }

--- a/modules/srm-server/src/test/java/org/dcache/srm/scheduler/SchedulerContainerTests.java
+++ b/modules/srm-server/src/test/java/org/dcache/srm/scheduler/SchedulerContainerTests.java
@@ -231,10 +231,10 @@ public class SchedulerContainerTests
     {
         LsFileRequest job = mockJob(LsFileRequest.class, ASYNCWAIT, "ls_localhost");
 
-        container.restoreJobsOnSrmStart(Lists.newArrayList(job));
+        container.restoreJobsOnSrmStart(Lists.newArrayList(job), false);
 
         ArgumentCaptor<Scheduler> schedCapture = ArgumentCaptor.forClass(Scheduler.class);
-        verify(job, times(1)).onSrmRestart(schedCapture.capture());
+        verify(job, times(1)).onSrmRestart(schedCapture.capture(), eq(false));
         assertThat(schedCapture.getValue(), is(lsScheduler));
     }
 
@@ -244,10 +244,10 @@ public class SchedulerContainerTests
         BringOnlineFileRequest job = mockJob(BringOnlineFileRequest.class,
                 ASYNCWAIT, "bring_online_localhost");
 
-        container.restoreJobsOnSrmStart(Lists.newArrayList(job));
+        container.restoreJobsOnSrmStart(Lists.newArrayList(job), false);
 
         ArgumentCaptor<Scheduler> schedCapture = ArgumentCaptor.forClass(Scheduler.class);
-        verify(job, times(1)).onSrmRestart(schedCapture.capture());
+        verify(job, times(1)).onSrmRestart(schedCapture.capture(), eq(false));
         assertThat(schedCapture.getValue(), is(bringOnlineScheduler));
     }
 
@@ -257,10 +257,10 @@ public class SchedulerContainerTests
         GetFileRequest job = mockJob(GetFileRequest.class, ASYNCWAIT,
                 "get_localhost");
 
-        container.restoreJobsOnSrmStart(Lists.newArrayList(job));
+        container.restoreJobsOnSrmStart(Lists.newArrayList(job), false);
 
         ArgumentCaptor<Scheduler> schedCapture = ArgumentCaptor.forClass(Scheduler.class);
-        verify(job, times(1)).onSrmRestart(schedCapture.capture());
+        verify(job, times(1)).onSrmRestart(schedCapture.capture(), eq(false));
         assertThat(schedCapture.getValue(), is(getScheduler));
     }
 
@@ -269,10 +269,10 @@ public class SchedulerContainerTests
     {
         CopyRequest job = mockJob(CopyRequest.class, ASYNCWAIT, "copy_localhost");
 
-        container.restoreJobsOnSrmStart(Lists.newArrayList(job));
+        container.restoreJobsOnSrmStart(Lists.newArrayList(job), false);
 
         ArgumentCaptor<Scheduler> schedCapture = ArgumentCaptor.forClass(Scheduler.class);
-        verify(job, times(1)).onSrmRestart(schedCapture.capture());
+        verify(job, times(1)).onSrmRestart(schedCapture.capture(), eq(false));
         assertThat(schedCapture.getValue(), is(genericScheduler));
     }
 
@@ -282,10 +282,10 @@ public class SchedulerContainerTests
         CopyFileRequest job = mockJob(CopyFileRequest.class, ASYNCWAIT,
                 "copy_localhost");
 
-        container.restoreJobsOnSrmStart(Lists.newArrayList(job));
+        container.restoreJobsOnSrmStart(Lists.newArrayList(job), false);
 
         ArgumentCaptor<Scheduler> schedCapture = ArgumentCaptor.forClass(Scheduler.class);
-        verify(job, times(1)).onSrmRestart(schedCapture.capture());
+        verify(job, times(1)).onSrmRestart(schedCapture.capture(), eq(false));
         assertThat(schedCapture.getValue(), is(genericScheduler));
     }
 
@@ -295,10 +295,10 @@ public class SchedulerContainerTests
         PutFileRequest job = mockJob(PutFileRequest.class, ASYNCWAIT,
                 "put_localhost");
 
-        container.restoreJobsOnSrmStart(Lists.newArrayList(job));
+        container.restoreJobsOnSrmStart(Lists.newArrayList(job), false);
 
         ArgumentCaptor<Scheduler> schedCapture = ArgumentCaptor.forClass(Scheduler.class);
-        verify(job, times(1)).onSrmRestart(schedCapture.capture());
+        verify(job, times(1)).onSrmRestart(schedCapture.capture(), eq(false));
         assertThat(schedCapture.getValue(), is(putScheduler));
     }
 
@@ -308,10 +308,10 @@ public class SchedulerContainerTests
         ReserveSpaceRequest job = mockJob(ReserveSpaceRequest.class, ASYNCWAIT,
                 "reserve_space_localhost");
 
-        container.restoreJobsOnSrmStart(Lists.newArrayList(job));
+        container.restoreJobsOnSrmStart(Lists.newArrayList(job), false);
 
         ArgumentCaptor<Scheduler> schedCapture = ArgumentCaptor.forClass(Scheduler.class);
-        verify(job, times(1)).onSrmRestart(schedCapture.capture());
+        verify(job, times(1)).onSrmRestart(schedCapture.capture(), eq(false));
         assertThat(schedCapture.getValue(), is(reserveSpaceScheduler));
     }
 }

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -590,8 +590,9 @@ srm.persistence.reserve-space.enable=${srmReserveDatabaseEnabled}
 
 # ---- Enable cleaning of pending requests during restart
 #
-# If enabled and the srm is restarted and there are pending requests
-# their state will change to Failed or Done.
+# When true and the srm is restarted, all unfinished requests will be aborted right away.
+# This will invalidate all ongoing SRM transfers and all ongoing stage requests. If
+# false, most clients should not notice a brief restart.
 #
 (deprecated,one-of?true|false)srmCleanPendingRequestsOnRestart=false
 (one-of?true|false|${srmCleanPendingRequestsOnRestart})\


### PR DESCRIPTION
The srm can be configured to terminate pending requests during restart. This
was implemented by changing the request states to a terminal state directly in
the database. Thus the srm fails to remove pins and temporary upload
directories for such requests.

This patch resolves the issue by moving the cleaning into the request reloading
logic. This allows the requests to be aborted properly.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7977/
(cherry picked from commit a20324910a4114fb775c31247b6ba4bc2c153516)
(cherry picked from commit 0dc26ff5bff3d824b17d17396edc435949021132)