### PR TITLE
srm: Fix queue size reporting

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -974,7 +974,7 @@ public class Scheduler <T extends Job>
                                   Ints.max(24, 20 + fieldWidth),
                                   28 + fieldWidth);
         formatter.column2("Queued", getTotalTQueued(), State.TQUEUED);
-        formatter.column1("Waiting for CPU", getTotalTQueued(), State.PRIORITYTQUEUED);
+        formatter.column1("Waiting for CPU", getTotalPriorityTQueued(), State.PRIORITYTQUEUED);
         formatter.column1("Running (max " + getThreadPoolSize() + ")", getTotalRunningState(), State.RUNNING);
         formatter.column1("Running without thread", getTotalRunningWithoutThreadState(), State.RUNNINGWITHOUTTHREAD);
         formatter.column1("Waiting for callback", getTotalAsyncWait(), State.ASYNCWAIT);


### PR DESCRIPTION
We logged the lenght of the wrong queue in the SRM info output in the
"Waiting for CPU" row.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8226/
(cherry picked from commit d2803118e20d089aeb71c4cc2573d5580753bc91)