### PR TITLE
poolmanager: Allow fallback on write when pools are full

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
@@ -175,6 +175,7 @@ public class PoolMonitorV5
                                                  ",linkgroup=" + nullToEmpty(_linkGroup) + "]");
             }
 
+            CostException fallback = null;
             for (PoolPreferenceLevel level: levels) {
                 List<PoolInfo> pools =
                         level.getPoolList().stream()
@@ -183,8 +184,22 @@ public class PoolMonitorV5
                                 .collect(toList());
                 if (!pools.isEmpty()) {
                     Partition partition = _partitionManager.getPartition(level.getTag());
-                    return partition.selectWritePool(_costModule, pools, _fileAttributes, preallocated);
+                    try {
+                        return partition.selectWritePool(_costModule, pools, _fileAttributes, preallocated);
+                    } catch (CostException e) {
+                        if (!e.shouldFallBack()) {
+                            throw e;
+                        }
+                        fallback = e;
+                    }
                 }
+            }
+
+            /* We were asked to fall back, but all available links were
+             * exhausted. Let the caller deal with it.
+             */
+            if (fallback != null) {
+                throw fallback;
             }
 
             throw new CacheException(CacheException.NO_POOL_ONLINE,

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/LruPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/LruPartition.java
@@ -36,7 +36,7 @@ public class LruPartition extends Partition
     /**
      * Pool name to access order. Making this static will mean that
      * all instances of LruPartition will share this information. It
-     z     * will also ensure that this information is not serialized,
+     * will also ensure that this information is not serialized,
      * meaning that multiple deserialized instances preserve this
      * information.
      */

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/LruPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/LruPartition.java
@@ -1,6 +1,5 @@
 package org.dcache.poolmanager;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import java.util.List;
@@ -12,11 +11,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import diskCacheV111.poolManager.CostModule;
 import diskCacheV111.pools.PoolCostInfo.PoolSpaceInfo;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.CostException;
 
 import org.dcache.vehicles.FileAttributes;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.Iterables.filter;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -37,7 +36,7 @@ public class LruPartition extends Partition
     /**
      * Pool name to access order. Making this static will mean that
      * all instances of LruPartition will share this information. It
-     * will also ensure that this information is not serialized,
+     z     * will also ensure that this information is not serialized,
      * meaning that multiple deserialized instances preserve this
      * information.
      */
@@ -127,7 +126,7 @@ public class LruPartition extends Partition
         List<PoolInfo> freePools =
                 pools.stream().filter(pool -> canHoldFile(pool, preallocated)).collect(toList());
         if (freePools.isEmpty()) {
-            throw new CacheException(21, "All pools are full");
+            throw new CostException("All pools are full", null, false, false);
         }
         return select(freePools, _lastWrite);
     }

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/RandomPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/RandomPartition.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import diskCacheV111.poolManager.CostModule;
 import diskCacheV111.pools.PoolCostInfo.PoolSpaceInfo;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.CostException;
 
 import org.dcache.vehicles.FileAttributes;
 
@@ -70,7 +71,7 @@ public class RandomPartition extends Partition
         List<PoolInfo> freePools =
                 pools.stream().filter(pool -> canHoldFile(pool, preallocated)).collect(toList());
         if (freePools.isEmpty()) {
-            throw new CacheException(21, "All pools are full");
+            throw new CostException("All pools are full", null, false, false);
         }
         return select(freePools);
     }

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/WassPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/WassPartition.java
@@ -72,7 +72,7 @@ public class WassPartition extends ClassicPartition
     {
         PoolInfo pool = wass.selectByAvailableSpace(pools, preallocated, PoolInfo::getCostInfo);
         if (pool == null) {
-            throw new CacheException(21, "All pools are full");
+            throw new CostException("All pools are full", null, _fallbackOnSpace, false);
         }
         return pool;
     }


### PR DESCRIPTION
I am requesting backport because we have issues with fallback between
tape pools at NDGF and we need this patch to fix it.


Target: trunk
Request: 2.15
Require-notes: yes
Require-book; yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9110/

(cherry picked from commit d15e95e47e5f5025b1daa6f6ec47cb29fc93082a)