### PR TITLE
admin: Restore pcells compatibility with loginrbroker

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerInfo.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerInfo.java
@@ -130,6 +130,11 @@ public class LoginBrokerInfo implements Serializable
         return _protocolEngine;
     }
 
+    public String getRoot()
+    {
+        return _root;
+    }
+
     public FsPath getRoot(FsPath userRoot)
     {
         return (_root == null) ? userRoot : new FsPath(_root);

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/PcellsCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/PcellsCommand.java
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Stream;
 
 import diskCacheV111.admin.UserAdminShell;
 import diskCacheV111.services.space.LinkGroup;
@@ -27,6 +28,7 @@ import dmg.cells.applets.login.DomainObjectFrame;
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellPath;
 import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.cells.services.login.LoginBrokerInfo;
 import dmg.util.CommandException;
 
 import org.dcache.cells.CellStub;
@@ -129,6 +131,20 @@ public class PcellsCommand implements Command, Runnable
 
                                 default:
                                     result = _userAdminShell.executeCommand(frame.getDestination(), frame.getPayload());
+                                    if (result instanceof LoginBrokerInfo[]) {
+                                        result = Stream.of((LoginBrokerInfo[]) result)
+                                                .map(i -> new LoginBrokerInfo(i.getCellName(),
+                                                                              i.getDomainName(),
+                                                                              i.getProtocolFamily(),
+                                                                              i.getProtocolVersion(),
+                                                                              i.getProtocolEngine(),
+                                                                              i.getRoot(),
+                                                                              i.getAddresses(),
+                                                                              i.getPort(),
+                                                                              i.getLoad(),
+                                                                              i.getUpdateTime()))
+                                                .toArray(LoginBrokerInfo[]::new);
+                                    }
                                     break;
                                 }
                             }


### PR DESCRIPTION
pcells queries loginbroker to obtain LoginBrokerInfo. Unfortunately the SRM
submits a subclass of LoginBrokerInfo and this subclass is unavailble in
pcells. Since pcells doesn't care about the information in the subclass,
this patch updates the admin pcells subsystem to sanitize the reply.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8189/
(cherry picked from commit 733024b12c98a05219f8a50cdfb9d6cbadcba495)