### PR TITLE
gplazma: Improve logging in voms plugin

### DIFF
--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/VoRoleMapPlugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/VoRoleMapPlugin.java
@@ -67,10 +67,8 @@ public class VoRoleMapPlugin implements GPlazmaMappingPlugin
         return false;
     }
 
-    private boolean addMappingFor(FQAN fqan,
-                                  GlobusPrincipal globusPrincipal,
-                                  boolean isPrimary,
-                                  Set<Principal> principals)
+    private boolean addMappingFor(GlobusPrincipal globusPrincipal, FQANPrincipal fqanPrincipal,
+                                  FQAN fqan, boolean isPrimary, Set<Principal> principals)
     {
         String dn = globusPrincipal.getName();
         List<String> names =
@@ -81,7 +79,7 @@ public class VoRoleMapPlugin implements GPlazmaMappingPlugin
 
         String name = names.get(0);
         principals.add(new GroupNamePrincipal(name, isPrimary));
-        _log.info("VOMS authorization successful for user with DN: {} and FQAN: {} for user name: {}.", dn, fqan, name);
+        _log.info("VOMS authorization successful for user with DN: {} and FQAN: {} for user name: {}.", dn, fqanPrincipal, name);
         return true;
     }
 
@@ -103,7 +101,7 @@ public class VoRoleMapPlugin implements GPlazmaMappingPlugin
             FQAN fqan = fqanPrincipal.getFqan();
             do {
                 for (GlobusPrincipal globusPrincipal: globusPrincipals) {
-                    if (addMappingFor(fqan, globusPrincipal, isPrimary, principals)) {
+                    if (addMappingFor(globusPrincipal, fqanPrincipal, fqan, isPrimary, principals)) {
                         authorized = true;
                         found = true;
                         hasPrimary |= isPrimary;


### PR DESCRIPTION
Motivation:

Our voms plugin confusingly logs duplicate lines like this:

17 Dec 2015 22:02:45 (gPlazma) [door:GFTP-rizzo-AAUnHlgiO_A GFTP-rizzo-AAUnHlgiO_A Login MAP vorolemap] VOMS authorization successful for user with DN: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=atlact1/CN=555105/CN=Robot: ATLAS aCT 1 and FQAN: /atlas for user name: atlas-user.
17 Dec 2015 22:02:45 (gPlazma) [door:GFTP-rizzo-AAUnHlgiO_A GFTP-rizzo-AAUnHlgiO_A Login MAP vorolemap] VOMS authorization successful for user with DN: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=atlact1/CN=555105/CN=Robot: ATLAS aCT 1 and FQAN: /atlas for user name: atlas-user.

Turns out this stems from a login with these principals:

17 Dec 2015 22:02:45 (gPlazma) [door:GFTP-rizzo-AAUnHlgiO_A GFTP-rizzo-AAUnHlgiO_A Login MAP vorolemap] calling (principals: [S:/2001:1470:ff80:6d:20e:1eff:fe01:9e4, FQANPrincipal[/atlas/lcg1], /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=atlact1/CN=555105/CN=Robot: ATLAS aCT 1, FQANPrincipal[/atlas], FQANPrincipal[/atlas/Role=pilot,primary]])

The issue is that the prefix match algorithm processes prefixes of /atlas/Role=pilot and when
it finds a match it just logs the prefix. This is misleading as we don't log the user's actual
FQAN that we mapped.

Modification:

Log the original FQAN rather than the prefix.

Result:

No duplicate log entries.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8887/
(cherry picked from commit 61eaf48ef52b9edf3c3084c14cf2d172ad8c0ed3)