### PR TITLE
nfs: try to re-use transfer class on client retry

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ExceptionUtils.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ExceptionUtils.java
@@ -7,6 +7,8 @@ import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.status.*;
 
 import static diskCacheV111.util.CacheException.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Utility class to convert {@link CacheException} into corresponding
@@ -34,6 +36,12 @@ public class ExceptionUtils {
             return (ChimeraNFSException)t;
         } else if (t instanceof CacheException) {
             return asNfsException((CacheException)t, defaultException);
+        } else if (t instanceof ExecutionException ) {
+            return asNfsException(t.getCause(), defaultException);
+        } else if (t instanceof TimeoutException) {
+            return new DelayException(t.getMessage(), t);
+        } else if (t instanceof RuntimeException) {
+            return new ServerFaultException(t.getMessage(), t);
         } else {
             return buildNfsException(defaultException, t);
         }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1,7 +1,9 @@
 package org.dcache.chimera.nfsv41.door;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.glassfish.grizzly.Buffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,8 @@ import dmg.util.command.Option;
 
 import java.io.Serializable;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.dcache.auth.Subjects;
@@ -143,6 +147,8 @@ public class NFSv41Door extends AbstractCellComponent implements
      * never block longer than 10s.
      */
     private final static long NFS_REPLY_TIMEOUT = TimeUnit.SECONDS.toMillis(3);
+
+    private static final long NFS_REQUEST_BLOCKING = 100; // in Millis
 
     /**
      * Given that the timeout is pretty short, the retry period has to
@@ -419,57 +425,79 @@ public class NFSv41Door extends AbstractCellComponent implements
         NDC.push(inode.toString());
         NDC.push(context.getRpcCall().getTransport().getRemoteSocketAddress().toString());
         try {
-            deviceid4 deviceid;
 
             if (layoutType != layouttype4.LAYOUT4_NFSV4_1_FILES) {
                 _log.warn("unsupported layout type ({}) requests from");
                 throw new LayoutUnavailableException("Unsuported layout type: " + layoutType);
             }
 
-            if (inode.type() != FsInodeType.INODE || inode.getLevel() != 0) {
-                /*
-                 * all non regular files ( AKA pnfs dot files ) provided by door itself.
-                 */
-                deviceid = MDS_ID;
+            deviceid4 deviceid;
+
+            final NFS4Client client;
+            if (context.getMinorversion() == 0) {
+                /* if we need to run proxy-io with NFSv4.0 */
+                client = context.getStateHandler().getClientIdByStateId(stateid);
             } else {
+                client = context.getSession().getClient();
+            }
 
-                final InetSocketAddress remote = context.getRpcCall().getTransport().getRemoteSocketAddress();
-                final PnfsId pnfsId = new PnfsId(inode.toString());
-                final NFS4ProtocolInfo protocolInfo = new NFS4ProtocolInfo(remote,
-                            new org.dcache.chimera.nfs.v4.xdr.stateid4(stateid),
-                            nfsInode.toNfsHandle()
-                        );
+            final NFS4State nfsState = client.state(stateid);
 
-                NfsTransfer transfer = _ioMessages.get(stateid);
-                if (transfer == null) {
-                    transfer = new NfsTransfer(_pnfsHandler, nfsInode,
-                            context.getRpcCall().getCredential().getSubject());
+            // serialize all requests by the same stateid
+            synchronized(nfsState) {
 
-                    transfer.setProtocolInfo(protocolInfo);
-                    transfer.setCellName(this.getCellName());
-                    transfer.setDomainName(this.getCellDomainName());
-                    transfer.setBillingStub(_billingStub);
-                    transfer.setPoolStub(_poolManagerStub);
-                    transfer.setPoolManagerStub(_poolManagerStub);
-                    transfer.setPnfsId(pnfsId);
-                    transfer.setClientAddress(remote);
-                    transfer.readNameSpaceEntry(ioMode != layoutiomode4.LAYOUTIOMODE4_READ);
+                if (inode.type() != FsInodeType.INODE || inode.getLevel() != 0) {
+                    /*
+                     * all non regular files ( AKA pnfs dot files ) provided by door itself.
+                     */
+                    deviceid = MDS_ID;
+                } else {
 
-                    if (transfer.isWrite()) {
-                        _log.debug("looking for write pool for {}", transfer.getPnfsId());
-                    } else {
-                        _log.debug("looking for read pool for {}", transfer.getPnfsId());
+                    final InetSocketAddress remote = context.getRpcCall().getTransport().getRemoteSocketAddress();
+                    final PnfsId pnfsId = new PnfsId(inode.toString());
+                    final NFS4ProtocolInfo protocolInfo = new NFS4ProtocolInfo(remote,
+                                new org.dcache.chimera.nfs.v4.xdr.stateid4(stateid),
+                                nfsInode.toNfsHandle()
+                            );
+
+                    NfsTransfer transfer = _ioMessages.get(stateid);
+                    if (transfer == null) {
+                        transfer = new NfsTransfer(_pnfsHandler, nfsInode,
+                                context.getRpcCall().getCredential().getSubject());
+
+                        transfer.setProtocolInfo(protocolInfo);
+                        transfer.setCellName(this.getCellName());
+                        transfer.setDomainName(this.getCellDomainName());
+                        transfer.setBillingStub(_billingStub);
+                        transfer.setPoolStub(_poolManagerStub);
+                        transfer.setPoolManagerStub(_poolManagerStub);
+                        transfer.setPnfsId(pnfsId);
+                        transfer.setClientAddress(remote);
+                        transfer.readNameSpaceEntry(ioMode != layoutiomode4.LAYOUTIOMODE4_READ);
+
+                        if (transfer.isWrite()) {
+                            _log.debug("looking for write pool for {}", transfer.getPnfsId());
+                        } else {
+                            _log.debug("looking for read pool for {}", transfer.getPnfsId());
+                        }
+
+                        /*
+                         * Bind transfer to open-state.
+                         * Cleanup transfer when state invalidated
+                         */
+                        nfsState.addDisposeListener((NFS4State state) -> {
+                            Transfer t = _ioMessages.remove(stateid);
+                            if (t != null) {
+                                t.killMover(0);
+                            }
+                        });
+
+                         _ioMessages.put(stateid, transfer);
                     }
 
-                    _ioMessages.put(stateid, transfer);
-
-                    transfer.selectPoolAndStartMover(_ioQueue, RETRY_POLICY);
-
-                    _log.debug("mover ready: pool={} moverid={}", transfer.getPool(), transfer.getMoverId());
+                    PoolDS ds = transfer.getPoolDataServer(_ioQueue, NFS_REQUEST_BLOCKING);
+                    deviceid = ds.getDeviceId();
                 }
-
-                PoolDS ds = transfer.waitForRedirect(NFS_REPLY_TIMEOUT);
-                deviceid = ds.getDeviceId();
             }
 
             nfs_fh4 fh = new nfs_fh4(nfsInode.toNfsHandle());
@@ -478,15 +506,6 @@ public class NFSv41Door extends AbstractCellComponent implements
             layout4 layout = Layout.getLayoutSegment(deviceid, NFSv4Defaults.NFS4_STRIPE_SIZE, fh, ioMode,
                     0, nfs4_prot.NFS4_UINT64_MAX);
 
-            /*
-               if we need to run proxy-io with NFSv4.0
-            */
-            final NFS4Client client;
-            if (context.getMinorversion() == 0) {
-                client = context.getStateHandler().getClientIdByStateId(stateid);
-            } else {
-                client = context.getSession().getClient();
-            }
             /*
              * on on error client will issue layout return.
              * return we need a different stateid for layout to keep
@@ -501,7 +520,7 @@ public class NFSv41Door extends AbstractCellComponent implements
              * as  we will never see layout return with this stateid clean it
              * when open state id is disposed
              */
-            client.state(stateid).addDisposeListener(
+            nfsState.addDisposeListener(
                     // use java7 for 2.10 backport
                     new StateDisposeListener() {
 
@@ -517,11 +536,9 @@ public class NFSv41Door extends AbstractCellComponent implements
             );
             return new Layout(true, layoutStateId.stateid(), new layout4[]{layout});
 
-        } catch (CacheException e) {
-	    cleanStateAndKillMover(stateid);
+        } catch (CacheException | TimeoutException | ExecutionException e) {
             throw asNfsException(e, LayoutTryLaterException.class);
         } catch (InterruptedException e) {
-            cleanStateAndKillMover(stateid);
             throw new LayoutTryLaterException(e.getMessage(), e);
         } finally {
             CDC.clearMessageContext();
@@ -529,13 +546,6 @@ public class NFSv41Door extends AbstractCellComponent implements
             NDC.pop();
         }
 
-    }
-
-    private void cleanStateAndKillMover(stateid4 stateid) {
-        Transfer t = _ioMessages.remove(stateid);
-        if (t != null) {
-            t.killMover(0);
-        }
     }
 
     @Override
@@ -563,7 +573,7 @@ public class NFSv41Door extends AbstractCellComponent implements
         transfer.killMover(0);
 
         try {
-            if(!transfer.waitForMover(500)) {
+            if(transfer.hasMover() && !transfer.waitForMover(500)) {
                 throw new DelayException("Mover not stopped");
             }
         } catch (FileNotFoundCacheException e){
@@ -838,6 +848,32 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         Inode getInode() {
             return _nfsInode;
+        }
+
+        PoolDS  getPoolDataServer(String queue, long timeout) throws
+                InterruptedException, ExecutionException,
+                TimeoutException, CacheException {
+
+            ListenableFuture<Void> redirectFuture;
+            synchronized (this) {
+                /*
+                 * Check try to re-run the selection if no pool selected yet.
+                 * Restart/ping mover if not running yet.
+                 */
+                if (getPool() == null) {
+                    // we did not select a pool
+                    redirectFuture = selectPoolAndStartMoverAsync(queue, RETRY_POLICY);
+                } else {
+                    // we may re-send the request, but pool will handle it
+                    redirectFuture = startMoverAsync(queue, NFS_REQUEST_BLOCKING);
+                }
+            }
+
+            Stopwatch sw = Stopwatch.createStarted();
+            redirectFuture.get(NFS_REQUEST_BLOCKING, TimeUnit.MILLISECONDS);
+            _log.debug("mover ready: pool={} moverid={}", getPool(), getMoverId());
+
+            return  waitForRedirect(NFS_REQUEST_BLOCKING - sw.elapsed(TimeUnit.MILLISECONDS));
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/util/RedirectedTransfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/RedirectedTransfer.java
@@ -66,7 +66,7 @@ public class RedirectedTransfer<T> extends Transfer
         try {
             setStatus("Mover " + getPool() + "/" +
                       getMoverId() + ": Waiting for redirect");
-            long deadline = addWithInfinity(System.currentTimeMillis(), millis);
+            long deadline = addWithInfinity(System.currentTimeMillis(), Math.max(0, millis));
             while (hasMover() && !_isRedirected &&
                    System.currentTimeMillis() < deadline) {
                 wait(subWithInfinity(deadline, System.currentTimeMillis()));


### PR DESCRIPTION
If door failed to receive redirect with in allowed time window it will kill
mover and forget about transfer. In case of WRITE a new file will be created
and location will be updated in the namespace. The following attempt from
the client to get a pool will create a read mover and all WRITE ops will
fail with ERR_PERM.

To avoid such situations try to re-use existing transfer class and bind cleanup
procedure to state disposal, which happens on close or when nfs server
cleans dead clients.

Fixes: https://github.com/dCache/dcache/issues/1846

Acked-by: Gerd Behrmann
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit 0bd49eed0dc4f24940137e42d680a91ff220e2ed)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>