### PR TITLE
pool: simplify duplicate request handling

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -709,16 +709,23 @@ public class PoolV4
 
     private boolean isDuplicateIoRequest(CellPath pathFromSource, PoolIoFileMessage message)
     {
-        if (!(message instanceof PoolAcceptFileMessage)
-                && !message.isPool2Pool()) {
-            long id = message.getId();
-            String door = pathFromSource.getSourceAddress().toString();
-            JobInfo job = _ioQueue.findJob(door, id);
-            if (job != null) {
-                switch (_dupRequest) {
+        if (_dupRequest == DUP_REQ_NONE) {
+            // we don't care
+            return false;
+        }
+
+        if ((message instanceof PoolAcceptFileMessage) || message.isPool2Pool()) {
+            // duplicate write and p2p requests are ignored
+            return false;
+        }
+
+        long id = message.getId();
+        String door = pathFromSource.getSourceAddress().toString();
+        JobInfo job = _ioQueue.findJob(door, id);
+        if (job != null) {
+            switch (_dupRequest) {
                 case DUP_REQ_NONE:
-                    _log.info("Dup Request : none <" + door + ":" + id + ">");
-                    break;
+                    throw new RuntimeException("must not reach");
                 case DUP_REQ_IGNORE:
                     _log.info("Dup Request : ignoring <" + door + ":" + id + ">");
                     return true;
@@ -726,12 +733,11 @@ public class PoolV4
                     long jobId = job.getJobId();
                     _log.info("Dup Request : refreshing <" + door + ":"
                             + id + "> old = " + jobId);
-                    _ioQueue.cancel((int)jobId);
+                    _ioQueue.cancel((int) jobId);
                     break;
                 default:
                     throw new RuntimeException("Dup Request : PANIC (code corrupted) <"
                             + door + ":" + id + ">");
-                }
             }
         }
         return false;


### PR DESCRIPTION
before mover created pool checks for duplicated requests.
This is dome by scanning all movers. The result of this
expensive operation is thrown away if duplicate request mode is
set to 'none'.

re-factor PoolV4#isDuplicateIoRequest to skip the scan if result is ignored.

Acked-by: Gerd Behrmann
Acked-by: Paul Millar
Target: master, 2.13, 2.12, 2.11, 2.10
Require-notes: no
Require-book: no
(cherry picked from commit edffb456c086da5388766d3dac39c26c29b82769)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>