### PR TITLE
xrootd: Update alice token plugin to fix IPv6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -635,7 +635,7 @@
             <dependency>
                 <groupId>org.dcache</groupId>
                 <artifactId>xrootd4j-authz-plugin-alice</artifactId>
-                <version>1.0.3</version>
+                <version>1.0.4</version>
                 <exclusions>
                   <exclusion>
                     <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
Changes:

d4e5992 alice-token: Make host name check work on dual stacked machines

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8833/
(cherry picked from commit efee30f2e3123252f0432e79728541a89e4a888f)