### PR TITLE
pnfsmanager: Use per-thread upload directory to reduce lock contention

### DIFF
--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -94,7 +94,7 @@
       <property name="extractor" ref="extractor"/>
       <property name="aclEnabled" value="${pnfsmanager.enable.acl}"/>
       <property name="atimeGap" value="${pnfsmanager.atime-gap}" />
-      <property name="uploadDirectory" value="${pnfsmanager.upload-directory}"/>
+      <property name="uploadDirectory" value="${pnfsmanager.upload-directory}/%d"/>
   </bean>
 
   <bean id="acl-admin" class="org.dcache.acl.AclAdmin">


### PR DESCRIPTION
Directory creation and deletion in Chimera updates the link count and time
stamps on the inode of the parent directory. For the upload directory this
means that concurrent operations all block on updating this inode, thus leading
to lock contention. This patch avoids this by introducing a per-thread
sub-directory under the base upload directory. Thus two threads will never
block on accessing the same base upload directory.

No configuration changes are needed, but sites will see a change in how TURLs
are constructed.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8254/
(cherry picked from commit e1a6b336f82c8f9e27445eb3cc3dcc34b0379d3f)
(cherry picked from commit f5631282edf2da726d08c8e24e99bd86a8b0a11e)