### PR TITLE
pool: Fix timeout behavior of HSM requests

### DIFF
--- a/modules/dcache-nearline-spi/src/main/java/org/dcache/pool/nearline/spi/NearlineRequest.java
+++ b/modules/dcache-nearline-spi/src/main/java/org/dcache/pool/nearline/spi/NearlineRequest.java
@@ -47,6 +47,14 @@ public interface NearlineRequest<T>
      * request will be cancelled, nor is it a promise that the request will
      * not be cancelled ahead of time.
      *
+     * The current implementation of timeouts is temporary. Currently the
+     * pool allows timeouts to be configured starting at the activation
+     * timeout and the deadline reflects these. Eventually, pool specific
+     * timeouts wil be removed and replaced by two timeouts: One defined
+     * by the user submitting the request (e.g. a stage request by the SRM)
+     * and optionally a provider specific timeout. This deadline will reflect
+     * the former.
+     *
      * @return Deadline in milliseconds since the epoch
      */
     long getDeadline();

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -373,7 +373,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
      */
     private abstract static class AbstractRequest<K> implements Comparable<AbstractRequest<K>>
     {
-        private enum State { QUEUED, ACTIVE, CANCELED }
+        protected enum State { QUEUED, ACTIVE, CANCELED }
 
         private final List<CompletionHandler<Void,K>> callbacks = new ArrayList<>();
         protected final long createdAt = System.currentTimeMillis();
@@ -525,7 +525,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
              * the shutdown call might have missed them when cancelling requests.
              */
             if (state.isShutdown()) {
-                cancelRequests(0);
+                cancelRequests();
             }
         }
 
@@ -541,16 +541,24 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         }
 
         /**
-         * Cancels requests older than {@code age}.
+         * Cancels requests whose deadline has past.
          */
-        public void cancelRequests(long age)
+        public void cancelExpiredRequests()
         {
             long now = System.currentTimeMillis();
             for (R request : requests.values()) {
-                if (now - request.getCreatedAt() >= age) {
+                if (request.getDeadline() <= now) {
                     request.cancel();
                 }
             }
+        }
+
+        /**
+         * Cancels all requests.
+         */
+        public void cancelRequests()
+        {
+            requests.values().forEach(AbstractRequest::cancel);
         }
 
         /**
@@ -560,7 +568,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         public void shutdown()
         {
             state.shutdown();
-            cancelRequests(0);
+            cancelRequests();
         }
 
         /**
@@ -729,7 +737,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         @Override
         public long getDeadline()
         {
-            return createdAt + flushTimeout;
+            return (state.get() == State.ACTIVE) ? activatedAt + flushTimeout : Long.MAX_VALUE;
         }
 
         @Override
@@ -1016,7 +1024,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         @Override
         public long getDeadline()
         {
-            return createdAt + stageTimeout;
+            return (state.get() == State.ACTIVE) ? activatedAt + stageTimeout : Long.MAX_VALUE;
         }
 
         @Override
@@ -1108,9 +1116,10 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             return uri;
         }
 
+        @Override
         public long getDeadline()
         {
-            return createdAt + removeTimeout;
+            return (state.get() == State.ACTIVE) ? activatedAt + removeTimeout : Long.MAX_VALUE;
         }
 
         public void failed(Exception cause)
@@ -1318,9 +1327,9 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         @Override
         public void run()
         {
-            flushRequests.cancelRequests(flushTimeout);
-            stageRequests.cancelRequests(stageTimeout);
-            removeRequests.cancelRequests(removeTimeout);
+            flushRequests.cancelExpiredRequests();
+            stageRequests.cancelExpiredRequests();
+            removeRequests.cancelExpiredRequests();
         }
     }
 


### PR DESCRIPTION
Timeouts in the pool were implemented from the request creation time rather
than the request activation time. This is a regression compared to 2.6 and
leads to problems when requests are queued: Since reqeusts are executed in FIFO
order, the requests that are activated are always the oldest requests.  Since
those older than the deadline have been removed, the oldest requests left are
often close to the deadline and will be cancelled shortly after activation.
This leads to a lot of churn with no real progress.

The intended implementation of timouts for HSM requests was never finished: The
intention was the whoever requests an HSM operation (in particular stage) would
specify a lifetime. E.g. SRM allows this. This would be the deadline and an
advanced provider could use this to schedule requests. Specific providers could
implement their own timeouts for particular operations, e.g.  callouts to
scripts. This was the reason for why the deadline was measured from the
creation time. Currently however only the latter form of timeout is implemented
and not within the provider but in the framework. Eventually this needs to be
cleaned up. For the time being this patch changes the deadline to be calculated
from the activation time.  Requests in the queue never time out.

This implementation is to be considered temporary (although without a limit on
when it will be changed).

Target: trunk
Require-notes: yes
Request: 2.12
Request: 2.11
Request: 2.10
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8620
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8224/
(cherry picked from commit 1aa2b291865a682d53782a2b6f9cde637782a06d)