### PR TITLE
doors: Preserve name when publishing the address of doors

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
@@ -328,7 +328,7 @@ public class LoginBrokerPublisher
             if (address.isAnyLocalAddress()) {
                 setAddressSupplier(createAnyAddressSupplier());
             } else {
-                setAddressSupplier(createSingleAddressSupplier(address));
+                setAddressSupplier(createSingleAddressSupplier(NetworkUtils.withCanonicalAddress(address)));
             }
         } else {
             setAddressSupplier(createSingleAddressSupplier(InetAddress.getByName(host)));
@@ -540,7 +540,7 @@ public class LoginBrokerPublisher
 
     public static Supplier<List<InetAddress>> createSingleAddressSupplier(InetAddress address)
     {
-        return () -> Collections.singletonList(NetworkUtils.withCanonicalAddress(address));
+        return () -> Collections.singletonList(address);
     }
 
     public static Supplier<List<InetAddress>> createAnyAddressSupplier()


### PR DESCRIPTION
Motivation:

We document that doors preserve the name set in *.net.listen when publishing
the door, yet the code actually does a reverse lookup on the address.

Modification:

Don't inject the canonical name from DNS when a host name was configured.

Result:

Fixes a bug in which a host name set in *.net.listen properties was not preserved
when publishing a door or generating SURLs.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8926
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9148/
(cherry picked from commit 070ccad40cc750171678f3fe070991f782da064c)