### PR TITLE
pool: Fix locking bug causing high memory usage during pool initialization

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -141,7 +141,7 @@ public class CacheRepositoryV5
         CLOSED
     }
 
-    private State _state = State.UNINITIALIZED;
+    private volatile State _state = State.UNINITIALIZED;
 
     /**
      * Shared repository account object for tracking space.
@@ -184,7 +184,7 @@ public class CacheRepositoryV5
      * Throws an IllegalStateException if the repository has been
      * initialized.
      */
-    private synchronized void assertUninitialized()
+    private void assertUninitialized()
     {
         if (_state != State.UNINITIALIZED) {
             throw new IllegalStateException("Operation not allowed after initialization");
@@ -194,10 +194,11 @@ public class CacheRepositoryV5
     /**
      * Throws an IllegalStateException if the repository is not open.
      */
-    private synchronized void assertOpen()
+    private void assertOpen()
     {
-        if (_state != State.OPEN) {
-            throw new IllegalStateException("Operation not allowed while repository is in state " + _state);
+        State state = _state;
+        if (state != State.OPEN) {
+            throw new IllegalStateException("Operation not allowed while repository is in state " + state);
         }
     }
 
@@ -205,11 +206,11 @@ public class CacheRepositoryV5
      * Throws an IllegalStateException if the repository is not in
      * either INITIALIZED, LOADING or OPEN.
      */
-    private synchronized void assertInitialized()
+    private void assertInitialized()
     {
-        if (_state != State.INITIALIZED && _state != State.LOADING &&
-            _state != State.OPEN) {
-            throw new IllegalStateException("Operation not allowed while repository is in state " + _state);
+        State state = _state;
+        if (state != State.INITIALIZED && state != State.LOADING && state != State.OPEN) {
+            throw new IllegalStateException("Operation not allowed while repository is in state " + state);
         }
     }
 
@@ -772,9 +773,10 @@ public class CacheRepositoryV5
     @Override
     public void getInfo(PrintWriter pw)
     {
-        pw.println("State : " + _state);
+        State state = _state;
+        pw.println("State : " + state);
         try {
-            pw.println("Files : " + (_state == State.OPEN ?_store.list().size() : ""));
+            pw.println("Files : " + (state == State.OPEN || state == State.LOADING || state == State.INITIALIZED ?_store.list().size() : ""));
         } catch (CacheException e) {
             pw.println("Files : " + e.getMessage());
         }


### PR DESCRIPTION
Motivation:

The pool supports using a Berkeley DB JE database for meta data. Much of the
meta data is read on demand, thus reducing the memory requirements of the pool.
However due to a bug, state change notifications sent for each entry during
loading may end up being queued rather than processed. This happens whe the
pool contains precious files. The flush subsystem listens for these state
change notifications and reads the repository entry for precious files. This
blocks due to a lock held during repository initialization. This in turn blocks
the thread processing state change notifications, meaning that all subsequent
notifications are queued until the end of the pool startup. This is the cause
of high memory usage.

The cache repository class uses a state field to track at which point various
methods are safe to call. This is partially to avoid locking the repository -
something done exactly to avoid the above scenario. Unfortunately, the methods
to check this state field are synchronized and thus they block during pool
initialization.

Modification:

Makes the state field volatile and the methods to check the state
non-synchronized.  Callers have to synchronize if they want to ensure that the
state does not change for some critical region (the state update is
synchronized).

Result:

Significantly lower memory consumption during startup for pools with precious
files. Lower memory consumption translates to faster startup.

Target: trunk
Require-notes: yes
Require-book: yes
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8397/
(cherry picked from commit 4ec8d0c3cff512b321f4d2a70cccafe7166627d0)