### PR TITLE
pool: dedicated port range for nfs

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -70,17 +70,12 @@ public class NfsTransferService extends AbstractCellComponent
     private boolean _sortMultipathList;
     private PnfsHandler _pnfsHandler;
     private ChecksumModule _checksumModule;
+    private int _minTcpPort;
+    private int _maxTcpPort;
 
     public void init() throws IOException, GSSException, OncRpcException {
 
-        String dcachePorts = System.getProperty("org.dcache.net.tcp.portrange");
-        PortRange portRange;
-        if (dcachePorts != null) {
-            portRange = PortRange.valueOf(dcachePorts);
-        } else {
-            portRange = new PortRange(0);
-        }
-
+        PortRange portRange = new PortRange(_minTcpPort, _maxTcpPort);
         _nfsIO = new NFSv4MoverHandler(portRange, _withGss, getCellName(), _door, _bootVerifier);
         _localSocketAddresses = localSocketAddresses(NetworkUtils.getLocalAddresses(), _nfsIO.getLocalAddress().getPort());
 
@@ -120,6 +115,16 @@ public class NfsTransferService extends AbstractCellComponent
     @Required
     public void setChecksumModule(ChecksumModule checksumModule) {
         _checksumModule = checksumModule;
+    }
+
+    @Required
+    public void setMinTcpPort(int minPort) {
+        _minTcpPort = minPort;
+    }
+
+    @Required
+    public void setMaxTcpPort(int maxPort) {
+        _maxTcpPort = maxPort;
     }
 
     public void shutdown() throws IOException {

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -339,6 +339,8 @@
       <property name="faultListener" ref="pool"/>
       <property name="doorStub" ref="doorStub"/>
       <property name="checksumModule" ref="csm"/>
+      <property name="minTcpPort" value="${pool.mover.nfs.port.min}"/>
+      <property name="maxTcpPort" value="${pool.mover.nfs.port.max}"/>
   </bean>
 
   <bean id="xrootd-transfer-service" class="org.dcache.xrootd.pool.XrootdTransferService"

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -158,6 +158,16 @@ pool.plugins.sweeper = org.dcache.pool.classic.SpaceSweeper2
 #
 (one-of?true|false)pool.mover.nfs.rpcsec_gss = false
 
+#  ---- NFS mover port range
+#
+# This option controls TCP port range used by NFS mover. In most
+# cases we would like to reduce the range to a single port to
+# let client to reconnect. If client failed to reconnect to the
+# mover, then a RPC request may stay in clients task queue in a
+# 'D' state and increase CPU load by one.
+pool.mover.nfs.port.min = ${dcache.net.lan.port.min}
+pool.mover.nfs.port.max = ${dcache.net.lan.port.max}
+
 #  ---- Port used for passive DCAP movers
 #
 #   When zero then a random port from the LAN port range is used.

--- a/skel/share/services/nfs.batch
+++ b/skel/share/services/nfs.batch
@@ -42,6 +42,8 @@ check -strong nfs.db.connections.max
 check -strong nfs.namespace-cache.time
 check -strong nfs.namespace-cache.time.unit
 check -strong nfs.namespace-cache.size
+check -strong pool.mover.nfs.port.min
+check -strong pool.mover.nfs.port.max
 check nfs.db.password
 check nfs.db.password.file
 check nfs.domain


### PR DESCRIPTION
Linux client will keep a rpc task with a hope
that server will be back. As we randomly select
tcp port number, the kernel task will stay
for ever in a D state and bump CPU load by one.

adds new properties:

pool.mover.nfs.port.min
pool.mover.nfs.port.max

a best practice will be dedicated port per pool.

Acked-by: Paul MIllar
Acked-by: Gerd Behrmann
Target: master, 2.12, 2.11, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 4de6fd1e436ed4a4980b63e3b07c1f8027b44ab1)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>