### PR TITLE
voms: Fix resource leak regression

### DIFF
--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -190,6 +190,22 @@
     <constructor-arg ref="auth-persistence-manager"/>
   </bean>
 
+    <bean id="voms-validator" class="org.italiangrid.voms.VOMSValidators"
+          factory-method="newValidator" destroy-method="shutdown">
+        <description>Validator for VOMS attribute certificates</description>
+        <constructor-arg>
+            <bean class="org.italiangrid.voms.store.VOMSTrustStores" factory-method="newTrustStore">
+                <constructor-arg><list><value>${srm.authn.vomsdir}</value></list></constructor-arg>
+            </bean>
+        </constructor-arg>
+        <constructor-arg>
+            <bean class="org.italiangrid.voms.util.CertificateValidatorBuilder" factory-method="buildCertificateValidator"
+                    destroy-method="dispose">
+                <constructor-arg value="${srm.authn.capath}"/>
+            </bean>
+        </constructor-arg>
+    </bean>
+
     <bean id="srm-credential-store"
           class="org.dcache.srm.request.sql.DatabaseRequestCredentialStorage">
         <description>SRM credential store</description>
@@ -247,8 +263,7 @@
                      '${srm.limits.external-copy-script.timeout.unit}')}" />
     <property name="srmHost" value="${srm.net.host}"/>
     <property name="srmHostsAsArray" value="${srm.net.local-hosts}"/>
-    <property name="caCertificatePath" value="${srm.authn.capath}"/>
-    <property name="vomsdir" value="${srm.authn.vomsdir}"/>
+    <property name="vomsValidator" ref="voms-validator"/>
     <property name="sizeOfSingleRemoveBatch"
               value="${srm.limits.remove-batch-size}"/>
     <property name="maxNumberOfLsEntries"
@@ -671,10 +686,8 @@
         class="org.dcache.gridsite.SrmCredentialStore">
       <description>Bridge between GridSite- and SRM- credential storage</description>
 
-      <property name="requestCredentialStorage"
-              ref="srm-credential-store"/>
-      <property name="caCertificatePath" value="${srm.authn.capath}"/>
-      <property name="vomsdir" value="${srm.authn.vomsdir}"/>
+      <property name="requestCredentialStorage" ref="srm-credential-store"/>
+      <property name="vomsValidator" ref="voms-validator"/>
   </bean>
 
   <bean id="gridsite-credential-delegation-factory"
@@ -793,6 +806,8 @@
                                      value-ref="gridsite-credential-delegation-factory"/>
                                           <entry key="#{ T(org.dcache.gridsite.ServletDelegation).ATTRIBUTE_NAME_SERVICE_METADATA }"
                                      value-ref="gridsite-service-metadata"/>
+                                          <entry key="#{ T(org.dcache.gridsite.ServletDelegation).ATTRIBUTE_NAME_VOMS_VALIDATOR }"
+                                     value-ref="voms-validator"/>
                                         </map>
                                     </constructor-arg>
                                 </bean>

--- a/modules/gplazma2-voms/src/main/java/org/dcache/gplazma/plugins/VomsPlugin.java
+++ b/modules/gplazma2-voms/src/main/java/org/dcache/gplazma/plugins/VomsPlugin.java
@@ -34,8 +34,7 @@ public class VomsPlugin implements GPlazmaAuthenticationPlugin {
 
     private static final String CADIR = "gplazma.vomsdir.ca";
     private static final String VOMSDIR = "gplazma.vomsdir.dir";
-    private final VOMSTrustStore vomsTrustStore;
-    private final X509CertChainValidatorExt certChainValidator;
+    private final VOMSACValidator validator;
 
     public VomsPlugin(Properties properties) throws CertificateException,
                     CRLException, IOException {
@@ -45,8 +44,9 @@ public class VomsPlugin implements GPlazmaAuthenticationPlugin {
         checkArgument(caDir != null, "Undefined property: " + VOMSDIR);
         checkArgument(vomsDir != null, "Undefined property: " + CADIR);
 
-        vomsTrustStore = VOMSTrustStores.newTrustStore(asList(vomsDir));
-        certChainValidator = new CertificateValidatorBuilder().trustAnchorsDir(caDir).build();
+        VOMSTrustStore vomsTrustStore = VOMSTrustStores.newTrustStore(asList(vomsDir));
+        X509CertChainValidatorExt certChainValidator = new CertificateValidatorBuilder().trustAnchorsDir(caDir).build();
+        validator = VOMSValidators.newValidator(vomsTrustStore, certChainValidator);
     }
 
     @Override
@@ -54,9 +54,6 @@ public class VomsPlugin implements GPlazmaAuthenticationPlugin {
                     Set<Object> privateCredentials,
                     Set<Principal> identifiedPrincipals)
                     throws AuthenticationException {
-        VOMSACValidator validator
-            = VOMSValidators.newValidator(vomsTrustStore, certChainValidator);
-
         boolean primary = true;
         boolean hasX509 = false;
         boolean hasFQANs = false;

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/InMemoryCredentialStore.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/InMemoryCredentialStore.java
@@ -17,17 +17,12 @@
  */
 package org.dcache.gridsite;
 
-import eu.emi.security.authn.x509.X509CertChainValidatorExt;
 import org.globus.gsi.gssapi.GSSConstants;
 import org.gridforum.jgss.ExtendedGSSCredential;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
 import org.italiangrid.voms.VOMSAttribute;
-import org.italiangrid.voms.VOMSValidators;
 import org.italiangrid.voms.ac.VOMSACValidator;
-import org.italiangrid.voms.store.VOMSTrustStore;
-import org.italiangrid.voms.store.VOMSTrustStores;
-import org.italiangrid.voms.util.CertificateValidatorBuilder;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.security.cert.X509Certificate;
@@ -40,7 +35,6 @@ import java.util.Objects;
 import org.dcache.auth.FQAN;
 import org.dcache.delegation.gridsite2.DelegationException;
 
-import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.dcache.gridsite.Utilities.assertThat;
 
@@ -54,19 +48,12 @@ public class InMemoryCredentialStore implements CredentialStore
 {
     private final Map<DelegationIdentity,GSSCredential> _storage = new HashMap<>();
 
-    private VOMSTrustStore vomsTrustStore;
-    private X509CertChainValidatorExt certChainValidator;
+    private VOMSACValidator validator;
 
     @Required
-    public void setCaCertificatePath(String caDir)
+    public void setVomsValidator(VOMSACValidator validator)
     {
-        certChainValidator = new CertificateValidatorBuilder().trustAnchorsDir(caDir).build();
-    }
-
-    @Required
-    public void setVomsdir(String vomsDir)
-    {
-        vomsTrustStore = VOMSTrustStores.newTrustStore(singletonList(vomsDir));
+        this.validator = validator;
     }
 
     @Override
@@ -180,7 +167,6 @@ public class InMemoryCredentialStore implements CredentialStore
                 FQAN primaryFqan;
                 if (credential instanceof ExtendedGSSCredential) {
                     X509Certificate[] chain = (X509Certificate[]) ((ExtendedGSSCredential) credential).inquireByOid(GSSConstants.X509_CERT_CHAIN);
-                    VOMSACValidator validator = VOMSValidators.newValidator(vomsTrustStore, certChainValidator);
                     primaryFqan = getPrimary(validator.validate(chain));
                 } else {
                     primaryFqan = null;

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/ServletDelegation.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/ServletDelegation.java
@@ -18,11 +18,11 @@
 package org.dcache.gridsite;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.Iterables;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
-
 import org.globus.gsi.bc.BouncyCastleUtil;
+import org.italiangrid.voms.VOMSAttribute;
+import org.italiangrid.voms.ac.VOMSACValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,6 @@ import javax.xml.rpc.holders.StringHolder;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
@@ -40,10 +39,6 @@ import org.dcache.delegation.gridsite2.Delegation;
 import org.dcache.delegation.gridsite2.DelegationException;
 import org.dcache.srm.util.Axis;
 import org.dcache.util.Version;
-
-import org.italiangrid.voms.VOMSValidators;
-import org.italiangrid.voms.ac.VOMSACValidator;
-import org.italiangrid.voms.VOMSAttribute;
 
 import static java.util.Arrays.asList;
 import static org.dcache.gridsite.Utilities.assertThat;
@@ -71,11 +66,20 @@ public class ServletDelegation implements Delegation
             "org.dcache.gridsite.credential-delegation-factory";
     public static final String ATTRIBUTE_NAME_SERVICE_METADATA =
             "org.dcache.gridsite.service-metadata";
+    public static final String ATTRIBUTE_NAME_VOMS_VALIDATOR =
+            "org.dcache.gridsite.voms-validator";
 
     private final Map<String,String> _serviceMetadata = getServiceMetadata();
     private final CredentialDelegationStore _delegations = getDelegationStore();
     private final CredentialDelegationFactory _factory = getFactory();
     private final CredentialStore _credentials = getCredentialStore();
+    private final VOMSACValidator validator = getVomsValidator();
+
+    private static VOMSACValidator getVomsValidator()
+    {
+        return Axis.getAttribute(ATTRIBUTE_NAME_VOMS_VALIDATOR,
+                VOMSACValidator.class);
+    }
 
     private static CredentialStore getCredentialStore()
     {
@@ -221,8 +225,6 @@ public class ServletDelegation implements Delegation
 
     private String getFqanList() throws DelegationException
     {
-        VOMSACValidator validator = VOMSValidators.newValidator();
-
         List<VOMSAttribute> vomsAttrs = validator.validate(getClientCertificates());
         List<String> fqans = new ArrayList<>();
 

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
@@ -17,17 +17,12 @@
  */
 package org.dcache.gridsite;
 
-import eu.emi.security.authn.x509.X509CertChainValidatorExt;
 import org.globus.gsi.gssapi.GSSConstants;
 import org.gridforum.jgss.ExtendedGSSCredential;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
 import org.italiangrid.voms.VOMSAttribute;
-import org.italiangrid.voms.VOMSValidators;
 import org.italiangrid.voms.ac.VOMSACValidator;
-import org.italiangrid.voms.store.VOMSTrustStore;
-import org.italiangrid.voms.store.VOMSTrustStores;
-import org.italiangrid.voms.util.CertificateValidatorBuilder;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.io.IOException;
@@ -43,7 +38,6 @@ import org.dcache.srm.request.RequestCredential;
 import org.dcache.srm.request.RequestCredentialStorage;
 import org.dcache.util.Glob;
 
-import static java.util.Collections.singletonList;
 import static org.dcache.gridsite.Utilities.assertThat;
 
 /**
@@ -53,19 +47,11 @@ import static org.dcache.gridsite.Utilities.assertThat;
 public class SrmCredentialStore implements CredentialStore
 {
     private RequestCredentialStorage _store;
-    private X509CertChainValidatorExt certChainValidator;
-    private VOMSTrustStore vomsTrustStore;
+    private VOMSACValidator validator;
 
-    @Required
-    public void setCaCertificatePath(String caDir)
+    public void setVomsValidator(VOMSACValidator validator)
     {
-        certChainValidator = new CertificateValidatorBuilder().trustAnchorsDir(caDir).build();
-    }
-
-    @Required
-    public void setVomsdir(String vomsDir)
-    {
-        vomsTrustStore = VOMSTrustStores.newTrustStore(singletonList(vomsDir));
+        this.validator = validator;
     }
 
     @Required
@@ -91,7 +77,6 @@ public class SrmCredentialStore implements CredentialStore
             FQAN primaryFqan;
             if (credential instanceof ExtendedGSSCredential) {
                 X509Certificate[] chain = (X509Certificate[]) ((ExtendedGSSCredential) credential).inquireByOid(GSSConstants.X509_CERT_CHAIN);
-                VOMSACValidator validator = VOMSValidators.newValidator(vomsTrustStore, certChainValidator);
                 primaryFqan = getPrimary(validator.validate(chain));
             } else {
                 primaryFqan = null;

--- a/modules/srm-server/src/main/java/org/dcache/srm/server/SRMServerV1.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/server/SRMServerV1.java
@@ -35,8 +35,7 @@ public class SRMServerV1 implements org.dcache.srm.client.axis.ISRM_PortType{
          srmAuth = new SrmAuthorizer(config.getAuthorization(),
                 srm.getRequestCredentialStorage(),
                 config.isClientDNSLookup(),
-                config.getVomsdir(),
-                config.getCaCertificatePath());
+                config.getVomsValidator());
          isClientDNSLookup = config.isClientDNSLookup();
          srmServerCounters = srm.getSrmServerV1Counters();
          srmServerGauges = srm.getSrmServerV1Gauges();

--- a/modules/srm-server/src/main/java/org/dcache/srm/server/SRMServerV2.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/server/SRMServerV2.java
@@ -223,7 +223,7 @@ public class SRMServerV2 implements ISRM  {
         Configuration config = Axis.getConfiguration();
         srmAuth = new SrmAuthorizer(config.getAuthorization(),
                 srm.getRequestCredentialStorage(),
-                config.isClientDNSLookup(), config.getVomsdir(), config.getCaCertificatePath());
+                config.isClientDNSLookup(), config.getVomsValidator());
         srmServerCounters = srm.getSrmServerV2Counters();
         srmServerGauges = srm.getSrmServerV2Gauges();
         pingExtraInfo = buildExtraInfo(config.getPingExtraInfo());

--- a/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
@@ -76,6 +76,7 @@ package org.dcache.srm.util;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import org.italiangrid.voms.ac.VOMSACValidator;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.sql.DataSource;
@@ -211,6 +212,7 @@ public class Configuration {
     private String vomsdir;
 
     private ImmutableMap<String,String> pingExtraInfo = ImmutableMap.of();
+    private VOMSACValidator vomsValidator;
 
     /** Creates a new instance of Configuration */
     public Configuration() {
@@ -1130,24 +1132,14 @@ public class Configuration {
         return databaseParameters.get(name);
     }
 
-    public void setCaCertificatePath(String caCertificatePath)
+    public void setVomsValidator(VOMSACValidator vomsValidator)
     {
-        this.caCertificatePath = caCertificatePath;
+        this.vomsValidator = vomsValidator;
     }
 
-    public String getCaCertificatePath()
+    public VOMSACValidator getVomsValidator()
     {
-        return caCertificatePath;
-    }
-
-    public void setVomsdir(String vomsdir)
-    {
-        this.vomsdir = vomsdir;
-    }
-
-    public String getVomsdir()
-    {
-        return vomsdir;
+        return vomsValidator;
     }
 
     public class DatabaseParameters


### PR DESCRIPTION
Motivation:

The voms validator starts an internal thread to periodically reload
the vomsdir configuration. Because of this thread it is crucial to
reuse the voms trust store as well as to properly shut it down when
not using it anymore. Most certain we should not instantiate the
trust store per connection as we currently do in gsidcap and for
gridsite delegation.

Modification:

Instantiate the VOMS validator once per service. Where possible we
shut it down when the service is shut down (this is not always
possible due to interface limitations).

For grid site delegation this patch also makes it respect the vomsdir
and capath configuration of the srm service.

Result:

Avoid resource leak in gsidcap and srm. Make srm respect capath and
vomsdir configuration.

Target: 2.13
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>
Patch: https://rb.dcache.org/r/8682/