### PR TITLE
spacemanager: Allow unowned files in reservations

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/util/VOInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/util/VOInfo.java
@@ -1,25 +1,15 @@
-/*
- * VOInfo.java
- *
- * Created on October 24, 2006, 4:18 PM
- *
- * To change this template, choose Tools | Template Manager
- * and open the template in the editor.
- */
-
 package diskCacheV111.util;
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.dcache.util.Glob;
 
-
-/**
- *
- * @author timur
- */
-public class VOInfo implements Serializable{
+public class VOInfo implements Serializable
+{
     private static final long serialVersionUID = -8014669884189610627L;
 
     private static final Pattern p1 = Pattern.compile( "(.*)/Role=(.*)");
@@ -70,11 +60,7 @@ public class VOInfo implements Serializable{
         throw new RuntimeException("Failed to find a matcher for FQAN pattern: " + pattern);
     }
 
-    /** Creates a new instance of VOInfo */
     public VOInfo(String voGroup,String voRole) {
-        if(voGroup == null) {
-            throw new IllegalArgumentException("null group");
-        }
         this.voGroup = voGroup;
         this.voRole = voRole;
     }
@@ -84,17 +70,19 @@ public class VOInfo implements Serializable{
         return voGroup+":"+voRole;
     }
 
+    @Nullable
     public String getVoGroup() {
         return voGroup;
     }
 
+    @Nullable
     public String getVoRole() {
         return voRole;
     }
 
     @Override
     public int hashCode(){
-        return voGroup.hashCode() ^ voRole.hashCode();
+        return Objects.hashCode(voGroup) ^ Objects.hashCode(voRole);
     }
 
     @Override
@@ -103,11 +91,15 @@ public class VOInfo implements Serializable{
             return false;
         }
         VOInfo voinfo = (VOInfo) o;
-        return voGroup.equals(voinfo.voGroup) && voRole.equals(voinfo.voRole) ;
+        return Objects.equals(voGroup, voinfo.voGroup) && Objects.equals(voRole, voinfo.voRole);
     }
 
-    public boolean match(final String group,
-                         final String role) {
+    public boolean match(final String group, final String role)
+    {
+        if (voGroup == null) {
+            return false;
+        }
+
         boolean roleMatches;
 
         if( voRole != null) {


### PR DESCRIPTION
Motivation:

Space manager tracks the "owner" of a file in a reservation. This owner is
unused, yet the code insist on there being an owner. Before 2.13, an owner can
only be an FQAN or user name and thus uploads to reservations fail with
protocols not providing either. NFS is such a protocol.

Most of the code doesn't care that there is no owner, but a specific utility
class, VOInfo, rejects a null value.

Modification:

VOInfo is updated to allow null values for group. The implementation of
hashCode and equals is updated to work with null values. This also fixes a
potential issue with null values for role which were allowed but would have
failed.

Result:

Fixes #1622.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Issue: #1622
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8294/
(cherry picked from commit dfafdf6f467dd69c9a9ddf8095c73a90772539aa)