### PR TITLE
xrootd: Fix GSI authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.2.10.v20150310</version.jetty>
         <version.wicket>6.19.0</version.wicket>
-        <version.xrootd4j>2.1.0</version.xrootd4j>
+        <version.xrootd4j>2.1.1</version.xrootd4j>
         <version.jglobus>2.0.6-rc9.d</version.jglobus>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
Motivation:

GSI authentication is broken due to a bug in the response encoding
used for the authentication protocol.

Modification:

Upgrade to xrootd4j 2.0.1, which contains a fix.

Result:

GSI authentication works.

Target: trunk
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8367/
(cherry picked from commit 095d6897157aedef3c9b537a12600a2c03f7783e)