### PR TITLE
ChimeraCleaner: reallow to be compiled/run on different Java versions

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
@@ -348,7 +348,7 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
                     }
                 }
 
-                poolList.removeAll(_poolsBlackList.keySet());
+                poolList.removeAll(getBlacklistedPoolsList());
             }
 
             if (!poolList.isEmpty()) {
@@ -367,6 +367,9 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
             _log.info("Cleaner was interrupted");
         } catch (RuntimeException e) {
             _log.error("Bug detected" , e);
+        } catch (Throwable e) {
+            _log.error("Unexpected error detected, cleaner will stop, inform developers", e);
+            throw e;
         }
     }
 
@@ -656,7 +659,7 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
 
         StringBuilder sb = new StringBuilder();
 
-        for( String pool : _poolsBlackList.keySet() ) {
+        for( String pool : getBlacklistedPoolsList() ) {
             sb.append(pool).append("\n");
         }
 
@@ -844,6 +847,20 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
     @Override
     public void getInfo( PrintWriter pw ){
         pw.println("ChimeraCleaner $Revision: 1.23 $");
+    }
+
+    /**
+     * Returns list of all currently blacklisted pools.
+     *
+     * We need this method, because Java 8 changed the way keySet()
+     * is implemented by ConcurrentHashMap,
+     *   http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ConcurrentHashMap.html#keySet%28%29
+     *   http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html#keySet--
+     * so we can't rely on the Set() being returned on each version.
+     */
+    private List<String> getBlacklistedPoolsList()
+    {
+        return Collections.list(_poolsBlackList.keys());
     }
 
     //for HSM. delete files from trash-table


### PR DESCRIPTION
Return class of ConcurrentHashMap.keySet() was changed from Set() in
Java <= 7 to ConcurrentHashMap.KeySetView in Java 8,
  http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ConcurrentHashMap.html#keySet%28%29
  https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html#keySet--
and old method signature wasn't preserved.

So, anything compiled with Java 8 will throw an exception with
Java 7 runtime like
{{{
java.lang.NoSuchMethodError: java.util.concurrent.ConcurrentHashMap.keySet()Ljava/util/concurrent/ConcurrentHashMap$KeySetView
;
        at org.dcache.chimera.namespace.ChimeraCleaner.ac_ls_blacklist(ChimeraCleaner.java:651) ~[dcache-chimera-2.10.41.jar:2
.10.41]
}}}

And such exception will terminate the current and subsequent executions
of the run() method, as warranted by
SheduledExecutorService.scheduleWithFixedDelay(),
  https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ScheduledExecutorService.html#scheduleWithFixedDelay%28java.lang.Runnable,%20long,%20long,%20java.util.concurrent.TimeUnit%29

Also, give a meaningful notification on an similar exception:
cleaner will still be stopped, but admins will know the reason
and will be able to inform developers and provide at least stack
trace.

Signed-off-by: Eygene Ryabinkin <rea@grid.kiae.ru>
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>