### PR TITLE
pool: Make context factory non-lazy for remote gsiftp transfers

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteGsiftpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteGsiftpTransferService.java
@@ -157,6 +157,7 @@ public class RemoteGsiftpTransferService extends AbstractMoverProtocolTransferSe
                             .withCrlCheckingMode(crlCheckingMode)
                             .withOcspCheckingMode(ocspCheckingMode)
                             .withNamespaceMode(namespaceMode)
+                            .withLazy(false)
                             .withLoggingContext(new CDC()::restore)
                             .build();
         }


### PR DESCRIPTION
Motivation:

CANL supports lazy and non-lazy trust managers. The lazy one is faster
if only one or few CAs have to be read (as would the case for a client
utility), while the non-lazy one is better suited for a server.

The remote gsiftp transfer service originally did no cache the trust
manager and thus used the lazy one. Subsequently the transfer service
was updated to cache the trust manager, but the lazy mode was not changed.

Modification:

Use a non-lazy trust manager.

Result:

No user visible changes.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.14
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8795/
(cherry picked from commit aeadaa4db96924cdcccd06b6f27e31607540e766)