### PR TITLE
srm: add short request lifetime work-around

### DIFF
--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -469,6 +469,7 @@
 	    <property name="prefix" value="srm.ping-extra-info"/>
 	</bean>
     </property>
+    <property name="maximumClientAssumedBandwidth" value="${srm.request.maximum-client-assumed-bandwidth}"/>
   </bean>
 
   <bean id="scheduling-strategy-provider" class="org.dcache.srm.scheduler.SchedulingStrategyFactoryBean">

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToGet.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToGet.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 import org.dcache.srm.AbstractStorageElement;
 import org.dcache.srm.SRM;
@@ -18,6 +17,7 @@ import org.dcache.srm.request.GetRequest;
 import org.dcache.srm.scheduler.IllegalStateTransition;
 import org.dcache.srm.util.Configuration;
 import org.dcache.srm.util.JDC;
+import org.dcache.srm.util.Lifetimes;
 import org.dcache.srm.util.Tools;
 import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
 import org.dcache.srm.v2_2.SrmPrepareToGetRequest;
@@ -89,7 +89,8 @@ public class SrmPrepareToGet
     {
         String[] protocols = getTransferProtocols(request);
         String clientHost = getClientHost(request).or(this.clientHost);
-        long lifetime = getLifetime(request, configuration.getGetLifetime());
+
+        long lifetime = Lifetimes.calculateLifetime(request.getDesiredTotalRequestTime(), configuration.getGetLifetime());
         String[] supportedProtocols = storage.supportedGetProtocols();
         URI[] surls = getSurls(request);
 
@@ -157,30 +158,6 @@ public class SrmPrepareToGet
             }
         }
         return null;
-    }
-
-    private static long getLifetime(SrmPrepareToGetRequest request, long max) throws SRMInvalidRequestException
-    {
-        long lifetimeInSeconds = 0;
-        if (request.getDesiredTotalRequestTime() != null) {
-            long reqLifetime = request.getDesiredTotalRequestTime();
-            if (reqLifetime < 0) {
-                /* [ SRM 2.2, 5.2.1 ]
-                 * m) If input parameter desiredTotalRequestTime is 0 (zero), each file request
-                 *    must be tried at least once. Negative value must be invalid.
-                 */
-                throw new SRMInvalidRequestException("Negative desiredTotalRequestTime is invalid.");
-            }
-            lifetimeInSeconds = reqLifetime;
-        }
-
-        if (lifetimeInSeconds > 0) {
-            long lifetime = TimeUnit.SECONDS.toMillis(lifetimeInSeconds);
-            return (lifetime > max) ? max : lifetime;
-        } else {
-            // Revisit: Behaviour doesn't match the SRM spec
-            return max;
-        }
     }
 
     private static TGetFileRequest[] getFileRequests(SrmPrepareToGetRequest request)

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToPut.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmPrepareToPut.java
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 import org.dcache.srm.AbstractStorageElement;
 import org.dcache.srm.SRM;
@@ -19,6 +18,7 @@ import org.dcache.srm.request.PutRequest;
 import org.dcache.srm.scheduler.IllegalStateTransition;
 import org.dcache.srm.util.Configuration;
 import org.dcache.srm.util.JDC;
+import org.dcache.srm.util.Lifetimes;
 import org.dcache.srm.util.Tools;
 import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
 import org.dcache.srm.v2_2.SrmPrepareToPutRequest;
@@ -106,7 +106,11 @@ public class SrmPrepareToPut
         }
         TPutFileRequest[] fileRequests = getFileRequests(request);
 
-        long lifetime = getLifetime(request, configuration.getPutLifetime());
+        // assume transfers will take place in parallel
+        long effectiveSize = largestFileOf(fileRequests);
+        long lifetime = Lifetimes.calculateLifetime(request.getDesiredTotalRequestTime(),
+                effectiveSize, configuration.getMaximumClientAssumedBandwidth(),
+                configuration.getPutLifetime());
         TOverwriteMode overwriteMode = getOverwriteMode(request);
 
         String[] supportedProtocols = storage.supportedPutProtocols();
@@ -176,6 +180,21 @@ public class SrmPrepareToPut
         }
     }
 
+
+    private long largestFileOf(TPutFileRequest[] requests)
+    {
+        long effectiveSize = 0;
+
+        for (TPutFileRequest request : requests) {
+            UnsignedLong size = request.getExpectedFileSize();
+            if (size != null && size.longValue() > effectiveSize) {
+                effectiveSize = size.longValue();
+            }
+        }
+
+        return effectiveSize;
+    }
+
     private static String getExtraInfo(SrmPrepareToPutRequest request, String key)
     {
         ArrayOfTExtraInfo storageSystemInfo = request.getStorageSystemInfo();
@@ -192,28 +211,6 @@ public class SrmPrepareToPut
             }
         }
         return null;
-    }
-
-    private static long getLifetime(SrmPrepareToPutRequest request, long max) throws SRMInvalidRequestException
-    {
-        long lifetimeInSeconds = 0;
-        if (request.getDesiredTotalRequestTime() != null) {
-            long reqLifetime = request.getDesiredTotalRequestTime();
-            if (reqLifetime < 0) {
-                /* [ SRM 2.2, 5.5.2 ]
-                 * q)    If input parameter desiredTotalRequestTime is 0 (zero), each file
-                 *       request must be tried at least once. Negative value must be invalid.
-                 */
-                throw new SRMInvalidRequestException("Negative desiredTotalRequestTime is invalid.");
-            }
-            lifetimeInSeconds = reqLifetime;
-        }
-        if (lifetimeInSeconds <= 0) {
-            // Revisit: Behaviour doesn't match the SRM spec
-            return max;
-        }
-        long lifetime = TimeUnit.SECONDS.toMillis(lifetimeInSeconds);
-        return lifetime > max ? max : lifetime;
     }
 
     private static TOverwriteMode getOverwriteMode(SrmPrepareToPutRequest request)

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/CopyFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/CopyFileRequest.java
@@ -319,6 +319,8 @@ public final class CopyFileRequest extends FileRequest<CopyRequest> implements D
         } finally {
             runlock();
         }
+
+        reassessLifetime(size);
     }
 
     @Override
@@ -463,7 +465,7 @@ public final class CopyFileRequest extends FileRequest<CopyRequest> implements D
             }
             return;
         }
-        size = fmd.size;
+        setSize(fmd.size);
 
         if (getDestinationFileId() == null) {
             addHistoryEvent("Doing name space lookup.");

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
@@ -241,7 +241,6 @@ public final class GetFileRequest extends FileRequest<GetRequest> {
         }
     }
 
-
     @Override
     public RequestFileStatus getRequestFileStatus(){
         RequestFileStatus rfs;
@@ -575,6 +574,8 @@ public final class GetFileRequest extends FileRequest<GetRequest> {
         } finally {
             wunlock();
         }
+
+        reassessLifetime(fileMetaData.size);
     }
 
     public TReturnStatus release()

--- a/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
@@ -84,6 +84,8 @@ import org.dcache.srm.SRMAuthorization;
 import org.dcache.srm.SRMUserPersistenceManager;
 import org.dcache.srm.client.Transport;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class Configuration {
 
     private static final String INFINITY = "infinity";
@@ -158,6 +160,8 @@ public class Configuration {
     protected long copyLifetime = 24*60*60*1000;
     protected long reserveSpaceLifetime = 24*60*60*1000;
     protected long defaultSpaceLifetime = 24*60*60*1000;
+
+    protected long maximumClientAssumedBandwidth = 0;
 
     protected boolean useUrlcopyScript=false;
     protected boolean useDcapForSrmCopy=false;
@@ -711,6 +715,28 @@ public class Configuration {
     public PlatformTransactionManager getTransactionManager()
     {
         return transactionManager;
+    }
+
+    /**
+     * Set the maximum allowed client-assumed bandwidth.  If clients make
+     * requests with too short a lifetime then they are assuming a bandwidth in
+     * excess of this maximum.  Such requests will be given longer, more
+     * realistic lifetimes.
+     * @value the bandwidth in kiB/s or zero to disable this feature.
+     */
+    public void setMaximumClientAssumedBandwidth(long value)
+    {
+        checkArgument(value >= 0, "Bandwidth must be 0 or a positive value");
+        maximumClientAssumedBandwidth = value;
+    }
+
+    /**
+     * Get the maximum allowed client-assumed bandwidth.
+     * @return the bandwidth in kiB/s or zero if this feature is disable.
+     */
+    public long getMaximumClientAssumedBandwidth()
+    {
+        return maximumClientAssumedBandwidth;
     }
 
     /**

--- a/modules/srm-server/src/main/java/org/dcache/srm/util/Lifetimes.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/util/Lifetimes.java
@@ -1,0 +1,96 @@
+package org.dcache.srm.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import org.dcache.srm.SRM;
+import org.dcache.srm.SRMException;
+import org.dcache.srm.SRMInvalidRequestException;
+import org.dcache.util.TimeUtils;
+import org.dcache.util.TimeUtils.TimeUnitFormat;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ *  Utility methods for handling lifetime of requests.
+ */
+public class Lifetimes
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(Lifetimes.class);
+
+    /**
+     * Calculate the lifetime of this request.
+     * @param requestedLifetime the requested lifetime in seconds, or null if absent from request
+     * @param maximumLifetime the maximum allowed lifetime in milliseconds.
+     * @return the lifetime of this request in milliseconds
+     * @throws SRMInvalidRequestException
+     */
+    public static long calculateLifetime(Integer requestedLifetime, long maximumLifetime)
+            throws SRMInvalidRequestException
+    {
+        return Lifetimes.calculateLifetime(requestedLifetime, 0, 0, maximumLifetime);
+    }
+
+    /**
+     * Calculate the lifetime of this request.  If the client supplied lifetime
+     * requires an average bandwidth greater than {@literal bandwidth} then
+     * an extended lifetime is returned.
+     * @param requestedLifetime the requested lifetime in seconds, or null if absent from request
+     * @param size the size of the file or zero if no value is supplied
+     * @param bandwidth the maximum bandwidth the client may assume for this transfer in kiB/s, or zero if there is no limit
+     * @param maximumLifetime the maximum allowed lifetime in milliseconds.
+     * @return the lifetime of this request in milliseconds
+     * @throws SRMInvalidRequestException
+     */
+    public static long calculateLifetime(Integer requestedLifetime, long size,
+            long bandwidth, long maximumLifetime) throws SRMInvalidRequestException
+    {
+        long lifetimeInSeconds = (requestedLifetime != null) ? requestedLifetime : 0;
+
+        if (lifetimeInSeconds < 0) {
+            /* [ SRM 2.2, 5.2.1 ]
+             * m) If input parameter desiredTotalRequestTime is 0 (zero), each file request
+             *    must be tried at least once. Negative value must be invalid.
+             */
+            throw new SRMInvalidRequestException("Negative desiredTotalRequestTime is invalid.");
+        } else if (lifetimeInSeconds == 0) {
+            // Revisit: Behaviour doesn't match the SRM spec
+            return maximumLifetime;
+        } else {
+            long lifetime = TimeUnit.SECONDS.toMillis(lifetimeInSeconds);
+            lifetime = calculateRequestLifetimeWithWorkaround(lifetime, size, bandwidth, maximumLifetime);
+            return Math.min(lifetime, maximumLifetime);
+        }
+    }
+
+    /**
+     * Calculate an updated request lifetime that tries to ensure sufficient
+     * time to transfer the supplied number of bytes, assuming a minimum
+     * average bandwidth.  The supplied lifetime is returned unless this is
+     * (possibly) insufficient, in which case the estimated duration is returned.
+     * @param lifetime client-supplied request lifetime, in milliseconds
+     * @param size the number of bytes to transfer
+     * @param bandwidth the maximum bandwidth the client may assume in kiB/s
+     * @param maximumLifetime the configured maximum lifetime in milliseconds
+     * @return a reasonable request lifetime, in milliseconds
+     */
+    public static long calculateRequestLifetimeWithWorkaround(long lifetime,
+            long size, long bandwidth, long maximumLifetime)
+    {
+        if (size > 0 && bandwidth > 0) {
+            long estimatedDuration = SECONDS.toMillis((size/bandwidth) / 1024L);
+            long cappedDuration = Math.min(estimatedDuration, maximumLifetime);
+            if (lifetime < cappedDuration) {
+                LOGGER.info("Requested lifetime of {} too short to transfer {} bytes; adjusting to {}",
+                        TimeUtils.duration(lifetime, MILLISECONDS, TimeUnitFormat.SHORT),
+                        size,
+                        TimeUtils.duration(cappedDuration, MILLISECONDS, TimeUnitFormat.SHORT));
+                lifetime = cappedDuration;
+            }
+        }
+        return lifetime;
+    }
+}

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -1303,6 +1303,48 @@ srm.ping-extra-info!backend_type = dCache
 srm.ping-extra-info!backend_version = ${dcache.version}
 
 
+#
+#  Maximum client-assumed average bandwidth
+#
+#  Certain SRM requests have a lifetime; in particular, for GET, PUT
+#  and COPY requests the request lifetime describes for how long files
+#  may be transferred.  Given the number of bytes to be transferred,
+#  the client is assuming some minimum average bandwidth by specifying
+#  a request lifetime.  If the actual average bandwidth is lower than
+#  this client-assumed bandwidth then the request will expire during
+#  the tranfer.
+#
+#  dCache does nothing if the lifetime expires during a download (GET)
+#  request; however, elapsed lifetimes will result in failed upload
+#  requests (PUT) and third-party transfer (COPY) requests.
+#
+#  Some broken clients have hard-coded, short lifetimes for their
+#  requests (e.g., five minutes).  As a consequence, they experience
+#  (often sporadic) failures depending on the size of the file(s)
+#  involved, the network conditions, and how much IO load the pool is
+#  suffering.  This makes such problems difficult to diagnose and the
+#  overall service unreliable.
+#
+#  As a work-around, dCache may be configured to assume some
+#  (conservative) estimate of the average bandwidth.  It checks the
+#  client-assumed average bandwidth is reasonable; if it is too high
+#  (request lifetime is too short) then it increases the request
+#  lifetime.  This gives the transfer a reasonable chance of
+#  succeeding.
+#
+#  To enable this work-around, set the configuration property to a
+#  very conservative estimate of the average bandwidth, in kiB/s, as
+#  an integer.  This should include the effect of both the slowest
+#  pool's IO bandwidth and slowest network bandwidth.
+#
+#  Setting too large a value will result in the work-around being
+#  ineffective at protecting dCache against broken clients.  Setting
+#  the value too low and transfer slots will remain for longer should
+#  a client "disappear" after initialising a transfer.
+#
+#  A value of 0 switches off this feature.
+#
+srm.request.maximum-client-assumed-bandwidth = 0
 
 #
 #   Document which TCP ports are opened


### PR DESCRIPTION
Motivation:

Some clients make requests with ridiculously short
desiredTotalRequestTime values and users are surprised when these
requests fail and open support tickets.

Modification:

Add a sanity check, based on an admin's estimate of the minimum bandwidth
that file transfers will likely suffer.  If the requested lifetime is
shorter than the estimated transfer under worse conditions, then the
lifetime is extended up to the configured maximum value.

Result:

Request from broken clients are more likely to succeed.

Target: master
Patch: https://rb.dcache.org/r/9123
Acked-by: Gerd Behrmann
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10