### PR TITLE
pool: Upgrade xrootd4j to 3.0.2

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/ChunkedFileDescriptorReadvResponse.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/ChunkedFileDescriptorReadvResponse.java
@@ -2,6 +2,7 @@ package org.dcache.xrootd.pool;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -45,10 +46,14 @@ public class ChunkedFileDescriptorReadvResponse extends AbstractChunkedReadvResp
         FileDescriptor descriptor = descriptors.get(fd);
 
         ByteBuf chunk = alloc.ioBuffer(length);
-        ByteBuffer buffer = chunk.nioBuffer(0, length);
-        descriptor.read(buffer, position);
-        chunk.writerIndex(buffer.position());
-
-        return chunk;
+        try {
+            ByteBuffer buffer = chunk.nioBuffer(0, length);
+            descriptor.read(buffer, position);
+            chunk.writerIndex(buffer.position());
+            return chunk;
+        } catch (RuntimeException | IOException e) {
+            ReferenceCountUtil.release(chunk);
+            throw e;
+        }
     }
 }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -54,6 +54,7 @@ import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.dcache.xrootd.protocol.messages.AuthenticationRequest;
 import org.dcache.xrootd.protocol.messages.CloseRequest;
 import org.dcache.xrootd.protocol.messages.DirListRequest;
+import org.dcache.xrootd.protocol.messages.EndSessionRequest;
 import org.dcache.xrootd.protocol.messages.GenericReadRequestMessage.EmbeddedReadRequest;
 import org.dcache.xrootd.protocol.messages.LoginRequest;
 import org.dcache.xrootd.protocol.messages.MkDirRequest;
@@ -610,6 +611,12 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         default:
             return unsupported(ctx, msg);
         }
+    }
+
+    @Override
+    protected Object doOnEndSession(ChannelHandlerContext ctx, EndSessionRequest request) throws XrootdException
+    {
+        return withOk(request);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.3.6.v20151106</version.jetty>
         <version.wicket>7.1.0</version.wicket>
-        <version.xrootd4j>3.0.1</version.xrootd4j>
+        <version.xrootd4j>3.0.2</version.xrootd4j>
 
         <!-- BouncyCastle seems to change the naming convention of
              their ArtifactId fairly often.  Here is a summary of


### PR DESCRIPTION
Motivation:

The pool suffers from xrootd buffer leaks and lacks support for endsess.

Modification:

Upgrade xrootd4j and implement the buffer leaks fixes in our custom
chunked responses.

Also add a noop implementation of endsess to avoid spamming the logs -
pools automatically ends the session when the client disconnects.

Result:

Fixes buffer leaks in the xrootd mover.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8923/
(cherry picked from commit 5c35fcdc481787c48ed03ee8e7d67024ff3b9c3a)