### PR TITLE
dcache: removed unecessary use of non-short-circuit logic

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -302,7 +302,7 @@ public class UserAdminShell
          } catch (CacheException | InterruptedException e) {
              throw new AclException("Problem: " + e.getMessage());
          }
-         if (r.length < 6 | !(r[5] instanceof Boolean)) {
+         if (r.length < 6 || !(r[5] instanceof Boolean)) {
              throw new AclException("Protocol violation 4456");
          }
 


### PR DESCRIPTION
This code seems to be using non-short-circuit logic (e.g., & or |) rather than short-circuit logic (&& or ||).

Ticket:
Acked-by: Gerd Behrmann behrmann@gmail.com
Acked-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
Target: trunk
Require-book: no
Require-notes: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Patch: https://rb.dcache.org/r/8782/