### PR TITLE
xacml: fix voms attribute validation

### DIFF
--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -216,6 +216,12 @@ gplazma.xacml.hostcert=${dcache.authn.hostcert.cert}
 #  ---- Path to the directory containing trusted CA certificates
 gplazma.xacml.ca=${dcache.authn.capath}
 
+#  ---- Path to the vomsdir directory
+gplazma.xacml.vomsdir.dir=${dcache.authn.vomsdir}
+
+#  ---- Path to the directory containing trusted CA certificates
+gplazma.xacml.vomsdir.ca=${dcache.authn.capath}
+
 
 # ---- LDAP plugin
 #


### PR DESCRIPTION
In the move of the XACML plugin from gPlazma 1 to 2, it was decided to continue supporting voms attribute validation as optional,
because some of the Fermi installations did not have the vomsdir properly set up.

In subsequent patches, this option, along with the configuration of the validator based on the CADIR and VOMSDIR
properties, got swallowed somehow.

As it turns out, we have actually been running validation all the time, with the default settings.

In light of this, we have decided to drop the option and enforce attribute validation (as it should be done),
and to configure the validator (as it was once done) from the paths.

We have also made the XACML path properties independent of the VOMS properties.

There is a potential here to pare down the XACML authentication routine such that it depends on the
X509 and/or VOMS principals already being in the chain, thus eliminating code duplication.  This
will be for a subsequent patch.

Target: 2.13
Acked-by: Gerd Behrmann
Require-book: no
Require-notes: yes