### PR TITLE
srm: Fix scheduler counter initialization on restart

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -1117,6 +1117,9 @@ public abstract class Job  {
                 return;
             }
 
+            setScheduler(scheduler.getId(), scheduler.getTimestamp());
+            notifySchedulerOfStateChange(State.RESTORED, state);
+
             if (shouldFailJobs) {
                 setState(State.FAILED, "Aborted due to SRM service restart.");
                 return;
@@ -1126,8 +1129,6 @@ public abstract class Job  {
                 setState(State.FAILED, "Expired during SRM service restart.");
                 return;
             }
-
-            setScheduler(scheduler.getId(), scheduler.getTimestamp());
 
             switch (state) {
             // Pending jobs were never worked on before the SRM restart; we
@@ -1146,7 +1147,6 @@ public abstract class Job  {
             // the job into the DONE state, respectively.
             case READY:
             case RQUEUED:
-                scheduler.add(this);
                 break;
 
             // Other job states need request-specific recovery process.

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -255,42 +255,6 @@ public class Scheduler <T extends Job>
         }
     }
 
-    /**
-     * Add a job that requires no scheduling.  This is called during SRM
-     * restart.
-     *
-     * REVISIT: should this be merged with schedule or non-scheduled job handling
-     * moved outside of Scheduler.
-     */
-    public void add(Job job) throws IllegalStateException
-    {
-        job.wlock();
-        try {
-            switch (job.getState()) {
-            case RQUEUED:
-                increaseNumberOfReadyQueued(job);
-                readyQueue(job);
-                break;
-
-            case READY:
-                // NB. this may increase number of READY jobs beyond the
-                // accepted limit (i.e., the limit was decreased during SRM
-                // restart); however, there's not much we can do about this
-                // as the client already knows about this TURL, so we cannot
-                // reduce the number of active TURLs.
-                increaseNumberOfReady(job);
-                break;
-
-            default:
-                throw new IllegalStateException("cannot accept job in state " +
-                        job.getState());
-            }
-        } finally {
-            job.wunlock();
-        }
-    }
-
-
     private void increaseNumberOfRunningState(Job job)
     {
         runningStateJobsNum.increment(job.getSubmitterId());
@@ -483,11 +447,6 @@ public class Scheduler <T extends Job>
     private int getTotalInprogress()
     {
         return getTotalAsyncWait() + getTotalPriorityTQueued() + getTotalRunningState() + getTotalRunningWithoutThreadState();
-    }
-
-    private void readyQueue(Job job)
-    {
-        readyQueue.put(job);
     }
 
     public double getLoad()
@@ -720,7 +679,6 @@ public class Scheduler <T extends Job>
                     try {
                         if (job.getState() == State.RUNNING) {
                             job.setState(State.RQUEUED, "Putting on a \"Ready\" Queue.");
-                            readyQueue(job);
                         }
                     } catch (IllegalStateTransition e) {
                         LOGGER.error("Illegal State Transition : " + e.getMessage());
@@ -777,6 +735,7 @@ public class Scheduler <T extends Job>
             break;
         case RQUEUED:
             increaseNumberOfReadyQueued(job);
+            readyQueue.put(job);
             break;
         case READY:
         case TRANSFERRING:


### PR DESCRIPTION
SRM jobs notify their scheduler whenever their state changes. The scheduler in
turn maintains counts on how many jobs are in a particular state. Upon restart
there are cases in which we change job state to Failed, causing the scheduler
counters to be decremented, but without the jobs having been accounted for
first.

This patch solves this problem by triggering an artificial state change
notification for every restored job from RESTORED to the actual state.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8160/
(cherry picked from commit 295e150edd71df4b872cb91de8e81b88af1c67c9)