### PR TITLE
nfs: try to re-use transfer class on client retry

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/RedirectedTransfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/RedirectedTransfer.java
@@ -66,7 +66,7 @@ public class RedirectedTransfer<T> extends Transfer
         try {
             setStatus("Mover " + getPool() + "/" +
                       getMoverId() + ": Waiting for redirect");
-            long deadline = addWithInfinity(System.currentTimeMillis(), millis);
+            long deadline = addWithInfinity(System.currentTimeMillis(), Math.max(0, millis));
             while (hasMover() && !_isRedirected &&
                    System.currentTimeMillis() < deadline) {
                 wait(subWithInfinity(deadline, System.currentTimeMillis()));


### PR DESCRIPTION
If door failed to receive redirect with in allowed time window it will kill
mover and forget about transfer. In case of WRITE a new file will be created
and location will be updated in the namespace. The following attempt from
the client to get a pool will create a read mover and all WRITE ops will
fail with ERR_PERM.

To avoid such situations try to re-use existing transfer class and bind cleanup
procedure to state disposal, which happens on close or when nfs server
cleans dead clients.

Fixes: https://github.com/dCache/dcache/issues/1846

Acked-by:
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit a76117c3da8f295db2d4a37739c11b9e303b486e)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>