### PR TITLE
pool: Show progress during repository initialization

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -145,6 +145,11 @@ public class CacheRepositoryV5
     private volatile State _state = State.UNINITIALIZED;
 
     /**
+     * Initialization progress between 0 and 1.
+     */
+    private float _initializationProgress;
+
+    /**
      * Shared repository account object for tracking space.
      */
     private Account _account;
@@ -354,8 +359,10 @@ public class CacheRepositoryV5
 
             /* Collect all entries.
              */
-            _log.info("Checking meta data for {} files", ids.size());
+            int fileCount = ids.size();
+            _log.info("Checking meta data for {} files", fileCount);
             long usedDataSpace = 0L;
+            int cnt = 0;
             List<MetaDataRecord> entries = new ArrayList<>();
             for (PnfsId id: ids) {
                 MetaDataRecord entry = readMetaDataRecord(id);
@@ -364,6 +371,8 @@ public class CacheRepositoryV5
                     _log.debug("{} {}", id, entry.getState());
                     entries.add(entry);
                 }
+                _initializationProgress = ((float) cnt) / fileCount;
+                cnt++;
             }
 
             /* Allocate space.
@@ -774,7 +783,11 @@ public class CacheRepositoryV5
     public void getInfo(PrintWriter pw)
     {
         State state = _state;
-        pw.println("State : " + state);
+        pw.append("State : ").append(state.toString());
+        if (state == State.LOADING) {
+            pw.append(" (").append(String.valueOf((int) (_initializationProgress * 100))).append("% done)");
+        }
+        pw.println();
         try {
             pw.println("Files : " + (state == State.OPEN || state == State.LOADING || state == State.INITIALIZED ?_store.list().size() : ""));
         } catch (CacheException e) {


### PR DESCRIPTION
Motivation:

Pool startup can be slow.

Modification:

Added progress output to the info command for the "LOADING" state.

Result:

May take some of the tension out of slow pool initialization.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8913/
(cherry picked from commit 08dbe65e0530d996e645f5f33dc71d0fb34cd12e)