### PR TITLE
xrootd: Fix 'xrootd logs stack-trace on malformed request'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.2.8.v20150217</version.jetty>
         <version.wicket>6.19.0</version.wicket>
-        <version.xrootd4j>2.0.1</version.xrootd4j>
+        <version.xrootd4j>2.0.2</version.xrootd4j>
         <version.jglobus>2.0.6-rc9.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 


### PR DESCRIPTION
Motivation:

Xrootd logs a stack-trace when receiving a malformed xrootd handshake.

Modification:

Upgrade to xrootd4j 2.0.2.

Result:

Fixes #1714.

Target: 2.12
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8374/