### PR TITLE
webdav: Fix proxied upload with chunked encoding

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -1306,6 +1306,8 @@ public class DcacheResourceFactory
      */
     private class WriteTransfer extends HttpTransfer
     {
+        private boolean hasLength;
+
         public WriteTransfer(PnfsHandler pnfs, Subject subject, FsPath path)
                 throws URISyntaxException
         {
@@ -1325,8 +1327,9 @@ public class DcacheResourceFactory
                     connection.setRequestMethod("PUT");
                     connection.setRequestProperty("Connection", "Close");
                     connection.setDoOutput(true);
-                    if (getFileAttributes().isDefined(SIZE)) {
-                        connection.setFixedLengthStreamingMode(getFileAttributes().getSize());
+                    FileAttributes fileAttributes = getFileAttributes();
+                    if (hasLength || fileAttributes.isDefined(SIZE) && fileAttributes.getSize() > 0) {
+                        connection.setFixedLengthStreamingMode(fileAttributes.getSize());
                     } else {
                         connection.setChunkedStreamingMode(8192);
                     }
@@ -1361,6 +1364,7 @@ public class DcacheResourceFactory
         public void setLength(Long length)
         {
             if (length != null) {
+                hasLength = true;
                 super.setLength(length);
             }
         }


### PR DESCRIPTION
Motivation:

A WebDAV door may proxy uploads. When relaying the data to the pool, the door
may send the expected file size to the pool in an HTTP header or use chunked
encoding. Which it chooses depends on whether the file size is known. The file
size may be know because the client itself submitted the file size in an HTTP
header, or because the client negotiated the transfer with SRM.

Since Chimera defaults to a file size of zero, the door will falsely set that
as the expected size even when no size is known and the client is using chunked
encoding. Such an upload will fails. ARC is a client using chunked encoding
for upload.

Modification:

This bug was previously fixed in 2.12. The fix was too intrusive to be
backported.  This patch makes a local fix in the WebDAV door to detect the
cases in which a client provided a size through either SRM or through an HTTP
header.

Result:

Fixes proxied chunked upload through HTTP. Fixes compatibility with ARC.

Target: 2.11
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8311/
(cherry picked from commit d02a1c94252d71a931e9a8a0500ffbf25d4a29a5)