### PR TITLE
doors: Fix pool selection timeout handling

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
@@ -44,6 +44,8 @@ import org.dcache.vehicles.PnfsGetFileAttributes;
 import org.dcache.vehicles.PnfsRemoveChecksumMessage;
 import org.dcache.vehicles.PnfsSetFileAttributes;
 
+import static com.google.common.base.Preconditions.checkState;
+
 public class PnfsHandler
     implements CellMessageSender
 {
@@ -176,7 +178,7 @@ public class PnfsHandler
 
    public void addCacheLocation(PnfsId id, String pool) throws CacheException
    {
-       pnfsRequest( new PnfsAddCacheLocationMessage(id, pool));
+       pnfsRequest(new PnfsAddCacheLocationMessage(id, pool));
    }
 
    public List<String> getCacheLocations( PnfsId pnfsId )throws CacheException {
@@ -211,22 +213,32 @@ public class PnfsHandler
      * to the PnfsManager are reported as a timeout CacheException.
      */
    public <T extends PnfsMessage> T pnfsRequest( T msg )
-           throws CacheException {
+           throws CacheException
+   {
+       checkState(_cellStub != null);
+       return pnfsRequest(msg, _cellStub.getTimeoutInMillis());
+   }
 
-       if (_cellStub == null) {
-           throw new IllegalStateException("Missing endpoint");
+    /**
+     * Sends a message to the request manager and blocks until a reply
+     * is received. In case of errors in the reply, those are thrown
+     * as a CacheException. Timeouts and failure to send the message
+     * to the PnfsManager are reported as a timeout CacheException.
+     */
+   public <T extends PnfsMessage> T pnfsRequest(T msg, long timeout)
+           throws CacheException
+   {
+       checkState(_cellStub != null);
+       try {
+           msg.setReplyRequired(true);
+           if (_subject != null) {
+               msg.setSubject(_subject);
+           }
+           return _cellStub.sendAndWait(msg, timeout);
+       } catch (InterruptedException e) {
+           throw  new CacheException(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
+                                     "Sending message to " + _cellStub.getDestinationPath() + " interrupted");
        }
-
-        try {
-            msg.setReplyRequired(true);
-            if (_subject != null) {
-                msg.setSubject(_subject);
-            }
-            return _cellStub.sendAndWait(msg);
-        } catch (InterruptedException e) {
-            throw  new CacheException(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
-                    "Sending message to " + _cellStub.getDestinationPath() + " interrupted");
-        }
    }
 
     public PnfsCreateEntryMessage createPnfsDirectory(String path)


### PR DESCRIPTION
Motivation:

Doors ignore the pool manager communication timeout and only apply
a door specific total timeout. This timeout is for some doors
infinite and thus pool selection would never time out or be
resubmitted.

Modification:

Applies the pool manager communication timeout as an upper bound
on pool selection. When expired, the pool selection is retried
according to the retry policy of the door.

The total timeout is also applied to the pnfs manager communication
that happens upon retry. This greatly reduces the risk that the
remaining timeout becomes negative after this point.

Result:

Pool selection gets resubmited and error messages with negative
message TTL should be gone.

Target: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Milar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8491/