### PR TITLE
admin: Avoid endless exception loop upon client disconnect

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/ConsoleReaderCommand.java
@@ -231,6 +231,8 @@ public class ConsoleReaderCommand implements Command, Runnable {
                 _console.flush();
                 _console.getCursorBuffer().clear();
                 result = null;
+            } catch (IOException e) {
+                throw e;
             } catch (Exception e) {
                 result = e.getMessage();
                 if(result == null) {
@@ -256,6 +258,7 @@ public class ConsoleReaderCommand implements Command, Runnable {
                     s = Strings.toMultilineString(result);
                     if (!s.isEmpty()) {
                         _console.println(s);
+                        _console.flush();
                     }
                 }
             }


### PR DESCRIPTION
If the client disconnects such that the admin service fails to write to the
output stream, the services enters an endless loop in which Apach SSHD throws
an SSHException (subclass of IOException). The admin service catches this and
attempts to report an error to the client, which will trigger another
exception, repeating this process indefinitly.

This patch makes sure that IOExceptions are propagated.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/8186/
(cherry picked from commit 10ae6b07a28542fc22a9d91886816cc76bfc0b2d)