### PR TITLE
chimera: Fix single command invocation of chimera utility

### DIFF
--- a/modules/common-cli/src/main/java/org/dcache/util/cli/ShellApplication.java
+++ b/modules/common-cli/src/main/java/org/dcache/util/cli/ShellApplication.java
@@ -168,8 +168,8 @@ public abstract class ShellApplication implements Closeable
             if (out.charAt(out.length() - 1) != '\n') {
                 console.println();
             }
-            console.flush();
         }
+        console.flush();
     }
 
     /**


### PR DESCRIPTION
Motivation:

When the chimera utility is invoked with a command like 'ls' on a small
directory, it does not provide any output. This is caused by a missing flush of
the output stream for commands that print directly to the console rather than
returning a value.

Modifications:

Unconditionally flush the output stream at the end of the invocation.

Result:

All chimera CLI commands provide the same output as they would if invoked
interactively.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8271/
(cherry picked from commit c817b78c29ae1618102a71cc47cc47d9a1a87691)