### PR TITLE
pool: Don't consider failure to find migration job a bug

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -933,7 +933,7 @@ public class MigrationModule
         String id;
 
         @Override
-        public String call()
+        public String call() throws NoSuchElementException
         {
             Job job = getJob(id);
             job.suspend();
@@ -949,7 +949,7 @@ public class MigrationModule
         String id;
 
         @Override
-        public String call()
+        public String call() throws NoSuchElementException
         {
             Job job = getJob(id);
             job.resume();
@@ -968,7 +968,7 @@ public class MigrationModule
         String id;
 
         @Override
-        public String call()
+        public String call() throws NoSuchElementException
         {
             Job job = getJob(id);
             job.cancel(force);
@@ -1007,7 +1007,7 @@ public class MigrationModule
     public class MigrationListCommand implements Callable<String>
     {
         @Override
-        public String call() throws Exception
+        public String call() throws NoSuchElementException
         {
             StringBuilder s = new StringBuilder();
             for (String id: _jobs.keySet()) {


### PR DESCRIPTION
Motivation:

Undeclared exceptions thrown by shell commands are considered bugs.

Modification:

Declare NoSuchElementException on various migration module commands.

Result:

Resolved an issue that would generate the following fault:

11 Feb 2016 14:25:22 (bccs_uib_no_042) [admin] Command failed due to a bug, please contact support@dcache.org.
dmg.util.CommandPanicException: (1) Command failed: java.util.NoSuchElementException: Job not found

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Femi Adeyemi <olufemi.segun.adeyemi@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9019/
(cherry picked from commit a5862cf79b55df2ba48e12f77c6ab5278f0472ca)