### PR TITLE
2.13: upgrade third party dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,13 @@
         <target.version>1.8</target.version>
 
         <version.slf4j>1.7.10</version.slf4j>
-        <version.milton>2.7.0.3</version.milton>
-        <version.spring>4.1.6.RELEASE</version.spring>
+        <version.milton>2.7.1.3</version.milton>
+        <version.spring>4.1.9.RELEASE</version.spring>
         <!-- Remember to sync aspectj version in dcache.properties -->
-        <version.aspectj>1.8.5</version.aspectj>
+        <version.aspectj>1.8.7</version.aspectj>
         <version.smc>6.3.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
-        <version.jetty>9.2.10.v20150310</version.jetty>
+        <version.jetty>9.2.14.v20151106</version.jetty>
         <version.wicket>6.19.0</version.wicket>
         <version.xrootd4j>2.1.3</version.xrootd4j>
         <version.jglobus>2.0.6-rc9.d</version.jglobus>
@@ -99,7 +99,7 @@
          -->
         <bouncycastle.bcprov>bcprov-jdk16</bouncycastle.bcprov>
         <bouncycastle.version>1.46</bouncycastle.version>
-        <datanucleus-core.version>4.0.5</datanucleus-core.version>
+        <datanucleus-core.version>4.0.7</datanucleus-core.version>
         <datanucleus.plugin.version>4.0.0-release</datanucleus.plugin.version>
     </properties>
 
@@ -321,8 +321,7 @@
             <dependency>
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
-                <version>2.3.7</version>
-                <!-- Version 2.3.8 downgrades JavaAssist and becomes incompatible with Mockito/PowerMock -->
+                <version>2.3.12</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>
@@ -357,7 +356,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.0.28.Final</version>
+                <version>4.0.33.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.sleepycat</groupId>
@@ -397,12 +396,12 @@
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-api-jpa</artifactId>
-                <version>4.0.6</version>
+                <version>4.0.8</version>
             </dependency>
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-rdbms</artifactId>
-                <version>4.0.8</version>
+                <version>4.0.12</version>
             </dependency>
             <dependency>
                 <groupId>org.datanucleus</groupId>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -184,7 +184,7 @@ dcache.log.access.max-history=30
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath=${dcache.java.oom.file} \
     -XX:+UseCompressedOops \
-    -javaagent:${dcache.paths.classes}/aspectjweaver-1.8.5.jar \
+    -javaagent:${dcache.paths.classes}/aspectjweaver-1.8.7.jar \
     ${dcache.java.options.common} \
     ${dcache.java.options.extra}
 


### PR DESCRIPTION
Motivation:

Keep up to date with bug fixes.

Modification:

DataNucleus 4.0.7
Jetty 9.2.14
Spring 4.1.9
Milton 2.7.1.3
AspectJ 1.8.7
Netty 4.0.33
HikariCP 2.3.12

Result:

Fewer bugs.

Target: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8901/