### PR TITLE
pool: Use disk ordered cursor for listing meta data on pool startup

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
@@ -8,11 +8,10 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
@@ -119,17 +118,17 @@ public class ConsistentStore
      * redundant meta data entries in the process.
      */
     @Override
-    public synchronized Collection<PnfsId> list() throws CacheException
+    public synchronized Set<PnfsId> index() throws CacheException
     {
         Stopwatch watch = Stopwatch.createStarted();
-        Collection<PnfsId> files = _fileStore.list();
+        Set<PnfsId> files = _fileStore.index();
         _log.info("Indexed {} entries in {} in {}.", files.size(), _fileStore, watch);
 
         watch.reset().start();
-        Collection<PnfsId> records = _metaDataStore.list();
+        Set<PnfsId> records = _metaDataStore.index();
         _log.info("Indexed {} entries in {} in {}.", records.size(), _metaDataStore, watch);
 
-        records.removeAll(new HashSet<>(files));
+        records.removeAll(files);
         for (PnfsId id: records) {
             _log.warn(String.format(REMOVING_REDUNDANT_META_DATA, id));
             _metaDataStore.remove(id);

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/FileStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/FileStore.java
@@ -1,7 +1,7 @@
 package org.dcache.pool.repository;
 
 import java.io.File;
-import java.util.List;
+import java.util.Set;
 
 import diskCacheV111.util.PnfsId;
 
@@ -17,9 +17,9 @@ public interface FileStore
     public File get(PnfsId id);
 
     /**
-     * Returns a list of PNFS ids of available data files.
+     * Returns the PNFS-IDs of available data files.
      */
-    public List<PnfsId> list();
+    Set<PnfsId> index();
 
     /**
      * Provides the amount of free space on the file system containing

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/FlatFileStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/FlatFileStore.java
@@ -4,7 +4,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import diskCacheV111.util.PnfsId;
 
@@ -47,10 +49,10 @@ public class FlatFileStore implements FileStore
     }
 
     @Override
-    public List<PnfsId> list()
+    public Set<PnfsId> index()
     {
         String[] files = _dataDir.list();
-        List<PnfsId> ids = new ArrayList<>(files.length);
+        Set<PnfsId> ids = new HashSet<>(files.length);
 
         for (String name : files) {
             try {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCache.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCache.java
@@ -2,6 +2,7 @@ package org.dcache.pool.repository;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -44,7 +45,7 @@ public class MetaDataCache
     {
         _inner = inner;
 
-        Collection<PnfsId> list = inner.list();
+        Collection<PnfsId> list = inner.index();
         _entries = new ConcurrentHashMap<>(
                 (int)(list.size() / LOAD_FACTOR + 1), LOAD_FACTOR);
         for (PnfsId id: list) {
@@ -190,9 +191,9 @@ public class MetaDataCache
     }
 
     @Override
-    public Collection<PnfsId> list()
+    public Set<PnfsId> index()
     {
-        return Collections.unmodifiableCollection(_entries.keySet());
+        return Collections.unmodifiableSet(_entries.keySet());
     }
 
     @Override

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStore.java
@@ -1,6 +1,6 @@
 package org.dcache.pool.repository;
 
-import java.util.Collection;
+import java.util.Set;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
@@ -18,7 +18,7 @@ public interface MetaDataStore
     /**
      * Returns a collection of PNFS ids of available entries.
      */
-    Collection<PnfsId> list() throws CacheException;
+    Set<PnfsId> index() throws CacheException;
 
     /**
      * Retrieves an existing entry previously created with

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreCopyTool.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreCopyTool.java
@@ -43,12 +43,12 @@ public class MetaDataStoreCopyTool
         MetaDataStore toStore =
             createStore(Class.forName(args[2]).asSubclass(MetaDataStore.class), fileStore, poolDir);
 
-        if (!toStore.list().isEmpty()) {
+        if (!toStore.index().isEmpty()) {
             System.err.println("ERROR: Target store is not empty");
             System.exit(1);
         }
 
-        Collection<PnfsId> ids = fromStore.list();
+        Collection<PnfsId> ids = fromStore.index();
         int size = ids.size();
         int count = 1;
         for (PnfsId id: ids) {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreYamlTool.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreYamlTool.java
@@ -43,7 +43,7 @@ public class MetaDataStoreYamlTool
 
         PrintWriter out = new PrintWriter(System.out);
         PrintWriter error = new PrintWriter(System.err);
-        for (PnfsId id: metaStore.list()) {
+        for (PnfsId id: metaStore.index()) {
             try {
                 MetaDataRecord record = metaStore.get(id);
                 FileAttributes attributes = record.getFileAttributes();

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
@@ -13,8 +13,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
@@ -104,17 +104,10 @@ public class BerkeleyDBMetaDataRepository
     }
 
     @Override
-    public Collection<PnfsId> list() throws CacheException
+    public Set<PnfsId> index() throws CacheException
     {
         try {
-            Set<PnfsId> ids = new HashSet<>();
-            for (Object id : _views.getStorageInfoMap().keySet()) {
-                ids.add(new PnfsId((String) id));
-            }
-            for (Object id : _views.getStateMap().keySet()) {
-                ids.add(new PnfsId((String) id));
-            }
-            return ids;
+            return _views.collectKeys(Collectors.mapping(PnfsId::new, Collectors.toSet()));
         } catch (EnvironmentFailureException e) {
             if (!isValid()) {
                 throw new DiskErrorCacheException("Meta data lookup failed and a pool restart is required: " + e.getMessage(), e);

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/MetaDataRepositoryDatabase.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/MetaDataRepositoryDatabase.java
@@ -4,13 +4,11 @@ import com.sleepycat.bind.serial.StoredClassCatalog;
 import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseConfig;
 import com.sleepycat.je.DatabaseException;
+import com.sleepycat.je.DiskOrderedCursor;
+import com.sleepycat.je.DiskOrderedCursorConfig;
 import com.sleepycat.je.Environment;
 import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.EnvironmentFailureException;
-import com.sleepycat.je.ExceptionEvent;
-import com.sleepycat.je.ExceptionListener;
-import com.sleepycat.je.RunRecoveryException;
-import com.sleepycat.je.config.EnvironmentParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,5 +111,12 @@ public class MetaDataRepositoryDatabase
     public final Database getStateDatabase()
     {
         return stateDatabase;
+    }
+
+    public DiskOrderedCursor openKeyCursor()
+    {
+        DiskOrderedCursorConfig config = new DiskOrderedCursorConfig();
+        config.setKeysOnly(true);
+        return env.openDiskOrderedCursor(new Database[]{storageInfoDatabase, stateDatabase}, config);
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
@@ -64,7 +64,7 @@ public class FileMetaDataRepository
     }
 
     @Override
-    public Collection<PnfsId> list()
+    public Set<PnfsId> index()
     {
         String[] files = _metadir.list();
         Set<PnfsId> ids = new HashSet<>(files.length);

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -145,6 +145,11 @@ public class CacheRepositoryV5
     private volatile State _state = State.UNINITIALIZED;
 
     /**
+     * Initialization progress between 0 and 1.
+     */
+    private float _initializationProgress;
+
+    /**
      * Shared repository account object for tracking space.
      */
     private Account _account;
@@ -344,7 +349,6 @@ public class CacheRepositoryV5
             }
 
             List<PnfsId> ids = new ArrayList<>(_store.index());
-            _log.info("Found {} data files", ids.size());
 
             /* On some file systems (e.g. GPFS) stat'ing files in
              * lexicographic order seems to trigger the pre-fetch
@@ -354,8 +358,10 @@ public class CacheRepositoryV5
 
             /* Collect all entries.
              */
-            _log.info("Checking meta data for {} files", ids.size());
+            int fileCount = ids.size();
+            _log.info("Checking meta data for {} files", fileCount);
             long usedDataSpace = 0L;
+            int cnt = 0;
             List<MetaDataRecord> entries = new ArrayList<>();
             for (PnfsId id: ids) {
                 MetaDataRecord entry = readMetaDataRecord(id);
@@ -364,6 +370,8 @@ public class CacheRepositoryV5
                     _log.debug("{} {}", id, entry.getState());
                     entries.add(entry);
                 }
+                _initializationProgress = ((float) cnt) / fileCount;
+                cnt++;
             }
 
             /* Allocate space.
@@ -774,7 +782,11 @@ public class CacheRepositoryV5
     public void getInfo(PrintWriter pw)
     {
         State state = _state;
-        pw.println("State : " + state);
+        pw.append("State : ").append(state.toString());
+        if (state == State.LOADING) {
+            pw.append(" (").append(String.valueOf((int) (_initializationProgress * 100))).append("% done)");
+        }
+        pw.println();
         try {
             pw.println("Files : " + (state == State.OPEN || state == State.LOADING || state == State.INITIALIZED ? _store.index().size() : ""));
         } catch (CacheException e) {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -343,7 +343,7 @@ public class CacheRepositoryV5
                 _state = State.LOADING;
             }
 
-            List<PnfsId> ids = new ArrayList<>(_store.list());
+            List<PnfsId> ids = new ArrayList<>(_store.index());
             _log.info("Found {} data files", ids.size());
 
             /* On some file systems (e.g. GPFS) stat'ing files in
@@ -426,7 +426,7 @@ public class CacheRepositoryV5
     {
         assertOpen();
         try {
-            return Collections.unmodifiableCollection(_store.list()).iterator();
+            return Collections.unmodifiableCollection(_store.index()).iterator();
         } catch (DiskErrorCacheException | RuntimeException e) {
             fail(FaultAction.DEAD, "Internal repository error", e);
             throw Throwables.propagate(e);
@@ -776,7 +776,7 @@ public class CacheRepositoryV5
         State state = _state;
         pw.println("State : " + state);
         try {
-            pw.println("Files : " + (state == State.OPEN || state == State.LOADING || state == State.INITIALIZED ?_store.list().size() : ""));
+            pw.println("Files : " + (state == State.OPEN || state == State.LOADING || state == State.INITIALIZED ? _store.index().size() : ""));
         } catch (CacheException e) {
             pw.println("Files : " + e.getMessage());
         }

--- a/modules/dcache/src/test/java/org/dcache/tests/repository/MetaDataRepositoryHelper.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/repository/MetaDataRepositoryHelper.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import diskCacheV111.util.CacheException;
@@ -243,8 +244,8 @@ public class MetaDataRepositoryHelper implements MetaDataStore {
     }
 
     @Override
-    public Collection<PnfsId> list() {
-        return Collections.unmodifiableCollection(_entryList.keySet());
+    public Set<PnfsId> index() {
+        return Collections.unmodifiableSet(_entryList.keySet());
     }
 
     @Override

--- a/modules/dcache/src/test/java/org/dcache/tests/repository/RepositoryHealerTestChimeraHelper.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/repository/RepositoryHealerTestChimeraHelper.java
@@ -16,8 +16,10 @@ import java.net.URL;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 
 import diskCacheV111.util.PnfsId;
@@ -104,10 +106,10 @@ public class RepositoryHealerTestChimeraHelper implements FileStore {
 
 
     @Override
-    public List<PnfsId> list() {
+    public Set<PnfsId> index() {
 
 
-        List<PnfsId> entries = new ArrayList<>();
+        Set<PnfsId> entries = new HashSet<>();
 
 
         try {


### PR DESCRIPTION
Motivation:

Pool startup is slow for large pools.

Modification:

Use a disk ordered cursor to iterate over the meta data in approximate
disk order.

Result:

Faster pool startup.

Target: trunk
Request: 2.14
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8898/
(cherry picked from commit 6470bc5ca2d8e7deeeba992e6b919669474b8654)