### PR TITLE
xrootd: Upgrade to xrootd4j 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.2.8.v20150217</version.jetty>
         <version.wicket>6.19.0</version.wicket>
-        <version.xrootd4j>2.0.2</version.xrootd4j>
+        <version.xrootd4j>2.1.3</version.xrootd4j>
         <version.jglobus>2.0.6-rc9.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 


### PR DESCRIPTION
Changes:

af9ccda xrootd4j: Expose response details in asynchronous response
376fa3d gsi-plugin: throw IOException if private key format is unknown
698b1c9 xrootd4j: Fix computed length of bucket encoding
46f039e xrootd4j: Remove handshake handler after handshake
f152587 xrootd4j: Implement asynchroneous response messages
8bc07d1 xrootd4j: Refactor response encoding

The reason to upgrade 2.12 to the 2.1 branch is to allow the same plugins to
work in 2.12, 2.13 and 2.14. The difference on the 2.1 branch is the addition
of asynchronous responses. These are not used with 2.12, but a plugin compiled
with them will be loadable in 2.12 too this way.

Target: 2.12
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8832/