### PR TITLE
pool: Redirect xrootd client to door on failure to open file

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.xrootd.pool;
 
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -34,7 +35,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileCorruptedCacheException;
@@ -225,14 +228,14 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         try {
             UUID uuid = getUuid(msg.getOpaque());
             if (uuid == null) {
-                _log.warn("Request contains no UUID: {}", msg);
+                _log.info("Request to open {} contains no UUID.", msg.getPath());
                 throw new XrootdException(kXR_NotAuthorized, "Request lacks the " + UUID_PREFIX + " property.");
             }
 
             NettyTransferService<XrootdProtocolInfo>.NettyMoverChannel file = _server.openFile(uuid, false);
             if (file == null) {
-                _log.warn("No mover found for {}", msg);
-                throw new XrootdException(kXR_NotAuthorized, UUID_PREFIX + " is no longer valid.");
+                _log.info("No mover found for {} with UUID {}.", msg.getPath(), uuid);
+                return redirectToDoor(ctx, msg, () -> { throw new XrootdException(kXR_NotAuthorized, UUID_PREFIX + " is no longer valid."); });
             }
 
             try {
@@ -354,8 +357,20 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
     private <R extends XrootdRequest> XrootdResponse<R> redirectToDoor(ChannelHandlerContext ctx, R msg)
         throws XrootdException
     {
+        return redirectToDoor(ctx, msg, () -> unsupported(ctx, msg));
+    }
+
+    private <R extends XrootdRequest> XrootdResponse<R> redirectToDoor(ChannelHandlerContext ctx, R msg, Callable<XrootdResponse<R>> onError)
+        throws XrootdException
+    {
         if (_redirectingDoor == null) {
-            return unsupported(ctx, msg);
+            try {
+                return onError.call();
+            } catch (XrootdException e) {
+                throw e;
+            } catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
         } else {
             return new RedirectResponse<>(msg,
                                           _redirectingDoor.getHostName(),


### PR DESCRIPTION
Motivation:

Xrootd clients have to provide a UUID obtained from the door when opening a
file on a pool. If no UUID is included or if it is no longer valid we currently
log an error message and return an error to the client.

Modification:

Attempt to redirect the client to a door - this is only possible if the
client already opened another file as we otherwise do not know the door
to redirect the client to.

Reduce the log level of the message logged to info as this is a relatively
common occurence and there is no reason to spam our log files.

Avoid logging the entire request as it may contain a confidential authorization
token.

Result:

Reduced log spam on pools in case xrootd clients fail to present a valid UUID.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8921/
(cherry picked from commit 9a7f9f866ca749476e73e65d8f347dca23d528f7)