### PR TITLE
pool: Fix health check of file store

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -815,6 +815,7 @@ public class CacheRepositoryV5
     {
         _stateChangeListeners.stop();
         _state = State.CLOSED;
+        _store.close();
     }
 
     // Operations on MetaDataRecord ///////////////////////////////////////

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -103,11 +103,19 @@
     <constructor-arg value="${pool.path}"/>
   </bean>
 
-  <bean id="meta-store" class="${pool.plugins.meta}"
-        destroy-method="close">
-    <description>Store for pool meta data</description>
-    <constructor-arg ref="file-store"/>
-    <constructor-arg value="${pool.path}"/>
+  <bean id="meta-store" class="org.dcache.pool.repository.ConsistentStore">
+      <constructor-arg ref="csm"/>
+      <constructor-arg ref="pnfs"/>
+      <constructor-arg ref="file-store"/>
+      <constructor-arg>
+          <bean class="${pool.plugins.meta}">
+              <description>Store for pool meta data</description>
+              <constructor-arg ref="file-store"/>
+              <constructor-arg value="${pool.path}"/>
+          </bean>
+      </constructor-arg>
+      <constructor-arg ref="replica-state-policy"/>
+      <property name="poolName" value="${pool.name}"/>
   </bean>
 
   <bean id="sweeper" class="${pool.plugins.sweeper}"
@@ -129,16 +137,7 @@
     <property name="volatile"
               value="#{ '${pool.lfs}' == 'volatile' or '${pool.lfs}' == 'transient' }"/>
     <property name="maxDiskSpaceString" value="${pool.size}"/>
-    <property name="metaDataStore">
-      <bean class="org.dcache.pool.repository.ConsistentStore">
-        <constructor-arg ref="csm"/>
-        <constructor-arg ref="pnfs"/>
-        <constructor-arg ref="file-store"/>
-        <constructor-arg ref="meta-store"/>
-        <constructor-arg ref="replica-state-policy"/>
-        <property name="poolName" value="${pool.name}"/>
-       </bean>
-    </property>
+    <property name="metaDataStore" ref="meta-store"/>
   </bean>
 
   <bean id="repository-interpreter" class="org.dcache.pool.repository.RepositoryInterpreter">


### PR DESCRIPTION
Motivation:

Both the file and meta data stores support health checks, however they were
only called for the meta data store. This is because it is the ConsistentStore
that binds the two stores together, but the health checker called into the low
level meta store directly.

Modification:

"Lift" the ConsistentStore in the spring file such that it is injected both
into the repository and the health checker. Also moved the call to close into
the repository as the repository is wrapping the store with a cache and the
cache should be closed too.

Result:

Periodic health checks for the data directory.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8911/
(cherry picked from commit e78e4e368400f1035a8fab0d85c6c807ddaa429e)