### PR TITLE
rpm: explicit requre 'which` package

### DIFF
--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -16,6 +16,7 @@ Requires(post): chkconfig
 Requires(preun): chkconfig
 # This is for /sbin/service
 Requires(preun): initscripts
+Requires: which
 
 License: Distributable
 Group: Applications/System


### PR DESCRIPTION
Motivation:
dcache scripts require 'which' command to be available,
which is not the case for minimal server  RHEL?) installations.

Modification:
add explicit dependency on 'which' package

Result:

Acked-by: Gerd Benrmann
Target: master, 2.15, 2.14, 2.13
Require-book: no
Require-notes: no
(cherry picked from commit 2d6c612c320e93cc250040a016e1a682f792458d)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>