### PR TITLE
Fix timeout math to avoid overflow

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
@@ -41,6 +41,9 @@ import dmg.util.logback.FilterShell;
 import org.dcache.util.Args;
 import org.dcache.util.Version;
 
+import static org.dcache.util.MathUtils.addWithInfinity;
+import static org.dcache.util.MathUtils.subWithInfinity;
+
 /**
  *
  *
@@ -634,7 +637,7 @@ public class CellAdapter
                     Object    key   = entry.getKey();
                     CellLock  lock  = entry.getValue();
                     sb.append(key.toString()).append(" r=");
-                    long res = lock.getTimeout() - System.currentTimeMillis();
+                    long res = subWithInfinity(lock.getTimeout(), System.currentTimeMillis());
                     sb.append(res/1000).append(" sec;");
                     CellMessage msg = lock.getMessage();
                     if (msg == null) {
@@ -993,7 +996,7 @@ public class CellAdapter
             this.callback = callback;
             this.msg = msg;
             this.executor = executor;
-            deadline = System.currentTimeMillis() + timeout;
+            deadline = addWithInfinity(System.currentTimeMillis(), timeout);
         }
 
         @Override
@@ -1022,7 +1025,7 @@ public class CellAdapter
 
         @Override
         public void run() {
-            long timeout = deadline - System.currentTimeMillis();
+            long timeout = subWithInfinity(deadline, System.currentTimeMillis());
             if (timeout > 0) {
                 sendMessage(msg, this, executor, timeout);
             } else {

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellLock.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellLock.java
@@ -3,6 +3,7 @@ package dmg.cells.nucleus;
 import java.util.concurrent.Executor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.dcache.util.MathUtils.addWithInfinity;
 
 public class CellLock
 {
@@ -17,7 +18,7 @@ public class CellLock
     {
         _callback = checkNotNull(callback);
         _executor = checkNotNull(executor);
-        _timeout = System.currentTimeMillis() + timeout;
+        _timeout = addWithInfinity(System.currentTimeMillis(), timeout);
         _message = msg;
     }
 

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -47,6 +47,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.consumingIterable;
 import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
+import static org.dcache.util.MathUtils.addWithInfinity;
+import static org.dcache.util.MathUtils.subWithInfinity;
 
 /**
  *
@@ -706,10 +708,10 @@ public class CellNucleus implements ThreadFactory
     private boolean joinThreads(Collection<Thread> threads, long timeout)
         throws InterruptedException
     {
-        long deadline = System.currentTimeMillis() + timeout;
+        long deadline = addWithInfinity(System.currentTimeMillis(), timeout);
         for (Thread thread: threads) {
             if (thread.isAlive()) {
-                long wait = deadline - System.currentTimeMillis();
+                long wait = subWithInfinity(deadline, System.currentTimeMillis());
                 if (wait <= 0) {
                     return false;
                 }

--- a/modules/cells/src/main/java/dmg/util/Gate.java
+++ b/modules/cells/src/main/java/dmg/util/Gate.java
@@ -1,5 +1,8 @@
 package dmg.util ;
 
+import static org.dcache.util.MathUtils.addWithInfinity;
+import static org.dcache.util.MathUtils.subWithInfinity;
+
 public class Gate {
    private boolean _isOpen = true ;
    public Gate(){}
@@ -9,9 +12,9 @@ public class Gate {
 
    public synchronized boolean await(long millis) throws InterruptedException
    {
-       long deadline = System.currentTimeMillis() + millis;
+       long deadline = addWithInfinity(System.currentTimeMillis(), millis);
        while (!_isOpen && deadline > System.currentTimeMillis()) {
-           wait(deadline - System.currentTimeMillis());
+           wait(subWithInfinity(deadline, System.currentTimeMillis()));
        }
        return _isOpen;
    }

--- a/modules/common/src/main/java/org/dcache/util/MathUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/MathUtils.java
@@ -1,20 +1,20 @@
 package org.dcache.util;
 
-public class MathUtils {
-
+public class MathUtils
+{
     /**
      * Return the absolute value of an integer, modulo some other integer.
      * This is similar to the naive {@code Math.abs(value) % modulo} except it handles
      * the case when value is Integer.MIN_VALUE correctly.
      */
-    static public int absModulo(int value, int modulo)
+    public static int absModulo(int value, int modulo)
     {
         return Math.abs(value % modulo);
     }
 
     /**
      * Implements long addition, treating MAX_VALUE and MIN_VALUE as positive
-     * and negative infinity respecitvely. Semantics are similar to Double
+     * and negative infinity respectively. Semantics are similar to Double
      * arithmetic. Overflow results in positive infinity, underflow in
      * negative infinity.
      *
@@ -48,7 +48,7 @@ public class MathUtils {
 
     /**
      * Implements long subtraction, treating MAX_VALUE and MIN_VALUE as
-     * positive and negative infinity respecitvely. Semantics are similar
+     * positive and negative infinity respectively. Semantics are similar
      * to Double arithmetic. Overflow results in positive infinity, underflow
      * in negative infinity.
      *

--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoor.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoor.java
@@ -24,6 +24,9 @@ import org.dcache.auth.Subjects;
 import org.dcache.util.Args;
 import org.dcache.util.Transfer;
 
+import static org.dcache.util.MathUtils.addWithInfinity;
+import static org.dcache.util.MathUtils.subWithInfinity;
+
 /**
   * @author Patrick Fuhrmann
   * @version 1.0, Aug 04 2001
@@ -259,9 +262,9 @@ public class      DCapDoor
     }
     private synchronized void waitForFinish( long timeout )
             throws InterruptedException {
-       long end = System.currentTimeMillis() + timeout ;
+       long end = addWithInfinity(System.currentTimeMillis(), timeout);
        while( _state != __WeAreFinished ){
-           long rest = end - System.currentTimeMillis() ;
+           long rest = subWithInfinity(end, System.currentTimeMillis());
            _log.info( "waitForFinish : waiting for "+rest+" seconds" ) ;
            if( rest <=0  ) {
                break;

--- a/modules/dcache/src/main/java/org/dcache/util/RedirectedTransfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/RedirectedTransfer.java
@@ -9,6 +9,9 @@ import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.TimeoutCacheException;
 
+import static org.dcache.util.MathUtils.addWithInfinity;
+import static org.dcache.util.MathUtils.subWithInfinity;
+
 /**
  * A transfer where the mover can send a redirect message to the door.
  */
@@ -63,10 +66,10 @@ public class RedirectedTransfer<T> extends Transfer
         try {
             setStatus("Mover " + getPool() + "/" +
                       getMoverId() + ": Waiting for redirect");
-            long deadline = System.currentTimeMillis() + millis;
+            long deadline = addWithInfinity(System.currentTimeMillis(), millis);
             while (hasMover() && !_isRedirected &&
                    System.currentTimeMillis() < deadline) {
-                wait(deadline - System.currentTimeMillis());
+                wait(subWithInfinity(deadline, System.currentTimeMillis()));
             }
 
             if (waitForMover(0)) {

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -579,9 +579,9 @@ public class Transfer implements Comparable<Transfer>
     public synchronized boolean waitForMover(long millis)
             throws CacheException, InterruptedException
     {
-        long deadline = System.currentTimeMillis() + millis;
+        long deadline = addWithInfinity(System.currentTimeMillis(), millis);
         while (!_hasMoverFinished && System.currentTimeMillis() < deadline) {
-            wait(deadline - System.currentTimeMillis());
+            wait(subWithInfinity(deadline, System.currentTimeMillis()));
         }
 
         if (_error != null) {


### PR DESCRIPTION
Motivation:

In some cases we use Long.MAX_VALUE as a timeout that for all means
and purposes means infinity. This value however causes overflow when
used in expressions adding the current time with the timeout. This
overflow means that rather to never time out we time out more or less
immediately.

Modification:

Use the addWithInfinity and subWithInfinity methods that deal with
this situation.

Result:

No premature timeout for transfers.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8490/
(cherry picked from commit 1ec64006e7417198ff60757f59e8cca2b4e0ce7e)