### PR TITLE
poolmanager: Acquire read lock when serializing cost module and partition manager

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/CostModuleV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/CostModuleV1.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
@@ -674,5 +675,10 @@ public class CostModuleV1
         in.defaultReadObject();
         _handlers = new CellMessageDispatcher("messageToForward");
         _handlers.addMessageListener(this);
+    }
+
+    private synchronized void writeObject(ObjectOutputStream stream) throws IOException
+    {
+        stream.defaultWriteObject();
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/PartitionManager.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/PartitionManager.java
@@ -3,6 +3,8 @@ package org.dcache.poolmanager;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
 
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.Formatter;
@@ -448,5 +450,10 @@ public class PartitionManager
             }
             pw.println();
         }
+    }
+
+    private synchronized void writeObject(ObjectOutputStream stream) throws IOException
+    {
+        stream.defaultWriteObject();
     }
 }


### PR DESCRIPTION
Motivation:

Java serialization is not thread safe, yet cost module and partition manager
currently do not protect against modifications during serialization.

Modification:

Acquire a lock during serialization.

Result:

Fixes a race condition in pool manager that could feed erroneous
data to pin manager, space manager, srm, xrootd and webdav.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9076/
(cherry picked from commit 093579ee716fb9c0cceea9159aaa38a92a2e8d1d)