### PR TITLE
srm-client: Fix type mismatch in third party copy client

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
@@ -406,7 +406,7 @@ public class SRMCopyClientV2 extends SRMClient implements Runnable {
                                     " explanation="+frstatus.getExplanation()
                             );
                             if (!RequestStatusTool.isTransientStateStatus(frstatus)) {
-                                pendingSurlsMap.remove(arrayOfStatuses[i].getSourceSURL());
+                                pendingSurlsMap.remove(new java.net.URI(arrayOfStatuses[i].getSourceSURL().toString()));
                             }
                         }
                     }


### PR DESCRIPTION
Target: trunk
Request: 2.15
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9104/
(cherry picked from commit 91157dd87938fdd6042c98a8b34aaa7a2f6e5251)