### PR TITLE
srm: Use correct logging context when saving jobs

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorage.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 
 import org.dcache.srm.request.Job;
+import org.dcache.srm.util.JDC;
 
 public class AsynchronousSaveJobStorage<J extends Job> implements JobStorage<J>
 {
@@ -86,16 +87,19 @@ public class AsynchronousSaveJobStorage<J extends Job> implements JobStorage<J>
                             @Override
                             public void run()
                             {
-                                UpdateState state = states.put(job.getId(), UpdateState.PROCESSING);
-                                try {
-                                    storage.saveJob(job, state == UpdateState.QUEUED_FORCED);
-                                } catch (DataAccessException e) {
-                                    LOGGER.error("SQL statement failed: {}", e.getMessage());
-                                } catch (Throwable e) {
-                                    Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), e);
-                                } finally {
-                                    if (!states.remove(job.getId(), UpdateState.PROCESSING)) {
-                                        executor.execute(this);
+                                try (JDC ignored = job.applyJdc()) {
+                                    UpdateState state = states.put(job.getId(), UpdateState.PROCESSING);
+                                    try {
+                                        storage.saveJob(job, state == UpdateState.QUEUED_FORCED);
+                                    } catch (DataAccessException e) {
+                                        LOGGER.error("SQL statement failed: {}", e.getMessage());
+                                    } catch (Throwable e) {
+                                        Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(
+                                                Thread.currentThread(), e);
+                                    } finally {
+                                        if (!states.remove(job.getId(), UpdateState.PROCESSING)) {
+                                            executor.execute(this);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Motivation:

Jobs are persistet asynchronously. If we do not reset the logging context, log
messages will be logged with the context of what ever job was saved first and
triggered the thread to be created.

Modification:

Apply the JDC of the job when saving jobs.

Result:

Correct context information when saving jobs fails.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8734/
(cherry picked from commit 802a833e18670b573b380274384f22af5105332f)