### PR TITLE
cells: Fix route propagation trigger on non-default topologies

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/RoutingManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/RoutingManager.java
@@ -242,7 +242,7 @@ public class RoutingManager
                         .filter(p -> !p.contains(_domainAddress))    // Avoid routing loops
                         .collect(toSet());                           // No duplicate routes
 
-        boolean changed = false;
+        boolean changed = !_domainHash.containsKey(domain);
         if (oldPaths == null) {
             _log.info("Adding domain {}", domain);
             for (CellPath path : newPaths) {


### PR DESCRIPTION
Motivation:

For topologies where the distiance to dCacheDomain is bigger than 1, the
intermediate domain or domains are responsible for propagating route
information. However, if the downstream domain doesn't have downstream routes
itself and also doesn't have wellknown cells, the intermediate domain failed to
recognize the addition of the downstream domain as a change and consequently
failed to propagate the new route upstream.

Modification:

Recognize the addition of a new downstream domain as a change no matter whether
it advertizes any routes.

Result:

Routing in non-default topologies fixed.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
(cherry picked from commit 5d1a04396e00be96d5ea3064b01d032cc35c5311)