### PR TITLE
all: Fix several NPEs when submitting billing messages

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -2089,7 +2089,7 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                 getPoolMessage = new PoolMgrSelectWritePoolMsg(_fileAttributes, _protocolInfo, getPreallocated());
                 getPoolMessage.setIoQueueName(_ioQueueName );
                 if( _path != null ) {
-                    getPoolMessage.setBillingPath(new FsPath(_info.getBillingPath()));
+                    getPoolMessage.setBillingPath(_info.getBillingPath());
                 }
             }else{
                 //
@@ -2242,8 +2242,8 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                 return ;
             }
 
-            poolMessage.setBillingPath(new FsPath(_info.getBillingPath()));
-            poolMessage.setTransferPath(new FsPath(_info.getTransferPath()));
+            poolMessage.setBillingPath(_info.getBillingPath());
+            poolMessage.setTransferPath(_info.getTransferPath());
             poolMessage.setId( _sessionId ) ;
             poolMessage.setSubject(_subject);
 

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -4262,7 +4262,7 @@ public abstract class AbstractFtpDoorV1
             DoorRequestInfoMessage infoRemove =
                 new DoorRequestInfoMessage(_cellAddress.toString(), "remove");
             infoRemove.setSubject(_subject);
-            infoRemove.setBillingPath(path);
+            infoRemove.setBillingPath(path.toString());
             infoRemove.setPnfsId(pnfsId);
             infoRemove.setClient(_clientDataAddress.getAddress().getHostAddress());
 

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -1089,7 +1089,7 @@ public final class Storage
             DoorRequestInfoMessage infoMsg =
                     new DoorRequestInfoMessage(getCellAddress().toString());
             infoMsg.setSubject(subject);
-            infoMsg.setBillingPath(fullPath);
+            infoMsg.setBillingPath(fullPath.toString());
             infoMsg.setTransferPath(localTransferPath);
             infoMsg.setTransaction(CDC.getSession());
             infoMsg.setPnfsId(msg.getPnfsId());

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -864,7 +864,7 @@ public class DcacheResourceFactory
                 new DoorRequestInfoMessage(getCellAddress().toString(), "remove");
             Subject subject = getSubject();
             infoRemove.setSubject(subject);
-            infoRemove.setBillingPath(path);
+            infoRemove.setBillingPath(path.toString());
             infoRemove.setPnfsId(attributes.getPnfsId());
             infoRemove.setFileSize(attributes.getSize());
             infoRemove.setClient(Subjects.getOrigin(subject).getAddress().getHostAddress());

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -483,7 +483,7 @@ public class XrootdDoor
             DoorRequestInfoMessage infoRemove =
                     new DoorRequestInfoMessage(getCellAddress().toString(), "remove");
             infoRemove.setSubject(subject);
-            infoRemove.setBillingPath(path);
+            infoRemove.setBillingPath(path.toString());
             infoRemove.setPnfsId(pnfsId);
             Origin origin = Subjects.getOrigin(subject);
             if (origin != null) {

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -761,8 +761,8 @@ public class RequestContainerV5
         private   StorageInfo  _storageInfo;
         private   ProtocolInfo _protocolInfo;
         private   String       _linkGroup;
-        private   FsPath _billingPath;
-        private   FsPath _transferPath;
+        private   String _billingPath;
+        private   String _transferPath;
 
         private   boolean _enforceP2P;
         private   int     _destinationFileStatus = Pool2PoolTransferMsg.UNDETERMINED ;

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -18,7 +18,6 @@ import java.util.concurrent.Executor;
 
 import diskCacheV111.doors.FTPTransactionLog;
 import diskCacheV111.util.CacheException;
-import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.DoorRequestInfoMessage;
 import diskCacheV111.vehicles.DoorTransferFinishedMessage;
@@ -373,7 +372,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         PoolMgrSelectPoolMsg request = store
                 ? new PoolMgrSelectWritePoolMsg(fileAttributes, protocol_info)
                 : new PoolMgrSelectReadPoolMsg(fileAttributes, protocol_info, _readPoolSelectionContext);
-        request.setBillingPath(new FsPath(pnfsPath));
+        request.setBillingPath(pnfsPath);
         request.setSubject(transferRequest.getSubject());
         log.debug("PoolMgrSelectPoolMsg: " + request);
         setState(WAITING_FOR_POOL_INFO_STATE);
@@ -409,8 +408,8 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                 pool,
                 protocol_info,
                 fileAttributes);
-        poolMessage.setBillingPath(new FsPath(info.getBillingPath()));
-        poolMessage.setTransferPath(new FsPath(info.getTransferPath()));
+        poolMessage.setBillingPath(info.getBillingPath());
+        poolMessage.setTransferPath(info.getTransferPath());
         poolMessage.setSubject(transferRequest.getSubject());
         if (manager.getIoQueueName() != null) {
             poolMessage.setIoQueueName(manager.getIoQueueName());

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
@@ -5,8 +5,6 @@ import org.stringtemplate.v4.ST;
 
 import javax.security.auth.Subject;
 
-import diskCacheV111.util.FsPath;
-
 import org.dcache.auth.Subjects;
 
 public class DoorRequestInfoMessage extends PnfsFileInfoMessage
@@ -92,10 +90,5 @@ public class DoorRequestInfoMessage extends PnfsFileInfoMessage
     public void setTransferPath(String path)
     {
         _transferPath = path;
-    }
-
-    public void setTransferPath(FsPath path)
-    {
-        setTransferPath(path.toString());
     }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/MoverInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/MoverInfoMessage.java
@@ -3,7 +3,6 @@ package diskCacheV111.vehicles ;
 
 import org.stringtemplate.v4.ST;
 
-import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class MoverInfoMessage extends PnfsFileInfoMessage {
@@ -57,11 +56,6 @@ public class MoverInfoMessage extends PnfsFileInfoMessage {
     public void setTransferPath(String path)
     {
         _transferPath = path;
-    }
-
-    public void setTransferPath(FsPath path)
-    {
-        setTransferPath(path.toString());
     }
 
     public String getAdditionalInfo() {

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsFileInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsFileInfoMessage.java
@@ -6,7 +6,6 @@ import org.stringtemplate.v4.ST;
 
 import java.util.Objects;
 
-import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class PnfsFileInfoMessage extends InfoMessage {
@@ -39,8 +38,7 @@ public class PnfsFileInfoMessage extends InfoMessage {
    }
    public StorageInfo getStorageInfo(){ return _storageInfo ; }
    public String getBillingPath() { return _path; }
-   public void setBillingPath(String path) { _path = path; }
-   public void setBillingPath(FsPath path) { _path = Objects.toString(path, "Unknown"); }
+   public void setBillingPath(String path) { _path = Objects.toString(path, "Unknown"); }
 
     @Override
     public void fillTemplate(ST template)

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolHitInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolHitInfoMessage.java
@@ -3,7 +3,6 @@ package diskCacheV111.vehicles ;
 
 import org.stringtemplate.v4.ST;
 
-import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class PoolHitInfoMessage extends PnfsFileInfoMessage {
@@ -47,11 +46,6 @@ public class PoolHitInfoMessage extends PnfsFileInfoMessage {
     public void setTransferPath(String path)
     {
         _transferPath = path;
-    }
-
-    public void setTransferPath(FsPath path)
-    {
-        setTransferPath(path.toString());
     }
 
     public String toString()

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolIoFileMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolIoFileMessage.java
@@ -2,7 +2,6 @@ package diskCacheV111.vehicles;
 
 import java.util.EnumSet;
 
-import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 import org.dcache.vehicles.FileAttributes;
@@ -84,24 +83,24 @@ public class PoolIoFileMessage extends PoolMessage {
         return _initiator;
     }
 
-    public FsPath getBillingPath()
+    public String getBillingPath()
     {
-        return _pnfsPath != null ? new FsPath(_pnfsPath) : null;
+        return _pnfsPath != null ? _pnfsPath : null;
     }
 
-    public void setBillingPath(FsPath path)
+    public void setBillingPath(String path)
     {
-        _pnfsPath = path.toString();
+        _pnfsPath = path;
     }
 
-    public FsPath getTransferPath()
+    public String getTransferPath()
     {
-        return _transferPath != null ? new FsPath(_transferPath) : getBillingPath();
+        return _transferPath != null ? _transferPath : getBillingPath();
     }
 
-    public void setTransferPath(FsPath path)
+    public void setTransferPath(String path)
     {
-        _transferPath = path.toString();
+        _transferPath = path;
     }
 
     public FileAttributes getFileAttributes()

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectPoolMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectPoolMsg.java
@@ -57,21 +57,21 @@ public class PoolMgrSelectPoolMsg extends PoolMgrGetPoolMsg {
     public void setIoQueueName( String ioQueueName ){ _ioQueueName = ioQueueName ; }
     public String getIoQueueName(){ return _ioQueueName ; }
 
-    public FsPath getBillingPath() {
-        return _pnfsPath != null ? new FsPath(_pnfsPath) : null;
+    public String getBillingPath() {
+        return _pnfsPath;
     }
 
-    public void setBillingPath(FsPath pnfsPath) {
-        _pnfsPath = pnfsPath.toString();
+    public void setBillingPath(String pnfsPath) {
+        _pnfsPath = pnfsPath;
     }
 
-    public FsPath getTransferPath()
+    public String getTransferPath()
     {
-        return _transferPath != null ? new FsPath(_transferPath) : getBillingPath();
+        return _transferPath != null ? _transferPath : getBillingPath();
     }
 
-    public void setTransferPath(FsPath path) {
-        _transferPath = path.toString();
+    public void setTransferPath(String path) {
+        _transferPath = path;
     }
 
     public void setLinkGroup(String linkGroup) {

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/WarningPnfsFileInfoMessage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/WarningPnfsFileInfoMessage.java
@@ -2,7 +2,6 @@
 
 package diskCacheV111.vehicles ;
 
-import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 
 public class WarningPnfsFileInfoMessage extends PnfsFileInfoMessage {
@@ -27,10 +26,5 @@ public class WarningPnfsFileInfoMessage extends PnfsFileInfoMessage {
     public void setTransferPath(String path)
     {
         _transferPath = path;
-    }
-
-    public void setTransferPath(FsPath path)
-    {
-        setTransferPath(path.toString());
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -30,7 +30,6 @@ import java.nio.channels.CompletionHandler;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
-import diskCacheV111.util.FsPath;
 import diskCacheV111.vehicles.PoolAcceptFileMessage;
 import diskCacheV111.vehicles.PoolIoFileMessage;
 import diskCacheV111.vehicles.ProtocolInfo;
@@ -68,8 +67,8 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends Mover<P>> 
     protected final IoMode _ioMode;
     protected final TransferService<Mover<P>> _transferService;
     protected final PostTransferService _postTransferService;
-    protected final FsPath _billingPath;
-    protected final FsPath _transferPath;
+    protected final String _billingPath;
+    protected final String _transferPath;
     protected volatile int _errorCode;
     protected volatile String _errorMessage = "";
 
@@ -169,13 +168,13 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends Mover<P>> 
     }
 
     @Override
-    public FsPath getBillingPath()
+    public String getBillingPath()
     {
         return _billingPath;
     }
 
     @Override
-    public FsPath getTransferPath()
+    public String getTransferPath()
     {
         return _transferPath;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
@@ -136,12 +136,12 @@ public interface Mover<T extends ProtocolInfo>
     /**
      * Returns the billable name space path of the file being transferred.
      */
-    FsPath getBillingPath();
+    String getBillingPath();
 
     /**
      * Returns the temporary name space path of the file being transferred.
      */
-    FsPath getTransferPath();
+    String getTransferPath();
 
     /**
      * Initiates the actual transfer phase. The operation is asynchronous.

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -283,20 +283,20 @@ public class Transfer implements Comparable<Transfer>
     /**
      * The name space path of the file being transferred.
      */
-    public synchronized FsPath getTransferPath()
+    public synchronized String getTransferPath()
     {
-        return _path;
+        return _path.toString();
     }
 
     /**
      * The billable name space path of the file being transferred.
      */
-    public synchronized FsPath getBillingPath()
+    public synchronized String getBillingPath()
     {
         if (_fileAttributes.isDefined(STORAGEINFO) && _fileAttributes.getStorageInfo().getKey("path") != null) {
-            return new FsPath(_fileAttributes.getStorageInfo().getKey("path"));
+            return _fileAttributes.getStorageInfo().getKey("path");
         } else {
-            return _path;
+            return _path.toString();
         }
     }
 


### PR DESCRIPTION
The recent changes for adding billing and transfer paths to billing messages has triggered
several NPEs, in particular when doing pool to pool transfers. Contrary to my initial believe,
there are plenty of cases in which a path isn't know and the billing/transfer paths thus
are null.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/8173/
(cherry picked from commit a766de3d1ed422cc265d7a9c8e56f422738312d7)
(cherry picked from commit 1bfb84407faa3c6a87c1a781a2a6f72f96f2c83e)