### PR TITLE
dcap: Fix socket factory argument parsing

### DIFF
--- a/modules/javatunnel/src/main/java/javatunnel/SelfTest.java
+++ b/modules/javatunnel/src/main/java/javatunnel/SelfTest.java
@@ -99,7 +99,7 @@ class SelfTest {
             DataInputStream is;
             try {
 
-                String[] initArgs = {"javatunnel.GssTunnel", "nfs/anahit.desy.de@DESY.DE"};
+                String initArgs = "javatunnel.GssTunnel nfs/anahit.desy.de@DESY.DE";
 
                 ServerSocketFactory factory = new TunnelServerSocketCreator(initArgs);
 

--- a/modules/javatunnel/src/main/java/javatunnel/TunnelServerSocketCreator.java
+++ b/modules/javatunnel/src/main/java/javatunnel/TunnelServerSocketCreator.java
@@ -12,24 +12,22 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 
+import org.dcache.util.Args;
+
 public class TunnelServerSocketCreator extends ServerSocketFactory {
 
 
     Convertable _tunnel;
 
-    public TunnelServerSocketCreator(String[] args)
-            throws Throwable {
-
-        super();
-
-        Class<? extends Convertable> c  = Class.forName(args[0]).asSubclass(Convertable.class);
-        Class<?> [] classArgs = { String.class } ;
-        Constructor<? extends Convertable> cc = c.getConstructor(classArgs);
-        Object[] a = new Object[1];
-        a[0] = args[1];
-
+    public TunnelServerSocketCreator(String arguments)
+            throws Throwable
+    {
+        Args args = new Args(arguments);
+        Class<? extends Convertable> c  = Class.forName(args.argv(0)).asSubclass(Convertable.class);
+        args.shift();
+        Constructor<? extends Convertable> cc = c.getConstructor(String.class);
         try {
-            _tunnel = cc.newInstance(a);
+            _tunnel = cc.newInstance(args.toString());
         } catch (InvocationTargetException e) {
             throw e.getCause();
         }

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -30,8 +30,8 @@ exec file:${dcache.paths.share}/cells/stage.fragment dcap doors
 
 set env arguments-plain "-localOk"
 set env arguments-auth "-pswdfile=${dcap.authn.passwd} -authorization=required"
-set env arguments-gsi "-localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator,javatunnel.GsiTunnel,-service_key='${dcap.authn.hostcert.key}' -service_cert='${dcap.authn.hostcert.cert}' -service_trusted_certs='${dcap.authn.capath}' -service_voms_dir='${dcap.authn.vomsdir}' -ciphers='${dcap.authn.ciphers}'\\\""
-set env arguments-kerberos "-localOk -authorization=strong -socketfactory=javatunnel.TunnelServerSocketCreator,javatunnel.GssTunnel,'${dcap.authn.kerberos.service-principle-name}'"
+set env arguments-gsi "-localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator javatunnel.GsiTunnel -service_key='${dcap.authn.hostcert.key}' -service_cert='${dcap.authn.hostcert.cert}' -service_trusted_certs='${dcap.authn.capath}' -service_voms_dir='${dcap.authn.vomsdir}' -ciphers='${dcap.authn.ciphers}'\\\""
+set env arguments-kerberos "-localOk -authorization=strong -socketfactory=javatunnel.TunnelServerSocketCreator javatunnel.GssTunnel '${dcap.authn.kerberos.service-principle-name}'"
 
 create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
             "${dcap.net.port} diskCacheV111.doors.DCapDoor \

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -31,7 +31,7 @@ exec file:${dcache.paths.share}/cells/stage.fragment dcap doors
 set env arguments-plain "-localOk"
 set env arguments-auth "-pswdfile=${dcap.authn.passwd} -authorization=required"
 set env arguments-gsi "-localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator javatunnel.GsiTunnel -service_key='${dcap.authn.hostcert.key}' -service_cert='${dcap.authn.hostcert.cert}' -service_trusted_certs='${dcap.authn.capath}' -service_voms_dir='${dcap.authn.vomsdir}' -ciphers='${dcap.authn.ciphers}'\\\""
-set env arguments-kerberos "-localOk -authorization=strong -socketfactory=javatunnel.TunnelServerSocketCreator javatunnel.GssTunnel '${dcap.authn.kerberos.service-principle-name}'"
+set env arguments-kerberos "-localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator javatunnel.GssTunnel '${dcap.authn.kerberos.service-principle-name}'\\\""
 
 create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
             "${dcap.net.port} diskCacheV111.doors.DCapDoor \


### PR DESCRIPTION
Motivation:

DCAP has a pluggable socket factory system. The argument parsing
relies on a comma separated list of arguments, but this system fails
if any of the arguments themselves contain a comma. This is the case
for our list of blocked ciphers, which means only the first in the
list is actually passed on to the socket factory.

Modification:

Use space separated arguments and make use of the Args class to get
proper quoted of arguments.

Result:

Respect all ciphers flags specified in the configuration.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Christian Bernardt <christian.bernardt@desy.de>
Patch: https://rb.dcache.org/r/8580/
(cherry picked from commit e0ddf8359aaf33379ecf5aa5ce32f41705b991c3)
(cherry picked from commit 583d58aebd517885a255f2d71fad3fca7a6c483a)
(cherry picked from commit dd36b02226447aef2543247911fe53b6ce23f80b)