### PR TITLE
info: Publish host name rather than host address

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/loginbroker/LoginBrokerLsMsgHandler.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/loginbroker/LoginBrokerLsMsgHandler.java
@@ -148,7 +148,7 @@ public class LoginBrokerLsMsgHandler extends CellMessageHandlerSkel {
 
 		StatePath pathToInterfaceBranch = parentPath.newChild(address.getHostAddress());
 
-		String hostName = address.getHostAddress();
+		String hostName = address.getHostName();
 		update.appendUpdate( pathToInterfaceBranch.newChild("FQDN"), new StringStateValue(hostName, lifetime));
 
 		String urlName = isInetAddress(hostName) ? toUriString(address) : hostName;


### PR DESCRIPTION
Motivation:

The info service publishes both host names and host addresses, however due to a
bug it actually publishes the address in both fields.

Modification:

Publish the host name in the appropriate field. This host name is provided by
the door.

Result:

The info provider once again publishes the host name into BDII.

Target: 2.12
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8321/