### PR TITLE
xrootd: Roll back asynchronous reply on open

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -187,6 +187,13 @@ public class XrootdRedirectHandler extends AbstractXrootdRequestHandler
     protected XrootdResponse<OpenRequest> doOnOpen(ChannelHandlerContext ctx, OpenRequest req)
         throws XrootdException
     {
+        /* We ought to process this asynchronously to not block the calling thread during
+         * staging or queuing. We should also switch to an asynchronous reply model if
+         * the request is nearline or is queued on a pool. The naive approach to always
+         * use an asynchronous reply model doesn't work because the xrootd 3.x client
+         * introduces an artificial 1 second delay when processing such a response.
+         */
+
         Channel channel = ctx.channel();
         InetSocketAddress localAddress = (InetSocketAddress) channel.localAddress();
         InetSocketAddress remoteAddress = (InetSocketAddress) channel.remoteAddress();
@@ -213,7 +220,6 @@ public class XrootdRedirectHandler extends AbstractXrootdRequestHandler
 
         /* Interact with core dCache to open the requested file.
          */
-        respond(ctx, new AwaitAsyncResponse<>(req, Integer.MAX_VALUE));
         try {
             XrootdTransfer transfer;
             if (neededPerm == FilePerm.WRITE) {
@@ -237,31 +243,30 @@ public class XrootdRedirectHandler extends AbstractXrootdRequestHandler
             /* xrootd developers say that IPv6 addresses must always be URI quoted.
              * The spec doesn't require this, but clients depend on it.
              */
-            return new AsyncResponse<>(new RedirectResponse<>(
-                    req, InetAddresses.toUriString(address.getAddress()), address.getPort(), opaque, ""));
+            return new RedirectResponse<>(
+                    req, InetAddresses.toUriString(address.getAddress()), address.getPort(), opaque, "");
         } catch (FileNotFoundCacheException e) {
-            return new AsyncResponse<>(withError(req, kXR_NotFound, "No such file"));
+            return withError(req, kXR_NotFound, "No such file");
         } catch (FileExistsCacheException e) {
-            return new AsyncResponse<>(withError(req, kXR_Unsupported, "File already exists"));
+            return withError(req, kXR_Unsupported, "File already exists");
         } catch (TimeoutCacheException e) {
-            return new AsyncResponse<>(withError(req, kXR_ServerError, "Internal timeout"));
+            return withError(req, kXR_ServerError, "Internal timeout");
         } catch (PermissionDeniedCacheException e) {
-            return new AsyncResponse<>(withError(req, kXR_NotAuthorized, e.getMessage()));
+            return withError(req, kXR_NotAuthorized, e.getMessage());
         } catch (FileIsNewCacheException e) {
-            return new AsyncResponse<>(withError(req, kXR_FileLocked, "File is locked by upload"));
+            return withError(req, kXR_FileLocked, "File is locked by upload");
         } catch (NotFileCacheException e) {
-            return new AsyncResponse<>(withError(req, kXR_NotFile, "Not a file"));
+            return withError(req, kXR_NotFile, "Not a file");
         } catch (CacheException e) {
-            return new AsyncResponse<>(
-                    withError(req, kXR_ServerError,
-                              String.format("Failed to open file (%s [%d])", e.getMessage(), e.getRc())));
+            return withError(req, kXR_ServerError,
+                             String.format("Failed to open file (%s [%d])", e.getMessage(), e.getRc()));
         } catch (InterruptedException e) {
             /* Interrupt may be caused by cell shutdown or client
              * disconnect.  If the client disconnected, then the error
              * message will never reach the client, so saying that the
              * server shut down is okay.
              */
-            return new AsyncResponse<>(withError(req, kXR_ServerError, "Server shutdown"));
+            return withError(req, kXR_ServerError, "Server shutdown");
         }
     }
 


### PR DESCRIPTION
Motivation:

Upon opening a file at the xrootd door, dCache generates an await-async
response.  It does this because pool selection and mover startup may take a
long time (staging, p2p, queing) and this way we tell the client that it
may have to wait. The actual response to the open request is an asynchronous
redirect.

An asynchronous response allowed by the xrootd protocol and both the old (3.x)
and new (4.x) xrootd clients handle it. The implementation in the old client
is however a hack:

- The asynchronous response processing code recognizes the redirect and
  implements it by: first setting the remote host to that of the redirection
  target; then forcefully closing the logical connection to the door; then
  injecting a fake kXR_wait response to wake up the thread doing the kXR_open.

- kXR_wait is a response the server may use to force the client into a polling
  behaviour. It instructs the client to sleep for some time and then retry the
  request. dCache doesn't generate the kXR_wait response - it is faked by the
  asynchronuos response processing code in the client.

- The result is that the client's thread doing kXR_open wakes up, sees the
  faked kXR_wait response, waits for 1 second (as specified in the asynchronous
  response processing code), retries the request to the door, fails because
  the asynchronous response processing code has closed the logial connection,
  reestablishes the connection but this time to the redirection target (because
  the asynchronous response processing code changed the remote host) and then
  resubmits the open request.

The result is an artifical 1 second delay on redirect. When used from within
ROOT, the intial retry induced by kXR_wait results in an error message being
output ("Unknown logical conn").

The 4.x client doesn't suffer from this (but the old client still shipped with
the 4.x package does).

Modification:

Even though it isn't our fault, the prevelance of the old client forces us
to change back to the old behaviour and generate a synchronous reply.

Result:

Worked around an xrootd 3.x client misbehaviour that caused the client to
artificially sleep for 1 secon when opening files and in some cases output
the error "Unkown logical conn X".

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8941/
(cherry picked from commit 1baaf2f88e7c912249be0ef4dc16886a4bdfa349)