### PR TITLE
ftp,dcap: Fix LoginBrokerRequestTopic subscription

### DIFF
--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -62,7 +62,7 @@ create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
              -listen=${dcap.net.listen} \
              -export=${dcap.cell.export} \
              -lookupPool=${dcap.cell.name.dir} \
-             -subscribe=${dcap.cell.subscribe} \
+             -subscribe=${dcap.cell.subscribe} \
              -acceptErrorWait=60000 \
              -keepAlive=300 \
              -poolRetry=2700 \

--- a/skel/share/services/ftp.batch
+++ b/skel/share/services/ftp.batch
@@ -60,7 +60,7 @@ create dmg.cells.services.login.LoginManager ${ftp.cell.name} \
    -listen=${ftp.net.listen} \
    -prot=raw \
    -export=${ftp.cell.export} \
-   -subscribe=${ftp.cell.subscribe} \
+   -subscribe=${ftp.cell.subscribe} \
    -root=\"${ftp.root}\" \
    -upload=\"${ftp.authz.upload-directory}\" \
    -clientDataPortRange=${ftp.net.port-range} \


### PR DESCRIPTION
Motivation:

Doors subsribe to the LoginBrokerRequestTopic, but the dcap.batch and ftp.batch
files contain a non-whitespace space following the topic name, causing these
doors to subscribe to the wrong topic.

Modification:

Replace the space.

Result:

Faster discovery of FTP and DCAP doors after a dCache restart. Possibly also
solves the following routing error:

 09 Dec 2015 10:23:11 (SRM-bombay) [*] Failed to deliver LoginBrokerInfoRequest message <1449649391771:176> to [>LoginBrokerRequestTopic@local]: Route for >*@srm-bombayDomain< not found at >dCacheDomain<

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8857/
(cherry picked from commit aecc399583e67e6675319e67be8c75047c1105ef)