### PR TITLE
spacemanager, srm: Do not allow update to full spaces

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/JdbcSpaceManagerDatabase.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/JdbcSpaceManagerDatabase.java
@@ -746,7 +746,7 @@ public class JdbcSpaceManagerDatabase extends JdbcDaoSupport implements SpaceMan
         if (space.getState() == SpaceState.RELEASED) {
             throw new SpaceReleasedException("space with id=" + reservationId + " was released");
         }
-        if (space.getAvailableSpaceInBytes() < sizeInBytes) {
+        if (space.getAvailableSpaceInBytes() <= 0 || space.getAvailableSpaceInBytes() < sizeInBytes) {
             throw new NoFreeSpaceException("space with id=" + reservationId + " does not have enough space");
         }
 

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -1004,7 +1004,7 @@ public final class Storage
                         return immediateFailedCheckedFuture(new SRMSpaceLifetimeExpiredException(
                                 "Space reservation associated with the space token " + spaceToken + " is expired."));
                     }
-                    if (size != null && space.getAvailableSpaceInBytes() < size) {
+                    if (space.getAvailableSpaceInBytes() <= 0 || size != null && space.getAvailableSpaceInBytes() < size) {
                         return immediateFailedCheckedFuture(new SRMExceedAllocationException(
                                 "Space associated with the space token " + spaceToken + " is not enough to hold SURL."));
                     }


### PR DESCRIPTION
Motivation:

A space reservation is exactly what the name indicates: a reservation of some
space. It isn't a quota. Yet, in some cases we treat it as if it were a quota:
Specifically if we know the file size prior to an upload, we will reject the
upload if it doesn't fit within the reservation.

If we do not know the file size ahead of upload, we cannot know if the file
will fit. Instead we silently enlarge the reservation (if possible) to make it
hold the file after upload completes. Since a reservation is not a quota, this
is legal.

Many people use reservation as if they were quotas and get confused by this
behaviour. This is in particular the case because they are unaware which
clients specify a file size prior to upload and which do not.

Modification:

Reject uploads to a space reservation if it has no free space at all. This
affects both uploads for which a size was specified and those for which a
size was not specified.

Result:

Fixes an issue in which protocols or clients that do not provide a file size
prior to upload could write to tokens even if they were full. One negative
consequence is that this will also prevent upload of empty files to such
reservations (even if they logically fit).

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8962/
(cherry picked from commit f6f1524f3c70bb7a70e527a7797aa1b94a7cba7f)