### PR TITLE
nfs: notify billing on file removes

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoMdsOpFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoMdsOpFactory.java
@@ -1,9 +1,18 @@
 package org.dcache.chimera.nfsv41.door.proxy;
 
+import java.io.IOException;
+import java.security.PrivilegedAction;
+import java.util.Optional;
+import javax.security.auth.Subject;
+import org.dcache.auth.Origin;
+import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
+import org.dcache.nfs.v4.CompoundContext;
 import org.dcache.nfs.v4.NFSv4OperationFactory;
 import org.dcache.nfs.v4.xdr.nfs_argop4;
 import org.dcache.nfs.v4.xdr.nfs_opnum4;
+import org.dcache.nfs.v4.xdr.nfs_resop4;
+import org.dcache.xdr.OncRpcException;
 
 /**
  * NFS operation factory which uses Proxy IO adapter for read requests
@@ -19,17 +28,40 @@ public class ProxyIoMdsOpFactory implements NFSv4OperationFactory {
     }
 
     @Override
-    public AbstractNFSv4Operation getOperation(nfs_argop4 op) {
-        switch (op.argop) {
+    public AbstractNFSv4Operation getOperation(nfs_argop4 opArgs) {
+        final AbstractNFSv4Operation operation;
+        switch (opArgs.argop) {
             case nfs_opnum4.OP_READ:
-                return new ProxyIoREAD(op, _proxyIoFactory);
+                operation = new ProxyIoREAD(opArgs, _proxyIoFactory);
+                break;
             case nfs_opnum4.OP_WRITE:
-                return new ProxyIoWRITE(op, _proxyIoFactory);
+                operation =  new ProxyIoWRITE(opArgs, _proxyIoFactory);
+                break;
             case nfs_opnum4.OP_CLOSE:
-                return new ProxyIoClose(op);
+                operation = new ProxyIoClose(opArgs);
+                break;
             default:
-                return _inner.getOperation(op);
+                operation = _inner.getOperation(opArgs);
         }
+
+        return new AbstractNFSv4Operation(opArgs, opArgs.argop) {
+            @Override
+            public void process(CompoundContext context, nfs_resop4 result) throws ChimeraNFSException, IOException, OncRpcException {
+                Optional<IOException> optionalException = Subject.doAs(context.getSubject(), (PrivilegedAction<Optional<IOException>>) () -> {
+                    try {
+                        context.getSubject().getPrincipals().add( new Origin(context.getRemoteSocketAddress().getAddress()));
+                        operation.process(context, result);
+                    } catch (IOException e) {
+                        return Optional.of(e);
+                    }
+                    return Optional.empty();
+                });
+
+                if(optionalException.isPresent()) {
+                    throw optionalException.get();
+                }
+            }
+        };
     }
 
 }

--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -100,6 +100,7 @@
         <property name="pnfsHandler" ref="pnfs"/>
         <property name="poolManagerStub" ref="poolManagerStub"/>
         <property name="pinManagerStub" ref="pinManagerStub"/>
+        <property name="billingStub" ref="billing-stub"/>
     </bean>
 
     <bean id="export" class="org.dcache.nfs.ExportFile">


### PR DESCRIPTION
Motivation:
All dCache doors send file remove events to billing. But
this is not the case for NFS door.

Modification:
Update DCacheAwareJdbcFs to notify billing on remove.
Update ProxyIo operation factory to inject Subject and Origin
into  AccessControlContext by using Subject.doAs

To solve a differential equation you have to stare at it until solution
pop up in your head......

Result:
removes record available in the billing files:

03.02 10:54:54 [door:NFS-dcache-lab007@dCacheDomain:remove] ["":3750:3750:131.169.185.68] [00009AF283A381A04E77991D8F180ABB3971,0] [parent:[0000AEF4B059F44D40369E7B5351667E1DFD]/file.50] <Unknown> 0 0 {0:""}

Ticket: #8547
Acked-by: Paul MIllar
Acked-by: Gerd Behrmann
Target: master, 2.15, 2.14, 2.13
Require-book: no
Require-notes: yes
(cherry picked from commit 91b46965b7ea0223f30fe59205a311e121182399)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>