### PR TITLE
srm: Return SRM_INVALID_PATH when target directory is a file

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -1117,6 +1117,7 @@ public final class Storage
                                              future.setException(new SRMDuplicationException(msg));
                                              break;
                                          case CacheException.FILE_NOT_FOUND:
+                                         case CacheException.NOT_DIR:
                                              future.setException(new SRMInvalidPathException(msg));
                                              break;
                                          case CacheException.TIMEOUT:


### PR DESCRIPTION
Motivation:

When writing to a path /a/b/c, if b exists and is a file, SRM currently
returns SRM_INTERNAL_ERROR.

Modification:

Change the return code to SRM_INVALID_PATH.

Result:

Fixes an invalid return code in the SRM in which SRM_INTERNAL_ERROR
was returned rather than SRM_INVALID_PATH.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Femi Adeyemi <olufemi.segun.adeyemi@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
(cherry picked from commit 6faedb3ed94c774a25351ca8ba55eff411964b94)