### PR TITLE
srm: Fix cache invalidation of space meta data

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -310,7 +310,7 @@ public final class Storage
      * Used during  uploads to verify the availability of a space reservation. In case
      * of stale data, a TURL may be handed out to the client even though the reservation
      * doesn't exist or is full. In that case the upload to the TURL will fail. This is
-     * however a failure path to would exist in any case, as the reservation may expire
+     * however a failure path that would exist in any case, as the reservation may expire
      * after handing out the TURL.
      */
     private final LoadingCache<String,Optional<Space>> spaces =
@@ -2244,8 +2244,29 @@ public final class Storage
             SrmReleaseSpaceCallback callbacks) {
         if (_isSpaceManagerEnabled) {
             SrmReleaseSpaceCompanion.releaseSpace(((DcacheUser) user).getSubject(),
-                    spaceToken, releaseSizeInBytes, callbacks, _spaceManagerStub, _executor);
-            spaces.invalidate(spaceToken);
+                                                  spaceToken, releaseSizeInBytes, new SrmReleaseSpaceCallback()
+                    {
+                        public void failed(String reason)
+                        {
+                            callbacks.failed(reason);
+                        }
+
+                        public void internalError(String reason)
+                        {
+                            callbacks.internalError(reason);
+                        }
+
+                        public void invalidRequest(String reason)
+                        {
+                            callbacks.invalidRequest(reason);
+                        }
+
+                        public void success(String spaceReservationToken, long remainingSpaceSize)
+                        {
+                            spaces.invalidate(spaceToken);
+                            callbacks.success(spaceReservationToken, remainingSpaceSize);
+                        }
+                    }, _spaceManagerStub, _executor);
         } else {
             callbacks.failed(SPACEMANAGER_DISABLED_MESSAGE);
         }


### PR DESCRIPTION
Motivation:

The SRM caches space meta data. This cache needs to be invalidated if a client
does something that modifies the meta data. Releasing spaces is done
asynchronously with a callback, yet the cache invalidation happens in the
forward call and thus may happen before the space is actually released. Thus
there is a race in which the cache could be repopulated with the old data
before the space is released in space manager.

Modification:

Intercept the callback and invalidate the cache inside the callback.

Result:

The cache is invalidated after the space is released, thus resolving the
described race condition.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8273/
(cherry picked from commit c15a133be42385cbe0c2c8d986231b016f410b77)