### PR TITLE
    move execution of the superclass method before any concrete class…

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
@@ -39,8 +39,8 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
     @Override
     public void init() throws UnknownHostException
     {
-        _gssFlavor = "unknown";
         super.init();
+        _gssFlavor = "unknown";
     }
 
     @Override

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/KerberosFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/KerberosFtpDoorV1.java
@@ -50,12 +50,12 @@ public class KerberosFtpDoorV1 extends GssFtpDoorV1
     @Override
     public void init() throws UnknownHostException
     {
+        super.init();
         _gssFlavor = "k5";
         ftpDoorName = "Kerberos FTP";
         if (_kdcListOption != null) {
             _kdcList = _kdcListOption.split(",");
         }
-        super.init();
     }
 
     @Override


### PR DESCRIPTION
… initializations

    Acked-by: Gerd Behrmann <behrmann@ndgf.org>, Albert Rossi <arossi@fnal.gov>
    Patch: https://rb.dcache.org/r/8379/
    Target: trunk
    Request: 2.13, 2.12, 2.11, 2.10
    Require-book: no
    Require-notes: no
(cherry picked from commit ca0b0a527df12a5bfb4992f7ec000845e17edf44)