### PR TITLE
pool: Add HSM options to hsm script remove callout

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/script/ScriptNearlineStorage.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/script/ScriptNearlineStorage.java
@@ -209,7 +209,7 @@ public class ScriptNearlineStorage extends AbstractBlockingNearlineStorage
 
     private String getRemoveCommand(URI uri)
     {
-        String s = command + " remove -uri=" + uri;
+        String s = command + " remove -uri=" + uri + options;
         LOGGER.debug("COMMAND: {}", s);
         return s;
     }


### PR DESCRIPTION
We forgot to add the options specified with the 'hsm set' commands when doing
the remove callout using the script driver.  This is a regression compared to
the old HSM interface.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Request: 2.9
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
(cherry picked from commit a2aab5f567565e45930c0a64a1f3f6faa6595a0e)