### PR TITLE
srm: Fix NPE when saving requests with an unknown user

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/DcacheUser.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/DcacheUser.java
@@ -108,9 +108,9 @@ public class DcacheUser implements SRMUser
     }
 
     @Override
-    public long getId()
+    public Long getId()
     {
-        return token.getId();
+        return (token == null) ? null : token.getId();
     }
 
     @Override

--- a/modules/srm-server/src/main/java/org/dcache/srm/SRMUser.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRMUser.java
@@ -77,7 +77,7 @@ import org.dcache.srm.request.Request;
 public interface SRMUser
 {
     int getPriority();
-    long getId();
+    Long getId();
     boolean isReadOnly();
 
     /**

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/FileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/FileRequest.java
@@ -306,27 +306,6 @@ public abstract class FileRequest<R extends ContainerRequest> extends Job {
 
     public abstract long extendLifetime(long newLifetime) throws SRMException ;
 
-    /**
-     *
-     * @return
-     */
-     @Override
-     public String getSubmitterId() {
-         try {
-            return Long.toString(getUser().getId());
-         } catch (Exception e) {
-             //
-             // Throwing the exception from this method
-             //  will prevent the change of the status of this request
-             //  to canceled, done or failed.
-             // Therefore we catch the exception and
-             // just report the submitter id as unknown
-             //
-             logger.error(e.toString());
-             return "unknown";
-         }
-     }
-
     @Override
     public JDC applyJdc()
     {

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -508,12 +508,6 @@ public abstract class Job  {
         }
     }
 
-    /** Getter for property creator.
-     * @return Value of property creator.
-     *
-     */
-    public abstract String getSubmitterId();
-
     /** Getter for property priority.
      * @return Value of property priority.
      *

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Request.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Request.java
@@ -323,11 +323,6 @@ public abstract class Request extends Job {
     }
 
     @Override
-    public String getSubmitterId() {
-        return Long.toString(user.getId());
-    }
-
-    @Override
     public void checkExpiration()
     {
         wlock();


### PR DESCRIPTION
Motivation:

Recent changes allow requests to have an anonymous users - these are users
without an id. Such requests are usually only created during upgrade as
the schema change forces us to wipe the user information in the database.

Such requests currently trigger an NPE:

05 Nov 2015 13:32:20 (SRM-bunsen) [] Uncaught exception in thread srm-db-save-3
java.lang.NullPointerException: null
       at diskCacheV111.srm.dcache.DcacheUser.getId(DcacheUser.java:113) ~[dcache-srm-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
       at org.dcache.srm.request.sql.GetRequestStorage.getUpdateStatement(GetRequestStorage.java:123) ~[srm-server-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
       at org.dcache.srm.request.sql.DatabaseJobStorage.updateJob(DatabaseJobStorage.java:218) ~[srm-server-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
       at org.dcache.srm.request.sql.DatabaseJobStorage.lambda$null$2(DatabaseJobStorage.java:292) ~[srm-server-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
       at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:349) ~[spring-jdbc-4.2.2.RELEASE.jar:4.2.2.RELEASE]

Modification:

Allow a null value to be returned. This correspond to what is stored in that
column in the database.

Result:

NPE is gone. Also changed the request authorization in SRM 1 to not rely on the
ID.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.14
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8729/
(cherry picked from commit 675d41637927292a3ab4725ebaee6c8c803aeed1)