### PR TITLE
pool: Disable pool on meta data failures

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -534,7 +534,7 @@ public class PoolV4
             break;
         }
 
-        String message = "Fault occured in " + event.getSource() + ": "
+        String message = "Fault occurred in " + event.getSource() + ": "
                         + event.getMessage() +". " + poolState;
 
         if (cause != null) {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
@@ -118,11 +118,11 @@ public class ConsistentStore
      * redundant meta data entries in the process.
      */
     @Override
-    public synchronized Collection<PnfsId> list()
+    public synchronized Collection<PnfsId> list() throws CacheException
     {
         Collection<PnfsId> files = _fileStore.list();
         Collection<PnfsId> records = _metaDataStore.list();
-        records.removeAll(new HashSet(files));
+        records.removeAll(new HashSet<>(files));
         for (PnfsId id: records) {
             _log.warn(String.format(REMOVING_REDUNDANT_META_DATA, id));
             _metaDataStore.remove(id);
@@ -202,7 +202,7 @@ public class ConsistentStore
         return entry;
     }
 
-    private boolean isBroken(MetaDataRecord entry)
+    private boolean isBroken(MetaDataRecord entry) throws CacheException
     {
         boolean isBroken = true;
         if (entry != null) {
@@ -408,7 +408,7 @@ public class ConsistentStore
      * Calls through to the wrapped meta data store.
      */
     @Override
-    public void remove(PnfsId id)
+    public void remove(PnfsId id) throws CacheException
     {
         File f = _fileStore.get(id);
         if (!f.delete() && f.exists()) {
@@ -459,7 +459,7 @@ public class ConsistentStore
         return _metaDataStore.getTotalSpace();
     }
 
-    private void delete(PnfsId id, File file)
+    private void delete(PnfsId id, File file) throws CacheException
     {
         _metaDataStore.remove(id);
         if (!file.delete() && file.exists()) {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCache.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCache.java
@@ -40,7 +40,7 @@ public class MetaDataCache
      *
      * The operation may be slow as the list method of inner is called.
      */
-    public MetaDataCache(MetaDataStore inner)
+    public MetaDataCache(MetaDataStore inner) throws CacheException
     {
         _inner = inner;
 
@@ -145,7 +145,7 @@ public class MetaDataCache
             return _record;
         }
 
-        private synchronized void remove()
+        private synchronized void remove() throws CacheException
         {
             if (_entries.get(_id) == this) {
                 assert _entries.get(_id) == this;
@@ -181,7 +181,7 @@ public class MetaDataCache
     }
 
     @Override
-    public void remove(PnfsId id)
+    public void remove(PnfsId id) throws CacheException
     {
         Monitor monitor = _entries.get(id);
         if (monitor != null) {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataRecord.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataRecord.java
@@ -44,7 +44,7 @@ public interface MetaDataRecord
 
     public void setFileAttributes(FileAttributes attributes) throws CacheException;
 
-    public FileAttributes getFileAttributes();
+    public FileAttributes getFileAttributes() throws CacheException;
 
     public void setState(EntryState state)
         throws CacheException;
@@ -81,7 +81,7 @@ public interface MetaDataRecord
      *
      * @return The expired sticky flags removed from the record.
      */
-    public List<StickyRecord> removeExpiredStickyFlags();
+    public List<StickyRecord> removeExpiredStickyFlags() throws CacheException;
 
     /**
      * Set sticky flag for a given owner and time. There is at most

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStore.java
@@ -18,7 +18,7 @@ public interface MetaDataStore
     /**
      * Returns a collection of PNFS ids of available entries.
      */
-    Collection<PnfsId> list();
+    Collection<PnfsId> list() throws CacheException;
 
     /**
      * Retrieves an existing entry previously created with
@@ -79,7 +79,8 @@ public interface MetaDataStore
      *
      * @param id PNFS id of the entry to return.
      */
-    void remove(PnfsId id);
+    void remove(PnfsId id)
+            throws CacheException;
 
     /**
      * Returns whether the store appears healthy. How this is

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/Repository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/Repository.java
@@ -37,7 +37,7 @@ public interface Repository
      * @throws IllegalStateException if called multiple times
      */
     void init()
-        throws IllegalStateException;
+            throws IllegalStateException, CacheException;
 
     /**
      * Loads the repository from the on disk state. Must be done

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -157,19 +158,24 @@ public class FileMetaDataRepository
         } catch (IOException e) {
             throw new DiskErrorCacheException(
                     "Failed to read meta data for " + id + ": " + e.getMessage(), e);
-        } catch (RuntimeException e) {
-            throw new RuntimeException("Failed to read meta data for " + id, e);
         }
         return null;
     }
 
     @Override
-    public void remove(PnfsId id) {
-        File controlFile = new File(_metadir, id.toString());
-        File siFile = new File(_metadir, "SI-"+id.toString());
+    public void remove(PnfsId id)
+            throws CacheException
+    {
+        try {
+            File controlFile = new File(_metadir, id.toString());
+            File siFile = new File(_metadir, "SI-"+id.toString());
 
-        controlFile.delete();
-        siFile.delete();
+            Files.deleteIfExists(controlFile.toPath());
+            Files.deleteIfExists(siFile.toPath());
+        } catch (IOException e) {
+            throw new DiskErrorCacheException(
+                    "Failed to remove meta data for " + id + ": " + e.getMessage(), e);
+        }
     }
 
     @Override

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v3/entry/CacheRepositoryEntryState.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v3/entry/CacheRepositoryEntryState.java
@@ -69,16 +69,11 @@ public class CacheRepositoryEntryState
         makeStatePersistent();
     }
 
-    public List<StickyRecord> removeExpiredStickyFlags()
+    public List<StickyRecord> removeExpiredStickyFlags() throws IOException
     {
         List<StickyRecord> removed = _sticky.removeExpired();
-        try {
-            if (!removed.isEmpty()) {
-                makeStatePersistent();
-            }
-        } catch (IOException e) {
-            _logBussiness.error("Failed to store repository state: " +
-                                e.getMessage());
+        if (!removed.isEmpty()) {
+            makeStatePersistent();
         }
         return removed;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheEntryImpl.java
@@ -2,6 +2,8 @@ package org.dcache.pool.repository.v5;
 
 import java.util.Collection;
 
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.StorageInfo;
 
@@ -23,7 +25,7 @@ public class CacheEntryImpl implements CacheEntry
     private final Collection<StickyRecord> _sticky;
     private final FileAttributes _fileAttributes;
 
-    public CacheEntryImpl(MetaDataRecord entry)
+    public CacheEntryImpl(MetaDataRecord entry) throws CacheException
     {
         synchronized (entry) {
             _size = entry.getSize();

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReadHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReadHandleImpl.java
@@ -5,6 +5,7 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.util.PnfsHandler;
 
 import org.dcache.namespace.FileAttribute;
@@ -26,7 +27,7 @@ class ReadHandleImpl implements ReplicaDescriptor
 
     ReadHandleImpl(CacheRepositoryV5 repository,
                    PnfsHandler pnfs,
-                   MetaDataRecord entry)
+                   MetaDataRecord entry) throws CacheException
     {
         _repository = checkNotNull(repository);
         _pnfs = checkNotNull(pnfs);

--- a/modules/dcache/src/test/java/org/dcache/pool/repository/ConsistentStoreTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/repository/ConsistentStoreTest.java
@@ -328,7 +328,7 @@ public class ConsistentStoreTest
     }
 
     @Test
-    public void shouldSilentlyIgnoreRemoveOfNonExistingReplicas()
+    public void shouldSilentlyIgnoreRemoveOfNonExistingReplicas() throws CacheException
     {
         _consistentStore.remove(PNFSID);
     }


### PR DESCRIPTION
Motivation:

When meta data operations fail, the pool state is not consistent with
the disk state. We do not have any other choice than to force a pool
restart.

Modification:

Catches RuntimeException and CacheException at high level points and
disables the pool as appropriate. Error is not caught as default
exception handlers take care of those. Extends the MetaDataStore
interface to allow more methods to propagate failures. Updates the
implementations of those to wrap known failure modes with the
appropriate CacheException subclasses.

Result:

Disables the pool when meta data errors occur, forcing the admin to
restart the pool. Avoids logging previously uncaught exceptions as
bugs.

Fixes #1708.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8364/
(cherry picked from commit 14ee077c87266191ca8f83b517d27422920a7cf4)
(cherry picked from commit 651876bc1861fd5816ebf7c7fbd21061482e7e38)