### PR TITLE
improve to the webdav.templates.config!footer URL

### DIFF
--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -473,7 +473,7 @@ webdav.templates.config!header_brand = dCache
 webdav.templates.config!header_text = ${dcache.description}
 
 #  The text appearing in the footer.
-webdav.templates.config!footer = Powered by <a href="http://www.dcache.org/">dCache</a>
+webdav.templates.config!footer = Powered by <a href="https://dcache.org/">dCache</a>
 
 
 #  ---- Location for static content


### PR DESCRIPTION
• Use HTTPS, now that it’s working and the certificates verify.
• Ommit the “www.” subdomain; it’s ugly any everyone knows it’s the web.

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>