### PR TITLE
pool: send connection header when closing a connection.

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/HttpRequestHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpRequestHandler.java
@@ -8,12 +8,10 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.CharsetUtil;
-import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,15 +34,12 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<Object>
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(HttpRequestHandler.class);
-    private boolean _isKeepAlive;
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, Object msg)
     {
         if (msg instanceof HttpRequest) {
             HttpRequest request = (HttpRequest) msg;
-
-            _isKeepAlive = HttpHeaders.isKeepAlive(request);
 
             ChannelFuture future;
             if (request.getMethod() == HttpMethod.GET) {
@@ -62,9 +57,6 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<Object>
             }
             if (future != null) {
                 future.addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-                if (!isKeepAlive()) {
-                    future.addListener(ChannelFutureListener.CLOSE);
-                }
                 return;
             }
         }
@@ -72,9 +64,6 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<Object>
             ChannelFuture future = doOnContent(ctx, (HttpContent) msg);
             if (future != null) {
                 future.addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-                if (!isKeepAlive()) {
-                    future.addListener(ChannelFutureListener.CLOSE);
-                }
             }
         }
     }
@@ -144,11 +133,6 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<Object>
         } else {
             LOGGER.warn(t.toString());
         }
-    }
-
-    protected boolean isKeepAlive()
-    {
-        return _isKeepAlive;
     }
 
     /**

--- a/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
@@ -160,6 +160,7 @@ public class HttpTransferService extends NettyTransferService<HttpProtocolInfo>
                                               clientIdleTimeout,
                                               clientIdleTimeoutUnit));
         pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
+        pipeline.addLast("keepalive", new KeepAliveHandler());
 
         if (!customHeaders.isEmpty()) {
             pipeline.addLast("custom-headers", new CustomResponseHeadersHandler(customHeaders));

--- a/modules/dcache/src/main/java/org/dcache/http/KeepAliveHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/KeepAliveHandler.java
@@ -1,0 +1,64 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2015 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.http;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Adjust response headers based on whether or not the connection is to
+ * be closed.  Note, this class name is based on the miss-named "HTTP Keep-Alive"
+ * concept and is unrelated to TCP Keep-Alive.
+ */
+public class KeepAliveHandler extends ChannelDuplexHandler
+{
+    private boolean _isKeepAlive;
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception
+    {
+        if (msg instanceof HttpRequest) {
+            _isKeepAlive = HttpHeaders.isKeepAlive((HttpRequest) msg);
+        }
+
+        super.channelRead(ctx, msg);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext context, Object message, ChannelPromise promise)
+            throws Exception
+    {
+        if (message instanceof HttpResponse) {
+            HttpHeaders.setKeepAlive((HttpResponse) message, _isKeepAlive);
+        }
+
+        if (message instanceof LastHttpContent && !_isKeepAlive && promise != null) {
+            promise.addListener(ChannelFutureListener.CLOSE);
+        }
+
+        super.write(context, message, promise);
+    }
+}


### PR DESCRIPTION
HTTP/1.0 allows the client to request a connection is kept open. With
HTTP/1.1 this became the default, but a client could request the
connection is closed once the server has completed sending the
response.

The pool honours this and will close the connection if it detects
this is appropriate: HTTP/1.0 request without Connection: Keep-Alive
header, or HTTP/1.1 request with Connection: Close.

RFC 2616 (8.1.2.1) states "If the server chooses to close the
connection immediately after sending the response, it SHOULD send a
Connection header including the connection-token close."

Currently dCache sends no Connection header in the response when
shutting down the connection.  Although not required by RFC 2616, we
have no good reason to deviate from recommended behaviour.
Therefore, this patch updates the pool to include the connection
response when it will close the connection.

Target: master
Patch: https://rb.dcache.org/r/8754
Acked-by: Gerd Behrmann
Requires-notes: yes
Requires-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10