### PR TITLE
chimera: Add ACL insert triggers for HSQLDB

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changelog-master.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changelog-master.xml
@@ -15,5 +15,6 @@
     <include file="org/dcache/chimera/changelog/changeset-2.8.xml"/>
     <include file="org/dcache/chimera/changelog/changeset-2.9.xml"/>
     <include file="org/dcache/chimera/changelog/changeset-2.10.xml"/>
+    <include file="org/dcache/chimera/changelog/changeset-2.14.xml"/>
 
 </databaseChangeLog>

--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="behrmann" id="1" dbms="hsqldb">
+        <createProcedure>
+            CREATE TRIGGER tgs_insert_acl_dir AFTER INSERT ON t_dirs
+              REFERENCING NEW ROW new
+              FOR EACH ROW WHEN (new.iname = '..' AND (SELECT itype FROM t_inodes WHERE ipnfsid = new.ipnfsid) = 16384)
+                INSERT INTO t_acl
+                  SELECT new.ipnfsid, 0, type, BITANDNOT(flags, 8), access_msk, who, who_id, address_msk, ace_order
+                  FROM t_acl
+                  WHERE rs_id = new.iparent AND BITAND(flags, 3) > 0;
+        </createProcedure>
+        <createProcedure>
+            CREATE TRIGGER tgs_insert_acl_file AFTER INSERT ON t_dirs
+              REFERENCING NEW ROW new
+              FOR EACH ROW WHEN (new.iname != '..' OR (SELECT itype FROM t_inodes WHERE ipnfsid = new.ipnfsid) != 16384)
+                INSERT INTO t_acl
+                  SELECT new.ipnfsid, 1, type, BITANDNOT(flags, 11), access_msk, who, who_id, address_msk, ace_order
+                  FROM t_acl
+                  WHERE rs_id = new.iparent AND BITAND(flags, 1) > 0;
+        </createProcedure>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: no
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/8300/
(cherry picked from commit d38b70ae23189834aae9b7d29b31bd70a1009cb8)
(cherry picked from commit 516ea4b142fafef29d1edaf948dac6d1b4764089)