### PR TITLE
pool: Add nearline storage default timeouts

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -124,9 +124,9 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
     private PnfsHandler pnfs;
     private CellStub billingStub;
     private HsmSet hsmSet;
-    private long stageTimeout;
-    private long flushTimeout;
-    private long removeTimeout;
+    private long stageTimeout = TimeUnit.HOURS.toMillis(4);
+    private long flushTimeout = TimeUnit.HOURS.toMillis(4);
+    private long removeTimeout = TimeUnit.HOURS.toMillis(4);
     private ScheduledFuture<?> timeoutFuture;
 
     @Required

--- a/skel/share/services/pool.batch
+++ b/skel/share/services/pool.batch
@@ -69,6 +69,7 @@ define context PoolDefaults endDefine
 
    rh set timeout 14400
    st set timeout 14400
+   rm set timeout 14400
 
    mover set max active 100
    p2p set max active 10


### PR DESCRIPTION
Motivation:

Flush, stage and remove operations have separate timeouts.
For flush and stage we provided default timeouts in the
default pool setup file, but for remove we didn't. Thus
remove operations time out quickly.

Modification:

Add defaults to the default setup and also in the code to
cover existing pools.

Result:

Tape remove requests don't get killed too early.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Femi Adeyemi <olufemi.segun.adeyemi@desy.de>
Patch: https://rb.dcache.org/r/8629/
(cherry picked from commit 5c3800d9127fc4ad7ea8cb6bf029137aa0996510)