### PR TITLE
srm: Fix read path check for srmPrepareToGet

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -715,7 +715,7 @@ public final class Storage
         }
 
         return getTurl(loginBrokerSource.readDoorsByProtocol(), user, path, protocols,
-                       srmGetNotSupportedProtocols, previousTurl, d -> d.canWrite(user.getRoot(), path));
+                       srmGetNotSupportedProtocols, previousTurl, d -> d.canRead(user.getRoot(), path));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Transfer doors export a list of read paths and write paths. The SRM
takes these into account when selecting a door for upload or download.

The current code contains a cut'n'paste error in that the door selection
for downloads uses the write paths of a door rather than the read paths.
This means that srmPrepareToGet will fail for any read only door.

Modification:

Use the read paths when selecting a read door.

Result:

srmPrepareToGet works with read only doors.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8385/
(cherry picked from commit 24b08f9c5e6296c066ab19fc7f4a555b2b3e6f19)