### PR TITLE
cell: Don't quote string command in event logger

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/EventLogger.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/EventLogger.java
@@ -42,7 +42,7 @@ public class EventLogger
         if (o == null) {
             return "";
         } else if (o instanceof String) {
-            return "\"" + o + "\"";
+            return o.toString();
         } else {
             return o.getClass().getSimpleName();
         }


### PR DESCRIPTION
Motivation:

Cells supports an event log in which low level communication events are logged.
For string messages it will log the string command being used.  The code
currently quotes the string, but with the use of the NetLoggerBuilder this
causes the string to be quoted twice and the inner quotes are escaped. This
leads to something like "\"ps\"" being logged.

Modification:

Do not quote string messages. NetLoggerBuilder will apply quoting if the string
contains white space or other characters requiring quoting.

Result:

Cleaner event log output without double quoted string commands.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8390/
(cherry picked from commit e23a6309de0cc56ddc28d1294cddf937c9f99aa0)