### PR TITLE
spacemanager: Fix listing by pnfs id

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerCommandLineInterface.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerCommandLineInterface.java
@@ -572,7 +572,7 @@ public class SpaceManagerCommandLineInterface implements CellCommandListener
         @Argument(required = false,
                   usage = "Only show files with this PNFSID or path.",
                   valueSpec = "PNFSID|PATH")
-        Glob pattern;
+        String file;
 
         @Override
         public String executeInTransaction() throws DataAccessException, CacheException
@@ -590,14 +590,9 @@ public class SpaceManagerCommandLineInterface implements CellCommandListener
             }
 
             Iterable<File> files;
-            if (pattern != null) {
-                PnfsId pnfsId = pnfs.getPnfsIdByPath(pattern.toString());
+            if (file != null) {
+                PnfsId pnfsId = PnfsId.isValid(file) ? new PnfsId(file) : pnfs.getPnfsIdByPath(file);
                 files = db.get(filesWhereOptionsMatch().wherePnfsIdIs(pnfsId), limit);
-                try {
-                    List<File> moreFiles = db.get(filesWhereOptionsMatch().wherePnfsIdIs(new PnfsId(pattern.toString())), limit);
-                    files = concat(moreFiles, files);
-                } catch (IllegalArgumentException ignored) {
-                }
             } else {
                 files = db.get(filesWhereOptionsMatch(), limit);
             }
@@ -653,7 +648,7 @@ public class SpaceManagerCommandLineInterface implements CellCommandListener
             }
             if (states != null && states.length > 0) {
                 files.whereStateIsIn(states);
-            } else if (!all && pattern == null) {
+            } else if (!all && file == null) {
                 files.whereStateIsIn(FileState.TRANSFERRING);
             }
             return files;


### PR DESCRIPTION
Motivation:

Space manager has a command to list a file by path or PNFS ID, however
currently this functionality is broken when used with a PNFS ID. This is likely
a result of changes made when paths were removed from the space manager tables.

Modification:

Fix the list to distinguish between PNFS ID and path. Remove the glob support as
it cannot be used anyway after the path was removed from local tables.

Result:

Listing by PNFS ID works.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8877/
(cherry picked from commit 712a1fb55897c5738b5229460c7907f41c476eea)