### PR TITLE
Fix shutdown of bounded executor

### DIFF
--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -181,7 +181,7 @@
         <property name="fsStatTimeUnit" value="${nfs.fs-stat-cache.time.unit}" />
     </bean>
 
-    <bean id="messageThreadPool" class="org.dcache.util.BoundedExecutor"
+    <bean id="messageThreadPool" class="org.dcache.util.BoundedCachedExecutor"
         destroy-method="shutdown">
         <description>Thread pool for message processing</description>
         <constructor-arg value="${nfs.cell.limits.message.threads.max}"/>

--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -107,7 +107,7 @@
   </bean>
 
   <bean id="messageExecutor"
-        class="org.dcache.util.BoundedExecutor"
+        class="org.dcache.util.BoundedCachedExecutor"
         destroy-method="shutdown">
       <description>Thread pool for message processing</description>
       <constructor-arg value="${srm.cell.limits.message.threads.max}"/>

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -71,7 +71,7 @@
         destroy-method="shutdown">
       <description>Thread pool for xrootd request processing</description>
       <constructor-arg>
-          <bean class="org.dcache.util.BoundedExecutor">
+          <bean class="org.dcache.util.BoundedCachedExecutor" destroy-method="shutdown">
               <constructor-arg value="${xrootd.limits.threads}"/>
           </bean>
       </constructor-arg>

--- a/modules/dcache/src/main/java/org/dcache/util/BoundedCachedExecutor.java
+++ b/modules/dcache/src/main/java/org/dcache/util/BoundedCachedExecutor.java
@@ -1,0 +1,67 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2015 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A BoundedExecutor that uses a cached thread pool to source threads.
+ */
+public class BoundedCachedExecutor extends BoundedExecutor
+{
+    private final ExecutorService executor;
+
+    public BoundedCachedExecutor(int maxThreads)
+    {
+        this(Executors.newCachedThreadPool(), maxThreads);
+    }
+
+    public BoundedCachedExecutor(int maxThreads, int maxQueued)
+    {
+        this(Executors.newCachedThreadPool(), maxThreads, maxQueued);
+    }
+
+    protected BoundedCachedExecutor(ExecutorService executor, int maxThreads)
+    {
+        super(executor, maxThreads);
+        this.executor = executor;
+    }
+
+    protected BoundedCachedExecutor(ExecutorService executor, int maxThreads, int maxQueued)
+    {
+        super(executor, maxThreads, maxQueued);
+        this.executor = executor;
+    }
+
+    @Override
+    public void shutdown()
+    {
+        super.shutdown();
+        executor.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow()
+    {
+        List<Runnable> runnables = super.shutdownNow();
+        executor.shutdown();
+        return runnables;
+    }
+}

--- a/modules/dcache/src/main/java/org/dcache/util/BoundedExecutor.java
+++ b/modules/dcache/src/main/java/org/dcache/util/BoundedExecutor.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -46,16 +45,6 @@ public class BoundedExecutor extends AbstractExecutorService
 
     private final Worker worker = new Worker();
     private boolean isShutdown;
-
-    public BoundedExecutor(int maxThreads)
-    {
-        this(Executors.newCachedThreadPool(), maxThreads);
-    }
-
-    public BoundedExecutor(int maxThreads, int maxQueued)
-    {
-        this(Executors.newCachedThreadPool(), maxThreads, maxQueued);
-    }
 
     public BoundedExecutor(Executor executor, int maxThreads)
     {


### PR DESCRIPTION
Motivation:

BoundedExecutor wraps another executor to provide a bound on the number of threads
being used. It does not assume control over the lifecycle of the wrapped executor
as one of the use cases is to have several bounded executors source threads from
the same executor.

Yet for convenience the class provides constructors to create and wrap a cached
thread pool. In that case the wrapped executor is never shut down.

Modification:

Remove the two constructors that create a cached thread pool. Instead a subclass
is created to provide this functionality. The subclass terminates the wrapped
executor on shutdown.

Result:

No hanging thread pool on shutdown.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8738/
(cherry picked from commit 18ab73df2fc2c942c5d2e7aba8c44e27ba04a038)