### PR TITLE
libs: Update to voms-api-java 2.0.10.1

### DIFF
--- a/modules/dcache-webdav/pom.xml
+++ b/modules/dcache-webdav/pom.xml
@@ -85,8 +85,8 @@
         <artifactId>spring-expression</artifactId>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+        <groupId>org.italiangrid</groupId>
+        <artifactId>voms-api-java</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/modules/gplazma2-grid/pom.xml
+++ b/modules/gplazma2-grid/pom.xml
@@ -30,8 +30,8 @@
 
 
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+        <groupId>org.italiangrid</groupId>
+        <artifactId>voms-api-java</artifactId>
     </dependency>
     <dependency>
         <groupId>org.dcache</groupId>

--- a/modules/gplazma2-gsi/pom.xml
+++ b/modules/gplazma2-gsi/pom.xml
@@ -28,8 +28,8 @@
         <version>${project.version}</version>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+      <groupId>org.italiangrid</groupId>
+      <artifactId>voms-api-java</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/modules/gplazma2-voms/pom.xml
+++ b/modules/gplazma2-voms/pom.xml
@@ -23,8 +23,8 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+        <groupId>org.italiangrid</groupId>
+        <artifactId>voms-api-java</artifactId>
     </dependency>
     <dependency>
         <groupId>org.dcache</groupId>

--- a/modules/gplazma2-xacml/pom.xml
+++ b/modules/gplazma2-xacml/pom.xml
@@ -27,8 +27,8 @@
 	  <artifactId>ssl-proxies</artifactId>
 	</dependency>
         <dependency>
-            <groupId>eu.emi</groupId>
-            <artifactId>vomsjapi</artifactId>
+            <groupId>org.italiangrid</groupId>
+            <artifactId>voms-api-java</artifactId>
         </dependency>
         <dependency>
             <groupId>eu.emi</groupId>

--- a/modules/gplazma2/pom.xml
+++ b/modules/gplazma2/pom.xml
@@ -28,8 +28,8 @@
         <version>${project.version}</version>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+        <groupId>org.italiangrid</groupId>
+        <artifactId>voms-api-java</artifactId>
     </dependency>
 
     <dependency>

--- a/modules/javatunnel/pom.xml
+++ b/modules/javatunnel/pom.xml
@@ -34,8 +34,8 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-        <groupId>eu.emi</groupId>
-        <artifactId>vomsjapi</artifactId>
+      <groupId>org.italiangrid</groupId>
+      <artifactId>voms-api-java</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -190,9 +190,19 @@
                 <version>1.0.1-1</version>
             </dependency>
             <dependency>
-                <groupId>eu.emi</groupId>
-                <artifactId>vomsjapi</artifactId>
-                <version>2.0.6</version>
+                <groupId>org.italiangrid</groupId>
+                <artifactId>voms-api-java</artifactId>
+                <version>2.0.10.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-ext-jdk16</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.glite.authz</groupId>


### PR DESCRIPTION
Motivation:

The Java VOMS API version 2 relies on BouncyCastle 1.45. We however need
version 1.46 to resolve lock congestion issues on CRL verification with
JGlobus. Another patch updates voms-api-java to BouncyCastle 1.46.

Modification:

Changes the dependency to the new voms-api-java artifact id and excludes log4j
and the ext version of bcprov that voms-api-java would otherwise pull in. This
patch is not final, as we need a proper version of the custom voms-api-java
build first.

Result:

The VOMS gPlazma plugin works with BouncyCatle 1.46.

Target: trunk
Request: 2.12
Reqeust: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8280/
(cherry picked from commit 8ee7fa5981ca181d23a21fdec04e4d6eade0479e)