### PR TITLE
gplazma: Make GlobusPrincipal compatibly with JGlobus

### DIFF
--- a/modules/common/src/main/java/org/globus/gsi/gssapi/jaas/GlobusPrincipal.java
+++ b/modules/common/src/main/java/org/globus/gsi/gssapi/jaas/GlobusPrincipal.java
@@ -14,10 +14,6 @@
  */
 package org.globus.gsi.gssapi.jaas;
 
-import eu.emi.security.authn.x509.impl.OpensslNameUtils;
-
-import javax.security.auth.x500.X500Principal;
-
 /**
  * A Globus DN principal. The Globus DN is in the form: "/CN=foo/O=bar".
  */
@@ -25,11 +21,6 @@ public class GlobusPrincipal
         extends SimplePrincipal
 {
     private static final long serialVersionUID = 302803142179565960L;
-
-    public GlobusPrincipal(X500Principal principal)
-    {
-        this(OpensslNameUtils.convertFromRfc2253(principal.getName(), true));
-    }
 
     public GlobusPrincipal(String globusDn)
     {

--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
@@ -1,5 +1,6 @@
 package org.dcache.gplazma.plugins;
 
+import eu.emi.security.authn.x509.impl.OpensslNameUtils;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DEREncodable;
@@ -31,7 +32,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static eu.emi.security.authn.x509.helpers.CertificateHelpers.getExtensionBytes;
 import static org.dcache.auth.EntityDefinition.*;
 import static org.dcache.auth.LoA.*;
-import static org.dcache.gplazma.util.CertPaths.*;
+import static org.dcache.gplazma.util.CertPaths.isX509CertPath;
 import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
 
 /**
@@ -75,7 +76,8 @@ public class X509Plugin implements GPlazmaAuthenticationPlugin
                 if (eec == null) {
                     message = "X.509 chain contains no End-Entity Certificate";
                 } else {
-                    identifiedPrincipals.add(new GlobusPrincipal(eec.getSubjectX500Principal()));
+                    identifiedPrincipals.add(new GlobusPrincipal(
+                            OpensslNameUtils.convertFromRfc2253(eec.getSubjectX500Principal().getName(), true)));
 
                     if (isPolicyPrincipalsEnabled) {
                         listPolicies(eec).stream().


### PR DESCRIPTION
Motivation:

In anticipation of removing JGlobus we copied the GlobusPrincipal to the dCache
code. It was subsequently extended with an additional contructor. Later we
reintroduced JGlobus, causing there to be two versions of this class on the
classpath - one with the extra constructor and one without. Depending on load
order, the x509 plugin could fail with a NoSuchMethodError.

Modification:

Inline the constructor. The class is still duplicated in anticipation of
removing JGlobus.

Result:

Fixes http://rt.dcache.org/Ticket/Display.html?id=8859

Ticket: http://rt.dcache.org/Ticket/Display.html?id=8859
Require-notes: yes
Require-book: no
Target: trunk
Request: 2.14
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8863/
(cherry picked from commit 7ec11fde269034374d59f76c13499a3b0a2f5b06)