### PR TITLE
replicamanager: add an admin command to re-fetch resilient pool group

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/replicaManager/ReplicaManagerV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/replicaManager/ReplicaManagerV2.java
@@ -38,6 +38,8 @@ import diskCacheV111.vehicles.PoolStatusChangedMessage;
 
 import dmg.cells.nucleus.CellEvent;
 import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.util.command.Command;
+import dmg.util.command.DelayedCommand;
 
 import org.dcache.util.Args;
 
@@ -2242,6 +2244,60 @@ public class ReplicaManagerV2 extends DCacheCoreControllerV2
       dbUpdatePoolRunnable r = new dbUpdatePoolRunnable( poolName );
       getNucleus().newThread(r,"RepMgr-dbUpdatePool").start();
       return "Initiated";
+    }
+
+    //--------------------------------------------------------------------------
+    // === Pool ===
+    //----------------------------------------------------------------------------
+    @Command(name = "update poolgroup", hint = "re-fetch pool group and initialize newly discovered pools")
+    public class UpdatePoolGroup extends DelayedCommand<String>
+    {
+
+        @Override
+        protected String execute() throws Exception {
+
+            List<String> currentPools = _resilientPools.getResilientPools();
+            List<String> newPools = _resilientPools.init();
+            List<String> addedPools = new ArrayList<>();
+
+            for (String pool : newPools) {
+                if (currentPools.contains(pool)) {
+                    continue;
+                }
+
+                synchronized (_dbLock) {
+
+                    String oldStatus = _poolMap.get(pool);
+
+                    _dbrmv2.setPoolStatus(pool, ReplicaDb1.OFFLINE); // ... and add it - so record will be
+
+                    try {
+                        dbUpdatePool(pool);
+                    } catch (Exception ee) {
+                        _log.info(" initDb - Problem fetching repository from " + pool + " : " + ee);
+                        _log.info(" initDb - pool " + pool + " stays '" + ReplicaDb1.OFFLINE + "'");
+                        continue;
+                    }
+
+                // Set status online for only 'new' (unknown) pools,
+                    // otherwise leave pool state as it was before
+                    String newStatus = (oldStatus == null || oldStatus
+                            .equals("UNKNOWN"))
+                                    ? ReplicaDb1.ONLINE
+                                    : oldStatus;
+
+                    _dbrmv2.setPoolStatus(pool, newStatus);
+
+                    if (newStatus.equals(ReplicaDb1.ONLINE)) {
+                        _poolsToWait.remove(pool);
+                    }
+                }
+                addedPools.add(pool);
+            }
+
+            return "Added pools: " + addedPools;
+        }
+
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Acked-by: Albert Rossi
Target: master, 2.12
Require-notes: yes
Require-book: no
(cherry picked from commit 2cb3c2b7fc584363aa08194a26d841ddbc3491f0)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>