### PR TITLE
pool: use "same thread strategy" for nfs movers

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
@@ -230,7 +230,7 @@ public class NFSv4MoverHandler {
                 .withMaxPort(portRange.getUpper())
                 .withTCP()
                 .withoutAutoPublish()
-                .withWorkerThreadIoStrategy();
+                .withSameThreadIoStrategy();
 
         if (withGss) {
             RpcLoginService rpcLoginService = new RpcLoginService() {


### PR DESCRIPTION
Motivation:
NFS mover has two thread pools to process nfs requests:
one to accept request over the wire and one to execute
request inside the mover. Such schema allows to process
multiple requests from the same client in parallel. Nevertheless,
most of IO operations in one or the other form synchronized and
parallel processing serialized by a shared lock (ChecksumChannel). Worse,
a single 'chatty' client can fill up request queue and block all threads.

By switching to single thread pool model we guarantee that only
one thread will be blocked.

Modification:
Switch to same-thread strategy. The sellector thread will perform IO operation.

Result:
better concurrency under high load. On unbalanced servers (few CPUs but many disks)
number of processing thread can be un-optimal. A corresponding change to underlaying
rpc code under it's way.

Acked-by: Gerd Behrmann
Target: master, 2.14, 2.13
Require-book: no
Require-notes: yes
(cherry picked from commit d8b899d4f92b513efe5616519bd907fbe9ba429a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>