### PR TITLE
poolmanager: Acquire read lock when serializing pool selection unit

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -6,6 +6,8 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
@@ -2293,6 +2295,16 @@ public class PoolSelectionUnitV2
                 return "One pool";
             default:
                 return String.valueOf(count) + " pools";
+        }
+    }
+
+    private void writeObject(ObjectOutputStream stream) throws IOException
+    {
+        _psuReadLock.lock();
+        try {
+            stream.defaultWriteObject();
+        } finally {
+            _psuReadLock.unlock();
         }
     }
 }


### PR DESCRIPTION
Motivation:

Java serialization is not thread safe, yet pool selection unit
currently does not protect against modifications while it is
serialized.

Modification:

Acquire a read lock during serialization.

Result:

Fixes a race condition in pool manager that could feed erroneous
data to pin manager, space manager, srm, xrootd and webdav.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9075/
(cherry picked from commit be1d495da5195ab3bf3bce083b272c4989e40a78)