### PR TITLE
pool: Extend migration module with -meta-only option

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
@@ -113,7 +113,7 @@ public class Job
 
         _taskParameters = new TaskParameters(context.getPoolStub(), context.getPnfsStub(), context.getPinManagerStub(),
                                              context.getExecutor(), definition.selectionStrategy,
-                                             definition.poolList, definition.isEager,
+                                             definition.poolList, definition.isEager, definition.isMetaOnly,
                                              definition.computeChecksumOnUpdate, definition.forceSourceMode,
                                              definition.maintainAtime, definition.replicas);
 

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/JobDefinition.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/JobDefinition.java
@@ -66,6 +66,12 @@ public class JobDefinition
     public final boolean isEager;
 
     /**
+     * Wether the job will only copy meta data to existing replicas or create
+     * new replicas.
+     */
+    public final boolean isMetaOnly;
+
+    /**
      * Whether to move pins to the target pool after successful migration.
      */
     public final boolean mustMovePins;
@@ -111,6 +117,7 @@ public class JobDefinition
                          long refreshPeriod,
                          boolean isPermanent,
                          boolean isEager,
+                         boolean isMetaOnly,
                          int replicas,
                          boolean mustMovePins,
                          boolean computeChecksumOnUpdate,
@@ -129,6 +136,7 @@ public class JobDefinition
         this.refreshPeriod = refreshPeriod;
         this.isPermanent = isPermanent;
         this.isEager = isEager;
+        this.isMetaOnly = isMetaOnly;
         this.replicas = replicas;
         this.mustMovePins = mustMovePins;
         this.computeChecksumOnUpdate = computeChecksumOnUpdate;

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -507,6 +507,13 @@ public class MigrationModule
                 usage = "Determines the interpretation of the target names.")
         String target = "pool";
 
+        @Option(name="meta-only",
+                category="Target options",
+                usage="Only transfers meta data to an existing target replica. If a given file " +
+                      "does not have any other replicas on any of the target pools, the file " +
+                      "is skipped.")
+        boolean metaOnly;
+
         @Option(name="pause-when", metaVar="expr",
                 category="Lifetime options",
                 usage = "Pauses the job when the expression becomes true. The job " +
@@ -828,6 +835,7 @@ public class MigrationModule
                             refresh * 1000,
                             permanent,
                             eager,
+                            metaOnly,
                             replicas,
                             mustMovePins,
                             verify,

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
@@ -177,6 +177,7 @@ public class MigrationModuleServer
         private final boolean _computeChecksumOnUpdate;
         private final boolean _forceSourceMode;
         private final Long _atime;
+        private final boolean _isMetaOnly;
         private Integer _companion;
         private Future<?> _updateTask;
 
@@ -191,6 +192,7 @@ public class MigrationModuleServer
             _computeChecksumOnUpdate = message.getComputeChecksumOnUpdate();
             _forceSourceMode = message.isForceSourceMode();
             _atime = message.getAtime();
+            _isMetaOnly = message.isMetaOnly();
 
             if (_targetState != PRECIOUS && _targetState != CACHED) {
                 throw new IllegalArgumentException("State must be either CACHED or PRECIOUS");
@@ -218,6 +220,9 @@ public class MigrationModuleServer
         {
             EntryState state = _repository.getState(_pnfsId);
             if (state == EntryState.NEW) {
+                if (_isMetaOnly) {
+                    throw new CacheException(CacheException.FILE_NOT_IN_REPOSITORY, "Pool does not contain " + _pnfsId);
+                }
                 _companion = _p2p.newCompanion(_pool, _fileAttributes,
                                                _targetState, _stickyRecords,
                                                this, _forceSourceMode,

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/PoolMigrationCopyReplicaMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/PoolMigrationCopyReplicaMessage.java
@@ -27,6 +27,7 @@ public class PoolMigrationCopyReplicaMessage extends PoolMigrationMessage
     private final boolean _computeChecksumOnUpdate;
     private final boolean _forceSourceMode;
     private final Long _atime;
+    private final boolean _isMetaOnly;
 
     public PoolMigrationCopyReplicaMessage(UUID uuid, String pool,
                                            FileAttributes fileAttributes,
@@ -34,7 +35,7 @@ public class PoolMigrationCopyReplicaMessage extends PoolMigrationMessage
                                            List<StickyRecord> stickyRecords,
                                            boolean computeChecksumOnUpdate,
                                            boolean forceSourceMode,
-                                           Long atime)
+                                           Long atime, boolean isMetaOnly)
     {
         super(uuid, pool, fileAttributes.getPnfsId());
         _fileAttributes = checkNotNull(fileAttributes);
@@ -43,6 +44,7 @@ public class PoolMigrationCopyReplicaMessage extends PoolMigrationMessage
         _computeChecksumOnUpdate = computeChecksumOnUpdate;
         _forceSourceMode = forceSourceMode;
         _atime = atime;
+        _isMetaOnly = isMetaOnly;
     }
 
     public EntryState getState()
@@ -68,6 +70,11 @@ public class PoolMigrationCopyReplicaMessage extends PoolMigrationMessage
     public boolean isForceSourceMode()
     {
         return _forceSourceMode;
+    }
+
+    public boolean isMetaOnly()
+    {
+        return _isMetaOnly;
     }
 
     /**

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
@@ -33,6 +33,7 @@ import org.dcache.util.FireAndForgetTask;
 import org.dcache.util.ReflectionUtils;
 import org.dcache.vehicles.FileAttributes;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
@@ -143,6 +144,15 @@ public class Task
     public boolean isEager()
     {
         return _parameters.isEager;
+    }
+
+    /**
+     * Meta only jobs only upgrade existing replicas - they never copy replicas. If
+     * no or not enough existing replicas exist, the task fails permanently.
+     */
+    public boolean isMetaOnly()
+    {
+        return _parameters.isMetaOnly;
     }
 
     /**
@@ -259,6 +269,8 @@ public class Task
     /** FSM Action */
     synchronized void initiateCopy()
     {
+        checkState(!isMetaOnly());
+
         try {
             initiateCopy(selectPool());
         } catch (NoSuchElementException e) {
@@ -286,7 +298,8 @@ public class Task
                                                     _targetStickyRecords,
                                                     _parameters.computeChecksumOnUpdate,
                                                     _parameters.forceSourceMode,
-                                                    _parameters.maintainAtime ? _atime : null);
+                                                    _parameters.maintainAtime ? _atime : null,
+                                                    _parameters.isMetaOnly);
         CellStub.addCallback(_parameters.pool.send(_target, copyReplicaMessage),
                              new Callback<>("copy_"), _parameters.executor);
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/TaskParameters.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/TaskParameters.java
@@ -65,6 +65,12 @@ public class TaskParameters
     public final boolean isEager;
 
     /**
+     * Wether the job will only copy meta data to existing replicas or create
+     * new replicas.
+     */
+    public final boolean isMetaOnly;
+
+    /**
      * Whether to verify the checksum when reusing existing target replicas.
      */
     public final boolean computeChecksumOnUpdate;
@@ -85,11 +91,10 @@ public class TaskParameters
      */
     public final int replicas;
 
-    public TaskParameters(CellStub pool, CellStub pnfs, CellStub pinManager,
-                          ScheduledExecutorService executor,
+    public TaskParameters(CellStub pool, CellStub pnfs, CellStub pinManager, ScheduledExecutorService executor,
                           PoolSelectionStrategy selectionStrategy, RefreshablePoolList poolList, boolean isEager,
-                          boolean computeChecksumOnUpdate, boolean forceSourceMode, boolean maintainAtime,
-                          int replicas)
+                          boolean isMetaOnly, boolean computeChecksumOnUpdate, boolean forceSourceMode,
+                          boolean maintainAtime, int replicas)
     {
         this.pool = pool;
         this.pnfs = pnfs;
@@ -98,6 +103,7 @@ public class TaskParameters
         this.selectionStrategy = selectionStrategy;
         this.poolList = poolList;
         this.isEager = isEager;
+        this.isMetaOnly = isMetaOnly;
         this.computeChecksumOnUpdate = computeChecksumOnUpdate;
         this.forceSourceMode = forceSourceMode;
         this.maintainAtime = maintainAtime;

--- a/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
+++ b/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
@@ -49,8 +49,14 @@ Entry
                 {
                 }
         query_success
+                [ !ctxt.isMetaOnly() ]
                 InitiatingCopy
                 {
+                }
+        query_success
+                Failed
+                {
+                        failPermanently(FILE_NOT_IN_REPOSITORY, "File skipped because it has no existing replicas");
                 }
 }
 
@@ -68,7 +74,7 @@ Entry
                 {
                 }
         copy_timeout
-                [ ctxt.isEager() ]
+                [ ctxt.isEager() && !ctxt.isMetaOnly() ]
                 InitiatingCopy
                 {
                 }
@@ -84,7 +90,7 @@ Entry
                         updateExistingReplica();
                 }
         copy_noroute
-                [ ctxt.isEager() ]
+                [ ctxt.isEager() && !ctxt.isMetaOnly() ]
                 InitiatingCopy
                 {
                 }
@@ -106,8 +112,14 @@ Entry
                         updateExistingReplica();
                 }
         copy_failure(rc: Integer, cause: Object)
+                [ !ctxt.isMetaOnly() ]
                 InitiatingCopy
                 {
+                }
+        copy_failure(rc: Integer, cause: Object)
+                Failed
+                {
+                        fail(rc, String.format("Transfer to %s failed (%s)", ctxt.getTarget(), cause));
                 }
         copy_success
                 Copying
@@ -237,8 +249,14 @@ WaitingForCopyReplicaReply
                 {
                 }
         copy_success
+                [ !ctxt.isMetaOnly() ]
                 InitiatingCopy
                 {
+                }
+        copy_success
+                Failed
+                {
+                        failPermanently(FILE_NOT_IN_REPOSITORY, "File skipped because it does not have enough existing replicas");
                 }
         copy_nopools
                 Failed
@@ -312,9 +330,15 @@ Exit
                 {
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
-                [ ctxt.needsMoreReplicas() ]
+                [ ctxt.needsMoreReplicas() && !ctxt.isMetaOnly() ]
                 InitiatingCopy
                 {
+                }
+        messageArrived(message: PoolMigrationCopyFinishedMessage)
+                [ ctxt.needsMoreReplicas() ]
+                Failed
+                {
+                        failPermanently(FILE_NOT_IN_REPOSITORY, "File skipped because it does not have enough existing replicas");
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
                 [ ctxt.getMustMovePins() ]
@@ -382,9 +406,15 @@ Entry
                 {
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
-                [ ctxt.needsMoreReplicas() ]
+                [ ctxt.needsMoreReplicas() && !ctxt.isMetaOnly() ]
                 InitiatingCopy
                 {
+                }
+        messageArrived(message: PoolMigrationCopyFinishedMessage)
+                [ ctxt.needsMoreReplicas() ]
+                Failed
+                {
+                        failPermanently(FILE_NOT_IN_REPOSITORY, "File skipped because it does not have enough existing replicas");
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
                 [ ctxt.getMustMovePins() ]
@@ -468,9 +498,15 @@ Exit
                 {
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
-                [ ctxt.needsMoreReplicas() ]
+                [ ctxt.needsMoreReplicas() && !ctxt.isMetaOnly() ]
                 InitiatingCopy
                 {
+                }
+        messageArrived(message: PoolMigrationCopyFinishedMessage)
+                [ ctxt.needsMoreReplicas() ]
+                Failed
+                {
+                        failPermanently(FILE_NOT_IN_REPOSITORY, "File skipped because it does not have enough existing replicas");
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
                 [ ctxt.getMustMovePins() ]
@@ -530,9 +566,15 @@ Exit
                 {
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
-                [ ctxt.needsMoreReplicas() ]
+                [ ctxt.needsMoreReplicas() && !ctxt.isMetaOnly() ]
                 InitiatingCopy
                 {
+                }
+        messageArrived(message: PoolMigrationCopyFinishedMessage)
+                [ ctxt.needsMoreReplicas() ]
+                Failed
+                {
+                        failPermanently(FILE_NOT_IN_REPOSITORY, "File skipped because it does not have enough existing replicas");
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
                 [ ctxt.getMustMovePins() ]


### PR DESCRIPTION
Motivation:

A recent bug caused sticky bits to be lost in certain situations. A procedure
to repair the damage involves using a migration job to eliminate duplicates.
To make this work we have to be able to limit migration jobs to only transfer
the meta data and skip any files that do not already have other copies.

Modification:

Add the -meta-only option to migration jobs. If set, a migration task will
only run the steps involving upgrading existing replicas and skip files that
would require transferring the file itself.

Result:

migration copy/cache/move accept the new -meta-only option. Backport is requested
to allow sites with existing versions repair the damange from the above mentioned
bug.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8875/
(cherry picked from commit 857aea93fe7ed352b4379c8f4022ed37fbc6dc68)