### PR TITLE
admin: Respect user timeout

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -1373,7 +1373,7 @@ public class UserAdminShell
             throws NoRouteToCellException, InterruptedException, CommandException
     {
        try {
-           return _cellStub.send(cellPath, object, Object.class).get();
+           return _cellStub.send(cellPath, object, Object.class, _timeout).get();
        } catch (ExecutionException e) {
            Throwable cause = e.getCause();
            if (_fullException) {


### PR DESCRIPTION
Motivation:

The admin shell provides a 'set timeout' command through which the user
can define the timeout of commands. dCache 2.12 does not respect this
timeout when executing user commands.

Modification:

Applies the timeout when sending messages to other cells.

Result:

A request will time out after the specified time period has elapsed and
the cell has not replied already.

Target: 2.12
Require-notes: yes
Require-book: no
Issue: #1620
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8285/