### PR TITLE
pool: Fix filtering of options in script HSM driver

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/script/ScriptNearlineStorage.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/script/ScriptNearlineStorage.java
@@ -259,7 +259,7 @@ public class ScriptNearlineStorage extends AbstractBlockingNearlineStorage
     private List<String> buildOptions(Map<String, String> properties)
     {
         return properties.entrySet().stream()
-                .filter(property -> !PROPERTIES.contains(property))
+                .filter(entry -> !PROPERTIES.contains(entry.getKey()))
                 .map(entry -> "-" + entry.getKey() + (Strings.isNullOrEmpty(entry.getValue()) ? "" : "="+entry.getValue()))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
Motivation:

The script HSM driver filters a number of options before calling the script as
these options are used internall by the driver. A regression in 2.13 broke this
filtering.

Modification:

When filtering on a map, we have to remember to filter on the key, not the entire
entry.

Result:

Fixed a regression introduced in 2.13 in which internal options like -c:puts were
erroneously included to the call out to the HSM script.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9103/
(cherry picked from commit 5f7ac60dd9eeaa0d7632276e841098bd9f7233ab)