### PR TITLE
xrootd: Add kXR_dstat support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.3.6.v20151106</version.jetty>
         <version.wicket>7.1.0</version.wicket>
-        <version.xrootd4j>3.0.3</version.xrootd4j>
+        <version.xrootd4j>3.0.5</version.xrootd4j>
 
         <!-- BouncyCastle seems to change the naming convention of
              their ArtifactId fairly often.  Here is a summary of


### PR DESCRIPTION
Motivation:

The xrootd 3.0.0 specification introduced the kXR_dstat option to the kXR_dirlist
request to allow stat information to be inlined in the list response.

Modification:

Adds support for kXR_dstat in dCache.

Result:

Adds support for efficient verbose listing with xrootd by introducing support
for the kXR_dstat option. For VOs that rely on token authorization, this is
a requirement for functional verbose listing.

Target: trunk
Request: 2.14
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9021/
(cherry picked from commit 501c3343e54bb9884873292ea04188d47b1e7b81)