### PR TITLE
pool: Fix NPE when restoring file

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
@@ -33,6 +33,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
+import diskCacheV111.util.FileNotInCacheException;
 import diskCacheV111.vehicles.StorageInfo;
 
 import dmg.cells.nucleus.CellCommandListener;
@@ -269,9 +270,9 @@ public class HsmSet
 
     /**
      * Returns the name of an HSM accessible for this pool and which
-     * contains the given file. Returns null if no such HSM exists.
+     * contains the given file.
      */
-    public String getInstanceName(FileAttributes fileAttributes)
+    public String getInstanceName(FileAttributes fileAttributes) throws FileNotInCacheException
     {
         StorageInfo file = fileAttributes.getStorageInfo();
         if (file.locations().isEmpty() && _hsm.containsKey(fileAttributes.getHsm())) {
@@ -283,7 +284,7 @@ public class HsmSet
                 return location.getAuthority();
             }
         }
-        return null;
+        throw new FileNotInCacheException("Pool does not have access to any of the HSM locations " + file.locations());
     }
 
     public static final String hh_hsm_create = "<type> [<name> [<provider>]] [-<key>=<value>] ...";

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1276,7 +1276,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
         @Override
         public void failed(Throwable exc, PnfsId pnfsId)
         {
-            reply("Failed to fetch " + pnfsId + ": " + exc);
+            reply("Failed to fetch " + pnfsId + ": " + (exc instanceof CacheException ? exc.getMessage() : exc));
         }
 
         @Override


### PR DESCRIPTION
Motivation:

If a pool receives a request to restore a file from an HSM it does not have access to,
it currently generates a null pointer exception.

Modification:

Change the method to lookup the local HSM of a file to throw an exception rather than
null.

Result:

No more NPE.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Femi Adeymi <olufemi.segun.adeymi@desy.de>
Patch: https://rb.dcache.org/r/8765/
(cherry picked from commit 6e42dced0effd3de30df6cb3ff743b29562b54a8)