### PR TITLE
srm: Add authorization to put done and abort requests

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/DcacheUser.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/DcacheUser.java
@@ -24,6 +24,7 @@ import diskCacheV111.util.FsPath;
 
 import org.dcache.auth.Subjects;
 import org.dcache.srm.SRMUser;
+import org.dcache.srm.request.Request;
 import org.dcache.util.NetLoggerBuilder;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -87,6 +88,14 @@ public class DcacheUser implements SRMUser
     public String getDisplayName()
     {
         return Subjects.getDisplayName(subject);
+    }
+
+    @Override
+    public boolean hasAccessTo(Request request)
+    {
+        Subject owner = ((DcacheUser) request.getUser()).getSubject();
+        return Subjects.hasUid(subject, Subjects.getUid(owner)) ||
+               Subjects.hasGid(subject, Subjects.getPrimaryGid(owner));
     }
 
     @Override

--- a/modules/srm-server/src/main/java/org/dcache/srm/SRMUser.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRMUser.java
@@ -72,6 +72,8 @@ COPYRIGHT STATUS:
 
 package org.dcache.srm;
 
+import org.dcache.srm.request.Request;
+
 public interface SRMUser
 {
     int getPriority();
@@ -87,4 +89,14 @@ public interface SRMUser
      * Provide a longer description of this user.
      */
     CharSequence getDescriptiveName();
+
+    /**
+     * The SRM protocols has calls to act on existing request. This method is
+     * used to authorize such calls. It returns true if and only if this user
+     * is authorized to access the given request.
+     *
+     * The method does not distinguish between the level of access - the decision
+     * is binary - nor does the method distinguish between different calls.
+     */
+    boolean hasAccessTo(Request request);
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmAbortRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmAbortRequest.java
@@ -2,6 +2,8 @@ package org.dcache.srm.handler;
 
 import org.dcache.srm.AbstractStorageElement;
 import org.dcache.srm.SRM;
+import org.dcache.srm.SRMAuthorizationException;
+import org.dcache.srm.SRMException;
 import org.dcache.srm.SRMInvalidRequestException;
 import org.dcache.srm.SRMUser;
 import org.dcache.srm.request.Request;
@@ -16,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class SrmAbortRequest
 {
     private final SrmAbortRequestRequest request;
+    private final SRMUser user;
     private SrmAbortRequestResponse response;
 
     public SrmAbortRequest(
@@ -25,6 +28,7 @@ public class SrmAbortRequest
             SRM srm,
             String clientHost)
     {
+        this.user = user;
         this.request = checkNotNull(request);
     }
 
@@ -33,18 +37,21 @@ public class SrmAbortRequest
         if (response == null) {
             try {
                 response = abortRequest();
-            } catch (SRMInvalidRequestException e) {
-                response = getFailedResponse(e.getMessage(), TStatusCode.SRM_INVALID_REQUEST);
+            } catch (SRMException e) {
+                response = getFailedResponse(e.getMessage(), e.getStatusCode());
             }
         }
         return response;
     }
 
     private SrmAbortRequestResponse abortRequest()
-            throws SRMInvalidRequestException
+            throws SRMInvalidRequestException, SRMAuthorizationException
     {
-        Request requestToAbort = Request.getRequest(this.request.getRequestToken(), Request.class);
+        Request requestToAbort = Request.getRequest(request.getRequestToken(), Request.class);
         try (JDC ignored = requestToAbort.applyJdc()) {
+            if (!user.hasAccessTo(requestToAbort)) {
+                throw new SRMAuthorizationException("User is not the owner of request " + request.getRequestToken() + ".");
+            }
             return new SrmAbortRequestResponse(requestToAbort.abort("Request aborted by client."));
         }
     }

--- a/modules/srm-server/src/main/java/org/dcache/srm/unixfs/UnixfsUser.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/unixfs/UnixfsUser.java
@@ -11,6 +11,7 @@
 package org.dcache.srm.unixfs;
 
 import org.dcache.srm.SRMUser;
+import org.dcache.srm.request.Request;
 
 
 public class UnixfsUser implements SRMUser
@@ -72,7 +73,12 @@ public class UnixfsUser implements SRMUser
       return uid + ":" + gid;
   }
 
-  /** */
+  @Override
+  public boolean hasAccessTo(Request request)
+  {
+      return ((UnixfsUser) request.getUser()).getUid() == uid;
+  }
+
   public boolean equals(Object o) {
     if( ! (o instanceof UnixfsUser)) {
         return false;


### PR DESCRIPTION
Motivation:

For uploads, pnfsmanager used to authorize the completion or cancellation calls
based on the UID and the GID. A fix to a bug related to the setgid bit forced
those authorization checks to be removed (see https://rb.dcache.org/r/8388/).
This left those operations unauthorized.

Modification:

Adds authorization checks in the SRM for put done, abort files and abort calls.
Only clients with the same UID as the owner of the original request and clients
which have the primary GID of the owner of the original request as one of their
GIDs can make those calls.

Result:

The SRM returns SRM_AUTHORIZATION_FAILURE on srmPutDone, srmAbortFiles, and
srmAbortRequests if the client is not authorized to make these calls.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8436/
(cherry picked from commit e9355dbb2f1127af9a0c31195ae9df1950b52880)