### PR TITLE
HSM Script: pass arguments in array

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/EnstoreStorageInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/EnstoreStorageInfo.java
@@ -50,7 +50,7 @@ public class EnstoreStorageInfo extends GenericStorageInfo {
              ";family="+(_family==null?"<Unknown>":_family)+
              ";bfid="+getBitfileId()+
              ";volume="+_volume+
-             ";location="+_location+";" ;
+             ";location="+_location+";";
    }
    public String getStorageGroup(){ return _group ; }
    public String getFileFamily(){ return _family ; }

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/HsmDriverOSM.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/HsmDriverOSM.java
@@ -64,7 +64,7 @@ import org.dcache.util.Args;
 
              OSMStorageInfo osm = (OSMStorageInfo)storageInfo ;
 
-             String tape  = osm.getKey( "hsm.osm.volumeName" ) ;
+             String tape  = osm.getKey("hsm.osm.volumeName") ;
              String store = osm.getStore() ;
 
              if( ( tape == null )  || ( tape.equals("")  ) ||
@@ -73,9 +73,7 @@ import org.dcache.util.Args;
                          IllegalArgumentException("Not enough info in storageInfo (volumeName)");
              }
 
-             String command = _command+" -S "+store+" lsvol -l "+tape ;
-
-             RunSystem system = new RunSystem( command , 1000, 10000L );
+             RunSystem system = new RunSystem(1000, 10000L, _command, "-S", store, "lsvol", "-l", "tape");
              system.go();
 
              int    rc     = system.getExitValue() ;
@@ -85,7 +83,7 @@ import org.dcache.util.Args;
              if( ( rc != 0 ) || ( error.length() != 0 )  || ( output.length() == 0 ) ) {
                  throw new
                          IllegalArgumentException(error == null ?
-                         "Unknow error in responds to >" + command + "<" :
+                         "Unknow error in responds to >" + _command + "-S" + store + "lsvol" + "-l" + "tape" + "<" :
                          error);
              }
 
@@ -110,7 +108,7 @@ import org.dcache.util.Args;
                  volStat = st.nextToken() ;
              }catch(Exception ee ){
                 throw new
-                IllegalArgumentException("Format error in output of >"+command+"< : "+output);
+                IllegalArgumentException("Format error in output of >" + _command + "-S" + store + "lsvol" + "-l" + "tape" + "< : "+output);
              }
              String details = "volumeNbf="+volNbf+";volumeStatus="+volStat+";volumeCapacity="+volCap+";";
              String tmp = osm.getKey("hsm.details");
@@ -135,9 +133,7 @@ import org.dcache.util.Args;
                          IllegalArgumentException("Not enough info in storageInfo");
              }
 
-             String command = _command+" -S "+store+" lsbf -a "+bfid ;
-
-             RunSystem system = new RunSystem( command , 1000, 10000L );
+             RunSystem system = new RunSystem(1000, 10000L, _command, "-S", store, "lsbf", "-a", bfid);
              system.go();
 
              int    rc     = system.getExitValue() ;
@@ -147,7 +143,7 @@ import org.dcache.util.Args;
              if( ( rc != 0 ) || ( error.length() != 0 )  || ( output.length() == 0 ) ) {
                  throw new
                          IllegalArgumentException(error == null ?
-                         "Unknow error in responds to >" + command + "<" :
+                         "Unknow error in responds to >" + _command + "-S" + store + "lsbf" + "-a" + bfid + "<" :
                          error);
              }
 
@@ -170,7 +166,7 @@ import org.dcache.util.Args;
                  status = st.nextToken() ;
              }catch(Exception ee ){
                 throw new
-                IllegalArgumentException("Format error in output of >"+command+"< : "+output);
+                IllegalArgumentException("Format error in output of >"+ _command + "-S" + store + "lsbf" + "-a" + bfid +"< : "+output);
              }
              osm.setKey("hsm.details","volumeName="+tape+";bfStatus="+status+";");
              osm.setKey("hsm.osm.volumeName",tape);

--- a/modules/dcache/src/main/java/diskCacheV111/util/HsmRunSystem.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/HsmRunSystem.java
@@ -20,9 +20,9 @@ public class HsmRunSystem extends RunSystem
 
     private final String storageName;
 
-    public HsmRunSystem(String storageName, String exec, int maxLines, long timeout)
+    public HsmRunSystem(String storageName, int maxLines, long timeout, String ... exec)
     {
-        super(exec, maxLines, timeout);
+        super(maxLines, timeout, exec);
         this.storageName = storageName;
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/util/RunSystem.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/RunSystem.java
@@ -15,7 +15,7 @@ import java.io.StringWriter;
 public class RunSystem implements Runnable {
     private final static Logger _log = LoggerFactory.getLogger(RunSystem.class);
     private final static Runtime __runtime = Runtime.getRuntime() ;
-    private final String _exec ;
+    private final String[] _exec ;
     private final int    _maxLines ;
     private final long   _timeout ;
     private final Thread _readErrorThread ;
@@ -37,7 +37,7 @@ public class RunSystem implements Runnable {
     private static int __counter = 100 ;
     private static synchronized int nextId(){ return __counter++ ; }
 
-    public RunSystem(String exec, int maxLines, long timeout)
+    public RunSystem(int maxLines, long timeout, String ... exec)
     {
         _exec     = exec ;
         _maxLines = maxLines ;
@@ -218,7 +218,7 @@ public class RunSystem implements Runnable {
         long timeout = Long.parseLong( args[2] ) * 1000 ;
         int  maxLines = Integer.parseInt( args[1] ) ;
 
-        RunSystem run = new RunSystem( args[0] , maxLines , timeout) ;
+        RunSystem run = new RunSystem(maxLines, timeout, args[0] ) ;
         run.go() ;
 
         int rc = run.getExitValue() ;


### PR DESCRIPTION
-si parameter could contain spaces and special characters that would
cause the commandline for the scripts to be invalid. To solve that,
this patch passes the commands with its parameters as array instead of
one string.

Ticket: #number
Acked-by:
Target: trunk
Require-book: no
Require-notes: no