### PR TITLE
libs: update to nfs4j-0.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -802,7 +802,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.9.5</version>
+            <version>0.9.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
bugfix release:

Changelog for nfs4j-0.9.5..nfs4j-0.9.6
    * [5008c1f] [maven-release-plugin] prepare for next development iteration
    * [4d85f19] nfs4: fix session4#toString
    * [9206f3d] nfs-acl: respect ace flags when compacting them
    * [00a0413] [maven-release-plugin] prepare release nfs4j-0.9.6

Target: 2.11, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 092e99d980aa9ab85de7c5510c62e8fd1e6262ed)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>