### PR TITLE
pool: Avoid lock contention on DNS lookup in p2p component

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
@@ -15,6 +15,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -455,36 +456,41 @@ class Companion
     /** Asynchronously requests delivery from the source pool. */
     synchronized void sendDeliveryRequest()
     {
-        HttpProtocolInfo protocolInfo =
-            new HttpProtocolInfo(PROTOCOL_INFO_NAME,
-                                 PROTOCOL_INFO_MAJOR_VERSION,
-                                 PROTOCOL_INFO_MINOR_VERSION,
-                                 new InetSocketAddress(_address, 0),
-                                 _destinationPoolCellname,
-                                 _destinationPoolCellDomainName,
-                                 "/" + _pnfsId,
-                                 null);
-        protocolInfo.setSessionId(_id);
+        try {
+            InetAddress address = (_address == null) ? InetAddress.getLocalHost() : _address;
+            HttpProtocolInfo protocolInfo =
+                new HttpProtocolInfo(PROTOCOL_INFO_NAME,
+                                     PROTOCOL_INFO_MAJOR_VERSION,
+                                     PROTOCOL_INFO_MINOR_VERSION,
+                                     new InetSocketAddress(address, 0),
+                                     _destinationPoolCellname,
+                                     _destinationPoolCellDomainName,
+                                     "/" + _pnfsId,
+                                     null);
+            protocolInfo.setSessionId(_id);
 
-        PoolDeliverFileMessage request =
-                new PoolDeliverFileMessage(_sourcePoolName,
-                                           protocolInfo,
-                                           _fileAttributes);
-        request.setPool2Pool();
-        request.setInitiator(getInitiator());
-        request.setId(_id);
-        request.setForceSourceMode(_forceSourceMode);
+            PoolDeliverFileMessage request =
+                    new PoolDeliverFileMessage(_sourcePoolName,
+                                               protocolInfo,
+                                               _fileAttributes);
+            request.setPool2Pool();
+            request.setInitiator(getInitiator());
+            request.setId(_id);
+            request.setForceSourceMode(_forceSourceMode);
 
-        CellStub.addCallback(_pool.send(new CellPath(_sourcePoolName), request),
-                             new Callback<PoolDeliverFileMessage>()
-                             {
-                                 @Override
-                                 public void success(PoolDeliverFileMessage message)
+            CellStub.addCallback(_pool.send(new CellPath(_sourcePoolName), request),
+                                 new Callback<PoolDeliverFileMessage>()
                                  {
-                                     setMoverId(message.getMoverId());
-                                     super.success(message);
-                                 }
-                             }, _executor);
+                                     @Override
+                                     public void success(PoolDeliverFileMessage message)
+                                     {
+                                         setMoverId(message.getMoverId());
+                                         super.success(message);
+                                     }
+                                 }, _executor);
+        } catch (UnknownHostException e) {
+            _executor.execute(() -> _fsm.failure(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e));
+        }
     }
 
     private String getInitiator()

--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/P2PClient.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/P2PClient.java
@@ -2,9 +2,6 @@
 
 package org.dcache.pool.p2p;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.InetAddress;
@@ -92,12 +89,6 @@ public class P2PClient
             (_companions.size() > _maxActive)
             ? (_companions.size() - _maxActive)
             : 0;
-    }
-
-    public synchronized InetAddress getInterface()
-        throws UnknownHostException
-    {
-        return (_interface == null) ? InetAddress.getLocalHost() : _interface;
     }
 
     public synchronized void messageArrived(DoorTransferFinishedMessage message)
@@ -252,7 +243,7 @@ public class P2PClient
         Callback cb = new Callback(callback);
 
         Companion companion =
-            new Companion(_executor, getInterface(), _repository,
+            new Companion(_executor, _interface, _repository,
                           _checksumModule,
                           _pnfs, _pool,
                           fileAttributes,
@@ -298,10 +289,8 @@ public class P2PClient
     @Override
     public synchronized void getInfo(PrintWriter pw)
     {
-        try {
-            pw.println("  Interface  : " + getInterface());
-        } catch (UnknownHostException e) {
-            pw.println("  Interface  : " + e.getMessage());
+        if (_interface != null) {
+            pw.println("  Interface  : " + _interface);
         }
         pw.println("  Max Active : " + _maxActive);
         pw.println("Pnfs Timeout : " + _pnfs.getTimeout() + " " + _pnfs.getTimeoutUnit());
@@ -367,7 +356,7 @@ public class P2PClient
             String host = args.argv(0);
             _interface =  host.equals("*") ? null : InetAddress.getByName(host);
         }
-        return "PP interface is " + getInterface();
+        return "PP interface is " + ((_interface == null) ? "selected automatically" : _interface) + ".";
     }
 
     public static final String hh_pp_get_file = "<pnfsId> <pool>";


### PR DESCRIPTION
Motivation:

Slow or unrespsonive DNS lookup on a pool has caused lock contention in the P2PClient
component:

"pool-18-thread-3" #318 prio=5 os_prio=0 tid=0x00007fe06803d800 nid=0x60f6 runnable [0x00007fdf685c6000]
   java.lang.Thread.State: RUNNABLE
    at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method)
    at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:928)
    at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1323)
    at java.net.InetAddress.getLocalHost(InetAddress.java:1500)
    - locked <0x0000000640050980> (a java.lang.Object)
    at org.dcache.pool.p2p.P2PClient.getInterface(P2PClient.java:100)
    - eliminated <0x000000064738e490> (a org.dcache.pool.p2p.P2PClient)
    at org.dcache.pool.p2p.P2PClient.getInfo(P2PClient.java:302)
    - locked <0x000000064738e490> (a org.dcache.pool.p2p.P2PClient)

Since getInfo is called by the System cell, this can cause a pool and most of the domain
to become unresponsive.

Modification:

Move the DNS lookup into the Companion. This allows the DNS lookup to be made from
the thread pool of the companion rather. The info output will not show a specific
interface unless a specific interface has been set.

Result:

Fixes a lock contention issue in the pool in which slow DNS lookups during pool
to pool activity could cause the pool and the domain to appear unresponsive.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.14
Request: 2.13
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9042/
(cherry picked from commit ea7118835adf08c12c910a36ed1e34d036dfc86e)