### PR TITLE
webdav: add support for 3rd-party HTTP pull

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceHandlerHelper.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceHandlerHelper.java
@@ -1,0 +1,48 @@
+package org.dcache.webdav;
+
+import io.milton.http.AuthenticationService;
+import io.milton.http.HandlerHelper;
+import io.milton.http.HttpManager;
+import io.milton.http.Request;
+import io.milton.http.ResourceHandler;
+import io.milton.http.ResourceHandlerHelper;
+import io.milton.http.Response;
+import io.milton.http.UrlAdapter;
+import io.milton.http.exceptions.BadRequestException;
+import io.milton.http.exceptions.ConflictException;
+import io.milton.http.exceptions.NotAuthorizedException;
+import io.milton.http.http11.Http11ResponseHandler;
+import io.milton.resource.Resource;
+
+import org.dcache.webdav.transfer.CopyFilter;
+
+/**
+ * This class provides extended behaviour for Milton so it can support
+ * some experimental/new protocol extensions, like 3rd-party transfers.
+ */
+public class DcacheResourceHandlerHelper extends ResourceHandlerHelper
+{
+    public DcacheResourceHandlerHelper(HandlerHelper handlerHelper,
+            UrlAdapter urlAdapter, Http11ResponseHandler responseHandler,
+            AuthenticationService authenticationService)
+    {
+        super(handlerHelper, urlAdapter, responseHandler, authenticationService);
+    }
+
+    @Override
+    public void process(HttpManager manager, Request request, Response response,
+                        ResourceHandler handler) throws NotAuthorizedException,
+                                                        ConflictException,
+                                                        BadRequestException
+    {
+        if (CopyFilter.isRequestThirdPartyCopy(request)) {
+            /* Bypass check to see if file exists: our CopyFilter will handle the request */
+            DcacheResourceFactory factory = (DcacheResourceFactory) manager.getResourceFactory();
+            String url = getUrlAdapter().getUrl(request);
+            Resource resource = factory.getResource(null, url);
+            handler.processResource(manager, request, response, resource);
+        } else {
+            super.process(manager, request, response, handler);
+        }
+    }
+}


### PR DESCRIPTION
While dCache has supported 3rd-party HTTP push requests for some time,
the corresponding pull support was missing as it isn't allowed under
WebDAV COPY command.

This patch adds support for HTTP pull, by the client specifying a
Source header field.  The URL of the HTTP COPY request (i.e., the
local file) may be empty or may already exist.  If it exists then
the Overwrite header is honoured.

Target: master
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Patch: https://rb.dcache.org/r/8952/

Conflicts:
	modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java