### PR TITLE
doors: Do not log failure to delete absent files on upload failures:

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -971,6 +971,9 @@ public class Transfer implements Comparable<Transfer>
             setStatus("PnfsManager: Deleting name space entry");
             try {
                 _pnfs.deletePnfsEntry(pnfsId, _path.toString());
+            } catch (FileNotFoundCacheException e) {
+                _log.debug("Failed to delete file after failed upload: " +
+                           _path + " (" + pnfsId + "): " + e.getMessage());
             } catch (CacheException e) {
                 _log.error("Failed to delete file after failed upload: " +
                            _path + " (" + pnfsId + "): " + e.getMessage());


### PR DESCRIPTION
Motivation:

15 Oct 2015 14:16:34 (Xrootd-srm-alice-ipv4) [door:Xrootd-srm-alice-ipv4:AAUiIzoywfA] Failed to delete file after failed upload: /pnfs/ndgf.org/data/alice/T1D0/05/02269/393238a0-6f65-11e5-9717-0b39a10abeef (0000514BCE681C4D4BCEAFEF7B58FD08F5A4): Pnfsid does not correspond to provided file

Modification:

Lowers log level to debug.

Result:

Less noise in the logs.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Femi Adeyemi <olufemi.segun.adeyemi@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8658/
(cherry picked from commit 49fcd3e9542cbc01584f16654cbb6d9a9af399bb)