### PR TITLE
2.11: upgrade third party dependencies

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
@@ -535,7 +535,7 @@ public class HttpPoolRequestHandler extends HttpRequestHandler
         Exception exception = null;
 
         try {
-            checkContentHeader(request.getHeaderNames(), asList(CONTENT_LENGTH));
+            checkContentHeader(request.headers().names(), asList(CONTENT_LENGTH));
 
             file = open(request, true);
 
@@ -608,7 +608,7 @@ public class HttpPoolRequestHandler extends HttpRequestHandler
                 write(_writeChannel, chunk.getContent());
                 if (chunk.isLast()) {
                     if (chunk instanceof HttpChunkTrailer) {
-                        checkContentHeader(((HttpChunkTrailer) chunk).getHeaderNames(),
+                        checkContentHeader(((HttpChunkTrailer) chunk).trailingHeaders().names(),
                                 asList(CONTENT_LENGTH));
                     }
                     future = sendPutResponse(context, _writeChannel);

--- a/modules/dcache/src/test/java/org/dcache/http/HttpPoolRequestHandlerTests.java
+++ b/modules/dcache/src/test/java/org/dcache/http/HttpPoolRequestHandlerTests.java
@@ -686,14 +686,14 @@ public class HttpPoolRequestHandlerTests
             String name = entry.getKey();
             List<String> values = Lists.newArrayList(entry.getValue());
 
-            given(request.getHeaders(name)).willReturn(values);
+            given(request.headers().getAll(name)).willReturn(values);
             given(headers.getAll(name)).willReturn(values);
             given(headers.contains(name)).willReturn(Boolean.TRUE);
 
             String lastValue = values.isEmpty() ? null :
                     values.get(values.size()-1);
 
-            given(request.getHeader(name)).willReturn(lastValue);
+            given(request.headers().get(name)).willReturn(lastValue);
             given(headers.get(name)).willReturn(lastValue);
         }
 
@@ -707,7 +707,7 @@ public class HttpPoolRequestHandlerTests
             }
         });
 
-        given(request.getHeaderNames()).willReturn(headersSource.keySet());
+        given(request.headers().names()).willReturn(headersSource.keySet());
         given(request.getProtocolVersion()).
                 willReturn(info.getProtocolVersion());
         given(request.getUri()).willReturn(info.getUri());
@@ -811,12 +811,12 @@ public class HttpPoolRequestHandlerTests
 
             HttpResponse response = (HttpResponse) o;
 
-            if(!response.containsHeader(_name)) {
+            if(!response.headers().contains(_name)) {
                 return false;
             }
 
             if(_value != null) {
-                List<String> values = response.getHeaders(_name);
+                List<String> values = response.headers().getAll(_name);
                 return values.contains(_value);
             } else {
                 return true;

--- a/pom.xml
+++ b/pom.xml
@@ -41,15 +41,15 @@
         <source.version>1.7</source.version>
         <target.version>1.7</target.version>
 
-        <version.slf4j>1.7.7</version.slf4j>
-        <version.milton>2.7.0.3</version.milton>
-        <version.spring>4.0.6.RELEASE</version.spring>
+        <version.slf4j>1.7.10</version.slf4j>
+        <version.milton>2.7.1.3</version.milton>
+        <version.spring>4.0.9.RELEASE</version.spring>
         <!-- Remember to sync aspectj version in dcache.properties -->
-        <version.aspectj>1.8.2</version.aspectj>
+        <version.aspectj>1.8.7</version.aspectj>
         <version.smc>6.3.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
-        <version.jetty>9.2.4.v20141103</version.jetty>
-        <version.wicket>6.16.0</version.wicket>
+        <version.jetty>9.2.14.v20151106</version.jetty>
+        <version.wicket>6.19.0</version.wicket>
         <version.xrootd4j>1.3.8</version.xrootd4j>
         <version.jglobus>2.0.6-rc9.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
@@ -81,7 +81,7 @@
          -->
         <bouncycastle.bcprov>bcprov-jdk16</bouncycastle.bcprov>
         <bouncycastle.version>1.46</bouncycastle.version>
-        <datanucleus-core.version>4.0.1</datanucleus-core.version>
+        <datanucleus-core.version>4.0.7</datanucleus-core.version>
         <datanucleus.plugin.version>4.0.0-release</datanucleus.plugin.version>
     </properties>
 
@@ -345,7 +345,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.9.4.Final</version>
+                <version>3.10.5.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.grizzly</groupId>
@@ -390,27 +390,27 @@
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-cache</artifactId>
-                <version>${datanucleus-core.version}</version>
+                <version>4.0.4</version>
             </dependency>
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-api-jdo</artifactId>
-                <version>${datanucleus-core.version}</version>
+                <version>4.0.5</version>
             </dependency>
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-api-jpa</artifactId>
-                <version>${datanucleus-core.version}</version>
+                <version>4.0.8</version>
             </dependency>
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-rdbms</artifactId>
-                <version>${datanucleus-core.version}</version>
+                <version>4.0.12</version>
             </dependency>
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-xml</artifactId>
-                <version>${datanucleus-core.version}</version>
+                <version>4.0.5</version>
             </dependency>
             <dependency>
                 <groupId>net.sf.saxon</groupId>
@@ -860,7 +860,7 @@
         <dependency>
            <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
-            <version>1.5.5</version>
+            <version>1.6.2</version>
             <scope>test</scope>
             <exclusions>
                 <!-- powermock-api-mockito depends on mockito-all,
@@ -885,7 +885,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.4</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -897,7 +897,7 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.5.5</version>
+            <version>1.6.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -183,7 +183,7 @@ dcache.log.access.max-history=30
     -Djava.security.auth.login.config=${dcache.authn.jaas.config} \
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath=${dcache.java.oom.file} \
-    -javaagent:${dcache.paths.classes}/aspectjweaver-1.8.2.jar \
+    -javaagent:${dcache.paths.classes}/aspectjweaver-1.8.7.jar \
     -XX:+UseCompressedOops \
     ${dcache.java.options.common} \
     ${dcache.java.options.extra}


### PR DESCRIPTION
Motivation:

Keep up to date with bug fixes.

Modification:

DataNucleus 4.0.7
Jetty 9.2.14
Spring 4.0.9
Milton 2.7.1.3
AspectJ 1.8.7
Netty 3.10.5
PowerMock 1.6.2
Mockito 1.0.19

Result:

Fewer bugs.

Target: 2.11
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8904/