### PR TITLE
pool: reduce load on back-end file system

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.Subject;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.nio.channels.CompletionHandler;
 
@@ -246,7 +247,7 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
         case WRITE:
             try {
                 channel = new FileRepositoryChannel(_handle.getFile(), "rw");
-            } catch (FileNotFoundException e) {
+            } catch (IOException e) {
                 throw new DiskErrorCacheException(
                         "File could not be created; please check the file system", e);
             }
@@ -254,7 +255,7 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
         case READ:
             try {
                 channel = new FileRepositoryChannel(_handle.getFile(), "r");
-            } catch (FileNotFoundException e) {
+            } catch (IOException e) {
                 throw new DiskErrorCacheException("File could not be opened  [" +
                         e.getMessage() + "]; please check the file system", e);
             }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/FileRepositoryChannel.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/FileRepositoryChannel.java
@@ -3,20 +3,36 @@ package org.dcache.pool.repository;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.io.SyncFailedException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static java.nio.file.StandardOpenOption.*;
 
 public class FileRepositoryChannel implements RepositoryChannel {
 
-    private final FileChannel _fileChannel;
-    private final RandomAccessFile _raf;
-    private final File _file;
+    private static final FileAttribute<?>[] NO_ATTRIBUTES = new FileAttribute<?>[0];
+    private static final Set<StandardOpenOption> O_READ = EnumSet.of(READ);
+    private static final Set<StandardOpenOption> O_RW = EnumSet.of(READ, WRITE, CREATE_NEW);
+    private static final Set<StandardOpenOption> O_RWD = EnumSet.of(READ, WRITE, CREATE_NEW, DSYNC);
+    private static final Set<StandardOpenOption> O_RWS = EnumSet.of(READ, WRITE, CREATE_NEW, DSYNC, SYNC);
 
-    public FileRepositoryChannel(String f, String mode) throws FileNotFoundException {
+    private final FileChannel _fileChannel;
+
+    /**
+     * Cached value of the file size.
+     */
+    private final long _size;
+
+    public FileRepositoryChannel(String f, String mode) throws FileNotFoundException, IOException {
         this(new File(f), mode);
     }
 
@@ -24,7 +40,7 @@ public class FileRepositoryChannel implements RepositoryChannel {
      * Creates a {@link RepositortyChannel} to read from, and optionally to
      * write to, the file specified by the {@link File} argument.
      *
-     * <a name="mode"><p> The <tt>mode</tt> argument specifies the access mode
+     * The <tt>mode</tt> argument specifies the access mode
      * in which the file is to be opened.  The permitted values and their
      * meanings are:
      *
@@ -80,10 +96,34 @@ public class FileRepositoryChannel implements RepositoryChannel {
      *            that name cannot be created, or if some other error occurs
      *            while opening or creating the file
      */
-    public FileRepositoryChannel(File f, String mode) throws FileNotFoundException {
-        _file = f;
-        _raf = new RandomAccessFile(f, mode);
-        _fileChannel = _raf.getChannel();
+    @SuppressWarnings("fallthrough")
+    public FileRepositoryChannel(File file, String mode) throws FileNotFoundException, IOException {
+        Path path = file.toPath();
+        Set<StandardOpenOption> openOptions;
+        switch (mode) {
+            case "rws":
+                openOptions = O_RWS;
+		break;
+            case "rwd":
+                openOptions = O_RWD;
+		break;
+            case "rw":
+                openOptions = O_RW;
+		break;
+            case "r":
+                openOptions = O_READ;
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal mode \"" + mode + "\"");
+        }
+
+        _fileChannel = FileChannel.open(path, openOptions, NO_ATTRIBUTES);
+        if (mode.equals("r")) {
+            // read-only. Cache the file size;
+            _size = _fileChannel.size();
+        } else {
+            _size = -1L;
+        }
     }
 
     @Override
@@ -99,12 +139,12 @@ public class FileRepositoryChannel implements RepositoryChannel {
 
     @Override
     public long size() throws IOException {
-        return _file.length();
+        return _size != -1 ? _size : _fileChannel.size();
     }
 
     @Override
     public void sync() throws SyncFailedException, IOException {
-        _raf.getFD().sync();
+        _fileChannel.force(true);
     }
 
     @Override

--- a/modules/dcache/src/test/java/org/dcache/pool/movers/ChecksumChannelTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/movers/ChecksumChannelTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.UUID;
 
 import diskCacheV111.util.ChecksumFactory;
 
@@ -25,7 +26,6 @@ import org.dcache.util.ChecksumType;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 public class ChecksumChannelTest {
 
 
+    private final String TMP_DIR = System.getProperty("java.io.tmpdir");
     private ChecksumChannel chksumChannel;
 
     private byte[] data = "\0Just\0A\0Short\0TestString\0To\0Verify\0\0Checksumming\0\0Works\12".getBytes(StandardCharsets.ISO_8859_1); // \12 is a octal 10, linefeed
@@ -45,7 +46,7 @@ public class ChecksumChannelTest {
 
     @Before
     public void setUp() throws NoSuchAlgorithmException, IOException {
-        testFile = File.createTempFile("ChecksumChannelTest", ".tmp");
+        testFile = new File(TMP_DIR, "ChecksumChannelTest" + UUID.randomUUID().toString() + ".tmp");
         RepositoryChannel mockRepositoryChannel = new FileRepositoryChannel(testFile, "rw");
         ChecksumFactory checksumFactory = ChecksumFactory.getFactory(ChecksumType.MD5_TYPE);
         chksumChannel = new ChecksumChannel(mockRepositoryChannel, checksumFactory);


### PR DESCRIPTION
the nfs read request uses file size and current position to detect and
report EOF marker. As a result any file READ request will issue File#length().
Reduce the load on backend file system by caching file size for read-only
movers.

Small refactoring to use FileChannel only instead of FileChannel + File + RandomAccessFile.

acked-by: Gerd Behrmann
Target: master, 2.12
Require-notes: no
Require-book: no
(cherry picked from commit d1c977dee1cb8bf973e2d10a8b5ae78b02600fd2)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>