### PR TITLE
chimera: Provide SIZE attribute if a file got any locations

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -704,7 +704,7 @@ public class ChimeraNameSpaceProvider
                 stat = inode.statCache();
                 // REVISIT when we have another way to detect new files
                 ExtendedInode level2 = inode.getLevel(2);
-                boolean isNew = (stat.getSize() == 0) && (!level2.exists());
+                boolean isNew = (stat.getSize() == 0) && !level2.exists() && inode.getLocations().isEmpty();
                 if (!isNew) {
                     attributes.setSize(stat.getSize());
                 }


### PR DESCRIPTION
We use a heuristic to determine if a file is "completely" registered
in Chimera: Traditionally, if a file in the name space is empty and
has no level 2, then we consider it a "new" file still being uploaded.

We recently changed Chimera to not provide a file size for such new
files. The above check used to make sense with PNFS, but with Chimera
there is no guarantee that anything gets written to level 2 (we
don't use level 2 to store checksums or locations anymore). Thus
we see:

06 May 2015 15:19:51 (SpaceManager) [] Expiration failed: java.lang.IllegalStateException: Attribute is not defined: SIZE

in our logs for an empty file with a registered location.

This patch refines the check in chimera to take the pressence of
pool or tape locations into account.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.e>
Patch: https://rb.dcache.org/r/8197/
(cherry picked from commit bc7da55febf8b9e34dd5ff2325b1ac9b15bbca5b)