### PR TITLE
srm: Add safe-guard against invalid file ID in put requests

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -1158,24 +1158,26 @@ public final class Storage
     public void abortPut(SRMUser user, String localTransferPath, URI surl, String reason) throws SRMException
     {
         try {
-            Subject subject = ((DcacheUser) user).getSubject();
-            FsPath actualPnfsPath = getPath(surl);
-            PnfsCancelUpload msg =
-                    new PnfsCancelUpload(subject, new FsPath(localTransferPath), actualPnfsPath);
-            _pnfsStub.sendAndWait(msg);
+            if (localTransferPath.startsWith("/")) { // safe-guard against incompatible file id from earlier versions
+                Subject subject = ((DcacheUser) user).getSubject();
+                FsPath actualPnfsPath = getPath(surl);
+                PnfsCancelUpload msg =
+                        new PnfsCancelUpload(subject, new FsPath(localTransferPath), actualPnfsPath);
+                _pnfsStub.sendAndWait(msg);
 
-            DoorRequestInfoMessage infoMsg =
-                    new DoorRequestInfoMessage(getCellAddress().toString());
-            infoMsg.setSubject(subject);
-            infoMsg.setBillingPath(actualPnfsPath.toString());
-            infoMsg.setTransaction(CDC.getSession());
-            infoMsg.setPnfsId(msg.getPnfsId());
-            infoMsg.setResult(CacheException.DEFAULT_ERROR_CODE, reason);
-            Origin origin = Subjects.getOrigin(subject);
-            if (origin != null) {
-                infoMsg.setClient(origin.getAddress().getHostAddress());
+                DoorRequestInfoMessage infoMsg =
+                        new DoorRequestInfoMessage(getCellAddress().toString());
+                infoMsg.setSubject(subject);
+                infoMsg.setBillingPath(actualPnfsPath.toString());
+                infoMsg.setTransaction(CDC.getSession());
+                infoMsg.setPnfsId(msg.getPnfsId());
+                infoMsg.setResult(CacheException.DEFAULT_ERROR_CODE, reason);
+                Origin origin = Subjects.getOrigin(subject);
+                if (origin != null) {
+                    infoMsg.setClient(origin.getAddress().getHostAddress());
+                }
+                _billingStub.notify(infoMsg);
             }
-            _billingStub.notify(infoMsg);
         } catch (PermissionDeniedCacheException e) {
             throw new SRMAuthorizationException("Permission denied.", e);
         } catch (CacheException e) {


### PR DESCRIPTION
Motivation:

When aborting an upload, the SRM sends an abort upload request to
PnfsManager and PnfsManager will delete the temporary upload
directory and all files it contains. The SRM tracks the temporary
upload path in the fileid field of the putfilerequests table.

If this field contains a value different from a regular path, either
because it was changed outside of dCache, or it contains entries
from a very old version of dCache (which stored PNFS IDs in that
field), then bad things happen: Due to another bug in dCache,
the parent directory of a relative simple relative path like "foo"
becomes the root, which would be the directory PnfsManager deletes
recursively.

Modification:

Add a simple check to SRM to only submit a cancel request to
PnfsManager if the field looks like an absolute file system
path.

Result:

Fixed a potential data loss scenario in case of corrupted or very
old SRM database entries.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Dmitry Litvintsev <litvinse@fnal.gov>
Patch: https://rb.dcache.org/r/9023/
(cherry picked from commit 8d2056e17a4bfd23782d01c4e469cc9bc38e89e9)
(cherry picked from commit f41c5c2898fdb3953c04fc43acbdb4155b06a4dd)
(cherry picked from commit 3dd6d29a38d28005f4736f9422a33b1a972f84ee)