### PR TITLE
webdav: add support for 3rd-party HTTP pull

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceHandlerHelper.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceHandlerHelper.java
@@ -1,0 +1,48 @@
+package org.dcache.webdav;
+
+import io.milton.http.AuthenticationService;
+import io.milton.http.HandlerHelper;
+import io.milton.http.HttpManager;
+import io.milton.http.Request;
+import io.milton.http.ResourceHandler;
+import io.milton.http.ResourceHandlerHelper;
+import io.milton.http.Response;
+import io.milton.http.UrlAdapter;
+import io.milton.http.exceptions.BadRequestException;
+import io.milton.http.exceptions.ConflictException;
+import io.milton.http.exceptions.NotAuthorizedException;
+import io.milton.http.http11.Http11ResponseHandler;
+import io.milton.resource.Resource;
+
+import org.dcache.webdav.transfer.CopyFilter;
+
+/**
+ * This class provides extended behaviour for Milton so it can support
+ * some experimental/new protocol extensions, like 3rd-party transfers.
+ */
+public class DcacheResourceHandlerHelper extends ResourceHandlerHelper
+{
+    public DcacheResourceHandlerHelper(HandlerHelper handlerHelper,
+            UrlAdapter urlAdapter, Http11ResponseHandler responseHandler,
+            AuthenticationService authenticationService)
+    {
+        super(handlerHelper, urlAdapter, responseHandler, authenticationService);
+    }
+
+    @Override
+    public void process(HttpManager manager, Request request, Response response,
+                        ResourceHandler handler) throws NotAuthorizedException,
+                                                        ConflictException,
+                                                        BadRequestException
+    {
+        if (CopyFilter.isRequestThirdPartyCopy(request)) {
+            /* Bypass check to see if file exists: our CopyFilter will handle the request */
+            DcacheResourceFactory factory = (DcacheResourceFactory) manager.getResourceFactory();
+            String url = getUrlAdapter().getUrl(request);
+            Resource resource = factory.getResource(null, url);
+            handler.processResource(manager, request, response, resource);
+        } else {
+            super.process(manager, request, response, handler);
+        }
+    }
+}

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
@@ -24,6 +24,7 @@ import io.milton.http.FilterChain;
 import io.milton.http.Request;
 import io.milton.http.Response;
 import io.milton.http.Response.Status;
+import io.milton.http.exceptions.BadRequestException;
 import io.milton.servlet.ServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.AccessController;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +55,7 @@ import org.dcache.auth.Subjects;
 import org.dcache.cells.CellStub;
 import org.dcache.namespace.FileType;
 import org.dcache.vehicles.FileAttributes;
+import org.dcache.webdav.transfer.RemoteTransferHandler.Direction;
 import org.dcache.webdav.transfer.RemoteTransferHandler.TransferType;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -95,6 +98,10 @@ public class CopyFilter implements Filter
     private static final String REQUEST_HEADER_CREDENTIAL = "Credential";
     private static final Set<AccessMask> READ_ACCESS_MASK =
             EnumSet.of(AccessMask.READ_DATA);
+    private static final Set<AccessMask> WRITE_ACCESS_MASK =
+            EnumSet.of(AccessMask.WRITE_DATA);
+    private static final Set<AccessMask> CREATE_ACCESS_MASK =
+            EnumSet.of(AccessMask.ADD_FILE);
 
     /**
      * Describes where to fetch the delegated credential, if at all.
@@ -183,62 +190,88 @@ public class CopyFilter implements Filter
             }
         } catch (ErrorResponseException e) {
             response.sendError(e.getStatus(), e.getMessage());
+        } catch (BadRequestException e) {
+            response.sendError(Status.SC_BAD_REQUEST, e.getMessage());
         } catch (InterruptedException ignored) {
             response.sendError(Response.Status.SC_SERVICE_UNAVAILABLE,
                     "dCache is shutting down");
         }
     }
 
-    private boolean isRequestThirdPartyCopy(Request request)
-            throws ErrorResponseException
+    public static boolean isRequestThirdPartyCopy(Request request)
+            throws BadRequestException
     {
         if (request.getMethod() != Request.Method.COPY) {
             return false;
         }
 
-        URI uri = getDestination(request);
+        URI uri = getRemoteLocation();
 
-        // We treat any Destination URI that has scheme and host parts as a
+        // We treat any URI that has scheme and host parts as a
         // third-party transfer request.  This isn't guaranteed but
         // probably good enough for now.
         return uri.getScheme() != null && uri.getHost() != null;
     }
 
-    private static URI getDestination(Request request) throws ErrorResponseException
+    private static Direction getDirection() throws BadRequestException
     {
-        String destination = request.getDestinationHeader();
-        if (destination == null) {
-            throw new RuntimeException("Destination request header is missing"); // Bug in Milton
+        // Note that each invocation of Request#getHeaders creates a HashMap
+        // and populates it with all headers.  Therefore, we use ServletRequest
+        // which Milton only makes available via a ThreadLocal.
+        HttpServletRequest servletRequest = ServletRequest.getRequest();
+
+        String pullUrl = servletRequest.getHeader(Direction.PULL.getHeaderName());
+        String pushUrl = servletRequest.getHeader(Direction.PUSH.getHeaderName());
+
+        if (pullUrl == null && pushUrl == null) {
+            throw new BadRequestException("COPY request is missing both " +
+                    Direction.PUSH.getHeaderName() + " and " +
+                    Direction.PULL.getHeaderName() + " request headers");
         }
 
+        if (pullUrl != null && pushUrl != null) {
+            throw new BadRequestException("COPY request contains both " +
+                    Direction.PUSH.getHeaderName() + " and " +
+                    Direction.PULL.getHeaderName() + " request headers");
+        }
+
+        return pushUrl != null ? Direction.PUSH : Direction.PULL;
+    }
+
+    private static URI getRemoteLocation() throws BadRequestException
+    {
+        Direction direction = getDirection();
+        String remote = ServletRequest.getRequest().getHeader(direction.getHeaderName());
+
         try {
-            return new URI(request.getDestinationHeader());
+            return new URI(remote);
         } catch (URISyntaxException e) {
-            throw new ErrorResponseException(Status.SC_BAD_REQUEST,
-                    "Destination request header contains an invalid URI: " +
-                            e.getMessage());
+            throw new BadRequestException(direction.getHeaderName() +
+                    " request header contains an invalid URI: " + e.getMessage());
         }
     }
 
     private void processThirdPartyCopy(Request request, Response response)
-            throws ErrorResponseException, InterruptedException
+            throws BadRequestException, InterruptedException, ErrorResponseException
     {
-        URI destination = getDestination(request);
+        Direction direction = getDirection();
+        URI remote = getRemoteLocation();
 
-        TransferType type = TransferType.fromScheme(destination.getScheme());
+        TransferType type = TransferType.fromScheme(remote.getScheme());
         if (type == null) {
             throw new ErrorResponseException(Status.SC_BAD_REQUEST,
-                    "Destination URI contains unsupported scheme; supported " +
-                            "schemes are " + Joiner.on(", ").join(TransferType.validSchemes()));
+                    "The " + direction.getHeaderName() + " request header URI " +
+                    "contains unsupported scheme; supported schemes are " +
+                    Joiner.on(", ").join(TransferType.validSchemes()));
         }
 
-        if (destination.getPath() == null) {
+        if (remote.getPath() == null) {
             throw new ErrorResponseException(Status.SC_BAD_REQUEST,
-                    "Destination is missing a path");
+                    direction.getHeaderName() + " header is missing a path");
         }
 
         FsPath path = getFullPath(request.getAbsolutePath());
-        checkPath(path);
+        checkPath(path, direction);
 
         CredentialSource source = getCredentialSource(request, type);
         X509Credential credential = fetchCredential(source);
@@ -246,8 +279,8 @@ public class CopyFilter implements Filter
             redirectWithDelegation(response);
         } else {
             _remoteTransfers.acceptRequest(response.getOutputStream(),
-                    request.getHeaders(), getSubject(), path, destination,
-                    credential);
+                    request.getHeaders(), getSubject(), path, remote,
+                    credential, direction);
         }
     }
 
@@ -270,7 +303,7 @@ public class CopyFilter implements Filter
         if (!type.isSupported(source)) {
             throw new ErrorResponseException(Status.SC_BAD_REQUEST,
                     "HTTP header 'Credential' value \"" + headerValue + "\" is not " +
-                    "supported for transport " + getDestination(request).getScheme());
+                    "supported for transport " + type.getScheme());
         }
 
         return source;
@@ -372,35 +405,78 @@ public class CopyFilter implements Filter
         return request.getParameter(QUERY_KEY_ASKED_TO_DELEGATE) != null;
     }
 
+    private boolean clientAllowsOverwrite() throws ErrorResponseException
+    {
+        String overwrite = ServletRequest.getRequest().getHeader("Overwrite");
+        if (overwrite != null) {
+            switch (overwrite) {
+            case "T":
+                return true;
+            case "F":
+                return false;
+            default:
+                throw new ErrorResponseException(Status.SC_BAD_REQUEST,
+                        "Invalid Overwrite request header value: must be either 'T' or 'F'");
+            }
+        }
+
+        return true;
+    }
+
     /**
-     * Check whether the source may be transferred.  Updates the response as
-     * a side-effect if the returned value is false.
+     * Check whether the path is allowed for this transfer.
      */
-    private void checkPath(FsPath path) throws ErrorResponseException
+    private void checkPath(FsPath path, Direction direction) throws ErrorResponseException
     {
         PnfsHandler pnfs = new PnfsHandler(_pnfs, getSubject());
 
+        // Always check any client-supplied Overwrite header.
+        boolean overwriteAllowed = clientAllowsOverwrite();
+
+        Set<AccessMask> mask = direction == Direction.PUSH ? READ_ACCESS_MASK : WRITE_ACCESS_MASK;
         FileAttributes attributes;
         try {
-            attributes = pnfs.getFileAttributes(path.toString(),
-                    EnumSet.of(PNFSID, TYPE), READ_ACCESS_MASK, false);
-        } catch (FileNotFoundCacheException e) {
-            _log.debug("No such file: {}", e.getMessage());
-            throw new ErrorResponseException(Response.Status.SC_NOT_FOUND, "no such file");
+            try {
+                attributes = pnfs.getFileAttributes(path.toString(),
+                        EnumSet.of(PNFSID, TYPE), mask, false);
+
+                if (attributes.getFileType() != FileType.REGULAR) {
+                    throw new ErrorResponseException(Status.SC_BAD_REQUEST, "Not a file");
+                }
+
+                if (direction == Direction.PULL) {
+                    if (!overwriteAllowed) {
+                        throw new ErrorResponseException(Status.SC_PRECONDITION_FAILED,
+                                "File already exists");
+                    }
+
+                    // REVISIT: ideally, the transfermanager would handle
+                    // deleting existing entry.
+                    try {
+                        pnfs.deletePnfsEntry(attributes.getPnfsId(), path.toString(),
+                                EnumSet.of(FileType.REGULAR));
+                    } catch (FileNotFoundCacheException ignored) {
+                        // Ignore this: someone else deleted the file, which
+                        // suggests we might be unlucky pulling the data.
+                    }
+                }
+            } catch (FileNotFoundCacheException e) {
+                if (direction == Direction.PUSH) {
+                    throw new ErrorResponseException(Status.SC_NOT_FOUND, "no such file");
+                } else {
+                    pnfs.getFileAttributes(path.getParent().toString(), Collections.emptySet(),
+                                           CREATE_ACCESS_MASK, false);
+                }
+            }
         } catch (PermissionDeniedCacheException e) {
             _log.debug("Permission denied: {}", e.getMessage());
-            throw new ErrorResponseException(Response.Status.SC_UNAUTHORIZED,
+            throw new ErrorResponseException(Status.SC_UNAUTHORIZED,
                     "Permission denied");
         } catch (CacheException e) {
             _log.error("failed query file {} for copy request: {}", path,
                     e.getMessage());
-            throw new ErrorResponseException(Response.Status.SC_INTERNAL_SERVER_ERROR,
+            throw new ErrorResponseException(Status.SC_INTERNAL_SERVER_ERROR,
                     "Internal problem with server");
-        }
-
-        if (attributes.getFileType() != FileType.REGULAR) {
-            throw new ErrorResponseException(Response.Status.SC_BAD_REQUEST,
-                    "Source is not a file");
         }
     }
 

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -90,13 +90,39 @@ import static org.dcache.webdav.transfer.CopyFilter.CredentialSource.*;
  */
 public class RemoteTransferHandler implements CellMessageReceiver
 {
+
+    /**
+     * The different directions that the data will travel.
+     */
+    public enum Direction
+    {
+        /** Request to pull data from remote site. */
+        PULL("Source"),
+
+        /** Request to push data to some remote site. */
+        PUSH("Destination");
+
+        private final String header;
+
+        Direction(String header)
+        {
+            this.header = header;
+        }
+
+        public String getHeaderName()
+        {
+            return header;
+        }
+    }
+
+
     /**
      * The different transport schemes supported.
      */
     public enum TransferType {
-        GSIFTP(2811, GRIDSITE, EnumSet.noneOf(CredentialSource.class)),
-        HTTP(80,     NONE,     EnumSet.noneOf(CredentialSource.class)),
-        HTTPS(443,   GRIDSITE, EnumSet.of(NONE));
+        GSIFTP("gsiftp", 2811, GRIDSITE, EnumSet.noneOf(CredentialSource.class)),
+        HTTP(    "http",   80,     NONE, EnumSet.noneOf(CredentialSource.class)),
+        HTTPS(  "https",  443, GRIDSITE, EnumSet.of(NONE));
 
         private static final ImmutableMap<String,TransferType> BY_SCHEME =
             ImmutableMap.of("gsiftp", GSIFTP, "http", HTTP, "https", HTTPS);
@@ -104,14 +130,16 @@ public class RemoteTransferHandler implements CellMessageReceiver
         private final int _defaultPort;
         private final CredentialSource _defaultCredentialSource;
         private final EnumSet<CredentialSource> _supported;
+        private final String _scheme;
 
-        TransferType(int port, CredentialSource defaultSource,
+        TransferType(String scheme, int port, CredentialSource defaultSource,
                 EnumSet<CredentialSource> additionalSources)
         {
             _defaultPort = port;
             _defaultCredentialSource = defaultSource;
             _supported = EnumSet.copyOf(additionalSources);
             _supported.add(defaultSource);
+            _scheme = scheme;
         }
 
         public int getDefaultPort()
@@ -127,6 +155,11 @@ public class RemoteTransferHandler implements CellMessageReceiver
         public boolean isSupported(CredentialSource source)
         {
             return _supported.contains(source);
+        }
+
+        public String getScheme()
+        {
+            return _scheme;
         }
 
         public static TransferType fromScheme(String scheme)
@@ -188,13 +221,15 @@ public class RemoteTransferHandler implements CellMessageReceiver
     }
 
     public void acceptRequest(OutputStream out, Map<String,String> requestHeaders,
-            Subject subject, FsPath path, URI destination, X509Credential credential)
+            Subject subject, FsPath path, URI remote, X509Credential credential,
+            Direction direction)
             throws ErrorResponseException, InterruptedException
     {
         EnumSet<TransferFlag> flags = EnumSet.noneOf(TransferFlag.class);
         flags = addVerificationFlag(flags, requestHeaders);
         ImmutableMap<String,String> transferHeaders = buildTransferHeaders(requestHeaders);
-        RemoteTransfer transfer = new RemoteTransfer(out, subject, path, destination, credential, flags, transferHeaders);
+        RemoteTransfer transfer = new RemoteTransfer(out, subject, path, remote,
+                credential, flags, transferHeaders, direction);
 
         long id;
 
@@ -302,6 +337,7 @@ public class RemoteTransferHandler implements CellMessageReceiver
         private final PrintWriter _out;
         private final EnumSet<TransferFlag> _flags;
         private final ImmutableMap<String,String> _transferHeaders;
+        private final Direction _direction;
         private String _problem;
         private long _id;
         private final EndPoint _endpoint = HttpConnection.getCurrentConnection().getEndPoint();
@@ -310,7 +346,8 @@ public class RemoteTransferHandler implements CellMessageReceiver
 
         public RemoteTransfer(OutputStream out, Subject subject, FsPath path,
                 URI destination, @Nullable X509Credential credential,
-                EnumSet<TransferFlag> flags, ImmutableMap<String,String> transferHeaders)
+                EnumSet<TransferFlag> flags, ImmutableMap<String,String> transferHeaders,
+                Direction direction)
                 throws ErrorResponseException
         {
             _subject = subject;
@@ -327,12 +364,14 @@ public class RemoteTransferHandler implements CellMessageReceiver
             _out = new PrintWriter(out);
             _flags = flags;
             _transferHeaders = transferHeaders;
+            _direction = direction;
         }
 
         private long start() throws ErrorResponseException, InterruptedException
         {
+            boolean isStore = _direction == Direction.PULL;
             RemoteTransferManagerMessage message =
-                    new RemoteTransferManagerMessage(_destination, _path, false,
+                    new RemoteTransferManagerMessage(_destination, _path, isStore,
                             DUMMY_LONG, buildProtocolInfo());
 
             message.setSubject(_subject);
@@ -509,9 +548,9 @@ public class RemoteTransferHandler implements CellMessageReceiver
             case TransferManagerHandler.RECEIVED_PNFS_INFO_STATE:
                 return "recieved file metadata";
             case TransferManagerHandler.WAITING_FOR_PNFS_ENTRY_CREATION_INFO_STATE:
-                return "creating empty local file";
+                return "creating namespace entry";
             case TransferManagerHandler.RECEIVED_PNFS_ENTRY_CREATION_INFO_STATE:
-                return "empty local file created";
+                return "namespace entry created";
             case TransferManagerHandler.WAITING_FOR_POOL_INFO_STATE:
                 return "selecting pool";
             case TransferManagerHandler.RECEIVED_POOL_INFO_STATE:
@@ -539,7 +578,7 @@ public class RemoteTransferHandler implements CellMessageReceiver
             case TransferManagerHandler.UNKNOWN_ID:
                 return "unknown transfer";
             default:
-                return "unknown state";
+                return "unknown state: " + state;
             }
         }
     }


### PR DESCRIPTION
While dCache has supported 3rd-party HTTP push requests for some time,
the corresponding pull support was missing as it isn't allowed under
WebDAV COPY command.

This patch adds support for HTTP pull, by the client specifying a
Source header field.  The URL of the HTTP COPY request (i.e., the
local file) may be empty or may already exist.  If it exists then
the Overwrite header is honoured.

Target: master
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Patch: https://rb.dcache.org/r/8952/

Conflicts:
	modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java