### PR TITLE
chimera: Fix regression in inheriting ACLs on directory creation

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-1.9.12.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-1.9.12.xml
@@ -5,7 +5,7 @@
      xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet author="tigran" id="7.2" dbms="postgresql">
+    <changeSet author="tigran" id="7.3" dbms="postgresql">
         <createProcedure>
             DROP TRIGGER IF EXISTS tgr_insertACL ON t_dirs;
 
@@ -17,31 +17,34 @@
                 id character varying(36);
                 parentid character varying(36);
             BEGIN
-
-                id := NEW.ipnfsid;
-                parentid := NEW.iparent;
-
+                msk := 0;
                 SELECT INTO rstype itype FROM t_inodes WHERE ipnfsid = NEW.ipnfsid;
 
-                IF (rstype = 16384 AND NEW.iname = '..') THEN
-                    rstype := 0;    -- inserted object is a directory
-                    flag := 3;      -- check flags for 'd' and 'f' bits
-                    msk := 8;       -- mask contains 'o' bit
-                ELSE
+                IF rstype = 32768  THEN
+                    id := NEW.ipnfsid;
+                    parentid := NEW.iparent;
                     rstype := 1;    -- inserted object is a file
                     flag := 1;      -- check flags for 'f' bit
                     msk := 11;      -- mask contains 'o','d' and 'f' bits
+                ELSIF (rstype = 16384 AND NEW.iname = '..') THEN
+                    id := NEW.iparent;
+                    parentid := NEW.ipnfsid;
+                    rstype := 0;    -- inserted object is a directory
+                    flag := 3;      -- check flags for 'd' and 'f' bits
+                    msk := 8;       -- mask contains 'o' bit
                 END IF;
 
-                INSERT INTO t_acl
-                    SELECT id, rstype, type, (flags | msk) # msk, access_msk, who, who_id, address_msk, ace_order
-                        FROM t_acl
-                            WHERE  rs_id = parentid AND ((flags &amp; flag) > 0);
+                IF msk > 0 THEN
+                    INSERT INTO t_acl
+                        SELECT id, rstype, type, (flags | msk) # msk, access_msk, who, who_id, address_msk, ace_order
+                            FROM t_acl
+                                WHERE  rs_id = parentid AND ((flags &amp; flag) > 0);
+                END IF;
                 RETURN NULL;
             END;
             $$ LANGUAGE plpgsql;
 
-            CREATE TRIGGER tgr_insertACL AFTER INSERT ON t_dirs FOR EACH ROW EXECUTE PROCEDURE f_insertACL();
+            CREATE TRIGGER  tgr_insertACL AFTER INSERT ON  t_dirs FOR EACH ROW EXECUTE PROCEDURE  f_insertACL();
         </createProcedure>
     </changeSet>
 

--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
@@ -40,7 +40,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet author="behrmann" id="3" dbms="postgresql">
+    <changeSet author="behrmann" id="3.1" dbms="postgresql">
         <sql>
             DROP TRIGGER IF EXISTS tgr_insertACL ON t_dirs;
             DROP FUNCTION IF EXISTS f_insertACL();
@@ -58,25 +58,29 @@
                     id character varying(36);
                     parentid character varying(36);
                 BEGIN
-                    id := NEW.ipnfsid;
-                    parentid := NEW.iparent;
-
+                    msk := 0;
                     SELECT INTO rstype itype FROM t_inodes WHERE ipnfsid = NEW.ipnfsid;
 
-                    IF (rstype = 16384 AND NEW.iname = '..') THEN
-                        rstype := 0;    -- inserted object is a directory
-                        flag := 3;      -- check flags for 'd' and 'f' bits
-                        msk := 8;       -- mask contains 'o' bit
-                    ELSE
+                    IF rstype = 32768  THEN
+                        id := NEW.ipnfsid;
+                        parentid := NEW.iparent;
                         rstype := 1;    -- inserted object is a file
                         flag := 1;      -- check flags for 'f' bit
                         msk := 11;      -- mask contains 'o','d' and 'f' bits
+                    ELSIF (rstype = 16384 AND NEW.iname = '..') THEN
+                        id := NEW.iparent;
+                        parentid := NEW.ipnfsid;
+                        rstype := 0;    -- inserted object is a directory
+                        flag := 3;      -- check flags for 'd' and 'f' bits
+                        msk := 8;       -- mask contains 'o' bit
                     END IF;
 
-                    INSERT INTO t_acl
-                        SELECT id, rstype, type, (flags | msk) # msk, access_msk, who, who_id, ace_order, address_msk
-                        FROM t_acl
-                        WHERE  rs_id = parentid AND ((flags &amp; flag) > 0);
+                    IF msk > 0 THEN
+                        INSERT INTO t_acl
+                            SELECT id, rstype, type, (flags | msk) # msk, access_msk, who, who_id, address_msk, ace_order
+                                FROM t_acl
+                                    WHERE  rs_id = parentid AND ((flags &amp; flag) > 0);
+                    END IF;
                     RETURN NULL;
                 END;
                 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Motivation:

2.13 introduced a regression which caused directories to inherit
ACLs as if they were files rather than directories.

Modification:

Partially revert f88ecf06676b064df24ada38ad57a64c02d1e199.

Result:

Fixes a regression in directory creation in which the newly created
directory would inherit ACLs as if it were a file rather than a
directory.

The bug was a regression in 2.13 and is not present in previous or
later releases. That is, 2.14 and newer are fine. I request backport
for these branches only to support correct schema downgrade.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8915
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9129/
(cherry picked from commit e2d611349a9abddcc4b9729036f614b74d662d5b)