### PR TITLE
Fix build and startup regression

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/NetworkUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/NetworkUtils.java
@@ -46,7 +46,7 @@ public abstract class NetworkUtils {
 
     public static final String LOCAL_HOST_ADDRESS_PROPERTY = "org.dcache.net.localaddresses";
 
-    private static final String canonicalHostName;
+    private static String canonicalHostName;
     private static final int RANDOM_PORT = 23241;
 
     private static final List<InetAddress> FAKED_ADDRESSES;
@@ -61,10 +61,12 @@ public abstract class NetworkUtils {
             fakedAddresses.add(InetAddresses.forString(address));
         }
         FAKED_ADDRESSES = fakedAddresses.build();
-        canonicalHostName = getPreferredHostName();
     }
 
-    public static String getCanonicalHostName() {
+    public static synchronized String getCanonicalHostName() {
+        if (canonicalHostName == null) {
+            canonicalHostName = getPreferredHostName();
+        }
         return canonicalHostName;
     }
 


### PR DESCRIPTION
Motivation:

Our build has slowly become slower. One cause is the introduction
of identifying a canonical host name during class loading. This
will get invoked even if not needed. This in particular slows
down various command line utilites invoked during build.

Modification:

Only determine the canonical hostname if needed.

Result:

Faster build and faster startup of dCache and various utilities.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Acked-by: Femi Adeyemi <olufemi.segun.adeyemi@desy.de>
Patch: https://rb.dcache.org/r/8591/
(cherry picked from commit ec6d1530045265fabbad4f7dcb515c4e3d1e7d8e)