### PR TITLE
httpd: Do now show maximum for restore and flush queues

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/poolmanager/PoolCostMsgHandler.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/poolmanager/PoolCostMsgHandler.java
@@ -81,8 +81,8 @@ public class PoolCostMsgHandler extends CellMessageHandlerSkel {
 			 *  Add all the standard queues
 			 */
 
-			addQueueInfo( update, pathToQueues, "store", thisPoolInfo.getStoreQueue(), metricLifetime);
-			addQueueInfo( update, pathToQueues, "restore", thisPoolInfo.getRestoreQueue(), metricLifetime);
+			addTapeQueueInfo( update, pathToQueues, "store", thisPoolInfo.getStoreQueue(), metricLifetime);
+			addTapeQueueInfo( update, pathToQueues, "restore", thisPoolInfo.getRestoreQueue(), metricLifetime);
 			addQueueInfo( update, pathToQueues, "mover", thisPoolInfo.getMoverQueue(), metricLifetime);
 			addQueueInfo( update, pathToQueues, "p2p-queue", thisPoolInfo.getP2pQueue(), metricLifetime);
 			addQueueInfo( update, pathToQueues, "p2p-clientqueue", thisPoolInfo.getP2pClientQueue(), metricLifetime);
@@ -153,6 +153,41 @@ public class PoolCostMsgHandler extends CellMessageHandlerSkel {
 					new IntegerStateValue(info.getActive(), lifetime));
 		stateUpdate.appendUpdate(queuePath.newChild("max-active"),
 				new IntegerStateValue(info.getMaxActive(), lifetime));
+		stateUpdate.appendUpdate(queuePath.newChild("queued"),
+				new IntegerStateValue(info.getQueued(), lifetime));
+	}
+
+	/**
+	 * Add information about a specific tape queue to a pool's portion of dCache state.
+	 * The state tree looks like:
+	 *
+	 * <pre>
+	 * [dCache]
+	 *  |
+	 *  +--[pools]
+	 *  |   |
+	 *  |   +--[&lt;poolName>]
+	 *  |   |   |
+	 *  |   |   +--[queues]
+	 *  |   |   |   |
+	 *  |   |   |   +--[&lt;queueName1>]
+	 *  |   |   |   |    |
+	 *  |   |   |   |    +--active: nnn
+	 *  |   |   |   |    +--queued: nnn
+	 *  |   |   |   |
+	 *  |   |   |   +--[&lt;queueName2>]
+	 * </pre>
+	 *
+	 * @param pathToQueues the StatePath pointing to queues (e.g.,
+	 * "pools.mypool_1.queues")
+	 * @param queueName the name of the queue.
+	 */
+	private void addTapeQueueInfo( StateUpdate stateUpdate, StatePath pathToQueues,
+								String queueName, PoolQueueInfo info, long lifetime) {
+		StatePath queuePath = pathToQueues.newChild(queueName);
+
+		stateUpdate.appendUpdate(queuePath.newChild("active"),
+					new IntegerStateValue(info.getActive(), lifetime));
 		stateUpdate.appendUpdate(queuePath.newChild("queued"),
 				new IntegerStateValue(info.getQueued(), lifetime));
 	}

--- a/modules/dcache/src/main/java/diskCacheV111/cells/WebCollectorV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/WebCollectorV3.java
@@ -605,12 +605,12 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
                 };
         rows[1] = new int[]{
                     restore.getActive(),
-                    restore.getMaxActive(),
+                    -1,
                     restore.getQueued()
                 };
         rows[2] = new int[]{
                     store.getActive(),
-                    store.getMaxActive(),
+                    -1,
                     store.getQueued()
                 };
 
@@ -697,7 +697,11 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
                 page.td(3, "integrated", "Integrated");
             } else {
                 page.td("active", row[0]);
-                page.td("max", row[1]);
+                if (row[1] >= 0) {
+                    page.td("max", row[1]);
+                } else {
+                    page.td("max");
+                }
                 if (row[2] > 0) {
                     page.td("queued", row[2]);
                 } else {
@@ -891,7 +895,11 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
 
         for (int[] row : total) {
             page.td("active", row[0]);
-            page.td("max", row[1]);
+            if (row[1] >= 0) {
+                page.td("max", row[1]);
+            } else {
+                page.td("max");
+            }
             page.td("queued", row[2]);
         }
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/web/PoolQueueTableWriter.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/web/PoolQueueTableWriter.java
@@ -112,7 +112,11 @@ public class PoolQueueTableWriter
 
         for (int[] row : total) {
             _html.td("active", row[0]);
-            _html.td("max", row[1]);
+            if (row[1] >= 0) {
+                _html.td("max", row[1]);
+            } else {
+                _html.td("max");
+            }
             _html.td("queued", row[2]);
         }
 
@@ -141,7 +145,11 @@ public class PoolQueueTableWriter
                     _html.td(3, "integrated", "Integrated");
                 } else {
                     _html.td("active", row[0]);
-                    _html.td("max",    row[1]);
+                    if (row[1] >= 0) {
+                        _html.td("max", row[1]);
+                    } else {
+                        _html.td("max");
+                    }
                     if (row[2] > 0) {
                         _html.td("queued", row[2]);
                     } else {
@@ -245,12 +253,12 @@ public class PoolQueueTableWriter
 
             rows[1] = new int[3];
             rows[1][0] = restore.getActive();
-            rows[1][1] = restore.getMaxActive();
+            rows[1][1] = -1;
             rows[1][2] = restore.getQueued();
 
             rows[2] = new int[3];
             rows[2][0] = store.getActive();
-            rows[2][1] = store.getMaxActive();
+            rows[2][1] = -1;
             rows[2][2] = store.getQueued();
 
             if (p2pServer == null) {


### PR DESCRIPTION
Motivation:

Pools no longer have a maximum for active restores or flushes. A specific
provider implementation may have such limits, but the pool and the rest of
dCache are unaware of such implementation details. httpd, webadmin and info
however show 0 as the maximum.

Modification:

Updates httpd and info to not show a maximum. In case of httpd this is achieved
by showing an empty column (easier than hiding the entire column). Somebody
else has to update webadmin.

Target: trunk
Require-notes: yes
Require-book: yes
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Bug: #1638
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8319/
(cherry picked from commit 38ec2c7111950c9ae7c0e6b9649d27de58358a4e)