### PR TITLE
srm-client: Add initialization of Axis handler in SRM 1 client

### DIFF
--- a/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV1.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV1.java
@@ -225,6 +225,7 @@ public class SRMClientV1 implements diskCacheV111.srm.ISRM {
         SimpleProvider provider = new SimpleProvider();
         GsiHttpClientSender sender = new GsiHttpClientSender();
         sender.setSslContextFactory(CanlContextFactory.createDefault());
+        sender.init();
         provider.deployTransport(HttpClientTransport.DEFAULT_TRANSPORT_NAME, new SimpleTargetedChain(sender));
         org.dcache.srm.client.axis.SRMServerV1Locator sl = new org.dcache.srm.client.axis.SRMServerV1Locator(provider);
         URL url = new URL(service_url);


### PR DESCRIPTION
Motivation:

An NPE is generated when using the v1 client.

Modification:

Initialize the handler invoking the HTTP components client.

Result:

The srm v1 client works.

Target: trunk
Request: 2.14
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de
Patch: https://rb.dcache.org/r/8731/
(cherry picked from commit 702c1dad85ad3e8d5be2358206a7471e9b1a3c60)