### PR TITLE
cells: Fix erroneous reuse of message envelope in location manager registration

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -367,7 +367,6 @@ public class LoginManager
     //
     private class AsynchronousLocationRegistrationTask implements CellMessageAnswerable, Runnable
     {
-        private final CellMessage _msg;
         private final int _port;
         private final CellPath _path;
 
@@ -375,14 +374,14 @@ public class LoginManager
         {
             _port = _listenThread.getListenPort();
             _path = new CellPath(dest);
-            _msg = new CellMessage(_path, "listening on " + getCellName() + " " + _port);
         }
 
         @Override
         public void run()
         {
             LOGGER.info("Sending 'listening on {} {}'", getCellName(), _port);
-            sendMessage(_msg, this, MoreExecutors.directExecutor(), 5000);
+            sendMessage(new CellMessage(_path, "listening on " + getCellName() + " " + _port),
+                        this, MoreExecutors.directExecutor(), 5000);
         }
 
         @Override


### PR DESCRIPTION
Motivation:

CellMessages have a time to live and thus should not be reused. Further more,
reusing a CellMessage will cause the source address to be added to the source
path, which thus will grow longer and longer whenever CellMessage is reused.

LoginManager was reusing a CellMessage when registration with location manager
failed. This could lead to errors like:

16 mar. 2016 20:56:10 (lm) [l-AAUuK4vg42A] Discarding 'listening on l-AAUuK4vg42A 53684' because its age of 18721640 ms exceeds its time to live of 4500 ms.
16 mar. 2016 20:56:20 (l-AAUuK4vg42A) [] No reply from [>lm@local]

Modification:

Create a fresh envelope whenever retrying a registration.

Result:

Fixed an issue in which registration with location manager would keep failing
with an error about the time to live of the registration message being exceeded.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9137/
(cherry picked from commit 320b00f12cc1ef837ef8430559e9767017010793)