### PR TITLE
pnfsmanager: Resolve upload directory leak caused by missing reply flag

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -1199,6 +1199,7 @@ public class PnfsManagerV3
                                                                     message.getSpaceToken(),
                                                                     message.getOptions());
             message.setUploadPath(uploadPath);
+            message.setSucceeded();
         } catch (CacheException e) {
             message.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
@@ -1220,6 +1221,7 @@ public class PnfsManagerV3
                 message.setFileAttributes(
                         _nameSpaceProvider.getFileAttributes(Subjects.ROOT, pnfsId, attributes));
             }
+            message.setSucceeded();
         } catch (CacheException e) {
             message.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
@@ -1232,6 +1234,7 @@ public class PnfsManagerV3
     {
         try {
             _nameSpaceProvider.cancelUpload(message.getSubject(), message.getUploadPath(), message.getPath());
+            message.setSucceeded();
         } catch (CacheException e) {
             message.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {


### PR DESCRIPTION
PnfsManager fails to flag replies to the upload directory handling messages
as replies. Consequently, the protection added in the SRM to clean up upload
directories for timed out requests is not triggered. Thus if PNFS requests
time out, the system leaked upload directories.

Target: trunk
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8270/
(cherry picked from commit 0b80ed86ee475a6a55a099b04daf5d07b128d9a5)