### PR TITLE
system-test: Enable MVCC and logging for HSQLDB

### DIFF
--- a/plugins/hsqldb/src/main/skel/hsqldb.properties
+++ b/plugins/hsqldb/src/main/skel/hsqldb.properties
@@ -3,29 +3,29 @@ hsqldb.path = ${dcache.home}/var/db
 (immutable)billing.db.hsql.schema.changelog-when-true=org/dcache/hsqldb/changelog/billing-master.xml
 (immutable)billing.db.hsql.schema.changelog-when-false=
 
-billing.db.url=jdbc:hsqldb:file:${hsqldb.path}/${billing.db.name};shutdown=true
+billing.db.url=jdbc:hsqldb:file:${hsqldb.path}/${billing.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
 billing.db.schema.changelog=${billing.db.hsql.schema.changelog-when-${billing.enable.db}}
 
-chimera.db.url = jdbc:hsqldb:file:${hsqldb.path}/${chimera.db.name};shutdown=true
+chimera.db.url = jdbc:hsqldb:file:${hsqldb.path}/${chimera.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
 chimera.db.dialect = HsqlDB
 
 pinmanager.db.name = pinmanager
-pinmanager.db.url = jdbc:hsqldb:file:${hsqldb.path}/${pinmanager.db.name};shutdown=true
+pinmanager.db.url = jdbc:hsqldb:file:${hsqldb.path}/${pinmanager.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
 pinmanager.db.schema.changelog=org/dcache/hsqldb/changelog/pinmanager-master.xml
 
-replica.db.url = jdbc:hsqldb:file:${hsqldb.path}/${replica.db.name};shutdown=true
+replica.db.url = jdbc:hsqldb:file:${hsqldb.path}/${replica.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
 replica.db.schema.changelog=org/dcache/hsqldb/changelog/replica-master.xml
 
 spacemanager.db.name = spacemanager
-spacemanager.db.url = jdbc:hsqldb:file:${hsqldb.path}/${spacemanager.db.name};shutdown=true
+spacemanager.db.url = jdbc:hsqldb:file:${hsqldb.path}/${spacemanager.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
 
 srm.db.name = srm
-srm.db.url = jdbc:hsqldb:file:${hsqldb.path}/${srm.db.name};shutdown=true
+srm.db.url = jdbc:hsqldb:file:${hsqldb.path}/${srm.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
 
 transfermanagers.db.name = transfermanagers
-transfermanagers.db.url = jdbc:hsqldb:file:${hsqldb.path}/${transfermanagers.db.name};shutdown=true
+transfermanagers.db.url = jdbc:hsqldb:file:${hsqldb.path}/${transfermanagers.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
 
 alarms.url-when-type-is-off =
 alarms.url-when-type-is-xml = xml:file:${alarms.db.xml.path}
-alarms.url-when-type-is-rdbms = jdbc:hsqldb:file:${hsqldb.path}/${alarms.db.name};shutdown=true
+alarms.url-when-type-is-rdbms = jdbc:hsqldb:file:${hsqldb.path}/${alarms.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
 alarms.db.url = ${alarms.url-when-type-is-${alarms.db.type}}


### PR DESCRIPTION
Without MVCC, HSQLDB resorts to table level locks. With pin manager, these
locks lead to aborted transactions as soon as more than one request is
processed at a time. The patch enables MVCC for all databases. This also
makes the behaviour of HSQLDB closer to that of PostgreSQL.

The patch also enables SQL statement logging in HSQLDB. This makes it
easier to debug database related problems.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8234/
(cherry picked from commit bd8dd02fac1fe84f03bb7c2b8ea6c244eb1ab3df)