### PR TITLE
pool: Explicitly enable compressed oops to calculate correct cache size

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -183,6 +183,7 @@ dcache.log.access.max-history=30
     -Djava.security.auth.login.config=${dcache.authn.jaas.config} \
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath=${dcache.java.oom.file} \
+    -XX:+UseCompressedOops \
     -javaagent:${dcache.paths.classes}/aspectjweaver-1.8.5.jar \
     ${dcache.java.options.common} \
     ${dcache.java.options.extra}


### PR DESCRIPTION
Motivation:

The Berkeley DB used for meta data uses a cache. To correctly calculate the
cache usage, it needs to know whether compressed oops (object references) are
enabled or not. The JVM defaults to enabling this, but unless given on the
command line the library is unaware that this it is enabled.

Modifcation:

Add -XX:+UseCompressedOops to command line.

Result:

The JVM behaviour should be unchanged as this is already the default. However
the Berkeley DB JE lib will recognize this option and calculate the correct
cache size.

There is of course a small risk that changes in memory usage may push a pool
above its limits and trigger an OOM.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8398/
(cherry picked from commit 9f5871d7da568386a9890b40f3700854ee26c25b)