### PR TITLE
xrootd: Fix race condition in request cancelation

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -134,7 +134,7 @@ public class XrootdRedirectHandler extends AbstractXrootdRequestHandler
     {
         ListenableFuture<?> future = _executor.submit(() -> super.requestReceived(ctx, req));
         _requests.add(future);
-        future.addListener(() -> _requests.remove(future), MoreExecutors.directExecutor());
+        future.addListener(() -> _requests.remove(future), _executor);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

07 Oct 2015 12:59:03 (Xrootd-srm-alice-ipv4) [door:Xrootd-srm-alice-ipv4:AAUhgZCOXKA] Uncaught exception in thread xrootd-net-13
java.util.ConcurrentModificationException: null
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1429) ~[na:1.8.0_60]
        at java.util.HashMap$KeyIterator.next(HashMap.java:1453) ~[na:1.8.0_60]
        at org.dcache.xrootd.door.XrootdRedirectHandler.channelInactive(XrootdRedirectHandler.java:147) ~[dcache-xrootd-2.13.9.jar:2.13.9]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:208) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:194) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at org.dcache.xrootd.plugins.AccessLogHandler.channelInactive(AccessLogHandler.java:107) [dcache-xrootd-2.13.9.jar:2.1.2]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:208) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:194) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:208) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:194) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at org.dcache.xrootd.core.XrootdAuthenticationHandler.channelInactive(XrootdAuthenticationHandler.java:89) [xrootd4j-2.1.2.jar:2.1.2]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:208) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:194) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:306) [netty-codec-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:208) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:194) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at org.dcache.xrootd.door.ConnectionTracker.channelInactive(ConnectionTracker.java:48) [dcache-xrootd-2.13.9.jar:2.13.9]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:208) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:194) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at org.dcache.xrootd.door.NettyXrootdServer$SessionHandler.channelInactive(NettyXrootdServer.java:269) [dcache-xrootd-2.13.9.jar:2.13.9]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:208) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:194) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:828) [netty-transport-4.0.28.Final.jar:4.0.28.Final]
        at io.netty.channel.AbstractChannel$AbstractUnsafe$7.run(AbstractChannel.java:621) [netty-transport-4.0.28.Final.jar:4.0.28.Final]

Modification:

The exception is caused by the cancellation call triggering the deregistration
callback directly. Thus the synchronization on the request set doesn't help
as it is the thread iterating that is removing the element from the set.

The fix is to issue the callback on the executor.

Result:

The race condition is gone.

Target: trunk
Request: 2.13
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/8615/
(cherry picked from commit 268e141cc0cf73340abd1a2e4c6c2d5bc2a371f5)