### PR TITLE
doors: Fix timeout handling during retries

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
@@ -218,12 +218,21 @@ public class PnfsHandler
     public <T extends PnfsMessage> ListenableFuture<T> requestAsync(T msg)
     {
         checkState(_cellStub != null, "Missing endpoint");
+        return requestAsync(msg, _cellStub.getTimeoutInMillis());
+    }
+
+    /**
+     * Sends a message to the pnfs manager and returns a promise of a future reply.
+     */
+    public <T extends PnfsMessage> ListenableFuture<T> requestAsync(T msg, long timeout)
+    {
+        checkState(_cellStub != null, "Missing endpoint");
 
         msg.setReplyRequired(true);
         if (_subject != null) {
             msg.setSubject(_subject);
         }
-        return _cellStub.send(msg);
+        return _cellStub.send(msg, timeout);
     }
 
     public PnfsCreateEntryMessage createPnfsDirectory(String path)


### PR DESCRIPTION
Motivation:

Doors will retry pool selection and mover startup several times (subject to a
door specific policy). A timeout limits the total duration and this timeout is
applied as an upper bound for pool selection and mover submission; yet it
wasn't applied for pnfs manager interactions that happen during the retry loop.

This could in some cases cause errors in pool manager about discarded messages
with a negative TTL.

Modification:

Applies the total timeout as an upper bound to the pnfs manager interaction.

Result:

Greatly reduced risk of ending up with a negative TTL.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8492/
(cherry picked from commit 73b2d94848f60fee085d2fcdbc4c0ce3900e6e03)