### PR TITLE
pool: Fix NPE in pool yaml tool

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreYamlTool.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreYamlTool.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Map;
 
+import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.StorageInfo;
 
@@ -46,12 +47,15 @@ public class MetaDataStoreYamlTool
         for (PnfsId id: metaStore.list()) {
             try {
                 MetaDataRecord record = metaStore.get(id);
+                if (record == null) {
+                    continue;
+                }
                 FileAttributes attributes = record.getFileAttributes();
 
                 out.format("%s:\n", id);
                 out.format("  state: %s\n", record.getState());
                 out.format("  sticky:\n");
-                for (StickyRecord sticky: record.stickyRecords()) {
+                for (StickyRecord sticky : record.stickyRecords()) {
                     out.format("    %s: %d\n", sticky.owner(), sticky.expire());
                 }
                 if (attributes.isDefined(FileAttribute.STORAGECLASS)) {
@@ -64,7 +68,7 @@ public class MetaDataStoreYamlTool
                     StorageInfo info = attributes.getStorageInfo();
                     out.format("  bitfileid: %s\n", info.getBitfileId());
                     out.format("  locations:\n");
-                    for (URI location: info.locations()) {
+                    for (URI location : info.locations()) {
                         out.format("    - %s\n", location);
                     }
                 }
@@ -76,7 +80,7 @@ public class MetaDataStoreYamlTool
                 }
                 if (attributes.isDefined(FileAttribute.FLAGS)) {
                     out.format("  map:\n");
-                    for (Map.Entry<String,String> entry : attributes.getFlags().entrySet()) {
+                    for (Map.Entry<String, String> entry : attributes.getFlags().entrySet()) {
                         out.format("    %s: %s\n", entry.getKey(), entry.getValue());
                     }
                 }
@@ -86,7 +90,7 @@ public class MetaDataStoreYamlTool
                 if (attributes.isDefined(FileAttribute.ACCESS_LATENCY)) {
                     out.format("  accesslatency: %s\n", attributes.getAccessLatency());
                 }
-            } catch (Exception e) {
+            } catch (CacheException e) {
                 error.println("Failed to read " + id + ": " + e.getMessage());
             }
         }


### PR DESCRIPTION
Motivation:

Recent changes allow the meta data store discover more incomplete
meta data entries. As a consequence the pool yaml dump tool may
cause an NPE.

Modification:

Skip entries for which MetaDataStore#get returns null. Propagate
non-CacheExceptions.

Result:

Fixed a null pointer exception regression in the 'dcache pool yaml'
command.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/8994/
(cherry picked from commit be0b14ade725c4ac633f986711752689ef9f6a52)