### PR TITLE
chimera: Null value passed to non-null parameter in org.dcache.chimer…

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/cli/Shell.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/cli/Shell.java
@@ -793,7 +793,7 @@ public class Shell extends ShellApplication
         @Override
         public Serializable call() throws IOException
         {
-            byte[] bytes = data != null
+            byte[] bytes = data == null
                     ? toByteArray(System.in)
                     : newLineTerminated(data).getBytes();
             writeDataIntoFile(bytes);


### PR DESCRIPTION
…a.cli.Shell$WriteCommand.call()

Error in the application of ternary operator "?".

Ticket:
Acked-by: Gerd Behrmann behrmann@gmail.com
Target: trunk
Require-book: no
Require-notes: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Request: 2.9
Request: 2.8
Request: 2.7
Request: 2.6
Patch: https://rb.dcache.org/r/8749/