### PR TITLE
pool: introduce unique port number for nfs mover

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -340,6 +340,7 @@
       <property name="checksumModule" ref="csm"/>
       <property name="minTcpPort" value="${pool.mover.nfs.port.min}"/>
       <property name="maxTcpPort" value="${pool.mover.nfs.port.max}"/>
+      <property name="tcpPortFile" value="${pool.path}/mover-tcp-port.nfs"/>
   </bean>
 
   <bean id="xrootd-transfer-service" class="org.dcache.xrootd.pool.XrootdTransferService"

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -165,6 +165,9 @@ pool.plugins.sweeper = org.dcache.pool.classic.SpaceSweeper2
 # let client to reconnect. If client failed to reconnect to the
 # mover, then a RPC request may stay in clients task queue in a
 # 'D' state and increase CPU load by one.
+#
+# If range configured to have more than one port, pool will
+# randomly select one and and reuse it after restart.
 pool.mover.nfs.port.min = ${dcache.net.lan.port.min}
 pool.mover.nfs.port.max = ${dcache.net.lan.port.max}
 


### PR DESCRIPTION
It's recommended to keep TCP port number used by NFS mover over restarts
to avoid orphan RPC tasks on the client nodes.

With this change pool will save the used port number in

${pool.path}/mover-tcp-port.nfs

and use it after restart.

Acked-by: Albert Rossi
Acked-by: Gerd Behrmann
Target: master, 2.13, 2.12, 2.11, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 2cda82dbf78b1b10ed5672254aa8e68bb9af97a6)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>