### PR TITLE
srm,dcap: Respect cadir and vomsdir settings

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GsiFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GsiFtpDoorV1.java
@@ -23,18 +23,16 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
-import diskCacheV111.doors.FTPTransactionLog;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PermissionDeniedCacheException;
 
 import org.dcache.auth.LoginNamePrincipal;
 import org.dcache.auth.Subjects;
-import org.dcache.auth.util.X509Utils;
 import org.dcache.cells.Option;
 import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.util.X509Utils;
 import org.dcache.util.CertificateFactories;
 import org.dcache.util.Crypto;
-import org.dcache.util.NetLoggerBuilder;
 
 import static java.util.Arrays.asList;
 

--- a/modules/gplazma2-grid/pom.xml
+++ b/modules/gplazma2-grid/pom.xml
@@ -35,11 +35,6 @@
     </dependency>
     <dependency>
         <groupId>org.dcache</groupId>
-        <artifactId>gplazma2-gsi</artifactId>
-        <version>${project.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.dcache</groupId>
         <artifactId>gplazma2</artifactId>
         <version>${project.version}</version>
     </dependency>

--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
@@ -7,8 +7,8 @@ import java.security.cert.CertPath;
 import java.util.Properties;
 import java.util.Set;
 
-import org.dcache.auth.util.X509Utils;
 import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.util.X509Utils;
 import org.dcache.util.CertPaths;
 
 import static org.dcache.gplazma.util.Preconditions.checkAuthentication;

--- a/modules/gplazma2-voms/pom.xml
+++ b/modules/gplazma2-voms/pom.xml
@@ -28,11 +28,6 @@
     </dependency>
     <dependency>
         <groupId>org.dcache</groupId>
-        <artifactId>gplazma2-gsi</artifactId>
-        <version>${project.version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.dcache</groupId>
         <artifactId>gplazma2</artifactId>
         <version>${project.version}</version>
     </dependency>

--- a/modules/gplazma2-xacml/pom.xml
+++ b/modules/gplazma2-xacml/pom.xml
@@ -54,11 +54,6 @@
         </dependency>
         <dependency>
             <groupId>org.dcache</groupId>
-            <artifactId>gplazma2-gsi</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dcache</groupId>
             <artifactId>gplazma2</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
+++ b/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
@@ -19,6 +19,8 @@ import org.opensciencegrid.authz.xacml.common.XACMLConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.security.auth.x500.X500Principal;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.SocketException;
@@ -34,13 +36,12 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import javax.security.auth.x500.X500Principal;
 
 import org.dcache.auth.LoginGidPrincipal;
 import org.dcache.auth.LoginNamePrincipal;
 import org.dcache.auth.UserNamePrincipal;
-import org.dcache.auth.util.X509Utils;
 import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.util.X509Utils;
 import org.dcache.util.CertPaths;
 import org.dcache.util.NetworkUtils;
 

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/util/GSSUtils.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/util/GSSUtils.java
@@ -1,6 +1,7 @@
-package org.dcache.auth.util;
+package org.dcache.gplazma.util;
 
 
+import eu.emi.security.authn.x509.X509CertChainValidatorExt;
 import org.globus.gsi.gssapi.GSSConstants;
 import org.globus.gsi.gssapi.auth.AuthorizationException;
 import org.gridforum.jgss.ExtendedGSSContext;
@@ -16,6 +17,11 @@ import java.util.Set;
 
 import org.italiangrid.voms.VOMSAttribute;
 import org.italiangrid.voms.VOMSValidators;
+import org.italiangrid.voms.store.VOMSTrustStore;
+import org.italiangrid.voms.store.VOMSTrustStores;
+import org.italiangrid.voms.util.CertificateValidatorBuilder;
+
+import static java.util.Arrays.asList;
 
 /**
  * Extraction and conversion methods useful when dealing with GSS/VOMS
@@ -29,8 +35,6 @@ import org.italiangrid.voms.VOMSValidators;
  */
 public class GSSUtils {
 
-    static final String SYS_VOMSDIR = "VOMSDIR";
-    static final String SYS_CADIR = "CADIR";
     static final String CAPNULL = "/Capability=NULL";
     static final String ROLENULL = "/Role=NULL";
 
@@ -77,7 +81,9 @@ public class GSSUtils {
 
     public static Iterable<String> extractFQANs(String vomsDir, String caDir, X509Certificate[] chain)
     {
-        VOMSACValidator validator = VOMSValidators.newValidator();
+        VOMSTrustStore vomsTrustStore = VOMSTrustStores.newTrustStore(asList(vomsDir));
+        X509CertChainValidatorExt certChainValidator = new CertificateValidatorBuilder().trustAnchorsDir(caDir).build();
+        VOMSACValidator validator = VOMSValidators.newValidator(vomsTrustStore, certChainValidator);
         List<VOMSAttribute> listOfAttributes = validator.validate(chain);
         return getFQANSfromVOMSAttributes(listOfAttributes);
     }

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/util/X509Utils.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/util/X509Utils.java
@@ -1,4 +1,4 @@
-package org.dcache.auth.util;
+package org.dcache.gplazma.util;
 
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1Set;

--- a/modules/javatunnel/pom.xml
+++ b/modules/javatunnel/pom.xml
@@ -21,11 +21,6 @@
     </dependency>
     <dependency>
       <groupId>org.dcache</groupId>
-      <artifactId>gplazma2-gsi</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.dcache</groupId>
       <artifactId>gplazma2</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
+++ b/modules/javatunnel/src/main/java/javatunnel/GsiTunnel.java
@@ -21,10 +21,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.cert.X509Certificate;
-import org.bouncycastle.voms.VOMSAttribute;
 
 import org.dcache.auth.FQANPrincipal;
-import org.dcache.auth.util.GSSUtils;
+import org.dcache.gplazma.util.GSSUtils;
 import org.dcache.util.Args;
 import org.dcache.util.Crypto;
 

--- a/modules/srm-server/pom.xml
+++ b/modules/srm-server/pom.xml
@@ -76,11 +76,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.dcache</groupId>
-      <artifactId>gplazma2-gsi</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
         <groupId>org.dcache</groupId>
         <artifactId>cells</artifactId>
         <version>${project.version}</version>

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/InMemoryCredentialStore.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/InMemoryCredentialStore.java
@@ -28,8 +28,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import org.dcache.auth.util.GSSUtils;
 import org.dcache.delegation.gridsite2.DelegationException;
+import org.dcache.gplazma.util.GSSUtils;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.dcache.gridsite.Utilities.assertThat;

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
 
-import org.dcache.auth.util.GSSUtils;
 import org.dcache.delegation.gridsite2.DelegationException;
+import org.dcache.gplazma.util.GSSUtils;
 import org.dcache.srm.request.RequestCredential;
 import org.dcache.srm.request.RequestCredentialStorage;
 import org.dcache.util.Glob;

--- a/modules/srm-server/src/main/java/org/dcache/srm/server/SrmAuthorizer.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/server/SrmAuthorizer.java
@@ -65,8 +65,6 @@ exporting documents or software obtained from this server.
 package org.dcache.srm.server;
 
 import com.google.common.collect.Iterables;
-import com.google.common.net.InetAddresses;
-import org.globus.gsi.gssapi.auth.AuthorizationException;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
 import org.slf4j.Logger;
@@ -74,7 +72,7 @@ import org.slf4j.LoggerFactory;
 
 import java.security.cert.X509Certificate;
 
-import org.dcache.auth.util.GSSUtils;
+import org.dcache.gplazma.util.GSSUtils;
 import org.dcache.srm.SRMAuthenticationException;
 import org.dcache.srm.SRMAuthorization;
 import org.dcache.srm.SRMAuthorizationException;


### PR DESCRIPTION
Motivation:

A recent upgrade of the VOMS library used by dCache left the cadir and vomsdir
configuraion to be ignored by SRM and DCAP services.

Modification:

Restore the use of these properties. Relocate relevant utility classes to avoid
that specific doors have direct dependencies on gplazma plugins.

Result:

The services once again use the configured cadir and vomsdir.

Target: trunk
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8473/
(cherry picked from commit 0f77a7a700ea8351b251e0ab15364f4f5baae7dc)