### PR TITLE
chimera: Resolve performance regression in directory deletion

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -1805,7 +1805,7 @@ class FsSqlDriver {
 
     private static final String srmGetTagsIdsOfPnfsid = "SELECT itagid FROM t_tags WHERE ipnfsid=?";
     private static final String sqlRemoveTag = "DELETE FROM t_tags WHERE ipnfsid=?";
-    private static final String sqlRemoveTagInodes = "DELETE FROM t_tags_inodes i WHERE itagid = ? AND NOT EXISTS (SELECT 1 FROM t_tags t WHERE t.itagid=i.itagid)";
+    private static final String sqlRemoveTagInodes = "DELETE FROM t_tags_inodes i WHERE itagid=? AND NOT EXISTS (SELECT 1 FROM t_tags WHERE itagid=?)";
 
     void removeTag(Connection dbConnection, FsInode dir) throws SQLException {
 
@@ -1851,7 +1851,9 @@ class FsSqlDriver {
             ps3 = dbConnection.prepareStatement(sqlRemoveTagInodes);
             if (rs.next()) {
                 do {
-                    ps3.setString(1, rs.getString(1));
+                    String tagid = rs.getString(1);
+                    ps3.setString(1, tagid);
+                    ps3.setString(2, tagid);
                     ps3.addBatch();
                 } while (rs.next());
                 ps3.executeBatch();


### PR DESCRIPTION
Motivation:

Upon deleting directories we remove the tags associated with the directory.  To
do this we have to check whether other directories refer to the same tags.
PostgreSQL correctly translates the SQL expression we use to this to an
anti-join, but the anti-join is strangely expensive when the right side of the
join has many entries.

Modification:

Alter the expression such that the sub-query is a constant. This is equivalent
for our use-case and is enough to make PostgreSQL use a faster query plan.

Result:

Resolves a performance regression in directory removal.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
(cherry picked from commit 7f1ab213addc6b8fd61f619fd50f377fd87f65f9)
(cherry picked from commit 23cd4acd8f40e56bc8e240c00f390a7688c4e17d)