### PR TITLE
doors: Include root path in login broker info output

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
@@ -1,6 +1,7 @@
 package dmg.cells.services.login;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.net.InetAddresses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -283,6 +284,7 @@ public class LoginBrokerPublisher
         pw.println("    Port             : " + _port);
         pw.println("    Addresses        : " + _lastAddresses);
         pw.println("    Tags             : " + _tags);
+        pw.println("    Root             : " + Strings.nullToEmpty(_root));
         pw.println("    Read paths       : " + _readPaths + (_readEnabled ? "" : " (disabled)"));
         pw.println("    Write paths      : " + _writePaths  + (_writeEnabled ? "" : " (disabled)"));
         pw.println("    Update Time      : " + _brokerUpdateTime + " " + _brokerUpdateTimeUnit);


### PR DESCRIPTION
Motivation:

The component that publishes information about doors on a loginbroker topic
adds various information about the published information to the cell info
output. It however fails to include the root path, something the SRM uses
during door selection. This information is useful when debugging door selection
problems.

Modification:

Add the root path to the info output.

Result:

    Root             : /

Target: trunk
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8391/
(cherry picked from commit abc45830be66f5de7e5c04005469ff168c15a46b)