### PR TITLE
pinmanager: Fix listing by id

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCLI.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCLI.java
@@ -1,5 +1,6 @@
 package org.dcache.pinmanager;
 
+import com.google.common.primitives.Longs;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.io.BufferedReader;
@@ -200,18 +201,21 @@ public class PinManagerCLI
     public class ListCommand implements Callable<String>
     {
         @Argument(index = 0, required = false, valueSpec="PIN|PNFSID")
-        String id;
+        String s;
 
         @Override
         public String call() throws IllegalArgumentException
         {
             Collection<Pin> pins;
-            if (id != null) {
-                if (!PnfsId.isValid(id)) {
-                    Pin pin = _dao.getPin(Long.parseLong(id));
-                    return (pin == null) ? "" : pin.toString();
+            if (s != null) {
+                Long id = Longs.tryParse(s);
+                if (id != null) {
+                    Pin pin = _dao.getPin(id);
+                    if (pin != null) {
+                        return pin.toString();
+                    }
                 }
-                pins = _dao.getPins(new PnfsId(id));
+                pins = _dao.getPins(new PnfsId(s));
             } else {
                 pins = _dao.getPins();
             }


### PR DESCRIPTION
The pin manager allows pins to be listed by pin ID or PNFS ID. Since any
non-negative long is also a valid PNFS ID, the PnfsId#isvalid method is not
particularly useful to distinguish the two cases. Thus listing by pin ID
doesn't actually work. This patch resolves this issue.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8228/
(cherry picked from commit 7451599bd2e5a46a7e9f7a08bf1e6c5b0cb65fb2)