### PR TITLE
pnfsmanager: Inherit ACLs on upload with SRM

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FileSystemProvider.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FileSystemProvider.java
@@ -120,11 +120,12 @@ public interface FileSystemProvider extends Closeable {
      * @param owner UID of owner
      * @param group GID of group
      * @param mode Permissions
+     * @param acl ACL to set on new directory
      * @param tags Tags to set on new directory
      * @return Inode of newly created directory
      * @throws ChimeraFsException
      */
-    FsInode mkdir(FsInode parent, String name, int owner, int group, int mode, Map<String,byte[]> tags)
+    FsInode mkdir(FsInode parent, String name, int owner, int group, int mode, List<ACE> acl, Map<String, byte[]> tags)
             throws ChimeraFsException;
 
     public abstract FsInode path2inode(String path) throws ChimeraFsException;

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode.java
@@ -18,6 +18,10 @@ package org.dcache.chimera;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.dcache.acl.ACE;
 import org.dcache.chimera.posix.Stat;
 
 /**
@@ -315,6 +319,14 @@ public class FsInode {
      */
     public FsInode mkdir(String name, int owner, int group, int mode) throws ChimeraFsException {
         return _fs.mkdir(this, name, owner, group, mode);
+    }
+
+    /**
+     * crate a directory with name 'newDir' in current inode with different access rights
+     */
+    public FsInode mkdir(String name, int owner, int group, int mode, List<ACE> acl, Map<String, byte[]> tags)
+            throws ChimeraFsException {
+        return _fs.mkdir(this, name, owner, group, mode, acl, tags);
     }
 
     /**

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -427,10 +427,11 @@ class FsSqlDriver {
     }
 
     FsInode mkdir(Connection dbConnection, FsInode parent, String name, int owner, int group, int mode,
-                  Map<String,byte[]> tags) throws ChimeraFsException, SQLException
+            List<ACE> acl, Map<String,byte[]> tags) throws ChimeraFsException, SQLException
     {
         FsInode inode = mkdir(dbConnection, parent, name, owner, group, mode);
         createTags(dbConnection, inode, owner, group, mode & 0666, tags);
+        setACL(dbConnection, inode, acl);
         return inode;
     }
 
@@ -2673,9 +2674,10 @@ class FsSqlDriver {
      * @param dbConnection
      * @param inode
      * @param acl
+     * @return true if ACLs of inode might have been modified, false otherwise
      * @throws SQLException
      */
-    void setACL(Connection dbConnection, FsInode inode, List<ACE> acl) throws SQLException {
+    public boolean setACL(Connection dbConnection, FsInode inode, List<ACE> acl) throws SQLException {
 
         PreparedStatement stDeleteACL = null;
         PreparedStatement stAddACL = null;
@@ -2683,32 +2685,32 @@ class FsSqlDriver {
         try {
             stDeleteACL = dbConnection.prepareStatement(sqlDeleteACL);
             stDeleteACL.setString(1, inode.toString());
-            stDeleteACL.executeUpdate();
+            boolean modified = stDeleteACL.executeUpdate() > 0;
 
-            if(acl.isEmpty()) {
-                return;
+            if (!acl.isEmpty()) {
+                stAddACL = dbConnection.prepareStatement(sqlAddACL);
+
+                int order = 0;
+                RsType rsType = inode.isDirectory() ? RsType.DIR : RsType.FILE;
+                for (ACE ace : acl) {
+
+                    stAddACL.setString(1, inode.toString());
+                    stAddACL.setInt(2, rsType.getValue());
+                    stAddACL.setInt(3, ace.getType().getValue());
+                    stAddACL.setInt(4, ace.getFlags());
+                    stAddACL.setInt(5, ace.getAccessMsk());
+                    stAddACL.setInt(6, ace.getWho().getValue());
+                    stAddACL.setInt(7, ace.getWhoID());
+                    stAddACL.setString(8, ace.getAddressMsk());
+                    stAddACL.setInt(9, order);
+
+                    stAddACL.addBatch();
+                    order++;
+                }
+                stAddACL.executeBatch();
+                modified = true;
             }
-            stAddACL = dbConnection.prepareStatement(sqlAddACL);
-
-            int order = 0;
-            RsType rsType = inode.isDirectory() ? RsType.DIR : RsType.FILE;
-            for (ACE ace : acl) {
-
-                stAddACL.setString(1, inode.toString());
-                stAddACL.setInt(2, rsType.getValue() );
-                stAddACL.setInt(3, ace.getType().getValue());
-                stAddACL.setInt(4, ace.getFlags());
-                stAddACL.setInt(5, ace.getAccessMsk());
-                stAddACL.setInt(6, ace.getWho().getValue());
-                stAddACL.setInt(7, ace.getWhoID());
-                stAddACL.setString(8, ace.getAddressMsk());
-                stAddACL.setInt(9, order);
-
-                stAddACL.addBatch();
-                order++;
-            }
-            stAddACL.executeBatch();
-            setFileCTime(dbConnection, inode, 0, System.currentTimeMillis());
+            return modified;
         }finally{
             SqlHelper.tryToClose(stDeleteACL);
             SqlHelper.tryToClose(stAddACL);

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -842,7 +842,9 @@ public class JdbcFs implements FileSystemProvider {
     }
 
     @Override
-    public FsInode mkdir(FsInode parent, String name, int owner, int group, int mode, Map<String,byte[]> tags) throws ChimeraFsException
+    public FsInode mkdir(FsInode parent, String name, int owner, int group, int mode,
+                         List<ACE> acl, Map<String, byte[]> tags)
+            throws ChimeraFsException
     {
         checkNameLength(name);
 
@@ -866,7 +868,7 @@ public class JdbcFs implements FileSystemProvider {
                 mode |= UnixPermission.S_ISGID;
             }
 
-            inode = _sqlDriver.mkdir(dbConnection, parent, name, owner, group, mode, tags);
+            inode = _sqlDriver.mkdir(dbConnection, parent, name, owner, group, mode, acl, tags);
             dbConnection.commit();
         } catch (SQLException se) {
 
@@ -2690,7 +2692,9 @@ public class JdbcFs implements FileSystemProvider {
         try {
             dbConnection.setAutoCommit(false);
 
-            _sqlDriver.setACL(dbConnection, inode, acl);
+            if (_sqlDriver.setACL(dbConnection, inode, acl)) {
+                _sqlDriver.setFileCTime(dbConnection, inode, 0, System.currentTimeMillis());
+            }
             dbConnection.commit();
 
         } catch (SQLException e) {

--- a/modules/chimera/src/main/java/org/dcache/chimera/PgSQLFsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PgSQLFsSqlDriver.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.dcache.acl.ACE;
 import org.dcache.chimera.posix.Stat;
 import org.dcache.commons.util.SqlHelper;
 
@@ -55,13 +56,14 @@ class PgSQLFsSqlDriver extends FsSqlDriver {
 
     @Override
     FsInode mkdir(Connection dbConnection, FsInode parent, String name, int owner, int group, int mode,
-                  Map<String, byte[]> tags) throws ChimeraFsException, SQLException
+                  List<ACE> acl, Map<String, byte[]> tags) throws ChimeraFsException, SQLException
     {
         FsInode inode = mkdir(dbConnection, parent, name, owner, group, mode);
         /* There is a trigger that copies tags on mkdir, but we don't want those tags.
          */
         removeTag(dbConnection, inode);
         createTags(dbConnection, inode, owner, group, mode & 0666, tags);
+        setACL(dbConnection, inode, acl);
         return inode;
     }
 

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -8,6 +8,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -78,7 +79,7 @@ public class BasicTest extends ChimeraTestCaseHelper {
     @Test
     public void testMkDirWithTags() throws Exception {
         byte[] bytes = "value".getBytes();
-        FsInode dir1 = _fs.mkdir(_rootInode, "junit", 1, 2, 02755, ImmutableMap.of("tag", bytes));
+        FsInode dir1 = _fs.mkdir(_rootInode, "junit", 1, 2, 02755, Collections.<ACE>emptyList(), ImmutableMap.of("tag", bytes));
         assertThat(_fs.getAllTags(dir1), hasEntry("tag", bytes));
     }
 

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -18,6 +18,7 @@ import javax.security.auth.Subject;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -1245,7 +1246,8 @@ public class ChimeraNameSpaceProvider
 
             /* Upload directory must exist and have the right permissions.
              */
-            FsInode inodeOfUploadDir = installSystemDirectory(uploadDirectory, 0711, Collections.emptyList(), Collections.emptyMap());
+            FsInode inodeOfUploadDir = installSystemDirectory(uploadDirectory, 0711, Collections.<ACE>emptyList(),
+                                                              Collections.<String,byte[]>emptyMap());
             if (inodeOfUploadDir.statCache().getUid() != 0) {
                 _log.error("Owner must be root: {}", uploadDirectory);
                 throw new CacheException("Owner must be root: " + uploadDirectory);

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -40,6 +40,7 @@ import diskCacheV111.util.PnfsId;
 import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.vehicles.StorageInfo;
 
+import org.dcache.acl.ACE;
 import org.dcache.acl.ACL;
 import org.dcache.auth.Subjects;
 import org.dcache.chimera.ChimeraFsException;
@@ -1185,24 +1186,11 @@ public class ChimeraNameSpaceProvider
                 mode = parentOfPath.statCache().getMode() & UMASK_DIR;
             }
 
-            /* Upload directory may optionally be relative to the user's root path. Whether
-             * that's the case depends on if the configured upload directory is an absolute
-             * or relative path.
+            /* ACLs are copied from real parent to the temporary upload directory
+             * such that the upload is allowed (in case write permissions rely
+             * on ACLs) and such that the file will inherit the correct ACLs.
              */
-            FsPath uploadDirectory = new FsPath(rootPath);
-            uploadDirectory.add(String.format(_uploadDirectory, threadId.get()));
-
-            /* Upload directory must exist and have the right permissions.
-             */
-            FsInode inodeOfUploadDir = installDirectory(Subjects.ROOT, uploadDirectory, 0, 0, 0711);
-            if (inodeOfUploadDir.statCache().getUid() != 0) {
-                _log.error("Owner must be root: {}", uploadDirectory);
-                throw new CacheException("Owner must be root: " + uploadDirectory);
-            }
-            if ((inodeOfUploadDir.statCache().getMode() & UnixPermission.S_PERMS) != 0711) {
-                _log.error("File mode must be 0711: {}", uploadDirectory);
-                throw new CacheException("File mode must be 0711: " + uploadDirectory);
-            }
+            List<ACE> acl = _fs.getACL(parentOfPath);
 
             /* The temporary upload directory has the same tags as the real parent,
              * except target file specific properties are stored as tags local to
@@ -1229,10 +1217,29 @@ public class ChimeraNameSpaceProvider
             }
             tags.put(TAG_PATH, path.toString().getBytes(Charsets.UTF_8));
 
+            /* Upload directory may optionally be relative to the user's root path. Whether
+             * that's the case depends on if the configured upload directory is an absolute
+             * or relative path.
+             */
+            FsPath uploadDirectory = new FsPath(rootPath);
+            uploadDirectory.add(String.format(_uploadDirectory, threadId.get()));
+
+            /* Upload directory must exist and have the right permissions.
+             */
+            FsInode inodeOfUploadDir = installDirectory(Subjects.ROOT, uploadDirectory, 0, 0, 0711);
+            if (inodeOfUploadDir.statCache().getUid() != 0) {
+                _log.error("Owner must be root: {}", uploadDirectory);
+                throw new CacheException("Owner must be root: " + uploadDirectory);
+            }
+            if ((inodeOfUploadDir.statCache().getMode() & UnixPermission.S_PERMS) != 0711) {
+                _log.error("File mode must be 0711: {}", uploadDirectory);
+                throw new CacheException("File mode must be 0711: " + uploadDirectory);
+            }
+
             /* Use cryptographically strong pseudo random UUID to create temporary upload directory.
              */
             UUID uuid = UUID.randomUUID();
-            _fs.mkdir(inodeOfUploadDir, uuid.toString(), uid, gid, mode, tags);
+            _fs.mkdir(inodeOfUploadDir, uuid.toString(), uid, gid, mode, acl, tags);
 
             return new FsPath(uploadDirectory, uuid.toString(), path.getName());
         } catch (ChimeraFsException e) {

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ExtendedInode.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ExtendedInode.java
@@ -28,6 +28,7 @@ import com.google.common.io.ByteSource;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import diskCacheV111.util.AccessLatency;
@@ -35,6 +36,7 @@ import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.util.RetentionPolicy;
 
+import org.dcache.acl.ACE;
 import org.dcache.acl.ACL;
 import org.dcache.acl.enums.RsType;
 import org.dcache.chimera.ChimeraFsException;
@@ -120,6 +122,13 @@ public class ExtendedInode extends FsInode
     public ExtendedInode mkdir(String name, int owner, int group, int mode) throws ChimeraFsException
     {
         return new ExtendedInode(this, super.mkdir(name, owner, group, mode));
+    }
+
+    @Override
+    public ExtendedInode mkdir(String name, int owner, int group, int mode, List<ACE> acl, Map<String, byte[]> tags)
+            throws ChimeraFsException
+    {
+        return new ExtendedInode(this, super.mkdir(name, owner, group, mode, acl, tags));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

The SRM uses temporary upload directories, but pnfsmanager fails to copy the
ACLs of the actual target directory to the upload directory.  Thus the newly
uploaded file will inherit the ACLs from the base upload directory rather than
the taget directory.

Modification:

The name space provider copies the ACLs of the target directory to the
temporary upload directory. Chimera had to be modified to accept ACLs on mkdir
to efficiently set those. The setACL code path in Chimera got change to avoid
an unecessary reset of the ctime when the ACLs are not changed or set on a
newly created directory.

Result:

Fixes #1639

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8303/
(cherry picked from commit 9feb7c34a7364cfdac277240da8dab492502ee69)
(cherry picked from commit 7f383a015345490b09406a5d2ba0d70914a7c63e)