### PR TITLE
pool: Log information on runtime for listing the repository

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
@@ -1,5 +1,6 @@
 package org.dcache.pool.repository;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,8 +121,14 @@ public class ConsistentStore
     @Override
     public synchronized Collection<PnfsId> list() throws CacheException
     {
+        Stopwatch watch = Stopwatch.createStarted();
         Collection<PnfsId> files = _fileStore.list();
+        _log.info("Indexed {} entries in {} in {}.", files.size(), _fileStore, watch);
+
+        watch.reset().start();
         Collection<PnfsId> records = _metaDataStore.list();
+        _log.info("Indexed {} entries in {} in {}.", records.size(), _metaDataStore, watch);
+
         records.removeAll(new HashSet<>(files));
         for (PnfsId id: records) {
             _log.warn(String.format(REMOVING_REDUNDANT_META_DATA, id));


### PR DESCRIPTION
Motivation:

To better analyse performance aspects of pool startup.

Modification:

Logs the time it takes to list the data directory and the meta
data database.

Result:

13:06:43 [Thread-29] [] Listed /Users/behrmann/thinkpad/dCache/dcache-git/packages/system-test/target/dcache/var/pools/pool_write/data in 167,1 μs
13:06:43 [Thread-29] [] Listed /Users/behrmann/thinkpad/dCache/dcache-git/packages/system-test/target/dcache/var/pools/pool_write/control in 110,5 μs

Target: trunk
Request: 2.14
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8909/
(cherry picked from commit 1f9349ea5d2b78c6ee66473bedd76d6c375649f8)