### PR TITLE
pool: reduce load on back-end file system

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2013 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2013 - 2015 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -26,6 +26,7 @@ import javax.security.auth.Subject;
 
 import java.io.FileNotFoundException;
 import java.io.InterruptedIOException;
+import java.io.IOException;
 import java.nio.channels.CompletionHandler;
 
 import diskCacheV111.util.CacheException;
@@ -246,7 +247,7 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
         case WRITE:
             try {
                 channel = new FileRepositoryChannel(_handle.getFile(), "rw");
-            } catch (FileNotFoundException e) {
+            } catch (IOException e) {
                 throw new DiskErrorCacheException(
                         "File could not be created; please check the file system", e);
             }
@@ -254,7 +255,7 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
         case READ:
             try {
                 channel = new FileRepositoryChannel(_handle.getFile(), "r");
-            } catch (FileNotFoundException e) {
+            } catch (IOException e) {
                 throw new DiskErrorCacheException("File could not be opened  [" +
                         e.getMessage() + "]; please check the file system", e);
             }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/FileRepositoryChannel.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/FileRepositoryChannel.java
@@ -16,7 +16,13 @@ public class FileRepositoryChannel implements RepositoryChannel {
     private final RandomAccessFile _raf;
     private final File _file;
 
-    public FileRepositoryChannel(String f, String mode) throws FileNotFoundException {
+    /*
+     * Cached value of files size. If value is -1, then we have to get file size
+     * by querying the underlying file system.
+     */
+    private final long _fileSize;
+
+    public FileRepositoryChannel(String f, String mode) throws FileNotFoundException, IOException {
         this(new File(f), mode);
     }
 
@@ -80,10 +86,11 @@ public class FileRepositoryChannel implements RepositoryChannel {
      *            that name cannot be created, or if some other error occurs
      *            while opening or creating the file
      */
-    public FileRepositoryChannel(File f, String mode) throws FileNotFoundException {
+    public FileRepositoryChannel(File f, String mode) throws FileNotFoundException, IOException {
         _file = f;
         _raf = new RandomAccessFile(f, mode);
         _fileChannel = _raf.getChannel();
+        _fileSize = mode.equals("r") ? _raf.length() : -1;
     }
 
     @Override
@@ -99,7 +106,7 @@ public class FileRepositoryChannel implements RepositoryChannel {
 
     @Override
     public long size() throws IOException {
-        return _file.length();
+        return _fileSize == -1 ? _file.length() : _fileSize;
     }
 
     @Override


### PR DESCRIPTION
this is a minimalistic version of d1c977d

the nfs read request uses file size and current position to detect and
report EOF marker. As a result any file READ request will issue File#length().
Reduce the load on backend file system by caching file size for read-only
movers.

Acked-by: Paul Millar
Target: master, 2,13, 2.12, 2.11, 2.10
Require-notes: no
Require-book: no
(cherry picked from commit 890fd8096af70fac7cefa39ecb5049e633f66c58)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>