### PR TITLE
xrootd: Fix classification of uploads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <version.xerces>2.10.0</version.xerces>
         <version.jetty>8.1.17.v20150415</version.jetty>
         <version.wicket>6.19.0</version.wicket>
-        <version.xrootd4j>1.3.8</version.xrootd4j>
+        <version.xrootd4j>1.3.9</version.xrootd4j>
         <version.jglobus>2.0.6-rc9.d</version.jglobus>
         <version.openmq>4.5.2</version.openmq>
 


### PR DESCRIPTION
Motivation:

We have observed upload failures from Alice jobs. These jobs specify the options
delete, mkpath and retstat, but neither new or open_updt. dCache classifies such
requests as reads and subsequently fails stating that the file does not exist.
Clearly the delete option only makes sense for an upload, thus this is a bug
in dCache.

Modification:

Upgrade xrootd4j and rely on the fixed classification provided by the new version.

Result:

Fixes an xrootd protocol incompatibility that caused uploads to be considered
as downloads.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8932/
(cherry picked from commit ac00962decb5d1866484125ec36183d77175387f)
(cherry picked from commit c0f8ae6eb83b45afb577a71666b62b75e34cb9ac)
(cherry picked from commit 7955b7c69fc85a2b03c8e67f31e62566e16c9e9b)
(cherry picked from commit c087a981a7af5e001c903f761400c1394d7cad7c)
(cherry picked from commit abc99ab7f1bdc230f1ef5ec93096338a7ee9756c)