### PR TITLE
srm: Fix credential delegation

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/jetty/GlobusContextFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/util/jetty/GlobusContextFactory.java
@@ -43,6 +43,7 @@ import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.security.cert.CRL;
 import java.security.cert.CertStore;
+import java.security.cert.CertificateFactory;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -63,6 +64,7 @@ public class GlobusContextFactory extends SslContextFactory
     private Map<String, ProxyPolicyHandler> proxyPolicyHandlers;
     private boolean isGsiEnabled;
     private boolean isUsingLegacyClose;
+    private CertificateFactory cf;
 
     public GlobusContextFactory()
     {
@@ -155,6 +157,8 @@ public class GlobusContextFactory extends SslContextFactory
         }
         setSslContext(sslContext);
 
+        cf = CertificateFactory.getInstance("X.509");
+
         if (LOGGER.isDebugEnabled())
         {
             SSLEngine engine = newSSLEngine();
@@ -224,7 +228,7 @@ public class GlobusContextFactory extends SslContextFactory
     private SSLEngine wrapEngine(SSLEngine engine)
     {
         if (isGsiEnabled) {
-            GsiEngine gsiEngine = new GsiEngine(engine);
+            GsiEngine gsiEngine = new GsiEngine(engine, cf);
             gsiEngine.setUsingLegacyClose(isUsingLegacyClose);
             return new GsiFrameEngine(gsiEngine);
         } else {

--- a/modules/dcache/src/main/java/org/dcache/util/jetty/InterceptingSSLEngine.java
+++ b/modules/dcache/src/main/java/org/dcache/util/jetty/InterceptingSSLEngine.java
@@ -61,9 +61,7 @@ public class InterceptingSSLEngine extends ForwardingSSLEngine
     }
 
     /**
-     * Receives one SSL frame worth of data in the buffer and calls the callback when done.
-     * If the buffer is not large enough to receive the payload in the frame, the connection
-     * is closed.
+     * Receives one SSL frame worth of data and calls the callback when done.
      */
     public void receive(Callback callback)
     {
@@ -75,9 +73,8 @@ public class InterceptingSSLEngine extends ForwardingSSLEngine
     }
 
     /**
-     * Sends the data {@code out} and then receives one SSL frame worth of data into the {@code in}
-     * buffer and calls the callback. If the buffer is not large enough to receive the payload in the
-     * frame, the connection is closed.
+     * Sends the data {@code out} and then receives one SSL frame worth of data and calls
+     * the callback.
      */
     public void sendThenReceive(ByteBuffer out, Callback callback)
     {
@@ -180,9 +177,8 @@ public class InterceptingSSLEngine extends ForwardingSSLEngine
                 return new SSLEngineResult(SSLEngineResult.Status.OK, SSLEngineResult.HandshakeStatus.NEED_UNWRAP,
                                            result.bytesConsumed(), 0);
             default:
-                SSLEngineResult result2 = delegate().unwrap(src, dsts, offset, length);
-                return new SSLEngineResult(result2.getStatus(), result2.getHandshakeStatus(),
-                                           result.bytesConsumed() + result2.bytesConsumed(), result.bytesProduced());
+                return new SSLEngineResult(SSLEngineResult.Status.OK, SSLEngineResult.HandshakeStatus.FINISHED,
+                                           result.bytesConsumed(), 0);
             }
 
         default:


### PR DESCRIPTION
Motivation:

We use a subclass of SSLEngine to implement the GSI delegation. This subclass
relies on the client sending the proxy certificate in a single SSL frame. This
is not always the case: The classic example is when the proxy is very large and
doesn't fit in a single frame, but other cases of the SSL engine splitting the
payload into multiple frames have been observed.

Modification:

Detects incomplete certificates by parsing the ASN1 object and detecting an
EOFException. In that case another SSL frame is read and the operation is
repeated.

Although not the most elegant solution, the alternative would have been to
implement (or copy) a full BER parser to determine the length of the encoded
certificate.

Also fixes a bug in GsiEngine in which after completed delegation it reads
another SSL frame from the input. As a result it never returns a handshake
status of FINISHED. The SSLEngine specification states that unwrap should
only consume a single SSL frame per invocation.

Result:

Improved compatibility.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8480/
(cherry picked from commit 604a0babd4c780382eee8938be58dba2300bc564)