### PR TITLE
chimera: Fix cut'n'paste bug in path2inodes stored procedure

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
@@ -275,7 +275,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet author="behrmann" id="6" dbms="postgresql">
+    <changeSet author="behrmann" id="6.1" dbms="postgresql">
         <createProcedure>
             CREATE OR REPLACE FUNCTION
                 path2inodes(root varchar, path varchar, OUT inode t_inodes)
@@ -310,7 +310,7 @@
                     WHEN elements[i] = '.' THEN
                         CONTINUE;
                     WHEN elements[i] = '..' THEN
-                        IF id = '000000000000000000000000000000000000' THEN
+                        IF dir = '000000000000000000000000000000000000' THEN
                             CONTINUE;
                         ELSE
                             SELECT t_inodes.* INTO inode


### PR DESCRIPTION
Motivation:

The id variable is not defined in the stored procedure.

Modification:

Use the correct dir variable.

Result:

Using .. in a path should work.

Target: trunk
Request: 2.14
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8770/
(cherry picked from commit d2fe52f621269d896dc9ab9321ae1ab8fd2f444f)