### PR TITLE
(2.12) alarms: modify logback encoding to show actual alarm type

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryHandler.java
@@ -74,13 +74,16 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.dcache.alarms.AlarmMarkerFactory;
 import org.dcache.alarms.AlarmPriority;
 import org.dcache.alarms.AlarmPriorityMap;
 import org.dcache.alarms.dao.LogEntry;
@@ -97,6 +100,8 @@ import org.dcache.alarms.dao.LogEntryDAO;
 public class LogEntryHandler {
     private static final Logger LOGGER
         = LoggerFactory.getLogger(LogEntryHandler.class);
+
+    private static final String MDC_TYPE = "type";
 
     /**
      * Future runnable worker task.
@@ -122,6 +127,7 @@ public class LogEntryHandler {
                  * service itself.
                  */
                 if (historyEnabled && priority >= historyThreshold.ordinal()) {
+                    setType(event);
                     historyAppender.doAppend(event);
                 }
 
@@ -130,6 +136,7 @@ public class LogEntryHandler {
                  * email.
                  */
                 if (emailEnabled && priority >= emailThreshold.ordinal()) {
+                    setType(event);
                     emailAppender.doAppend(event);
                 }
 
@@ -358,6 +365,19 @@ public class LogEntryHandler {
             return;
         }
         executor.execute(new LogEntryTask(eventObject));
+    }
+
+    private void setType(ILoggingEvent eventObject) {
+        if (eventObject.getMDCPropertyMap().containsKey(MDC_TYPE)) {
+            return;
+        }
+
+        Marker sub = AlarmMarkerFactory.getTypeSubmarker(eventObject.getMarker());
+        Iterator<Marker> it = sub.iterator();
+        if (it.hasNext()) {
+            String type = it.next().getName();
+            eventObject.getMDCPropertyMap().put(MDC_TYPE, type);
+        }
     }
 
     private void startEmailAppender() {

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -171,7 +171,7 @@ alarms.email.buffer-size=1
 
 #  ---- Pattern to use to encode email alert.
 #
-alarms.email.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %marker \\(%X{host}\\)\\(%X{service}\\)\\(%X{domain}\\) %m%n
+alarms.email.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %X{type} \\(%X{host}\\)\\(%X{service}\\)\\(%X{domain}\\) %m%n
 
 #  ---- Level of priority serving as threshold for logging history entry.
 #       All alerts at this level or above are logged to the history file.
@@ -179,7 +179,7 @@ alarms.email.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %marker \\(%X{host}\\)\\(
 
 #  ---- Pattern to use to encode history log entry.
 #
-alarms.history.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %marker \\(%X{host}\\)\\(%X{service}\\)\\(%X{domain}\\) %m%n
+alarms.history.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %X{type} \\(%X{host}\\)\\(%X{service}\\)\\(%X{domain}\\) %m%n
 
 #  ---- Path of history log file
 #


### PR DESCRIPTION
Motivation:

Logback pattern encoding allows for the display of marker names
using either '%marker' or '%markerSimpleName'.  The way Alarms currently
uses markers, however, is to chain the actual value of a sub-marker as
another sub-marker.

The current encoding thus merely displays the marker names, which is
not all that informative (and perhaps even annoying): e.g.,

17 Nov 2015 07:07:17 ALARM [ ALARM_TYPE ] (fndca3a.fnal.gov)(user-command)(<na>) This is a test alarm for OutOfMemory error reporting.

Modification:

Upon arrival of the event at the server, during the preprocessing of
the alarm for either email or the optional history file, the submarker
is accessed and added to the event's MDC property map.  The pattern
encoding is changed to display the new MDC property instead of the marker.

Result:

A more meaningful printout, e.g.,

17 Nov 2015 07:07:17 FATAL_JVM_ERROR (fndca3a.fnal.gov)(user-command)(<na>) This is a test alarm for OutOfMemory error reporting.

Target: master
Require-book: no
Require-notes: yes
Request: 2.14
Request: 2.13
Request: 2.12
Acked-by: Gerd
Patch: https://rb.dcache.org/r/8781/