### PR TITLE
srm: Allow transition from InProgress to Queued

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -320,6 +320,7 @@ public abstract class Job  {
         case INPROGRESS:
             return newState == State.CANCELED
                     || newState == State.FAILED
+                    || newState == State.QUEUED
                     || newState == State.RQUEUED
                     || newState == State.READY
                     || newState == State.DONE;


### PR DESCRIPTION
Motivation:

With the simplification of scheduler states, we ended up disallowing
transitioning from InProgress to Queued. This transition is used
when restarting requests after an SRM restart.

Modification:

Allow the transition.

Result:

Avoids this error upon restart:

14 Dec 2015 12:33:48 (SRM) [] Failed to restore job: Illegal state transition from InProgress to Queued

Target: trunk
Request: 2.14
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8869/
(cherry picked from commit 050f8fbc8a63428c6952b476c22835f81b83b64f)