### PR TITLE
pool: Fix obsoletion of pp set pnfs timeout command

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/P2PClient.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/P2PClient.java
@@ -296,7 +296,6 @@ public class P2PClient
             pw.println("  Interface  : " + _interface);
         }
         pw.println("  Max Active : " + _maxActive);
-        pw.println("Pnfs Timeout : " + _pnfs.getTimeout() + " " + _pnfs.getTimeoutUnit());
     }
 
     @Override
@@ -304,7 +303,6 @@ public class P2PClient
     {
         pw.println("#\n#  Pool to Pool (P2P)\n#");
         pw.println("pp set max active " + _maxActive);
-        pw.println("pp set pnfs timeout " + (_pnfs.getTimeoutInMillis() / 1000L));
         if (_interface != null) {
             pw.println("pp interface " + _interface.getHostAddress());
         }
@@ -315,6 +313,9 @@ public class P2PClient
             description = "This command is obsolete.")
     public class PpSetPnfsTimeoutCommand implements Callable<String>
     {
+        @Argument
+        int timeout;
+
         @Override
         public String call()
         {


### PR DESCRIPTION
Motivation:

While adding documentation for pp commands, the pp set pnfs timeout command
was made obsolete. However the obsolete command doesn't accept a timeout
argument, meaning that pool startup will fail when the setup file contains
this command.

Furthermore, the pool still generates this command when writing the setup
file.

Modification:

Let pp set pnfs timeout accept an integer argument. Don't write the command
to the setup file.

Result:

The pool doesn't fail with

25 Feb 2016 12:10:38 (System) [] Failure at startup: (666) URL [file:/usr/share/dcache/services/pool.batch]: line 102: (3) (0) Error at /var/lib/dcache/pools/001/setup:40: (2) Too many arguments: 300

Target: trunk
Request: 2.15
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9061/
(cherry picked from commit f2cdf2731fb6e91d1823897824d737c2be509905)