### PR TITLE
doors: Log real path in billing

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -1103,7 +1103,8 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
             }
 
             if (_path != null) {
-                _info.setPath(_path);
+                _info.setBillingPath(_path);
+                _info.setTransferPath(_path);
             }
 
             _message.setId(_sessionId);
@@ -1401,7 +1402,7 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
             infoRemove.setSubject(_subject);
             infoRemove.setPnfsId(attributes.getPnfsId());
             infoRemove.setFileSize(attributes.getSize());
-            infoRemove.setPath(path);
+            infoRemove.setBillingPath(path);
             infoRemove.setClient(_clientAddress.getHostAddress());
 
             postToBilling(infoRemove);
@@ -1973,6 +1974,10 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                        pnfsEntry.getPnfsId(), pnfsEntry.getPnfsPath());
             _message = pnfsEntry;
 
+            if (pnfsEntry.getFileAttributes().isDefined(STORAGEINFO) && pnfsEntry.getFileAttributes().getStorageInfo().getKey("path") != null) {
+                _info.setBillingPath(pnfsEntry.getFileAttributes().getStorageInfo().getKey("path"));
+            }
+
             _isNew = true;
 
             return true ;
@@ -2084,7 +2089,7 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                 getPoolMessage = new PoolMgrSelectWritePoolMsg(_fileAttributes, _protocolInfo, getPreallocated());
                 getPoolMessage.setIoQueueName(_ioQueueName );
                 if( _path != null ) {
-                    getPoolMessage.setPnfsPath(new FsPath(_path));
+                    getPoolMessage.setBillingPath(new FsPath(_info.getBillingPath()));
                 }
             }else{
                 //
@@ -2237,7 +2242,8 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                 return ;
             }
 
-            poolMessage.setPnfsPath(new FsPath(_path));
+            poolMessage.setBillingPath(new FsPath(_info.getBillingPath()));
+            poolMessage.setTransferPath(new FsPath(_info.getTransferPath()));
             poolMessage.setId( _sessionId ) ;
             poolMessage.setSubject(_subject);
 

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -4273,7 +4273,7 @@ public abstract class AbstractFtpDoorV1
             DoorRequestInfoMessage infoRemove =
                 new DoorRequestInfoMessage(_cellAddress.toString(), "remove");
             infoRemove.setSubject(_subject);
-            infoRemove.setPath(path);
+            infoRemove.setBillingPath(path);
             infoRemove.setPnfsId(pnfsId);
             infoRemove.setClient(_clientDataAddress.getAddress().getHostAddress());
 

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -864,7 +864,7 @@ public class DcacheResourceFactory
                 new DoorRequestInfoMessage(getCellAddress().toString(), "remove");
             Subject subject = getSubject();
             infoRemove.setSubject(subject);
-            infoRemove.setPath(path);
+            infoRemove.setBillingPath(path);
             infoRemove.setPnfsId(attributes.getPnfsId());
             infoRemove.setFileSize(attributes.getSize());
             infoRemove.setClient(Subjects.getOrigin(subject).getAddress().getHostAddress());

--- a/modules/dcache-xrootd/src/main/java/org/dcache/vehicles/XrootdProtocolInfo.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/vehicles/XrootdProtocolInfo.java
@@ -36,8 +36,6 @@ public class XrootdProtocolInfo implements IpProtocolInfo {
 
     private final int _xrootdFileHandle;
 
-    private String _path;
-
     private final UUID _uuid;
 
     private final InetSocketAddress _doorAddress;
@@ -105,16 +103,6 @@ public class XrootdProtocolInfo implements IpProtocolInfo {
 
     public InetSocketAddress getDoorAddress() {
         return _doorAddress;
-    }
-
-    public void setPath(String path)
-    {
-        _path = path;
-    }
-
-    public String getPath()
-    {
-        return _path;
     }
 
     @Override

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -483,7 +483,7 @@ public class XrootdDoor
             DoorRequestInfoMessage infoRemove =
                     new DoorRequestInfoMessage(getCellAddress().toString(), "remove");
             infoRemove.setSubject(subject);
-            infoRemove.setPath(path);
+            infoRemove.setBillingPath(path);
             infoRemove.setPnfsId(pnfsId);
             Origin origin = Subjects.getOrigin(subject);
             if (origin != null) {

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
@@ -42,18 +42,15 @@ public class XrootdTransfer extends RedirectedTransfer<InetSocketAddress>
 
     protected synchronized ProtocolInfo createProtocolInfo() {
         InetSocketAddress client = getClientAddress();
-        XrootdProtocolInfo protocolInfo =
-            new XrootdProtocolInfo(XrootdDoor.XROOTD_PROTOCOL_STRING,
-                                   XrootdDoor.XROOTD_PROTOCOL_MAJOR_VERSION,
-                                   XrootdDoor.XROOTD_PROTOCOL_MINOR_VERSION,
-                                   client,
-                                   new CellPath(getCellName(), getDomainName()),
-                                   getPnfsId(),
-                                   _fileHandle,
-                                   _uuid,
-                                   _doorAddress);
-        protocolInfo.setPath(_path.toString());
-        return protocolInfo;
+        return new XrootdProtocolInfo(XrootdDoor.XROOTD_PROTOCOL_STRING,
+                                      XrootdDoor.XROOTD_PROTOCOL_MAJOR_VERSION,
+                                      XrootdDoor.XROOTD_PROTOCOL_MINOR_VERSION,
+                                      client,
+                                      new CellPath(getCellName(), getDomainName()),
+                                      getPnfsId(),
+                                      _fileHandle,
+                                      _uuid,
+                                      _doorAddress);
     }
 
     @Override

--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/RemoveFileCompanion.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/RemoveFileCompanion.java
@@ -195,7 +195,7 @@ public class RemoveFileCompanion
                 new DoorRequestInfoMessage(info.getCellName() + "@" +
                                            info.getDomainName(), "remove");
             msg.setSubject(_subject);
-            msg.setPath(_path);
+            msg.setBillingPath(_path);
             msg.setPnfsId(pnfsid);
             msg.setClient(Subjects.getOrigin(_subject).getAddress().getHostAddress());
 

--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -1089,7 +1089,8 @@ public final class Storage
             DoorRequestInfoMessage infoMsg =
                     new DoorRequestInfoMessage(getCellAddress().toString());
             infoMsg.setSubject(subject);
-            infoMsg.setPath(fullPath.toString());
+            infoMsg.setBillingPath(fullPath);
+            infoMsg.setTransferPath(localTransferPath);
             infoMsg.setTransaction(CDC.getSession());
             infoMsg.setPnfsId(msg.getPnfsId());
             infoMsg.setResult(0, "");
@@ -1128,7 +1129,7 @@ public final class Storage
             DoorRequestInfoMessage infoMsg =
                     new DoorRequestInfoMessage(getCellAddress().toString());
             infoMsg.setSubject(subject);
-            infoMsg.setPath(actualPnfsPath.toString());
+            infoMsg.setBillingPath(actualPnfsPath.toString());
             infoMsg.setTransaction(CDC.getSession());
             infoMsg.setPnfsId(msg.getPnfsId());
             infoMsg.setResult(CacheException.DEFAULT_ERROR_CODE, reason);

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
@@ -5,6 +5,8 @@ import org.stringtemplate.v4.ST;
 
 import javax.security.auth.Subject;
 
+import diskCacheV111.util.FsPath;
+
 import org.dcache.auth.Subjects;
 
 public class DoorRequestInfoMessage extends PnfsFileInfoMessage
@@ -13,6 +15,7 @@ public class DoorRequestInfoMessage extends PnfsFileInfoMessage
     private String _client = "unknown";
 
     private static final long serialVersionUID = 2469895982145157834L;
+    private String _transferPath;
 
     public DoorRequestInfoMessage(String cellName) {
         super("request", "door", cellName, null);
@@ -79,5 +82,20 @@ public class DoorRequestInfoMessage extends PnfsFileInfoMessage
         template.add("gid", getGid());
         template.add("owner", getOwner());
         template.add("client", getClient());
+    }
+
+    public String getTransferPath()
+    {
+        return _transferPath != null ? _transferPath : getBillingPath();
+    }
+
+    public void setTransferPath(String path)
+    {
+        _transferPath = path;
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        setTransferPath(path.toString());
     }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/MoverInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/MoverInfoMessage.java
@@ -3,6 +3,7 @@ package diskCacheV111.vehicles ;
 
 import org.stringtemplate.v4.ST;
 
+import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class MoverInfoMessage extends PnfsFileInfoMessage {
@@ -16,8 +17,9 @@ public class MoverInfoMessage extends PnfsFileInfoMessage {
    private boolean _isP2p;
 
    private static final long serialVersionUID = -7013160118909496211L;
+    private String _transferPath;
 
-   public MoverInfoMessage( String cellName ,
+    public MoverInfoMessage( String cellName ,
                             PnfsId pnfsId     ){
 
       super( "transfer" , "pool" , cellName , pnfsId ) ;
@@ -47,6 +49,21 @@ public class MoverInfoMessage extends PnfsFileInfoMessage {
    public boolean isP2P(){ return _isP2p ; }
    public ProtocolInfo getProtocolInfo(){ return _protocolInfo ; }
 
+    public String getTransferPath()
+    {
+        return _transferPath != null ? _transferPath : getBillingPath();
+    }
+
+    public void setTransferPath(String path)
+    {
+        _transferPath = path;
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        setTransferPath(path.toString());
+    }
+
     public String getAdditionalInfo() {
        return _dataTransferred + " "
                 + _connectionTime + " "
@@ -71,5 +88,6 @@ public class MoverInfoMessage extends PnfsFileInfoMessage {
         template.add("protocol", _protocolInfo);
         template.add("initiator", _initiator);
         template.add("p2p", _isP2p);
+        template.add("transferPath", getTransferPath());
     }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsFileInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsFileInfoMessage.java
@@ -38,16 +38,16 @@ public class PnfsFileInfoMessage extends InfoMessage {
       _storageInfo = storageInfo ;
    }
    public StorageInfo getStorageInfo(){ return _storageInfo ; }
-   public String getPath() { return _path; }
-   public void setPath(String path) { _path = path; }
-   public void setPath(FsPath path) { _path = Objects.toString(path, "Unknown"); }
+   public String getBillingPath() { return _path; }
+   public void setBillingPath(String path) { _path = path; }
+   public void setBillingPath(FsPath path) { _path = Objects.toString(path, "Unknown"); }
 
     @Override
     public void fillTemplate(ST template)
     {
         super.fillTemplate(template);
         template.add("pnfsid", getPnfsId());
-        template.add("path", getPath());
+        template.add("path", getBillingPath());
         template.add("filesize", getFileSize());
         template.add("storage", getStorageInfo());
     }

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolHitInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolHitInfoMessage.java
@@ -3,6 +3,7 @@ package diskCacheV111.vehicles ;
 
 import org.stringtemplate.v4.ST;
 
+import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class PoolHitInfoMessage extends PnfsFileInfoMessage {
@@ -11,6 +12,7 @@ public class PoolHitInfoMessage extends PnfsFileInfoMessage {
     private boolean      _fileCached;
 
     private static final long serialVersionUID = -1487408937648228544L;
+    private String _transferPath;
 
     public PoolHitInfoMessage(String cellName, PnfsId pnfsId)
     {
@@ -35,6 +37,21 @@ public class PoolHitInfoMessage extends PnfsFileInfoMessage {
     public ProtocolInfo getProtocolInfo()
     {
 		return _protocolInfo;
+    }
+
+    public String getTransferPath()
+    {
+        return _transferPath != null ? _transferPath : getBillingPath();
+    }
+
+    public void setTransferPath(String path)
+    {
+        _transferPath = path;
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        setTransferPath(path.toString());
     }
 
     public String toString()

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolIoFileMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolIoFileMessage.java
@@ -1,7 +1,6 @@
 package diskCacheV111.vehicles;
 
 import java.util.EnumSet;
-import java.util.Objects;
 
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
@@ -23,6 +22,7 @@ public class PoolIoFileMessage extends PoolMessage {
     private String       _initiator = "<undefined>";
     private boolean      _forceSourceMode;
     private String _pnfsPath;
+    private String _transferPath;
 
     private static final long serialVersionUID = -6549886547049510754L;
 
@@ -42,7 +42,7 @@ public class PoolIoFileMessage extends PoolMessage {
     public PoolIoFileMessage( String pool ,
                               PnfsId pnfsId ,
                               ProtocolInfo protocolInfo  ){
-       super( pool ) ;
+       super(pool) ;
        _protocolInfo = protocolInfo ;
         _fileAttributes = new FileAttributes();
         _fileAttributes.setPnfsId(pnfsId);
@@ -84,14 +84,24 @@ public class PoolIoFileMessage extends PoolMessage {
         return _initiator;
     }
 
-    public FsPath getPnfsPath()
+    public FsPath getBillingPath()
     {
         return _pnfsPath != null ? new FsPath(_pnfsPath) : null;
     }
 
-    public void setPnfsPath(FsPath path)
+    public void setBillingPath(FsPath path)
     {
-        this._pnfsPath = Objects.toString(path, null);
+        _pnfsPath = path.toString();
+    }
+
+    public FsPath getTransferPath()
+    {
+        return _transferPath != null ? new FsPath(_transferPath) : getBillingPath();
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        _transferPath = path.toString();
     }
 
     public FileAttributes getFileAttributes()

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectPoolMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectPoolMsg.java
@@ -24,6 +24,7 @@ public class PoolMgrSelectPoolMsg extends PoolMgrGetPoolMsg {
     private final EnumSet<RequestContainerV5.RequestState> _allowedStates;
 
     private boolean _skipCostUpdate;
+    private String _transferPath;
 
     public PoolMgrSelectPoolMsg(FileAttributes fileAttributes,
                                 ProtocolInfo protocolInfo)
@@ -56,12 +57,21 @@ public class PoolMgrSelectPoolMsg extends PoolMgrGetPoolMsg {
     public void setIoQueueName( String ioQueueName ){ _ioQueueName = ioQueueName ; }
     public String getIoQueueName(){ return _ioQueueName ; }
 
-    public FsPath getPnfsPath() {
+    public FsPath getBillingPath() {
         return _pnfsPath != null ? new FsPath(_pnfsPath) : null;
     }
 
-    public void setPnfsPath(FsPath pnfsPath) {
-        this._pnfsPath = pnfsPath.toString();
+    public void setBillingPath(FsPath pnfsPath) {
+        _pnfsPath = pnfsPath.toString();
+    }
+
+    public FsPath getTransferPath()
+    {
+        return _transferPath != null ? new FsPath(_transferPath) : getBillingPath();
+    }
+
+    public void setTransferPath(FsPath path) {
+        _transferPath = path.toString();
     }
 
     public void setLinkGroup(String linkGroup) {

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/WarningPnfsFileInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/WarningPnfsFileInfoMessage.java
@@ -2,13 +2,15 @@
 
 package diskCacheV111.vehicles ;
 
+import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class WarningPnfsFileInfoMessage extends PnfsFileInfoMessage {
 
     private static final long serialVersionUID = -5457677492665743755L;
+    private String _transferPath;
 
-   public WarningPnfsFileInfoMessage( String cellType ,
+    public WarningPnfsFileInfoMessage( String cellType ,
                               String cellName ,
                               PnfsId pnfsId ,
                               int rc ,
@@ -16,4 +18,19 @@ public class WarningPnfsFileInfoMessage extends PnfsFileInfoMessage {
       super("warning" , cellType , cellName , pnfsId ) ;
       setResult( rc , returnMessage ) ;
    }
+
+    public String getTransferPath()
+    {
+        return _transferPath != null ? _transferPath : getBillingPath();
+    }
+
+    public void setTransferPath(String path)
+    {
+        _transferPath = path;
+    }
+
+    public void setTransferPath(FsPath path)
+    {
+        setTransferPath(path.toString());
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -153,9 +153,10 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
         info.setFileSize(fileSize);
         info.setResult(mover.getErrorCode(), mover.getErrorMessage());
         info.setTransferAttributes(mover.getBytesTransferred(),
-                mover.getTransferTime(),
-                mover.getProtocolInfo());
-        info.setPath(mover.getPath());
+                                   mover.getTransferTime(),
+                                   mover.getProtocolInfo());
+        info.setBillingPath(mover.getBillingPath());
+        info.setTransferPath(mover.getTransferPath());
 
         try {
             _billing.notify(info);

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -67,7 +67,8 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends Mover<P>> 
     protected final IoMode _ioMode;
     protected final TransferService<Mover<P>> _transferService;
     protected final PostTransferService _postTransferService;
-    protected final FsPath _path;
+    protected final FsPath _billingPath;
+    protected final FsPath _transferPath;
     protected volatile int _errorCode;
     protected volatile String _errorMessage = "";
 
@@ -83,7 +84,8 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends Mover<P>> 
         _ioMode = (message instanceof PoolAcceptFileMessage) ? IoMode.WRITE : IoMode.READ;
         _subject = message.getSubject();
         _id = message.getId();
-        _path = message.getPnfsPath();
+        _billingPath = message.getBillingPath();
+        _transferPath = message.getTransferPath();
         _pathToDoor = pathToDoor;
         _handle = handle;
         _transferService = (TransferService<Mover<P>>) transferService;
@@ -166,9 +168,15 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends Mover<P>> 
     }
 
     @Override
-    public FsPath getPath()
+    public FsPath getBillingPath()
     {
-        return _path;
+        return _billingPath;
+    }
+
+    @Override
+    public FsPath getTransferPath()
+    {
+        return _transferPath;
     }
 
     @Override

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
@@ -134,9 +134,14 @@ public interface Mover<T extends ProtocolInfo>
     Set<Checksum> getExpectedChecksums();
 
     /**
-     * Returns the name space path of the file being transferred.
+     * Returns the billable name space path of the file being transferred.
      */
-    FsPath getPath();
+    FsPath getBillingPath();
+
+    /**
+     * Returns the temporary name space path of the file being transferred.
+     */
+    FsPath getTransferPath();
 
     /**
      * Initiates the actual transfer phase. The operation is asynchronous.

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -688,6 +688,10 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             super(nearlineStorage);
             infoMsg = new StorageInfoMessage(getCellAddress().toString(), pnfsId, false);
             descriptor = repository.openEntry(pnfsId, NO_FLAGS);
+            String path = descriptor.getFileAttributes().getStorageInfo().getKey("path");
+            if (path != null) {
+                infoMsg.setBillingPath(path);
+            }
             LOGGER.debug("Flush request created for {}.", pnfsId);
         }
 

--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/data/DoorRequestData.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/data/DoorRequestData.java
@@ -97,7 +97,7 @@ public final class DoorRequestData extends PnfsConnectInfo {
         mappedUID = info.getUid();
         mappedGID = info.getGid();
         client = info.getClient();
-        path = info.getPath();
+        path = info.getBillingPath();
     }
 
     public String getOwner() {

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -280,6 +280,26 @@ public class Transfer implements Comparable<Transfer>
     }
 
     /**
+     * The name space path of the file being transferred.
+     */
+    public synchronized FsPath getTransferPath()
+    {
+        return _path;
+    }
+
+    /**
+     * The billable name space path of the file being transferred.
+     */
+    public synchronized FsPath getBillingPath()
+    {
+        if (_fileAttributes.isDefined(STORAGEINFO) && _fileAttributes.getStorageInfo().getKey("path") != null) {
+            return new FsPath(_fileAttributes.getStorageInfo().getKey("path"));
+        } else {
+            return _path;
+        }
+    }
+
+    /**
      * Returns the PnfsId of the file to be transferred.
      */
     public synchronized PnfsId getPnfsId()
@@ -764,7 +784,8 @@ public class Transfer implements Comparable<Transfer>
                                                   allocated);
                 request.setId(_sessionId);
                 request.setSubject(_subject);
-                request.setPnfsPath(_path);
+                request.setBillingPath(getBillingPath());
+                request.setTransferPath(getTransferPath());
 
                 PoolMgrSelectWritePoolMsg reply =
                     _poolManager.sendAndWait(request, timeout);
@@ -784,7 +805,8 @@ public class Transfer implements Comparable<Transfer>
                                                  allowedStates);
                 request.setId(_sessionId);
                 request.setSubject(_subject);
-                request.setPnfsPath(_path);
+                request.setBillingPath(getBillingPath());
+                request.setTransferPath(getTransferPath());
 
                 PoolMgrSelectReadPoolMsg reply =
                     _poolManager.sendAndWait(request, timeout);
@@ -844,7 +866,8 @@ public class Transfer implements Comparable<Transfer>
                 message =
                     new PoolDeliverFileMessage(pool, protocolInfo, fileAttributes);
             }
-            message.setPnfsPath(_path);
+            message.setBillingPath(getBillingPath());
+            message.setTransferPath(getTransferPath());
             message.setIoQueueName(queue);
             message.setInitiator(getTransaction());
             message.setId(_sessionId);
@@ -970,7 +993,8 @@ public class Transfer implements Comparable<Transfer>
             DoorRequestInfoMessage msg =
                 new DoorRequestInfoMessage(getCellName() + "@" + getDomainName());
             msg.setSubject(_subject);
-            msg.setPath(_path);
+            msg.setBillingPath(getBillingPath());
+            msg.setTransferPath(getTransferPath());
             msg.setTransactionDuration(System.currentTimeMillis() - _startedAt);
             msg.setTransaction(getTransaction());
             msg.setClient(_clientAddress.getAddress().getHostAddress());

--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -117,6 +117,7 @@ billing.text.dir=${billingLogsDir}
 #   initiator       String       Name of cell that initiated the transfer;
 #                                if p2p, begins with "pool:"; otherwise "door:"
 #   p2p             Boolean      True if transfer is pool to pool
+#   transferPath    String       Actual transfer path
 #
 # Message: DoorRequestInfoMessage extends PnfsFileInfoMessage
 # -----------------------------------------------------------
@@ -128,6 +129,7 @@ billing.text.dir=${billingLogsDir}
 #   gid               Integer    GID of user
 #   owner             String     DN or user name
 #   client            String     Client IP address
+#   transferPath      String     Actual transfer path
 #
 #
 # Message: StorageInfoMessage extends PnfsFileInfoMessage
@@ -151,6 +153,7 @@ billing.text.dir=${billingLogsDir}
 #   ---------       ----         -----------
 #   protocol        ProtocolInfo Protocol related information
 #   cached          Boolean      Whether file was already online
+#   transferPath    String       Actual transfer path
 #
 #
 # Type: Date


### PR DESCRIPTION
When introducing the upload directories (i.e. unique write TURLs), I choose to
log the upload path in billing and only log the real path in the billing entry
created by the SRM. The idea was to allow us to distinguish between uploads
belonging to different SRM sessions.

Nobody seems to appreciate this use of the path in the billing and at the same
time the use of the upload path causes lots of confusion. This patch thus
ensures that the real path is logged to billing instead. This also makes sense
when viewing it from the point of this being an accounting record: If you want
to hold the user responsible, the record should be phrased in terms the user
understands (i.e. the real path).

The real path is only available as the "path" flag in StorageInfo, so this
patch extracts that field and injects it into the relevant mesages. To make it
clear that this is a path intended for billing, a number of setters and getters
of various messages have been renamed (the fields in the messages have not been
renamed to maintain backwards compatibility).

The temporary upload path is available as a new field in billing called
transferPath. It is not used by default, but sites that want the temporary path
logged can do so.

One unused field from the XrootdProtocolInfo has been removed.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8140/
(cherry picked from commit a463837a0613eb4c3bf64c4049c6e9be56402889)
(cherry picked from commit 1dc76219510c6a25f8b1645a7c233978fc5cf4f1)
(cherry picked from commit d9f7517bc816c5d90d73d736a084f9367268a5e9)