### PR TITLE
common-security: Do not log stack traces for CANL notifications

### DIFF
--- a/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
@@ -199,13 +199,21 @@ public class CanlContextFactory implements SslContextFactory
                                                   certificateAuthorityUpdateInterval,
                                                   validatorParams, lazyMode);
             v.addUpdateListener((location, type, level, cause) -> {
-                try (AutoCloseable context = contextSupplier.get()) {
+                try (AutoCloseable ignored = contextSupplier.get()) {
                     switch (level) {
                     case ERROR:
-                        LOGGER.error("Error loading {} from {}: ", type, location, cause);
+                        if (cause != null) {
+                            LOGGER.error("Error loading {} from {}: {}", type, location, cause.getMessage());
+                        } else {
+                            LOGGER.error("Error loading {} from {}.", type, location);
+                        }
                         break;
                     case WARNING:
-                        LOGGER.warn("Problem loading {} from {}: ", type, location, cause);
+                        if (cause != null) {
+                            LOGGER.warn("Problem loading {} from {}: {}", type, location, cause.getMessage());
+                        } else {
+                            LOGGER.warn("Problem loading {} from {}.", type, location);
+                        }
                         break;
                     case NOTIFICATION:
                         LOGGER.info("Reloaded {} from {}: ", type, location);


### PR DESCRIPTION
Motivation:

CANL will notify a listener of any problems loading trust material. These are
not bugs and should not cause a stack trace to be logged.

Modification:

Do not log a stack trace on CANL notifications. Only the exception message
is logged.

Result:

Avoid these errors in the log:

03 Nov 2015 07:35:52 (SRM-bunsen) [] Problem loading OCSP from http://ocsp.cern.ch/ocsp:
org.bouncycastle.ocsp.OCSPException: Response has expired on: Tue Nov 03 06:35:24 CET 2015
        at eu.emi.security.authn.x509.helpers.ocsp.OCSPClientImpl.verifyTimeRange(OCSPClientImpl.java:387) ~[canl-1.3.3.jar:1.3.3]
        at eu.emi.security.authn.x509.helpers.ocsp.OCSPClientImpl.verifyResponse(OCSPClientImpl.java:363) ~[canl-1.3.3.jar:1.3.3]
        at eu.emi.security.authn.x509.helpers.ocsp.OCSPCachingClient.queryForCertificate(OCSPCachingClient.java:108) ~[canl-1.3.3.jar:1.3.3]
        at eu.emi.security.authn.x509.helpers.ocsp.OCSPCachingClient.queryForCertificate(OCSPCachingClient.java:61) ~[canl-1.3.3.jar:1.3.3]
        at eu.emi.security.authn.x509.helpers.ocsp.OCSPVerifier.verify(OCSPVerifier.java:95) ~[canl-1.3.3.jar:1.3.3]

Target: trunk
Request: 2.14
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8735/
(cherry picked from commit 614b64cf5495bf8d2e257c73f55199330678bf9d)