### PR TITLE
chimera: throw FileExistChimeraException if tag already exists

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -1749,9 +1749,12 @@ public class JdbcFs implements FileSystemProvider {
             _sqlDriver.createTag(dbConnection, inode, name, uid, gid, mode);
             dbConnection.commit();
         } catch (SQLException e) {
-            _log.error("createTag", e);
             tryToRollback(dbConnection);
-            throw new IOHimeraFsException(e.getMessage(), e);
+            if (_sqlDriver.isDuplicatedKeyError(e)) {
+                throw new FileExistsChimeraFsException();
+            }
+            _log.error("createTag", e);
+            throw new IOHimeraFsException(e.getMessage());
         } finally {
             tryToClose(dbConnection);
         }

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -1097,4 +1097,12 @@ public class BasicTest extends ChimeraTestCaseHelper {
         stat.setSize(1);
         link.setStat(stat);
     }
+
+    @Test(expected = FileExistsChimeraFsException.class)
+    public void testCreateDuplicateTag() throws Exception {
+        FsInode dir = _rootInode.mkdir("dir1");
+        _fs.createTag(dir, "aTag", 0, 0, 0644);
+        _fs.createTag(dir, "aTag", 0, 0, 0644);
+    }
+
 }


### PR DESCRIPTION
fixes: #1671
acked-by: Paul Millar
Target: master, 2.13, 2.12, 2.11, 2.10
Require-notes: yes
Require-book: no
(cherry picked from commit 0dc406322bbecd53d061ebbb1cfb73777de8efca)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>