### PR TITLE
pool: Do not fail read if xrootd client doesn't close file

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -166,9 +166,11 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                 if (descriptor.isPersistOnSuccessfulClose()) {
                     descriptor.getChannel().release(new FileCorruptedCacheException(
                             "File was opened with Persist On Successful Close and not closed."));
-                } else {
+                } else if (descriptor.getChannel().getIoMode() == IoMode.WRITE) {
                     descriptor.getChannel().release(new CacheException(
                             "Client disconnected without closing file."));
+                } else {
+                    descriptor.getChannel().release();
                 }
             }
         }


### PR DESCRIPTION
Motivation:

Xrootd has a flag for POSC semantics:

    The kXR_posc option requests safe file persistence which persists the file
    only when it has been explicitly closed.

In can be concluded that for files opened with this flag, disconnecting without
closing the file is not really an error.

Modification:

Do not generate an error if files being read are not explicitly closed.

We still generate an error for writes without a close. dCache persists such
files so semantically it is in line with the xrootd specification. Generating
an error in these cases may help recognize failing clients.

Result:

No more

    666:"Client disconnected without closing file."

errors on xrootd reads.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8920/
(cherry picked from commit 1d00d9377f0f57553dea678f034568eae45510ba)