### PR TITLE
Fix limited class path generation

### DIFF
--- a/skel/share/lib/loadConfig.sh
+++ b/skel/share/lib/loadConfig.sh
@@ -138,8 +138,9 @@ printLimitedClassPath() # $1..$n = list of jar files
     classpath="$(printPluginClassPath)"
     classes_path="$(getProperty dcache.paths.classes)"
     for name in "$@"; do
-        jar="$(echo $classes_path/$name-*.jar)"
-        classpath="${classpath}:${jar}"
+        for jar in $classes_path/$name-*.jar; do
+            classpath="${classpath}:${jar}"
+        done
     done
 
     echo ${classpath#:}


### PR DESCRIPTION
Motivation:

Many of our shell utilities limit the class path to only the needed JARs to
speed up JVM startup. The shell function that builds this limited class path
has a bug that causes it to insert spaces into the class path if more than
one JAR matches a given pattern.

This affects the chimera utility because the prefix 'acl' matches both the acl
and acl-vehicles jars. That is the cause of issue #1636.

Modification:

Loops over the expanded list of JARs instead of adding the space delimited
list directly.

Result:

Fixes #1636. That issue was only present in 2.13, but the bug in the shell
function exists in all supported versions.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8298/
(cherry picked from commit 73fc966a492609454d0a53fce7b5e68b2d91dcbb)