### PR TITLE
cli: remove stray separator in predefined alarms printout

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/admin/AlarmCommandHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/admin/AlarmCommandHandler.java
@@ -353,8 +353,7 @@ public final class AlarmCommandHandler implements CellCommandListener {
     class PredifinedListCommand implements Callable<String> {
         public String call() throws Exception {
             return "PREDEFINED DCACHE ALARM TYPES:\n\n"
-                            + ListPredefinedTypes.getSortedList()
-                            + "---------------------------------------------\n";
+                            + ListPredefinedTypes.getSortedList();
         }
     }
 


### PR DESCRIPTION
Target: 2.12
Require-book: no
Require-notes: yes
Patch: https://rb.dcache.org/r/8210
Acked-by: Gerd

RELEASE NOTES: Removes a stray end separator in printout of predefined alarms.