### PR TITLE
common: Move NetLoggerBuilder out of common

### DIFF
--- a/modules/cells/src/main/java/org/dcache/util/NetLoggerBuilder.java
+++ b/modules/cells/src/main/java/org/dcache/util/NetLoggerBuilder.java
@@ -8,8 +8,6 @@ import org.slf4j.Logger;
 
 import javax.security.auth.Subject;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.Principal;
 import java.time.ZonedDateTime;


### PR DESCRIPTION
Motivation:

NetLoggerBuilder depends on Java 8 while the common module must
be compilable with Java 7.

Modification:

Move the NetLoggerBuilder class to the cells module.

Result:

One less Java 7 compilation problem.

Target: trunk
Request: 2.14
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8906/
(cherry picked from commit 4eed1d57585ea88181361fc04f2ebdb6af29c888)