### PR TITLE
boot: Don't fail on missing layout file

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/boot/LayoutBuilder.java
+++ b/modules/dcache/src/main/java/org/dcache/boot/LayoutBuilder.java
@@ -5,15 +5,19 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
+
+import diskCacheV111.util.FileNotFoundCacheException;
 
 import org.dcache.util.ConfigurationProperties;
 
@@ -157,12 +161,18 @@ public class LayoutBuilder
         }
         URI uri = new URI(path);
         Layout layout = new Layout(config);
-        layout.load(uri);
+        if (!path.isEmpty()) {
+            try {
+                layout.load(uri);
+            } catch (FileNotFoundException e) {
+                config.getProblemConsumer().warning(e.getMessage());
+            }
 
-        if (Objects.equals(uri.getScheme(), "file")) {
-            _sourceFiles.add(new File(uri.getPath()));
-        } else {
-            layout.properties().setProperty(PROPERTY_DCACHE_CONFIG_CACHE, "false");
+            if (Objects.equals(uri.getScheme(), "file")) {
+                _sourceFiles.add(new File(uri.getPath()));
+            } else {
+                layout.properties().setProperty(PROPERTY_DCACHE_CONFIG_CACHE, "false");
+            }
         }
         layout.properties().setProperty(PROPERTY_DCACHE_CONFIG_FILES,
                 Joiner.on(" ").join(transform(_sourceFiles, QUOTE_FILE)));


### PR DESCRIPTION
Currently, when installing the dCache package and then immediately removing it
again, the uninstall fails beause 'dcache stop' cannot complete when the layout
file is missing.

Also, on a node that doesn't need to run any dCache services, doing a setup
without a layout file is currently not possible. This could for instance be a
node that needs to run the info provider and nothing else.

This patch solves this by not making the boot loader fall over when the layout
file is missing. Instead it adds the failure as a warning to the problem
consumer. The check-config command will output a nice warning. To supress the
warning, one can set dcache.layout.uri to the empty string.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/7431/
(cherry picked from commit 7b3fbd52d58d8ee7d8ad4b28d1f2cdb5cc792d5c)