### PR TITLE
webdav: fix 404 error if attempting to delete a nonexistent file

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -211,7 +211,11 @@
         </property>
         <property name="defaultStandardFilter" ref="dispatch-filter"/>
         <property name="enableDigestAuth" value="false"/>
-        <property name="enableBasicAuth" value="#{ '${webdav.authn.basic}' == 'true' }"/>
+
+	<!-- Always enable BASIC auth support in Milton; it is never used for actual
+	     authentication, but we identify logged in users by simulating that a BASIC
+	     authentication has happened -->
+        <property name="enableBasicAuth" value="true"/>
         <property name="enableExpectContinue" value="false"/>
         <property name="enableCompression" value="false"/>
         <property name="enableFormAuth" value="false"/>

--- a/packages/system-test/src/main/bin/test
+++ b/packages/system-test/src/main/bin/test
@@ -6,6 +6,7 @@ require 'fileutils'
 require 'tempfile'
 require 'ansi/code'
 require 'etc'
+require 'open3'
 
 include ANSI::Code
 
@@ -30,6 +31,28 @@ include ANSI::Code
 
 def makeTempName
   "test-#{@unique}-#{@count += 1}"
+end
+
+def runExpectingStatus(expectedCode, *args)
+  a = args.insert(1, "-D-").flatten
+  puts yellow { a.join(" ") + " [=> #{expectedCode}]" }
+  begin
+    print faint
+    stdin, stdout, stderr, wait_thr = Open3.popen3(*a)
+    result = stdout.gets
+    stdin.close
+    stdout.close
+    stderr.close
+    if wait_thr.value != 0
+      raise "Failed #{wait_thr.value}"
+    end
+    actualCode = result.scan(/[0-9]{3}/)[0].to_i
+    if actualCode != expectedCode
+      raise "Wrong status code: #{actualCode}"
+    end
+  ensure
+    print reset
+  end
 end
 
 def run(*args)
@@ -192,19 +215,43 @@ def gsidcap(source, dest, *args)
 end
 
 def http(source, dest, *args)
+  args << "-s"
   tmp1 = makeTempName
-  run(@curl, args, "-f", "-s", "-u", "#{Etc.getlogin}:password", "-L", "-T", source, "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
-  run(@curl, args, "-f", "-s", "-L", "-o", dest, "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
+  run(@curl, args, "-f", "-o", "/dev/null", "-u", "#{Etc.getlogin}:password", "-L", "-T", source, "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
+  run(@curl, args, "-f", "-L", "-o", dest, "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
   run(@curl, args, "-f", "-u", "#{Etc.getlogin}:password", "-X", "DELETE", "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(404, @curl, args, "-u", "#{Etc.getlogin}:password", "-X", "DELETE",
+      "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(404, @curl, args, "-X", "DELETE",
+      "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
+end
+
+def httpNoAnonymous(source, dest, *args)
+  args << "-s"
+  tmp1 = makeTempName
+  runExpectingStatus(401, @curl, args, "-o", "/dev/null", "-L", "-T", source, "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
+  run(@curl, args, "-f", "-o", "/dev/null", "-u", "#{Etc.getlogin}:password", "-L", "-T", source, "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(401, @curl, args, "-L", "-o", dest, "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
+  run(@curl, args, "-f", "-u", "#{Etc.getlogin}:password", "-L", "-o", dest, "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
+  run(@curl, args, "-f", "-u", "#{Etc.getlogin}:password", "-X", "DELETE", "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(404, @curl, args, "-u", "#{Etc.getlogin}:password", "-X", "DELETE",
+      "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(401, @curl, args, "-X", "DELETE",
+      "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
 end
 
 def https(source, dest, *args)
+  args << "--capath" << "/etc/grid-security/certificates" << "-s"
   tmp1 = makeTempName
-  run(@curl, args, "--capath /etc/grid-security/certificates", "-s", "-u", "#{Etc.getlogin}:password", "-L", "-T",
-      source, "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
-  run(@curl, args, "--capath /etc/grid-security/certificates", "-s", "-L", "-o",
-      dest, "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
-  run(@curl, args, "--capath /etc/grid-security/certificates", "-u", "#{Etc.getlogin}:password", "-X", "DELETE",
+  run(@curl, args, "-u", "#{Etc.getlogin}:password", "-L", "-T", source,
+      "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
+  run(@curl, args, "-L", "-o", dest,
+      "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
+  run(@curl, args, "-u", "#{Etc.getlogin}:password", "-X", "DELETE",
+      "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(404, @curl, args, "-u", "#{Etc.getlogin}:password", "-X", "DELETE",
+      "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(404, @curl, args, "-X", "DELETE",
       "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
 end
 
@@ -269,7 +316,7 @@ def OptionParser.parse(args)
               ],
     :arc => [ [ :arcSrm ],
               [ :arcHttps ] ],
-    :http => [ [ :http ], [ :https ] ]
+    :http => [ [ :http ], [ :https ], [ :httpNoAnonymous ] ]
   }
 
   parser = OptionParser.new do |opts|

--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -148,6 +148,12 @@ webdav.redirect.on-read=false
 webdav.redirect.on-write=false
 webdav.net.internal=127.0.0.1
 
+[dCacheDomain/webdav]
+webdav.cell.name=WebDAV-NA-${host.name}
+webdav.net.port=2882
+webdav.authn.basic=true
+webdav.authn.protocol=http
+
 [dCacheDomain/srm]
 srm.net.host=localhost
 srm.version=1,2


### PR DESCRIPTION
Motivation:

Milton returns a 401 (Unauthorized) Status Code, instead of 404 (Not
Found), if an unauthenticated user attempts to delete an absent file.
This is desirable as it prevents dCache from leaking information about
which files exist.

If BASIC authentication is switched off, Milton believes all
authenticated users (i.e., users authenticating via X.509) are
unauthenticated, so returns 401 instead of 404.

Modification:

Always enable BASIC authentication support within Milton.  System-test
is updated to demonstrate (and ensure) correct behaviour.

Result:

Authenticated users see a 404 status code when attempting to delete a
missing file; unauthenticated users see a 401 status code.

Target: master
Patch: https://rb.dcache.org/r/9066/
Acked-by: Gerd Behrmann
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10