### PR TITLE
spacemanager: Fix pool monitor fetch race during startup

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/LinkGroupLoader.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/LinkGroupLoader.java
@@ -82,7 +82,12 @@ public class LinkGroupLoader
     public void start()
     {
         executor = Executors.newSingleThreadScheduledExecutor();
-        executor.schedule(this, 100, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void afterStart()
+    {
+        executor.schedule(this, 0, TimeUnit.MILLISECONDS);
     }
 
     public void stop()


### PR DESCRIPTION
Motivation:

During startup it may happen that space manager queries pool manager before the
space manager is registered as a running cell. This means the space manager is
unable to receive the reply and will log:

23 Feb 2016 07:44:07 (SpaceManager) [] Link group update failed: Failed to fetch pool monitor: Request to [>PoolManager@local] timed out.; nested exception is CacheException(rc=10006;msg=Request to [>PoolManager@local] timed out.)

Modification:

Moves the start of the link group refresh to the after-start phase of cell initialization.

Refines exception handling in the pool monitor client stub to avoid stack traces in
case pool monitor update is interrupted.

Result:

Fixes a race condition during space manager startup that could lead to log messages
about failed link group updates and failed transfers.

Target: trunk
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9045/
(cherry picked from commit 9fd38d295720bbdde6d7a612e6ab882a31db6f87)