### PR TITLE
srm: Rename count column

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/LsRequestStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/LsRequestStorage.java
@@ -52,7 +52,7 @@ public class LsRequestStorage extends DatabaseContainerRequestStorage<LsRequest,
         "EXPLANATION ,"+
         "LONGFORMAT ,"+
         "NUMOFLEVELS ,"+
-        "COUNT ,"+
+        "CNT ,"+
         "LSOFFSET ) "+
         "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
@@ -98,7 +98,7 @@ public class LsRequestStorage extends DatabaseContainerRequestStorage<LsRequest,
                 " EXPLANATION=?,"+
                 " LONGFORMAT=?,"+
                 " NUMOFLEVELS=?,"+
-                " COUNT=?,"+
+                " CNT=?,"+
                 " LSOFFSET=? "+
                 " WHERE ID=?";
     @Override

--- a/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-2.14.xml
+++ b/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-2.14.xml
@@ -4,7 +4,25 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-    <changeSet id="1" author="behrmann">
+    <changeSet id="0" author="behrmann">
+        <preConditions onFail="MARK_RAN" onFailMessage="Not renaming count column as lsrequests table does not exist (this is not an error)">
+            <tableExists tableName="lsrequests"/>
+        </preConditions>
+
+        <comment>Rename count column as it is an SQL keyword and causes challenges with quoting in liquibase</comment>
+
+        <sql>
+            ALTER TABLE lsrequests RENAME COLUMN "count" TO cnt;
+        </sql>
+
+        <rollback>
+            <sql>
+                ALTER TABLE lsrequests RENAME COLUMN cnt TO "count";
+            </sql>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="1.11" author="behrmann">
         <preConditions onFail="MARK_RAN" onFailMessage="Not creating SRM schema as it already exists (this is not an error)">
             <not><tableExists tableName="srmjobstate"/></not>
         </preConditions>
@@ -478,7 +496,7 @@
             <column name="explanation" type="varchar(32762)"/>
             <column name="longformat" type="integer"/>
             <column name="numoflevels" type="integer"/>
-            <column name="count" type="integer"/>
+            <column name="cnt" type="integer"/> <!-- don't use 'count' as that is an SQL keyword and causes quoting challenges -->
             <column name="lsoffset" type="integer"/>
         </createTable>
 


### PR DESCRIPTION
Motivation:

Since count is a keyword, liquibase quotes the name when creating the table. This
currently breaks HSQLDB support for SRM.

Modification:

Rename the count column to cnt to avoid the problem.

Result:

Works with HSQLDB.

Target: trunk
Request: 2.14
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8732/
(cherry picked from commit e7a899c551eaaab016d53ae3de163ed0921610c9)