### PR TITLE
pnfsmanager: Use per-thread upload directory to reduce lock contention

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 import diskCacheV111.namespace.NameSpaceProvider;
@@ -90,6 +91,16 @@ public class ChimeraNameSpaceProvider
     private PermissionHandler _permissionHandler;
     private String _uploadDirectory;
 
+    private final ThreadLocal<Integer> threadId = new ThreadLocal<Integer>() {
+        private final AtomicInteger counter = new AtomicInteger();
+
+        @Override
+        protected Integer initialValue()
+        {
+            return counter.getAndIncrement();
+        }
+    };
+
     @Required
     public void setExtractor(ChimeraStorageInfoExtractable extractor)
     {
@@ -126,6 +137,15 @@ public class ChimeraNameSpaceProvider
         _aclEnabled = isEnabled;
     }
 
+    /**
+     * Base directory for temporary upload directories. If not an absolute path, the directory
+     * is relative to the user's root directory.
+     *
+     * May be parametrised by a thread id by inserting %d into the string. This allows Chimera
+     * lock contention on the base directory to be reduced. If used it is important that the
+     * same set threads call into the provider repeatedly as otherwise a large number of
+     * base directories will be created.
+     */
     @Required
     public void setUploadDirectory(String path)
     {
@@ -1122,7 +1142,7 @@ public class ChimeraNameSpaceProvider
              * or relative path.
              */
             FsPath uploadDirectory = new FsPath(rootPath);
-            uploadDirectory.add(_uploadDirectory);
+            uploadDirectory.add(String.format(_uploadDirectory, threadId.get()));
 
             /* Upload directory must exist and have the right permissions.
              */

--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -86,7 +86,7 @@
       <property name="fileSystem" ref="file-system"/>
       <property name="extractor" ref="extractor"/>
       <property name="aclEnabled" value="${pnfsmanager.enable.acl}"/>
-      <property name="uploadDirectory" value="${pnfsmanager.upload-directory}"/>
+      <property name="uploadDirectory" value="${pnfsmanager.upload-directory}/%d"/>
   </bean>
 
   <bean id="acl-admin" class="org.dcache.acl.AclAdmin">


### PR DESCRIPTION
Directory creation and deletion in Chimera updates the link count and time
stamps on the inode of the parent directory. For the upload directory this
means that concurrent operations all block on updating this inode, thus leading
to lock contention. This patch avoids this by introducing a per-thread
sub-directory under the base upload directory. Thus two threads will never
block on accessing the same base upload directory.

No configuration changes are needed, but sites will see a change in how TURLs
are constructed.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8254/
(cherry picked from commit e1a6b336f82c8f9e27445eb3cc3dcc34b0379d3f)