### PR TITLE
chimera: fix regressin introduced by fa9a749c4

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -220,6 +220,7 @@ class FsSqlDriver {
                             Stat stat = toStat(rs);
                             FsInode inode = new FsInode(dir.getFs(), rs.getString("ipnfsid"), FsInodeType.INODE, 0, stat);
                             inode.setParent(dir);
+                            stat.setIno((int)inode.id());
                             return new HimeraDirectoryEntry(rs.getString("iname"), inode, stat);
                         } catch (SQLException e) {
                             _log.error("failed to fetch next entry: {}", e.getMessage());


### PR DESCRIPTION
Motivation:
the file's ino field is not initialized and produced stacktrace:

java.lang.IllegalStateException: Attribute is not defined: INO
	at org.dcache.chimera.posix.Stat.guard(Stat.java:353) ~[chimera-2.15.0-SNAPSHOT.jar:2.15.0-SNAPSHOT]
	at org.dcache.chimera.posix.Stat.getIno(Stat.java:103) ~[chimera-2.15.0-SNAPSHOT.jar:2.15.0-SNAPSHOT]
	at org.dcache.chimera.nfsv41.door.ChimeraVfs.fromChimeraStat(ChimeraVfs.java:316) ~[dcache-nfs-2.15.0-SNAPSHOT.jar:2.15.0-SNAPSHOT]
	at org.dcache.chimera.nfsv41.door.ChimeraVfs.access$200(ChimeraVfs.java:70) ~[dcache-nfs-2.15.0-SNAPSHOT.jar:2.15.0-SNAPSHOT]
	at org.dcache.chimera.nfsv41.door.ChimeraVfs$ChimeraDirectoryEntryToVfs.apply(ChimeraVfs.java:412) ~[dcache-nfs-2.15.0-SNAPSHOT.jar:2.15.0-SNAPSHOT]
	at org.dcache.chimera.nfsv41.door.ChimeraVfs$ChimeraDirectoryEntryToVfs.apply(ChimeraVfs.java:408) ~[dcache-nfs-2.15.0-SNAPSHOT.jar:2.15.0-SNAPSHOT]
	at com.google.common.collect.Lists$TransformingRandomAccessList.get(Lists.java:608) ~[guava-18.0.jar:na]
	at com.google.common.collect.Lists$TransformingRandomAccessList.get(Lists.java:608) ~[guava-18.0.jar:na]
	at org.dcache.nfs.v4.OperationREADDIR.process(OperationREADDIR.java:220) ~[nfs4j-core-0.11.2.jar:0.11.2]
	at org.dcache.nfs.v4.NFSServerV41.NFSPROC4_COMPOUND_4(NFSServerV41.java:152) ~[nfs4j-core-0.11.2.jar:0.11.2]
	at org.dcache.nfs.v4.xdr.nfs4_prot_NFS4_PROGRAM_ServerStub.dispatchOncRpcCall(nfs4_prot_NFS4_PROGRAM_ServerStub.java:48) [nfs4j-core-0.11.2.jar:0.11.2]
	at org.dcache.xdr.RpcDispatcher$1.run(RpcDispatcher.java:82) [oncrpc4j-core-2.4.2.jar:na]
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:591) [grizzly-framework-2.3.23.jar:2.3.23]
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:571) [grizzly-framework-2.3.23.jar:2.3.23]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_31]

Modification:
Add missing field

Result:
it's possible to do list directory over NFS

Acked-by: Gerd Behrmann
Acked-by: Paul Millar
Acked-by: Dmitry Litvintsev
Target: master, 2.14
Require-book: no
Require-notes: no
(cherry picked from commit 11f6b0efd0dbeedf77b0a26d77740a737be905d6)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>