### PR TITLE
pool: Let random pool selection select pools with removable files

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/RandomPoolSelectionStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/RandomPoolSelectionStrategy.java
@@ -30,7 +30,7 @@ public class RandomPoolSelectionStrategy
                     public boolean apply(PoolManagerPoolInformation pool)
                     {
                         PoolCostInfo.PoolSpaceInfo info = pool.getPoolCostInfo().getSpaceInfo();
-                        return info.getFreeSpace() >= info.getGap();
+                        return info.getFreeSpace() + info.getRemovableSpace() >= info.getGap();
                     }
                 });
         if (isEmpty(nonFullPools)) {


### PR DESCRIPTION
Motivation:

Migration module has a selectable pool selection strategy. In random pool
selection, the pool is chosen randomly from the set of non-full pools. This
filtering does not consider that a full pool may have garbage collectable files
and that the transfer would succeed. This is a regression introduced in 2.10.8.

Modification:

Allow pools where the sum of free and removable space is bigger than the gap
to be selected as migration targets.

Result:

Fixes issue #1619.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Issue: #1619
Acked-by: Albert Rossi <arossi@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8295/
(cherry picked from commit f39aa93665fe292cae8952de969f2f0c868a66c5)