### PR TITLE
xrootd: Upgrade to xrootd4j 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.2.10.v20150310</version.jetty>
         <version.wicket>6.19.0</version.wicket>
-        <version.xrootd4j>2.1.2</version.xrootd4j>
+        <version.xrootd4j>2.1.3</version.xrootd4j>
         <version.jglobus>2.0.6-rc9.d</version.jglobus>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
Changes:

af9ccda xrootd4j: Expose response details in asynchronous response
376fa3d gsi-plugin: throw IOException if private key format is unknown

Target: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8831/