### PR TITLE
chimera: Propagate failures to read or write in-db data

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode.java
@@ -298,23 +298,16 @@ public class FsInode {
         return (_stat == null) ? stat() : _stat;
     }
 
-    public int write(long pos, byte[] data, int offset, int len) {
-        int ret = -1;
-        try {
-            ret = _fs.write(this, _level, pos, data, offset, len);
-            _stat = null;
-        } catch (ChimeraFsException e) {
-        }
+    public int write(long pos, byte[] data, int offset, int len) throws ChimeraFsException
+    {
+        int ret = _fs.write(this, _level, pos, data, offset, len);
+        _stat = null;
         return ret;
     }
 
-    public int read(long pos, byte[] data, int offset, int len) {
-        int ret = -1;
-        try {
-            ret = _fs.read(this, _level, pos, data, offset, len);
-        } catch (ChimeraFsException e) {
-        }
-        return ret;
+    public int read(long pos, byte[] data, int offset, int len) throws ChimeraFsException
+    {
+        return _fs.read(this, _level, pos, data, offset, len);
     }
 
     /**

--- a/modules/chimera/src/main/java/org/dcache/chimera/HFile.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/HFile.java
@@ -182,20 +182,20 @@ public class HFile extends File {
         return _inode;
     }
 
-    public int write(byte[] data) {
+    public int write(byte[] data) throws IOException {
         return write(0, data, 0, data.length);
     }
 
-    public int write(long pos, byte[] data, int offset, int len) {
+    public int write(long pos, byte[] data, int offset, int len) throws IOException {
         return _inode.write(pos, data, offset, len);
 
     }
 
-    public int read(byte[] data) {
+    public int read(byte[] data) throws IOException {
         return read(0, data, 0, data.length);
     }
 
-    public int read(long pos, byte[] data, int offset, int len) {
+    public int read(long pos, byte[] data, int offset, int len) throws IOException {
         return _inode.read(pos, data, offset, len);
     }
 

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCacheInfo.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCacheInfo.java
@@ -139,8 +139,8 @@ public class ChimeraCacheInfo implements Serializable {
 		_cacheFlags.commit();
 	}
 
-	public void writeCacheInfo(FsInode inode)
-        {
+	public void writeCacheInfo(FsInode inode) throws ChimeraFsException
+	{
 
 		//
 		// currently we accept 1 and 2 but we only write 2.


### PR DESCRIPTION
Motivation:

Chimera silently ignores failures to read or write file data stored inside
the database. Yet the low-level driver call does throw an exception and
consequently aborts the current transaction. This subsequently leads to
failures like these:

05 Nov 2015 13:40:54 (PnfsManager) [bccs_uib_no_018 PnfsFlag 0000114C14F4DB024A3EB3CDADCFB93E4F7A] Exception in updateFlag
org.springframework.jdbc.UncategorizedSQLException: PreparedStatementCallback; uncategorized SQLException for SQL [SELECT isize,inlink,itype,imode,iuid,igid,iatime,ictime,imtime,icrtime,igeneration,iaccess_latency,iretention_policy FROM t_inodes WHERE ipnfsid=?]; SQL state [25P02]; error code
 [0]; ERROR: current transaction is aborted, commands ignored until end of transaction block; nested exception is org.postgresql.util.PSQLException: ERROR: current transaction is aborted, commands ignored until end of transaction block
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:84) ~[spring-jdbc-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:81) ~[spring-jdbc-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:81) ~[spring-jdbc-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:645) ~[spring-jdbc-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:680) ~[spring-jdbc-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:712) ~[spring-jdbc-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.dcache.chimera.FsSqlDriver.stat(FsSqlDriver.java:281) ~[chimera-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at org.dcache.chimera.JdbcFs.stat(JdbcFs.java:527) ~[chimera-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at sun.reflect.GeneratedMethodAccessor351.invoke(Unknown Source) ~[na:na]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_65]
        at java.lang.reflect.Method.invoke(Method.java:497) ~[na:1.8.0_65]
        at org.dcache.commons.stats.MonitoringProxy.invoke(MonitoringProxy.java:54) ~[dcache-common-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at com.sun.proxy.$Proxy29.stat(Unknown Source) ~[na:na]
        at org.dcache.chimera.FsInode.stat(FsInode.java:286) ~[chimera-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at org.dcache.chimera.FsInode.statCache(FsInode.java:298) ~[chimera-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at org.dcache.chimera.FsInode.exists(FsInode.java:389) ~[chimera-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.getFileAttributes(ChimeraNameSpaceProvider.java:759) ~[dcache-chimera-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.setFileAttributes(ChimeraNameSpaceProvider.java:993) ~[dcache-chimera-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at diskCacheV111.namespace.PnfsManagerV3.updateFlag(PnfsManagerV3.java:878) [dcache-core-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at diskCacheV111.namespace.PnfsManagerV3.updateFlag(PnfsManagerV3.java:853) [dcache-core-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at diskCacheV111.namespace.PnfsManagerV3.processMessageTransactionally_aroundBody24(PnfsManagerV3.java:1542) [dcache-core-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at diskCacheV111.namespace.PnfsManagerV3$AjcClosure25.run(PnfsManagerV3.java:1) [dcache-core-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96cproceed(AbstractTransactionAspect.aj:66) [spring-aspects-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.springframework.transaction.aspectj.AbstractTransactionAspect$AbstractTransactionAspect$1.proceedWithInvocation(AbstractTransactionAspect.aj:72) [spring-aspects-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:281) [spring-tx-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96c(AbstractTransactionAspect.aj:70) [spring-aspects-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at diskCacheV111.namespace.PnfsManagerV3.processMessageTransactionally(PnfsManagerV3.java:1517) [dcache-core-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at diskCacheV111.namespace.PnfsManagerV3.processPnfsMessage(PnfsManagerV3.java:1485) [dcache-core-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at diskCacheV111.namespace.PnfsManagerV3$ProcessThread.run(PnfsManagerV3.java:1408) [dcache-core-2.14.0-SNAPSHOT.jar:2.14.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_65]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_65]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_65]
Caused by: org.postgresql.util.PSQLException: ERROR: current transaction is aborted, commands ignored until end of transaction block
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2182) ~[postgresql-9.4-1203-jdbc42.jar:9.4]
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1911) ~[postgresql-9.4-1203-jdbc42.jar:9.4]
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:173) ~[postgresql-9.4-1203-jdbc42.jar:9.4]
        at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:618) ~[postgresql-9.4-1203-jdbc42.jar:9.4]
        at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:468) ~[postgresql-9.4-1203-jdbc42.jar:9.4]
        at org.postgresql.jdbc2.AbstractJdbc2Statement.executeQuery(AbstractJdbc2Statement.java:353) ~[postgresql-9.4-1203-jdbc42.jar:9.4]
        at com.zaxxer.hikari.proxy.PreparedStatementProxy.executeQuery(PreparedStatementProxy.java:52) ~[HikariCP-2.4.1.jar:na]
        at com.zaxxer.hikari.proxy.HikariPreparedStatementProxy.executeQuery(HikariPreparedStatementProxy.java) ~[HikariCP-2.4.1.jar:na]
        at org.springframework.jdbc.core.JdbcTemplate$1.doInPreparedStatement(JdbcTemplate.java:688) ~[spring-jdbc-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:629) ~[spring-jdbc-4.2.2.RELEASE.jar:4.2.2.RELEASE]
        ... 28 common frames omitted

Modification:

Propagate the exception such that the caller knows it fails and that the transaction is
aborted.

Result:

The above failure should be resolved.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.14
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8736/
(cherry picked from commit cd6df7391446a97e18cef9f7717a47c818e9f0c5)