### PR TITLE
srm: Disable delegation on srmCopy to or from other SRMs

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/client/RemoteTurlGetterV2.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/client/RemoteTurlGetterV2.java
@@ -174,8 +174,8 @@ public final class RemoteTurlGetterV2 extends TurlGetterPutter {
                     credential.getDelegatedCredential(),
                     retry_timout,
                     retry_num,
-                    true,
-                    true,
+                    false,
+                    false,
                     transport);
             int len = SURLs.length;
             TGetFileRequest fileRequests[] = new TGetFileRequest[len];
@@ -412,8 +412,8 @@ public final class RemoteTurlGetterV2 extends TurlGetterPutter {
                 credential.getDelegatedCredential(),
                 retry_timeout,
                 retry_num,
-                true,
-                true,
+                false,
+                false,
                 transport);
         String requestToken = requestTokenString;
         URI surlArray[] = new URI[1];

--- a/modules/srm-server/src/main/java/org/dcache/srm/client/RemoteTurlPutterV2.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/client/RemoteTurlPutterV2.java
@@ -201,8 +201,8 @@ public final class RemoteTurlPutterV2 extends TurlGetterPutter
                     credential.getDelegatedCredential(),
                     retry_timout,
                     retry_num,
-                    true,
-                    true,
+                    false,
+                    false,
                     transport);
 
             int len = SURLs.length;
@@ -459,8 +459,8 @@ public final class RemoteTurlPutterV2 extends TurlGetterPutter
                 credential.getDelegatedCredential(),
                 retry_timeout,
                 retry_num,
-                true,
-                true,
+                false,
+                false,
                 transport);
         String requestToken = requestTokenString;
         URI surlArray[] = new URI[1];


### PR DESCRIPTION
Motivation:

The only SRM operation that requires delegation is srmCopy. Currently our SRM
delegates the users credentials to the remote system when issuing
srmPrepareToGet or srmPrepareToPut as part of a server side third party SRM
copy. We have observed problems at some sites during this delegation step
(currently the source of those problems is unknown).

Modification:

Disable delegation when the SRM server talks to other SRM servers.

Result:

Adds workaround for delegation issued observed at some sites during server side
SRM third party copy processing. The workaround is to disable delegation as it
isn't needed for put or get operations. This also avoids leaking the clients
credentials to the remote system and reduces CPU overhead of establishing a
connection to the remote.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9087/
(cherry picked from commit 2c518326c177991436a8d15062ee70b29449d8fa)