### PR TITLE
pool: Refine Berkeley DB failure handling

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
@@ -2,8 +2,8 @@ package org.dcache.pool.repository.meta.db;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.io.Files;
-import com.sleepycat.je.DatabaseException;
+import com.sleepycat.je.EnvironmentFailureException;
+import com.sleepycat.je.OperationFailureException;
 import com.sleepycat.util.RuntimeExceptionWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,7 +185,7 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
     }
 
     @Override
-    public synchronized FileAttributes getFileAttributes() throws DiskErrorCacheException
+    public synchronized FileAttributes getFileAttributes() throws CacheException
     {
         try {
             FileAttributes attributes = new FileAttributes();
@@ -195,13 +195,18 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
                 StorageInfos.injectInto(storageInfo, attributes);
             }
             return attributes;
-        } catch (DatabaseException e) {
-            throw new DiskErrorCacheException("Meta data lookup failed: " + e.getMessage(), e);
+        } catch (EnvironmentFailureException e) {
+            if (!_repository.isValid()) {
+                throw new DiskErrorCacheException("Meta data lookup failed and a pool restart is required: " + e.getMessage(), e);
+            }
+            throw new CacheException("Meta data lookup failed: " + e.getMessage(), e);
+        } catch (OperationFailureException e) {
+            throw new CacheException("Meta data lookup failed: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public void setFileAttributes(FileAttributes attributes) throws DiskErrorCacheException
+    public void setFileAttributes(FileAttributes attributes) throws CacheException
     {
         try {
             String id = _pnfsId.toString();
@@ -210,8 +215,13 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
             } else {
                 _repository.getStorageInfoMap().remove(id);
             }
-        } catch (DatabaseException e) {
-            throw new DiskErrorCacheException("Meta data update failed: " + e.getMessage(), e);
+        } catch (EnvironmentFailureException e) {
+            if (!_repository.isValid()) {
+                throw new DiskErrorCacheException("Meta data update failed and a pool restart is required: " + e.getMessage(), e);
+            }
+            throw new CacheException("Meta data update failed: " + e.getMessage(), e);
+        } catch (OperationFailureException e) {
+            throw new CacheException("Meta data update failed: " + e.getMessage(), e);
         }
     }
 
@@ -228,7 +238,7 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
     }
 
     @Override
-    public synchronized void setState(EntryState state) throws DiskErrorCacheException
+    public synchronized void setState(EntryState state) throws CacheException
     {
         if (_state != state) {
             _state = state;
@@ -249,7 +259,7 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
     }
 
     @Override
-    public synchronized Collection<StickyRecord> removeExpiredStickyFlags() throws DiskErrorCacheException
+    public synchronized Collection<StickyRecord> removeExpiredStickyFlags() throws CacheException
     {
         long now = System.currentTimeMillis();
         List<StickyRecord> removed = Lists.newArrayList(filter(_sticky, r -> !r.isValidAt(now)));
@@ -297,12 +307,17 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
         return _sticky;
     }
 
-    private synchronized void storeState() throws DiskErrorCacheException
+    private synchronized void storeState() throws CacheException
     {
         try {
             _repository.getStateMap().put(_pnfsId.toString(), new CacheRepositoryEntryState(_state, _sticky));
-        } catch (DatabaseException e) {
-            throw new DiskErrorCacheException("Meta data updated failed: " + e.getMessage(), e);
+        } catch (EnvironmentFailureException e) {
+            if (!_repository.isValid()) {
+                throw new DiskErrorCacheException("Meta data update failed and a pool restart is required: " + e.getMessage(), e);
+            }
+            throw new CacheException("Meta data update failed: " + e.getMessage(), e);
+        } catch (OperationFailureException e) {
+            throw new CacheException("Meta data update failed: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Motivation:

Our users see many lock timeouts in production.

Modification:

Increase the default lock timeout to 60 seconds (up from 500 ms). Since we should not
suffer from deadlocks with our simple database, increasing the lock timeout should be
safe.

Increased the number of lock tables to reduce contention. The JE documentation says
this should be increased from the default when the database is accessed from several
threads.

Refined how we handle DB exceptions. Specifically we only disable the pool if
the exception indicates that the JE environment has become invalid. Thus even
if lock timeouts occur, the pool will survive and will not have to be
restrated.  The JE documentation says that we should automatically retry lock
conflict exceptions, but we do not do this at the present time.

Result:

Hopefully fewer problems with lock timeouts.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Dmitry Litvintsev <litvinse@fnal.gov>
Patch: https://rb.dcache.org/r/8699/
(cherry picked from commit d08db110a2a0e56107b15274065f0e026430ea23)