### PR TITLE
pool: introduce unique port number for nfs mover

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -1,17 +1,22 @@
 package org.dcache.chimera.nfsv41.mover;
 
 import com.google.common.base.Function;
+import com.google.common.io.Files;
 import org.ietf.jgss.GSSException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.BindException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.nio.channels.CompletionHandler;
+import java.nio.charset.StandardCharsets;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
@@ -73,11 +78,60 @@ public class NfsTransferService extends AbstractCellComponent
     private int _minTcpPort;
     private int _maxTcpPort;
 
+    /**
+     * file to store TCP port number used by pool.
+     */
+    private File _tcpPortFile;
+
     public void init() throws IOException, GSSException, OncRpcException {
 
-        PortRange portRange = new PortRange(_minTcpPort, _maxTcpPort);
-        _nfsIO = new NFSv4MoverHandler(portRange, _withGss, getCellName(), _door, _bootVerifier);
+        PortRange portRange;
+        int minTcpPort = _minTcpPort;
+        int maxTcpPort = _maxTcpPort;
+
+        try {
+            String line = Files.readFirstLine(_tcpPortFile, StandardCharsets.US_ASCII);
+            int savedPort = Integer.parseInt(line);
+            if (savedPort >= _minTcpPort && savedPort <= _maxTcpPort) {
+                /*
+                 *if saved port with in the range, then restrict range to a single port
+                 * to enforce it.
+                 */
+                minTcpPort = savedPort;
+                maxTcpPort = savedPort;
+            }
+        } catch (NumberFormatException e) {
+            // garbage in the file.
+            _log.warn("Invalid content in the port file {} : {}", _tcpPortFile, e.getMessage());
+        } catch (FileNotFoundException e) {
+        }
+
+        boolean bound = false;
+        int retry = 3;
+        BindException bindException = null;
+        do {
+            retry--;
+            portRange = new PortRange(minTcpPort, maxTcpPort);
+            try {
+                _nfsIO = new NFSv4MoverHandler(portRange, _withGss, getCellName(), _door, _bootVerifier);
+                bound = true;
+            } catch (BindException e) {
+                bindException = e;
+                minTcpPort = _minTcpPort;
+                maxTcpPort = _maxTcpPort;
+            }
+        } while (!bound && retry > 0);
+
+        if (!bound) {
+            throw new BindException("Can't bind to a port within the rage: " + portRange + " : " + bindException);
+        }
         _localSocketAddresses = localSocketAddresses(NetworkUtils.getLocalAddresses(), _nfsIO.getLocalAddress().getPort());
+
+        // if we had a port range, then store selected port for the next time.
+        if (minTcpPort != maxTcpPort) {
+            _tcpPortFile.delete();
+            Files.write(Integer.toString(_nfsIO.getLocalAddress().getPort()), _tcpPortFile, StandardCharsets.US_ASCII);
+        }
 
         /*
          * we assume, that client's can't handle multipath list correctly
@@ -125,6 +179,10 @@ public class NfsTransferService extends AbstractCellComponent
     @Required
     public void setMaxTcpPort(int maxPort) {
         _maxTcpPort = maxPort;
+    }
+
+    public void setTcpPortFile(File path) {
+        _tcpPortFile = path;
     }
 
     public void shutdown() throws IOException {

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -341,6 +341,7 @@
       <property name="checksumModule" ref="csm"/>
       <property name="minTcpPort" value="${pool.mover.nfs.port.min}"/>
       <property name="maxTcpPort" value="${pool.mover.nfs.port.max}"/>
+      <property name="tcpPortFile" value="${pool.path}/mover-tcp-port.nfs"/>
   </bean>
 
   <bean id="xrootd-transfer-service" class="org.dcache.xrootd.pool.XrootdTransferService"

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -165,6 +165,9 @@ pool.plugins.sweeper = org.dcache.pool.classic.SpaceSweeper2
 # let client to reconnect. If client failed to reconnect to the
 # mover, then a RPC request may stay in clients task queue in a
 # 'D' state and increase CPU load by one.
+#
+# If range configured to have more than one port, pool will
+# randomly select one and and reuse it after restart.
 pool.mover.nfs.port.min = ${dcache.net.lan.port.min}
 pool.mover.nfs.port.max = ${dcache.net.lan.port.max}
 


### PR DESCRIPTION
It's recommended to keep TCP port number used by NFS mover over restarts
to avoid orphan RPC tasks on the client nodes.

With this change pool will save the used port number in

${pool.path}/mover-tcp-port.nfs

and use it after restart.

Acked-by: Albert Rossi
Acked-by: Gerd Behrmann
Target: master, 2.13, 2.12, 2.11, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 2cda82dbf78b1b10ed5672254aa8e68bb9af97a6)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>