### PR TITLE
pool: Do not announce cell until the cell is running

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -440,17 +440,14 @@ public class PoolV4
     public void init()
     {
         checkState(!_isVolatile || !_hasTapeBackend, "Volatile pool cannot have a tape backend");
-        /*
-         * Do not send alarm.
-         */
-        disablePool(PoolV2Mode.DISABLED_STRICT, 1, "Initializing");
-        _pingThread.start();
     }
 
     @Override
     public void afterStart()
     {
         assertNotRunning("Cannot initialize several times");
+        disablePool(PoolV2Mode.DISABLED_STRICT, 1, "Awaiting initialization");
+        _pingThread.start();
         _running = true;
         new Thread() {
             @Override


### PR DESCRIPTION
Motivation:

We don't want to announce the pool to the world until it is able
to respond to at least basic queries.

Modification:

Delay start of the ping thread until the after start callback. This
is still happening before the repository is initialized.

Result:

Probably minor, but it matches similar changes done in the stable
branches.

Target: trunk
Request: 2.13
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8698/
(cherry picked from commit 68b0dc2ad6f0b874a90003bb492096efc750ced7)