### PR TITLE
common-security,ftp-client: Allow compilation with Java 7

### DIFF
--- a/modules/common-security/pom.xml
+++ b/modules/common-security/pom.xml
@@ -36,4 +36,18 @@
             <artifactId>canl</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- Use Java 7 because srm-client uses this module. -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/common-security/src/main/java/javatunnel/token/Base64TokenReader.java
+++ b/modules/common-security/src/main/java/javatunnel/token/Base64TokenReader.java
@@ -17,11 +17,12 @@
  */
 package javatunnel.token;
 
+import com.google.common.io.BaseEncoding;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.Base64;
 
 public class Base64TokenReader implements TokenReader
 {
@@ -42,7 +43,7 @@ public class Base64TokenReader implements TokenReader
         if (!s.startsWith("enc ")) {
             throw new IOException("Invalid framing; expected enc command.");
         }
-        return Base64.getDecoder().decode(s.substring(4));
+        return BaseEncoding.base64().decode(s.substring(4));
     }
 
     @Override

--- a/modules/common-security/src/main/java/javatunnel/token/Base64TokenWriter.java
+++ b/modules/common-security/src/main/java/javatunnel/token/Base64TokenWriter.java
@@ -17,10 +17,11 @@
  */
 package javatunnel.token;
 
+import com.google.common.io.BaseEncoding;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.util.Base64;
 
 public class Base64TokenWriter implements TokenWriter
 {
@@ -34,7 +35,7 @@ public class Base64TokenWriter implements TokenWriter
     @Override
     public void write(byte[] token) throws IOException
     {
-        out.write("enc " + Base64.getEncoder().encodeToString(token) + "\n");
+        out.write("enc " + BaseEncoding.base64().encode(token) + "\n");
         out.flush();
     }
 

--- a/modules/common-security/src/main/java/org/dcache/dss/ClientGsiEngineDssContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/ClientGsiEngineDssContextFactory.java
@@ -28,11 +28,16 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.security.cert.CertificateFactory;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.dcache.gsi.ClientGsiEngine;
 import org.dcache.ssl.SslContextFactory;
 import org.dcache.util.CertificateFactories;
+
+import static com.google.common.base.Predicates.in;
+import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.toArray;
+import static java.util.Arrays.asList;
 
 public class ClientGsiEngineDssContextFactory implements DssContextFactory
 {
@@ -67,12 +72,10 @@ public class ClientGsiEngineDssContextFactory implements DssContextFactory
                             remoteSocketAddress.getHostString(),
                             remoteSocketAddress.getPort());
             SSLParameters sslParameters = delegate.getSSLParameters();
-            sslParameters.setCipherSuites(Stream.of(sslParameters.getCipherSuites())
-                                                  .filter(cipher -> !bannedCiphers.contains(cipher))
-                                                  .toArray(String[]::new));
-            sslParameters.setProtocols(Stream.of(sslParameters.getProtocols())
-                                               .filter(protocol -> !bannedProtocols.contains(protocol))
-                                               .toArray(String[]::new));
+            String[] cipherSuites = toArray(filter(asList(sslParameters.getCipherSuites()), not(in(bannedCiphers))), String.class);
+            String[] protocols = toArray(filter(asList(sslParameters.getProtocols()), not(in(bannedProtocols))), String.class);
+            sslParameters.setCipherSuites(cipherSuites);
+            sslParameters.setProtocols(protocols);
             sslParameters.setWantClientAuth(true);
             sslParameters.setNeedClientAuth(true);
             delegate.setSSLParameters(sslParameters);

--- a/modules/common-security/src/main/java/org/dcache/dss/KerberosDssContext.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/KerberosDssContext.java
@@ -23,7 +23,6 @@ import org.ietf.jgss.GSSException;
 import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosPrincipal;
 
-import java.security.Principal;
 import java.util.Collections;
 import java.util.Set;
 
@@ -36,7 +35,7 @@ public class KerberosDssContext extends GssDssContext
 
     protected Subject createSubject() throws GSSException
     {
-        Set<Principal> principals = Collections.singleton(new KerberosPrincipal(context.getSrcName().toString()));
+        Set<KerberosPrincipal> principals = Collections.singleton(new KerberosPrincipal(context.getSrcName().toString()));
         return new Subject(false, principals, Collections.emptySet(), Collections.emptySet());
     }
 }

--- a/modules/common-security/src/main/java/org/dcache/dss/SslEngineDssContext.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/SslEngineDssContext.java
@@ -26,10 +26,12 @@ import javax.security.auth.Subject;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.security.Principal;
 import java.security.cert.CertPath;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.util.Collections;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Arrays.asList;
@@ -268,7 +270,7 @@ public class SslEngineDssContext implements DssContext
         try {
             Certificate[] chain = engine.getSession().getPeerCertificates();
             CertPath certPath = cf.generateCertPath(asList(chain));
-            return new Subject(false, emptySet(), singleton(certPath), emptySet());
+            return new Subject(false, Collections.<Principal>emptySet(), singleton(certPath), emptySet());
         } catch (SSLPeerUnverifiedException e) {
             throw new IOException("Failed to establish identity of SSL peer: " + e.getMessage(), e);
         } catch (CertificateException e) {

--- a/modules/common-security/src/main/java/org/dcache/gsi/KeyPairCache.java
+++ b/modules/common-security/src/main/java/org/dcache/gsi/KeyPairCache.java
@@ -30,6 +30,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -80,7 +81,14 @@ public class KeyPairCache
                                     Integer keySize, KeyPair previous)
                             {
                                 ListenableFutureTask<KeyPair> task =
-                                        ListenableFutureTask.create(() -> generate(keySize));
+                                        ListenableFutureTask.create(new Callable<KeyPair>()
+                                        {
+                                            @Override
+                                            public KeyPair call() throws Exception
+                                            {
+                                                return generate(keySize);
+                                            }
+                                        });
                                 _executor.execute(task);
                                 return task;
                             }

--- a/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.ssl;
 
+import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import eu.emi.security.authn.x509.CrlCheckingMode;
 import eu.emi.security.authn.x509.NamespaceCheckingMode;
@@ -24,7 +25,10 @@ import eu.emi.security.authn.x509.OCSPCheckingMode;
 import eu.emi.security.authn.x509.OCSPParametes;
 import eu.emi.security.authn.x509.ProxySupport;
 import eu.emi.security.authn.x509.RevocationParameters;
+import eu.emi.security.authn.x509.StoreUpdateListener;
+import eu.emi.security.authn.x509.ValidationError;
 import eu.emi.security.authn.x509.ValidationErrorCategory;
+import eu.emi.security.authn.x509.ValidationErrorListener;
 import eu.emi.security.authn.x509.X509CertChainValidator;
 import eu.emi.security.authn.x509.X509Credential;
 import eu.emi.security.authn.x509.helpers.ssl.SSLTrustManager;
@@ -46,7 +50,6 @@ import java.security.cert.X509Certificate;
 import java.util.EnumSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import org.dcache.util.CachingCertificateValidator;
 
@@ -69,6 +72,14 @@ public class CanlContextFactory implements SslContextFactory
 
     private final SecureRandom secureRandom = new SecureRandom();
     private final TrustManager[] trustManagers;
+
+    private static final AutoCloseable NOOP = new AutoCloseable()
+    {
+        @Override
+        public void close() throws Exception
+        {
+        }
+    };
 
     protected CanlContextFactory(TrustManager... trustManagers)
     {
@@ -112,7 +123,13 @@ public class CanlContextFactory implements SslContextFactory
         private Path certificatePath = FileSystems.getDefault().getPath("/etc/grid-security/hostcert.pem");
         private long credentialUpdateInterval = 1;
         private TimeUnit credentialUpdateIntervalUnit = TimeUnit.MINUTES;
-        private Supplier<AutoCloseable> contextSupplier = () -> () -> {
+        private Supplier<AutoCloseable> loggingContextSupplier = new Supplier<AutoCloseable>()
+        {
+            @Override
+            public AutoCloseable get()
+            {
+                return NOOP;
+            }
         };
         private long validationCacheLifetime = 300000;
 
@@ -188,7 +205,7 @@ public class CanlContextFactory implements SslContextFactory
 
         public Builder withLoggingContext(Supplier<AutoCloseable> contextSupplier)
         {
-            this.contextSupplier = contextSupplier;
+            this.loggingContextSupplier = contextSupplier;
             return this;
         }
 
@@ -216,47 +233,65 @@ public class CanlContextFactory implements SslContextFactory
                                                           certificateAuthorityUpdateInterval,
                                                           validatorParams, lazyMode),
                             validationCacheLifetime);
-            v.addUpdateListener((location, type, level, cause) -> {
-                try (AutoCloseable ignored = contextSupplier.get()) {
-                    switch (level) {
-                    case ERROR:
-                        if (cause != null) {
-                            LOGGER.error("Error loading {} from {}: {}", type, location, cause.getMessage());
-                        } else {
-                            LOGGER.error("Error loading {} from {}.", type, location);
+            v.addUpdateListener(new StoreUpdateListener()
+            {
+                @Override
+                public void loadingNotification(String location, String type, Severity level, Exception cause)
+                {
+                    try (AutoCloseable ignored = loggingContextSupplier.get()) {
+                        switch (level) {
+                        case ERROR:
+                            if (cause != null) {
+                                LOGGER.error("Error loading {} from {}: {}", type, location, cause.getMessage());
+                            } else {
+                                LOGGER.error("Error loading {} from {}.", type, location);
+                            }
+                            break;
+                        case WARNING:
+                            if (cause != null) {
+                                LOGGER.warn("Problem loading {} from {}: {}", type, location, cause.getMessage());
+                            } else {
+                                LOGGER.warn("Problem loading {} from {}.", type, location);
+                            }
+                            break;
+                        case NOTIFICATION:
+                            LOGGER.debug("Reloaded {} from {}: ", type, location);
+                            break;
                         }
-                        break;
-                    case WARNING:
-                        if (cause != null) {
-                            LOGGER.warn("Problem loading {} from {}: {}", type, location, cause.getMessage());
-                        } else {
-                            LOGGER.warn("Problem loading {} from {}.", type, location);
-                        }
-                        break;
-                    case NOTIFICATION:
-                        LOGGER.debug("Reloaded {} from {}: ", type, location);
-                        break;
+                    } catch (Exception e) {
+                        Throwables.propagate(e);
                     }
-                } catch (Exception e) {
-                    Throwables.propagate(e);
                 }
             });
-            v.addValidationListener(error -> {
-                if (VALIDATION_ERRORS_TO_LOG.contains(error.getErrorCategory())) {
-                    X509Certificate[] chain = error.getChain();
-                    String subject = (chain != null && chain.length > 0) ? chain[0].getSubjectX500Principal().getName() : "";
-                    LOGGER.warn("The peer's certificate with DN {} was rejected: {}", subject, error);
+            v.addValidationListener(new ValidationErrorListener()
+            {
+                @Override
+                public boolean onValidationError(ValidationError error)
+                {
+                    if (VALIDATION_ERRORS_TO_LOG.contains(error.getErrorCategory())) {
+                        X509Certificate[] chain = error.getChain();
+                        String subject = (chain != null && chain.length > 0) ? chain[0].getSubjectX500Principal().getName() : "";
+                        LOGGER.warn("The peer's certificate with DN {} was rejected: {}", subject, error);
+                    }
+                    return false;
                 }
-                return false;
             });
             return new CanlContextFactory(new SSLTrustManager(v));
         }
 
         public Callable<SSLContext> buildWithCaching()
         {
-            CanlContextFactory factory = build();
+            final CanlContextFactory factory = build();
             Callable<SSLContext> newContext =
-                    () -> factory.getContext(new PEMCredential(keyPath.toString(), certificatePath.toString(), null));
+                    new Callable<SSLContext>()
+                    {
+                        @Override
+                        public SSLContext call() throws Exception
+                        {
+                            return factory.getContext(
+                                    new PEMCredential(keyPath.toString(), certificatePath.toString(), null));
+                        }
+                    };
             return  memoizeWithExpiration(memoizeFromFiles(newContext, keyPath, certificatePath),
                                           credentialUpdateInterval, credentialUpdateIntervalUnit);
         }

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/extended/GridFTPControlChannel.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/extended/GridFTPControlChannel.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.ftp.client.extended;
 
+import com.google.common.io.BaseEncoding;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 
 import javax.net.ssl.HostnameVerifier;
@@ -32,7 +33,6 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.util.Base64;
 
 import org.dcache.dss.DssContext;
 import org.dcache.dss.DssContextFactory;
@@ -101,9 +101,9 @@ public class GridFTPControlChannel extends FTPControlChannel
             byte[] inToken = new byte[0];
             do {
                 byte[] outToken = context.init(inToken);
-                reply = inner.exchange(new Command("ADAT", Base64.getEncoder().encodeToString(outToken != null ? outToken : new byte[0])));
+                reply = inner.exchange(new Command("ADAT", BaseEncoding.base64().encode(outToken != null ? outToken : new byte[0])));
                 if (reply.getMessage().startsWith("ADAT=")) {
-                    inToken = Base64.getDecoder().decode(reply.getMessage().substring(5));
+                    inToken = BaseEncoding.base64().decode(reply.getMessage().substring(5));
                 } else {
                     inToken = new byte[0];
                 }
@@ -198,7 +198,7 @@ public class GridFTPControlChannel extends FTPControlChannel
             throw ServerException.embedUnexpectedReplyCodeException(
                     new UnexpectedReplyCodeException(reply), "Expected 632 or 633 reply.");
         }
-        byte[] token = Base64.getDecoder().decode(reply.getMessage());
+        byte[] token = BaseEncoding.base64().decode(reply.getMessage());
         lastReply = new Reply(new BufferedReader(new StringReader(new String(context.unwrap(token)))));
         return lastReply;
     }
@@ -214,6 +214,6 @@ public class GridFTPControlChannel extends FTPControlChannel
     {
         byte[] bytes = cmd.toString().getBytes(StandardCharsets.US_ASCII);
         byte[] token = context.wrap(bytes, 0, bytes.length);
-        inner.write(new Command("ENC", Base64.getEncoder().encodeToString(token)));
+        inner.write(new Command("ENC", BaseEncoding.base64().encode(token)));
     }
 }


### PR DESCRIPTION
Motivation:

The srm-client depends on these modules and the srm-client must work
with Java 7.

Modification:

Replace use of Java 8 classes with Guava classes.

Result:

common-security and ftp-client compile with Java 7.

Target: trunk
Request: 2.14
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8908/
(cherry picked from commit 86fdfcf1356da7f0e1634e086d555a296534c7dc)