### PR TITLE
libs: update jglobus to 2.0.6.9d

### DIFF
--- a/modules/dcache-webdav/pom.xml
+++ b/modules/dcache-webdav/pom.xml
@@ -85,8 +85,8 @@
         <artifactId>spring-expression</artifactId>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+        <groupId>org.italiangrid</groupId>
+        <artifactId>voms-api-java</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/modules/gplazma2-grid/pom.xml
+++ b/modules/gplazma2-grid/pom.xml
@@ -30,8 +30,8 @@
 
 
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+        <groupId>org.italiangrid</groupId>
+        <artifactId>voms-api-java</artifactId>
     </dependency>
     <dependency>
         <groupId>org.dcache</groupId>

--- a/modules/gplazma2-gsi/pom.xml
+++ b/modules/gplazma2-gsi/pom.xml
@@ -28,8 +28,8 @@
         <version>${project.version}</version>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+      <groupId>org.italiangrid</groupId>
+      <artifactId>voms-api-java</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/modules/gplazma2-voms/pom.xml
+++ b/modules/gplazma2-voms/pom.xml
@@ -23,8 +23,8 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+        <groupId>org.italiangrid</groupId>
+        <artifactId>voms-api-java</artifactId>
     </dependency>
     <dependency>
         <groupId>org.dcache</groupId>

--- a/modules/gplazma2-xacml/pom.xml
+++ b/modules/gplazma2-xacml/pom.xml
@@ -27,8 +27,8 @@
 	  <artifactId>ssl-proxies</artifactId>
 	</dependency>
         <dependency>
-            <groupId>eu.emi</groupId>
-            <artifactId>vomsjapi</artifactId>
+            <groupId>org.italiangrid</groupId>
+            <artifactId>voms-api-java</artifactId>
         </dependency>
         <dependency>
             <groupId>eu.emi</groupId>

--- a/modules/gplazma2/pom.xml
+++ b/modules/gplazma2/pom.xml
@@ -28,8 +28,8 @@
         <version>${project.version}</version>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+        <groupId>org.italiangrid</groupId>
+        <artifactId>voms-api-java</artifactId>
     </dependency>
 
     <dependency>

--- a/modules/javatunnel/pom.xml
+++ b/modules/javatunnel/pom.xml
@@ -34,8 +34,8 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+      <groupId>org.italiangrid</groupId>
+      <artifactId>voms-api-java</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -209,9 +209,19 @@
                 <version>1.0.1-1</version>
             </dependency>
             <dependency>
-                <groupId>eu.emi</groupId>
-                <artifactId>vomsjapi</artifactId>
-                <version>2.0.6</version>
+                <groupId>org.italiangrid</groupId>
+                <artifactId>voms-api-java</artifactId>
+                <version>2.0.10.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-ext-jdk16</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.glite.authz</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
                1.43     bcprov-jdk16    JDK v1.6; used by JGlobus-1.8.x
          -->
         <bouncycastle.bcprov>bcprov-jdk16</bouncycastle.bcprov>
-        <bouncycastle.version>1.45</bouncycastle.version>
+        <bouncycastle.version>1.46</bouncycastle.version>
         <datanucleus-core.version>4.0.4</datanucleus-core.version>
         <datanucleus.plugin.version>4.0.0-release</datanucleus.plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.jetty>9.2.8.v20150217</version.jetty>
         <version.wicket>6.19.0</version.wicket>
         <version.xrootd4j>2.0.1</version.xrootd4j>
-        <version.jglobus>2.0.6-rc8.d</version.jglobus>
+        <version.jglobus>2.0.6-rc9.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
bugfix release:

Changelog for 2.0.6-rc8.d..2.0.6-rc9.d
    * [6961493] Upgrade to BouncyCastle 1.46
    * [996b954] Remove synchronization on CRL in CRLChecker
    * [fc1c506] pom: bump version number to 2.0.6-rc9.d

Acked-by: Gerd Behrmann
Target: master, 2.12, 2.11, 2.10
Require-book: no
Require-notes: yes
(cherry picked from commit ed08a8508a12bb12535514c114b9e51dfb75c955)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>