### PR TITLE
gplazma2: Add lifecycle methods to gplazma plugins

### DIFF
--- a/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
+++ b/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
@@ -111,6 +111,13 @@ public class Gplazma2LoginStrategy
             new GPlazma(configuration, getEnvironmentAsProperties(), _factory);
     }
 
+    public void shutdown()
+    {
+        if (_gplazma != null) {
+            _gplazma.shutdown();
+        }
+    }
+
     static LoginReply
         convertLoginReply(org.dcache.gplazma.LoginReply gPlazmaLoginReply)
     {

--- a/modules/dcache-gplazma/src/main/resources/org/dcache/services/login/gplazma.xml
+++ b/modules/dcache-gplazma/src/main/resources/org/dcache/services/login/gplazma.xml
@@ -51,7 +51,7 @@
     <constructor-arg ref="pnfs-handler"/>
   </bean>
 
-  <bean id="login-strategy" class="org.dcache.auth.Gplazma2LoginStrategy" init-method="init">
+  <bean id="login-strategy" class="org.dcache.auth.Gplazma2LoginStrategy" init-method="init" destroy-method="shutdown">
     <description>Interfaces with gPlazma</description>
     <property name="configurationFile" value="${gplazma.configuration.file}"/>
     <property name="nameSpace" ref="namespace"/>

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/plugins/GPlazmaPlugin.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/plugins/GPlazmaPlugin.java
@@ -1,4 +1,12 @@
 package org.dcache.gplazma.plugins;
 
-public interface GPlazmaPlugin {
+public interface GPlazmaPlugin
+{
+    default void start() throws Exception
+    {
+    }
+
+    default void stop() throws Exception
+    {
+    }
 }

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultAccountStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultAccountStrategy.java
@@ -27,7 +27,7 @@ public class DefaultAccountStrategy implements AccountStrategy
     private volatile PAMStyleStrategy<GPlazmaAccountPlugin> pamStyleAccountStrategy;
 
     @Override
-    public void setPlugins(List<GPlazmaPluginElement<GPlazmaAccountPlugin>> plugins)
+    public void setPlugins(List<GPlazmaPluginService<GPlazmaAccountPlugin>> plugins)
     {
         pamStyleAccountStrategy = new PAMStyleStrategy<>(plugins);
     }
@@ -36,7 +36,7 @@ public class DefaultAccountStrategy implements AccountStrategy
      * Devegates execution of the
      * {@link GPlazmaAccountPlugin#account(SessionID, Set<Principal>) GPlazmaAccountPlugin.account}
      * methods of the plugins supplied by
-     * {@link GPlazmaStrategy#setPlugins(List<GPlazmaPluginElement<T>>) GPlazmaStrategy.setPlugins}
+     * {@link GPlazmaStrategy#setPlugins(List< GPlazmaPluginService <T>>) GPlazmaStrategy.setPlugins}
      *  to
      * {@link  PAMStyleStrategy#callPlugins(PluginCaller<T>) PAMStyleStrategy.callPlugins(PluginCaller<T>)}
      * by providing anonymous implementation of the
@@ -57,7 +57,7 @@ public class DefaultAccountStrategy implements AccountStrategy
         pamStyleAccountStrategy.callPlugins(new PluginCaller<GPlazmaAccountPlugin>()
         {
             @Override
-            public void call(GPlazmaPluginElement<GPlazmaAccountPlugin> pe)
+            public void call(GPlazmaPluginService<GPlazmaAccountPlugin> pe)
                     throws AuthenticationException
             {
                 monitor.accountPluginBegins(pe.getName(), pe.getControl(),

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultAuthenticationStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultAuthenticationStrategy.java
@@ -27,7 +27,7 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy
     private volatile PAMStyleStrategy<GPlazmaAuthenticationPlugin> pamStyleAuthentiationStrategy;
 
     @Override
-    public void setPlugins(List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> plugins)
+    public void setPlugins(List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> plugins)
     {
         pamStyleAuthentiationStrategy = new PAMStyleStrategy<>(plugins);
     }
@@ -36,7 +36,7 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy
      * Devegates execution of the
      * {@link GPlazmaAuthenticationPlugin#authenticate(SessionID, Set<Object>,Set<Object>, Set<Principal>) GPlazmaAuthenticationPlugin.authenticate}
      * methods of the plugins supplied by
-     * {@link GPlazmaStrategy#setPlugins(List<GPlazmaPluginElement<T>>) GPlazmaStrategy.setPlugins}
+     * {@link GPlazmaStrategy#setPlugins(List< GPlazmaPluginService <T>>) GPlazmaStrategy.setPlugins}
      *  to
      * {@link  PAMStyleStrategy#callPlugins(PluginCaller<T>) PAMStyleStrategy.callPlugins(PluginCaller<T>)}
      * by providing anonymous implementation of the
@@ -55,7 +55,7 @@ public class DefaultAuthenticationStrategy implements AuthenticationStrategy
         pamStyleAuthentiationStrategy.callPlugins(new PluginCaller<GPlazmaAuthenticationPlugin>()
         {
             @Override
-            public void call(GPlazmaPluginElement<GPlazmaAuthenticationPlugin> pe)
+            public void call(GPlazmaPluginService<GPlazmaAuthenticationPlugin> pe)
                     throws AuthenticationException
             {
                 monitor.authPluginBegins(pe.getName(), pe.getControl(),

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultIdentityStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultIdentityStrategy.java
@@ -19,11 +19,11 @@ public class DefaultIdentityStrategy implements IdentityStrategy {
     private static final Logger _log =
             LoggerFactory.getLogger(DefaultIdentityStrategy.class);
 
-    private volatile List<GPlazmaPluginElement<GPlazmaIdentityPlugin>> ideStyleStrategies;
+    private volatile List<GPlazmaPluginService<GPlazmaIdentityPlugin>> ideStyleStrategies;
 
     @Override
     public Principal map(Principal principal) throws NoSuchPrincipalException {
-        for(GPlazmaPluginElement<GPlazmaIdentityPlugin> ideStyleStrategy: ideStyleStrategies) {
+        for(GPlazmaPluginService<GPlazmaIdentityPlugin> ideStyleStrategy: ideStyleStrategies) {
             try {
                 return ideStyleStrategy.getPlugin().map(principal);
             } catch(RuntimeException e) {
@@ -37,7 +37,7 @@ public class DefaultIdentityStrategy implements IdentityStrategy {
 
     @Override
     public Set<Principal> reverseMap(Principal principal) throws NoSuchPrincipalException {
-        for(GPlazmaPluginElement<GPlazmaIdentityPlugin> ideStyleStrategy: ideStyleStrategies) {
+        for(GPlazmaPluginService<GPlazmaIdentityPlugin> ideStyleStrategy: ideStyleStrategies) {
             try {
                 return ideStyleStrategy.getPlugin().reverseMap(principal);
             } catch(RuntimeException e) {
@@ -50,7 +50,7 @@ public class DefaultIdentityStrategy implements IdentityStrategy {
     }
 
     @Override
-    public void setPlugins(List<GPlazmaPluginElement<GPlazmaIdentityPlugin>> plugins) {
+    public void setPlugins(List<GPlazmaPluginService<GPlazmaIdentityPlugin>> plugins) {
         ideStyleStrategies = plugins;
     }
 

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultMappingStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultMappingStrategy.java
@@ -27,7 +27,7 @@ public class DefaultMappingStrategy implements MappingStrategy
     private volatile PAMStyleStrategy<GPlazmaMappingPlugin> pamStyleMappingStrategy;
 
     @Override
-    public void setPlugins(List<GPlazmaPluginElement<GPlazmaMappingPlugin>> plugins)
+    public void setPlugins(List<GPlazmaPluginService<GPlazmaMappingPlugin>> plugins)
     {
         pamStyleMappingStrategy = new PAMStyleStrategy<>(plugins);
     }
@@ -36,7 +36,7 @@ public class DefaultMappingStrategy implements MappingStrategy
      * Delegates execution of the
      * {@link GPlazmaMappingPlugin#map(Set<Principal>) GPlazmaMappingPlugin.map}
      * methods of the plugins supplied by
-     * {@link GPlazmaStrategy#setPlugins(List<GPlazmaPluginElement<T>>) GPlazmaStrategy.setPlugins}
+     * {@link GPlazmaStrategy#setPlugins(List< GPlazmaPluginService <T>>) GPlazmaStrategy.setPlugins}
      *  to
      * {@link  PAMStyleStrategy#callPlugins(PluginCaller<T>) PAMStyleStrategy.callPlugins(PluginCaller<T>)}
      * by providing anonymous implementation of the
@@ -56,7 +56,7 @@ public class DefaultMappingStrategy implements MappingStrategy
         pamStyleMappingStrategy.callPlugins( new PluginCaller<GPlazmaMappingPlugin>()
         {
             @Override
-            public void call(GPlazmaPluginElement<GPlazmaMappingPlugin> pe)
+            public void call(GPlazmaPluginService<GPlazmaMappingPlugin> pe)
                     throws AuthenticationException
             {
                 monitor.mapPluginBegins(pe.getName(), pe.getControl(), principals);

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultSessionStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/DefaultSessionStrategy.java
@@ -31,7 +31,7 @@ public class DefaultSessionStrategy implements SessionStrategy
      * @param plugins
      */
     @Override
-    public void setPlugins(List<GPlazmaPluginElement<GPlazmaSessionPlugin>> plugins)
+    public void setPlugins(List<GPlazmaPluginService<GPlazmaSessionPlugin>> plugins)
     {
         pamStyleSessionStrategy = new PAMStyleStrategy<>(plugins);
     }
@@ -40,7 +40,7 @@ public class DefaultSessionStrategy implements SessionStrategy
      * Devegates execution of the
      * {@link GPlazmaSessionPlugin#session(SessionID, Set<Principal>,Set<Object>) GPlazmaSessionPlugin.session}
      * methods of the plugins supplied by
-     * {@link GPlazmaStrategy#setPlugins(List<GPlazmaPluginElement<T>>) GPlazmaStrategy.setPlugins}
+     * {@link GPlazmaStrategy#setPlugins(List< GPlazmaPluginService <T>>) GPlazmaStrategy.setPlugins}
      *  to
      * {@link  PAMStyleStrategy#callPlugins(PluginCaller<T>) PAMStyleStrategy.callPlugins(PluginCaller<T>)}
      * by providing anonymous implementation of the
@@ -62,7 +62,7 @@ public class DefaultSessionStrategy implements SessionStrategy
         pamStyleSessionStrategy.callPlugins( new PluginCaller<GPlazmaSessionPlugin>()
         {
             @Override
-            public void call(GPlazmaPluginElement<GPlazmaSessionPlugin> pe)
+            public void call(GPlazmaPluginService<GPlazmaSessionPlugin> pe)
                     throws AuthenticationException
             {
                 monitor.sessionPluginBegins(pe.getName(), pe.getControl(),

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/GPlazmaStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/GPlazmaStrategy.java
@@ -5,5 +5,5 @@ import java.util.List;
 import org.dcache.gplazma.plugins.GPlazmaPlugin;
 
 public interface GPlazmaStrategy<T extends GPlazmaPlugin> {
-    public void setPlugins(List<GPlazmaPluginElement<T>> plugins);
+    public void setPlugins(List<GPlazmaPluginService<T>> plugins);
 }

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/PAMStyleStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/PAMStyleStrategy.java
@@ -28,20 +28,20 @@ public class PAMStyleStrategy<T extends GPlazmaPlugin>
     private static final Logger logger =
             LoggerFactory.getLogger(PAMStyleStrategy.class);
 
-    public List<GPlazmaPluginElement<T>> pluginElements;
+    public List<GPlazmaPluginService<T>> pluginElements;
 
     /**
      * creates a new instance of the PAMStyleStrategy
      * @param pluginElements
      */
-    public PAMStyleStrategy(List<GPlazmaPluginElement<T>> pluginElements)
+    public PAMStyleStrategy(List<GPlazmaPluginService<T>> pluginElements)
     {
         this.pluginElements = Collections.unmodifiableList(pluginElements);
     }
 
     /**
     * Execute the the
-     * {@link PluginCaller#call(GPlazmaPluginElement)}
+     * {@link PluginCaller#call(GPlazmaPluginService)}
      * methods of the plugins supplied in
      * {@link PAMStyleStrategy(List<T>) constructor}
      *  in the order of the plugin elements in the list.
@@ -87,7 +87,7 @@ public class PAMStyleStrategy<T extends GPlazmaPlugin>
             throws AuthenticationException
     {
         AuthenticationException firstRequiredPluginException=null;
-        for(GPlazmaPluginElement<T> pluginElement: pluginElements) {
+        for(GPlazmaPluginService<T> pluginElement: pluginElements) {
             ConfigurationItemControl control = pluginElement.getControl();
             NDC ndc = NDC.cloneNdc();
 

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/PluginCaller.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/PluginCaller.java
@@ -12,5 +12,5 @@ public interface PluginCaller<T extends GPlazmaPlugin> {
      * @param plugin
      * @throws AuthenticationException
      */
-    public void call(GPlazmaPluginElement<T> plugin) throws AuthenticationException;
+    public void call(GPlazmaPluginService<T> plugin) throws AuthenticationException;
 }

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/AccountStrategyTests.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/AccountStrategyTests.java
@@ -369,41 +369,41 @@ public class AccountStrategyTests
         return new Principal[0];
     }
 
-    private void givenStrategyWithPlugins(GPlazmaPluginElement<GPlazmaAccountPlugin>... plugins)
+    private void givenStrategyWithPlugins(GPlazmaPluginService<GPlazmaAccountPlugin>... plugins)
     {
         _strategy.setPlugins(Arrays.asList(plugins));
     }
 
-    private static GPlazmaPluginElement<GPlazmaAccountPlugin>[] noPlugins()
+    private static GPlazmaPluginService<GPlazmaAccountPlugin>[] noPlugins()
     {
-        return new GPlazmaPluginElement[0];
+        return new GPlazmaPluginService[0];
     }
 
-    private static GPlazmaPluginElement<GPlazmaAccountPlugin> sufficient(
+    private static GPlazmaPluginService<GPlazmaAccountPlugin> sufficient(
             Class<? extends GPlazmaAccountPlugin> type)
     {
         return configuredPlugin(type, ConfigurationItemControl.SUFFICIENT);
     }
 
-    private static GPlazmaPluginElement<GPlazmaAccountPlugin> required(
+    private static GPlazmaPluginService<GPlazmaAccountPlugin> required(
             Class<? extends GPlazmaAccountPlugin> type)
     {
         return configuredPlugin(type, ConfigurationItemControl.REQUIRED);
     }
 
-    private static GPlazmaPluginElement<GPlazmaAccountPlugin> requisite(
+    private static GPlazmaPluginService<GPlazmaAccountPlugin> requisite(
             Class<? extends GPlazmaAccountPlugin> type)
     {
         return configuredPlugin(type, ConfigurationItemControl.REQUISITE);
     }
 
-    private static GPlazmaPluginElement<GPlazmaAccountPlugin> optional(
+    private static GPlazmaPluginService<GPlazmaAccountPlugin> optional(
             Class<? extends GPlazmaAccountPlugin> type)
     {
         return configuredPlugin(type, ConfigurationItemControl.OPTIONAL);
     }
 
-    private static GPlazmaPluginElement<GPlazmaAccountPlugin> configuredPlugin(
+    private static GPlazmaPluginService<GPlazmaAccountPlugin> configuredPlugin(
             Class<? extends GPlazmaAccountPlugin> type,
             ConfigurationItemControl control)
     {
@@ -415,7 +415,7 @@ public class AccountStrategyTests
             throw new RuntimeException(e);
         }
 
-        return new GPlazmaPluginElement<>(plugin,
+        return new GPlazmaPluginService<>(plugin,
                 type.getSimpleName(), control);
     }
 

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/AuthenticationStrategyTests.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/AuthenticationStrategyTests.java
@@ -32,67 +32,67 @@ public class AuthenticationStrategyTests
     private static final LoginMonitor IGNORING_LOGIN_MONITOR =
             new IgnoringLoginMonitor();
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> empltyList =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> empltyList =
             Lists.newArrayList();
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> oneDoNothingPlugins =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> oneDoNothingPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",REQUIRED)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> successRequiredPlugins =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> successRequiredPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",REQUIRED)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",REQUIRED),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> successOptionalPlugins =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> successOptionalPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",OPTIONAL),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",OPTIONAL)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",OPTIONAL),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",OPTIONAL)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> successRequisitePlugins =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> successRequisitePlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",REQUISITE),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",REQUISITE)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",REQUISITE),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",REQUISITE)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> successSufficientPlugins =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> successSufficientPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",SUFFICIENT),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",SUFFICIENT)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new DoNotingStrategy(),"nothing",SUFFICIENT),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",SUFFICIENT)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> failedPlugins =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> failedPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUIRED)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",REQUIRED),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> testOptionalFailingPlugins =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> testOptionalFailingPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",OPTIONAL)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",REQUIRED),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",OPTIONAL)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> testRequesitePlugins1 =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> testRequesitePlugins1 =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUISITE),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUISITE),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> testRequesitePlugins2 =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> testRequesitePlugins2 =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUISITE),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUIRED),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUISITE),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaAuthenticationPlugin>> sufficientPluginFollowedByFailedArray =
+    private List<GPlazmaPluginService<GPlazmaAuthenticationPlugin>> sufficientPluginFollowedByFailedArray =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",SUFFICIENT),
-            new GPlazmaPluginElement<GPlazmaAuthenticationPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new AlwaysAuthenticateStrategy(),"always",SUFFICIENT),
+            new GPlazmaPluginService<GPlazmaAuthenticationPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
         );
 
     @Before

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/MappingStrategyMapTests.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/MappingStrategyMapTests.java
@@ -35,67 +35,67 @@ public class MappingStrategyMapTests
     private static final LoginMonitor IGNORING_LOGIN_MONITOR =
             new IgnoringLoginMonitor();
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> emptyList =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> emptyList =
             Lists.newArrayList();
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> oneDoNothingPlugins =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> oneDoNothingPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",REQUIRED)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> successRequiredPlugins =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> successRequiredPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",REQUIRED)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",REQUIRED),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> successOptionalPlugins =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> successOptionalPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",OPTIONAL),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",OPTIONAL)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",OPTIONAL),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",OPTIONAL)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> successRequisitePlugins =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> successRequisitePlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",REQUISITE),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",REQUISITE)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",REQUISITE),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",REQUISITE)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> successSufficientPlugins =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> successSufficientPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",SUFFICIENT),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",SUFFICIENT)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new DoNotingStrategy(),"nothing",SUFFICIENT),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",SUFFICIENT)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> failedPlugins =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> failedPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUIRED)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",REQUIRED),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> testOptionalFailingPlugins =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> testOptionalFailingPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",OPTIONAL)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",REQUIRED),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",OPTIONAL)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> testRequesitePlugins1 =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> testRequesitePlugins1 =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUISITE),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUISITE),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> testRequesitePlugins2 =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> testRequesitePlugins2 =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUISITE),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUIRED),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUISITE),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaMappingPlugin>> sufficientPluginFollowedByFailedArray =
+    private List<GPlazmaPluginService<GPlazmaMappingPlugin>> sufficientPluginFollowedByFailedArray =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",SUFFICIENT),
-            new GPlazmaPluginElement<GPlazmaMappingPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new AlwaysMapToCompleteSetStrategy(),"always",SUFFICIENT),
+            new GPlazmaPluginService<GPlazmaMappingPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
         );
 
     @Before

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/SessionStrategyTests.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/strategies/SessionStrategyTests.java
@@ -34,67 +34,67 @@ public class SessionStrategyTests
     private static final LoginMonitor IGNORING_LOGIN_MONITOR =
             new IgnoringLoginMonitor();
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> emptyList =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> emptyList =
         Lists.newArrayList();
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> oneDoNothingPlugins =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> oneDoNothingPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",REQUIRED)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> successRequiredPlugins =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> successRequiredPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",REQUIRED)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",REQUIRED),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> successOptionalPlugins =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> successOptionalPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",OPTIONAL),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",OPTIONAL)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",OPTIONAL),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",OPTIONAL)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> successRequisitePlugins =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> successRequisitePlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",REQUISITE),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",REQUISITE)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",REQUISITE),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",REQUISITE)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> successSufficientPlugins =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> successSufficientPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",SUFFICIENT),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",SUFFICIENT)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new DoNotingStrategy(),"nothing",SUFFICIENT),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",SUFFICIENT)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> failedPlugins =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> failedPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUIRED)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",REQUIRED),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> testOptionalFailingPlugins =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> testOptionalFailingPlugins =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",OPTIONAL)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",REQUIRED),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",OPTIONAL)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> testRequesitePlugins1 =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> testRequesitePlugins1 =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUISITE),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUISITE),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> testRequesitePlugins2 =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> testRequesitePlugins2 =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUIRED),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUISITE),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new ThrowTestAuthenticationExceptionStrategy(),"throw-test-auth",REQUIRED),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new ThrowAuthenticationExceptionStrategy(),"throw-auth",REQUISITE),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
         );
 
-    private List<GPlazmaPluginElement<GPlazmaSessionPlugin>> sufficientPluginFollowedByFailedArray =
+    private List<GPlazmaPluginService<GPlazmaSessionPlugin>> sufficientPluginFollowedByFailedArray =
         ImmutableList.of(
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",SUFFICIENT),
-            new GPlazmaPluginElement<GPlazmaSessionPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new AlwaysAssignAttributesStrategy(),"always",SUFFICIENT),
+            new GPlazmaPluginService<GPlazmaSessionPlugin>(new ThrowRuntimeExceptionStrategy(),"throw-run",REQUIRED)
         );
 
     @Before


### PR DESCRIPTION
Motivation:

Plugins often have to load trust store material and start threads
to keep this information up to date. gPlazma did not offer a way
to do a controlled shutdown of such threads.

Modification:

Adds lifecycle methods start and stop to GPlazmaPlugin. These are
default methods with an empty body to avoid breaking third party
plugins.

GPlazma is restructured to wrap each plugin as a Guava Service to
manage the lifecycle. Currently all service start and stop is done
in the foreground thread, but a future patch could facility
concurrent initialization and shutdown.

GPlazma is restructured to separate configuration from a particular
setup of concrete plugins, allowing for a more object oriented
style and allowing more final fields. A future patch could extend
upon this to allow configuration reloading without blocking
gPlazma calls.

The VOMS and XACML plugins make use of the lifecycle calls to
shut down the VOMS library refresh thread.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8739/
(cherry picked from commit 49f654bdce4b087e7c2e5386188d6d444b942fb6)