### PR TITLE
doors: Fix pool selection timeout handling

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -53,6 +53,7 @@ import org.dcache.commons.util.NDC;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.namespace.FileType;
 import org.dcache.vehicles.FileAttributes;
+import org.dcache.vehicles.PnfsGetFileAttributes;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.dcache.namespace.FileAttribute.*;
@@ -650,8 +651,12 @@ public class Transfer implements Comparable<Transfer>
      *
      * @throws CacheException if reading the entry failed
      */
-    public void readNameSpaceEntry()
-        throws CacheException
+    public void readNameSpaceEntry() throws CacheException
+    {
+        readNameSpaceEntry(_pnfs.getPnfsTimeout());
+    }
+
+    private void readNameSpaceEntry(long timeout) throws CacheException
     {
         setStatus("PnfsManager: Fetching storage info");
         try {
@@ -661,12 +666,11 @@ public class Transfer implements Comparable<Transfer>
             request.addAll(PoolMgrSelectReadPoolMsg.getRequiredAttributes());
             Set<AccessMask> mask = EnumSet.of(AccessMask.READ_DATA);
             PnfsId pnfsId = getPnfsId();
-            FileAttributes attributes;
-            if (pnfsId != null) {
-                attributes = _pnfs.getFileAttributes(pnfsId, request, mask);
-            } else {
-                attributes = _pnfs.getFileAttributes(_path.toString(), request, mask);
-            }
+            PnfsGetFileAttributes msg = (pnfsId != null)
+                                        ? new PnfsGetFileAttributes(pnfsId, request)
+                                        : new PnfsGetFileAttributes(_path.toString(), request);
+            msg.setAccessMask(mask);
+            FileAttributes attributes = _pnfs.pnfsRequest(msg, timeout).getFileAttributes();
 
             /* We can only read regular files.
              */
@@ -783,7 +787,7 @@ public class Transfer implements Comparable<Transfer>
      * Selects a pool suitable for the transfer.
      */
     public void selectPool()
-        throws CacheException, InterruptedException
+            throws CacheException, InterruptedException
     {
         selectPool(_poolManager.getTimeoutInMillis());
     }
@@ -1065,11 +1069,11 @@ public class Transfer implements Comparable<Transfer>
             long start = System.currentTimeMillis();
             CacheException lastFailure;
             try {
-                selectPool(subWithInfinity(deadLine, System.currentTimeMillis()));
+                selectPool(Math.min(_poolManager.getTimeoutInMillis(),
+                                    subWithInfinity(deadLine, System.currentTimeMillis())));
                 gotPool = true;
-                startMover(queue,
-                        Math.min(subWithInfinity(deadLine, System.currentTimeMillis()),
-                                policy.getMoverStartTimeout()));
+                startMover(queue, Math.min(policy.getMoverStartTimeout(),
+                                           subWithInfinity(deadLine, System.currentTimeMillis())));
                 return;
             } catch (TimeoutCacheException e) {
                 _log.warn(e.getMessage());
@@ -1128,7 +1132,8 @@ public class Transfer implements Comparable<Transfer>
             }
 
             if (!isWrite()) {
-                readNameSpaceEntry();
+                readNameSpaceEntry( Math.min(_pnfs.getPnfsTimeout(),
+                                             subWithInfinity(deadLine, System.currentTimeMillis())));
             }
         }
     }


### PR DESCRIPTION
Motivation:

Doors ignore the pool manager communication timeout and only apply
a door specific total timeout. This timeout is for some doors
infinite and thus pool selection would never time out or be
resubmitted.

Modification:

Applies the pool manager communication timeout as an upper bound
on pool selection. When expired, the pool selection is retried
according to the retry policy of the door.

The total timeout is also applied to the pnfs manager communication
that happens upon retry. This greatly reduces the risk that the
remaining timeout becomes negative after this point.

Result:

Pool selection gets resubmited and error messages with negative
message TTL should be gone.

Target: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Milar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8491/
(cherry picked from commit a952fd3c2580b8f479d5e995f4b27db10a085bb0)