### PR TITLE
(2.12) old replica manager: prevent pool being listed as offline when…

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -1342,6 +1342,19 @@ public class PoolV4
                  * supposed to be on the list, the exception is not a
                  * problem.
                  */
+            } catch (IllegalStateException e) {
+                /*
+                 * For the purposes of this listing, ignore files
+                 * with incomplete metadata (accessing an undefined file
+                 * attribute throws this exception).
+                 *
+                 * Otherwise the loading of the pool into the replica manager
+                 * database will fail and the pool will be marked offline when
+                 * it reality it is accessible (this method is only
+                 * used by DCacheCoreControllerV2).
+                 */
+                _log.warn("Skipping {} when listing contents of pool {}: {}.",
+                          pnfsid, _poolName, e.getMessage());
             }
         }
         return listing;


### PR DESCRIPTION
… there are files with corrupt metadata

Motivation:

The old replica manager on startup loads pool data into its own database by
querying the pool repositories using an ad hoc message which calls a method
to populate a list of cache entries.

Currently, this list method ignores errors involving potentially deleted
files, but fails when one or more of the expected file attributes is
undefined.  This provokes the entire pool being considered offline by
the replica manager, when the PoolManager shows it as up.

Modification:

Add a catch clause which similarly ignores the IllegalStateException
thrown by the guard on the file attributes accessor methods,
allowing the listing to proceed.  Log the pnfsid and error for
reference.

Result:

Pool listing does not fail globally and pool is not erroneously marked
as offline.

Target: 2.12
Require-book: no
Require-notes: yes (bug fix)
Bug:  http://rt.dcache.org/Ticket/Display.html?id=8816
Acked-by:  Dmitry
Acked-by:  Paul