### PR TITLE
pool: Do not output expired sticky flags

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -115,7 +115,8 @@ public class RepositoryInterpreter
                     throw new IllegalArgumentException("Replica does not match filter conditions.");
                 }
                 _repository.setSticky(pnfsId, owner, expire, true);
-                return _repository.getEntry(pnfsId).getStickyRecords().stream().map(Object::toString).collect(joining("\n"));
+                return _repository.getEntry(pnfsId).getStickyRecords().stream()
+                        .filter(StickyRecord::isValid).map(Object::toString).collect(joining("\n"));
             }
 
             if (al == null && rp == null && storage == null && cache == null && !all) {
@@ -153,7 +154,8 @@ public class RepositoryInterpreter
     {
         PnfsId pnfsId  = new PnfsId(args.argv(0));
         CacheEntry entry = _repository.getEntry(pnfsId);
-        return entry.getStickyRecords().stream().map(Object::toString).collect(joining("\n"));
+        return entry.getStickyRecords().stream()
+                .filter(StickyRecord::isValid).map(Object::toString).collect(joining("\n"));
     }
 
     public static final String fh_rep_ls =


### PR DESCRIPTION
Motivation:

The way we clear a sticky flag is to set it to an expiration date in the past -
it will expire right away. A consequence of this is that if the sticky flags are
output right after being set/cleared, a sticky flag with expiration at the Unix
epoch is included.

Modification:

Filter expired sticky flags in the output of 'rep ls sticky' and 'rep set sticky'.

Result:

Less confusing output from these commands.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8883/
(cherry picked from commit a3c02d0c51950093f89892eb80dc6eda8e29ecb8)