### PR TITLE
pool: Add migration option to filter by absense of sticky flags

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -344,11 +344,14 @@ public class MigrationModule
                 usage="Only copy replicas in the given state.")
         String state;
 
-        @Option(name="sticky", metaVar="owner", separator=",",
+        @Option(name="sticky", valueSpec="[-]owner", separator=",",
                 category="Filter options",
                 usage = "Only copy sticky replicas. Can optionally be limited to " +
                         "the list of owners. A sticky flag for each owner must be " +
-                        "present for the replica to be selected.")
+                        "present for the replica to be selected. Presence of an " +
+                        "owner may be negated by prefixing it with a minus sign; in " +
+                        "that case the filter matches a file that does not have a " +
+                        "sticky flag with the given owner.")
         String[] sticky;
 
         @Option(name="storage", metaVar="class",
@@ -737,7 +740,11 @@ public class MigrationModule
                     filters.add(new StickyFilter());
                 } else {
                     for (String owner: sticky) {
-                        filters.add(new StickyOwnerFilter(owner));
+                        if (owner.startsWith("-")) {
+                            filters.add(new NotStickyOwnerFilter(owner.substring(1)));
+                        } else {
+                            filters.add(new StickyOwnerFilter(owner));
+                        }
                     }
                 }
             }

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/NotStickyOwnerFilter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/NotStickyOwnerFilter.java
@@ -1,0 +1,29 @@
+package org.dcache.pool.migration;
+
+import org.dcache.pool.repository.CacheEntry;
+import org.dcache.pool.repository.StickyRecord;
+
+/**
+ * Repository entry filter accepting entries without sticky flags by a
+ * given owner.
+ */
+public class NotStickyOwnerFilter implements CacheEntryFilter
+{
+    private final String _owner;
+
+    public NotStickyOwnerFilter(String owner)
+    {
+        _owner = owner;
+    }
+
+    @Override
+    public boolean accept(CacheEntry entry)
+    {
+        for (StickyRecord record: entry.getStickyRecords()) {
+            if (record.owner().equals(_owner)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Motivation:

A regression caused sticky bits to be lost. To repair this, one could
use a migration job that specifically copies cached and not sticky disk
files to other pools and in the process sets the sticky bit. To allow
this one needs to be able to filter by files which are cached and not
sticky and this is currently not possible.

Modification:

Extends the -sticky option with the ability to negate the filter.

Result:

One can filter for all files not having the system sticky flag by
using -sticky=-system.

To allow sites to repair the recent bug, backporting the change is
requested.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8872/
(cherry picked from commit f168fd8d56e072ff60419599be59da419ccd79b2)