### PR TITLE
srm: Fix saving of transient states to database

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
@@ -124,12 +124,6 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
         this.transactionTemplate = new TransactionTemplate(configuration.getTransactionManager());
     }
 
-    @Override
-    public boolean isJdbcLogRequestHistoryInDBEnabled()
-    {
-        return logHistory;
-    }
-
     //this should always reflect the number of field definde in the
     // prefix above
     public abstract String getTableName();
@@ -283,10 +277,6 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
     @Override
     public void saveJob(final Job job, boolean force) throws DataAccessException
     {
-        if (!force && !logHistory) {
-            return;
-        }
-
         final List<Job.JobHistory> history = getJobHistoriesToSave(job);
         transactionTemplate.execute(status -> jdbcTemplate.execute((Connection con) -> {
             int rowCount = updateJob(con, job);

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorageFactory.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorageFactory.java
@@ -32,7 +32,7 @@ import org.dcache.srm.request.PutRequest;
 import org.dcache.srm.request.ReserveSpaceRequest;
 import org.dcache.srm.scheduler.AsynchronousSaveJobStorage;
 import org.dcache.srm.scheduler.CanonicalizingJobStorage;
-import org.dcache.srm.scheduler.FinalStateOnlyJobStorageDecorator;
+import org.dcache.srm.scheduler.ForceOnlyJobStorageDecorator;
 import org.dcache.srm.scheduler.JobStorage;
 import org.dcache.srm.scheduler.JobStorageFactory;
 import org.dcache.srm.scheduler.NoopJobStorage;
@@ -69,7 +69,7 @@ public class DatabaseJobStorageFactory extends JobStorageFactory
                     .newInstance(config, scheduledExecutor);
             js = new AsynchronousSaveJobStorage<>(js, executor);
             if (config.getStoreCompletedRequestsOnly()) {
-                js = new FinalStateOnlyJobStorageDecorator<>(js);
+                js = new ForceOnlyJobStorageDecorator<>(js);
             }
         } else {
             js = new NoopJobStorage<>();

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorage.java
@@ -66,10 +66,6 @@ public class AsynchronousSaveJobStorage<J extends Job> implements JobStorage<J>
 
     public void saveJob(final J job, final boolean force)
     {
-        if (!force && !isJdbcLogRequestHistoryInDBEnabled()) {
-            return;
-        }
-
         UpdateState existingState;
         if (force) {
             existingState = states.put(job.getId(), UpdateState.QUEUED_FORCED);
@@ -122,12 +118,6 @@ public class AsynchronousSaveJobStorage<J extends Job> implements JobStorage<J>
                 }
             }
         }
-    }
-
-    @Override
-    public boolean isJdbcLogRequestHistoryInDBEnabled()
-    {
-        return storage.isJdbcLogRequestHistoryInDBEnabled();
     }
 
     @Override

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/CanonicalizingJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/CanonicalizingJobStorage.java
@@ -107,12 +107,6 @@ public class CanonicalizingJobStorage<J extends Job> implements JobStorage<J>
     }
 
     @Override
-    public boolean isJdbcLogRequestHistoryInDBEnabled()
-    {
-        return storage.isJdbcLogRequestHistoryInDBEnabled();
-    }
-
-    @Override
     public Set<Long> getLatestCompletedJobIds(int maxNum) throws DataAccessException
     {
         return storage.getLatestCompletedJobIds(maxNum);

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/ForceOnlyJobStorageDecorator.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/ForceOnlyJobStorageDecorator.java
@@ -12,10 +12,10 @@ import org.dcache.srm.request.Job;
  *
  * @author timur
  */
-public class FinalStateOnlyJobStorageDecorator<J extends Job> implements JobStorage<J> {
+public class ForceOnlyJobStorageDecorator<J extends Job> implements JobStorage<J> {
 
     private final JobStorage<J> jobStorage;
-    public FinalStateOnlyJobStorageDecorator(JobStorage<J> jobStorage ) {
+    public ForceOnlyJobStorageDecorator(JobStorage<J> jobStorage ) {
         this.jobStorage = jobStorage;
     }
 
@@ -47,7 +47,7 @@ public class FinalStateOnlyJobStorageDecorator<J extends Job> implements JobStor
 
     @Override
     public void saveJob(J job, boolean force) throws DataAccessException {
-        if (force || job.getState().isFinal()) {
+        if (force) {
             jobStorage.saveJob(job, force);
         }
     }
@@ -82,9 +82,4 @@ public class FinalStateOnlyJobStorageDecorator<J extends Job> implements JobStor
         return jobStorage.getActiveJobs();
     }
 
-    @Override
-    public boolean isJdbcLogRequestHistoryInDBEnabled()
-    {
-        return jobStorage.isJdbcLogRequestHistoryInDBEnabled();
-    }
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/JobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/JobStorage.java
@@ -101,8 +101,6 @@ public interface JobStorage<J extends Job> {
     void saveJob(J job, boolean force)
             throws DataAccessException;
 
-    boolean isJdbcLogRequestHistoryInDBEnabled();
-
     Set<Long> getLatestCompletedJobIds(int maxNum) throws DataAccessException;
     Set<Long> getLatestDoneJobIds(int maxNum) throws DataAccessException;
     Set<Long> getLatestFailedJobIds(int maxNum) throws DataAccessException;

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/NoopJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/NoopJobStorage.java
@@ -74,9 +74,4 @@ public class NoopJobStorage<J extends Job> implements JobStorage<J> {
         return Collections.emptySet();
     }
 
-    @Override
-    public boolean isJdbcLogRequestHistoryInDBEnabled()
-    {
-        return false;
-    }
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
@@ -5,7 +5,6 @@ import org.springframework.dao.DataAccessException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -121,12 +120,6 @@ public class SharedMemoryCacheJobStorage<J extends Job> implements JobStorage<J>
         storage.saveJob(job, force);
         sharedMemoryCache.update(job);
         updateExpirationSet(job);
-    }
-
-    @Override
-    public boolean isJdbcLogRequestHistoryInDBEnabled()
-    {
-        return storage.isJdbcLogRequestHistoryInDBEnabled();
     }
 
     @Override

--- a/modules/srm-server/src/test/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorageTest.java
+++ b/modules/srm-server/src/test/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorageTest.java
@@ -29,37 +29,16 @@ public class AsynchronousSaveJobStorageTest
     }
 
     @Test
-    public void whenRequestHistoryLoggingIsDisabledAndSavingWithForceThenActualSaveIsWithForce() throws Exception
+    public void whenSavingWithForceThenActualSaveIsWithForce() throws Exception
     {
-        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(false);
         asyncStorage.saveJob(job, true);
         runTasks();
         verify(storage).saveJob(job, true);
     }
 
     @Test
-    public void whenRequestHistoryLoggingIsEnabledAndSavingWithForceThenActualSaveIsWithForce() throws Exception
+    public void whenSavingWithoutForceThenActualSaveIsWithoutForce() throws Exception
     {
-        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
-        asyncStorage.saveJob(job, true);
-        runTasks();
-        verify(storage).saveJob(job, true);
-    }
-
-    @Test
-    public void whenRequestHistoryLoggingIsEnabledAndSavingWithoutForceThenActualSaveIsWithoutForce() throws Exception
-    {
-        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
-        asyncStorage.saveJob(job, false);
-        runTasks();
-        verify(storage).saveJob(job, false);
-    }
-
-    @Test
-    public void whenSavingTwiceWithoutForceThenActualSaveIsOnceWithoutForce() throws Exception
-    {
-        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
-        asyncStorage.saveJob(job, false);
         asyncStorage.saveJob(job, false);
         runTasks();
         verify(storage).saveJob(job, false);
@@ -68,7 +47,6 @@ public class AsynchronousSaveJobStorageTest
     @Test
     public void whenSavingTwiceWithForceThenActualSaveIsOnceWithForce() throws Exception
     {
-        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
         asyncStorage.saveJob(job, true);
         asyncStorage.saveJob(job, true);
         runTasks();
@@ -78,7 +56,6 @@ public class AsynchronousSaveJobStorageTest
     @Test
     public void whenSavingTwiceWithAndWithoutForceThenActualSaveIsOnceWithForce() throws Exception
     {
-        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
         asyncStorage.saveJob(job, true);
         asyncStorage.saveJob(job, false);
         runTasks();
@@ -88,7 +65,6 @@ public class AsynchronousSaveJobStorageTest
     @Test
     public void whenSavingTwiceWithoutAndWithForceThenActualSaveIsOnceWithForce() throws Exception
     {
-        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
         asyncStorage.saveJob(job, false);
         asyncStorage.saveJob(job, true);
         runTasks();
@@ -100,7 +76,6 @@ public class AsynchronousSaveJobStorageTest
     {
         Executor executor = mock(Executor.class);
         asyncStorage = new AsynchronousSaveJobStorage<>(storage, executor);
-        when(storage.isJdbcLogRequestHistoryInDBEnabled()).thenReturn(true);
         doThrow(RejectedExecutionException.class).when(executor).execute(any(Runnable.class));
         asyncStorage.saveJob(job, true);
         verify(storage).saveJob(job, true);

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -758,8 +758,7 @@ srm.persistence.reserve-space.enable.history = ${srm.persistence.enable.history}
 # The setting does not control which information is stored in the database. When a
 # request is eventually stored, all available information is stored.
 #
-# If srm.persistence.enable or srm.persistence.enable.history are set to false,
-# this setting has no effect.
+# If srm.persistence.enable is set to false, this setting has no effect.
 #
 (one-of?true|false)srm.persistence.enable.store-transient-state = false
 


### PR DESCRIPTION
Motivation:

SRM has options of controlling whether job history is stored to the
database as well as whether transient (unimportant) states are
stored.

Yet, the various job storage decorators apply filtering based
on whether job history is enabled. Specifically this means that
if storage of transient states is enabled while job history is
disabled, transient states are not stored.

Modification:

Remove the unnecessary filtering from various job storage implementations.
Renamed FinalStateOnlyJobStorageDecorator to ForceOnlyJobStorageDecorator
since the Scheduler is already forcing save of jobs in final states and
there is no reason to check for final states in the decorator.

Result:

Fixed interpretation of srm.persistence.enable.store-transient-state when
srm.persistence.enable.history is disabled. This may put additional load
on the SRM database if store-transient-state is true and enable.history
is false - the old behaviour can be restored by setting both properties
to false.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8889/
(cherry picked from commit cadec146dfeeea28de822b032237c86892b2d2b6)