### PR TITLE
pool: Let script nearline storage provider scale down when lowering limits

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/BoundedExecutor.java
+++ b/modules/dcache/src/main/java/org/dcache/util/BoundedExecutor.java
@@ -196,7 +196,7 @@ public class BoundedExecutor extends AbstractExecutorService
         {
             monitor.enter();
             try {
-                if (workQueue.isEmpty()) {
+                if (workQueue.isEmpty() || threads > maxThreads) {
                     threads--;
                     workers.remove(Thread.currentThread());
                     return null;


### PR DESCRIPTION
Motivation:

The script nearline storage provider uses our BoundedExecutor for task
execution. It allows the concurrency limits to be reconfigured at runtime,
however the implementation fails to scale down until the executor runs
out of tasks.

Modification:

Explicitly shut down threads if we are above the limit.

Result:

Reconfiguring the script provider limits has the intended effect.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Femi Adeyemi <olufemi.segun.adeyemi@desy.de>
Patch: https://rb.dcache.org/r/8625/
(cherry picked from commit 0644d66153ff7a1b153b4a346ed98466b3c883e4)