### PR TITLE
cells: Fix NPE during shutdown

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -632,8 +632,9 @@ public class CellNucleus implements ThreadFactory
      */
     public void  threadGroupList() {
         Thread[] threads = new Thread[_threads.activeCount()];
-        _threads.enumerate(threads);
-        for(Thread thread : threads) {
+        int n = _threads.enumerate(threads);
+        for (int i = 0; i < n; i++) {
+            Thread thread = threads[i];
             LOGGER.warn("Thread: {} [{}{}{}] ({}) {}",
                     thread.getName(),
                     (thread.isAlive() ? "A" : "-"),


### PR DESCRIPTION
Motivation:

There is a race in enumerating the threads during shutdown. This race may
lead to a NPE:

    java.lang.NullPointerException: null
       at dmg.cells.nucleus.CellNucleus.threadGroupList(CellNucleus.java:640) ~[cells-2.13.12.jar:2.13.12]
       at dmg.cells.nucleus.CellGlue.threadGroupList(CellGlue.java:411) [cells-2.13.12.jar:2.13.12]
       at dmg.cells.nucleus.CellNucleus.listThreadGroupOf(CellNucleus.java:628) ~[cells-2.13.12.jar:2.13.12]
       at dmg.cells.nucleus.SystemCell.shutdownCells(SystemCell.java:195) ~[cells-2.13.12.jar:2.13.12]
       at dmg.cells.nucleus.SystemCell.shutdownSystem(SystemCell.java:165) ~[cells-2.13.12.jar:2.13.12]
       at dmg.cells.nucleus.SystemCell.cleanUp(SystemCell.java:209) ~[cells-2.13.12.jar:2.13.12]
       at dmg.cells.nucleus.CellAdapter.prepareRemoval(CellAdapter.java:716) ~[cells-2.13.12.jar:2.13.12]
       at dmg.cells.nucleus.CellNucleus.shutdown(CellNucleus.java:898) ~[cells-2.13.12.jar:2.13.12]
       at dmg.cells.nucleus.CellGlue.lambda$_kill$2(CellGlue.java:483) [cells-2.13.12.jar:2.13.12]
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_65]
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_65]
       at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_65]

Modification:

Take the number of threads that were enumerated into account when iterating
over them.

Result:

No more NPE.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8716/
(cherry picked from commit 6d6676e6e2c9d3e1610376c4db3158e582f0b85c)