### PR TITLE
Add precondition checks to FsPath to disallow relative paths

### DIFF
--- a/modules/common/src/main/java/diskCacheV111/util/FsPath.java
+++ b/modules/common/src/main/java/diskCacheV111/util/FsPath.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class FsPath {
 
     private final List<String> _list;
@@ -14,7 +16,11 @@ public class FsPath {
 
     public FsPath(String path) {
         this();
-        add(path);
+        checkArgument(path.startsWith("/"));
+        StringTokenizer st = new StringTokenizer(path, "/");
+        while (st.hasMoreTokens()) {
+            addSingleItem(st.nextToken());
+        }
     }
 
     public FsPath()
@@ -95,6 +101,7 @@ public class FsPath {
             }
             return;
         }
+        checkArgument(!item.isEmpty());
         _list.add(item);
     }
 

--- a/modules/common/src/main/java/diskCacheV111/util/FsPath.java
+++ b/modules/common/src/main/java/diskCacheV111/util/FsPath.java
@@ -1,10 +1,14 @@
 package diskCacheV111.util;
 
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Arrays.asList;
 
 public class FsPath {
 
@@ -156,6 +160,18 @@ public class FsPath {
             }
         }
         return true;
+    }
+
+    public boolean contains(String path)
+    {
+        List<String> pathSequence = Splitter.on("/").omitEmptyStrings().splitToList(path);
+        int len = pathSequence.size();
+        for (int i = 0; i <= _list.size() - len; i++) {
+            if (_list.subList(i, i + len).equals(pathSequence)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -86,7 +86,8 @@
       <property name="fileSystem" ref="file-system"/>
       <property name="extractor" ref="extractor"/>
       <property name="aclEnabled" value="${pnfsmanager.enable.acl}"/>
-      <property name="uploadDirectory" value="${pnfsmanager.upload-directory}/%d"/>
+      <property name="uploadDirectory" value="${pnfsmanager.upload-directory}"/>
+      <property name="uploadSubDirectory" value="%d"/>
   </bean>
 
   <bean id="acl-admin" class="org.dcache.acl.AclAdmin">

--- a/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/PnfsManagerTest.java
+++ b/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/PnfsManagerTest.java
@@ -107,6 +107,8 @@ public class PnfsManagerTest
         chimera.setPermissionHandler(new PosixPermissionHandler());
         chimera.setAclEnabled(false);
         chimera.setFileSystem(_fs);
+        chimera.setUploadDirectory("/upload");
+        chimera.setUploadSubDirectory("%d");
 
 
         _pnfsManager = new PnfsManagerV3();

--- a/modules/dcache-ftp/src/test/java/org/dcache/ftp/door/AbstractFtpDoorV1Test.java
+++ b/modules/dcache-ftp/src/test/java/org/dcache/ftp/door/AbstractFtpDoorV1Test.java
@@ -60,8 +60,8 @@ public class AbstractFtpDoorV1Test {
     public void setUp()
     {
         MockitoAnnotations.initMocks(this);
-        door._userRootPath = new FsPath("pathRoot");
-        door._doorRootPath = new FsPath("pathRoot");
+        door._userRootPath = new FsPath("/pathRoot");
+        door._doorRootPath = new FsPath("/pathRoot");
         door._cwd = "/cwd";
         door._pnfs = pnfs;
     }

--- a/modules/dcache/src/test/java/org/dcache/tests/util/FsPathTest.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/util/FsPathTest.java
@@ -46,4 +46,10 @@ public class FsPathTest
     {
         new FsPath("/my/root").relativize(new FsPath("/my/root2/foo/bar/"));
     }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testRelativePath()
+    {
+        new FsPath("foo");
+    }
 }

--- a/modules/dcache/src/test/java/org/dcache/tests/util/FsPathTest.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/util/FsPathTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import diskCacheV111.util.FsPath;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class FsPathTest
 {
@@ -51,5 +51,21 @@ public class FsPathTest
     public void testRelativePath()
     {
         new FsPath("foo");
+    }
+
+    @Test
+    public void testContains()
+    {
+        assertTrue(new FsPath("/foo").contains("foo"));
+        assertTrue(new FsPath("/foo").contains(""));
+        assertTrue(new FsPath("/foo/bar").contains("foo"));
+        assertTrue(new FsPath("/foo/bar").contains("foo/bar"));
+        assertTrue(new FsPath("/foo/bar").contains("foo/bar/"));
+        assertTrue(new FsPath("/foo/bar").contains("bar"));
+        assertTrue(new FsPath("/foo/bar").contains("bar/"));
+        assertTrue(new FsPath("/").contains(""));
+        assertFalse(new FsPath("/").contains("foo"));
+        assertFalse(new FsPath("/bar").contains("foo"));
+        assertFalse(new FsPath("/bar/foo").contains("foo/bar"));
     }
 }


### PR DESCRIPTION
Motivation:

FsPath represents a path in the dCache file name space. It is supposed
to always represent an absolute path, however if called with a relative
path the constructor will treat it as if it is absolute.

This is particularly dangerous when doing getParent() on an arbitrary
string like "foo" as it would result in a path to root (bad if e.g.
asking PnfsManager to cancel an upload to such a path as it would
recursively delete root!).

Modification:

Add precondition checks to FsPath.

Result:

Added safe guards preventing a relative path from being interpreted as
if it was absolute.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Dmitry Litvintsev <litvinse@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9022/
(cherry picked from commit 1002b5d5eba06afd205a1bc4fd41505f396d49a8)
(cherry picked from commit a5c515edda3131d43879acc05df070c0fa649da7)