### PR TITLE
(2.12) dcache-webadmin: add TimeoutCacheException to catch clause in …

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/IBillingService.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/IBillingService.java
@@ -62,6 +62,7 @@ package org.dcache.webadmin.controller;
 import java.io.File;
 
 import diskCacheV111.util.ServiceUnavailableException;
+import diskCacheV111.util.TimeoutCacheException;
 
 import dmg.cells.nucleus.NoRouteToCellException;
 
@@ -87,5 +88,6 @@ public interface IBillingService {
 
     void initialize();
 
-    void refresh() throws NoRouteToCellException, ServiceUnavailableException;
+    void refresh() throws NoRouteToCellException,
+                    TimeoutCacheException, ServiceUnavailableException;
 }


### PR DESCRIPTION
…billing service

https://rb.dcache.org/r/7306/ attempted to rectify the exiting of
the plot loop in the webadmin billing plot service, but negelected
to handle the TimeoutCacheException.  As a result, a timeout on
the message reply, which should not cause the thread to exit, is
fatal to the plotting page (the plots no longer update).

This patch adds that exception to those which should not be
considered unexpected RuntimeExceptions.  For the timeout and noroute
exceptions, the thread should retry after a given timeout.

Target:  2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran
Require-book:  no
Require-notes: yes

RELEASE NOTES:  Fixes bug which causes the billing plot thread to exit rather than retry because of a timeout.