### PR TITLE
srm: Add authorization to put done and abort requests

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/DcacheUser.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/DcacheUser.java
@@ -24,6 +24,7 @@ import diskCacheV111.util.FsPath;
 
 import org.dcache.auth.Subjects;
 import org.dcache.srm.SRMUser;
+import org.dcache.srm.request.Request;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -86,5 +87,13 @@ public class DcacheUser implements SRMUser
     public String getDisplayName()
     {
         return Subjects.getDisplayName(subject);
+    }
+
+    @Override
+    public boolean hasAccessTo(Request request)
+    {
+        Subject owner = ((DcacheUser) request.getUser()).getSubject();
+        return Subjects.hasUid(subject, Subjects.getUid(owner)) ||
+               Subjects.hasGid(subject, Subjects.getPrimaryGid(owner));
     }
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/SRMUser.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRMUser.java
@@ -72,6 +72,8 @@ COPYRIGHT STATUS:
 
 package org.dcache.srm;
 
+import org.dcache.srm.request.Request;
+
 public interface SRMUser
 {
     int getPriority();
@@ -82,4 +84,14 @@ public interface SRMUser
      * Provide a terse description of this user.
      */
     String getDisplayName();
+
+    /**
+     * The SRM protocols has calls to act on existing request. This method is
+     * used to authorize such calls. It returns true if and only if this user
+     * is authorized to access the given request.
+     *
+     * The method does not distinguish between the level of access - the decision
+     * is binary - nor does the method distinguish between different calls.
+     */
+    boolean hasAccessTo(Request request);
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmAbortFiles.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmAbortFiles.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 
 import org.dcache.srm.AbstractStorageElement;
 import org.dcache.srm.SRM;
+import org.dcache.srm.SRMAuthorizationException;
 import org.dcache.srm.SRMException;
 import org.dcache.srm.SRMFileRequestNotFoundException;
 import org.dcache.srm.SRMInvalidRequestException;
@@ -28,6 +29,7 @@ import static org.dcache.srm.handler.ReturnStatuses.getSummaryReturnStatus;
 public class SrmAbortFiles
 {
     private final SrmAbortFilesRequest request;
+    private final SRMUser user;
     private SrmAbortFilesResponse response;
 
     public SrmAbortFiles(
@@ -38,6 +40,7 @@ public class SrmAbortFiles
             SRM srm,
             String clientHost)
     {
+        this.user = user;
         this.request = checkNotNull(request);
     }
 
@@ -46,19 +49,23 @@ public class SrmAbortFiles
         if (response == null) {
             try {
                 response = abortFiles();
-            } catch (SRMInvalidRequestException e) {
-                response = getFailedResponse(e.getMessage(), TStatusCode.SRM_INVALID_REQUEST);
+            } catch (SRMException e) {
+                response = getFailedResponse(e.getMessage(), e.getStatusCode());
             }
         }
         return response;
     }
 
     private SrmAbortFilesResponse abortFiles()
-            throws SRMInvalidRequestException
+            throws SRMInvalidRequestException, SRMAuthorizationException
     {
         ContainerRequest<?> requestToAbort =
                 Request.getRequest(this.request.getRequestToken(), ContainerRequest.class);
         try (JDC ignored = requestToAbort.applyJdc()) {
+            if (!user.hasAccessTo(requestToAbort)) {
+                throw new SRMAuthorizationException("User is not the owner of request " + request.getRequestToken() + ".");
+            }
+
             org.apache.axis.types.URI[] surls = getSurls();
 
             TSURLReturnStatus[] surlReturnStatusArray = new TSURLReturnStatus[surls.length];

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPutDone.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPutDone.java
@@ -7,6 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.dcache.srm.AbstractStorageElement;
 import org.dcache.srm.SRM;
 import org.dcache.srm.SRMAbortedException;
+import org.dcache.srm.SRMAuthorizationException;
+import org.dcache.srm.SRMException;
 import org.dcache.srm.SRMFileRequestNotFoundException;
 import org.dcache.srm.SRMInternalErrorException;
 import org.dcache.srm.SRMInvalidRequestException;
@@ -52,15 +54,8 @@ public class SrmPutDone
         if (response == null) {
             try {
                 response = srmPutDone();
-            } catch (SRMInvalidRequestException e) {
-                response = getFailedResponse(e.getMessage(), TStatusCode.SRM_INVALID_REQUEST);
-            } catch (SRMRequestTimedOutException e) {
-                response = getFailedResponse(e.getMessage(), TStatusCode.SRM_REQUEST_TIMED_OUT);
-            } catch (SRMInternalErrorException e) {
-                LOGGER.error(e.getMessage());
-                response = getFailedResponse(e.getMessage(), TStatusCode.SRM_INTERNAL_ERROR);
-            } catch (SRMAbortedException e) {
-                response = getFailedResponse(e.getMessage(), TStatusCode.SRM_ABORTED);
+            } catch (SRMException e) {
+                response = getFailedResponse(e.getMessage(), e.getStatusCode());
             }
         }
         return response;
@@ -68,13 +63,17 @@ public class SrmPutDone
 
     private SrmPutDoneResponse srmPutDone()
             throws SRMInvalidRequestException, SRMRequestTimedOutException, SRMAbortedException,
-                   SRMInternalErrorException
+            SRMInternalErrorException, SRMAuthorizationException
     {
         URI[] surls = getSurls(request);
         PutRequest putRequest = Request.getRequest(request.getRequestToken(), PutRequest.class);
         try (JDC ignored = putRequest.applyJdc()) {
             putRequest.wlock();
             try {
+                if (!user.hasAccessTo(putRequest)) {
+                    throw new SRMAuthorizationException("User is not the owner of request " + request.getRequestToken() + ".");
+                }
+
                 switch (putRequest.getState()) {
                 case FAILED:
                     if (putRequest.getStatusCode() == TStatusCode.SRM_REQUEST_TIMED_OUT) {
@@ -95,7 +94,7 @@ public class SrmPutDone
                         PutFileRequest fileRequest = putRequest
                                 .getFileRequestBySurl(java.net.URI.create(surls[i].toString()));
                         try (JDC ignore = fileRequest.applyJdc()) {
-                            returnStatus = fileRequest.done(user);
+                            returnStatus = fileRequest.done(this.user);
                         }
                     } catch (SRMFileRequestNotFoundException e) {
                         returnStatus = new TReturnStatus(TStatusCode.SRM_INVALID_PATH, "File does not exist.");

--- a/modules/srm-server/src/main/java/org/dcache/srm/unixfs/UnixfsUser.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/unixfs/UnixfsUser.java
@@ -11,6 +11,7 @@
 package org.dcache.srm.unixfs;
 
 import org.dcache.srm.SRMUser;
+import org.dcache.srm.request.Request;
 
 
 public class UnixfsUser implements SRMUser
@@ -67,7 +68,12 @@ public class UnixfsUser implements SRMUser
       return Integer.toString(uid);
   }
 
-  /** */
+  @Override
+  public boolean hasAccessTo(Request request)
+  {
+      return ((UnixfsUser) request.getUser()).getUid() == uid;
+  }
+
   public boolean equals(Object o) {
     if( ! (o instanceof UnixfsUser)) {
         return false;


### PR DESCRIPTION
Motivation:

For uploads, pnfsmanager used to authorize the completion or cancellation calls
based on the UID and the GID. A fix to a bug related to the setgid bit forced
those authorization checks to be removed (see https://rb.dcache.org/r/8388/).
This left those operations unauthorized.

Modification:

Adds authorization checks in the SRM for put done, abort files and abort calls.
Only clients with the same UID as the owner of the original request and clients
which have the primary GID of the owner of the original request as one of their
GIDs can make those calls.

Result:

The SRM returns SRM_AUTHORIZATION_FAILURE on srmPutDone, srmAbortFiles, and
srmAbortRequests if the client is not authorized to make these calls.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8436/
(cherry picked from commit e9355dbb2f1127af9a0c31195ae9df1950b52880)