### PR TITLE
xrootd: Fix 'xrootd logs stack-trace on malformed request'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.2.10.v20150310</version.jetty>
         <version.wicket>6.19.0</version.wicket>
-        <version.xrootd4j>2.1.1</version.xrootd4j>
+        <version.xrootd4j>2.1.2</version.xrootd4j>
         <version.jglobus>2.0.6-rc9.d</version.jglobus>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
Motivation:

Xrootd logs a stack-trace when receiving a malformed xrootd handshake.

Modification:

Upgrade to xrootd4j 2.1.2.

Result:

Fixes #1714.

Target: trunk
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8373/
(cherry picked from commit ce113f30d036ba657e5a5df4662515f609844f1d)