### PR TITLE
libs: update to nfs4j-0.9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -816,7 +816,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.9.6</version>
+            <version>0.9.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
bugfix release:

Changelog for nfs4j-0.9.6..nfs4j-0.9.7
    * [95e2b62] libs: update to oncrpc4j-2.3.4
    * [993b741] nfs41: implement TEST_STATEID and FREE_TESTID

Acked-by:
Target: master
Require-book: no
Require-notes: yes