### PR TITLE
pool: Fix error reporting in remote HTTP mover

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol_1.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol_1.java
@@ -236,8 +236,8 @@ public class RemoteHttpDataTransferProtocol_1 implements MoverProtocol,
 
             if (_remoteSuppliedChecksum == null && info.isVerificationRequired()) {
                 throw new ClientProtocolException("failed to verify transfer: " +
-                        "server sent no useful checksum: " +
-                        rfc3230 == null ? "(none sent)" : rfc3230);
+                                                  "server sent no useful checksum: " +
+                                                  (rfc3230 == null ? "(none sent)" : rfc3230));
             }
 
             // NB. we MUST NOT close RepositoryChannel as pool wants to do this
@@ -380,9 +380,8 @@ public class RemoteHttpDataTransferProtocol_1 implements MoverProtocol,
             }
 
             if (info.isVerificationRequired() && !verified) {
-                throw new ThirdPartyTransferFailedCacheException("server " +
-                        "sent no useful checksum: " +
-                        rfc3230 == null ? "(none sent)" : rfc3230);
+                throw new ThirdPartyTransferFailedCacheException("server sent no useful checksum: " +
+                                                                 (rfc3230 == null ? "(none sent)" : rfc3230));
             }
         } catch (IOException e) {
             throw new ThirdPartyTransferFailedCacheException("failed to " +


### PR DESCRIPTION
Motivation:

The mover got the precendence rules of the ternary conditional expression
wrong.

Modification:

Add parantheses to obtain the intended semantics.

Result:

Corret error reporting.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8574/
(cherry picked from commit 0168ba93dd0a87d7e6cba6f9e0341e40c2b41d7f)
(cherry picked from commit 519ad35525d69f92f6d01f7f990b9e593d5af64b)