### PR TITLE
pool: Add option to migration module to filter by cache class

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/CacheClassFilter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/CacheClassFilter.java
@@ -1,0 +1,27 @@
+package org.dcache.pool.migration;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+import org.dcache.pool.repository.CacheEntry;
+
+/**
+ * Repository entry filter accepting entries with a particular cache
+ * class.
+ */
+public class CacheClassFilter implements CacheEntryFilter
+{
+    private final String _cc;
+
+    public CacheClassFilter(@Nullable String cc)
+    {
+        _cc = cc;
+    }
+
+    @Override
+    public boolean accept(CacheEntry entry)
+    {
+        return Objects.equals(_cc, entry.getFileAttributes().getCacheClass());
+    }
+}

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -1,5 +1,6 @@
 package org.dcache.pool.migration;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Range;
 import org.parboiled.Parboiled;
 import org.parboiled.parserunners.ReportingParseRunner;
@@ -353,8 +354,14 @@ public class MigrationModule
 
         @Option(name="storage", metaVar="class",
                 category="Filter options",
-                usage="Only copy replicas with the given access latency.")
+                usage="Only copy replicas with the given storage class.")
         String storage;
+
+        @Option(name="cache", metaVar="class",
+                category="Filter options",
+                usage="Only copy replicas with the given cache class. An empty string will match any " +
+                      "replica without a cache class.")
+        String cache;
 
         @Option(name="concurrency",
                 category="Transfer options",
@@ -716,6 +723,10 @@ public class MigrationModule
 
             if (storage != null) {
                 filters.add(new StorageClassFilter(storage));
+            }
+
+            if (cache != null) {
+                filters.add(new CacheClassFilter(Strings.emptyToNull(cache)));
             }
 
             if (pnfsid != null) {


### PR DESCRIPTION
Motivation:

A recent bug caused sticky bits to be lost in certain situations. A procedure
to repair the damage involves using a migration job targetting affected files.
At NDGF the cache class is used to distinguish tape files from disk files and
thus we need a filter by cache class.

Modification:

Adds the -cache option to the migration commands.

Result:

migration copy/move/cache accept the -cache option. Request backport to allow
the version affected by the bug to repair the damage.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8874/
(cherry picked from commit c69bdc96ac395883fe6448a236e980703fa2a81f)