### PR TITLE
system-test: Update ctlcluster command to configure CRL settings

### DIFF
--- a/packages/system-test/src/main/bin/ctlcluster
+++ b/packages/system-test/src/main/bin/ctlcluster
@@ -99,6 +99,7 @@ case "$1" in
 			dcache.net.listen=127.0.0.1
 			dcache.paths.grid-security=\${system-test.home}/etc/grid-security
 			dcache.paths.plugins=\${system-test.home}/plugins
+			dcache.authn.crl-mode=IF_VALID
 			pool.plugins.meta=org.dcache.pool.repository.meta.db.BerkeleyDBMetaDataRepository
 			hsqldb.path=\${system-test.home}/var/db
 			alarms.db.type=xml

--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -1,6 +1,5 @@
 system-test.home=${dcache.home}
 
-dcache.authn.crl-mode=IF_VALID
 dcache.broker.scheme=none
 dcache.pid.dir=/tmp
 dcache.java.memory.heap=1024m
@@ -12,6 +11,7 @@ dcache.net.wan.port.min=23000
 dcache.net.wan.port.max=25000
 dcache.paths.grid-security=${system-test.home}/etc/grid-security
 dcache.log.level.events=debug
+dcache.authn.crl-mode=IF_VALID
 dcache.authn.hostcert.refresh=5
 dcache.authn.hostcert.refresh.unit=SECONDS
 dcache.authn.capath.refresh=5


### PR DESCRIPTION
Motivation:

Since 2.14, we need to switch the CRL mode to IF_AVAILABLE for system-test
to make it work with our test CA. The ctlcluster command doesn't do this
when installing other releases in the cluster, causing third party transfers
to fail in such a test.

Modification:

Set the crl mode to IF_VALID.

Result:

No user visible changes.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.14
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8794/
(cherry picked from commit f1a82371e00e7e8d50c3663b1e855f8a38cf268b)