### PR TITLE
doors: Log real path in billing

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -1074,7 +1074,8 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
             }
 
             if (_path != null) {
-                _info.setPath(_path);
+                _info.setBillingPath(_path);
+                _info.setTransferPath(_path);
             }
 
             _message.setId(_sessionId);
@@ -1384,7 +1385,7 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
             infoRemove.setSubject(_subject);
             infoRemove.setPnfsId(attributes.getPnfsId());
             infoRemove.setFileSize(attributes.getSizeIfPresent().or(0L));
-            infoRemove.setPath(path);
+            infoRemove.setBillingPath(path);
             infoRemove.setClient(_clientAddress.getHostAddress());
 
             postToBilling(infoRemove);
@@ -1957,6 +1958,10 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                        pnfsEntry.getPnfsId(), pnfsEntry.getPnfsPath());
             _message = pnfsEntry;
 
+            if (pnfsEntry.getFileAttributes().isDefined(STORAGEINFO) && pnfsEntry.getFileAttributes().getStorageInfo().getKey("path") != null) {
+                _info.setBillingPath(pnfsEntry.getFileAttributes().getStorageInfo().getKey("path"));
+            }
+
             _isNew = true;
 
             return true ;
@@ -2068,7 +2073,7 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                 getPoolMessage = new PoolMgrSelectWritePoolMsg(_fileAttributes, _protocolInfo, getPreallocated());
                 getPoolMessage.setIoQueueName(_ioQueueName );
                 if( _path != null ) {
-                    getPoolMessage.setPnfsPath(new FsPath(_path));
+                    getPoolMessage.setBillingPath(new FsPath(_info.getBillingPath()));
                 }
             }else{
                 //
@@ -2221,7 +2226,8 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                 return ;
             }
 
-            poolMessage.setPnfsPath(new FsPath(_path));
+            poolMessage.setBillingPath(new FsPath(_info.getBillingPath()));
+            poolMessage.setTransferPath(new FsPath(_info.getTransferPath()));
             poolMessage.setId( _sessionId ) ;
             poolMessage.setSubject(_subject);
 

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -4270,7 +4270,7 @@ public abstract class AbstractFtpDoorV1
             DoorRequestInfoMessage infoRemove =
                 new DoorRequestInfoMessage(_cellAddress.toString(), "remove");
             infoRemove.setSubject(_subject);
-            infoRemove.setPath(path);
+            infoRemove.setBillingPath(path);
             infoRemove.setPnfsId(pnfsId);
             infoRemove.setClient(_clientDataAddress.getAddress().getHostAddress());
 

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/RemoveFileCompanion.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/RemoveFileCompanion.java
@@ -195,7 +195,7 @@ public class RemoveFileCompanion
                 new DoorRequestInfoMessage(info.getCellName() + "@" +
                                            info.getDomainName(), "remove");
             msg.setSubject(_subject);
-            msg.setPath(_path);
+            msg.setBillingPath(_path);
             msg.setPnfsId(pnfsid);
             msg.setClient(Subjects.getOrigin(_subject).getAddress().getHostAddress());
 

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -1127,7 +1127,8 @@ public final class Storage
             DoorRequestInfoMessage infoMsg =
                     new DoorRequestInfoMessage(getCellAddress().toString());
             infoMsg.setSubject(subject);
-            infoMsg.setPath(fullPath.toString());
+            infoMsg.setBillingPath(fullPath);
+            infoMsg.setTransferPath(localTransferPath);
             infoMsg.setTransaction(CDC.getSession());
             infoMsg.setPnfsId(msg.getPnfsId());
             infoMsg.setResult(0, "");
@@ -1166,7 +1167,7 @@ public final class Storage
             DoorRequestInfoMessage infoMsg =
                     new DoorRequestInfoMessage(getCellAddress().toString());
             infoMsg.setSubject(subject);
-            infoMsg.setPath(actualPnfsPath.toString());
+            infoMsg.setBillingPath(actualPnfsPath.toString());
             infoMsg.setTransaction(CDC.getSession());
             infoMsg.setPnfsId(msg.getPnfsId());
             infoMsg.setResult(CacheException.DEFAULT_ERROR_CODE, reason);

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
@@ -2,6 +2,8 @@ package diskCacheV111.vehicles;
 
 import javax.security.auth.Subject;
 
+import diskCacheV111.util.FsPath;
+
 import org.dcache.auth.Subjects;
 
 public class DoorRequestInfoMessage extends PnfsFileInfoMessage
@@ -10,6 +12,7 @@ public class DoorRequestInfoMessage extends PnfsFileInfoMessage
     private String _client = "unknown";
 
     private static final long serialVersionUID = 2469895982145157834L;
+    private String _transferPath;
 
     public DoorRequestInfoMessage(String cellName)
     {
@@ -78,5 +81,20 @@ public class DoorRequestInfoMessage extends PnfsFileInfoMessage
     public void accept(InfoMessageVisitor visitor)
     {
         visitor.visit(this);
+    }
+
+    public String getTransferPath()
+    {
+        return _transferPath != null ? _transferPath : getBillingPath();
+    }
+
+    public void setTransferPath(String path)
+    {
+        _transferPath = path;
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        setTransferPath(path.toString());
     }
 }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/MoverInfoMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/MoverInfoMessage.java
@@ -1,5 +1,6 @@
 package diskCacheV111.vehicles;
 
+import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class MoverInfoMessage extends PnfsFileInfoMessage
@@ -13,6 +14,7 @@ public class MoverInfoMessage extends PnfsFileInfoMessage
     private boolean _isP2p;
 
     private static final long serialVersionUID = -7013160118909496211L;
+    private String _transferPath;
 
     public MoverInfoMessage(String cellName,
                             PnfsId pnfsId)
@@ -74,6 +76,21 @@ public class MoverInfoMessage extends PnfsFileInfoMessage
     public ProtocolInfo getProtocolInfo()
     {
         return _protocolInfo;
+    }
+
+    public String getTransferPath()
+    {
+        return _transferPath != null ? _transferPath : getBillingPath();
+    }
+
+    public void setTransferPath(String path)
+    {
+        _transferPath = path;
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        setTransferPath(path.toString());
     }
 
     public String getAdditionalInfo()

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PnfsFileInfoMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PnfsFileInfoMessage.java
@@ -1,7 +1,5 @@
 package diskCacheV111.vehicles;
 
-import java.util.Objects;
-
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
@@ -61,18 +59,18 @@ public abstract class PnfsFileInfoMessage extends InfoMessage
         return _storageInfo;
     }
 
-    public String getPath()
+    public String getBillingPath()
     {
         return _path;
     }
 
-    public void setPath(String path)
+    public void setBillingPath(String path)
     {
         _path = path;
     }
 
-    public void setPath(FsPath path)
+    public void setBillingPath(FsPath path)
     {
-        _path = Objects.toString(path, "Unknown");
+        setBillingPath(path.toString());
     }
 }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PoolHitInfoMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PoolHitInfoMessage.java
@@ -1,5 +1,6 @@
 package diskCacheV111.vehicles;
 
+import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class PoolHitInfoMessage extends PnfsFileInfoMessage {
@@ -8,6 +9,7 @@ public class PoolHitInfoMessage extends PnfsFileInfoMessage {
     private boolean      _fileCached;
 
     private static final long serialVersionUID = -1487408937648228544L;
+    private String _transferPath;
 
     public PoolHitInfoMessage(String cellName, PnfsId pnfsId)
     {
@@ -32,6 +34,21 @@ public class PoolHitInfoMessage extends PnfsFileInfoMessage {
     public ProtocolInfo getProtocolInfo()
     {
 		return _protocolInfo;
+    }
+
+    public String getTransferPath()
+    {
+        return _transferPath != null ? _transferPath : getBillingPath();
+    }
+
+    public void setTransferPath(String path)
+    {
+        _transferPath = path;
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        setTransferPath(path.toString());
     }
 
     public String toString()

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PoolIoFileMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PoolIoFileMessage.java
@@ -1,7 +1,6 @@
 package diskCacheV111.vehicles;
 
 import java.util.EnumSet;
-import java.util.Objects;
 
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
@@ -23,6 +22,7 @@ public class PoolIoFileMessage extends PoolMessage {
     private String       _initiator = "<undefined>";
     private boolean      _forceSourceMode;
     private String _pnfsPath;
+    private String _transferPath;
 
     private static final long serialVersionUID = -6549886547049510754L;
 
@@ -42,7 +42,7 @@ public class PoolIoFileMessage extends PoolMessage {
     public PoolIoFileMessage( String pool ,
                               PnfsId pnfsId ,
                               ProtocolInfo protocolInfo  ){
-       super( pool ) ;
+       super(pool) ;
        _protocolInfo = protocolInfo ;
         _fileAttributes = new FileAttributes();
         _fileAttributes.setPnfsId(pnfsId);
@@ -84,14 +84,24 @@ public class PoolIoFileMessage extends PoolMessage {
         return _initiator;
     }
 
-    public FsPath getPnfsPath()
+    public FsPath getBillingPath()
     {
         return _pnfsPath != null ? new FsPath(_pnfsPath) : null;
     }
 
-    public void setPnfsPath(FsPath path)
+    public void setBillingPath(FsPath path)
     {
-        this._pnfsPath = Objects.toString(path, null);
+        _pnfsPath = path.toString();
+    }
+
+    public FsPath getTransferPath()
+    {
+        return _transferPath != null ? new FsPath(_transferPath) : getBillingPath();
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        _transferPath = path.toString();
     }
 
     public FileAttributes getFileAttributes()

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/WarningPnfsFileInfoMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/WarningPnfsFileInfoMessage.java
@@ -1,10 +1,12 @@
 package diskCacheV111.vehicles;
 
+import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class WarningPnfsFileInfoMessage extends PnfsFileInfoMessage
 {
     private static final long serialVersionUID = -5457677492665743755L;
+    private String _transferPath;
 
     public WarningPnfsFileInfoMessage(String cellType,
                                       String cellName,
@@ -20,5 +22,20 @@ public class WarningPnfsFileInfoMessage extends PnfsFileInfoMessage
     public void accept(InfoMessageVisitor visitor)
     {
         visitor.visit(this);
+    }
+
+    public String getTransferPath()
+    {
+        return _transferPath != null ? _transferPath : getBillingPath();
+    }
+
+    public void setTransferPath(String path)
+    {
+        _transferPath = path;
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        setTransferPath(path.toString());
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -878,7 +878,7 @@ public class DcacheResourceFactory
                 new DoorRequestInfoMessage(getCellAddress().toString(), "remove");
             Subject subject = getSubject();
             infoRemove.setSubject(subject);
-            infoRemove.setPath(path);
+            infoRemove.setBillingPath(path);
             infoRemove.setPnfsId(attributes.getPnfsId());
             infoRemove.setFileSize(attributes.getSizeIfPresent().or(0L));
             infoRemove.setClient(Subjects.getOrigin(subject).getAddress().getHostAddress());

--- a/modules/dcache-xrootd/src/main/java/org/dcache/vehicles/XrootdProtocolInfo.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/vehicles/XrootdProtocolInfo.java
@@ -36,8 +36,6 @@ public class XrootdProtocolInfo implements IpProtocolInfo {
 
     private final int _xrootdFileHandle;
 
-    private String _path;
-
     private final UUID _uuid;
 
     private final InetSocketAddress _doorAddress;
@@ -105,16 +103,6 @@ public class XrootdProtocolInfo implements IpProtocolInfo {
 
     public InetSocketAddress getDoorAddress() {
         return _doorAddress;
-    }
-
-    public void setPath(String path)
-    {
-        _path = path;
-    }
-
-    public String getPath()
-    {
-        return _path;
     }
 
     @Override

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -476,7 +476,7 @@ public class XrootdDoor
             DoorRequestInfoMessage infoRemove =
                     new DoorRequestInfoMessage(getCellAddress().toString(), "remove");
             infoRemove.setSubject(subject);
-            infoRemove.setPath(path);
+            infoRemove.setBillingPath(path);
             infoRemove.setPnfsId(pnfsId);
             Origin origin = Subjects.getOrigin(subject);
             if (origin != null) {

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
@@ -42,18 +42,15 @@ public class XrootdTransfer extends RedirectedTransfer<InetSocketAddress>
 
     protected synchronized ProtocolInfo createProtocolInfo() {
         InetSocketAddress client = getClientAddress();
-        XrootdProtocolInfo protocolInfo =
-            new XrootdProtocolInfo(XrootdDoor.XROOTD_PROTOCOL_STRING,
-                                   XrootdDoor.XROOTD_PROTOCOL_MAJOR_VERSION,
-                                   XrootdDoor.XROOTD_PROTOCOL_MINOR_VERSION,
-                                   client,
-                                   new CellPath(getCellName(), getDomainName()),
-                                   getPnfsId(),
-                                   _fileHandle,
-                                   _uuid,
-                                   _doorAddress);
-        protocolInfo.setPath(_path.toString());
-        return protocolInfo;
+        return new XrootdProtocolInfo(XrootdDoor.XROOTD_PROTOCOL_STRING,
+                                      XrootdDoor.XROOTD_PROTOCOL_MAJOR_VERSION,
+                                      XrootdDoor.XROOTD_PROTOCOL_MINOR_VERSION,
+                                      client,
+                                      new CellPath(getCellName(), getDomainName()),
+                                      getPnfsId(),
+                                      _fileHandle,
+                                      _uuid,
+                                      _doorAddress);
     }
 
     @Override

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -755,7 +755,8 @@ public class RequestContainerV5
         private   StorageInfo  _storageInfo;
         private   ProtocolInfo _protocolInfo;
         private   String       _linkGroup;
-        private   FsPath _path;
+        private   FsPath _billingPath;
+        private   FsPath _transferPath;
 
         private   boolean _enforceP2P;
         private   int     _destinationFileStatus = Pool2PoolTransferMsg.UNDETERMINED ;
@@ -806,7 +807,8 @@ public class RequestContainerV5
            _protocolInfo = request.getProtocolInfo();
            _fileAttributes = request.getFileAttributes();
            _storageInfo = _fileAttributes.getStorageInfo();
-           _path = request.getPnfsPath();
+           _billingPath = request.getBillingPath();
+           _transferPath = request.getTransferPath();
 
            _retryCounter = request.getContext().getRetryCounter();
            _stageCandidateHost = request.getContext().getPreviousStageHost();
@@ -1191,8 +1193,8 @@ public class RequestContainerV5
                 _state = RequestState.ST_DONE;
                 _forceContinue = true;
                 _status = "Failed";
-                sendInfoMessage(_pnfsId , _path, _fileAttributes,
-                                _currentRc , "Failed "+_currentRm);
+                sendInfoMessage(
+                        _currentRc , "Failed "+_currentRm);
             } else {
                 if (state == RequestState.ST_STAGE && !canStage()) {
                     _state = RequestState.ST_DONE;
@@ -1201,8 +1203,8 @@ public class RequestContainerV5
                     _log.debug("Subject is not authorized to stage");
                     _currentRc = CacheException.FILE_NOT_ONLINE;
                     _currentRm = "File not online. Staging not allowed.";
-                    sendInfoMessage(_pnfsId , _path, _fileAttributes,
-                                    _currentRc , "Permission denied." + _currentRm);
+                    sendInfoMessage(
+                            _currentRc , "Permission denied." + _currentRm);
                 } else if (!_allowedStates.contains(state)) {
                     _state = RequestState.ST_DONE;
                     _forceContinue = true;
@@ -1210,7 +1212,7 @@ public class RequestContainerV5
                     _log.debug("No permission to perform {}", state);
                     _currentRc = CacheException.PERMISSION_DENIED;
                     _currentRm = "Permission denied.";
-                    sendInfoMessage(_pnfsId, _path, _fileAttributes, _currentRc,
+                    sendInfoMessage(_currentRc,
                                     "Permission denied for " + state);
                 } else {
                     _state = state;
@@ -1373,8 +1375,8 @@ public class RequestContainerV5
                        nextStep(RequestState.ST_DONE , CONTINUE ) ;
                        _log.info("AskIfAvailable found the object");
                        if (_sendHitInfo ) {
-                           sendHitMsg(_pnfsId, _path, (_bestPool != null) ? _bestPool.getName() : "<UNKNOWN>",
-                                      _fileAttributes, _protocolInfo, true);   //VP
+                           sendHitMsg((_bestPool != null) ? _bestPool.getName() : "<UNKNOWN>",
+                                      true);   //VP
                        }
 
                     }else if( rc == RT_NOT_FOUND ){
@@ -1391,8 +1393,8 @@ public class RequestContainerV5
                           suspendIfEnabled("Suspended (pool unavailable)");
                        }
                        if (_sendHitInfo && _poolCandidate == null) {
-                           sendHitMsg(  _pnfsId, _path, (_bestPool!=null)?_bestPool.getName():"<UNKNOWN>",
-                                        _fileAttributes, _protocolInfo, false );   //VP
+                           sendHitMsg((_bestPool!=null)?_bestPool.getName():"<UNKNOWN>",
+                                      false );   //VP
                        }
                        //
                     }else if( rc == RT_NOT_PERMITTED ){
@@ -1451,9 +1453,9 @@ public class RequestContainerV5
                        setError(0, "");
 
                        if (_sendHitInfo ) {
-                           sendHitMsg(_pnfsId, _path,
+                           sendHitMsg(
                                    (_p2pSourcePool != null) ? _p2pSourcePool.getName() : "<UNKNOWN>",
-                                   _fileAttributes, _protocolInfo, true);   //VP
+                                   true);   //VP
                        }
 
                     }else if( rc == RT_NOT_PERMITTED ){
@@ -1710,8 +1712,8 @@ public class RequestContainerV5
            setError(5,"Resource temporarily unavailable : "+detail);
            nextStep(RequestState.ST_DONE , CONTINUE ) ;
            _status = "Failed" ;
-           sendInfoMessage( _pnfsId , _path, _fileAttributes,
-                            _currentRc , "Failed "+_currentRm );
+           sendInfoMessage(
+                   _currentRc , "Failed "+_currentRm );
         }
 
         private void fail()
@@ -1729,7 +1731,7 @@ public class RequestContainerV5
             _log.debug(" stateEngine: SUSPENDED/WAIT ");
             _status = status + " " + LocalDateTime.now().format(DATE_TIME_FORMAT);
             nextStep(RequestState.ST_SUSPENDED, WAIT);
-            sendInfoMessage(_pnfsId, _path, _fileAttributes,
+            sendInfoMessage(
                     _currentRc, "Suspended (" + _currentRm + ")");
         }
 
@@ -2046,39 +2048,36 @@ public class RequestContainerV5
                           (System.currentTimeMillis() - _started));
             }
         }
-    }
 
-    private void sendInfoMessage( PnfsId pnfsId , FsPath path,
-                                  FileAttributes fileAttributes,
-                                  int rc , String infoMessage ){
-      try{
-        WarningPnfsFileInfoMessage info =
-            new WarningPnfsFileInfoMessage(
-                                    "PoolManager","PoolManager",pnfsId ,
-                                    rc , infoMessage )  ;
-        info.setStorageInfo(fileAttributes.getStorageInfo());
-        info.setFileSize(fileAttributes.getSize());
-        info.setPath(path);
-        _billing.notify(info);
-      } catch (NoRouteToCellException e) {
-          _log.warn("Couldn't send WarningInfoMessage: {}", e.toString());
-      }
-    }
+        private void sendInfoMessage(int rc, String infoMessage)
+        {
+            try {
+                WarningPnfsFileInfoMessage info =
+                        new WarningPnfsFileInfoMessage("PoolManager","PoolManager", _pnfsId, rc, infoMessage);
+                info.setStorageInfo(_fileAttributes.getStorageInfo());
+                info.setFileSize(_fileAttributes.getSize());
+                info.setBillingPath(_billingPath);
+                info.setTransferPath(_transferPath);
+                _billing.notify(info);
+            } catch (NoRouteToCellException e) {
+                _log.warn("Couldn't send WarningInfoMessage: {}", e.toString());
+            }
+        }
 
-    private void sendHitMsg(PnfsId pnfsId, FsPath path, String poolName,
-                            FileAttributes fileAttributes, ProtocolInfo protocolInfo, boolean cached)
-    {
-        try {
-            PoolHitInfoMessage msg = new PoolHitInfoMessage(poolName, pnfsId);
-            msg.setPath(path);
-            msg.setFileCached(cached);
-            msg.setStorageInfo(fileAttributes.getStorageInfo());
-            msg.setFileSize(fileAttributes.getSize());
-            msg.setProtocolInfo(protocolInfo);
-            _billing.notify(msg);
-        } catch (NoRouteToCellException e) {
-            _log.warn("Couldn't report hit info for {}: {}",
-                      pnfsId, e.toString());
+        private void sendHitMsg(String poolName, boolean cached)
+        {
+            try {
+                PoolHitInfoMessage msg = new PoolHitInfoMessage(poolName, _pnfsId);
+                msg.setBillingPath(_billingPath);
+                msg.setTransferPath(_transferPath);
+                msg.setFileCached(cached);
+                msg.setStorageInfo(_fileAttributes.getStorageInfo());
+                msg.setFileSize(_fileAttributes.getSize());
+                msg.setProtocolInfo(_protocolInfo);
+                _billing.notify(msg);
+            } catch (NoRouteToCellException e) {
+                _log.warn("Couldn't report hit info for {}: {}", _pnfsId, e.toString());
+            }
         }
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -58,6 +58,8 @@ import org.dcache.namespace.PosixPermissionHandler;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.PnfsGetFileAttributes;
 
+import static org.dcache.namespace.FileAttribute.STORAGEINFO;
+
 public class TransferManagerHandler extends AbstractMessageCallback<Message>
 {
     private static final Logger log =
@@ -134,7 +136,8 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                 + manager.getCellDomainName());
         info.setTransactionDuration(-creationTime);
         info.setSubject(subject);
-        info.setPath(pnfsPath);
+        info.setBillingPath(pnfsPath);
+        info.setTransferPath(pnfsPath);
         info.setTimeQueued(-System.currentTimeMillis());
         this.requestor = requestor;
         try {
@@ -321,6 +324,10 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         pnfsIdString = pnfsId.toString();
         info.setPnfsId(pnfsId);
         info.setStorageInfo(create.getFileAttributes().getStorageInfo());
+        if (create.getFileAttributes().isDefined(STORAGEINFO) && create.getFileAttributes().getStorageInfo().getKey("path") != null) {
+            info.setBillingPath(create.getFileAttributes().getStorageInfo().getKey("path"));
+        }
+
         selectPool();
     }
 
@@ -366,7 +373,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         PoolMgrSelectPoolMsg request = store
                 ? new PoolMgrSelectWritePoolMsg(fileAttributes, protocol_info)
                 : new PoolMgrSelectReadPoolMsg(fileAttributes, protocol_info, _readPoolSelectionContext);
-        request.setPnfsPath(new FsPath(pnfsPath));
+        request.setBillingPath(new FsPath(pnfsPath));
         request.setSubject(transferRequest.getSubject());
         log.debug("PoolMgrSelectPoolMsg: " + request);
         setState(WAITING_FOR_POOL_INFO_STATE);
@@ -402,7 +409,8 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                 pool,
                 protocol_info,
                 fileAttributes);
-        poolMessage.setPnfsPath(new FsPath(pnfsPath));
+        poolMessage.setBillingPath(new FsPath(info.getBillingPath()));
+        poolMessage.setTransferPath(new FsPath(info.getTransferPath()));
         poolMessage.setSubject(transferRequest.getSubject());
         if (manager.getIoQueueName() != null) {
             poolMessage.setIoQueueName(manager.getIoQueueName());

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectPoolMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectPoolMsg.java
@@ -22,6 +22,7 @@ public class PoolMgrSelectPoolMsg extends PoolMgrGetPoolMsg {
     private final EnumSet<RequestContainerV5.RequestState> _allowedStates;
 
     private boolean _skipCostUpdate;
+    private String _transferPath;
 
     public PoolMgrSelectPoolMsg(FileAttributes fileAttributes,
                                 ProtocolInfo protocolInfo)
@@ -54,12 +55,21 @@ public class PoolMgrSelectPoolMsg extends PoolMgrGetPoolMsg {
     public void setIoQueueName( String ioQueueName ){ _ioQueueName = ioQueueName ; }
     public String getIoQueueName(){ return _ioQueueName ; }
 
-    public FsPath getPnfsPath() {
+    public FsPath getBillingPath() {
         return _pnfsPath != null ? new FsPath(_pnfsPath) : null;
     }
 
-    public void setPnfsPath(FsPath pnfsPath) {
-        this._pnfsPath = pnfsPath.toString();
+    public void setBillingPath(FsPath pnfsPath) {
+        _pnfsPath = pnfsPath.toString();
+    }
+
+    public FsPath getTransferPath()
+    {
+        return _transferPath != null ? new FsPath(_transferPath) : getBillingPath();
+    }
+
+    public void setTransferPath(FsPath path) {
+        _transferPath = path.toString();
     }
 
     public void setLinkGroup(String linkGroup) {

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/StringTemplateInfoMessageVisitor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/StringTemplateInfoMessageVisitor.java
@@ -49,7 +49,7 @@ public class StringTemplateInfoMessageVisitor implements InfoMessageVisitor
     {
         acceptInfoMessage(message);
         template.add("pnfsid", message.getPnfsId());
-        template.add("path", message.getPath());
+        template.add("path", message.getBillingPath());
         template.add("filesize", message.getFileSize());
         template.add("storage", message.getStorageInfo());
     }
@@ -63,6 +63,7 @@ public class StringTemplateInfoMessageVisitor implements InfoMessageVisitor
         template.add("gid", message.getGid());
         template.add("owner", message.getOwner());
         template.add("client", message.getClient());
+        template.add("transferPath", message.getTransferPath());
     }
 
     @Override
@@ -75,6 +76,7 @@ public class StringTemplateInfoMessageVisitor implements InfoMessageVisitor
         template.add("protocol", message.getProtocolInfo());
         template.add("initiator", message.getInitiator());
         template.add("p2p", message.isP2P());
+        template.add("transferPath", message.getTransferPath());
     }
 
     @Override
@@ -83,6 +85,7 @@ public class StringTemplateInfoMessageVisitor implements InfoMessageVisitor
         acceptFileInfoMessage(message);
         template.add("protocol", message.getProtocolInfo());
         template.add("cached", message.getFileCached());
+        template.add("transferPath", message.getTransferPath());
     }
 
     @Override
@@ -102,5 +105,6 @@ public class StringTemplateInfoMessageVisitor implements InfoMessageVisitor
     public void visit(WarningPnfsFileInfoMessage message)
     {
         acceptFileInfoMessage(message);
+        template.add("transferPath", message.getTransferPath());
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -158,9 +158,10 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
         info.setFileSize(fileSize);
         info.setResult(mover.getErrorCode(), mover.getErrorMessage());
         info.setTransferAttributes(mover.getBytesTransferred(),
-                mover.getTransferTime(),
-                mover.getProtocolInfo());
-        info.setPath(mover.getPath());
+                                   mover.getTransferTime(),
+                                   mover.getProtocolInfo());
+        info.setBillingPath(mover.getBillingPath());
+        info.setTransferPath(mover.getTransferPath());
 
         try {
             _billing.notify(info);

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -64,7 +64,8 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
     protected final ReplicaDescriptor _handle;
     protected final IoMode _ioMode;
     protected final TransferService<M> _transferService;
-    protected final FsPath _path;
+    protected final FsPath _billingPath;
+    protected final FsPath _transferPath;
     protected volatile int _errorCode;
     protected volatile String _errorMessage = "";
 
@@ -81,7 +82,8 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
         _ioMode = (message instanceof PoolAcceptFileMessage) ? IoMode.WRITE : IoMode.READ;
         _subject = message.getSubject();
         _id = message.getId();
-        _path = message.getPnfsPath();
+        _billingPath = message.getBillingPath();
+        _transferPath = message.getTransferPath();
         _pathToDoor = pathToDoor;
         _handle = handle;
         _transferService = transferService;
@@ -163,9 +165,15 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
     }
 
     @Override
-    public FsPath getPath()
+    public FsPath getBillingPath()
     {
-        return _path;
+        return _billingPath;
+    }
+
+    @Override
+    public FsPath getTransferPath()
+    {
+        return _transferPath;
     }
 
     @Override

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
@@ -134,9 +134,14 @@ public interface Mover<T extends ProtocolInfo>
     Set<Checksum> getExpectedChecksums();
 
     /**
-     * Returns the name space path of the file being transferred.
+     * Returns the billable name space path of the file being transferred.
      */
-    FsPath getPath();
+    FsPath getBillingPath();
+
+    /**
+     * Returns the temporary name space path of the file being transferred.
+     */
+    FsPath getTransferPath();
 
     /**
      * Initiates the actual transfer phase. The operation is asynchronous. Completion

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -707,6 +707,10 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             super(nearlineStorage);
             infoMsg = new StorageInfoMessage(getCellAddress().toString(), pnfsId, false);
             descriptor = repository.openEntry(pnfsId, NO_FLAGS);
+            String path = descriptor.getFileAttributes().getStorageInfo().getKey("path");
+            if (path != null) {
+                infoMsg.setBillingPath(path);
+            }
             LOGGER.debug("Flush request created for {}.", pnfsId);
         }
 

--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/data/DoorRequestData.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/data/DoorRequestData.java
@@ -97,7 +97,7 @@ public final class DoorRequestData extends PnfsConnectInfo {
         mappedUID = info.getUid();
         mappedGID = info.getGid();
         client = info.getClient();
-        path = info.getPath();
+        path = info.getBillingPath();
     }
 
     public String getOwner() {

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -285,6 +285,26 @@ public class Transfer implements Comparable<Transfer>
     }
 
     /**
+     * The name space path of the file being transferred.
+     */
+    public synchronized FsPath getTransferPath()
+    {
+        return _path;
+    }
+
+    /**
+     * The billable name space path of the file being transferred.
+     */
+    public synchronized FsPath getBillingPath()
+    {
+        if (_fileAttributes.isDefined(STORAGEINFO) && _fileAttributes.getStorageInfo().getKey("path") != null) {
+            return new FsPath(_fileAttributes.getStorageInfo().getKey("path"));
+        } else {
+            return _path;
+        }
+    }
+
+    /**
      * Returns the PnfsId of the file to be transferred.
      */
     public synchronized PnfsId getPnfsId()
@@ -806,7 +826,8 @@ public class Transfer implements Comparable<Transfer>
                                                   allocated);
                 request.setId(_id);
                 request.setSubject(_subject);
-                request.setPnfsPath(_path);
+                request.setBillingPath(getBillingPath());
+                request.setTransferPath(getTransferPath());
 
                 PoolMgrSelectWritePoolMsg reply =
                     _poolManager.sendAndWait(request, timeout);
@@ -826,7 +847,8 @@ public class Transfer implements Comparable<Transfer>
                                                  allowedStates);
                 request.setId(_id);
                 request.setSubject(_subject);
-                request.setPnfsPath(_path);
+                request.setBillingPath(getBillingPath());
+                request.setTransferPath(getTransferPath());
 
                 PoolMgrSelectReadPoolMsg reply =
                     _poolManager.sendAndWait(request, timeout);
@@ -884,7 +906,8 @@ public class Transfer implements Comparable<Transfer>
                 message =
                     new PoolDeliverFileMessage(pool, protocolInfo, fileAttributes);
             }
-            message.setPnfsPath(_path);
+            message.setBillingPath(getBillingPath());
+            message.setTransferPath(getTransferPath());
             message.setIoQueueName(queue);
             message.setInitiator(getTransaction());
             message.setId(_id);
@@ -1010,7 +1033,8 @@ public class Transfer implements Comparable<Transfer>
             DoorRequestInfoMessage msg =
                 new DoorRequestInfoMessage(getCellName() + "@" + getDomainName());
             msg.setSubject(_subject);
-            msg.setPath(_path);
+            msg.setBillingPath(getBillingPath());
+            msg.setTransferPath(getTransferPath());
             msg.setTransactionDuration(System.currentTimeMillis() - _startedAt);
             msg.setTransaction(getTransaction());
             msg.setClient(_clientAddress.getAddress().getHostAddress());

--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -116,6 +116,7 @@ billing.text.dir = ${dcache.paths.billing}
 #   initiator       String       Name of cell that initiated the transfer;
 #                                if p2p, begins with "pool:"; otherwise "door:"
 #   p2p             Boolean      True if transfer is pool to pool
+#   transferPath    String       Actual transfer path
 #
 # Message: DoorRequestInfoMessage extends PnfsFileInfoMessage
 # -----------------------------------------------------------
@@ -127,6 +128,7 @@ billing.text.dir = ${dcache.paths.billing}
 #   gid               Integer    GID of user
 #   owner             String     DN or user name
 #   client            String     Client IP address
+#   transferPath      String     Actual transfer path
 #
 #
 # Message: StorageInfoMessage extends PnfsFileInfoMessage
@@ -150,6 +152,7 @@ billing.text.dir = ${dcache.paths.billing}
 #   ---------       ----         -----------
 #   protocol        ProtocolInfo Protocol related information
 #   cached          Boolean      Whether file was already online
+#   transferPath    String       Actual transfer path
 #
 #
 # Type: Date


### PR DESCRIPTION
When introducing the upload directories (i.e. unique write TURLs), I choose to
log the upload path in billing and only log the real path in the billing entry
created by the SRM. The idea was to allow us to distinguish between uploads
belonging to different SRM sessions.

Nobody seems to appreciate this use of the path in the billing and at the same
time the use of the upload path causes lots of confusion. This patch thus
ensures that the real path is logged to billing instead. This also makes sense
when viewing it from the point of this being an accounting record: If you want
to hold the user responsible, the record should be phrased in terms the user
understands (i.e. the real path).

The real path is only available as the "path" flag in StorageInfo, so this
patch extracts that field and injects it into the relevant mesages. To make it
clear that this is a path intended for billing, a number of setters and getters
of various messages have been renamed (the fields in the messages have not been
renamed to maintain backwards compatibility).

The temporary upload path is available as a new field in billing called
transferPath. It is not used by default, but sites that want the temporary path
logged can do so.

One unused field from the XrootdProtocolInfo has been removed.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8140/
(cherry picked from commit a463837a0613eb4c3bf64c4049c6e9be56402889)