### PR TITLE
Update nfs admin 2.12

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -641,10 +641,7 @@ public class NFSv41Door extends AbstractCellComponent implements
             if (_proxyIoFactory != null) {
                 pw.println();
                 pw.println("  Known proxy adapters (proxy-io):");
-                for (ProxyIoAdapter proxyIoAdapter : _proxyIoFactory.getAdapters()) {
-                    pw.print("    ");
-                    pw.println(proxyIoAdapter);
-                }
+                _proxyIoFactory.forEach(a -> { pw.print("    "); pw.println(a); });
             }
 
             pw.println();

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -797,7 +797,10 @@ public class NFSv41Door extends AbstractCellComponent implements
             }
 
             StringBuilder sb = new StringBuilder();
-            _proxyIoFactory.forEach(t -> sb.append(t).append('\n'));
+            _proxyIoFactory.forEach(p -> {
+                NfsTransfer t = _ioMessages.get(p.getStateId());
+                sb.append(t).append('\n');
+            });
             return sb.toString();
         }
     }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIo.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIo.java
@@ -146,9 +146,8 @@ public class NfsProxyIo implements ProxyIoAdapter {
     }
 
     @Override
-    public int getSessionId() {
-        // forced by interface
-        throw new UnsupportedOperationException("Not supported yet.");
+    public stateid4 getStateId() {
+        return stateid;
     }
 
     @Override

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIoFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIoFactory.java
@@ -197,4 +197,9 @@ retry:  while (true) {
     public void forEach(Consumer<ProxyIoAdapter> action) {
         _proxyIO.asMap().values().forEach(action);
     }
+
+    @Override
+    public int getCount() {
+        return (int)_proxyIO.size();
+    }
 }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIoFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIoFactory.java
@@ -194,7 +194,7 @@ retry:  while (true) {
     }
 
     @Override
-    public Iterable<ProxyIoAdapter> getAdapters() {
-        return _proxyIO.asMap().values();
+    public void forEach(Consumer<ProxyIoAdapter> action) {
+        _proxyIO.asMap().values().forEach(action);
     }
 }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoAdapter.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoAdapter.java
@@ -3,6 +3,7 @@ package org.dcache.chimera.nfsv41.door.proxy;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import org.dcache.nfs.v4.xdr.stateid4;
 import org.dcache.nfs.vfs.VirtualFileSystem;
 
 /**
@@ -34,7 +35,10 @@ public interface ProxyIoAdapter extends Closeable {
      */
     VirtualFileSystem.WriteResult write(ByteBuffer src, long position) throws IOException;
 
-    int getSessionId();
+    /**
+     * Returns open-stateid associated with this proxy-io adapter.
+     */
+    stateid4 getStateId();
 
     // FIXME: move into generic NFS code
     public static class ReadResult {

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoFactory.java
@@ -39,6 +39,11 @@ public interface ProxyIoFactory {
     void forEach(Consumer<ProxyIoAdapter> action);
 
     /**
+     * Get number of active adapter.
+     */
+    int getCount();
+
+    /**
      * Close all active proxies and free up any additional resources.
      * After calling this method, the behavior of all other methods is not
      * guaranteed.

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoFactory.java
@@ -1,6 +1,7 @@
 package org.dcache.chimera.nfsv41.door.proxy;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 import org.dcache.nfs.v4.CompoundContext;
 import org.dcache.nfs.v4.xdr.stateid4;
 import org.dcache.nfs.vfs.Inode;
@@ -33,9 +34,9 @@ public interface ProxyIoFactory {
     void shutdownAdapter(stateid4 stateid);
 
     /**
-     * Allow the caller to iterate over all currently active proxies.
+     * Performs the given action for active {@link ProxyIoAdapter}.
      */
-    Iterable<ProxyIoAdapter> getAdapters();
+    void forEach(Consumer<ProxyIoAdapter> action);
 
     /**
      * Close all active proxies and free up any additional resources.


### PR DESCRIPTION
update nfs door admin interface to be simpler to use. The info command prints only summary. The admin is free to use one of new commands to see transfers, pools, cliet sessions or proxy ios.
