### PR TITLE
spacemanager: Randomize backoff in case of transient errors

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -1209,13 +1209,15 @@ public final class SpaceManagerService
                 }
             } catch (InterruptedException ignored) {
             } catch (Exception e) {
-                /* Put the request at the end of the queue to (a) avoid starving other requests, (b) avoid
-                 * retrying the same operation over and over in a tight loop.
-                 */
+                long delay = (long) (Math.random() * next());
+                LOGGER.info("Request processing failed ({}) and will sleep for {} ms.", e.toString(), delay);
                 try {
                     Thread.sleep(next());
                 } catch (InterruptedException ignored) {
                 }
+                /* Put the request at the end of the queue to (a) avoid starving other requests, (b) avoid
+                 * retrying the same operation over and over in a tight loop.
+                 */
                 executor.execute(this);
             }
         }


### PR DESCRIPTION
Motivation:

The space manager uses a backoff algorithm to ease load place on the database
in case of transient errors. These would usually be aborted transactions due to
conflicting updates.

Since the backoff algorithm is deterministic, all requests failing at the same
time would retry at the same time.

Modification:

Randomize the backoff. The backoff is still based on the Fibonacci sequence,
however the sequence provides a bound for a random value rather than being
used directly.

Log the transient failure at info level to provide some feedback on what is
going on.

Result:

Reduces the risk that transient update conflicts in space manager are
retried at the same time and conflict again.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8839
Acked-by: Albert Rossi <arossi@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8961/
(cherry picked from commit cdf640cde7d8dfe336014101f0faffd0f63828be)
(cherry picked from commit f828a77fc13ec174f8bf871fc44b3d8251959f8e)