### PR TITLE
pool: Fix accounting error in repository statistics

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/StickyChangeEvent.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/StickyChangeEvent.java
@@ -6,28 +6,13 @@ package org.dcache.pool.repository;
  */
 public class StickyChangeEvent extends EntryChangeEvent
 {
-    private final StickyRecord _sticky;
-
-    public StickyChangeEvent(CacheEntry oldEntry, CacheEntry newEntry, StickyRecord sticky)
+    public StickyChangeEvent(CacheEntry oldEntry, CacheEntry newEntry)
     {
         super(oldEntry, newEntry);
-        _sticky = sticky;
-    }
-
-    /**
-     * Returns the state of the change sticky record after the
-     * update. Any sticky record with an expiration time in the past
-     * should be considered removed from the entry.
-     */
-    public StickyRecord getStickyRecord()
-    {
-        return _sticky;
     }
 
     public String toString()
     {
-        return
-            String.format("StickyRecordChangeEvent [id=%s,sticky=%s]",
-                          getPnfsId(), _sticky);
+        return String.format("StickyRecordChangeEvent [id=%s]", getPnfsId());
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -869,10 +869,10 @@ public class CacheRepositoryV5
      * record.
      */
     @GuardedBy("getMetaDataRecord(newEntry.getPnfsid())")
-    protected void stickyChanged(CacheEntry oldEntry, CacheEntry newEntry, StickyRecord record)
+    protected void stickyChanged(CacheEntry oldEntry, CacheEntry newEntry)
     {
         updateRemovable(newEntry);
-        StickyChangeEvent event = new StickyChangeEvent(oldEntry, newEntry, record);
+        StickyChangeEvent event = new StickyChangeEvent(oldEntry, newEntry);
         _stateChangeListeners.stickyChanged(event);
     }
 
@@ -956,7 +956,7 @@ public class CacheRepositoryV5
                 CacheEntry oldEntry = new CacheEntryImpl(entry);
                 if (entry.setSticky(owner, expire, overwrite) && _state == State.OPEN) {
                     CacheEntryImpl newEntry = new CacheEntryImpl(entry);
-                    stickyChanged(oldEntry, newEntry, new StickyRecord(owner, expire));
+                    stickyChanged(oldEntry, newEntry);
                     scheduleExpirationTask(entry);
                 }
             }
@@ -1051,9 +1051,9 @@ public class CacheRepositoryV5
         synchronized (entry) {
             CacheEntry oldEntry = new CacheEntryImpl(entry);
             Collection<StickyRecord> removed = entry.removeExpiredStickyFlags();
-            for (StickyRecord record: removed) {
+            if (!removed.isEmpty()) {
                 CacheEntryImpl newEntry = new CacheEntryImpl(entry);
-                stickyChanged(oldEntry, newEntry, record);
+                stickyChanged(oldEntry, newEntry);
             }
             scheduleExpirationTask(entry);
         }


### PR DESCRIPTION
Motivation:

We pre-calculate the output of 'rep ls -s' by listening for repository
change events. We have observed this pre-calculation to claim that we
have a negative number of files with a sticky flag.

The repository generates change events when sticky flags expire. The change
event is generated for each expired sticky flag, however the before and after
state inluded in the event is the same for all these notifications. For the
code maintaining the repository statistics this is fatal as it will observe the
same file changing from sticky to non-sticky several times even when reality
two sticky flags were expired in one operation.

Modification:

Do not include the sticky flag that changed in the notification; it was not
used by any listener and if needed it can be extracted by calculsting the
difference of the before and after state.

Result:

Fixed an accounting bug that could cause the output of 'rep ls -s' to be
wrong.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8925/
(cherry picked from commit 830070e6630db10ae2e35fff3998f66de3cfe3d1)