### PR TITLE
chimera: Do not ignore DuplicateKeyExceptions

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -806,7 +806,8 @@ class FsSqlDriver {
      */
     void addInodeLocation(FsInode inode, int type, String location) {
         Timestamp now = new Timestamp(System.currentTimeMillis());
-        _jdbc.update("INSERT INTO t_locationinfo VALUES(?,?,?,?,?,?,?)",
+        _jdbc.update("INSERT INTO t_locationinfo (SELECT * FROM (VALUES (?,?,?,?,?,?,?)) v WHERE NOT EXISTS " +
+                     "(SELECT 1 FROM t_locationinfo WHERE ipnfsid=? AND itype=? AND ilocation=?))",
                      ps -> {
                          ps.setString(1, inode.toString());
                          ps.setInt(2, type);
@@ -815,6 +816,9 @@ class FsSqlDriver {
                          ps.setTimestamp(5, now);
                          ps.setTimestamp(6, now);
                          ps.setInt(7, 1); // online
+                         ps.setString(8, inode.toString());
+                         ps.setInt(9, type);
+                         ps.setString(10, location);
                      });
     }
 
@@ -1229,12 +1233,14 @@ class FsSqlDriver {
      * @param storageInfo
      */
     void setStorageInfo(FsInode inode, InodeStorageInformation storageInfo) {
-        _jdbc.update("INSERT INTO t_storageinfo VALUES(?,?,?,?)",
+        _jdbc.update("INSERT INTO t_storageinfo (SELECT * FROM (VALUES (?,?,?,?)) v WHERE NOT EXISTS " +
+                     "(SELECT 1 FROM t_storageinfo WHERE ipnfsid=?))",
                      ps -> {
                          ps.setString(1, inode.toString());
                          ps.setString(2, storageInfo.hsmName());
                          ps.setString(3, storageInfo.storageGroup());
                          ps.setString(4, storageInfo.storageSubGroup());
+                         ps.setString(5, inode.toString());
                      });
     }
 
@@ -1275,11 +1281,13 @@ class FsSqlDriver {
      * @param value
      */
     void setInodeChecksum(FsInode inode, int type, String value) {
-        _jdbc.update("INSERT INTO t_inodes_checksum VALUES(?,?,?)",
+        _jdbc.update("INSERT INTO t_inodes_checksum (SELECT * FROM (VALUES (?,?,?)) v WHERE NOT EXISTS " +
+                     "(SELECT 1 FROM t_inodes_checksum WHERE ipnfsid=?))",
                      ps -> {
                          ps.setString(1, inode.toString());
                          ps.setInt(2, type);
                          ps.setString(3, value);
+                         ps.setString(4, inode.toString());
                      });
     }
 

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -1033,7 +1033,6 @@ public class JdbcFs implements FileSystemProvider {
         inTransaction(status -> {
             try {
                 _sqlDriver.addInodeLocation(inode, type, location);
-            } catch (DuplicateKeyException ignored) {
             } catch (ForeignKeyViolationException e) {
                 throw new FileNotFoundHimeraFsException(e);
             }
@@ -1156,7 +1155,6 @@ public class JdbcFs implements FileSystemProvider {
         inTransaction(status -> {
             try {
                 _sqlDriver.setStorageInfo(inode, storageInfo);
-            } catch (DuplicateKeyException ignored) {
             } catch (ForeignKeyViolationException e) {
                 throw new FileNotFoundHimeraFsException(e);
             }
@@ -1177,7 +1175,6 @@ public class JdbcFs implements FileSystemProvider {
         inTransaction(status -> {
             try {
                 _sqlDriver.setInodeChecksum(inode, type, checksum);
-            } catch (DuplicateKeyException ignored) {
             } catch (ForeignKeyViolationException e) {
                 throw new FileNotFoundHimeraFsException(e);
             }

--- a/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
@@ -24,6 +24,8 @@ import javax.sql.DataSource;
 
 import java.sql.Timestamp;
 
+import org.dcache.chimera.store.InodeStorageInformation;
+
 /**
  * PostgreSQL 9.5 and later specific
  *
@@ -85,5 +87,31 @@ class PgSQL95FsSqlDriver extends PgSQLFsSqlDriver {
                          ps.setTimestamp(6, now);
                          ps.setInt(7, 1); // online
                      });
+    }
+
+    @Override
+    void setStorageInfo(FsInode inode, InodeStorageInformation storageInfo)
+    {
+        _jdbc.update("INSERT INTO t_storageinfo VALUES (?,?,?,?) " +
+                     "ON CONFLICT ON CONSTRAINT t_storageinfo_pkey DO NOTHING",
+                     ps -> {
+                         ps.setString(1, inode.toString());
+                         ps.setString(2, storageInfo.hsmName());
+                         ps.setString(3, storageInfo.storageGroup());
+                         ps.setString(4, storageInfo.storageSubGroup());
+                     });
+    }
+
+    @Override
+    void setInodeChecksum(FsInode inode, int type, String value)
+    {
+        _jdbc.update("INSERT INTO t_inodes_checksum VALUES (?,?,?) " +
+                     "ON CONFLICT ON CONSTRAINT t_inodes_checksum_pkey DO NOTHING",
+                     ps -> {
+                         ps.setString(1, inode.toString());
+                         ps.setInt(2, type);
+                         ps.setString(3, value);
+                     });
+
     }
 }

--- a/modules/chimera/src/main/java/org/dcache/chimera/PgSQLFsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PgSQLFsSqlDriver.java
@@ -261,32 +261,4 @@ class PgSQLFsSqlDriver extends FsSqlDriver {
             throw new DuplicateKeyException("Entry already exists");
         }
     }
-
-    @Override
-    void addInodeLocation(FsInode inode, int type, String location)
-    {
-        int n = _jdbc.update("INSERT INTO t_locationinfo (SELECT ?,?,?,?,?,?,? WHERE NOT EXISTS " +
-                             "(SELECT 1 FROM T_LOCATIONINFO WHERE ipnfsid=? AND itype=? AND ilocation=?))",
-                             ps -> {
-                                 Timestamp now = new Timestamp(System.currentTimeMillis());
-                                 ps.setString(1, inode.toString());
-                                 ps.setInt(2, type);
-                                 ps.setString(3, location);
-                                 ps.setInt(4, 10); // default priority
-                                 ps.setTimestamp(5, now);
-                                 ps.setTimestamp(6, now);
-                                 ps.setInt(7, 1); // online
-                                 ps.setString(8, inode.toString());
-                                 ps.setInt(9, type);
-                                 ps.setString(10, location);
-                             });
-        if (n == 0) {
-            /*
-             * no updates as such entry already exists.
-             * To be compatible with others, throw corresponding
-             * DataAccessException
-             */
-            throw new DuplicateKeyException("Entry already exists");
-        }
-    }
 }


### PR DESCRIPTION
Motivation:

Chimera in several places silently ignores DuplicateKeyException, expecting
these conflicts to be normal behaviour. PostgreSQL however doesn't allow any
further queries once a transaction generates this error, thus some multi-query
operations will fail now that we run them in a single transaction.

Modification:

There are two possible solutions: Use save points at the cost of additional
server round trips, or avoid the duplicate key exceptions. The patch chooses
the latter approach.

Since different databases have different syntax for the required "upsert"
operation, we instead use a pattern already used by the chimera postgresql
driver: insert into x (select * from (values (?,?,?)) v where not exists
(select 1 from x where key=?); the syntax is slightly adjusted from previous
uses to be standard compliant. This is used  in the chimera base SQL driver,
removing the need to ignore duplication errors.

The PostgreSQL 9.5 driver overrides this to use the new 'on conflict' syntax.

Result:

Avoids

02 Dec 2015 03:52:12 (PnfsManager) [door:NFS-dcache-lab007:AAUl5mPoL6A dcache-lab001-A PnfsSetFileAttributes 00008DA7B31B331743A3AB401F958A11F5CF] Exception in setFileAttributes: {}
org.dcache.chimera.IOHimeraFsException: PreparedStatementCallback; uncategorized SQLException for SQL []; SQL state [25P02]; error code [0]; ERROR: current transaction is aborted, commands ignored until end of transaction block; nested exception is org.postgresql.util.PSQLException: ERROR: current transaction is aborted, commands ignored until end of transaction block

Also gets rid of warnings in the postgresql log about duplicate key violations.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8837/
(cherry picked from commit 4f222780f9917f912cc204e356ba7c3b3b5d5583)