### PR TITLE
srm: Map obsolete states in request history tables

### DIFF
--- a/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-2.14.xml
+++ b/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-2.14.xml
@@ -1141,4 +1141,41 @@
             <column name="requestid"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="13" author="behrmann">
+        <comment>Drop states 1,4,5, and 13 in request history</comment>
+
+        <sql>
+            UPDATE bringonlinerequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE bringonlinerequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+            UPDATE bringonlinefilerequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE bringonlinefilerequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+
+            UPDATE copyrequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE copyrequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+            UPDATE copyfilerequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE copyfilerequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+
+            UPDATE getrequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE getrequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+            UPDATE getfilerequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE getfilerequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+
+            UPDATE lsrequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE lsrequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+            UPDATE lsfilerequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE lsfilerequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+
+            UPDATE putrequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE putrequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+            UPDATE putfilerequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE putfilerequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+
+            UPDATE reservespacerequestshistory SET stateid=2 WHERE stateid=4;
+            UPDATE reservespacerequestshistory SET stateid=3 WHERE stateid IN (1,5,13);
+        </sql>
+
+        <rollback/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Motivation:

Several state IDs are obsolete and can no longer be represented in the SRM.
We got a changeset to remap these states in the SRM db request tables, but
we failed to do the same for the history tables.

Modification:

Adds liquibase change set to map the obsolete states to current states.

Result:

The history tables are updated upon upgrade. Allows the SRM to start.

Target: trunk
Request: 2.14
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8868/
(cherry picked from commit 1fe0c4a497a2277cdc43519e64334269ef0fdf32)