### PR TITLE
dcap: Fix socket factory argument parsing

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -23,7 +23,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.channels.ServerSocketChannel;
 import java.util.Map;
-import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
@@ -527,7 +526,7 @@ public class LoginManager
 
         private final InetSocketAddress _socketAddress;
         private final Constructor<?> _ssfConstructor;
-        private final String[] _farctoryArgs;
+        private final String _factoryArgs;
         private final long _acceptErrorTimeout;
 
         private volatile boolean _shutdown;
@@ -553,35 +552,27 @@ public class LoginManager
 
             String ssf = _args.getOpt("socketfactory");
             if (ssf != null) {
-                StringTokenizer st = new StringTokenizer(ssf, ",");
+                Args args = new Args(ssf);
+                checkArgument(args.argc() >= 1 , "Invalid Arguments for 'socketfactory'");
+                String tunnelFactoryClass = args.argv(0);
 
                 /*
-                 * socket factory initialization has following format:
-                 *   <classname>[<arg1>,...]
+                 * the rest is passed to factory constructor
                  */
-                checkArgument(st.countTokens() >= 2, "Invalid Arguments for 'socketfactory'");
-
-                String tunnelFactoryClass = st.nextToken();
-
-                /*
-                 * the rest is passed to factory constructor as String[]
-                 */
-                _farctoryArgs = new String[st.countTokens()];
-                for (int i = 0; st.hasMoreTokens(); i++) {
-                    _farctoryArgs[i] = st.nextToken();
-                }
+                args.shift();
+                _factoryArgs = args.toString();
 
                 Class<?> ssfClass = Class.forName(tunnelFactoryClass);
                 Constructor<?> constructor;
                 try {
-                    constructor = ssfClass.getConstructor(String[].class, Map.class);
+                    constructor = ssfClass.getConstructor(String.class, Map.class);
                 } catch (Exception ee) {
-                    constructor = ssfClass.getConstructor(String[].class);
+                    constructor = ssfClass.getConstructor(String.class);
                 }
                 _ssfConstructor = constructor;
             } else {
                 _ssfConstructor = null;
-                _farctoryArgs = null;
+                _factoryArgs = null;
             }
 
             openPort();
@@ -597,9 +588,9 @@ public class LoginManager
                     if (_ssfConstructor.getParameterTypes().length == 2) {
                         Map<String, Object> map = newHashMap(getDomainContext());
                         map.put("UserValidatable", LoginManager.this);
-                        obj = _ssfConstructor.newInstance(_farctoryArgs, map);
+                        obj = _ssfConstructor.newInstance(_factoryArgs, map);
                     } else {
-                        obj = _ssfConstructor.newInstance(new Object[] { _farctoryArgs });
+                        obj = _ssfConstructor.newInstance(_factoryArgs);
                     }
                 } catch (InvocationTargetException e) {
                     Throwables.propagateIfPossible(e.getCause(), Exception.class);

--- a/modules/javatunnel/src/main/java/javatunnel/SelfTest.java
+++ b/modules/javatunnel/src/main/java/javatunnel/SelfTest.java
@@ -99,7 +99,7 @@ class SelfTest {
             DataInputStream is;
             try {
 
-                String[] initArgs = {"javatunnel.GssTunnel", "nfs/anahit.desy.de@DESY.DE"};
+                String initArgs = "javatunnel.GssTunnel nfs/anahit.desy.de@DESY.DE";
 
                 ServerSocketFactory factory = new TunnelServerSocketCreator(initArgs);
 

--- a/modules/javatunnel/src/main/java/javatunnel/TunnelServerSocketCreator.java
+++ b/modules/javatunnel/src/main/java/javatunnel/TunnelServerSocketCreator.java
@@ -12,24 +12,22 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 
+import org.dcache.util.Args;
+
 public class TunnelServerSocketCreator extends ServerSocketFactory {
 
 
     Convertable _tunnel;
 
-    public TunnelServerSocketCreator(String[] args)
-            throws Throwable {
-
-        super();
-
-        Class<? extends Convertable> c  = Class.forName(args[0]).asSubclass(Convertable.class);
-        Class<?> [] classArgs = { String.class } ;
-        Constructor<? extends Convertable> cc = c.getConstructor(classArgs);
-        Object[] a = new Object[1];
-        a[0] = args[1];
-
+    public TunnelServerSocketCreator(String arguments)
+            throws Throwable
+    {
+        Args args = new Args(arguments);
+        Class<? extends Convertable> c  = Class.forName(args.argv(0)).asSubclass(Convertable.class);
+        args.shift();
+        Constructor<? extends Convertable> cc = c.getConstructor(String.class);
         try {
-            _tunnel = cc.newInstance(a);
+            _tunnel = cc.newInstance(args.toString());
         } catch (InvocationTargetException e) {
             throw e.getCause();
         }

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -54,8 +54,8 @@ set env paths-when-readonly-is-false "-brokerReadPaths=/ -brokerWritePaths=/"
 
 set env arguments-plain "${plain-paths-when-anonymous-access-is-${dcap.authz.anonymous-operations}} -localOk"
 set env arguments-auth "${paths-when-readonly-is-$dcap.authz.readonly}} -pswdfile=${dcap.authn.passwd} -authorization=required"
-set env arguments-gsi "${paths-when-readonly-is-$dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator,javatunnel.GsiTunnel,-service_key='${dcap.authn.hostcert.key}' -service_cert='${dcap.authn.hostcert.cert}' -service_trusted_certs='${dcap.authn.capath}' -service_voms_dir='${dcap.authn.vomsdir}' -ciphers='${dcap.authn.ciphers}'\\\""
-set env arguments-kerberos "{paths-when-readonly-is-$dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=javatunnel.TunnelServerSocketCreator,javatunnel.GssTunnel,'${dcap.authn.kerberos.service-principle-name}'"
+set env arguments-gsi "${paths-when-readonly-is-$dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator javatunnel.GsiTunnel -service_key='${dcap.authn.hostcert.key}' -service_cert='${dcap.authn.hostcert.cert}' -service_trusted_certs='${dcap.authn.capath}' -service_voms_dir='${dcap.authn.vomsdir}' -ciphers='${dcap.authn.ciphers}'\\\""
+set env arguments-kerberos "{paths-when-readonly-is-$dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=javatunnel.TunnelServerSocketCreator javatunnel.GssTunnel '${dcap.authn.kerberos.service-principle-name}'"
 
 create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
             "${dcap.net.port} diskCacheV111.doors.DCapDoor \

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -47,15 +47,15 @@ onerror shutdown
 
 set env plain-paths-when-anonymous-access-is-NONE "-brokerReadPaths= -brokerWritePaths="
 set env plain-paths-when-anonymous-access-is-READONLY "-brokerReadPaths=/ -brokerWritePaths="
-set env plain-paths-when-anonymous-access-is-FULL "${paths-when-readonly-is-$dcap.authz.readonly}}"
+set env plain-paths-when-anonymous-access-is-FULL "${paths-when-readonly-is-${dcap.authz.readonly}}"
 
 set env paths-when-readonly-is-true "-brokerReadPaths=/ -brokerWritePaths="
 set env paths-when-readonly-is-false "-brokerReadPaths=/ -brokerWritePaths=/"
 
 set env arguments-plain "${plain-paths-when-anonymous-access-is-${dcap.authz.anonymous-operations}} -localOk"
-set env arguments-auth "${paths-when-readonly-is-$dcap.authz.readonly}} -pswdfile=${dcap.authn.passwd} -authorization=required"
-set env arguments-gsi "${paths-when-readonly-is-$dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator javatunnel.GsiTunnel -service_key='${dcap.authn.hostcert.key}' -service_cert='${dcap.authn.hostcert.cert}' -service_trusted_certs='${dcap.authn.capath}' -service_voms_dir='${dcap.authn.vomsdir}' -ciphers='${dcap.authn.ciphers}'\\\""
-set env arguments-kerberos "{paths-when-readonly-is-$dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=javatunnel.TunnelServerSocketCreator javatunnel.GssTunnel '${dcap.authn.kerberos.service-principle-name}'"
+set env arguments-auth "${paths-when-readonly-is-${dcap.authz.readonly}} -pswdfile=${dcap.authn.passwd} -authorization=required"
+set env arguments-gsi "${paths-when-readonly-is-${dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator javatunnel.GsiTunnel -service_key='${dcap.authn.hostcert.key}' -service_cert='${dcap.authn.hostcert.cert}' -service_trusted_certs='${dcap.authn.capath}' -service_voms_dir='${dcap.authn.vomsdir}' -ciphers='${dcap.authn.ciphers}'\\\""
+set env arguments-kerberos "{paths-when-readonly-is-${dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator javatunnel.GssTunnel '${dcap.authn.kerberos.service-principle-name}'\\\""
 
 create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
             "${dcap.net.port} diskCacheV111.doors.DCapDoor \


### PR DESCRIPTION
Motivation:

DCAP has a pluggable socket factory system. The argument parsing
relies on a comma separated list of arguments, but this system fails
if any of the arguments themselves contain a comma. This is the case
for our list of blocked ciphers, which means only the first in the
list is actually passed on to the socket factory.

Modification:

Use space separated arguments and make use of the Args class to get
proper quoted of arguments.

Result:

Respect all ciphers flags specified in the configuration.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Christian Bernardt <christian.bernardt@desy.de>
Patch: https://rb.dcache.org/r/8580/
(cherry picked from commit e0ddf8359aaf33379ecf5aa5ce32f41705b991c3)