### PR TITLE
srm: Fix scheduler counter initialization on restart

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -1086,6 +1086,9 @@ public abstract class Job  {
                 return;
             }
 
+            setScheduler(scheduler.getId(), scheduler.getTimestamp());
+            notifySchedulerOfStateChange(State.RESTORED, state);
+
             if (shouldFailJobs) {
                 setState(State.FAILED, "Aborted due to SRM service restart.");
                 return;
@@ -1095,8 +1098,6 @@ public abstract class Job  {
                 setState(State.FAILED, "Expired during SRM service restart.");
                 return;
             }
-
-            setScheduler(scheduler.getId(), scheduler.getTimestamp());
 
             switch (state) {
             // Pending jobs were never worked on before the SRM restart; we
@@ -1115,7 +1116,6 @@ public abstract class Job  {
             // the job into the DONE state, respectively.
             case READY:
             case RQUEUED:
-                scheduler.add(this);
                 break;
 
             // Other job states need request-specific recovery process.


### PR DESCRIPTION
SRM jobs notify their scheduler whenever their state changes. The scheduler in
turn maintains counts on how many jobs are in a particular state. Upon restart
there are cases in which we change job state to Failed, causing the scheduler
counters to be decremented, but without the jobs having been accounted for
first.

This patch solves this problem by triggering an artificial state change
notification for every restored job from RESTORED to the actual state.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8160/
(cherry picked from commit 295e150edd71df4b872cb91de8e81b88af1c67c9)