### PR TITLE
pool: Only save sticky bits if not already set

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
@@ -266,7 +266,7 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
         if (_state == EntryState.REMOVED) {
             throw new CacheException("Entry in removed state");
         }
-        if (!overwrite && any(_sticky, r -> r.owner().equals(owner) && r.isValidAt(expire))) {
+        if (any(_sticky, r -> r.owner().equals(owner) && (r.expire() == expire || !overwrite && r.isValidAt(expire)))) {
             return false;
         }
         ImmutableList.Builder<StickyRecord> builder = ImmutableList.builder();


### PR DESCRIPTION
Motivation:

When bulk setting sticky bits, most replicas likely already have the bit and thus
one may reduce the number of database updates and change notifications.

Modification:

Detect if the same sticky flag already exists and do not update anything in that case.

Result:

Faster bulk 'rep set sticky' commands.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8882/
(cherry picked from commit 8bcb5227432ad5a1e76b73729c159c980a9f9e46)