### PR TITLE
pool: Fix race condition in migration module

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
@@ -197,6 +197,7 @@ public class Task
         messageArrived(PoolMigrationCopyFinishedMessage message)
     {
         if (_uuid.equals(message.getUUID())) {
+            _replicas.add(message.getPool());
             _fsm.messageArrived(message);
         }
     }
@@ -294,14 +295,7 @@ public class Task
                                                     _parameters.computeChecksumOnUpdate,
                                                     _parameters.forceSourceMode);
         CellStub.addCallback(_parameters.pool.send(_target, copyReplicaMessage),
-                             new Callback<PoolMigrationCopyReplicaMessage>("copy_") {
-                                 @Override
-                                 public void success(PoolMigrationCopyReplicaMessage message)
-                                 {
-                                     _replicas.add(_target.getCellName());
-                                     super.success(message);
-                                 }
-                             }, _parameters.executor);
+                             new Callback<>("copy_"), _parameters.executor);
     }
 
     /** FSM Action */


### PR DESCRIPTION
Motivation:

A regression was introduced by the addition of the -replicas option. A race
condition will in some cases cause additional replicas to be created. In other
cases it will cause failures with the error "No targets". The trigger is when
the file already exists on the target pool in combination with a particular
message ordering.

Modification:

The cause is that we add the target pool to the list of confirmed replicas
after receiving the PoolMigrationCopyReplicaMessage reply. If
PoolMigrationCopyFinishedMessage overtakes the reply, the subsequent check
whether additional replicas are needed will be erroneous.

The fix is to move the addition to the list to the point at which we receive
PoolMigrationCopyFinishedMessage. The state machine only checks the result
after receiving this message.

Result:

Fixes #1722.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8369/
(cherry picked from commit cd7637d239906c85990eb28aceb527e38c7159fc)