### PR TITLE
libx: update to nfs4j-0.10.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,11 +360,6 @@
                 <version>4.0.28.Final</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.grizzly</groupId>
-                <artifactId>grizzly-framework</artifactId>
-                <version>2.3.21</version>
-            </dependency>
-            <dependency>
                 <groupId>com.sleepycat</groupId>
                 <artifactId>je</artifactId>
                 <version>6.3.8</version>
@@ -804,7 +799,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.10.6</version>
+            <version>0.10.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.chimera</groupId>


### PR DESCRIPTION
pulls grizzly-2.3.23 with connection leak fix

bugfix release:
Changelog for nfs4j-0.10.6..nfs4j-0.10.7
    * [4bef995] [maven-release-plugin] prepare for next development iteration
    * [4dd99f7] nfs4: make constructors of OperationXXX public
    * [22e4f45] nfs4: trim result of OperationGETATTR#attrMask2String()
    * [e0fdfea] nfs4: fix error code in readdir
    * [01cbfca] nfs: fix bad cookie
    * [3a768e5] libs: update to oncrpc4j-2.3.5
    * [1aa9f26] [maven-release-plugin] prepare release nfs4j-0.10.7

Target: 2.13
Require-book: no
Require-notes: no