### PR TITLE
(2.12) pool manager: add pool name to alarm

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
@@ -301,8 +301,8 @@ public class PoolManagerV5
                     sendPoolStatusRelay(name, PoolStatusChangedMessage.DOWN,
                                         null, 666, "DEAD");
                     _logPoolMonitor.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.POOL_DOWN, name),
-                                    "Pool {} declared as DOWN, (no ping in "
-                                    + deathDetectedTimer/1000 +" seconds).");
+                                    "Pool {} declared as DOWN: no ping in "
+                                    + deathDetectedTimer/1000 +" seconds.", name);
                 }
             }
         }


### PR DESCRIPTION
Motivation:

To be useful, a pool down alert ought to carry the name
of the pool :-).

Modification:

Adds the name of the pool to the alarm/logging statement.

Result:

Admins are happy.

Target: 2.12
Requires-book: no
Requires-notes: yes
Acked-by: Dmitry
Acked-by: Paul
Patch: https://rb.dcache.org/r/8800