### PR TITLE
chimera: Fix path resolution on delete

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -390,36 +390,38 @@ public class ChimeraNameSpaceProvider
         throws CacheException
     {
         try {
+            File filePath = new File(path);
+
+            String parentPath = filePath.getParent();
+            if (parentPath == null) {
+                throw new CacheException("Cannot delete file system root.");
+            }
+
+            ExtendedInode parent = new ExtendedInode(_fs, pathToInode(subject, parentPath));
+            String name = filePath.getName();
+
             if (!Subjects.isRoot(subject)) {
-                File file = new File(path);
-                String parentPath = file.getParent();
+                ExtendedInode inode = parent.inodeOf(name);
 
-                if (parentPath != null) {
-                    ExtendedInode inode = new ExtendedInode(_fs, pathToInode(subject, path));
-                    FsInode inodeParent = _fs.path2inode(parentPath);
+                FileAttributes parentAttributes = getFileAttributesForPermissionHandler(parent);
+                FileAttributes fileAttributes = getFileAttributesForPermissionHandler(inode);
 
-                    FileAttributes parentAttributes =
-                        getFileAttributesForPermissionHandler(inodeParent);
-                    FileAttributes fileAttributes =
-                        getFileAttributesForPermissionHandler(inode);
-
-                    if (inode.isDirectory()) {
-                        if (_permissionHandler.canDeleteDir(subject,
-                                                            parentAttributes,
-                                                            fileAttributes) != ACCESS_ALLOWED) {
-                            throw new PermissionDeniedCacheException("Access denied: " + path);
-                        }
-                    } else {
-                        if (_permissionHandler.canDeleteFile(subject,
-                                                             parentAttributes,
-                                                             fileAttributes) != ACCESS_ALLOWED) {
-                            throw new PermissionDeniedCacheException("Access denied: " + path);
-                        }
+                if (inode.isDirectory()) {
+                    if (_permissionHandler.canDeleteDir(subject,
+                                                        parentAttributes,
+                                                        fileAttributes) != ACCESS_ALLOWED) {
+                        throw new PermissionDeniedCacheException("Access denied: " + path);
+                    }
+                } else {
+                    if (_permissionHandler.canDeleteFile(subject,
+                                                         parentAttributes,
+                                                         fileAttributes) != ACCESS_ALLOWED) {
+                        throw new PermissionDeniedCacheException("Access denied: " + path);
                     }
                 }
             }
 
-            _fs.remove(path);
+            _fs.remove(parent, name);
         }catch(FileNotFoundHimeraFsException fnf) {
             throw new FileNotFoundCacheException("No such file or directory: " + path);
         }catch(DirNotEmptyHimeraFsException e) {


### PR DESCRIPTION
Motivation:

When deleting a path /a/b/c ending in a symlink (i.e. c is a symlink),
the name space provider follows the symlink when verifying permissions.
This may mean that the request is denied, e.g. if following the symlink
is not allowed for the subject or if the object being linked to has an
ACL preventing deletion. This is wrong as only the symlink is deleted.

The actual delete happens on the symlink.

The current code is also suboptimal in that the path is actually resolved
three times.

Modification:

Resolves the path to the parent once (following symlinks) and then
does the permission checks on the element in that directory.

Result:

Correct permission checks and reduced overhead for file deletion.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8382/
(cherry picked from commit b37e0eb059f22bd824d24043acf4a9698115480d)