### PR TITLE
nfs4: fix race in request processing

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import diskCacheV111.util.CacheException;
@@ -107,7 +106,6 @@ import org.dcache.nfs.vfs.VfsCacheConfig;
 import org.dcache.util.RedirectedTransfer;
 import org.dcache.util.Transfer;
 import org.dcache.util.TransferRetryPolicy;
-import org.dcache.utils.Bytes;
 import org.dcache.vehicles.DoorValidateMoverMessage;
 import org.dcache.xdr.OncRpcException;
 import org.dcache.xdr.OncRpcProgram;
@@ -125,14 +123,12 @@ public class NFSv41Door extends AbstractCellComponent implements
     /**
      * A mapping between pool name, nfs device id and pool's ip addresses.
      */
-    private final PoolDeviceMap _poolDeviceMap = new PoolDeviceMap();
+    private final PoolDeviceMap _poolDeviceMap = new PoolDeviceMap(new RoundRobinStripingPattern<>());
 
-    /** next device id, 0 reserved for MDS */
-    private final AtomicInteger _nextDeviceID = new AtomicInteger(1);
     /*
      * reserved device for IO through MDS (for pnfs dot files)
      */
-    private static final deviceid4 MDS_ID = deviceidOf(0);
+    private static final deviceid4 MDS_ID = PoolDeviceMap.deviceidOf(0);
 
     private final Map<stateid4, NfsTransfer> _ioMessages = new ConcurrentHashMap<>();
 
@@ -194,12 +190,6 @@ public class NFSv41Door extends AbstractCellComponent implements
 
     private static final TransferRetryPolicy RETRY_POLICY =
         new TransferRetryPolicy(Integer.MAX_VALUE, NFS_RETRY_PERIOD, NFS_REPLY_TIMEOUT);
-
-    /**
-     * Data striping pattern for a file.
-     */
-    private final StripingPattern<InetSocketAddress[]> _stripingPattern =
-            new RoundRobinStripingPattern<>();
 
     private VfsCacheConfig _vfsCacheConfig;
 
@@ -324,22 +314,12 @@ public class NFSv41Door extends AbstractCellComponent implements
     public void messageArrived(PoolPassiveIoFileMessage<org.dcache.chimera.nfs.v4.xdr.stateid4> message) {
 
         String poolName = message.getPoolName();
+        long verifier = message.getVerifier();
+        InetSocketAddress[] poolAddresses = message.socketAddresses();
 
         _log.debug("NFS mover ready: {}", poolName);
 
-        InetSocketAddress[] poolAddress = message.socketAddresses();
-        PoolDS device = _poolDeviceMap.getByPoolName(poolName);
-
-        if (device == null || isPoolRestarted(device, message)) {
-            /* pool is unknown yet or has been restarted so create new device and device-id */
-            final int id = this.nextDeviceID();
-            final deviceid4 deviceid = deviceidOf(id);
-            final PoolDS newDevice = new PoolDS(deviceid, _stripingPattern, poolAddress, message.getVerifier());
-
-            _log.debug("new mapping: {}", newDevice);
-            _poolDeviceMap.add(poolName, newDevice);
-            device = newDevice;
-        }
+        PoolDS device = _poolDeviceMap.getOrCreateDS(poolName, verifier, poolAddresses);
 
         org.dcache.chimera.nfs.v4.xdr.stateid4 legacyStateid = message.challange();
         NfsTransfer transfer = _ioMessages.get(new stateid4(legacyStateid.other, legacyStateid.seqid.value));
@@ -352,16 +332,6 @@ public class NFSv41Door extends AbstractCellComponent implements
         if(transfer != null) {
             transfer.redirect(device);
         }
-    }
-
-    private boolean isPoolRestarted(PoolDS ds, PoolPassiveIoFileMessage<org.dcache.chimera.nfs.v4.xdr.stateid4> message) {
-        long verifier = message.getVerifier();
-        if (verifier != 0) {
-            // pool supports verifier
-            return ds.getVerifier() != verifier;
-        }
-        // pre-2.9 pool
-        return !Arrays.equals(ds.getInetSocketAddress(), message.socketAddresses());
     }
 
     public void messageArrived(DoorTransferFinishedMessage transferFinishedMessage) {
@@ -393,10 +363,6 @@ public class NFSv41Door extends AbstractCellComponent implements
         }
         message.setIsValid(isValid);
         return message;
-    }
-
-    private int nextDeviceID() {
-        return _nextDeviceID.incrementAndGet();
     }
 
     // NFSv41DeviceManager interface
@@ -816,13 +782,6 @@ public class NFSv41Door extends AbstractCellComponent implements
             });
             return sb.toString();
         }
-    }
-
-    private static deviceid4 deviceidOf(int id) {
-        byte[] deviceidBytes = new byte[nfs4_prot.NFS4_DEVICEID4_SIZE];
-        Bytes.putInt(deviceidBytes, 0, id);
-
-        return new deviceid4(deviceidBytes);
     }
 
     static class PoolDS {


### PR DESCRIPTION
if a situation where a pool sends redirects for multiple requests at the same time
we may run into situation, where newly created device id will be overwritten with
an other requests while check-and-set operation is not atomic.

move pool-to-ds mapping creation/validation into PoolDeviceMap and replace
get + add with getOrCreate.

Ackek-by: Gerd Behrmann
Target: master, 2.13, 2.12, 2.11, 2.10
(cherry picked from commit cecc4c13e14d9165991889028e12637b6f60e357)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>