### PR TITLE
cells: Fix dumpster and default route removal

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellRoutingTable.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellRoutingTable.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -125,12 +126,14 @@ public class CellRoutingTable implements Serializable
             }
             break;
         case CellRoute.DEFAULT:
-            if (!_default.compareAndSet(route, null)) {
+            CellRoute currentDefault = _default.get();
+            if (!Objects.equals(currentDefault, route) || !_default.compareAndSet(currentDefault, null)) {
                 throw new IllegalArgumentException("Route entry not found for default");
             }
             break;
         case CellRoute.DUMPSTER:
-            if (!_dumpster.compareAndSet(route, null)) {
+            CellRoute currentDumpster = _dumpster.get();
+            if (!Objects.equals(currentDumpster, route) || !_dumpster.compareAndSet(currentDumpster, null)) {
                 throw new IllegalArgumentException("Route entry not found dumpster");
             }
             break;


### PR DESCRIPTION
Motivation:

Route removal for dumpster and default routes fail to work as compareAndSet
used in the code is by reference rather than equality.

Modification:

Explicitly call equals to compare the existing route with the route to be
removed.

Result:

Route removal for -dumpster and -default routes works.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Femi Adeyemi <olufemi.segun.adeyemi@desy.de>
Patch: https://rb.dcache.org/r/8466/
(cherry picked from commit decafd2f94f50b0b3884c6375e77ccdb14fe9438)