### PR TITLE
spacemanager: Fix race condition leading to leaked reservation entries

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -27,6 +27,7 @@
 //______________________________________________________________________________
 package diskCacheV111.services.space;
 
+import com.google.common.collect.Sets;
 import com.google.common.primitives.Longs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -112,6 +114,8 @@ public final class SpaceManagerService
                    Runnable
 {
         private static final Logger LOGGER = LoggerFactory.getLogger(SpaceManagerService.class);
+
+        private final Set<PnfsId> failedTransfers = Sets.newConcurrentHashSet();
 
         private long expireSpaceReservationsPeriod;
 
@@ -258,6 +262,50 @@ public final class SpaceManagerService
         private void expireSpaceReservations() throws DataAccessException
         {
                 LOGGER.trace("expireSpaceReservations()...");
+
+                /* Recover from transfer failures. If the pool returns an error code on upload, we cannot
+                 * know for certain whether the file is registered in the name space and thus whether we
+                 * would get a notification on delete. Thus to be on the safe side, we query the name space
+                 * entry during this recovery procedure.
+                 */
+                Iterator<PnfsId> iterator = failedTransfers.iterator();
+                while (iterator.hasNext()) {
+                    PnfsId pnfsId = iterator.next();
+                    try {
+                        EnumSet<FileAttribute> attributes =
+                                EnumSet.of(FileAttribute.SIZE,
+                                           FileAttribute.LOCATIONS,
+                                           FileAttribute.STORAGEINFO,
+                                           FileAttribute.ACCESS_LATENCY);
+                        FileAttributes fileAttributes = pnfs.getFileAttributes(pnfsId, attributes);
+                        if (fileAttributes.getStorageInfo().isStored()) {
+                            boolean isRemovable = !fileAttributes.getAccessLatency().equals(AccessLatency.ONLINE);
+                            fileFlushed(pnfsId, fileAttributes.getSize(), isRemovable);
+                        } else if (!fileAttributes.getLocations().isEmpty()) {
+                            transferFinished(pnfsId, fileAttributes.getSize());
+                        } else {
+                                /* Name space entry exists, but no tape or pool location is known. We leave
+                                 * the file in transferring and the recovery code below will eventually
+                                 * kick in.
+                                 */
+                        }
+                        iterator.remove();
+                    } catch (FileNotFoundCacheException e) {
+                        db.remove(db.files().wherePnfsIdIs(pnfsId));
+                    } catch (TransientDataAccessException e) {
+                        LOGGER.warn("Transient data access failure while processing failed transfer of {}: {}",
+                                    pnfsId, e.getMessage());
+                    } catch (DataAccessException e) {
+                        LOGGER.error("Data access failure while processing failed transfer of {}: {}",
+                                     pnfsId, e.getMessage());
+                        break;
+                    } catch (TimeoutCacheException e) {
+                        LOGGER.error("Failed to lookup file {} in name space: {}", pnfsId, e.getMessage());
+                        break;
+                    } catch (CacheException e) {
+                        LOGGER.error("Failed to lookup file {} in name space: {}", pnfsId, e.getMessage());
+                    }
+                }
 
                 /* Recover files from lost notifications. Space manager receives notifications
                  * on file transfer finishing (DoorTransferFinished), name space deletion
@@ -702,14 +750,20 @@ public final class SpaceManagerService
         private void transferFinished(DoorTransferFinishedMessage finished)
                 throws DataAccessException
         {
-        if (finished.getReturnCode() == CacheException.FILE_NOT_FOUND) {
-            /* File is gone from name space, but we may never receive a notification
-             * from cleaner if the file location didn't get registered first.
-             */
-            fileRemoved(finished.getPnfsId());
-        } else {
-            transferFinished(finished.getPnfsId(), finished.getFileAttributes().getSize());
-        }
+            switch (finished.getReturnCode()) {
+            case CacheException.FILE_NOT_FOUND:
+                /* File is gone from name space, but we may never receive a notification
+                 * from cleaner if the file location didn't get registered first.
+                 */
+                fileRemoved(finished.getPnfsId());
+                break;
+            case 0:
+                transferFinished(finished.getPnfsId(), finished.getFileAttributes().getSize());
+                break;
+            default:
+                failedTransfers.add(finished.getPnfsId());
+                break;
+            }
         }
 
         @Transactional
@@ -1034,6 +1088,7 @@ public final class SpaceManagerService
         private void namespaceEntryDeleted(PnfsDeleteEntryNotificationMessage msg) throws DataAccessException
         {
             db.remove(db.files().wherePnfsIdIs(msg.getPnfsId()).whereStateIsIn(FileState.FLUSHED, FileState.TRANSFERRING));
+            failedTransfers.remove(msg.getPnfsId());
         }
 
         private void getSpaceMetaData(GetSpaceMetaData gsmd) throws IllegalArgumentException {


### PR DESCRIPTION
Motivation:

Space manager suffers from a race causing it to leak reservation entries
upon upload failures. When it occurs, it leaves behind a reservation entry
even though the file has been deleted.

The race can be triggered in several ways. The likely scenario reported by a
site is when an SRM upload expires and the SRM deletes the name space entry and
upload directory for the file in combination with the client itself aborting
the FTP upload. In this case the upload on the pool will have failed, but in
dCache an upload failure is still considered a valid file and the file is
attemped to be registered with the name space; this registration fails because
the SRM has already deleted the name space entry. The error code from this
failure is however not propagated to the pool as the pool reports the primary
failure (the FTP upload failure) rather than the post processing failure. Thus
the space manager marks the file as being stored, yet the name space entry is
gone with no name space notification reporting the file as deleted.

The second scenario triggering the same issue is if the FTP upload fails, but
the name space entry registration fails for other reasons, eg, a communication
issue with PnfsManager. The pool will mark the file broken and will eventually
repeat the registration; if the name space entry was deleted by the time this
happens, the pool will delete the file and no notification will reach space
manager.

The first scenario could be fixed by letting the post processing failure mask
the primary failure (even though that would be bad style), but it would not
at all help with the second scenario.

The issue does not exist in 2.13+ as the notification mechanism has been
changed and made independent of an actual pool location being registered.

Modification:

Space manager now doesn't immediately mark a file as stored upon encountering a
failed upload. Instead the file is queued for a recovery procedure. During
recovery the name space entry is queried; if the file was deleted the
reservation entry is removed; if a location was registered the file is marked
as stored. Otherwise the existing recovery mechanism will kick in after 24
hours and repeat this procedure.

Result:

Fixes a race condition leading to leaked space manager entries. The space
manager needs to be upgraded to resolve the issue.

Target: 2.12
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8519/
(cherry picked from commit e53a6d55dd8354329ea0576e737687ba3fa94ff8)