### PR TITLE
ftp: fix several problems with restrictions

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/attributes/Activity.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/Activity.java
@@ -57,9 +57,12 @@ public enum Activity
 
     /**
      * Create a new file within dCache.  Note that creating new directory or a
-     * new sym-link requires MANAGE.  The target is the path of the new item.
+     * new sym-link is the MANAGE Activity.
      * <p>
-     * This Activity is undefined against a directory item.
+     * There are two kinds of UPLOAD activity: a specific upload and querying
+     * support for uploading.  For the former, the target is the path of the
+     * desired file; for the latter, the target is the parent directory of the
+     * file.
      */
     UPLOAD,
 


### PR DESCRIPTION
Motivation:

There are currently several problems with restrictions support in FTP,
centred on directory listing.  First, the long version of LIST output
checked the wrong directory when determining if listing is allowed.
Second, the READ_METADATA checks for MLSD and MLST commands had no
effect.  Third, the READ_METADATA checks for MLSD and MLST were
redundant. Forth, the PERM fact for MLSD and MLST failed to consider any
restrictions.

Modification:

Update code to check restrictions where necessary.

Result:

Directory listing through FTP reflects any restrictions imposed with
this login session.

Target: master
Patch: https://rb.dcache.org/r/9116/
Acked-by: Gerd Behrmann
Request: 2.15
Requires-notes: yes
Requires-book: no