### PR TITLE
ftp: Fix race on short transfers

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/AsynchronousRedirectedTransfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/AsynchronousRedirectedTransfer.java
@@ -14,10 +14,6 @@ import java.util.concurrent.FutureTask;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsHandler;
-import diskCacheV111.vehicles.PoolMoverKillMessage;
-
-import dmg.cells.nucleus.CellAddressCore;
-import dmg.cells.nucleus.CellPath;
 
 import org.dcache.auth.attributes.Restriction;
 
@@ -32,7 +28,6 @@ import static com.google.common.base.Preconditions.checkState;
  * are to implement onQueued, onRedirect, onFinish and onFailure. The class deals with out
  * of order notifications and guarantees that:
  *
- *  - a mover ID is known before onQueued is called
  *  - onQueued is always called before onRedirect
  *  - onRedirect is always called before onFinish
  *  - that onRedirect and onFinish are not called once onFailure was called
@@ -169,7 +164,7 @@ public abstract class AsynchronousRedirectedTransfer<T> extends Transfer
         private synchronized void doFinish()
         {
             try {
-                if (!isDone && getMoverId() != null  && isRedirected && isFinished) {
+                if (!isDone && isQueued && isRedirected && isFinished) {
                     onFinish();
                     isDone = true;
                 }
@@ -192,14 +187,7 @@ public abstract class AsynchronousRedirectedTransfer<T> extends Transfer
             if (queueFuture != null) {
                 queueFuture.cancel(true);
             }
-            if (hasMover()) {
-                int moverId = getMoverId();
-                String pool = getPool();
-                CellAddressCore poolAddress = getPoolAddress();
-                PoolMoverKillMessage message = new PoolMoverKillMessage(pool, moverId);
-                message.setReplyRequired(false);
-                _pool.notify(new CellPath(poolAddress), message);
-            }
+            killMover(0);
         }
 
         /**


### PR DESCRIPTION
Motivation:

For very short transfers, the DoorTransferFinished message may
overtake the initial PoolDeliverFileMessage reply. This may
trigger a race condition in the FTP door in which it will generate
the

    226 Transfer complete.

reply without the

    150 Opening BINARY data connection for

intermiate reply. This is a regression introduced when fixing
a deadlock regression.

Modification:

The problem is in AsynchronousRedirectedTransfer. It uses the pressence of a
mover id to check whether the PoolDeliverFileMessage has been delivered. Due to
asynchronously processing the various callbacks using an executor, the mover ID
may be set even when the doQueued callback has not been executed. Thus the class
does not guarantee the ordering is is supposed to guarantee.

The fix is to use the isQueued flag directly (this flag likely didn't exist in
the original version).

Also simplify doKill to use the Transfer#killMover message.

Result:

Fix a race condition in the FTP door in which transfers on short files could
result in errors like `Unexpected reply: 226 Transfer complete.`.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9081/
(cherry picked from commit 11ade1b0fd66a969ac757935b69076cbaaa72a00)