### PR TITLE
cells: Don't log AsynchronousCloseException when tunnel closes

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/network/LocationMgrTunnel.java
+++ b/modules/cells/src/main/java/dmg/cells/network/LocationMgrTunnel.java
@@ -13,6 +13,7 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.nio.channels.AsynchronousCloseException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -166,7 +167,7 @@ public class LocationMgrTunnel
             } finally {
                 _tunnels.remove(this);
             }
-        } catch (EOFException | InterruptedException e) {
+        } catch (AsynchronousCloseException | EOFException | InterruptedException e) {
         } catch (ClassNotFoundException e) {
             _log.warn("Cannot deserialize object. This is most likely due to a version mismatch.");
         } catch (IOException e) {


### PR DESCRIPTION
Motivation:

Depending on when the tunnel is closed, either EofException or
AsychronousCloseException may be thrown. We currently discard
EofException but log AsynchronousCloseException.

Modification:

Don't log AsynchronousCloseException.

Result:

No more

(c-dCacheDomain2-AAUovTh9g2g-AAUovTh-F9g) [] Error while reading from tunnel: java.nio.channels.AsynchronousCloseException

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Albert Rossir <arossi@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8918/
(cherry picked from commit a4a1b4eb948584ec9d6a3fe848dc50a4e8277ca5)