### PR TITLE
chimera: fix nameof and pathof for paths containing unicode

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_NAMEOF.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_NAMEOF.java
@@ -17,12 +17,13 @@
 package org.dcache.chimera;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 import org.dcache.chimera.posix.Stat;
 
 public class FsInode_NAMEOF extends FsInode {
 
-    String _name;
+    byte[] _name;
 
     public FsInode_NAMEOF(FileSystemProvider fs, String id) {
         super(fs, id, FsInodeType.NAMEOF);
@@ -38,20 +39,18 @@ public class FsInode_NAMEOF extends FsInode {
             } catch (ChimeraFsException e) {
                 return -1;
             }
-            _name = f.getName();
+            _name = (f.getName()+'\n').getBytes(StandardCharsets.UTF_8);
         }
-
-        byte[] b = (_name + "\n").getBytes();
 
         /*
          * are we still inside ?
          */
-        if (pos > b.length) {
+        if (pos > _name.length) {
             return 0;
         }
 
-        int copyLen = Math.min(len, b.length - (int) pos);
-        System.arraycopy(b, (int) pos, data, 0, copyLen);
+        int copyLen = Math.min(len, _name.length - (int) pos);
+        System.arraycopy(_name, (int) pos, data, 0, copyLen);
 
         return copyLen;
     }
@@ -62,9 +61,9 @@ public class FsInode_NAMEOF extends FsInode {
         ret.setMode((ret.getMode() & 0000777) | UnixPermission.S_IFREG);
         if (_name == null) {
             File f = new File(_fs.inode2path(this));
-            _name = f.getName();
+            _name = (f.getName()+'\n').getBytes(StandardCharsets.UTF_8);
         }
-        ret.setSize(_name.length() + 1);
+        ret.setSize(_name.length);
         return ret;
     }
 

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PATHOF.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PATHOF.java
@@ -16,11 +16,13 @@
  */
 package org.dcache.chimera;
 
+import java.nio.charset.StandardCharsets;
+
 import org.dcache.chimera.posix.Stat;
 
 public class FsInode_PATHOF extends FsInode {
 
-    private String _path;
+    private byte[] _path;
 
     public FsInode_PATHOF(FileSystemProvider fs, String id) {
         super(fs, id, FsInodeType.PATHOF);
@@ -31,22 +33,21 @@ public class FsInode_PATHOF extends FsInode {
 
         if (_path == null) {
             try {
-                _path = _fs.inode2path(this);
+                _path = (_fs.inode2path(this)+'\n').getBytes(StandardCharsets.UTF_8);
             } catch (ChimeraFsException e) {
                 return -1;
             }
         }
 
-        byte[] b = (_path + "\n").getBytes();
         /*
          * are we still inside ?
          */
-        if (pos > b.length) {
+        if (pos > _path.length) {
             return 0;
         }
 
-        int copyLen = Math.min(len, b.length - (int) pos);
-        System.arraycopy(b, (int) pos, data, 0, copyLen);
+        int copyLen = Math.min(len, _path.length - (int) pos);
+        System.arraycopy(_path, (int) pos, data, 0, copyLen);
 
         return copyLen;
     }
@@ -57,10 +58,10 @@ public class FsInode_PATHOF extends FsInode {
         Stat ret = super.stat();
         ret.setMode((ret.getMode() & 0000777) | UnixPermission.S_IFREG);
         if (_path == null) {
-            _path = _fs.inode2path(this);
+            _path = (_fs.inode2path(this)+'\n').getBytes(StandardCharsets.UTF_8);
         }
 
-        ret.setSize(_path.length() + 1);
+        ret.setSize(_path.length);
         return ret;
     }
 

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -25,7 +25,9 @@ import org.dcache.chimera.posix.Stat;
 import org.dcache.util.Checksum;
 import org.dcache.util.ChecksumType;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
 public class BasicTest extends ChimeraTestCaseHelper {
@@ -1105,4 +1107,41 @@ public class BasicTest extends ChimeraTestCaseHelper {
         _fs.createTag(dir, "aTag", 0, 0, 0644);
     }
 
+    @Test
+    public void testPathofUnicodePath() throws ChimeraFsException {
+        FsInode file = _rootInode.create("JC385 - 1300C 12h 15X - \uc624\uc5fc.jpg", 0, 0, 0644);
+        FsInode_PATHOF pathof = new FsInode_PATHOF(_fs, file._id);
+        byte[] buffer = new byte[64];
+        int len = pathof.read(0, buffer, 0, 64);
+        assertThat(len, is(equalTo(36)));
+    }
+
+    @Test
+    public void testPathofOnPartOfUnicodePath() throws ChimeraFsException {
+        FsInode file = _rootInode.create("JC385 - 1300C 12h 15X - \uc624\uc5fc.jpg", 0, 0, 0644);
+        FsInode_PATHOF pathof = new FsInode_PATHOF(_fs, file._id);
+        byte[] buffer = new byte[12];
+        int len = pathof.read(23, buffer, 0, 8);
+        assertThat(len, is(8));
+        assertArrayEquals(buffer, new byte[]{45, 32, -20, -104, -92, -20, -105, -68, 0, 0, 0, 0});
+    }
+
+    @Test
+    public void testNameofUnicodePath() throws ChimeraFsException {
+        FsInode file = _rootInode.create("JC385 - 1300C 12h 15X - \uc624\uc5fc.jpg", 0, 0, 0644);
+        FsInode_NAMEOF nameof = new FsInode_NAMEOF(_fs, file._id);
+        byte[] buffer = new byte[64];
+        int len = nameof.read(0, buffer, 0, 64);
+        assertThat(len, is(35));
+    }
+
+    @Test
+    public void testNameofOnPartOfUnicodePath() throws ChimeraFsException {
+        FsInode file = _rootInode.create("JC385 - 1300C 12h 15X - \uc624\uc5fc.jpg", 0, 0, 0644);
+        FsInode_NAMEOF nameof = new FsInode_NAMEOF(_fs, file._id);
+        byte[] buffer = new byte[12];
+        int len = nameof.read(23, buffer, 0, 8);
+        assertThat(len, is(8));
+        assertArrayEquals(buffer, new byte[]{32, -20, -104, -92, -20, -105, -68, 46, 0, 0, 0, 0});
+    }
 }


### PR DESCRIPTION
chimera pathof and nameof commands do not handle paths with unicode characters correctly, because it treats the paths as regular strings while the length of the string and the number of bytes occupied by the string differ.
This patch fixes this.

Ticket:
Acked-by: Paul
Target: master
Target: 2.13
Target: 2.12
Target: 2.11
Target: 2.10
Require-book: no
Require-notes: yes

Conflicts:
	modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java