### PR TITLE
chimera: Read AL and RP on directory listing

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -347,7 +347,6 @@ class FsSqlDriver {
     private Stat toStat(ResultSet rs) throws SQLException
     {
         Stat stat = new Stat();
-        int inodeType = rs.getInt("itype");
         stat.setCrTime(rs.getTimestamp("icrtime").getTime());
         stat.setGeneration(rs.getLong("igeneration"));
         int rp = rs.getInt("iretention_policy");
@@ -364,7 +363,7 @@ class FsSqlDriver {
         stat.setMTime(rs.getTimestamp("imtime").getTime());
         stat.setUid(rs.getInt("iuid"));
         stat.setGid(rs.getInt("igid"));
-        stat.setMode(rs.getInt("imode") | inodeType);
+        stat.setMode(rs.getInt("imode") | rs.getInt("itype"));
         stat.setNlink(rs.getInt("inlink"));
         stat.setDev(17);
         stat.setRdev(13);

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -87,8 +87,8 @@ public class JdbcFs implements FileSystemProvider {
      * the number of pnfs levels. Level zero associated with file real
      * content, which is not our regular case.
      */
-    static private final int LEVELS_NUMBER = 7;
-    private final FsInode _rootInode;
+    private static final int LEVELS_NUMBER = 7;
+    private final RootInode _rootInode;
     private final String _wormID;
 
     /**
@@ -168,7 +168,7 @@ public class JdbcFs implements FileSystemProvider {
         // try to get database dialect specific query engine
         _sqlDriver = FsSqlDriver.getDriverInstance(dialect, dataSource);
 
-        _rootInode = new FsInode(this, "000000000000000000000000000000000000");
+        _rootInode = new RootInode(this);
 
         String wormID = null;
         try {
@@ -608,7 +608,7 @@ public class JdbcFs implements FileSystemProvider {
 
     @Override
     public FsInode path2inode(String path) throws ChimeraFsException {
-        return path2inode(path, _rootInode);
+        return path2inode(path, new RootInode(this));
     }
 
     @Override
@@ -623,7 +623,7 @@ public class JdbcFs implements FileSystemProvider {
     @Override
     public List<FsInode> path2inodes(String path) throws ChimeraFsException
     {
-        return path2inodes(path, _rootInode);
+        return path2inodes(path, new RootInode(this));
     }
 
     @Override
@@ -855,7 +855,7 @@ public class JdbcFs implements FileSystemProvider {
 
     @Override
     public String inode2path(FsInode inode) throws ChimeraFsException {
-        return inode2path(inode, _rootInode);
+        return inode2path(inode, new RootInode(this));
     }
 
     /**
@@ -1272,9 +1272,9 @@ public class JdbcFs implements FileSystemProvider {
 
         StringBuilder sb = new StringBuilder();
 
-        sb.append("DB        : ").append(_dbConnectionsPool.toString()).append("\n");
+        sb.append("DB        : ").append(_dbConnectionsPool).append("\n");
         sb.append("DB Engine : ").append(databaseProductName).append(" ").append(databaseProductVersion).append("\n");
-        sb.append("rootID    : ").append(_rootInode.toString()).append("\n");
+        sb.append("rootID    : ").append(_rootInode).append("\n");
         sb.append("wormID    : ").append(_wormID).append("\n");
         sb.append("FsId      : ").append(_fsId).append("\n");
         return sb.toString();
@@ -1571,5 +1571,37 @@ public class JdbcFs implements FileSystemProvider {
     private interface FallibleTransactionCallback<T>
     {
         T doInTransaction(TransactionStatus status) throws ChimeraFsException;
+    }
+
+    private static class RootInode extends FsInode
+    {
+        public RootInode(FileSystemProvider fs)
+        {
+            super(fs, "000000000000000000000000000000000000");
+        }
+
+        @Override
+        public boolean exists() throws ChimeraFsException
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isDirectory()
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isLink()
+        {
+            return false;
+        }
+
+        @Override
+        public FsInode getParent()
+        {
+            return null;
+        }
     }
 }

--- a/modules/chimera/src/main/java/org/dcache/chimera/posix/Stat.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/posix/Stat.java
@@ -375,7 +375,7 @@ public class Stat {
      * @param other to get values from.
      */
     public void update(Stat other) {
-	for (Stat.StatAttributes attr : other.getDefinedAttributeses()) {
+        for (Stat.StatAttributes attr : other.getDefinedAttributeses()) {
 	    switch (attr) {
 		case DEV:
 		    this.setDev(other.getDev());
@@ -384,7 +384,7 @@ public class Stat {
 		    this.setIno(other.getIno());
 		    break;
 		case MODE:
-		    this.setMode(other.getMode());
+		    this.setMode(other.getMode() & UnixPermission.S_PERMS | getMode() & ~UnixPermission.S_PERMS);
 		    break;
 		case NLINK:
 		    this.setNlink(other.getNlink());


### PR DESCRIPTION
Motivation:

In 2.14 we embedded the access latency and retention policy in t_inodes and
thus in the Stat object. We fail to populate the access latency and retention
policy in the Stat object during directory listing.

This oversight is a direct consequence of code duplication in Chimera.

Modification:

Refactor the t_inodes to Stat mapping such that it can be reused between the
code doing listing and the implementation of the stat call.

Result:

Correct access latency and retention policy in directory listings (propably mostly
something WebDAV and SRM care about).

Target: trunk
Request: 2.14
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8844/
(cherry picked from commit fa9a749c47f3fdb22421ebb2f48d927d9c6f15da)