### PR TITLE
info-provider: publish door root path

### DIFF
--- a/skel/share/info-provider/glue-2.0-defn.xml
+++ b/skel/share/info-provider/glue-2.0-defn.xml
@@ -433,6 +433,8 @@
                     path="d:protocol/d:metric[@name='version']"/>
             </attr>
 
+            <attr name="GLUE2EntityOtherInfo">dCache.root=<lookup path="../../d:protocol/d:metric[@name='root']">/</lookup></attr>
+
             <attr name="GLUE2EndpointServiceForeignKey">
               <parent-rdn rdn="GLUE2ServiceID" use="value"/>
             </attr>


### PR DESCRIPTION
Motivation:

All dCache doors may be configured to show only a subtree of the
complete dCache namespace.  If different doors have different roots then
a client may need to adjust their path to access files or directories as
expected.

Modification:

Update info-provider to publish the door's root path as an additional
property.

Result:

The root path of door may be discovered.  This allows either clients to
adjust the path of files or some agent to automatically verify the
consistency of doors.

Target: master
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/8936/
Acked-by: Gerd Behrmann