### PR TITLE
common: Fix rounding error in request gauge

### DIFF
--- a/modules/common/src/main/java/org/dcache/commons/stats/RequestExecutionTimeGaugeImpl.java
+++ b/modules/common/src/main/java/org/dcache/commons/stats/RequestExecutionTimeGaugeImpl.java
@@ -34,13 +34,10 @@ public class RequestExecutionTimeGaugeImpl implements RequestExecutionTimeGaugeM
     private static final Logger LOG = LoggerFactory.getLogger(RequestExecutionTimeGaugeImpl.class);
 
     private final String name;
-    // These are the variables that keep the
-    // the average for the duration of the existance of the
-    // gauge
-    /**
-     * average
-     */
-    private long averageExecutionTime=0;
+
+    private long sumExecutionTime =0;
+    private long sumExecutionTimeSquared =0;
+
     /**
      * Minimum
      */
@@ -49,12 +46,7 @@ public class RequestExecutionTimeGaugeImpl implements RequestExecutionTimeGaugeM
      * Maximum
      */
     private long maxExecutionTime=0;
-    /**
-     *  Square of the RMS (Root Mean Square)
-     *  sum(value_i)/n
-     * RMSS(i+1)=(RMSS(i)+value(i+1)**2)/(i+1)
-     */
-    private long executionTimeRMSS=0;
+
     /**
      * number of updates
      */
@@ -113,25 +105,13 @@ public class RequestExecutionTimeGaugeImpl implements RequestExecutionTimeGaugeM
                     nextExecTime);
             return;
         }
-        // long term averages calculations
-         if( updateNum==0 ) {
-             averageExecutionTime = nextExecTime;
-             minExecutionTime = nextExecTime;
-             maxExecutionTime = nextExecTime;
-             executionTimeRMSS=nextExecTime*nextExecTime;
 
-         } else {
+        minExecutionTime = updateNum == 0 ? nextExecTime : Math.min(getMinExecutionTime(), nextExecTime);
+        maxExecutionTime = Math.max(getMaxExecutionTime(), nextExecTime);
 
-            averageExecutionTime =
-                (averageExecutionTime*updateNum +nextExecTime) /(updateNum+1);
-             minExecutionTime = getMinExecutionTime() <nextExecTime?
-                 getMinExecutionTime():nextExecTime;
-             maxExecutionTime = getMaxExecutionTime()>nextExecTime?
-                 getMaxExecutionTime():nextExecTime;
-             executionTimeRMSS=
-                     (executionTimeRMSS*updateNum+nextExecTime*nextExecTime)/
-                     (updateNum+1);
-         }
+        sumExecutionTime += nextExecTime;
+        sumExecutionTimeSquared += nextExecTime * nextExecTime;
+
         updateNum++;
 
         // period averages caclucations
@@ -144,17 +124,15 @@ public class RequestExecutionTimeGaugeImpl implements RequestExecutionTimeGaugeM
     }
 
     /**
-     * return average over the lifetime of the gauge
-     * @return
+     * Returns average over the lifetime of the gauge.
      */
     @Override
     public synchronized long getAverageExecutionTime() {
-        return averageExecutionTime;
+        return sumExecutionTime / updateNum;
     }
 
     /**
-     * return average over the last period, and start new period
-     * @return
+     * Returns average over the last period and reset the gauge.
      */
     @Override
     public synchronized long resetAndGetAverageExecutionTime() {
@@ -166,25 +144,20 @@ public class RequestExecutionTimeGaugeImpl implements RequestExecutionTimeGaugeM
     }
 
     /**
-     *
-     * @return String representation of this RequestExecutionTimeGauge
+     * Returns string representation of this RequestExecutionTimeGauge
      *  Only long term statistics is printed
      */
         @Override
     public synchronized String toString() {
 
-        String aName = name;
-        if(name.length() >34) {
-             aName = aName.substring(0,34);
-        }
-        long updatePeriod= System.currentTimeMillis() -
-                startTime;
+        String aName = (name.length() > 34) ? name.substring(0, 34) : name;
+        long updatePeriod = System.currentTimeMillis() - startTime;
         StringBuilder sb = new StringBuilder();
 
         Formatter formatter = new Formatter(sb);
 
         formatter.format("%-34s %12d\u00B1%10f %,12d %,12d %,12d %,12d %,12d",
-                aName, averageExecutionTime,getStandardError(),
+                aName, getAverageExecutionTime(),getStandardError(),
                 minExecutionTime,maxExecutionTime,
                 getStandardDeviation(), updateNum,
                 TimeUnit.MILLISECONDS.toSeconds(updatePeriod));
@@ -223,14 +196,15 @@ public class RequestExecutionTimeGaugeImpl implements RequestExecutionTimeGaugeM
      */
     @Override
     public synchronized double getExecutionTimeRMS() {
-        return Math.sqrt(executionTimeRMSS);
+        return Math.sqrt(sumExecutionTimeSquared / updateNum);
     }
 
     @Override
     public synchronized long getStandardDeviation() {
-        long deviationSquare = executionTimeRMSS - averageExecutionTime*averageExecutionTime;
-        assert (deviationSquare >=0);
-        return (long) Math.sqrt(executionTimeRMSS - averageExecutionTime*averageExecutionTime);
+        long averageExecutionTime = getAverageExecutionTime();
+        long deviationSquare = (sumExecutionTimeSquared / updateNum) - (averageExecutionTime * averageExecutionTime);
+        assert (deviationSquare >= 0);
+        return (long) Math.sqrt(deviationSquare);
     }
 
     /**


### PR DESCRIPTION
The gauge used for several request counters in dCache measures the average and
standard deviation of request execution times. The gauge internally maintains
the average and the average squared execution time.

Since these are kept as longs, they are subject to rounding errors. When
updating the average, the existing average is multiplied by the old sample
count and the rounding error is thus amplified.  I have seen cases where this
produces clearly wrong results (e.g. prepare-to-put calls that initially failed
quickly caused the average to be represented as 1 ms; assume that we have 1000
such failing calls; after dCache is fully started subsequent calls take 100 ms;
the average would then be updated as (1 * 1000 + 100) / 1001, which would then
be rounded to 1; thus no matter how many 100ms samples are added, the average
stays a 1 ms).

The patch resolves this by mantaining the sum of the execution times and
squared execution times.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8260/
(cherry picked from commit 4e65ce2a64d5218eb32cc76d1882282ff170e494)
(cherry picked from commit 4bec44b5e7ee357575ebc925c18aea9e6f550a82)