### PR TITLE
webdav: Add robots.txt

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -239,6 +239,15 @@
                       </bean>
                   </property>
               </bean>
+              <bean class="org.eclipse.jetty.server.handler.ContextHandler">
+                  <property name="contextPath" value="/robots.txt"/>
+                  <property name="allowNullPathInfo" value="true"/>
+                  <property name="handler">
+                      <bean class="org.dcache.services.httpd.handlers.ContextHandler">
+                          <constructor-arg value="robots.txt"/>
+                      </bean>
+                  </property>
+              </bean>
               <bean class="org.dcache.webdav.MiltonHandler">
                   <property name="httpManager" ref="http-manager"/>
               </bean>

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/ContextHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/ContextHandler.java
@@ -67,7 +67,7 @@ public class ContextHandler extends AbstractHandler implements DomainContextAwar
 
             proxy.getPrintWriter().println(html);
             proxy.getPrintWriter().flush();
-
+            baseRequest.setHandled(true);
         } catch (final Exception t) {
             throw new ServletException("ContextHandler", t);
         }

--- a/skel/share/services/webdav.batch
+++ b/skel/share/services/webdav.batch
@@ -75,6 +75,18 @@ check webdav.net.internal
 check webdav.mover.queue
 check webdav.authn.ciphers
 
+# Our /robots.txt file.  This advertises which parts of the HTTP
+# service indexing robots (web-crawlers) should index.  The particular
+# configuration below disallows all indexing.  Details on how to
+# configure robot.txt files are available from:
+# http://www.robotstxt.org/robotstxt.html
+####################################################################
+
+define context robots.txt endDefine
+User-agent: *
+Disallow: /
+endDefine
+
 define env verify-http.exe enddefine
 enddefine
 


### PR DESCRIPTION
Motivation:

Disallow crawler from indexing dCache.

Modification:

Adds a robots.txt to disallow all web crawlers.

Result:

Less load.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8661/
(cherry picked from commit bd5c32aaada67bcfefbbbca94080bd4e15a00910)