### PR TITLE
pool: Store nearline storage timeouts to pool setup file

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -225,11 +225,11 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
     @Override
     public void getInfo(PrintWriter pw)
     {
-        pw.append(" Restore Timeout  : ").print(stageTimeout / 1000L);
+        pw.append(" Restore Timeout  : ").print(TimeUnit.MILLISECONDS.toSeconds(stageTimeout));
         pw.println(" seconds");
-        pw.append("   Store Timeout  : ").print(flushTimeout / 1000L);
+        pw.append("   Store Timeout  : ").print(TimeUnit.MILLISECONDS.toSeconds(flushTimeout));
         pw.println(" seconds");
-        pw.append("  Remove Timeout  : ").print(removeTimeout / 1000L);
+        pw.append("  Remove Timeout  : ").print(TimeUnit.MILLISECONDS.toSeconds(removeTimeout));
         pw.println(" seconds");
         pw.println("  Job Queues (active/queued)");
         pw.append("    to store   ").print(getActiveStoreJobs());
@@ -241,6 +241,14 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         pw.append("    delete     " + "").print(getActiveRemoveJobs());
         pw.append("/").print(getRemoveQueueSize());
         pw.println();
+    }
+
+    @Override
+    public void printSetup(PrintWriter pw)
+    {
+        pw.append("rh set timeout ").println(TimeUnit.MILLISECONDS.toSeconds(stageTimeout));
+        pw.append("st set timeout ").println(TimeUnit.MILLISECONDS.toSeconds(flushTimeout));
+        pw.append("rm set timeout ").println(TimeUnit.MILLISECONDS.toSeconds(removeTimeout));
     }
 
     /**


### PR DESCRIPTION
Motivation:

The nearline storage subsystem was rewritten in 2.9. The new version fails to
persist timeouts to the pool setup file. This is a regression from the old
version.

Modification:

Save the stage, flush and remove timeouts to the pool setup file.

Result:

Fixes #1637.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8306/
(cherry picked from commit 0b8d50dd7a5b3b0d6232509642020f091e2b9945)