### PR TITLE
pom: generate rpm friendly dirty versions number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1061,7 +1061,7 @@
                     <useNativeGit>false</useNativeGit>
                     <gitDescribe>
                         <always>true</always>
-                        <dirty>-dirty-${user.name}</dirty>
+                        <dirty>_dirty_${user.name}</dirty>
                     </gitDescribe>
                 </configuration>
             </plugin>


### PR DESCRIPTION
RPM does not like version like

x.y.z-A-b

especially, that it have to add revision number.

Replave - with _ when we generate versions from a dirty repository
(dcache-2.15.0.42383c6_dirty_tigran-1.noarch.rpm)

Acked-by: Paul Millar
Acked-by: Gerd Behrmann
Target: master, 2.14
Require-book: no
Require-notes: no
(cherry picked from commit c1d2fe151a5cec01330cede62b15d44213702e98)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>