### PR TITLE
dcache-nfs, dcache: removed unecessary use of non-short-circuit logic

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
@@ -506,10 +506,10 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
             Who who = ace.getWho();
 
             if ((who == Who.EVERYONE)
-                    || (who == Who.OWNER & Subjects.hasUid(subject, owner))
-                    || (who == Who.OWNER_GROUP & Subjects.hasGid(subject, group))
-                    || (who == Who.GROUP & Subjects.hasGid(subject, ace.getWhoID()))
-                    || (who == Who.USER & Subjects.hasUid(subject, ace.getWhoID()))) {
+                    || (who == Who.OWNER && Subjects.hasUid(subject, owner))
+                    || (who == Who.OWNER_GROUP && Subjects.hasGid(subject, group))
+                    || (who == Who.GROUP && Subjects.hasGid(subject, ace.getWhoID()))
+                    || (who == Who.USER && Subjects.hasUid(subject, ace.getWhoID()))) {
 
                 if (ace.getType() == AceType.ACCESS_DENIED_ACE_TYPE) {
                     return Access.DENY;

--- a/modules/dcache/src/main/java/diskCacheV111/admin/LegacyAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/LegacyAdminShell.java
@@ -317,7 +317,7 @@ public class LegacyAdminShell
         } catch (CacheException | InterruptedException e) {
             throw new AclException("Problem: " + e.getMessage());
         }
-        if (r.length < 6 | !(r[5] instanceof Boolean)) {
+        if (r.length < 6 || !(r[5] instanceof Boolean)) {
             throw new AclException("Protocol violation 4456");
         }
 

--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -292,7 +292,7 @@ public class UserAdminShell
         } catch (CacheException | InterruptedException e) {
             throw new AclException("Problem: " + e.getMessage());
         }
-        if (r.length < 6 | !(r[5] instanceof Boolean)) {
+        if (r.length < 6 || !(r[5] instanceof Boolean)) {
             throw new AclException("Protocol violation 4456");
         }
 


### PR DESCRIPTION
This code seems to be using non-short-circuit logic (e.g., & or |) rather than short-circuit logic (&& or ||).

Ticket:
Acked-by: Gerd Behrmann <behrmann@gmail.com>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Target: trunk
Require-book: no
Require-notes: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Patch: https://rb.dcache.org/r/8782/