### PR TITLE
pool: Make bulk sticky bit operation robust against repository changes

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -124,9 +124,12 @@ public class RepositoryInterpreter
 
             long cnt = 0;
             for (PnfsId id : _repository) {
-                if (matches(id)) {
-                    _repository.setSticky(id, owner, expire, true);
-                    cnt++;
+                try {
+                    if (matches(id)) {
+                        _repository.setSticky(id, owner, expire, true);
+                        cnt++;
+                    }
+                } catch (FileNotInCacheException ignored) {
                 }
             }
 


### PR DESCRIPTION
Motivation:

When iterating over the repository one has to take into account that files
may be in a transient state or are removed before one is able to access it.

Modification:

Catch FileNotInCacheException when iterating over the repository in 'rep set
sticky'. The exception is silently ignored and the operation continues.

Result:

One can use 'rep set sticky' on pools in which files are uploaded or deleted.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8879/
(cherry picked from commit 2bbcef4fdf1386cb1fc8c277d92139ca041ac47c)