### PR TITLE
srm: Fix wrong Spring factory bean type

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SchedulingStrategyFactoryBean.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SchedulingStrategyFactoryBean.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.ServiceLoader;
 
-import org.dcache.srm.scheduler.spi.SchedulingStrategy;
 import org.dcache.srm.scheduler.spi.SchedulingStrategyProvider;
 
 /**
@@ -69,7 +68,7 @@ public class SchedulingStrategyFactoryBean implements FactoryBean<SchedulingStra
     @Override
     public Class<?> getObjectType()
     {
-        return SchedulingStrategy.class;
+        return SchedulingStrategyProvider.class;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Spring factory beans have a method to provide the type of the produced
bean. The recently introduced SchedulingStrategyFactoryBean returns the
wrong type.

Modification:

Return the correct type.

Result:

It is unknown how Spring uses the type, but fixing this avoids potential
issues in the future.

Target: trunk
Request: 2.13
Require-notes: no
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8361/
(cherry picked from commit a34fe50ba13dc56b44fd39c18689061ec4524cc7)