### PR TITLE
authorisation: reintroduce ReadOnly class

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/attributes/ReadOnly.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/ReadOnly.java
@@ -1,0 +1,67 @@
+package org.dcache.auth.attributes;
+
+import java.io.Serializable;
+
+/**
+ * Immutable encapsulation of whether a user is marked as a read only
+ * user.
+ *
+ * Class is included for backwards compatibility, allowing
+ * deserialisation of SRMUser associated with old SRM requests.
+ */
+@Deprecated
+public class ReadOnly implements LoginAttribute, Serializable
+{
+    private static final long serialVersionUID = -6487185735701329781L;
+
+    private boolean _isReadOnly;
+
+    public ReadOnly(boolean isReadOnly)
+    {
+        _isReadOnly = isReadOnly;
+    }
+
+    public ReadOnly(String readOnly)
+    {
+        this(Boolean.valueOf(readOnly));
+    }
+
+    public boolean isReadOnly()
+    {
+        return _isReadOnly;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ReadOnly)) {
+            return false;
+        }
+        ReadOnly other = (ReadOnly) obj;
+        return _isReadOnly == other._isReadOnly;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return _isReadOnly ? 1 : 0;
+    }
+
+    @Override
+    public String toString()
+    {
+        return _isReadOnly ? "ReadOnly" : "ReadWrite";
+    }
+
+    /**
+     * Provide backwards compatibility by converting a ReadOnly object to
+     * a corresponding Restriction.
+     */
+    public Object readResolve()
+    {
+        return _isReadOnly ? Restrictions.readOnly() : Restrictions.none();
+    }
+}


### PR DESCRIPTION
Motivation:

The SRM records which user is associated with long-lived requests by
serialising information about the user.  Currently, master and 2.15 do
not have the ReadOnly class, which prevents deserialisation that
information; and, in turn, prevents the srm service from starting.

Modification:

Reintroduce the ReadOnly attribute, with support in SRM for mapping
this to a Restriction if the user has read-only authorisation.

Result:

srm service will start when dCache has existing user requests; the
ReadOnly attribute is still enforced.

Target: master
Patch: https://rb.dcache.org/r/9114/
Acked-by: Gerd Behrmann
Requres-notes: yes
Requires-book: no
Request: 2.15