### PR TITLE
xrootd: Fix classification of uploads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.3.6.v20151106</version.jetty>
         <version.wicket>7.1.0</version.wicket>
-        <version.xrootd4j>3.0.2</version.xrootd4j>
+        <version.xrootd4j>3.0.3</version.xrootd4j>
 
         <!-- BouncyCastle seems to change the naming convention of
              their ArtifactId fairly often.  Here is a summary of


### PR DESCRIPTION
Motivation:

We have observed upload failures from Alice jobs. These jobs specify the options
delete, mkpath and retstat, but neither new or open_updt. dCache classifies such
requests as reads and subsequently fails stating that the file does not exist.
Clearly the delete option only makes sense for an upload, thus this is a bug
in dCache.

Modification:

Upgrade xrootd4j and rely on the fixed classification provided by the new version.

Result:

Fixes an xrootd protocol incompatibility that caused uploads to be considered
as downloads.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8932/
(cherry picked from commit ac00962decb5d1866484125ec36183d77175387f)