### PR TITLE
nfs: set EOF flag when channel indicated EOF

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
@@ -54,17 +54,17 @@ public class EDSOperationREAD extends AbstractNFSv4Operation {
             RepositoryChannel fc = mover.getMoverChannel();
 
             bb.rewind();
-            int bytesReaded = fc.read(bb, offset);
+            int bytesRead = fc.read(bb, offset);
 
             res.status = nfsstat.NFS_OK;
             res.resok4 = new READ4resok();
             res.resok4.data = bb;
 
-            if( offset + bytesReaded == fc.size() ) {
+            if( bytesRead == -1 || offset + bytesRead == fc.size() ) {
                 res.resok4.eof = true;
             }
 
-            _log.debug("MOVER: {}@{} readed, {} requested.", bytesReaded, offset, _args.opread.count.value);
+            _log.debug("MOVER: {}@{} read, {} requested.", bytesRead, offset, _args.opread.count.value);
 
         }catch(ChimeraNFSException he) {
             res.status = he.getStatus();


### PR DESCRIPTION
Motivation:
we set EOF flag in READ reply when

offset + bytesRead == fileSize;

This check is not always correct as if we read behind
EOF, then bytesRead can be e negative number and check
will produce incorrect result.

Modification:
set EOF it channel.read() returns -1.
fixed variable/logging spelling.

Result:
read beyond filesize returns EOF.

Acked-by: Paul Millar
Target: master, 2.14, 2.13
Require-book: no
Require-notes: yes
(cherry picked from commit dfc558204d00d7ee034c46b4d57f3ccf879a07ad)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>