### PR TITLE
nfs-proxy: keep track of written bytes

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapChannelImpl.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/DcapChannelImpl.java
@@ -31,7 +31,7 @@ public class DcapChannelImpl implements ProxyIoAdapter {
     private static final int SEEK_SET = 0;
 
     private final SocketChannel _channel;
-    private final long _size;
+    private long _size;
     private final int _sessionId;
 
     public DcapChannelImpl(InetSocketAddress addr, int session, byte[] challange, long size) throws IOException {
@@ -72,11 +72,15 @@ public class DcapChannelImpl implements ProxyIoAdapter {
 
         writeFully(_channel, command);
         getAck();
-        return sendData(src);
+        int n = sendData(src);
+        if (n > 0 && (position + n > _size)) {
+            _size = position + n;
+        }
+        return n;
     }
 
     @Override
-    public long size() {
+    public synchronized long size() {
         return _size;
     }
 


### PR DESCRIPTION
Motivation:
when dcap based proxy io adapter created, it initialized with size == 0.
If the same adapter used for read, the we fail to detect EOF as expected
size never updated.

Modification:
DcapChannelImpl updated to keep in sync expected file size.

Result:
read after write detect EOF.

Acked-by: 
Target: master
Require-book: no
Require-notes: no