### PR TITLE
webdav: Kill abandoned movers

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -68,8 +68,8 @@ import diskCacheV111.vehicles.ProtocolInfo;
 
 import dmg.cells.nucleus.AbstractCellComponent;
 import dmg.cells.nucleus.CellCommandListener;
-import dmg.cells.nucleus.CellMessage;
 import dmg.cells.nucleus.CellMessageReceiver;
+import dmg.cells.nucleus.CellPath;
 import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.cells.services.login.LoginManagerChildrenInfo;
 
@@ -980,8 +980,7 @@ public class DcacheResourceFactory
     /**
      * Message handler for redirect messages from the pools.
      */
-    public void messageArrived(CellMessage envelope,
-                               HttpDoorUrlInfoMessage message)
+    public void messageArrived(HttpDoorUrlInfoMessage message)
     {
         HttpTransfer transfer = _transfers.get((int) message.getId());
         if (transfer != null) {
@@ -1009,11 +1008,12 @@ public class DcacheResourceFactory
     public void messageArrived(PoolIoFileMessage message)
     {
         if (message.getReturnCode() == 0) {
+            String pool = message.getPoolName();
+            int moverId = message.getMoverId();
             try {
-                _poolStub.notify(new PoolMoverKillMessage(message.getPoolName(), message.getMoverId()));
+                _poolStub.notify(new CellPath(pool), new PoolMoverKillMessage(pool, moverId));
             } catch (NoRouteToCellException e) {
-                _log.debug("Failed to kill mover {}/{}: {}", message.getPoolName(), message.getMoverId(),
-                           e.getMessage());
+                _log.debug("Failed to kill mover {}/{}: {}", pool, moverId, e.getMessage());
             }
         }
     }


### PR DESCRIPTION
Motivation:

The webdav door contains logic that kills a successfully created mover if it
isn't bound to a particular transfer. It however fails to specify the mover
cell address.

Modification:

Address the kill message to the pool hosting the mover.

Result:

Reduce problems with abandoned movers.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/8632/
(cherry picked from commit fc1fc7c4f13cc254a103c0bb9907a4ef6496af9b)
(cherry picked from commit 01bf9bb7eaef3ae392930b58de169346eb1d6eca)