### PR TITLE
dcap:  fileAttributesNotAvailable must set pass ENOENT to the client

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -1219,7 +1219,7 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
 
         protected boolean fileAttributesNotAvailable() throws CacheException
         {
-            sendReply("fileAttributesNotAvailable", _message);
+            sendReply("fileAttributesNotAvailable", _message.getReturnCode(), "No such file or directory", "ENOENT");
             return false;
         }
 


### PR DESCRIPTION
passing correct error code helps libdcap to set corresponding error number.

Target: master, 2.12
Acked-by: Paul Millar
Require-notes: yes
Require-book: no
(cherry picked from commit 69e62982bfccc3782f43cfabf3ff189b3fbe18ec)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>