### PR TITLE
PnfsManager: fix restriction to prevent directory items

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/attributes/DenyActivityRestriction.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/DenyActivityRestriction.java
@@ -65,6 +65,12 @@ public class DenyActivityRestriction implements Restriction
     }
 
     @Override
+    public boolean isRestricted(Activity activity, FsPath directory, String name)
+    {
+        return denied.contains(activity);
+    }
+
+    @Override
     public int hashCode()
     {
         return denied.hashCode();

--- a/modules/common/src/main/java/org/dcache/auth/attributes/Restriction.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/Restriction.java
@@ -111,6 +111,18 @@ public interface Restriction extends LoginAttribute, Serializable
     boolean isRestricted(Activity activity, FsPath path);
 
     /**
+     * An optimised version of isRestricted.  A restriction must respond as
+     * if {@literal isRestricted(activity, new FsPath(directory).add(child));}
+     * were called, but the method may be able to avoid creating a new FsPath
+     * object.
+     * @param activity What the user is attempting.
+     * @param directory The directory containing the target
+     * @param child The name of the target object within directory.
+     * @return true if the user is not allowed this activity.
+     */
+    boolean isRestricted(Activity activity, FsPath directory, String child);
+
+    /**
      * Whether another object is an equivalent restriction.
      * @param other The object to compare
      * @return true iff {@literal other} implements {@literal Restriction}

--- a/modules/common/src/main/java/org/dcache/auth/attributes/Restrictions.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/Restrictions.java
@@ -170,6 +170,17 @@ public class Restrictions
         }
 
         @Override
+        public boolean isRestricted(Activity activity, FsPath directory, String name)
+        {
+            for (Restriction r : restrictions) {
+                if (r.isRestricted(activity, directory, name)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
         public boolean equals(Object other)
         {
             if (!(other instanceof CompositeRestriction)) {

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -81,6 +81,7 @@ import org.dcache.acl.enums.AccessType;
 import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.Activity;
 import org.dcache.auth.attributes.Restriction;
+import org.dcache.auth.attributes.Restrictions;
 import org.dcache.cells.CellStub;
 import org.dcache.chimera.UnixPermission;
 import org.dcache.commons.stats.RequestExecutionTimeGauges;
@@ -100,6 +101,7 @@ import org.dcache.vehicles.PnfsListDirectoryMessage;
 import org.dcache.vehicles.PnfsRemoveChecksumMessage;
 import org.dcache.vehicles.PnfsSetFileAttributes;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.dcache.auth.Subjects.ROOT;
 import static org.dcache.namespace.FileAttribute.*;
 import static org.dcache.acl.enums.AccessType.*;
@@ -1433,6 +1435,9 @@ public class PnfsManagerV3
         private final PnfsListDirectoryMessage _msg;
         private final long _delay;
         private final UOID _uoid;
+        private final FsPath _directory;
+        private final Subject _subject;
+        private final Restriction _restriction;
         private long _deadline;
         private int _messageCount;
 
@@ -1444,6 +1449,9 @@ public class PnfsManagerV3
             _requestor = requestor;
             _uoid = uoid;
             _delay = delay;
+            _directory = checkNotNull(_msg.getFsPath());
+            _subject = _msg.getSubject();
+            _restriction = _msg.getRestriction();
             _deadline =
                 (delay == Long.MAX_VALUE)
                 ? Long.MAX_VALUE
@@ -1465,13 +1473,16 @@ public class PnfsManagerV3
         @Override
         public void addEntry(String name, FileAttributes attrs)
         {
-            long now = System.currentTimeMillis();
-            _msg.addEntry(name, attrs);
-            if (_msg.getEntries().size() >= _directoryListLimit ||
-                now > _deadline) {
-                sendPartialReply();
-                _deadline =
-                    (_delay == Long.MAX_VALUE) ? Long.MAX_VALUE : now + _delay;
+            if (Subjects.isRoot(_subject)
+                    || !_restriction.isRestricted(READ_METADATA, _directory, name)) {
+                long now = System.currentTimeMillis();
+                _msg.addEntry(name, attrs);
+                if (_msg.getEntries().size() >= _directoryListLimit ||
+                    now > _deadline) {
+                    sendPartialReply();
+                    _deadline =
+                        (_delay == Long.MAX_VALUE) ? Long.MAX_VALUE : now + _delay;
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:

A restriction that prevents READ_METADATA activity should prevent an
item from appearing in a directory listing.  This was not enforced.

Modification:

PnfsManager is updated to omit directory items where the restriction
prevents READ_METADATA activity on them.

Result:

Directory items are hidden as expected.

Target: master
Patch: https://rb.dcache.org/r/9117/
Acked-by: Gerd Behrmann
Request: 2.15
Require-notes: yes
Require-book: no