### PR TITLE
(2.13) webadmin: improve user-friendliness of alarms page on load

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/alarms/AlarmsPage.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/alarms/AlarmsPage.java
@@ -106,7 +106,7 @@ public class AlarmsPage extends BasePage implements AuthenticatedWebPage {
             }
         };
 
-        Form<?> form = getAutoRefreshingForm("alarmsPageForm");
+        Form<?> form = getAutoRefreshingForm("alarmsPageForm", false);
         form.add(new QueryPanel("filterPanel", this));
         if(getWebadminApplication().getAlarmDisplayService().isConnected()) {
             displayPanel = new DisplayPanel("displayPanel", this);

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/panels/alarms/QueryPanel.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/panels/alarms/QueryPanel.java
@@ -72,6 +72,8 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
@@ -90,6 +92,7 @@ public class QueryPanel extends Panel {
 
     private static final long serialVersionUID = -1214958555513880556L;
     private static final String DATE = "yyyy/MM/dd";
+    private boolean initialized = false;
 
     public QueryPanel(String id, final AlarmsPage parent) {
         super(id);
@@ -104,6 +107,8 @@ public class QueryPanel extends Panel {
         addShowClosed(provider);
         addRangeFields(provider);
         add(parent.getRefreshButton());
+        addEnableAutorefresh(parent);
+        initialized = true;
     }
 
     private void addAlarmsGroup(AlarmTableProvider provider) {
@@ -131,6 +136,19 @@ public class QueryPanel extends Panel {
         add(ending);
     }
 
+    private void addEnableAutorefresh(AlarmsPage parent) {
+        IModel<Boolean> autofreshEnabled = new PropertyModel<>(parent,
+                        "autorefreshEnabled");
+        add(new CheckBox("autofreshEnabled", autofreshEnabled) {
+            private static final long serialVersionUID = -5500105320665027261L;
+
+            @Override
+            protected boolean wantOnSelectionChangedNotifications() {
+                return true;
+            }
+        });
+    }
+
     private void addExpressionFields(AlarmTableProvider provider) {
         IModel<String> filterValue = new PropertyModel<>(provider, "expression");
         add(new TextField<>("filterField", filterValue));
@@ -150,7 +168,11 @@ public class QueryPanel extends Panel {
         add(new TextField<Integer>("rangeFrom", from));
 
         IModel<Integer> to = new PropertyModel<>(provider, "to");
-        add(new TextField<Integer>("rangeTo", to));
+        TextField<Integer> toField = new TextField<Integer>("rangeTo", to);
+        if (!initialized) {
+            toField.setModelObject(100);
+        }
+        add(toField);
     }
 
     private void addPriorityChoice(AlarmTableProvider provider) {
@@ -186,5 +208,11 @@ public class QueryPanel extends Panel {
                 return provider.getMap().keySet().iterator();
             }
         });
+    }
+
+    private static String getFormattedNow() {
+        DateFormat format = new SimpleDateFormat(DATE);
+        format.setLenient(false);
+        return format.format(new Date());
     }
 }

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.html
@@ -46,14 +46,19 @@
                 <td><input
                         wicket:id="refresh"
                         type="submit"
-                        wicket:message="value:refreshButton" /></td>
+                        wicket:message="value:refreshButton" />
+                    </td>
             </tr>
             <tr>
                 <td><b><wicket:message key="type" /> </b></td>
                 <td><input
                         wicket:id="typeField"
                         type="text" /></td>
-                <td />
+                <td>
+                    <b><wicket:message key="autorefresh" /></b>
+                    <input
+                            wicket:id="autofreshEnabled"
+                            type="checkbox" /></td>
             </tr>
             <tr>
                 <td><b><wicket:message key="filter" /> </b></td>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.properties
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/alarms/QueryPanel.properties
@@ -15,3 +15,4 @@ range=Limit
 from=From
 to=Up To
 refreshButton=Refresh
+autorefresh=Autorefresh Enabled


### PR DESCRIPTION
Motivation:

When the alarms page is opened, refresh() is immediately called because Ajax autorefresh
is set for this service; owever, no default limits are given to the query range,
and if there are many entries in the database, the page can take rather long to load.
This is not user friendly and could be mistaken for a network issue of some sort.

Modification:

This patch adopts two small changes which should ameliorate this.

First, an autorefresh option has been incorporated into the BasePage API,
and exposed on Alarms page as a query checkbox option which is by default
off.   Hence, the page will load without automatically refreshing.

Second, we have also provided a default limit:

    to (range): a limit of 100 results is initially returned

The default end date is undefined (meaning the most recent event); events
are sorted by timestamp descending.

The type default is still set to Alarms, but this does not affect the query issued
to the underlying store, only the in-memory filter.

Result:

A more modest amount of time is initially required to connect, and
the page refresh need not refetch by default a maximum of 10000 entries.

Target: 2.13
Acked-by: Gerd
Require-book: yes
Require-notes: yes