### PR TITLE
chimera: Prevent filling of stat cache of root inode

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -77,8 +77,8 @@ public class JdbcFs implements FileSystemProvider {
      * the number of pnfs levels. Level zero associated with file real
      * content, which is not our regular case.
      */
-    static private final int LEVELS_NUMBER = 7;
-    private final FsInode _rootInode;
+    private static final int LEVELS_NUMBER = 7;
+    private final RootInode _rootInode;
     private final String _wormID;
 
     /**
@@ -154,7 +154,7 @@ public class JdbcFs implements FileSystemProvider {
         // try to get database dialect specific query engine
         _sqlDriver = FsSqlDriver.getDriverInstance(dialect);
 
-        _rootInode = new FsInode(this, "000000000000000000000000000000000000");
+        _rootInode = new RootInode(this);
 
         String wormID = null;
         try {
@@ -896,7 +896,7 @@ public class JdbcFs implements FileSystemProvider {
 
     @Override
     public FsInode path2inode(String path) throws ChimeraFsException {
-        return path2inode(path, _rootInode);
+        return path2inode(path, new RootInode(this));
     }
 
     @Override
@@ -934,7 +934,7 @@ public class JdbcFs implements FileSystemProvider {
     @Override
     public List<FsInode> path2inodes(String path) throws ChimeraFsException
     {
-        return path2inodes(path, _rootInode);
+        return path2inodes(path, new RootInode(this));
     }
 
     @Override
@@ -1204,7 +1204,7 @@ public class JdbcFs implements FileSystemProvider {
 
     @Override
     public String inode2path(FsInode inode) throws ChimeraFsException {
-        return inode2path(inode, _rootInode, true);
+        return inode2path(inode, new RootInode(this), true);
     }
 
     /**
@@ -2767,9 +2767,9 @@ public class JdbcFs implements FileSystemProvider {
 
         StringBuilder sb = new StringBuilder();
 
-        sb.append("DB        : ").append(_dbConnectionsPool.toString()).append("\n");
+        sb.append("DB        : ").append(_dbConnectionsPool).append("\n");
         sb.append("DB Engine : ").append(databaseProductName).append(" ").append(databaseProductVersion).append("\n");
-        sb.append("rootID    : ").append(_rootInode.toString()).append("\n");
+        sb.append("rootID    : ").append(_rootInode).append("\n");
         sb.append("wormID    : ").append(_wormID).append("\n");
         sb.append("FsId      : ").append(_fsId).append("\n");
         return sb.toString();
@@ -3063,5 +3063,37 @@ public class JdbcFs implements FileSystemProvider {
     @Override
     public void unpin(String pnfsid) throws ChimeraFsException {
        throw new ChimeraFsException(NOT_IMPL);
+    }
+
+    private static class RootInode extends FsInode
+    {
+        public RootInode(FileSystemProvider fs)
+        {
+            super(fs, "000000000000000000000000000000000000");
+        }
+
+        @Override
+        public boolean exists() throws ChimeraFsException
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isDirectory()
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isLink()
+        {
+            return false;
+        }
+
+        @Override
+        public FsInode getParent()
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Motivation:

The Chimera FsInode object can cache stat content of a t_inodes row. Such information
may be invalidated by concurrent operations, but since FsInode instances are usually
short-lived often local to a single transaction, this isn't normally a problem.

There is however one FsInode instance that has a longer life time: The one representing
the file system root allocated in the JdbcFs class. Currently this instance may
cache the stat information indefinitely and updates on the root inode (even if rare)
would not be visible until the next restart.

Modification:

Copy the root FsInode in any operation that may return it to the caller of JdbcFs or
which may access the stat information and thus trigger the population of the cache.

Introduce a subclass of FsInode specifically for the root inode: Some properties we
know even without accessing the t_inodes table, such as that it is a directory and
that it exists.

Result:

Correct information about the root directory, but unfortunately at the price of
an increase in stat calls.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8849/
(cherry picked from commit 2f11d0163550e451fc04711446f8ce7575166ea4)
(cherry picked from commit 8e3361ed514b14736ab5dd08c14e7f6e3334b535)