### PR TITLE
webdav: Respect webdav.static-content.uri property

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -193,7 +193,7 @@
       <property name="transferConfirmationTimeoutUnit" value="${webdav.mover.transfer-confirmation-timeout.unit}"/>
       <property name="internalAddress" value="${webdav.net.internal}"/>
       <property name="templateResource" value="${webdav.templates.html}"/>
-      <property name="staticContentPath" value="${webdav.static-content.location}"/>
+      <property name="staticContentPath" value="${webdav.static-content.uri}"/>
       <property name="redirectOnReadEnabled" value="${webdav.redirect.on-read}"/>
       <property name="redirectOnWriteEnabled" value="${webdav.redirect.on-write}"/>
       <property name="overwriteAllowed" value="${webdav.enable.overwrite}"/>
@@ -217,7 +217,7 @@
         <property name="enableCookieAuth" value="false"/>
         <property name="resourceFactory" ref="resource-factory"/>
         <property name="buffering" value="never"/>
-        <property name="staticContentPath" value="${webdav.static-content.location}"/>
+        <property name="staticContentPath" value="${webdav.static-content.uri}"/>
         <property name="templateResource" value="${webdav.templates.html}"/>
     </bean>
 


### PR DESCRIPTION
Motivation:

The webdav door has separate settings for how to map the static content
directory into the exposed name space and how to generate URIs pointing
to the static content. The implementation however ignored the latter
setting.

Modification:

Use webdav.static-content.uri to define the URI to static content.

Result:

webdav.static-content.uri is respected.

Target: trunk
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8662/
(cherry picked from commit 4fe019bcef92df05b648abaf9351f64ca065e4fc)
(cherry picked from commit ded846db4f54791ed9adcdf465dbda28085d1b36)