### PR TITLE
2.14: upgrade third party dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,14 +61,14 @@
         <target.version>1.8</target.version>
 
         <version.slf4j>1.7.10</version.slf4j>
-        <version.milton>2.7.0.3</version.milton>
-        <version.spring>4.2.2.RELEASE</version.spring>
+        <version.milton>2.7.1.3</version.milton>
+        <version.spring>4.2.4.RELEASE</version.spring>
         <!-- Remember to sync aspectj version in dcache.properties -->
         <version.aspectj>1.8.7</version.aspectj>
         <version.smc>6.3.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
-        <version.jetty>9.3.5.v20151012</version.jetty>
-        <version.wicket>7.0.0</version.wicket>
+        <version.jetty>9.3.6.v20151106</version.jetty>
+        <version.wicket>7.1.0</version.wicket>
         <version.xrootd4j>3.0.1</version.xrootd4j>
 
         <!-- BouncyCastle seems to change the naming convention of
@@ -98,7 +98,7 @@
          -->
         <bouncycastle.bcprov>bcprov-jdk16</bouncycastle.bcprov>
         <bouncycastle.version>1.46</bouncycastle.version>
-        <datanucleus-core.version>4.1.5</datanucleus-core.version>
+        <datanucleus-core.version>4.1.7</datanucleus-core.version>
         <datanucleus.plugin.version>4.0.1</datanucleus.plugin.version>
     </properties>
 
@@ -347,7 +347,7 @@
             <dependency>
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
-                <version>2.4.1</version>
+                <version>2.4.3</version>
             </dependency>
             <dependency>
                 <!-- 1204 appears to contain a bug in handling timestamp types (pinmanager fails) -->
@@ -383,7 +383,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.0.32.Final</version>
+                <version>4.0.33.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.sleepycat</groupId>
@@ -423,7 +423,7 @@
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-rdbms</artifactId>
-                <version>4.1.5</version>
+                <version>4.1.8</version>
             </dependency>
             <dependency>
                 <groupId>org.datanucleus</groupId>


### PR DESCRIPTION
Motivation:

Keep up to date with bug fixes.

Modification:

DataNucleus 4.1.7
Jetty 9.3.6
Spring 4.2.4
Milton 2.7.1.3
Wicket 7.1.0
Netty 4.0.33
HikariCP 2.4.3

Result:

Fewer bugs.

Target: 2.14
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8900/