### PR TITLE
cells: Tab complete on distant downstream domains too

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/RoutingManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/RoutingManager.java
@@ -393,8 +393,12 @@ public class RoutingManager
                     domains.put(getCellDomainName(), new ArrayList<>(_localExports));
                     /* Add the domains without wellknown cells too. */
                     _domainHash.keySet().stream()
-                            .filter(domain -> !domains.containsKey(domain))
-                            .forEach(domain -> domains.put(domain, new ArrayList<>()));
+                            .forEach(domain -> domains.computeIfAbsent(domain, d -> new ArrayList<>()));
+                    _domainHash.values().stream()
+                            .flatMap(Collection::stream)
+                            .map(CellPath::getDestinationAddress)
+                            .filter(address -> address.getCellName().equals("*"))
+                            .forEach(address -> domains.computeIfAbsent(address.getCellDomainName(), d -> new ArrayList<>()));
                 }
                 msg.revertDirection();
                 msg.setMessageObject(new GetAllDomainsReply(domains));


### PR DESCRIPTION
Motivation:

The root domain has routes to all other domains, even in non-default
topoligies. It however failed to add domains that neither had well known cells
nor were direct neighbors to the list of domains. Thus tab completion would
not work for such domains.

Modification:

Collect downstream domains of neightbors for the GetAllDomainsReply.

Result:

Tab completion works in non-default topologies.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
(cherry picked from commit 70396e4c07610cb87692ee2c40e36bb96dc0dff7)