### PR TITLE
chimera: Let SRM respect setgid on upload

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -1190,22 +1190,25 @@ public class ChimeraNameSpaceProvider
 
             /* Attributes are inherited from real parent directory.
              */
-            if (uid == DEFAULT) {
-                if (Subjects.isNobody(subject) || _inheritFileOwnership) {
-                    uid = parentOfPath.statCache().getUid();
-                } else {
-                    uid = (int) Subjects.getUid(subject);
-                }
+            if (mode == DEFAULT) {
+                mode = parentOfPath.statCache().getMode() & UnixPermission.S_PERMS;
             }
-            if (gid == DEFAULT) {
+            if ((parentOfPath.statCache().getMode() & UnixPermission.S_ISGID) != 0) {
+                gid = parentOfPath.statCache().getGid();
+                mode |= UnixPermission.S_ISGID;
+            } else if (gid == DEFAULT) {
                 if (Subjects.isNobody(subject) || _inheritFileOwnership) {
                     gid = parentOfPath.statCache().getGid();
                 } else {
                     gid = (int) Subjects.getPrimaryGid(subject);
                 }
             }
-            if (mode == DEFAULT) {
-                mode = parentOfPath.statCache().getMode() & UMASK_DIR;
+            if (uid == DEFAULT) {
+                if (Subjects.isNobody(subject) || _inheritFileOwnership) {
+                    uid = parentOfPath.statCache().getUid();
+                } else {
+                    uid = (int) Subjects.getUid(subject);
+                }
             }
 
             /* ACLs are copied from real parent to the temporary upload directory
@@ -1293,10 +1296,6 @@ public class ChimeraNameSpaceProvider
                 throw new FileNotFoundCacheException("No such file or directory: " + temporaryPath, e);
             }
 
-            /* Subject must be authorized to complete the upload.
-             */
-            checkUploadAuthorization(subject, temporaryDirInode);
-
             /* Target directory must exist.
              */
             FsInode finalDirInode;
@@ -1353,17 +1352,11 @@ public class ChimeraNameSpaceProvider
             /* Temporary upload directory must exist.
              */
             FsInode uploadDirInode;
-            FsInode temporaryDirInode;
             try {
                 uploadDirInode = _fs.path2inode(temporaryDir.getParent().toString());
-                temporaryDirInode = uploadDirInode.inodeOf(temporaryPath.getParent().getName());
             } catch (FileNotFoundHimeraFsException e) {
                 throw new FileNotFoundCacheException("No such file or directory: " + temporaryDir, e);
             }
-
-            /* Subject must be authorized to cancel the upload.
-             */
-            checkUploadAuthorization(subject, temporaryDirInode);
 
             /* Delete temporary upload directory and any files in it.
              */
@@ -1386,17 +1379,6 @@ public class ChimeraNameSpaceProvider
                 }
             }
             removeIfExists(parent, name);
-        }
-    }
-
-    private void checkUploadAuthorization(Subject subject, FsInode temporaryDir)
-            throws ChimeraFsException, PermissionDeniedCacheException
-    {
-        /* Subject must be owner of upload directory, i.e. subject must have initiated the download.
-         */
-        if (!Subjects.hasUid(subject, temporaryDir.statCache().getUid()) ||
-                !Subjects.hasGid(subject, temporaryDir.statCache().getGid())) {
-            throw new PermissionDeniedCacheException("File must be committed by owner.");
         }
     }
 


### PR DESCRIPTION
Motivation:

SRM instructs the pnfs manager to create temporary upload directories for each upload.
The pnfs manager fails to check the setgid bit on the target directory and thus the
group is not inherited when setting the setgid bit.

Modification:

Check if the setgid bit is set and if so copy both that bit and the group of
the target directory.

Also remove the authorization check on commit and cancel: Indepedently of the setgid
problem, this is necessary as the owner and group of the target directory may be
different from the uid and primary gid and thus the check is erroneous. The setgid
behaviour just happens to run into this flaw as it is one way in which the group may
become different than the primary gid.

Result:

Fixes #1747.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8388/
(cherry picked from commit 40a95161db3dc08d231d73dff6dd01c6bd0ed126)