### PR TITLE
srm-client: Fix GSI delegation for old servers

### DIFF
--- a/modules/srm-client/src/main/lib/srm
+++ b/modules/srm-client/src/main/lib/srm
@@ -139,6 +139,18 @@ if [ -n "$SRM_CONFIG" -a  "$SRM_CONFIG" != "NONE" -a -f "$SRM_CONFIG" ]; then
     SRMCP_OPTIONS="-conf=$SRM_CONFIG $SRMCP_OPTIONS"
 fi
 
+for arg in "$@"; do
+  case "$arg" in
+      -delegate|-delegate=true)
+          # CBC protection works around the TLS 1.0 BEAST attack; it does this by splitting the first
+          # payload into a 1 byte and a n-1 byte chunk. This breaks GSI delegation for JGlobus as
+          # JGlobus expects the certificate as a single TLS frame.
+          OPTIONS="-Djsse.enableCBCProtection=false ${OPTIONS}"
+          break
+          ;;
+  esac
+done
+
 cmd="$java_location $OPTIONS gov.fnal.srm.util.SRMDispatcher $SRMCP_OPTIONS $args"
 if [ "$DEBUG" = "true" ]; then
     echo "CLASSPATH: $SRM_CP"


### PR DESCRIPTION
Motivation:

During GSI delegation JGlobus expects the client to send the entire certificate
in a single SSL frame. A workaround for the TLS BEAST attack makes the JVM
split the first payload into two chunks, the first being 1 byte long. This
conflicts with the expectations of JGlobus and thus causes our 2.14 srm client
to fail with dCache older than 2.13. This was not a problem while the client
used JGlobus and thus didn't use protection against BEAST.

Modification:

Disable the protection against the BEAST attack in the SRM client when
delegating credentials to the server. This fixes the delegation with GSI at the
expense of vulenrability to BEAST if the server generates HTTPS TURLs.

Result:

GSI delegation works with JGlobus.

Target: trunk
Request: 2.14
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8896/
(cherry picked from commit bc96eddabe02ebd28d8dd12670700cebd6b269ce)