### PR TITLE
dcache: Fix compilation regression

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolMonitorInvocationHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolMonitorInvocationHandler.java
@@ -8,16 +8,13 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.springframework.aop.target.dynamic.Refreshable;
-import org.springframework.remoting.RemoteConnectFailureException;
 import org.springframework.remoting.RemoteInvocationFailureException;
 import org.springframework.remoting.RemoteProxyFailureException;
-import org.springframework.remoting.RemoteTimeoutException;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.TimeoutCacheException;
@@ -125,7 +122,7 @@ public class RemotePoolMonitorInvocationHandler implements InvocationHandler, Re
         } catch (InvocationTargetException e) {
             throw new RemoteInvocationFailureException("Failed to fetch pool monitor: " + e.getCause().getMessage(), e.getCause());
         } catch (TimeoutCacheException e) {
-            throw new RemoteTimeoutException("Failed to fetch pool monitor: " + e.getMessage(), e);
+            throw new RemoteProxyFailureException("Failed to fetch pool monitor: " + e.getMessage(), e);
         } catch (CacheException e) {
             throw new RemoteInvocationFailureException("Failed to fetch pool monitor: " + e.getMessage(), e);
         }


### PR DESCRIPTION
Fixes

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.3:compile (default-compile) on project dcache-core: Compilation failure: Compilation failure:
[ERROR] <https://ci.dcache.org/job/dCache-v2.13/ws/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolMonitorInvocationHandler.java>:[14,36] cannot find symbol
[ERROR] symbol:   class RemoteTimeoutException

Target: 2.13
Acked-by: Marina Sahakyan <marina.sahakyan@desy.de>
Patch: https://rb.dcache.org/r/9067/