### PR TITLE
xrootd: Kill mover on aborted write

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -443,6 +443,7 @@ public class XrootdDoor
             throw e;
         } finally {
             if (address == null) {
+                transfer.killMover(0);
                 _transfers.remove(handle);
             }
         }
@@ -746,15 +747,14 @@ public class XrootdDoor
      */
     public void messageArrived(PoolIoFileMessage message)
     {
-        String pool = message.getPoolName();
-        int moverId = message.getMoverId();
-        try {
-            PoolMoverKillMessage killMessage =
-                new PoolMoverKillMessage(pool, moverId);
-            killMessage.setReplyRequired(false);
-            _poolStub.notify(new CellPath(pool), killMessage);
-        } catch (NoRouteToCellException e) {
-            _log.error("Failed to kill mover {}/{}: {}", pool, moverId, e.getMessage());
+        if (message.getReturnCode() == 0) {
+            String pool = message.getPoolName();
+            int moverId = message.getMoverId();
+            try {
+                _poolStub.notify(new CellPath(pool), new PoolMoverKillMessage(pool, moverId));
+            } catch (NoRouteToCellException e) {
+                _log.error("Failed to kill mover {}/{}: {}", pool, moverId, e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

The xrootd door may time out while waiting for a redirect from the pool.
On write it currently fails to kill the mover if this happens.

Modification:

Kill the mover if the door times out or the client disconnects while
waiting for a redirect on write.

Don't attempt to kill the mover if mover creation failed.

Result:

Reduce problems with abandoned write movers.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8631/
(cherry picked from commit 57ee102bb912743807baa8e7cefd677250f07fd4)