### PR TITLE
libs: update to nfs4j-0.10.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -840,7 +840,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.10.5</version>
+            <version>0.10.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
bugfix release:

Changelog for nfs4j-0.10.5..nfs4j-0.10.6
    * [900facc] [maven-release-plugin] prepare for next development iteration
    * [d6bc8f0] nfs41: implement TEST_STATEID and FREE_TESTID
    * [ce604f2] [maven-release-plugin] prepare release nfs4j-0.10.6

Acked-by: Paul Millar
Target: master, 2.13, 2.12
Require-book: no
Require-notes: no
(cherry picked from commit 26182b75bbd1c6b19309a8980f0220a3d276c052)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>