### PR TITLE
pools: fix bug in set breakeven command

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -4,9 +4,6 @@ package org.dcache.pool.classic;
 
 import com.google.common.base.Throwables;
 import com.google.common.net.InetAddresses;
-import dmg.util.command.Argument;
-import dmg.util.command.Command;
-import dmg.util.command.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
@@ -83,6 +80,9 @@ import dmg.cells.nucleus.CellVersion;
 import dmg.cells.nucleus.DelayedReply;
 import dmg.cells.nucleus.Reply;
 import dmg.util.CommandSyntaxException;
+import dmg.util.command.Argument;
+import dmg.util.command.Command;
+import dmg.util.command.Option;
 
 import org.dcache.alarms.AlarmMarkerFactory;
 import org.dcache.alarms.PredefinedAlarm;
@@ -1509,14 +1509,14 @@ public class PoolV4
                     "than 1.0, the default value of " + DEFAULT_BREAK_EVEN + " is used.")
     public class SetBreakevenCommand implements Callable<String>
     {
-        @Argument(usage = "Specify the breakeven value. This value has to be a positive and " +
-                "less than 1.0.")
+        @Argument(usage = "Specify the breakeven value. This value has to be greater than or " +
+                "equal zero")
         double parameter = _breakEven;
 
         @Override
         public String call() throws IllegalArgumentException
         {
-            checkArgument(parameter > 0, "The breakeven parameter must be a positive number.");
+            checkArgument(parameter >= 0, "The breakeven parameter must be greater than or equal to zero.");
 
             if (parameter >= 1){
                 parameter = DEFAULT_BREAK_EVEN;


### PR DESCRIPTION
Motivation
>This is a follow-up to Gerd's comment on the post 8514 (https://rb.dcache.org/r/8514/). The set breakeven command contain a bug which cause the command not to accept zero.

Modification & Result
>The parameter value in checkArgument was adjutsed to accept zero.

Acked-by:
Target: trunk
Request: 2.15
Require-book: no
Require-notes: yes
Patch: https://rb.dcache.org/r/9119/