### PR TITLE
pnfsmanager: Protect against erroneous upload paths

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
@@ -93,27 +93,22 @@ public class ChimeraEnstoreStorageInfoExtractor extends ChimeraHsmStorageInfoExt
         else {
             dirInode = inode;
         }
-        try {
-            Map<String, String> hash = new HashMap<>();
-            ImmutableList<String> OSMTemplate = dirInode.getTag("OSMTemplate");
-            ImmutableList<String> group       = dirInode.getTag("storage_group");
-            ImmutableList<String> family      = dirInode.getTag("file_family");
+        Map<String, String> hash = new HashMap<>();
+        ImmutableList<String> OSMTemplate = dirInode.getTag("OSMTemplate");
+        ImmutableList<String> group       = dirInode.getTag("storage_group");
+        ImmutableList<String> family      = dirInode.getTag("file_family");
 
-            for (String line: OSMTemplate) {
-                StringTokenizer st = new StringTokenizer(line);
-                if (st.countTokens() >= 2) {
-                    hash.put(st.nextToken().intern(), st.nextToken());
-                }
+        for (String line: OSMTemplate) {
+            StringTokenizer st = new StringTokenizer(line);
+            if (st.countTokens() >= 2) {
+                hash.put(st.nextToken().intern(), st.nextToken());
             }
-            String sg = getFirstLine(group).transform(internString()).or("none");
-            String ff = getFirstLine(family).transform(internString()).or("none");
-            EnstoreStorageInfo info = new EnstoreStorageInfo(sg,ff);
-            info.addKeys(hash);
-            return info;
         }
-        catch (IOException e) {
-            throw new CacheException(e.getMessage());
-        }
+        String sg = getFirstLine(group).transform(internString()).or("none");
+        String ff = getFirstLine(family).transform(internString()).or("none");
+        EnstoreStorageInfo info = new EnstoreStorageInfo(sg,ff);
+        info.addKeys(hash);
+        return info;
     }
 
     private static boolean isEncoded(String s) throws UnsupportedEncodingException {

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
@@ -94,8 +93,6 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
             throw new FileNotFoundCacheException(e.getMessage(), e);
         } catch (ChimeraFsException e) {
             throw new CacheException("Failed to obtain AccessLatency: " + e.getMessage(), e);
-        } catch (IOException e) {
-            throw new CacheException(37, "Failed to obtain AccessLatency: " + e.getMessage(), e);
         }
     }
 
@@ -137,8 +134,6 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
             throw new FileNotFoundCacheException(e.getMessage(), e);
         } catch (ChimeraFsException e) {
             throw new CacheException("Failed to obtain RetentionPolicy: " + e.getMessage(), e);
-        } catch (IOException e) {
-            throw new CacheException(37, "Failed to obtain RetentionPolicy: " + e.getMessage(), e);
         }
     }
 
@@ -172,29 +167,25 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
             dirInode = inode.getParent();
         }
 
-        try {
-            // overwrite hsm type with hsmInstance tag
-            Optional<String> hsmInstance = getFirstLine(dirInode.getTag("hsmInstance"));
-            if (hsmInstance.isPresent()) {
-                info.setHsm(hsmInstance.get().intern());
-            }
+        // overwrite hsm type with hsmInstance tag
+        Optional<String> hsmInstance = getFirstLine(dirInode.getTag("hsmInstance"));
+        if (hsmInstance.isPresent()) {
+            info.setHsm(hsmInstance.get().intern());
+        }
 
-            Optional<String> cacheClass = getFirstLine(dirInode.getTag("cacheClass"));
-            if (cacheClass.isPresent()) {
-                info.setCacheClass(cacheClass.get().intern());
-            }
+        Optional<String> cacheClass = getFirstLine(dirInode.getTag("cacheClass"));
+        if (cacheClass.isPresent()) {
+            info.setCacheClass(cacheClass.get().intern());
+        }
 
-            Optional<String> spaceToken = getFirstLine(dirInode.getTag("WriteToken"));
-            if (spaceToken.isPresent() ) {
-                info.setKey("writeToken", spaceToken.get());
-            }
+        Optional<String> spaceToken = getFirstLine(dirInode.getTag("WriteToken"));
+        if (spaceToken.isPresent() ) {
+            info.setKey("writeToken", spaceToken.get());
+        }
 
-            Optional<String> path = getFirstLine(dirInode.getTag("Path"));
-            if (path.isPresent() ) {
-                info.setKey("path", path.get());
-            }
-        } catch (IOException e) {
-            throw new CacheException( 37, "Unable to fetch tags: " + e.getMessage());
+        Optional<String> path = getFirstLine(dirInode.getTag("Path"));
+        if (path.isPresent() ) {
+            info.setKey("path", path.get());
         }
 
         return info;

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -2,6 +2,7 @@ package org.dcache.chimera.namespace;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -31,7 +32,9 @@ import java.util.regex.Pattern;
 import diskCacheV111.namespace.NameSpaceProvider;
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileCorruptedCacheException;
 import diskCacheV111.util.FileExistsCacheException;
+import diskCacheV111.util.FileIsNewCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.InvalidMessageCacheException;
@@ -1309,7 +1312,8 @@ public class ChimeraNameSpaceProvider
     }
 
     @Override
-    public PnfsId commitUpload(Subject subject, FsPath temporaryPath, FsPath finalPath, Set<CreateOption> options)
+    public FileAttributes commitUpload(Subject subject, FsPath temporaryPath, FsPath finalPath,
+                                       Set<CreateOption> options, Set<FileAttribute> attributesToFetch)
             throws CacheException
     {
         try {
@@ -1318,17 +1322,36 @@ public class ChimeraNameSpaceProvider
 
             checkIsTemporaryDirectory(temporaryPath, temporaryDir);
 
-            /* File must have been uploaded.
+            /* File must have been created...
              */
-            FsInode uploadDirInode;
-            FsInode temporaryDirInode;
-            FsInode inodeOfFile;
+            ExtendedInode uploadDirInode;
+            ExtendedInode temporaryDirInode;
+            ExtendedInode inodeOfFile;
             try {
-                uploadDirInode = _fs.path2inode(temporaryDir.getParent().toString());
+                uploadDirInode = new ExtendedInode(_fs, _fs.path2inode(temporaryDir.getParent().toString()).toString());
                 temporaryDirInode = uploadDirInode.inodeOf(temporaryDir.getName());
                 inodeOfFile = temporaryDirInode.inodeOf(temporaryPath.getName());
             } catch (FileNotFoundHimeraFsException e) {
                 throw new FileNotFoundCacheException("No such file or directory: " + temporaryPath, e);
+            }
+
+            /* ...and upload must have completed...
+             */
+            ImmutableList<StorageLocatable> locations = inodeOfFile.getLocations();
+            if (locations.isEmpty()) {
+                throw new FileIsNewCacheException("Upload has not completed.");
+            }
+
+            /* ...and it must have the correct size.
+             */
+            ImmutableList<String> size = inodeOfFile.getTag(TAG_EXPECTED_SIZE);
+            if (!size.isEmpty()) {
+                long expectedSize = Long.parseLong(size.get(0));
+                long actualSize = inodeOfFile.statCache().getSize();
+                if (expectedSize != actualSize) {
+                    throw new FileCorruptedCacheException("File has unexpected size (expected=" + expectedSize +
+                                                          ";actual=" + actualSize + ").");
+                }
             }
 
             /* Target directory must exist.
@@ -1371,10 +1394,12 @@ public class ChimeraNameSpaceProvider
              */
             removeRecursively(uploadDirInode, temporaryDir.getName());
 
-            return new PnfsId(inodeOfFile.toString());
+            return getFileAttributes(inodeOfFile, attributesToFetch);
         } catch (ChimeraFsException e) {
             throw new CacheException(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
                                      e.getMessage());
+        } catch (NumberFormatException e) {
+            throw new FileCorruptedCacheException("Failed to commit file: " + e.getMessage());
         }
     }
 

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -34,6 +34,7 @@ import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileExistsCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
+import diskCacheV111.util.InvalidMessageCacheException;
 import diskCacheV111.util.NotDirCacheException;
 import diskCacheV111.util.NotFileCacheException;
 import diskCacheV111.util.PermissionDeniedCacheException;
@@ -91,6 +92,7 @@ public class ChimeraNameSpaceProvider
     private boolean _aclEnabled;
     private PermissionHandler _permissionHandler;
     private String _uploadDirectory;
+    private String _uploadSubDirectory;
 
     /**
      * A value of difference in seconds which controls file's access time updates.
@@ -146,16 +148,24 @@ public class ChimeraNameSpaceProvider
     /**
      * Base directory for temporary upload directories. If not an absolute path, the directory
      * is relative to the user's root directory.
+     */
+    @Required
+    public void setUploadDirectory(String path)
+    {
+        _uploadDirectory = path;
+    }
+
+    /**
+     * Sub directory in the upload directory in which to create temporary upload directories.
      *
      * May be parametrised by a thread id by inserting %d into the string. This allows Chimera
      * lock contention on the base directory to be reduced. If used it is important that the
      * same set threads call into the provider repeatedly as otherwise a large number of
      * base directories will be created.
      */
-    @Required
-    public void setUploadDirectory(String path)
+    public void setUploadSubDirectory(String path)
     {
-        _uploadDirectory = path;
+        _uploadSubDirectory = path;
     }
 
     @Required
@@ -1247,7 +1257,10 @@ public class ChimeraNameSpaceProvider
              * or relative path.
              */
             FsPath uploadDirectory = new FsPath(rootPath);
-            uploadDirectory.add(String.format(_uploadDirectory, threadId.get()));
+            uploadDirectory.add(_uploadDirectory);
+            if (_uploadSubDirectory != null) {
+                uploadDirectory.add(String.format(_uploadSubDirectory, threadId.get()));
+            }
 
             /* Upload directory must exist and have the right permissions.
              */
@@ -1275,6 +1288,26 @@ public class ChimeraNameSpaceProvider
         }
     }
 
+    protected void checkIsTemporaryDirectory(FsPath temporaryPath, FsPath temporaryDir)
+            throws NotFileCacheException, InvalidMessageCacheException
+    {
+        FsPath temporaryDirContainer = getParentOfFile(temporaryDir);
+        if (_uploadDirectory.startsWith("/")) {
+            if (!temporaryDirContainer.startsWith(new FsPath(_uploadDirectory))) {
+                throw new InvalidMessageCacheException(
+                        temporaryPath + " is not part of the " + _uploadDirectory + " tree.");
+            }
+        } else {
+            if (!temporaryDirContainer.contains(_uploadDirectory)) {
+                throw new InvalidMessageCacheException(
+                        temporaryPath + " is not part of the " + _uploadDirectory + " tree.");
+            }
+        }
+        if (temporaryDir.isEmpty()) {
+            throw new InvalidMessageCacheException("A temporary upload path cannot be in the root directory.");
+        }
+    }
+
     @Override
     public PnfsId commitUpload(Subject subject, FsPath temporaryPath, FsPath finalPath, Set<CreateOption> options)
             throws CacheException
@@ -1282,6 +1315,8 @@ public class ChimeraNameSpaceProvider
         try {
             FsPath temporaryDir = getParentOfFile(temporaryPath);
             FsPath finalDir = getParentOfFile(finalPath);
+
+            checkIsTemporaryDirectory(temporaryPath, temporaryDir);
 
             /* File must have been uploaded.
              */
@@ -1348,6 +1383,8 @@ public class ChimeraNameSpaceProvider
     {
         try {
             FsPath temporaryDir = getParentOfFile(temporaryPath);
+
+            checkIsTemporaryDirectory(temporaryPath, temporaryDir);
 
             /* Temporary upload directory must exist.
              */

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraOsmStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraOsmStorageInfoExtractor.java
@@ -2,7 +2,6 @@ package org.dcache.chimera.namespace;
 
 import com.google.common.collect.ImmutableList;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -78,33 +77,28 @@ public class ChimeraOsmStorageInfoExtractor extends ChimeraHsmStorageInfoExtract
         else {
             dirInode = inode;
         }
-        try {
-            HashMap<String, String> hash = new HashMap<>();
-            String store = null;
-            ImmutableList<String> OSMTemplate = dirInode.getTag("OSMTemplate");
-            if (!OSMTemplate.isEmpty()) {
-                for (String line: OSMTemplate) {
-                    StringTokenizer st = new StringTokenizer(line);
-                    if (st.countTokens() < 2) {
-                        continue;
-                    }
-                    hash.put(st.nextToken().intern(), st.nextToken());
+        HashMap<String, String> hash = new HashMap<>();
+        String store = null;
+        ImmutableList<String> OSMTemplate = dirInode.getTag("OSMTemplate");
+        if (!OSMTemplate.isEmpty()) {
+            for (String line: OSMTemplate) {
+                StringTokenizer st = new StringTokenizer(line);
+                if (st.countTokens() < 2) {
+                    continue;
                 }
-                store = hash.get("StoreName");
-                if (store == null) {
-                    throw new CacheException(37, "StoreName not found in template");
-                }
+                hash.put(st.nextToken().intern(), st.nextToken());
             }
+            store = hash.get("StoreName");
+            if (store == null) {
+                throw new CacheException(37, "StoreName not found in template");
+            }
+        }
 
-            ImmutableList<String> sGroup = dirInode.getTag("sGroup");
-            String group = getFirstLine(sGroup).transform(internString()).orNull();
-            OSMStorageInfo info = new OSMStorageInfo(store, group);
-            info.addKeys(hash);
-            return info;
-        }
-        catch (IOException e) {
-            throw new CacheException(e.getMessage());
-        }
+        ImmutableList<String> sGroup = dirInode.getTag("sGroup");
+        String group = getFirstLine(sGroup).transform(internString()).orNull();
+        OSMStorageInfo info = new OSMStorageInfo(store, group);
+        info.addKeys(hash);
+        return info;
     }
 
 }

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ExtendedInode.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ExtendedInode.java
@@ -21,6 +21,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -162,13 +163,16 @@ public class ExtendedInode extends FsInode
     }
 
     public ImmutableList<String> getTag(String tag)
-            throws IOException
     {
-        byte[] data = getTags().get(tag);
-        if (data == null || data.length == 0) {
-            return ImmutableList.of();
+        try {
+            byte[] data = getTags().get(tag);
+            if (data == null || data.length == 0) {
+                return ImmutableList.of();
+            }
+            return ByteSource.wrap(data).asCharSource(Charsets.UTF_8).readLines();
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
         }
-        return ByteSource.wrap(data).asCharSource(Charsets.UTF_8).readLines();
     }
 
     public ImmutableCollection<Checksum> getChecksums() throws ChimeraFsException

--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -87,7 +87,8 @@
       <property name="extractor" ref="extractor"/>
       <property name="aclEnabled" value="${pnfsmanager.enable.acl}"/>
       <property name="atimeGap" value="${pnfsmanager.atime-gap}" />
-      <property name="uploadDirectory" value="${pnfsmanager.upload-directory}/%d"/>
+      <property name="uploadDirectory" value="${pnfsmanager.upload-directory}"/>
+      <property name="uploadSubDirectory" value="%d"/>
   </bean>
 
   <bean id="acl-admin" class="org.dcache.acl.AclAdmin">

--- a/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/PnfsManagerTest.java
+++ b/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/PnfsManagerTest.java
@@ -104,6 +104,8 @@ public class PnfsManagerTest
         chimera.setPermissionHandler(new PosixPermissionHandler());
         chimera.setAclEnabled(false);
         chimera.setFileSystem(_fs);
+        chimera.setUploadDirectory("/upload");
+        chimera.setUploadSubDirectory("%d");
 
 
         _pnfsManager = new PnfsManagerV3();

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -136,7 +136,9 @@ import diskCacheV111.services.space.message.Release;
 import diskCacheV111.services.space.message.Reserve;
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileCorruptedCacheException;
 import diskCacheV111.util.FileExistsCacheException;
+import diskCacheV111.util.FileIsNewCacheException;
 import diskCacheV111.util.FileLocality;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
@@ -1083,7 +1085,7 @@ public final class Storage
                                          new FsPath(localTransferPath),
                                          fullPath,
                                          options,
-                                         EnumSet.of(SIZE, STORAGEINFO));
+                                         EnumSet.of(PNFSID, SIZE, STORAGEINFO));
             msg = _pnfsStub.sendAndWait(msg);
 
             DoorRequestInfoMessage infoMsg =
@@ -1092,7 +1094,7 @@ public final class Storage
             infoMsg.setBillingPath(fullPath.toString());
             infoMsg.setTransferPath(localTransferPath);
             infoMsg.setTransaction(CDC.getSession());
-            infoMsg.setPnfsId(msg.getPnfsId());
+            infoMsg.setPnfsId(msg.getFileAttributes().getPnfsId());
             infoMsg.setResult(0, "");
             infoMsg.setFileSize(msg.getFileAttributes().getSize());
             infoMsg.setStorageInfo(msg.getFileAttributes().getStorageInfo());
@@ -1103,6 +1105,8 @@ public final class Storage
             _billingStub.notify(infoMsg);
         } catch (FileNotFoundCacheException e) {
             throw new SRMInvalidPathException(e.getMessage(), e);
+        } catch (FileIsNewCacheException | FileCorruptedCacheException  e) {
+            throw new SRMException(e.getMessage(), e);
         } catch (PermissionDeniedCacheException e) {
             throw new SRMAuthorizationException("Permission denied.", e);
         } catch (FileExistsCacheException e) {

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/AbstractNameSpaceProvider.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/AbstractNameSpaceProvider.java
@@ -154,7 +154,8 @@ public class AbstractNameSpaceProvider
     }
 
     @Override
-    public PnfsId commitUpload(Subject subject, FsPath uploadPath, FsPath pnfsPath, Set<CreateOption> options)
+    public FileAttributes commitUpload(Subject subject, FsPath uploadPath, FsPath pnfsPath,
+                                       Set<CreateOption> options, Set<FileAttribute> attributesToFetch)
     {
         throw new UnsupportedOperationException();
     }

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/NameSpaceProvider.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/NameSpaceProvider.java
@@ -181,7 +181,7 @@ public interface NameSpaceProvider
      * @param subject Subject of user who invoked this method.
      * @param pnfsId of the file
      * @param attr array of requested attributes
-     * @param acquire attributes to query after the update, if any.
+     * @param fetch attributes to query after the update, if any.
      * @return the updated attributes selected by acquire
      */
     FileAttributes setFileAttributes(Subject subject, PnfsId pnfsId,
@@ -248,9 +248,11 @@ public interface NameSpaceProvider
      * @param uploadPath the temporary path as returned by createUploadPath
      * @param path the path of file that is uploaded
      * @param options options specifying how the path should be committed
-     * @return PnfsId of committed file
+     * @param fetch attributes of the file to return
+     * @return Requested file attributes of the committed file.
      */
-    PnfsId commitUpload(Subject subject, FsPath uploadPath, FsPath path, Set<CreateOption> options) throws CacheException;
+    FileAttributes commitUpload(Subject subject, FsPath uploadPath, FsPath path,
+                                Set<CreateOption> options, Set<FileAttribute> fetch) throws CacheException;
 
     /**
      * Remove temporary upload location.

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -1195,16 +1195,12 @@ public class PnfsManagerV3
     private void commitUpload(PnfsCommitUpload message)
     {
         try {
-            PnfsId pnfsId = _nameSpaceProvider.commitUpload(message.getSubject(),
-                                                            message.getUploadPath(),
-                                                            message.getPath(),
-                                                            message.getOptions());
-            message.setPnfsId(pnfsId);
-            Set<FileAttribute> attributes = message.getRequestedAttributes();
-            if (!attributes.isEmpty()) {
-                message.setFileAttributes(
-                        _nameSpaceProvider.getFileAttributes(Subjects.ROOT, pnfsId, attributes));
-            }
+            FileAttributes attributes = _nameSpaceProvider.commitUpload(message.getSubject(),
+                                                                        message.getUploadPath(),
+                                                                        message.getPath(),
+                                                                        message.getOptions(),
+                                                                        message.getRequestedAttributes());
+            message.setFileAttributes(attributes);
             message.setSucceeded();
         } catch (CacheException e) {
             message.setFailed(e.getRc(), e.getMessage());

--- a/modules/dcache/src/main/java/diskCacheV111/util/FsPath.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/FsPath.java
@@ -1,5 +1,7 @@
 package diskCacheV111.util;
 
+import com.google.common.base.Splitter;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -149,6 +151,18 @@ public class FsPath {
             }
         }
         return true;
+    }
+
+    public boolean contains(String path)
+    {
+        List<String> pathSequence = Splitter.on("/").omitEmptyStrings().splitToList(path);
+        int len = pathSequence.size();
+        for (int i = 0; i <= _list.size() - len; i++) {
+            if (_list.subList(i, i + len).equals(pathSequence)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsCommitUpload.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PnfsCommitUpload.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2014 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2014 - 2016 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,6 +17,8 @@
  */
 package diskCacheV111.vehicles;
 
+import com.google.common.collect.Sets;
+
 import javax.security.auth.Subject;
 
 import java.util.Collections;
@@ -27,6 +29,10 @@ import diskCacheV111.util.FsPath;
 import org.dcache.namespace.CreateOption;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.vehicles.FileAttributes;
+
+import static com.google.common.collect.Iterables.concat;
+import static java.util.Collections.singleton;
+import static org.dcache.namespace.FileAttribute.PNFSID;
 
 /**
  * Commit an upload path to its final name.
@@ -72,7 +78,8 @@ public class PnfsCommitUpload extends PnfsMessage
 
     public Set<FileAttribute> getRequestedAttributes()
     {
-        return requestedAttributes;
+        // REVISIT: Addition of PNFSID is for backwards compatibility with pre 2.15 - remove in 2.17
+        return Sets.newHashSet(concat(requestedAttributes, singleton(PNFSID)));
     }
 
     public FileAttributes getFileAttributes()
@@ -82,6 +89,9 @@ public class PnfsCommitUpload extends PnfsMessage
 
     public void setFileAttributes(FileAttributes fileAttributes)
     {
+        if (fileAttributes.isDefined(PNFSID)) {
+            setPnfsId(fileAttributes.getPnfsId());
+        }
         this.fileAttributes = fileAttributes;
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/auth/RemoteNameSpaceProvider.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/RemoteNameSpaceProvider.java
@@ -218,7 +218,8 @@ public class RemoteNameSpaceProvider implements NameSpaceProvider
     }
 
     @Override
-    public PnfsId commitUpload(Subject subject, FsPath uploadPath, FsPath pnfsPath, Set<CreateOption> options)
+    public FileAttributes commitUpload(Subject subject, FsPath uploadPath, FsPath pnfsPath,
+                                       Set<CreateOption> options, Set<FileAttribute> attributes)
             throws CacheException
     {
         PnfsCommitUpload msg = new PnfsCommitUpload(subject,
@@ -226,7 +227,7 @@ public class RemoteNameSpaceProvider implements NameSpaceProvider
                                                     pnfsPath,
                                                     options,
                                                     EnumSet.noneOf(FileAttribute.class));
-        return _pnfs.pnfsRequest(msg).getPnfsId();
+        return _pnfs.pnfsRequest(msg).getFileAttributes();
     }
 
     @Override

--- a/modules/dcache/src/test/java/org/dcache/tests/util/FsPathTest.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/util/FsPathTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import diskCacheV111.util.FsPath;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class FsPathTest
 {
@@ -45,5 +45,21 @@ public class FsPathTest
     public void testRelativizeNoPrefix()
     {
         new FsPath("/my/root").relativize(new FsPath("/my/root2/foo/bar/"));
+    }
+
+    @Test
+    public void testContains()
+    {
+        assertTrue(new FsPath("/foo").contains("foo"));
+        assertTrue(new FsPath("/foo").contains(""));
+        assertTrue(new FsPath("/foo/bar").contains("foo"));
+        assertTrue(new FsPath("/foo/bar").contains("foo/bar"));
+        assertTrue(new FsPath("/foo/bar").contains("foo/bar/"));
+        assertTrue(new FsPath("/foo/bar").contains("bar"));
+        assertTrue(new FsPath("/foo/bar").contains("bar/"));
+        assertTrue(new FsPath("/").contains(""));
+        assertFalse(new FsPath("/").contains("foo"));
+        assertFalse(new FsPath("/bar").contains("foo"));
+        assertFalse(new FsPath("/bar/foo").contains("foo/bar"));
     }
 }


### PR DESCRIPTION
Motivation:

SRM negotiates a temporary upload path with PnfsManager, either committing or
cancelling it at the end of the upload. PnfsManager blindly trusts this path,
which means it will delete the containing directory upon cancellation.

Modification:

Adds some basic sanity checks. These ensure that if an absolute upload path is
used, the temporary path must be within the upload path. If a user relative
upload path is given, such a sanity check is not possible as the user root
path is not know at this point.

Result:

Add protection against erroneous or malicious upload path cancellations.

Target: trank
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Dmitry Litvintsev <litvinse@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9024/
(cherry picked from commit 15b2a10690df1f8593869b9b2fbcf1f5a947185e)
(cherry picked from commit 6084a86e33cdcbb17e8bb692b086df671af54b44)
(cherry picked from commit e34706bd788b258b741dc8b5d5ea73f481534c5f)