### PR TITLE
pool: Fix lock contention during heavy p2p activity

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
@@ -95,6 +95,7 @@ class Companion
     private final CellStub _pnfs;
     private final CellStub _pool;
     private final boolean _forceSourceMode;
+    private final PnfsId _pnfsId;
 
     /** State machine driving the transfer. */
     private final CompanionContext _fsm;
@@ -174,6 +175,8 @@ class Companion
             throw new IllegalArgumentException("PNFSID is required, got " + _fileAttributes.getDefinedAttributes());
         }
 
+        _pnfsId = _fileAttributes.getPnfsId();
+
         _callback = callback;
         _forceSourceMode = forceSourceMode;
         _atime = atime;
@@ -190,7 +193,7 @@ class Companion
     /**
      * Returns the session ID identifying the transfer.
      */
-    synchronized public int getId()
+    public int getId()
     {
         return _id;
     }
@@ -198,12 +201,12 @@ class Companion
     /**
      * Returns the PNFS ID of the file to be transfered.
      */
-    synchronized public PnfsId getPnfsId()
+    public PnfsId getPnfsId()
     {
-        return _fileAttributes.getPnfsId();
+        return _pnfsId;
     }
 
-    synchronized public long getPingPeriod()
+    public long getPingPeriod()
     {
         return PING_PERIOD;
     }
@@ -218,14 +221,16 @@ class Companion
         return (_fsm.getState() != CompanionContext.FSM.Done);
     }
 
-    synchronized public String toString()
+    public String toString()
     {
+        // Unsynchronized access to the fsm state means we may show an old value, but it
+        // avoids blocking in toString().
         return ""
-            + _id
-            + " "
-            + getPnfsId()
-            + " "
-            + _fsm.getState();
+               + _id
+               + " "
+               + _pnfsId
+               + " "
+               + _fsm.getState();
     }
 
     /**
@@ -397,9 +402,9 @@ class Companion
     }
 
     /** Asynchronously retrieves the file attributes. */
-    synchronized void fetchFileAttributes()
+    void fetchFileAttributes()
     {
-        CellStub.addCallback(_pnfs.send(new PnfsGetFileAttributes(getPnfsId(), Pool2PoolTransferMsg.NEEDED_ATTRIBUTES)),
+        CellStub.addCallback(_pnfs.send(new PnfsGetFileAttributes(_pnfsId, Pool2PoolTransferMsg.NEEDED_ATTRIBUTES)),
                              new Callback<PnfsGetFileAttributes>()
                              {
                                  @Override
@@ -457,7 +462,7 @@ class Companion
                                  new InetSocketAddress(_address, 0),
                                  _destinationPoolCellname,
                                  _destinationPoolCellDomainName,
-                                 "/" +  getPnfsId(),
+                                 "/" + _pnfsId,
                                  null);
         protocolInfo.setSessionId(_id);
 
@@ -540,9 +545,9 @@ class Companion
     /**
      * Starts a thread that transfers the file from the source pool.
      */
-    synchronized void beginTransfer(final String uri)
+    void beginTransfer(final String uri)
     {
-        new Thread("P2P Transfer - " + getPnfsId() + " " + _sourcePoolName) {
+        new Thread("P2P Transfer - " + _pnfsId + " " + _sourcePoolName) {
             @Override
             public void run()
             {
@@ -563,13 +568,13 @@ class Companion
 
         if (_error != null) {
             if (_error instanceof RuntimeException || _error instanceof Error) {
-                _log.error(String.format("P2P for %s failed: %s", getPnfsId(), _error),
+                _log.error(String.format("P2P for %s failed: %s", _pnfsId, _error),
                            (Throwable) _error);
             } else {
-                _log.error(String.format("P2P for %s failed: %s", getPnfsId(), _error));
+                _log.error(String.format("P2P for %s failed: %s", _pnfsId, _error));
             }
         } else {
-            _log.info(String.format("P2P for %s completed", getPnfsId()));
+            _log.info(String.format("P2P for %s completed", _pnfsId));
         }
 
         if (_callback != null) {
@@ -588,7 +593,7 @@ class Companion
                         } else {
                             t = new CacheException(error.toString());
                         }
-                        _callback.cacheFileAvailable(getPnfsId(), t);
+                        _callback.cacheFileAvailable(_pnfsId, t);
                     }
                 }));
         }


### PR DESCRIPTION
Motivation:

We see contention on the P2PClient object:

"pool-3-thread-5" #210 prio=5 os_prio=0 tid=0x00007fcc80004800 nid=0x124a6 waiting for monitor entry [0x00007fcc44ccd000]
   java.lang.Thread.State: BLOCKED (on object monitor)
        at org.dcache.pool.p2p.P2PClient.removeCompanion(P2PClient.java:152)
        - waiting to lock <0x0000000080774ae8> (a org.dcache.pool.p2p.P2PClient)
        at org.dcache.pool.p2p.P2PClient.access$000(P2PClient.java:38)
        at org.dcache.pool.p2p.P2PClient$Callback.cacheFileAvailable(P2PClient.java:205)
        at org.dcache.pool.p2p.Companion$6.run(Companion.java:591)
        at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31)
        at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:153)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)

The thread that locked the P2PClient is itself blocked on its Companion:

"pool-3-thread-3" #208 prio=5 os_prio=0 tid=0x00007fcc80002800 nid=0x1206c waiting for monitor entry [0x00007fcc44ecf000]
   java.lang.Thread.State: BLOCKED (on object monitor)
        at org.dcache.pool.p2p.Companion.getPnfsId(Companion.java:203)
        - waiting to lock <0x00000000dae81318> (a org.dcache.pool.p2p.Companion)
        at org.dcache.pool.p2p.P2PClient.cancelCompanions(P2PClient.java:162)
        - locked <0x0000000080774ae8> (a org.dcache.pool.p2p.P2PClient)
        at org.dcache.pool.p2p.P2PClient.access$100(P2PClient.java:38)
        at org.dcache.pool.p2p.P2PClient$Callback.cacheFileAvailable(P2PClient.java:212)
        at org.dcache.pool.p2p.Companion$6.run(Companion.java:591)
        at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31)
        at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:153)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)

The companion in turn is blocked on doing meta data operations (due to a busy disk).

Modification:

Let the extractor keep the PnfsId in a final field and remove the
synchronization on methods that only access final fields.

Remove synchronization on Companion#toString. Since the FSM state is not synchronized, this
may lead to an old state being output, but that's better than synchronizing toString().

Result:

A lock contention issue causing unresponsive pools on heavy p2p activity was fixed.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8951/
(cherry picked from commit 337082f4fd0a1c981a0f02167906d23240f3b489)