### PR TITLE
srm: Optimize scheduler performance

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -544,11 +544,6 @@ public class Scheduler <T extends Job>
                 Job job = requestQueue.getGreatestValueObject(calc);
 
                 if (job == null) {
-                    //logger.debug("updateThreadQueue(), job is null, trying threadQueue.peek();");
-                    job = requestQueue.peek();
-                }
-
-                if (job == null) {
                     //logger.debug("updateThreadQueue no jobs were found, breaking the update loop");
                     break;
                 }


### PR DESCRIPTION
The SRM scheduler slows down drastically once several thousand requests are
queued. This is particularly devestating for bulk bring-online requests. This
patch applies some simple improvements to the queue management. The effect is
big enough that on my system-test build, a bulk stage request of 7000 files
went from at most pinning one to two files at a time to killing pinmanager (the
latter is of course not good, but that's a different problem - and one I guess
is related more to HSQLDB than to pinmanager itself).

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Issue: #1533
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8232/
(cherry picked from commit fcb66c73a37996c4343464f524092b1814a7a3b1)
(cherry picked from commit edd5fd2bc9c27ecd06f3c7bef7191a5194a9e8e7)