### PR TITLE
cells: Set correct logging context in cell callbacks

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -557,10 +557,52 @@ public class CellNucleus implements ThreadFactory
             }
         }
     }
-    public void addCellEventListener(CellEventListener listener) {
-        __cellGlue.addCellEventListener(this, listener);
 
+    public void addCellEventListener(CellEventListener listener) {
+        __cellGlue.addCellEventListener(this, new CellEventListener()
+        {
+            @Override
+            public void cellCreated(CellEvent ce)
+            {
+                try (CDC ignored = CDC.reset(CellNucleus.this)) {
+                    listener.cellCreated(ce);
+                }
+            }
+
+            @Override
+            public void cellDied(CellEvent ce)
+            {
+                try (CDC ignored = CDC.reset(CellNucleus.this)) {
+                    listener.cellDied(ce);
+                }
+            }
+
+            @Override
+            public void cellExported(CellEvent ce)
+            {
+                try (CDC ignored = CDC.reset(CellNucleus.this)) {
+                    listener.cellExported(ce);
+                }
+            }
+
+            @Override
+            public void routeAdded(CellEvent ce)
+            {
+                try (CDC ignored = CDC.reset(CellNucleus.this)) {
+                    listener.routeAdded(ce);
+                }
+            }
+
+            @Override
+            public void routeDeleted(CellEvent ce)
+            {
+                try (CDC ignored = CDC.reset(CellNucleus.this)) {
+                    listener.routeDeleted(ce);
+                }
+            }
+        });
     }
+
     public void export() { __cellGlue.export(this);  }
 
     public void subscribe(String topic) { __cellGlue.subscribe(this, topic); }


### PR DESCRIPTION
Motivation:

The cells framework provides various callbacks, but ommits establishing
the correct logging context.

Modification:

Wrap the callbacks to set the correct CDC.

Result:

Log messages from cell callbacks are logged to the correct pinboard. In
particular the routing manager pinboard now shows information previously
logged to various other cells.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9143/
(cherry picked from commit 8c6bdeb9c3962573b9124fcbcf1a84eb3e23a7ce)