### PR TITLE
spacemanager: Allow spaces to become unowned

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerCommandLineInterface.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerCommandLineInterface.java
@@ -176,30 +176,35 @@ public class SpaceManagerCommandLineInterface implements CellCommandListener
             }
 
             if (owner != null) {
-                String group;
-                String role;
+                if (owner.isEmpty()) {
+                    space.setVoGroup(null);
+                    space.setVoRole(null);
+                } else {
+                    String group;
+                    String role;
 
-                // check that linkgroup allows this owner combination
-                LinkGroup lg = db.getLinkGroup(space.getLinkGroupId());
+                    // check that linkgroup allows this owner combination
+                    LinkGroup lg = db.getLinkGroup(space.getLinkGroupId());
 
-                FQAN fqan = new FQAN(owner);
-                group = fqan.getGroup();
-                role = emptyToNull(fqan.getRole());
+                    FQAN fqan = new FQAN(owner);
+                    group = fqan.getGroup();
+                    role = emptyToNull(fqan.getRole());
 
-                boolean foundMatch = false;
-                for (VOInfo info : lg.getVOs()) {
-                    if (info.match(group, role)) {
-                        foundMatch = true;
-                        break;
+                    boolean foundMatch = false;
+                    for (VOInfo info : lg.getVOs()) {
+                        if (info.match(group, role)) {
+                            foundMatch = true;
+                            break;
+                        }
                     }
+                    if (!foundMatch) {
+                        return "Cannot change owner to " + owner + ". " +
+                               "Authorized for this link group are:\n" +
+                               Joiner.on('\n').join(lg.getVOs());
+                    }
+                    space.setVoGroup(group);
+                    space.setVoRole(role);
                 }
-                if (!foundMatch) {
-                    return "Cannot change owner to " + owner + ". " +
-                            "Authorized for this link group are:\n"+
-                            Joiner.on('\n').join(lg.getVOs());
-                }
-                space.setVoGroup(group);
-                space.setVoRole(role);
             }
 
             if (eternal) {
@@ -499,9 +504,9 @@ public class SpaceManagerCommandLineInterface implements CellCommandListener
 
     private String toOwner(String voGroup, String voRole)
     {
-        if (voGroup == null) {
+        if (voGroup == null || voGroup.isEmpty()) {
             return null;
-        } else if (voGroup.charAt(0) != '/' || voRole == null || voRole.equals("*")) {
+        } else if (voGroup.charAt(0) != '/' || voRole == null || voRole.isEmpty() || voRole.equals("*")) {
             return voGroup;
         } else {
             return voGroup + "/Role=" + voRole;


### PR DESCRIPTION
The update space command didn't support making a reservation unowned.

Also, the ls space command could in some cases generated index-out-of-bounds
exceptions.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8217/
(cherry picked from commit a4ce6393d9edaa8f339279abb28d4bc15d1245d0)