### PR TITLE
chimera: Fix regression in inheriting ACLs on directory creation (HSQLDB)

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
@@ -9,16 +9,16 @@
         <createProcedure>
             CREATE TRIGGER tgs_insert_acl_dir AFTER INSERT ON t_dirs
               REFERENCING NEW ROW new
-              FOR EACH ROW WHEN (new.iname = '..' AND (SELECT itype FROM t_inodes WHERE ipnfsid = new.ipnfsid) = 16384)
+              FOR EACH ROW WHEN (new.iname = '..' AND EXISTS (SELECT 1 FROM t_inodes WHERE ipnfsid = new.ipnfsid AND itype = 16384))
                 INSERT INTO t_acl
-                  SELECT new.ipnfsid, 0, type, BITANDNOT(flags, 8), access_msk, who, who_id, address_msk, ace_order
+                  SELECT new.iparent, 0, type, BITANDNOT(flags, 8), access_msk, who, who_id, address_msk, ace_order
                   FROM t_acl
-                  WHERE rs_id = new.iparent AND BITAND(flags, 3) > 0;
+                  WHERE rs_id = new.ipnfsid AND BITAND(flags, 3) > 0;
         </createProcedure>
         <createProcedure>
             CREATE TRIGGER tgs_insert_acl_file AFTER INSERT ON t_dirs
               REFERENCING NEW ROW new
-              FOR EACH ROW WHEN (new.iname != '..' OR (SELECT itype FROM t_inodes WHERE ipnfsid = new.ipnfsid) != 16384)
+              FOR EACH ROW WHEN (EXISTS (SELECT 1 FROM t_inodes WHERE ipnfsid = new.ipnfsid AND itype = 32768))
                 INSERT INTO t_acl
                   SELECT new.ipnfsid, 1, type, BITANDNOT(flags, 11), access_msk, who, who_id, address_msk, ace_order
                   FROM t_acl


### PR DESCRIPTION
HSQLDB version of e2d611349a9abddcc4b9729036f614b74d662d5b.

Target: 2.13
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/9131/
Acked-by: Christian Bernardt <christian.bernardt@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9131/