### PR TITLE
pool: Expose Berkeley DB configuration as dCache properties

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
@@ -468,4 +468,8 @@ public class ConsistentStore
         _pnfsHandler.clearCacheLocation(id);
     }
 
+    public MetaDataStore getStore()
+    {
+        return _metaDataStore;
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
@@ -3,16 +3,20 @@ package org.dcache.pool.repository.meta.db;
 import com.sleepycat.collections.StoredMap;
 import com.sleepycat.je.DatabaseException;
 
+import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.EnvironmentFailureException;
 import com.sleepycat.je.OperationFailureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.PostConstruct;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -21,10 +25,13 @@ import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.StorageInfo;
 
+import dmg.cells.nucleus.EnvironmentAware;
+
 import org.dcache.pool.repository.DuplicateEntryException;
 import org.dcache.pool.repository.FileStore;
 import org.dcache.pool.repository.MetaDataRecord;
 import org.dcache.pool.repository.MetaDataStore;
+import org.dcache.util.ConfigurationMapFactoryBean;
 
 /**
  * BerkeleyDB based MetaDataRepository implementation.
@@ -37,7 +44,7 @@ import org.dcache.pool.repository.MetaDataStore;
  * SoftReference.
  */
 public class BerkeleyDBMetaDataRepository
-    implements MetaDataStore
+    implements MetaDataStore, EnvironmentAware
 {
     private static Logger _log =
         LoggerFactory.getLogger(BerkeleyDBMetaDataRepository.class);
@@ -48,21 +55,27 @@ public class BerkeleyDBMetaDataRepository
      * The file store for which we hold the meta data.
      */
     private final FileStore _fileStore;
+    private final boolean _readOnly;
 
     /**
      * The BerkeleyDB database to use.
      */
-    private final MetaDataRepositoryDatabase _database;
+    private MetaDataRepositoryDatabase _database;
 
     /**
      * The BerkeleyDB database to use.
      */
-    private final MetaDataRepositoryViews _views;
+    private MetaDataRepositoryViews _views;
 
     /**
      * Directory containing the database.
      */
     private final File _dir;
+
+    /**
+     * Berkeley DB configuration properties.
+     */
+    private final Properties _properties = new Properties();
 
     /**
      * Opens a BerkeleyDB based meta data repository. If the database
@@ -79,9 +92,10 @@ public class BerkeleyDBMetaDataRepository
     public BerkeleyDBMetaDataRepository(FileStore fileStore,
                                         File directory,
                                         boolean readOnly)
-            throws FileNotFoundException, DatabaseException, CacheException
+            throws FileNotFoundException, DatabaseException
     {
         _fileStore = fileStore;
+        _readOnly = readOnly;
         _dir = new File(directory, DIRECTORY_NAME);
 
         if (!_dir.exists()) {
@@ -91,15 +105,30 @@ public class BerkeleyDBMetaDataRepository
         } else if (!_dir.isDirectory()) {
             throw new FileNotFoundException("No such directory: " + _dir);
         }
+    }
 
+    @Override
+    public void setEnvironment(Map<String, Object> environment)
+    {
+        ConfigurationMapFactoryBean factory = new ConfigurationMapFactoryBean();
+        factory.setEnvironment(environment);
+        factory.setPrefix("pool.plugins.meta.db");
+        factory.buildMap();
+        _properties.clear();
+        _properties.putAll(factory.getObject());
+    }
+
+    @PostConstruct
+    public void init() throws CacheException
+    {
         try {
-            _database = new MetaDataRepositoryDatabase(_dir, readOnly);
+            _database = new MetaDataRepositoryDatabase(_properties, _dir, _readOnly);
             _views = new MetaDataRepositoryViews(_database);
         } catch (EnvironmentFailureException e) {
             throw new CacheException(CacheException.PANIC, "Failed to open Berkeley DB database. When upgrading to " +
-                    "dCache 2.6, it may be necessary to run the /usr/sbin/dcache-pool-meta-preupgrade utility " +
-                    "before starting the pool. If that does not resolve the problem, you should contact " +
-                    "support@dcache.org", e);
+                                                           "dCache 2.6, it may be necessary to run the /usr/sbin/dcache-pool-meta-preupgrade utility " +
+                                                           "before starting the pool. If that does not resolve the problem, you should contact " +
+                                                           "support@dcache.org", e);
         }
     }
 
@@ -275,5 +304,15 @@ public class BerkeleyDBMetaDataRepository
     public boolean isValid()
     {
         return _database.getEnvironment().isValid();
+    }
+
+    public EnvironmentConfig getConfig()
+    {
+        return _database.getEnvironment().getConfig();
+    }
+
+    public File getPath()
+    {
+        return _dir;
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/MetaDataRepositoryDatabase.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/MetaDataRepositoryDatabase.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.concurrent.TimeUnit;
+import java.util.Properties;
 
 /**
  * MetaDataRepositoryDatabase encapsulates the initialisation of
@@ -36,17 +36,13 @@ public class MetaDataRepositoryDatabase
     private boolean _failed;
     private boolean _closed;
 
-    public MetaDataRepositoryDatabase(File homeDirectory, boolean readonly)
+    public MetaDataRepositoryDatabase(Properties properties, File homeDirectory, boolean readonly)
         throws DatabaseException
     {
-        EnvironmentConfig envConfig = new EnvironmentConfig();
+        EnvironmentConfig envConfig = new EnvironmentConfig(properties);
         envConfig.setTransactional(true);
         envConfig.setAllowCreate(true);
         envConfig.setReadOnly(readonly);
-        envConfig.setConfigParam(EnvironmentConfig.MAX_MEMORY_PERCENT, "20");
-        envConfig.setConfigParam(EnvironmentConfig.STATS_COLLECT, "false");
-        envConfig.setConfigParam(EnvironmentConfig.LOCK_N_LOCK_TABLES, "5");
-        envConfig.setLockTimeout(60, TimeUnit.SECONDS);
 
         env = new Environment(homeDirectory, envConfig);
 

--- a/modules/dcache/src/main/java/org/dcache/util/ConfigurationMapFactoryBean.java
+++ b/modules/dcache/src/main/java/org/dcache/util/ConfigurationMapFactoryBean.java
@@ -42,7 +42,7 @@ public class ConfigurationMapFactoryBean implements EnvironmentAware,
     }
 
     @PostConstruct
-    private void buildMap()
+    public void buildMap()
     {
         ImmutableMap.Builder<String,String> builder = ImmutableMap.builder();
 
@@ -71,7 +71,7 @@ public class ConfigurationMapFactoryBean implements EnvironmentAware,
     }
 
     @Override
-    public ImmutableMap<String, String> getObject() throws Exception
+    public ImmutableMap<String, String> getObject()
     {
         return _object;
     }

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -145,6 +145,28 @@ pool.plugins.meta = org.dcache.pool.repository.meta.file.FileMetaDataRepository
 #  ---- Garbage collector used when the pool runs out of space
 pool.plugins.sweeper = org.dcache.pool.classic.SpaceSweeper2
 
+#  ---- Configuration properties for Berkeley DB Java meta data repository
+#
+#   Berkeley DB Java edition is used by one of the available meta data
+#   repository plugins. The database provides a large number of tuning
+#   options. These are mapped to the pool.plugins.meta.db prefix.
+#
+#   Consult the Oracle Berkeley DB Java Edition documentation at
+#
+#       http://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/EnvironmentConfig.html
+#
+#   for details.
+#
+#   WARNING: Be aware that these settings may influence the consistency
+#   of the data.
+#
+(prefix)pool.plugins.meta.db = Configuration for the meta data database
+
+pool.plugins.meta.db!je.maxMemoryPercent = 20
+pool.plugins.meta.db!je.stats.collect = false
+pool.plugins.meta.db!je.lock.nLockTables = 5
+pool.plugins.meta.db!je.lock.timeout = 60 s
+
 #
 # Whether to enable RPCSEC_GSS for NFS mover
 #


### PR DESCRIPTION
Motivation:

The Berkeley DB library has a large number of tuning properties. These can
currently be set by creating a je.properties file in the pool's meta directory.
Given that in particular large pool may require some custom tuning, it would
be useful to provide more direct access to these properties.

Modification:

Define the pool.plugins.meta.db prefix and inject all sub-properties into
the Berkeley DB.

Also exposed the environment configuration as a getter to make it queriable
using the bean commands in the admin shell.

Result:

Berkeley DB configuration can be set in the regular dCache configuration
by prefixing these with pool.plugins.meta.db!.

Targe: trunk
Require-notes: yes
Require-book: yes
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8934/
(cherry picked from commit a046ff550e5f5e88363059e30978b1e7c9e288e2)