### PR TITLE
dcap: Fix broken argument parsing

### DIFF
--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -47,15 +47,15 @@ onerror shutdown
 
 set env plain-paths-when-anonymous-access-is-NONE "-brokerReadPaths= -brokerWritePaths="
 set env plain-paths-when-anonymous-access-is-READONLY "-brokerReadPaths=/ -brokerWritePaths="
-set env plain-paths-when-anonymous-access-is-FULL "${paths-when-readonly-is-$dcap.authz.readonly}}"
+set env plain-paths-when-anonymous-access-is-FULL "${paths-when-readonly-is-${dcap.authz.readonly}}"
 
 set env paths-when-readonly-is-true "-brokerReadPaths=/ -brokerWritePaths="
 set env paths-when-readonly-is-false "-brokerReadPaths=/ -brokerWritePaths=/"
 
 set env arguments-plain "${plain-paths-when-anonymous-access-is-${dcap.authz.anonymous-operations}} -localOk"
-set env arguments-auth "${paths-when-readonly-is-$dcap.authz.readonly}} -pswdfile=${dcap.authn.passwd} -authorization=required"
-set env arguments-gsi "${paths-when-readonly-is-$dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator,javatunnel.GsiTunnel,-service_key='${dcap.authn.hostcert.key}' -service_cert='${dcap.authn.hostcert.cert}' -service_trusted_certs='${dcap.authn.capath}' -service_voms_dir='${dcap.authn.vomsdir}' -ciphers='${dcap.authn.ciphers}'\\\""
-set env arguments-kerberos "{paths-when-readonly-is-$dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=javatunnel.TunnelServerSocketCreator,javatunnel.GssTunnel,'${dcap.authn.kerberos.service-principle-name}'"
+set env arguments-auth "${paths-when-readonly-is-${dcap.authz.readonly}} -pswdfile=${dcap.authn.passwd} -authorization=required"
+set env arguments-gsi "${paths-when-readonly-is-${dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=\\\"javatunnel.TunnelServerSocketCreator,javatunnel.GsiTunnel,-service_key='${dcap.authn.hostcert.key}' -service_cert='${dcap.authn.hostcert.cert}' -service_trusted_certs='${dcap.authn.capath}' -service_voms_dir='${dcap.authn.vomsdir}' -ciphers='${dcap.authn.ciphers}'\\\""
+set env arguments-kerberos "{paths-when-readonly-is-${dcap.authz.readonly}} -localOk -authorization=strong -socketfactory=javatunnel.TunnelServerSocketCreator,javatunnel.GssTunnel,'${dcap.authn.kerberos.service-principle-name}'"
 
 create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
             "${dcap.net.port} diskCacheV111.doors.DCapDoor \


### PR DESCRIPTION
Motivation:

The DCAP batch script contains a typo that causes it to publish the wrong
paths to SRM.

Result:

Generate the correct login broker paths.

Target: trunk
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8606/
(cherry picked from commit 708fdd477627e39f02ce001b6f1f13d69f2cec30)