### PR TITLE
nfs: ingore file_not_found on close

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
@@ -565,6 +566,10 @@ public class NFSv41Door extends AbstractCellComponent implements
             if(!transfer.waitForMover(500)) {
                 throw new DelayException("Mover not stopped");
             }
+        } catch (FileNotFoundCacheException e){
+            // REVISIT: remove when pool will stop sending this exception
+            _log.info("Failed removed while being open mover: {}@{} : {}",
+                    transfer.getMoverId(), transfer.getPool(), e.getMessage());
         } catch (CacheException | InterruptedException e) {
             _log.info("Failed to kill mover: {}@{} : {}",
                     transfer.getMoverId(), transfer.getPool(), e.getMessage());


### PR DESCRIPTION
Motivation:
When file deleted while was still open, then close will fail with IO error.

Modification:
update nfs door to ignore import FileNotFoundCacheException on close.

Result:
no more
02 Dec 2015 03:42:09 (NFS-dcache-dir-cloud01) [] NFS server fault: op: CLOSE : NFS4ERR_IO : Post-processing failed: No such file or directory: 00006FCCF8FBDA4B445CBD2D83036735DF31

Acked-by: Gerd Behrmann
Target: master, 2.14, 2.13
Require-book: no
Require-notes: no
(cherry picked from commit 84ab36f9574ea76a1e2c5de66a9dd5c032670360)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>