### PR TITLE
nfs: convert FILE_IN_CACHE into NFS_EIO

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ExceptionUtils.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ExceptionUtils.java
@@ -55,6 +55,8 @@ public class ExceptionUtils {
                 return new NoSpcException(e.getMessage(), e);
             case TIMEOUT:
                 return new DelayException(e.getMessage(), e);
+            case FILE_IN_CACHE:
+                return new NfsIoException(e.getMessage(), e);
             default:
                 return buildNfsException(defaultException, e);
         }


### PR DESCRIPTION
Motivation:
when a pool gets create write mover requests for existing file, then
FILE_IN_CACHE error is returned. Currently NFS door will map such
error to TRY_LATER error.

Modification:
map FILE_IN_CACHE to NFS_EIO to let client stop looping as well as
indicate that we can't recover from this situation.

Result:
stop infinite client-server ping-pong

Acked-by: Gerd Behrmann
Target: master, 2.14, 2.13
Require-book: no
Require-notes: no
(cherry picked from commit 44cc9bd25899171dd04f8f6484f5b24cb0f39258)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>