### PR TITLE
(2.13) alarms: change executor to have bounded queue and discard even…

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/alarms/logback/alarms.xml
+++ b/modules/dcache/src/main/resources/org/dcache/alarms/logback/alarms.xml
@@ -38,6 +38,9 @@
         <constructor-arg>
             <value>${alarms.limits.workers}</value>
         </constructor-arg>
+        <constructor-arg>
+            <value>${alarms.limits.queue-size}</value>
+        </constructor-arg>
         <property name="rootLevel" value="${alarms.log.root-level}"/>
         <property name="priorityMap" ref="priorityMap"/>
         <property name="converter" ref="logEventConverter"/>

--- a/modules/dcache/src/test/java/org/dcache/alarms/logback/LogEntryAppenderTest.java
+++ b/modules/dcache/src/test/java/org/dcache/alarms/logback/LogEntryAppenderTest.java
@@ -138,7 +138,7 @@ public class LogEntryAppenderTest {
         /*
          * Bypass the executor and run synchronously in this test.
          */
-        LogEntryHandler handler = new LogEntryHandler(1) {
+        LogEntryHandler handler = new LogEntryHandler(1, Integer.MAX_VALUE) {
             public void handle(ILoggingEvent eventObject) {
                 if (eventObject.getLevel().levelInt < Level.ERROR.levelInt) {
                     return;

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -49,6 +49,13 @@ alarms.priority-mapping.path=${alarms.dir}/alarms-priority.properties
 #
 alarms.limits.workers=1
 
+#  ---- Maximum size of waiting queue. When exceeded, events are discarded.
+#	A conservative estimate of the needed memory would be 128Mb for
+#	every 1000 queue slots.  Hence for the default setting given here,
+#	at least 1Gb of heap space should be allotted to the JVM.
+#
+alarms.limits.queue-size=10000
+
 #  ---- SMTP email forwarding property
 #
 #      Whether or not to send email alerts of alarms.

--- a/skel/share/services/alarms.batch
+++ b/skel/share/services/alarms.batch
@@ -34,6 +34,7 @@ check alarms.history.min-index
 check alarms.history.max-index
 check alarms.enable.cleaner
 check alarms.limits.workers
+check alarms.limits.queue-size
 
 define env checkAlarmCleanerProperites end
      check -strong alarms.cleaner.timeout


### PR DESCRIPTION
…ts on overrun

Motivation:

dCache logging clients send remote events using an Asynchronous appender which delegates to a SocketAppender.
The former provides better performance on the client side by buffering events
and allowing them to be consumed by the delegate.  Since the delegate in turn uses the TCP layer
to send events to the server, the usual buffering and discarding of events when no connection
can be established should occur.  Hence while the network bandwith provides the upper bound on
performance when the wrapper buffer/queue fills, the client should not block in such cases.

However, if the server becomes unresponsive (but does not close the client connection), the client can block.
Several sites have experienced this problem when using the rdbms backend to the logging service
(see RT 8879 Pool not responding: http://rt.dcache.org/Ticket/Display.html?id=8879; we have seen
nearly the identical problem here on production at Fermi).  Under heavy usage or logging bursts, the
executor queue of tasks fills up, either because of sluggish database response or connection contention,
and produces an OutOfMemory error.  At this point, depending on the state of the JVM, it is possible that
the server threads hang or freeze, not allowing the domain to restart, at least immediately.  The server
thus remains in an unresponsive state, holding on to the client connections, and causing the clients to
block on the threads attempting to do logging.

While it may be possible to improve the database performance, in general there needs to be a safety valve
(as there is on the billing service) whereby bursts of connection activity do not provoke an OOM.
Avoiding the OOM will avoid the principal cause for the critical condition under discussion.

Modification:

Instead of a fixed thread pool executor with unbounded blocking queue, we use a (Cached)BoundedExecutor
with queue size defined by an additional property.  When max size is reached, the service drops the event.
Given that this is not a function-critical service, we believe this compromise acceptable.  Note that we have
provided a suggested (very conservative) ratio of 128 Mb of VM heap for every 1000 queue slots, determined
by testing.

Result:

Under heavy load from the clients, the server discards events before the heap allocation can be used up,
avoiding loss of responsiveness and the blocking of clients.

Target: 2.13
Require-notes: yes
Require-book: no
Acked-by: Dmitry
Acked-by: Tigran