### PR TITLE
pool: Throw IllegalArgumentException on rep set sticky errors

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -107,19 +107,19 @@ public class RepositoryInterpreter
                 expire = 0;
                 break;
             default:
-                return "Invalid sticky state : " + state;
+                throw new IllegalArgumentException("Invalid sticky state : " + state);
             }
 
             if (pnfsId != null) {
                 if (!matches(pnfsId)) {
-                    return "Replica does not match filter conditions.";
+                    throw new IllegalArgumentException("Replica does not match filter conditions.");
                 }
                 _repository.setSticky(pnfsId, owner, expire, true);
                 return _repository.getEntry(pnfsId).getStickyRecords().stream().map(Object::toString).collect(joining("\n"));
             }
 
             if (al == null && rp == null && storage == null && cache == null && !all) {
-                return "Use -all to change sticky flag for all replicas.";
+                throw new IllegalArgumentException("Use -all to change sticky flag for all replicas.");
             }
 
             long cnt = 0;


### PR DESCRIPTION
Motivation:

The admin shell recognizes exceptions being thrown by commands and
uses this to apply color hightligting.

Modification:

Throw exceptions in case of errors in 'rep set sticky' execution.

Result:

Errors are printed in read. Particularly useful when running the
command on several pools using \s.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8878/
(cherry picked from commit 889ea4233a973747b497f9cd033f8bb8b9cffc03)