### PR TITLE
srm-client, dcache: fixed passing incompatible arguments to functions

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/P2PClient.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/P2PClient.java
@@ -120,7 +120,7 @@ public class P2PClient
             /* The original p2p is no longer around, but maybe we can use the redirect
              * for another p2p transfer.
              */
-            String pnfsId = message.getPnfsId();
+            PnfsId pnfsId = new PnfsId(message.getPnfsId());
             for (Companion c : _companions.values()) {
                 if (c.getPnfsId().equals(pnfsId)) {
                     c.messageArrived(message);

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
@@ -411,7 +411,7 @@ public class SRMCopyClientV2 extends SRMClient implements Runnable {
                                     " explanation="+frstatus.getExplanation()
                             );
                             if (!RequestStatusTool.isTransientStateStatus(frstatus)) {
-                                pendingSurlsMap.remove(arrayOfStatuses[i].getSourceSURL().toString());
+                                pendingSurlsMap.remove(arrayOfStatuses[i].getSourceSURL());
                             }
                         }
                     }


### PR DESCRIPTION
1. SRMCopyClientV2 : String was incompatible with expected argument type java.net.URI
2. P2PClient : Call to diskCacheV111.util.PnfsId.equals(String) will always return false

Ticket:
Acked-by: Gerd Behrmann <behrmann@gmail.com>
Acked-by: Paul Millar <paul.millar@desy.de>
Target: trunk
Require-book: no
Require-notes: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Patch: https://rb.dcache.org/r/8789/