### PR TITLE
admin: Fix endless loop in non-interactive mode

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacyAdminShellCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacyAdminShellCommand.java
@@ -32,7 +32,6 @@ import dmg.util.CommandThrowableException;
 import dmg.util.command.HelpFormat;
 
 import org.dcache.commons.util.Strings;
-import org.dcache.util.Args;
 
 import static org.fusesource.jansi.Ansi.Color.CYAN;
 import static org.fusesource.jansi.Ansi.Color.RED;
@@ -227,6 +226,7 @@ public class LegacyAdminShellCommand implements Command, Runnable
 
                 if (!s.isEmpty()) {
                     _console.println(s);
+                    _console.flush();
                 }
             }
         }

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/NoTerminalCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/NoTerminalCommand.java
@@ -80,12 +80,15 @@ public class NoTerminalCommand implements Command, Runnable
     public void run() {
         try {
             repl();
+        } catch (IOException e) {
+            _logger.warn(e.getMessage());
         } finally {
             _exitCallback.onExit(0);
         }
     }
 
-    private void repl() {
+    private void repl() throws IOException
+    {
         Ansi.setEnabled(false);
         while (true) {
             Object error = null;
@@ -145,6 +148,8 @@ public class NoTerminalCommand implements Command, Runnable
                 }
             } catch (InterruptedException e) {
                 error = null;
+            } catch (IOException e) {
+                throw e;
             } catch (Exception e) {
                 error = e.getMessage();
                 if (error == null) {


### PR DESCRIPTION
Motivation:

Fix 10ae6b07a28542fc22a9d91886816cc76bfc0b2d fixed an endless loop in our ansi
terminal triggered by a disconnected client. The fix failed to update the
non-interactive version.

Modification:

Apply the same fix to the non pty implementation. Also applies a flush to the legacy
admin shell (also part of the original patch for the ansi terminal).

Result:

No endless loop in the admin shell.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8880/
(cherry picked from commit 2d9ea1164fe7996a0bd6c7a27abc0e9d9b567078)