### PR TITLE
srm: Check for broken files during srmPutDone

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -111,6 +111,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -137,6 +138,7 @@ import diskCacheV111.services.space.message.Reserve;
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileExistsCacheException;
+import diskCacheV111.util.FileIsNewCacheException;
 import diskCacheV111.util.FileLocality;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
@@ -153,6 +155,7 @@ import diskCacheV111.vehicles.IpProtocolInfo;
 import diskCacheV111.vehicles.PnfsCancelUpload;
 import diskCacheV111.vehicles.PnfsCommitUpload;
 import diskCacheV111.vehicles.PnfsCreateUploadPath;
+import diskCacheV111.vehicles.PoolCheckFileMessage;
 import diskCacheV111.vehicles.RemoteHttpDataTransferProtocolInfo;
 import diskCacheV111.vehicles.RemoteHttpsDataTransferProtocolInfo;
 import diskCacheV111.vehicles.transferManager.CancelTransferMessage;
@@ -165,6 +168,7 @@ import diskCacheV111.vehicles.transferManager.TransferManagerMessage;
 import dmg.cells.nucleus.AbstractCellComponent;
 import dmg.cells.nucleus.CDC;
 import dmg.cells.nucleus.CellMessageReceiver;
+import dmg.cells.nucleus.CellPath;
 import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.cells.services.login.LoginBrokerInfo;
 
@@ -1074,6 +1078,9 @@ public final class Storage
         try {
             Subject subject = ((DcacheUser) user).getSubject();
             FsPath fullPath = getPath(surl);
+
+            checkNonBrokenUpload(localTransferPath);
+
             EnumSet<CreateOption> options = EnumSet.noneOf(CreateOption.class);
             if (overwrite) {
                 options.add(CreateOption.OVERWRITE_EXISTING);
@@ -1113,6 +1120,45 @@ public final class Storage
             throw new SRMInternalErrorException("Operation interrupted", e);
         } catch (NoRouteToCellException e) {
             _log.error(e.getMessage());
+        }
+    }
+
+    /**
+     * Check that file has a non-broken location. This is temporary code that will be
+     * removed once pools register actual file size and/or file brokenness in the
+     * name space.
+     */
+    private void checkNonBrokenUpload(String fullPath) throws InterruptedException, CacheException
+    {
+        FileAttributes fileAttributes = _pnfs.getFileAttributes(fullPath, EnumSet.of(PNFSID, LOCATIONS));
+        Iterator<String> iterator = fileAttributes.getLocations().iterator();
+        if (iterator.hasNext()) {
+            CacheException error;
+            String location;
+            do {
+                location = iterator.next();
+                try {
+                    checkPoolFile(location, fileAttributes);
+                    return;
+                } catch (CacheException e) {
+                    error = e;
+                }
+            } while (iterator.hasNext());
+            throw error;
+        }
+        throw new FileIsNewCacheException("No file was uploaded.");
+    }
+
+    private void checkPoolFile(String location, FileAttributes fileAttributes)
+            throws CacheException, InterruptedException
+    {
+        /* Since this is a temporary workaround, we borrow the pnfs stub.
+         */
+        PoolCheckFileMessage message = _pnfsStub.sendAndWait(new CellPath(location),
+                                                             new PoolCheckFileMessage(location,
+                                                                                      fileAttributes.getPnfsId()));
+        if (message.getWaiting()) {
+            throw new FileIsNewCacheException("Upload has not completed.");
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -36,6 +36,7 @@ import diskCacheV111.repository.CacheRepositoryEntryInfo;
 import diskCacheV111.repository.RepositoryCookie;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.CacheFileAvailable;
+import diskCacheV111.util.FileCorruptedCacheException;
 import diskCacheV111.util.FileInCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FileNotInCacheException;
@@ -964,8 +965,7 @@ public class PoolV4
             poolMessage.setWaiting(true);
             break;
         case BROKEN:
-            throw new CacheException(CacheException.DEFAULT_ERROR_CODE,
-                                     id.toString() + " is broken in " + _poolName);
+            throw new FileCorruptedCacheException(id.toString() + " is broken in " + _poolName);
         default:
             poolMessage.setHave(false);
             poolMessage.setWaiting(false);


### PR DESCRIPTION
Motivation:

Upon upload, files register expected file size and expected check sum
in the name space. Thus SRM cannot based on the name space entry alone
conclude if the file on the pool is broken or not.

The proper fix will be to adjust the pool failure semantics, however that is
too extensive a change to backport to stable branches.

Modification:

Add a callout to the pool to check for broken files during the srmPutDone
processing.

Result:

Adds logic to detect broken uploads when srmPutDone is called. srmPutDone
processing will become slower, but it will catch upload failures that would
otherwise go undetected.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9037/
(cherry picked from commit 48326f8aae51f0ae46851b29b9c7a81ccbb27299)
(cherry picked from commit 71864167506c9cee36e7a71b5eae0ce1010a1596)