### PR TITLE
Don't announce cells to other services until they have started

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerHandler.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerHandler.java
@@ -246,11 +246,6 @@ public class LoginBrokerHandler
         rescheduleTask();
     }
 
-    public synchronized String[] getLoginBrokers()
-    {
-        return Arrays.copyOf(_loginBrokers, _loginBrokers.length);
-    }
-
     public synchronized void setProtocolFamily(String protocolFamily)
     {
         _protocolFamily = protocolFamily;
@@ -331,12 +326,14 @@ public class LoginBrokerHandler
         rescheduleTask();
     }
 
-    public synchronized void start()
+    @Override
+    public synchronized void afterStart()
     {
         scheduleTask();
     }
 
-    public synchronized void stop()
+    @Override
+    public synchronized void beforeStop()
     {
         if (_task != null) {
             _task.cancel(false);

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -202,8 +202,6 @@ public class LoginManager
                 _loginBrokerHandler.setUpdateThreshold(_args.getDoubleOption("brokerUpdateOffset"));
                 _loginBrokerHandler.setRoot(Strings.emptyToNull(_args.getOption("root")));
                 _loginBrokerHandler.afterSetup();
-                _loginBrokerHandler.start();
-                _loginBrokerHandler.afterStart();
                 addCommandListener(_loginBrokerHandler);
 
                 if (_maxLogin < 0) {
@@ -236,6 +234,10 @@ public class LoginManager
         }
 
         start();
+
+        if (_loginBrokerHandler != null) {
+            _loginBrokerHandler.afterStart();
+        }
     }
 
     private static Class<?> toAuthClass(String authClassName, String protocol) throws ClassNotFoundException
@@ -515,12 +517,11 @@ public class LoginManager
     public void cleanUp()
     {
         LOGGER.info("cleanUp requested by nucleus, closing listen socket");
-        if (_listenThread != null) {
-            _listenThread.shutdown();
-        }
         if (_loginBrokerHandler != null) {
             _loginBrokerHandler.beforeStop();
-            _loginBrokerHandler.stop();
+        }
+        if (_listenThread != null) {
+            _listenThread.shutdown();
         }
         if (_scheduledExecutor != null) {
             _scheduledExecutor.shutdown();

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -277,6 +277,7 @@ public class NFSv41Door extends AbstractCellComponent implements
                 case V3:
                     NfsServerV3 nfs3 = new NfsServerV3(_exportFile, _vfs);
                     _rpcService.register(new OncRpcProgram(nfs3_prot.NFS_PROGRAM, nfs3_prot.NFS_V3), nfs3);
+                    _loginBrokerHandler.setLoginBrokers(null);
                     break;
                 case V41:
                      final NFSv41DeviceManager _dm = this;
@@ -291,7 +292,6 @@ public class NFSv41Door extends AbstractCellComponent implements
                     _nfs4 = new NFSServerV41(new ProxyIoMdsOpFactory(_proxyIoFactory, new MDSOperationFactory()),
                             _dm, _vfs, _idMapper, _exportFile);
                     _rpcService.register(new OncRpcProgram(nfs4_prot.NFS4_PROGRAM, nfs4_prot.NFS_V4), _nfs4);
-                    _loginBrokerHandler.start();
                     break;
                 default:
                     throw new IllegalArgumentException("Unsupported NFS version: " + version);
@@ -304,7 +304,6 @@ public class NFSv41Door extends AbstractCellComponent implements
     }
 
     public void destroy() throws IOException {
-        _loginBrokerHandler.stop();
         _rpcService.stop();
         if (_nfs4 != null) {
             _nfs4.getStateHandler().shutdown();

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/SrmLoginBrokerHandler.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/SrmLoginBrokerHandler.java
@@ -85,7 +85,6 @@ public class SrmLoginBrokerHandler extends LoginBrokerHandler
         });
     }
 
-    @Override
     public void start()
     {
         try {
@@ -95,8 +94,6 @@ public class SrmLoginBrokerHandler extends LoginBrokerHandler
             _log.error("Failed to create delegation endpoint: {}", e);
             throw Throwables.propagate(e);
         }
-
-        super.start();
     }
 
     @Override

--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -118,9 +118,7 @@
       </constructor-arg>
   </bean>
 
-  <bean id="lb" class="diskCacheV111.srm.dcache.SrmLoginBrokerHandler"
-        init-method="start"
-        destroy-method="stop">
+  <bean id="lb" class="diskCacheV111.srm.dcache.SrmLoginBrokerHandler" init-method="start">
     <description>Registers the door with a LoginBroker</description>
     <property name="executor">
       <bean class="java.util.concurrent.Executors"

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -250,8 +250,7 @@
   </bean>
 
 
-  <bean id="lb" class="dmg.cells.services.login.LoginBrokerHandler"
-	init-method="start" destroy-method="stop">
+  <bean id="lb" class="dmg.cells.services.login.LoginBrokerHandler">
       <description>Registers the door with a LoginBroker</description>
 
       <property name="executor" ref="scheduled-thread-pool"/>

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -169,9 +169,7 @@
     <property name="cellStub" ref="gPlazma-stub" />
   </bean>
 
-  <bean id="lb" class="dmg.cells.services.login.LoginBrokerHandler"
-        init-method="start"
-        destroy-method="stop">
+  <bean id="lb" class="dmg.cells.services.login.LoginBrokerHandler">
     <description>Notifies LoginBroker </description>
     <property name="executor" ref="scheduled-thread-pool"/>
     <property name="updateTime" value="${xrootd.service.loginbroker.update-period}"/>

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -446,11 +446,6 @@ public class PoolV4
     public void init()
     {
         checkState(!_isVolatile || !_hasTapeBackend, "Volatile pool cannot have a tape backend");
-        /*
-         * Do not send alarm.
-         */
-        disablePool(PoolV2Mode.DISABLED_STRICT, 1, "Initializing");
-        _pingThread.start();
     }
 
     @Override
@@ -458,6 +453,8 @@ public class PoolV4
     {
         assertNotRunning("Cannot initialize several times");
         _running = true;
+        disablePool(PoolV2Mode.DISABLED_STRICT, 1, "Awaiting initialization");
+        _pingThread.start();
         new Thread() {
             @Override
             public void run() {


### PR DESCRIPTION
Motivation:

Some cells broadcast their pressence to other services. Specificall pools and
doors do this. Obviously we shouldn't begin doing that until the cell is
actually initialized and ready to interact with other services.

Modification:

Delay the login broker publishing and the pool announcements to pool manager
until the after-start callback. This is called after the cell has completed
initialization and is ready to process messages.

Result:

Elliminates at least one xgetcellinfo ttl timeout observed during NFS door
startup.

Target: 2.11
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8697/