### PR TITLE
cells: Suppress illegal state exception during initialization

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
@@ -228,12 +228,17 @@ public class UniversalSpringCell
          */
         createContext();
 
+        try {
         /* Cell threading is configurable through arguments to
          * UniversalSpringCell. The executors have to be created as
          * beans in the Spring file, however the names of the beans
          * are provided as cell arguments.
          */
-        setupCellExecutors(args.getOpt("messageExecutor"));
+            setupCellExecutors(args.getOpt("messageExecutor"));
+        } catch (IllegalStateException e) {
+            LOGGER.debug("Aborting cell initialization due to illegal state exception while setting executors.");
+            return;
+        }
 
         /* This is a NOP except if somebody subclassed
          * UniversalSpringCell.


### PR DESCRIPTION
Motivation:

If a cell is killed while it is initializing it currently throws
an illegal state exception which in turn is logged as a bug.

Modification:

Simple workaround to catch and suppress the exception and abort
the cell initialization.

This part of the code is rewritten on master, so a simple workaround
is good enough for stable branches.

Result:

An illegal state exception thrown during aborted startup has been
resolved.

Target: 2.14
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8881
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/8984/
(cherry picked from commit 84acc3c0b2abb041dc7475e53ce7150cebb3ffaa)