### PR TITLE
poolmanager: Fix race condition in pool selection unit

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -367,34 +367,41 @@ public class PoolSelectionUnitV2
 
     @Override
     public SelectionPool getPool(String poolName, boolean create) {
-        Pool pool = _pools.get(poolName);
-        if ((pool != null) || !create) {
-            return pool;
-        }
-
-        pool = new Pool(poolName);
-
         _psuReadLock.lock();
         try {
-            _pools.put(pool.getName(), pool);
-            PGroup group = _pGroups.get("default");
-            if (group == null) {
-                throw new IllegalArgumentException("Not found : " + "default");
+            Pool pool = _pools.get(poolName);
+            if (pool != null || !create) {
+                return pool;
             }
-
-            //
-            // shall we disallow more than one parent group ?
-            //
-            // if( pool._pGroupList.size() > 0 )
-            // throw new
-            // IllegalArgumentException( poolName +" already member" ) ;
-
-            pool._pGroupList.put(group.getName(), group);
-            group._poolList.put(pool.getName(), pool);
         } finally {
             _psuReadLock.unlock();
         }
-        return pool;
+
+        _psuWriteLock.lock();
+        try {
+            Pool pool = _pools.get(poolName);
+            if (pool == null) {
+                pool = new Pool(poolName);
+                _pools.put(pool.getName(), pool);
+                PGroup group = _pGroups.get("default");
+                if (group == null) {
+                    throw new IllegalArgumentException("Not found : " + "default");
+                }
+
+                //
+                // shall we disallow more than one parent group ?
+                //
+                // if( pool._pGroupList.size() > 0 )
+                // throw new
+                // IllegalArgumentException( poolName +" already member" ) ;
+
+                pool._pGroupList.put(group.getName(), group);
+                group._poolList.put(pool.getName(), pool);
+            }
+            return pool;
+        } finally {
+            _psuWriteLock.unlock();
+        }
     }
 
     public Map<String, Link> match(Map<String, Link> map, Unit unit,


### PR DESCRIPTION
Motivation:

The pool selection unit has a locking bug in the pool query method.

Modification:

Acquire the read lock before reading from the pools map and acquire
a write lock before writing. Since a read lock cannot be upgraded
to a write lock, we need to check existence of a pool in the map
twice.

Result:

Fixes a race condition in pool manager.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9069/
(cherry picked from commit 77d6b411c2f35d0657600f43ac50e3eadf47adb8)