### PR TITLE
chimera-provider: allow to set acl even if ACL is not enabled.

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -903,10 +903,8 @@ public class ChimeraNameSpaceProvider
                         cacheInfo.writeCacheInfo(level2);
                         break;
                     case ACL:
-                        if(_aclEnabled) {
-                            ACL acl = attr.getAcl();
-                            _fs.setACL(inode, acl.getList());
-                        }
+                        ACL acl = attr.getAcl();
+                        _fs.setACL(inode, acl.getList());
                         break;
                     case STORAGEINFO:
                         _extractor.setStorageInfo(inode, attr.getStorageInfo());


### PR DESCRIPTION
in general, checking acls is must be independent from having acl enabled.
But this is not the case how dcache behaves.

Nevertheless, we need to set acls on one of the productions systems as desy.
This change allows to set acls even if ACL is not enabled. This is safe, as there
are no dCache components (doors) which can make use of it.

Target: master, 2.12
Acked-by: Gerd Behrmann
Require-notes: yes
Require-book: no
(cherry picked from commit f4de2d8eefb2c74e2eb30bc6609baf2040dc2351)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>