### PR TITLE
libs: update nfs4j to 0.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -830,7 +830,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.10.3</version>
+            <version>0.10.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
bugfix release:

Changelog for nfs4j-0.10.3..nfs4j-0.10.4
    * [5cd3b50] [maven-release-plugin] prepare for next development iteration
    * [c164ceb] nfs-acl: respect ace flags when compacting them
    * [57849b3] [maven-release-plugin] prepare release nfs4j-0.10.4

Acked-by: Paul Millar
Target: master, 2.12, 2.11, 2.10
Require-book: no
Require-notes: yes
(cherry picked from commit 13fb54e6cc78391a7e459edb9ded1dc932ed1a19)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>