### PR TITLE
admin: Fix cell name tab completion

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -688,7 +688,7 @@ public class UserAdminShell
             if (!buffer.contains("@") && _currentPosition != null) {
                 /* Add local cells in the connected domain too. */
                 candidates.addAll(
-                        getCells(_currentPosition.remote.getCellDomainName(),
+                        getCells(_currentPosition.remote.getDestinationAddress().getCellDomainName(),
                                  toGlobPredicate(buffer + "*")).get());
             }
             return 0;
@@ -721,7 +721,7 @@ public class UserAdminShell
                 candidates.addAll(expandCellPatterns(asList(buffer + "*")));
                 if (_currentPosition != null) {
                     candidates.addAll(
-                            getCells(_currentPosition.remote.getCellDomainName(),
+                            getCells(_currentPosition.remote.getDestinationAddress().getCellDomainName(),
                                      toGlobPredicate(buffer + "*")).get());
                 }
                 return 0;


### PR DESCRIPTION
Motivation:

Admin shell tab completes cell names. When the name to be completed does not
contain an @ symbol, the admin shell completes from the list of well known
names and all local cells of the connected domain. This completion however has
a bug that is triggered when there is more than one hob from the admin service
to the connected domain (eg admin is not in dCacheDomain and the shell is
connected to another domain that is not the dCacheDomain either). In this
case the local cells from dCacheDomain are used for completion.

Modifcation:

The bug is caused by using the current address of the cell path to the
connected cell. That happens to be the next hop, which is commonly
dCacheDomain. The fix is to use the last address of the path (the destination
address).

Result:

Correct tab completion for multi-domain deployments.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8389/
(cherry picked from commit 4e1f3166fed623c7902dac83087941eeb50e4f3c)