### PR TITLE
system-test: Fix grid-security settings

### DIFF
--- a/packages/system-test/src/main/bin/ctlcluster
+++ b/packages/system-test/src/main/bin/ctlcluster
@@ -97,10 +97,10 @@ case "$1" in
 			dcache.java.memory.heap=256m
 			dcache.java.memory.direct=32m
 			dcache.net.listen=127.0.0.1
-			dcache.paths.grid-security=${system-test.home}/etc/grid-security
-			dcache.paths.plugins=${system-test.home}/plugins
+			dcache.paths.grid-security=\${system-test.home}/etc/grid-security
+			dcache.paths.plugins=\${system-test.home}/plugins
 			pool.plugins.meta=org.dcache.pool.repository.meta.db.BerkeleyDBMetaDataRepository
-			hsqldb.path=${system-test.home}/var/db
+			hsqldb.path=\${system-test.home}/var/db
 			alarms.db.type=xml
 			billing.enable.db=true
 


### PR DESCRIPTION
Motivation:

The ctlcluster command fails to quote a variable, causing installed domains
to fail if they need access to the grid-security directory.

Modification:

Quote the variable.

Result:

ctlcluster switch command works.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8793/
(cherry picked from commit 5222a50d68870ac3eba9f7e98d0b25b811d4a1de)