### PR TITLE
poolmanager: Reduce log level of p2p denial

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -1958,7 +1958,7 @@ public class RequestContainerV5
                 return RT_FOUND;
             } catch (PermissionDeniedCacheException e) {
                 setError(e.getRc(), e.getMessage());
-                _log.warn("[p2p] {}", e.toString());
+                _log.info("[p2p] {}", e.toString());
                 return RT_NOT_PERMITTED;
             } catch (SourceCostException e) {
                 setError(e.getRc(), e.getMessage());


### PR DESCRIPTION
Motivation:

A pool to pool replication can be triggered by high load on the selected read
pool. The replication can however be rejected due to other contraints, such as
already having the maximum allowed number of copies of a particular file. This
is reported as a PermissionDeniedCacheException (which in itself is an issue,
as the replication is denied due to resource constraints and not due to an
authorization failure), which in turn is logged at warn level.  This tends to
fill the log file with messages about not replicating a file, even though the
transfer will succeed. Other resource errors during pool to pool processing are
logged at info level.

Modification:

Reduce the log level for messages like `P2P denied: already too many copies`
and `P2P denied: No pool candidates available/configured/left for p2p or file
already everywhere` to info.

Result:

Fixes #1603

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8313/
(cherry picked from commit ec1c6bb598f9edcc05231b01d15cc9e1cdfd692d)