### PR TITLE
pool: do not list a repository during initialization

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -774,7 +774,7 @@ public class CacheRepositoryV5
     {
         pw.println("State : " + _state);
         try {
-            pw.println("Files : " + _store.list().size());
+            pw.println("Files : " + (_state == State.OPEN ?_store.list().size() : ""));
         } catch (CacheException e) {
             pw.println("Files : " + e.getMessage());
         }


### PR DESCRIPTION
we run inventory as pool startup procedure. If a
concurrent getInfo arrives, then it will block on
repository lock. This will block message thread as well.

Do not try to get number of files in the repository
if repository is not operational yet.

Target: trunk, 2.13, 2.12, 2.11, 2.10
Require-notes: yes
Require-book: no
Acked-by: Gerd Behrmann
(cherry picked from commit 5e19ef8f86ca11bd397a36ca5ef5782b7d33723c)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>