### PR TITLE
pnfsmanager: Fix regression in SRM billing entries

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -1377,6 +1377,11 @@ public class ChimeraNameSpaceProvider
             } catch (FileNotFoundHimeraFsException ignored) {
             }
 
+            /* Read file attributes before moving the file. Otherwise the cached parent will
+             * be gone.
+             */
+            FileAttributes attributes = getFileAttributes(inodeOfFile, attributesToFetch);
+
             /* File is moved to correct directory.
              */
             _fs.rename(inodeOfFile, temporaryDirInode, temporaryPath.getName(), finalDirInode, finalPath.getName());
@@ -1385,7 +1390,7 @@ public class ChimeraNameSpaceProvider
              */
             removeRecursively(uploadDirInode, temporaryDir.getName(), temporaryDirInode);
 
-            return getFileAttributes(inodeOfFile, attributesToFetch);
+            return attributes;
         } catch (ChimeraFsException e) {
             throw new CacheException(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
                                      e.getMessage());


### PR DESCRIPTION
Motivation:

A recent regression causes billing entries for SRM uploads to lack
the storage class.

Modification:

The regression is caused by reading the file attributes after moving
the file out of the upload directory. Thus the cached parent directory
is invalid.

The resolution is to read the requested attributes before moving the
file.

Result:

Fixed a regression in which billing entries for SRM uploads lacked
the storage class.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Femi Adeyemi <olufemi.segun.adeyemi@desy.de>
Patch: https://rb.dcache.org/r/9113/
(cherry picked from commit 43cef580e0c9a11061d4f6fedf1964ad19c0d0ce)