### PR TITLE
acl: fix compatibility with linux ace

### DIFF
--- a/modules/acl/src/main/java/org/dcache/acl/enums/AceFlags.java
+++ b/modules/acl/src/main/java/org/dcache/acl/enums/AceFlags.java
@@ -29,7 +29,8 @@ public enum AceFlags {
      * Such ACEs only take effect once they are applied (with this bit cleared) to newly
      * created files and directories as specified by the above two flags.
      */
-    INHERIT_ONLY_ACE(0x00000008, 'o'),
+    INHERIT_ONLY_ACE_LEGACY(0x00000008, 'o'),
+    INHERIT_ONLY_ACE(0x00000008, 'r'),
 
     /**
      * Indicates that the "who" refers to a GROUP.
@@ -153,6 +154,7 @@ public enum AceFlags {
         case 'd':
             return DIRECTORY_INHERIT_ACE;
         case 'o':
+        case 'i':
             return INHERIT_ONLY_ACE;
         case 'g':
             return IDENTIFIER_GROUP;


### PR DESCRIPTION
the 'standard' flag for inherit only aces is 'i'.
Nevertheless our implementation uses 'o' and fails
to parse standart aces.

Acked-by: Gerd Behrmann
Target: master, 2.12, 2.11, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 768880bb100ea645bdd40238d6b95261b5ab383a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>