### PR TITLE
srm: Remove duplicate SURLs in bringonline and get requests

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
@@ -81,6 +81,7 @@ import javax.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 
 import org.dcache.srm.SRMFileRequestNotFoundException;
@@ -100,6 +101,8 @@ import org.dcache.srm.v2_2.TRequestType;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TSURLReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
+
+import static java.util.Arrays.asList;
 
 /*
  * @author  timur
@@ -122,12 +125,12 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
                               String description,
                               String client_host)
     {
-        super(user,requestCredentialId,
-            max_number_of_retries,
-            max_update_period,
-            lifetime,
-            description,
-            client_host);
+        super(user, requestCredentialId,
+              max_number_of_retries,
+              max_update_period,
+              lifetime,
+              description,
+              client_host);
         logger.debug("constructor");
         logger.debug("user = "+user);
         logger.debug("requestCredetialId="+requestCredentialId);
@@ -139,8 +142,10 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
             this.protocols = null;
         }
         this.desiredOnlineLifetimeInSeconds = desiredOnlineLifetimeInSeconds;
-        List<BringOnlineFileRequest> requests = Lists.newArrayListWithCapacity(surls.length);
-        for(URI surl : surls) {
+
+        HashSet<URI> uris = new HashSet<>(asList(surls));
+        List<BringOnlineFileRequest> requests = Lists.newArrayListWithCapacity(uris.size());
+        for(URI surl : uris) {
             BringOnlineFileRequest request = new BringOnlineFileRequest(getId(),
                     requestCredentialId, surl, lifetime, max_number_of_retries);
             requests.add(request);

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
@@ -82,6 +82,7 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 
 import org.dcache.srm.SRMFileRequestNotFoundException;
@@ -101,6 +102,8 @@ import org.dcache.srm.v2_2.TRequestType;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TSURLReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
+
+import static java.util.Arrays.asList;
 
 /*
  * @author  timur
@@ -130,8 +133,9 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
                 client_host);
         this.protocols = Arrays.copyOf(protocols, protocols.length);
 
-        List<GetFileRequest> requests = Lists.newArrayListWithCapacity(surls.length);
-        for(URI surl : surls) {
+        HashSet<URI> uris = new HashSet<>(asList(surls));
+        List<GetFileRequest> requests = Lists.newArrayListWithCapacity(uris.size());
+        for(URI surl : uris) {
             GetFileRequest request = new GetFileRequest(getId(),
                     requestCredentialId, surl, lifetime,
                     max_number_of_retries);


### PR DESCRIPTION
We have observed that Atlas is sometimes duplicating SURLs in requests. One may
argue that such requests are invalid, but on the other hand there is nothing in
the SRM spec. saying that they are. Semantically, such duplicates are no
different from just submiting the SURL once.

Pin manager however in some cases fails with a nasty stack trace when the same
SURL is requested twice with the same request ID. This happens when the two
requests are created concurrently as pin manager fails to isolate those
operations from each other. Due to issues in how the PostgreSQL JDBC driver is
constructed and how DataNucleus treats SQLExceptions, the actual primary key
constraint violation is lost, making it difficult for pin manager to recover
from this situation. We could bump up the transaction isolation, but we would
need to use SERIABLE.

Instead this patch chooses the pragmatic path and eliminates the duplicate SURLs
in the SRM.

The admin visible stack trace caused by this bug looked something like this:

03 May 2015 10:16:26 (PinManager) [] Uncaught exception in thread pool-4-thread-13
org.springframework.orm.jdo.JdoResourceFailureException: Exception thrown flushing changes to datastore; nested exception is javax.jdo.JDODataStoreException: Exception thrown flushing changes to datastore
NestedThrowables:
java.sql.BatchUpdateException: Batch entry 0 INSERT INTO "pins" ("created_at","expires_at","gid","pnfsid","pool","request_id","state","sticky","uid","id") VALUES ('2015-05-03 10:16:25.999000 +02:00:00','2015-05-03 12:17:25.999000 +02:00:00',5001,'0000416D7C9E3D78467CA897BA9872E8BBE2',NULL,'-1730570248','PINNING','PinManager-1f044020-a7f7-4d3c-bdef-377f864f2ae4',5001,34575144) was aborted.  Call getNextException to see the cause.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8198/
(cherry picked from commit 251a4ecdf55db88b8974a0e702012e3a0e846f06)
(cherry picked from commit d321114ffbc37978d8e5415717d1323d5995a2d2)