### PR TITLE
chimera: Alter statistics target for t_tags(itagid)

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.10.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.10.xml
@@ -11,4 +11,10 @@
             <column name="itagid"></column>
         </createIndex>
     </changeSet>
+
+    <changeSet id="2" author="behrmann" dbms="postgresql">
+        <comment>Adjust statistics target for t_tags(itagid) to avoid bad query planning for tag inode deletion</comment>
+        <sql>alter table t_tags alter itagid set statistics 1000</sql>
+        <rollback/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Motivation:

At NDGF we used to suffer from slow tag deletion issues due to bad
query plans. Several months ago we adjusted the statistics target
for t_tags(itagid) and ever since the problem has not reoccurred -
before that change it occurred several times a month.

Modification:

Add a changeset to alter the statistics target for t_tags(itagid).

Result:

Addressed a periodic performance problem that would cause directory
deletion to slow down in Chimera.

Target: trunk
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Dmitry Litvintsev <litvinse@fnal.gov>
Patch: https://rb.dcache.org/r/9025/
(cherry picked from commit e5f3b9a77c170e5ff960054cd5d05f6f2681b8a3)