### PR TITLE
srm: Don't log erroneous stack trace

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/server/SRMServerV1.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/server/SRMServerV1.java
@@ -27,26 +27,19 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
     private final RequestCounters<String> srmServerCounters;
     private final RequestExecutionTimeGauges<String> srmServerGauges;
 
-    public SRMServerV1() throws java.rmi.RemoteException {
-       try
-       {
-          // srmConn = SrmDCacheConnector.getInstance();
-          log = LoggerFactory.getLogger(this.getClass().getName());
+    public SRMServerV1()
+    {
+         log = LoggerFactory.getLogger(this.getClass().getName());
+         srm = Axis.getSRM();
+         Configuration config = Axis.getConfiguration();
 
-             srm = Axis.getSRM();
-             Configuration config = Axis.getConfiguration();
-
-             srmAuth = new SrmAuthorizer(config.getAuthorization(),
-                    srm.getRequestCredentialStorage(),
-                    config.isClientDNSLookup());
-             srmServerCounters = srm.getSrmServerV1Counters();
-             srmServerGauges = srm.getSrmServerV1Gauges();
-             vomsDir = config.getVomsdir();
-             caDir = config.getCaCertificatePath();
-       } catch (Exception e) {
-           throw new java.rmi.RemoteException("exception",e);
-       }
-
+         srmAuth = new SrmAuthorizer(config.getAuthorization(),
+                srm.getRequestCredentialStorage(),
+                config.isClientDNSLookup());
+         srmServerCounters = srm.getSrmServerV1Counters();
+         srmServerGauges = srm.getSrmServerV1Gauges();
+         vomsDir = config.getVomsdir();
+         caDir = config.getCaCertificatePath();
     }
 
       /**

--- a/modules/srm-server/src/main/java/org/dcache/srm/util/LoggingRPCProvider.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/util/LoggingRPCProvider.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.rmi.RemoteException;
 
 /**
  * This class wraps the default Axis Java dispatcher (RPCProvider) to provide
@@ -83,6 +84,13 @@ public class LoggingRPCProvider extends RPCProvider
                         "reason={}, string={}",
                         fault.getClass().getSimpleName(), fault.getFaultCode(),
                         fault.getFaultReason(), fault.getFaultString());
+            } else if(t instanceof RemoteException) {
+                if (t.getCause() == null) {
+                    _log.debug("Invocation produced fault: {}", t.getMessage());
+                } else {
+                    _log.debug("Invocation produced fault: {} (caused by {})",
+                               t.getMessage(), t.getCause());
+                }
             } else if(t instanceof RuntimeException) {
                 _log.error("Bug detected, please report this to " +
                         "support@dCache.org", t);


### PR DESCRIPTION
Motivation:

Some SRM requests generate RemoteExceptions as errors as part of their normal
behaviour. Take for instance an attempt to upload a file with SRM 1 to a
read-only account. It produces this stack trace:

08 jun. 2015 18:55:15 (SRM-Gerds-MacBook-Pro) [7lU:1:srm1:put] Session is read-only
08 jun. 2015 18:55:15 (SRM-Gerds-MacBook-Pro) [] Unexpected invocation exception
java.rmi.RemoteException: Session is read-only
        at org.dcache.srm.server.SRMServerV1.put(SRMServerV1.java:104) ~[srm-server-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_31]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_31]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_31]
        at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0_31]
        at org.apache.axis.providers.java.RPCProvider.invokeMethod(RPCProvider.java:397) [axis-1.4.jar:na]
        at org.dcache.srm.util.LoggingRPCProvider.invokeMethod(LoggingRPCProvider.java:50) ~[srm-server-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at org.apache.axis.providers.java.RPCProvider.processMessage(RPCProvider.java:186) [axis-1.4.jar:na]
        at org.apache.axis.providers.java.JavaProvider.invoke(JavaProvider.java:323) [axis-1.4.jar:na]
        at org.apache.axis.strategies.InvocationStrategy.visit(InvocationStrategy.java:32) [axis-1.4.jar:na]
        at org.apache.axis.SimpleChain.doVisiting(SimpleChain.java:118) [axis-1.4.jar:na]
        at org.apache.axis.SimpleChain.invoke(SimpleChain.java:83) [axis-1.4.jar:na]
        at org.apache.axis.handlers.soap.SOAPService.invoke(SOAPService.java:454) [axis-1.4.jar:na]
        at org.apache.axis.server.AxisServer.invoke(AxisServer.java:281) [axis-1.4.jar:na]
        at org.apache.axis.transport.http.AxisServlet.doPost(AxisServlet.java:699) [axis-1.4.jar:na]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:707) [javax.servlet-api-3.1.0.jar:3.1.0]
        at org.apache.axis.transport.http.AxisServletBase.service(AxisServletBase.java:327) [axis-1.4.jar:na]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) [javax.servlet-api-3.1.0.jar:3.1.0]
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:808) [jetty-servlet-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:587) [jetty-servlet-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577) [jetty-security-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515) [jetty-servlet-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:52) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.Server.handle(Server.java:497) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257) [jetty-server-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540) [jetty-io-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635) [jetty-util-9.2.10.v20150310.jar:9.2.10.v20150310]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555) [jetty-util-9.2.10.v20150310.jar:9.2.10.v20150310]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_31]

Modification:

RemoteException is now only logged at debug level and without a stack trace.

Result:

No stack trace is logged when SRM requests throw RemoteExceptions.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8293/
(cherry picked from commit 7090629889e0f0ad066d0090a7fe3b6e7e4ece3b)
(cherry picked from commit f7606529c92b650633a78d15fdec6f59ef52509e)