### PR TITLE
srm: Report correct estimated wait time for SRM 2.2 copy requests

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/CopyFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/CopyFileRequest.java
@@ -897,7 +897,7 @@ public final class CopyFileRequest extends FileRequest<CopyRequest> implements D
     {
         TCopyRequestFileStatus copyRequestFileStatus = new TCopyRequestFileStatus();
         copyRequestFileStatus.setFileSize(new UnsignedLong(size));
-        copyRequestFileStatus.setEstimatedWaitTime((int) (getRemainingLifetime() / 1000));
+        copyRequestFileStatus.setEstimatedWaitTime(getContainerRequest().getRetryDeltaTime());
         copyRequestFileStatus.setRemainingFileLifetime((int) (getRemainingLifetime() / 1000));
         org.apache.axis.types.URI sourceSurl;
         org.apache.axis.types.URI destinationSurl;

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
@@ -934,9 +934,11 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
 
     public final SrmCopyResponse getSrmCopyResponse() throws SRMInvalidRequestException
     {
-        ArrayOfTCopyRequestFileStatus arrayOfTCopyRequestFileStatus =
-                new ArrayOfTCopyRequestFileStatus(getArrayOfTCopyRequestFileStatuses());
-        return new SrmCopyResponse(getTReturnStatus(), getTRequestToken(), arrayOfTCopyRequestFileStatus, null);
+        SrmCopyResponse response = new SrmCopyResponse();
+        response.setReturnStatus(getTReturnStatus());
+        response.setRequestToken(getTRequestToken());
+        response.setArrayOfFileStatuses(new ArrayOfTCopyRequestFileStatus(getArrayOfTCopyRequestFileStatuses()));
+        return response;
     }
 
     private String getTRequestToken()
@@ -988,11 +990,8 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
     {
         SrmStatusOfCopyRequestResponse response = new SrmStatusOfCopyRequestResponse();
         response.setReturnStatus(getTReturnStatus());
-        ArrayOfTCopyRequestFileStatus arrayOfTCopyRequestFileStatus =
-            new ArrayOfTCopyRequestFileStatus();
-        arrayOfTCopyRequestFileStatus.setStatusArray(
-            getArrayOfTCopyRequestFileStatuses(fromurls,tourls));
-        response.setArrayOfFileStatuses(arrayOfTCopyRequestFileStatus);
+        TCopyRequestFileStatus[] fileStatuses = getArrayOfTCopyRequestFileStatuses(fromurls, tourls);
+        response.setArrayOfFileStatuses(new ArrayOfTCopyRequestFileStatus(fileStatuses));
         return response;
     }
 


### PR DESCRIPTION
Motivation:

Both SRM v1 and v2 support third party copy operations. These are scheduled
requests in which the client periodically polls the server to learn when the
copy has been completed. The server includes a hint for how long the client is
supposed to wait before polling next time.

When using SRMv2 the calculated value is not returned to the client.  Instead
the server uses the remaining lifetime. This leads to a perceived performance
difference between SRMv1 and SRMv2 because the client polls less frequently.

Modification:

Return the calculated estimated waiting time in the status response.

Harmonize status update calls between copy and other scheduled requests. This
ensures that the first estimated waiting time value return is 4 seconds.

Result:

Poll frequency is the same for both SRM versions.

Target: trunk
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8687/
(cherry picked from commit f95ef8fe985025c24061a8f3cf422db1a4a9a29a)