### PR TITLE
nfs-proxy: do not block forever on proxy requests

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIo.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIo.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import org.dcache.util.NetworkUtils;
 
 import org.dcache.nfs.nfsstat;
+import org.dcache.nfs.status.DelayException;
 import org.dcache.nfs.v4.client.CompoundBuilder;
 import org.dcache.nfs.v4.xdr.COMPOUND4args;
 import org.dcache.nfs.v4.xdr.COMPOUND4res;
@@ -51,6 +52,12 @@ public class NfsProxyIo implements ProxyIoAdapter {
 
     private final static String IMPL_DOMAIN = "dCache.ORG";
     private final static String IMPL_NAME = "proxyio-nfs-client";
+
+    /**
+     * How long we wait for an IO request. The typical NFS client will wait
+     * 30 sec. We will use a shorter timeout to avoid retry.
+     */
+    private final static int IO_TIMEOUT = (int)TimeUnit.SECONDS.toMillis(15);
 
     /**
      * Most up-to-date seqid for a given stateid as defined by rfc5661.
@@ -161,7 +168,12 @@ public class NfsProxyIo implements ProxyIoAdapter {
             throws OncRpcException, IOException {
         COMPOUND4res result = new COMPOUND4res();
 
-        client.call(nfs4_prot.NFSPROC4_COMPOUND_4, arg, result);
+        try {
+            client.call(nfs4_prot.NFSPROC4_COMPOUND_4, arg, result, IO_TIMEOUT);
+        } catch (IOException e) {
+            // unfortunately RPC library maps timeout to IOException
+            throw new DelayException();
+        }
 
         return result;
     }


### PR DESCRIPTION
if for some reason pool don't reply, the processing thread
will block forever. As client times out, it will send a new request
and the next thread will be block. This leads to DoS.

With this change we wait in timed fashion, free request thread
and reply NFSERR_DELAY to the client.

Observed at DESY due to a bug in pool code.

Target: master, 2.12, 2.11, 2.10
Acked-by: Paul Millar
(cherry picked from commit 54d532ca15d8b3e898cbd0bcd486e98c229eb87c)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>