### PR TITLE
srm: Fix sync to async mode timeout

### DIFF
--- a/modules/common/src/main/java/org/dcache/commons/util/AtomicCounter.java
+++ b/modules/common/src/main/java/org/dcache/commons/util/AtomicCounter.java
@@ -65,7 +65,7 @@ public class AtomicCounter
      *
      * @param value the value to wait for the counter to change away from
      * @param deadline the absolute time to wait until
-     * @return false if the deadline has elapsed upon return, else true
+     * @return true if the counter has a different value than {@code value} upon return
      * @throw InterruptedException if the current thread is interrupted
      */
     public boolean awaitChangeUntil(int value, Date deadline)

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
@@ -317,8 +317,8 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
         Date deadline = getDateRelativeToNow(timeout);
         int counter = _stateChangeCounter.get();
         SrmBringOnlineResponse response = getSrmBringOnlineResponse();
-        while (response.getReturnStatus().getStatusCode().isProcessing() &&
-               _stateChangeCounter.awaitChangeUntil(counter, deadline)) {
+        while (response.getReturnStatus().getStatusCode().isProcessing() && deadline.after(new Date())
+               && _stateChangeCounter.awaitChangeUntil(counter, deadline)) {
             counter = _stateChangeCounter.get();
             response = getSrmBringOnlineResponse();
         }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
@@ -314,8 +314,8 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
         Date deadline = getDateRelativeToNow(timeout);
         int counter = _stateChangeCounter.get();
         SrmPrepareToGetResponse response = getSrmPrepareToGetResponse();
-        while (response.getReturnStatus().getStatusCode().isProcessing() &&
-               _stateChangeCounter.awaitChangeUntil(counter, deadline)) {
+        while (response.getReturnStatus().getStatusCode().isProcessing() && deadline.after(new Date())
+               && _stateChangeCounter.awaitChangeUntil(counter, deadline)) {
             counter = _stateChangeCounter.get();
             response = getSrmPrepareToGetResponse();
         }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/LsRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/LsRequest.java
@@ -227,7 +227,7 @@ public final class LsRequest extends ContainerRequest<LsFileRequest> {
                 Date deadline = getDateRelativeToNow(timeout);
                 int counter = _stateChangeCounter.get();
                 SrmLsResponse response = getSrmLsResponse();
-                while (response.getReturnStatus().getStatusCode().isProcessing() &&
+                while (response.getReturnStatus().getStatusCode().isProcessing() && deadline.after(new Date()) &&
                        _stateChangeCounter.awaitChangeUntil(counter, deadline)) {
                         counter = _stateChangeCounter.get();
                         response = getSrmLsResponse();

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/PutRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/PutRequest.java
@@ -389,11 +389,12 @@ public final class PutRequest extends ContainerRequest<PutFileRequest> {
         Date deadline = getDateRelativeToNow(timeout);
         int counter = _stateChangeCounter.get();
         SrmPrepareToPutResponse response = getSrmPrepareToPutResponse();
-        while (response.getReturnStatus().getStatusCode().isProcessing() &&
-               _stateChangeCounter.awaitChangeUntil(counter, deadline)) {
+        while (response.getReturnStatus().getStatusCode().isProcessing() && deadline.after(new Date())
+               && _stateChangeCounter.awaitChangeUntil(counter, deadline)) {
             counter = _stateChangeCounter.get();
             response = getSrmPrepareToPutResponse();
         }
+
         return response;
     }
 


### PR DESCRIPTION
The logic for switching from synchroneous to asynchroenous mode needs to both
detect a timeout and completion of the request. For large bulk requests the
logic was flawed as continuous state changes of file level requests would keep
the SRM looping and miss the timeout.

Target: trunk
Require-notes: yes
Require-book: yes
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8229/
(cherry picked from commit 61c2b658df36f7072e78f2e064fdddb71f878b64)