### PR TITLE
pool: Fix timeout behavior of HSM requests

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/NearlineRequest.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/spi/NearlineRequest.java
@@ -47,6 +47,14 @@ public interface NearlineRequest<T>
      * request will be cancelled, nor is it a promise that the request will
      * not be cancelled ahead of time.
      *
+     * The current implementation of timeouts is temporary. Currently the
+     * pool allows timeouts to be configured starting at the activation
+     * timeout and the deadline reflects these. Eventually, pool specific
+     * timeouts wil be removed and replaced by two timeouts: One defined
+     * by the user submitting the request (e.g. a stage request by the SRM)
+     * and optionally a provider specific timeout. This deadline will reflect
+     * the former.
+     *
      * @return Deadline in milliseconds since the epoch
      */
     long getDeadline();


### PR DESCRIPTION
Timeouts in the pool were implemented from the request creation time rather
than the request activation time. This is a regression compared to 2.6 and
leads to problems when requests are queued: Since reqeusts are executed in FIFO
order, the requests that are activated are always the oldest requests.  Since
those older than the deadline have been removed, the oldest requests left are
often close to the deadline and will be cancelled shortly after activation.
This leads to a lot of churn with no real progress.

The intended implementation of timouts for HSM requests was never finished: The
intention was the whoever requests an HSM operation (in particular stage) would
specify a lifetime. E.g. SRM allows this. This would be the deadline and an
advanced provider could use this to schedule requests. Specific providers could
implement their own timeouts for particular operations, e.g.  callouts to
scripts. This was the reason for why the deadline was measured from the
creation time. Currently however only the latter form of timeout is implemented
and not within the provider but in the framework. Eventually this needs to be
cleaned up. For the time being this patch changes the deadline to be calculated
from the activation time.  Requests in the queue never time out.

This implementation is to be considered temporary (although without a limit on
when it will be changed).

Target: trunk
Require-notes: yes
Request: 2.12
Request: 2.11
Request: 2.10
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8620
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8224/
(cherry picked from commit 1aa2b291865a682d53782a2b6f9cde637782a06d)