### PR TITLE
pool: report IO error if we cant find NFS mover

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.nfsstat;
 import org.dcache.nfs.status.BadStateidException;
+import org.dcache.nfs.status.NfsIoException;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
 import org.dcache.nfs.v4.CompoundContext;
 import org.dcache.nfs.v4.xdr.READ4res;
@@ -40,7 +41,11 @@ public class EDSOperationREAD extends AbstractNFSv4Operation {
 
             NfsMover mover = _moverHandler.getOrCreateMover(_args.opread.stateid, context.currentInode().toNfsHandle());
             if(mover == null) {
-                throw new BadStateidException("No mover associated with given stateid: " + _args.opread.stateid);
+                /*
+                 * return IO error instead of BadStateidException to avoid state recovery.
+                 * The client will fall back to IO through MDS.
+                 */
+                throw new NfsIoException("No mover associated with given stateid: " + _args.opread.stateid);
             }
             mover.attachSession(context.getSession());
 


### PR DESCRIPTION
if pool cant find a corresponding mover, then BAD_STATEID error is returned.
This triggers client to start a state recovery. If we return IO error, client
will fall back to proxy io.

Acked-by: Gerd Behrmann
Acked-by: Paul Millar
Target: master, 2.12, 2.11, 2.10
Require-book: no
Require-notes: no
(cherry picked from commit 247c14d3ef2a7273f4671c931b076cbafe0b1932)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>