### PR TITLE
xrootd: Fix logging of Netty exceptions

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -123,7 +123,14 @@ public class XrootdRedirectHandler extends AbstractXrootdRequestHandler
         ChannelPromise promise = ctx.newPromise();
         ctx.executor().execute(() -> {
             try (CDC ignored = cdc.restore()) {
-                super.respond(ctx, response).addListener(new ChannelPromiseNotifier(promise));
+                ctx.writeAndFlush(response)
+                        .addListener(future -> {
+                                         if (!future.isSuccess()) {
+                                             exceptionCaught(ctx, future.cause());
+                                         }
+                                     }
+                        )
+                        .addListener(new ChannelPromiseNotifier(promise));
             }
         });
         return promise;


### PR DESCRIPTION
Motivation:

Since 2.12 the xrootd door will open files on a different thread pool than the
Netty requests are processed on. If the channel is closed before the reply is
generated, the associated pipeline may have been emptied, which means the
exception is not propapagated to the handler implement the door logic. As a
consequence the door logs:

30 Nov 2015 14:26:43 (Xrootd-srm-alice-ipv4) [door:Xrootd-srm-alice-ipv4:AAUlwf36cjA] An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.nio.channels.ClosedChannelException: null

Modification:

This patch delivers the exception directly to our handler rather than through
the channel pipeline.

Result:

The exception is no longer logged.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8826/
(cherry picked from commit b7bbbf3664768700c0a29e6b9de027b17b5bb872)
(cherry picked from commit 1169c85b0771cf23fd9724569bf82b3e4b748002)