### PR TITLE
srm: Abort pinning when cancelling bring-online requests

### DIFF
--- a/modules/srm/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
+++ b/modules/srm/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
@@ -412,27 +412,34 @@ public final class BringOnlineFileRequest extends FileRequest {
     @Override
     protected void stateChanged(State oldState) {
         State state = getState();
-        logger.debug("State changed from "+oldState+" to "+getState());
-        if(state == State.READY) {
+        logger.debug("State changed from {} to {}", oldState, getState());
+        switch (state) {
+        case READY:
             try {
                 getRequest().resetRetryDeltaTime();
-            }
-            catch (SRMInvalidRequestException ire) {
+            } catch (SRMInvalidRequestException ire) {
                 logger.error(ire.toString());
             }
-        }
-        if(state == State.CANCELED || state == State.FAILED ) {
-            if(getFileId() != null && getPinId() != null) {
-                UnpinCallbacks callbacks = new TheUnpinCallbacks(this.getId());
-                logger.info("state changed to final state, unpinning fileId= "+ getFileId()+" pinId = "+getPinId());
-                try {
-                    getStorage().unPinFile(getUser(),getFileId(),callbacks, getPinId());
+            break;
+        case CANCELED:
+        case FAILED:
+            try {
+                SRMUser user = getUser();
+                String pinId = getPinId();
+                String fileId = getFileId();
+                AbstractStorageElement storage = getStorage();
+                if (fileId != null && pinId != null) {
+                    logger.info("State changed to final state, unpinning fileId = {} pinId = {}.", fileId, pinId);
+                    UnpinCallbacks callbacks = new TheUnpinCallbacks(this.getId());
+                    getStorage().unPinFile(user, fileId,callbacks, pinId);
+                } else {
+                    unpinBySURLandRequestId(storage, user, getRequestId(), getSurl());
                 }
-                catch (SRMInvalidRequestException ire) {
-                    logger.error(ire.toString());
-                    return;
-                }
+            } catch (SRMException e) {
+                logger.error(e.toString());
+                return;
             }
+            break;
         }
         super.stateChanged(oldState);
     }


### PR DESCRIPTION
The SRM failed to abort pin operations when aborting bring-online requests.
This patch fixes this problem.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev <litvinse@fnal.gov>
Patch: https://rb.dcache.org/r/8239/
(cherry picked from commit 041fb5049a09dc140f4c9a8dc5931213c7f7d1cf)
(cherry picked from commit 00bf7253e8edf7253f876ba0948711697ed82052)
(cherry picked from commit 7bfd5c73d2533bfab61efc939ef286f41caab48f)
(cherry picked from commit 2501714045ccf913670e67a9ec6ecf8f68f282f4)