### PR TITLE
srm-client: Fix type error when aborting copy requests

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
@@ -446,15 +446,15 @@ public class SRMCopyClientV2 extends SRMClient implements Runnable {
         if (requestToken==null) {
             return;
         }
-        String[] surl_strings = pendingSurlsMap.keySet()
-                .toArray(new String[pendingSurlsMap.size()]);
+        java.net.URI[] surl_strings = pendingSurlsMap.keySet()
+                .toArray(new java.net.URI[pendingSurlsMap.size()]);
         int len = surl_strings.length;
         say("Releasing all remaining file requests");
         URI surlArray[] = new URI[len];
 
         for(int i=0;i<len;++i){
             URI uri =
-                new URI(surl_strings[i]);
+                new URI(surl_strings[i].toASCIIString());
             surlArray[i]=uri;
         }
         SrmAbortFilesRequest srmAbortFilesRequest = new SrmAbortFilesRequest();


### PR DESCRIPTION
Target: trunk
Request: 2.15
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9102/
(cherry picked from commit 9f9bcbe537a6ffed575315d251b1f31ffde31247)