### PR TITLE
cells: Improve robustness of message time to live

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellMessage.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellMessage.java
@@ -125,9 +125,10 @@ public boolean equals( Object obj ){
   //
   boolean isStreamMode(){ return _mode == STREAM_MODE  ; }
   void touch(){
-    if( _destination.isFirstDestination() ){
-        _umid = new UOID() ;
-    }
+      if( _destination.isFirstDestination() ){
+          _umid = new UOID() ;
+          _receivedAt = System.currentTimeMillis();
+      }
   }
 
     public CellMessage()


### PR DESCRIPTION
Motivation:

The cells envelope class, CellMessage, has a time-to-live field and a
received-at field. The received-at field is used to calculate the age of a
message on the local node to avoid assumptions about synchronized clocks
between dCache nodes. When deserializng the message, the received-at field is
reset. When sending messages between cells of the same domain, the clock is
obviously the same so received-at is preserved - in other words, it's not the
time the message was received by a cell but the time at which it was created in
the local cell.

The age of a message when checking the time-to-live field should however not
predate when the message was first sent. Usually that's not a problem as an
envelope is sent directly after being created, but it is valid to precreate the
envelope and send it later. In that case the received-at field would show the
local age to be larger than it really is.

Modification:

Reset the received-at field when it is sent the first time.

Result:

Fixes a problem in which messages sent between cells in the same domain could
appear older than they are and thus risk being discarded due to the
time-to-live being expired.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9138/
(cherry picked from commit 8d25340d7d724c11aa691d168a942900a4975445)