### PR TITLE
pool: send connection header when closing a connection.

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
@@ -5,7 +5,6 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -36,7 +35,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileCorruptedCacheException;
@@ -50,7 +48,6 @@ import org.dcache.pool.movers.IoMode;
 import org.dcache.pool.movers.NettyTransferService;
 import org.dcache.vehicles.FileAttributes;
 
-import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
 import static io.netty.handler.codec.http.HttpHeaders.Names.*;
 import static io.netty.handler.codec.http.HttpHeaders.Values.BYTES;
 import static io.netty.handler.codec.http.HttpHeaders.is100ContinueExpected;

--- a/modules/dcache/src/main/java/org/dcache/http/HttpRequestHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpRequestHandler.java
@@ -13,7 +13,6 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.CharsetUtil;
-import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,15 +35,12 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<Object>
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(HttpRequestHandler.class);
-    private boolean _isKeepAlive;
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, Object msg)
     {
         if (msg instanceof HttpRequest) {
             HttpRequest request = (HttpRequest) msg;
-
-            _isKeepAlive = HttpHeaders.isKeepAlive(request);
 
             ChannelFuture future;
             if (request.getMethod() == HttpMethod.GET) {
@@ -62,9 +58,6 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<Object>
             }
             if (future != null) {
                 future.addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-                if (!isKeepAlive()) {
-                    future.addListener(ChannelFutureListener.CLOSE);
-                }
                 return;
             }
         }
@@ -72,9 +65,6 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<Object>
             ChannelFuture future = doOnContent(ctx, (HttpContent) msg);
             if (future != null) {
                 future.addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-                if (!isKeepAlive()) {
-                    future.addListener(ChannelFutureListener.CLOSE);
-                }
             }
         }
     }
@@ -126,8 +116,8 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<Object>
     {
         if (t instanceof TooLongFrameException) {
             HttpTextResponse response = createErrorResponse(BAD_REQUEST, "Max request length exceeded");
-            response.headers().set(CONNECTION, CLOSE);
-            ctx.channel().writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+            HttpHeaders.setKeepAlive(response, false);
+            ctx.channel().writeAndFlush(response);
         } else if (ctx.channel().isActive()) {
             // We cannot know whether the error was generated before or
             // after we sent the response headers - if we already sent
@@ -144,11 +134,6 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<Object>
         } else {
             LOGGER.warn(t.toString());
         }
-    }
-
-    protected boolean isKeepAlive()
-    {
-        return _isKeepAlive;
     }
 
     /**

--- a/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
@@ -160,6 +160,7 @@ public class HttpTransferService extends NettyTransferService<HttpProtocolInfo>
                                               clientIdleTimeout,
                                               clientIdleTimeoutUnit));
         pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
+        pipeline.addLast("keepalive", new KeepAliveHandler());
 
         if (!customHeaders.isEmpty()) {
             pipeline.addLast("custom-headers", new CustomResponseHeadersHandler(customHeaders));

--- a/modules/dcache/src/main/java/org/dcache/http/KeepAliveHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/KeepAliveHandler.java
@@ -1,0 +1,142 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2015 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.http;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Add the HTTP KeepAlive related response header when appropriate and
+ * ensure the connection is terminated once advertised.
+ * <p>
+ * See Section 8 of RFC-2616 for more details.
+ */
+public class KeepAliveHandler extends ChannelDuplexHandler
+{
+    private static final Logger LOG = LoggerFactory.getLogger(KeepAliveHandler.class);
+
+    private boolean _hasPreviousRequest;
+    private boolean _isLastRequestKeepAlive;
+    private final Deque<Boolean> _inflightKeepAlive = new ArrayDeque();
+
+    @Override
+    public void channelRead(ChannelHandlerContext context, Object message) throws Exception
+    {
+        if (message instanceof HttpRequest) {
+            if (_hasPreviousRequest && !_isLastRequestKeepAlive) {
+                /*
+                 * The client has attempted to send a further request after
+                 * the previous request signaled the connection should be closed.
+                 *
+                 * For HTTP/1.1, this is plain broken: RFC 2616 (8.1.2)
+                 *     "Once a close has been signaled, the client MUST NOT
+                 *     send any more requests on that connection."
+                 *
+                 * For HTTP/1.0, this is undefined.
+                 *
+                 * For HTTP/1.1, dCache is required not to generate any further
+                 * responses: RFC 2616 (8.1.2.1)
+                 *     "If either the client or the server sends the close
+                 *     token in the Connection header, that request becomes
+                 *     the last one for the connection."
+                 *
+                 * Therefore, the request is simply dropped.  As soon as the
+                 * server side of the TCP connection is closed, the OS will
+                 * reply to any further traffic with a RST, tearing down the
+                 * client side of the TCP connection.
+                 */
+                LOG.debug("Broken client sent request after previously asking " +
+                        "the connection be closed.");
+                return;
+            }
+
+            _isLastRequestKeepAlive = HttpHeaders.isKeepAlive((HttpRequest) message);
+            _inflightKeepAlive.offerLast(_isLastRequestKeepAlive);
+            _hasPreviousRequest = true;
+        }
+
+        super.channelRead(context, message);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext context, Object message, ChannelPromise promise)
+            throws Exception
+    {
+        boolean is100Continue = false;
+
+        if (message instanceof HttpResponse) {
+            HttpResponse response = (HttpResponse) message;
+            is100Continue = response.getStatus().equals(HttpResponseStatus.CONTINUE);
+
+            boolean keepAlive = _inflightKeepAlive.getFirst();
+
+            /*
+             * An upstream handler can request the connection be closed even if
+             * the client make no such request.
+             */
+            if (keepAlive && !HttpHeaders.isKeepAlive(response)) {
+                _inflightKeepAlive.removeFirst();
+                _inflightKeepAlive.addFirst(Boolean.FALSE);
+                keepAlive = false;
+            }
+
+            /* REVISIT: It is not clear from RFC-2616 whether, when the client
+             * issues a request with both the "Expect: 100-continue" and the
+             * "Connection: close" headers, the initial CONTINUE response and
+             * the final response should both include the server's
+             * "Connection: close" header, or just the initial CONTINUE, or
+             * just the final response.
+             *
+             * We choose (somewhat arbitrarily) not to send the
+             * "Connection: close" header with CONTINUE responses.
+             */
+            if (!is100Continue) {
+                HttpHeaders.setKeepAlive(response, keepAlive);
+            }
+        }
+
+        ChannelFuture writePromise = context.write(message, promise);
+
+        /*
+         * Netty (currently) requires that the message(s) for the 100-continue
+         * partial response contain a LastHttpContent message; therefore, an
+         * HTTP PUT request with the "Expect: 100-continue" header will
+         * generate two LastHttpContent messages.
+         */
+        if (message instanceof LastHttpContent && !is100Continue) {
+            boolean keepAlive = _inflightKeepAlive.remove();
+
+            if (!keepAlive) {
+                writePromise.addListener(ChannelFutureListener.CLOSE);
+            }
+        }
+    }
+}


### PR DESCRIPTION
HTTP/1.0 allows the client to request a connection is kept open. With
HTTP/1.1 this became the default, but a client could request the
connection is closed once the server has completed sending the
response.

The pool honours this and will close the connection if it detects
this is appropriate: HTTP/1.0 request without Connection: Keep-Alive
header, or HTTP/1.1 request with Connection: Close.

RFC 2616 (8.1.2.1) states "If the server chooses to close the
connection immediately after sending the response, it SHOULD send a
Connection header including the connection-token close."

Currently dCache sends no Connection header in the response when
shutting down the connection.  Although not required by RFC 2616, we
have no good reason to deviate from recommended behaviour.
Therefore, this patch updates the pool to include the connection
response when it will close the connection.

This is an alternative patch to https://rb.dcache.org/r/8910/

Target: master
Requires-notes: yes
Requires-book: no
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/8754
Acked-by: Gerd Behrmann