### PR TITLE
Fix compatibility issues with ctlcluster

### DIFF
--- a/packages/system-test/src/main/bin/ctlcluster
+++ b/packages/system-test/src/main/bin/ctlcluster
@@ -87,11 +87,11 @@ case "$1" in
         esac
 
         # Add base config
-		CAT > "${DIR}/etc/dcache.conf" <<-EOF
+		cat > "${DIR}/etc/dcache.conf" <<-EOF
 			dcache.layout=system-test
 		EOF
 
-        CAT > "${DIR}/etc/layouts/system-test.conf" <<-EOF
+        cat > "${DIR}/etc/layouts/system-test.conf" <<-EOF
 			system-test.home=@TARGET@/dcache
 			dcache.pid.dir=/tmp
 			dcache.java.memory.heap=256m
@@ -108,7 +108,7 @@ case "$1" in
 		EOF
 
         # Enable cell communication
-        sed -i '' -e "/dcache.broker.scheme=none/d" "@TARGET@/dcache/etc/layouts/system-test.conf"
+        sed -i'' -e "/dcache.broker.scheme=none/d" "@TARGET@/dcache/etc/layouts/system-test.conf"
         ;;
 
     switch)


### PR DESCRIPTION
Motivation:

Installing another version of dCache into system-test using ctlcluster currently
only works on Mac OS X.

Modification:

- Fix use of capslock (I didn't known command names on Mac OS X are not case
  sensitive).

- Fixed sed arguments to be Linux compatible.

Result:

ctlcluster install works on Linux.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9063/
(cherry picked from commit 3e94b457a12358209b030ec19a793d67bb75c319)