### PR TITLE
xrootd: Fix classification of uploads

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -188,17 +188,11 @@ public class XrootdRedirectHandler extends AbstractXrootdRequestHandler
         Channel channel = ctx.channel();
         InetSocketAddress localAddress = (InetSocketAddress) channel.localAddress();
         InetSocketAddress remoteAddress = (InetSocketAddress) channel.remoteAddress();
-        int options = req.getOptions();
 
-        FilePerm neededPerm;
+        FilePerm neededPerm = req.getRequiredPermission();
 
-        if (req.isNew() || req.isReadWrite()) {
-            if (_isReadOnly) {
-                throw new XrootdException(kXR_NotAuthorized, "Read-only access");
-            }
-            neededPerm = FilePerm.WRITE;
-        } else {
-            neededPerm = FilePerm.READ;
+        if (neededPerm == FilePerm.WRITE && _isReadOnly) {
+            throw new XrootdException(kXR_NotAuthorized, "Read-only access");
         }
 
         _log.info("Opening {} for {}", req.getPath(), neededPerm.xmlText());
@@ -215,8 +209,8 @@ public class XrootdRedirectHandler extends AbstractXrootdRequestHandler
 
             XrootdTransfer transfer;
             if (neededPerm == FilePerm.WRITE) {
-                boolean createDir = (options & kXR_mkpath) == kXR_mkpath;
-                boolean overwrite = (options & kXR_delete) == kXR_delete;
+                boolean createDir = req.isMkPath();
+                boolean overwrite = req.isDelete();
 
                 transfer =
                     _door.write(remoteAddress, createFullPath(req.getPath()), uuid,

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.2.14.v20151106</version.jetty>
         <version.wicket>6.19.0</version.wicket>
-        <version.xrootd4j>2.1.3</version.xrootd4j>
+        <version.xrootd4j>2.1.5</version.xrootd4j>
         <version.jglobus>2.0.6-rc9.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 


### PR DESCRIPTION
Motivation:

We have observed upload failures from Alice jobs. These jobs specify the options
delete, mkpath and retstat, but neither new or open_updt. dCache classifies such
requests as reads and subsequently fails stating that the file does not exist.
Clearly the delete option only makes sense for an upload, thus this is a bug
in dCache.

Modification:

Upgrade xrootd4j and rely on the fixed classification provided by the new version.

Result:

Fixes an xrootd protocol incompatibility that caused uploads to be considered
as downloads.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8932/
(cherry picked from commit ac00962decb5d1866484125ec36183d77175387f)
(cherry picked from commit c0f8ae6eb83b45afb577a71666b62b75e34cb9ac)
(cherry picked from commit 7955b7c69fc85a2b03c8e67f31e62566e16c9e9b)