### PR TITLE
    2.12 alarms: change executor to have bounded queue and discard ev…

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryHandler.java
@@ -79,8 +79,11 @@ import org.slf4j.Marker;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.dcache.alarms.AlarmMarkerFactory;
@@ -97,7 +100,7 @@ import org.dcache.alarms.dao.LogEntryDAO;
  *
  * @author arossi
  */
-public class LogEntryHandler {
+public class LogEntryHandler implements RejectedExecutionHandler {
     private static final Logger LOGGER
         = LoggerFactory.getLogger(LogEntryHandler.class);
 
@@ -208,15 +211,24 @@ public class LogEntryHandler {
     /**
      * Concurrent handling.
      */
-    private ExecutorService executor;
+    private AbstractExecutorService executor;
 
     /**
      * State.
      */
     private final AtomicBoolean started = new AtomicBoolean(false);
 
-    public LogEntryHandler(int workers) {
-        executor = Executors.newFixedThreadPool(workers);
+    public LogEntryHandler(int workers, int maxQueued) {
+        executor = new ThreadPoolExecutor(1, workers, 0L, TimeUnit.MILLISECONDS,
+                                          new LinkedBlockingQueue<>(maxQueued),
+                                          this);
+    }
+
+    @Override
+    public void rejectedExecution(Runnable runnable, ThreadPoolExecutor executor) {
+        LogEntryTask task = (LogEntryTask)runnable;
+        LOGGER.info("Rejected task execution; discarded: {}.",
+                    task.event.getFormattedMessage());
     }
 
     public void setConverter(LoggingEventConverter converter) {
@@ -360,7 +372,7 @@ public class LogEntryHandler {
 
 
     public void handle(ILoggingEvent eventObject) {
-        LOGGER.debug("calling handler with {}.", eventObject.getFormattedMessage());
+        LOGGER.trace("calling handler with {}.", eventObject.getFormattedMessage());
         if (eventObject.getLevel().levelInt < rootLevel.levelInt) {
             return;
         }

--- a/modules/dcache/src/main/resources/org/dcache/alarms/logback/alarms.xml
+++ b/modules/dcache/src/main/resources/org/dcache/alarms/logback/alarms.xml
@@ -38,6 +38,9 @@
         <constructor-arg>
             <value>${alarms.limits.workers}</value>
         </constructor-arg>
+        <constructor-arg>
+            <value>${alarms.limits.queue-size}</value>
+        </constructor-arg>
         <property name="rootLevel" value="${alarms.log.root-level}"/>
         <property name="priorityMap" ref="priorityMap"/>
         <property name="converter" ref="logEventConverter"/>

--- a/modules/dcache/src/test/java/org/dcache/alarms/logback/LogEntryAppenderTest.java
+++ b/modules/dcache/src/test/java/org/dcache/alarms/logback/LogEntryAppenderTest.java
@@ -138,7 +138,7 @@ public class LogEntryAppenderTest {
         /*
          * Bypass the executor and run synchronously in this test.
          */
-        LogEntryHandler handler = new LogEntryHandler(1) {
+        LogEntryHandler handler = new LogEntryHandler(1, Integer.MAX_VALUE) {
             public void handle(ILoggingEvent eventObject) {
                 if (eventObject.getLevel().levelInt < Level.ERROR.levelInt) {
                     return;

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -49,6 +49,13 @@ alarms.priority-mapping.path=${alarms.dir}/alarms-priority.properties
 #
 alarms.limits.workers=1
 
+#  ---- Maximum size of waiting queue. When exceeded, events are discarded.
+#	A conservative estimate of the needed memory would be 128Mb for
+#	every 1000 queue slots.  Hence for the default setting given here,
+#	at least 1Gb of heap space should be allotted to the JVM.
+#
+alarms.limits.queue-size=10000
+
 #  ---- SMTP email forwarding property
 #
 #      Whether or not to send email alerts of alarms.

--- a/skel/share/services/alarms.batch
+++ b/skel/share/services/alarms.batch
@@ -34,6 +34,7 @@ check alarms.history.min-index
 check alarms.history.max-index
 check alarms.enable.cleaner
 check alarms.limits.workers
+check alarms.limits.queue-size
 
 define env checkAlarmCleanerProperites end
      check -strong alarms.cleaner.timeout


### PR DESCRIPTION
…ents on overrun

    See patch 8989, commit to master 05e8f4647c0d6b5e402c091730bfebe78b3d923b

    Because the BoundedExecutor class was not backported to 2.12, a special version
    of that patch is necessary.

    Here the usual java.util.concurrent.ThreadPoolExecutor is used, implementing
    the RejectedExecutionHandler to discard the event.

    Target: 2.12
    See https://rb.dcache.org/r/8989