### PR TITLE
transfers: fail request if pool/space manager reject request

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -1195,6 +1195,9 @@ public class Transfer implements Comparable<Transfer>
                             case CacheException.NO_POOL_ONLINE:
                                 _log.warn(t.getMessage());
                                 break;
+                            case CacheException.PERMISSION_DENIED:
+                                _log.info("request rejected due to permission settings: {}", t.getMessage());
+                                return immediateFailedFuture(t);
                             default:
                                 _log.error(t.getMessage());
                                 break;


### PR DESCRIPTION
Motivation:
In case of stage protection of unavailability of space reservation,
PERMISSION_DENIED error will be returned. Nevertheless transfer class
will retry request until timeout is reached.

Modification:
Transfer class fail on PERMISSION_DENIED as this is not a transient error.

Result:
requests fail right away without reaching the timeout

Acked-by: Paul Millar
Target: master, 2.14, 2.13
Require-book: no
Require-notes: yes
(cherry picked from commit 668cde7eaff41b906b81e1d7cfed1a796eda19b1)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>