### PR TITLE
cells: Fix route removal in routing manager

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -478,7 +478,9 @@ class CellGlue
         KillEvent killEvent = new KillEvent(sourceAddr, to);
         sendToAll(new CellEvent(cellToKill, CellEvent.CELL_DIED_EVENT));
 
-        _routingTable.delete(destination.getThisAddress());
+        for (CellRoute route : _routingTable.delete(destination.getThisAddress())) {
+            sendToAll(new CellEvent(route, CellEvent.CELL_ROUTE_DELETED_EVENT));
+        }
 
         Runnable command = () -> destination.shutdown(killEvent);
         try {

--- a/modules/cells/src/main/java/dmg/cells/services/RoutingManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/RoutingManager.java
@@ -12,6 +12,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -489,12 +490,12 @@ public class RoutingManager
         CellAddressCore gate = new CellAddressCore(cr.getTargetName());
         switch (cr.getRouteType()) {
         case CellRoute.DOMAIN:
+            updateDownstreamTopics(cr.getDomainName(), Collections.emptyList());
+            removeRoutingInfo(cr.getDomainName());
             if ((_watchCell != null) && gate.getCellName().equals(_watchCell)) {
                 CellRoute defRoute =
                         new CellRoute("", "*@" + cr.getDomainName(), CellRoute.DEFAULT);
                 _nucleus.routeDelete(defRoute);
-            } else {
-                removeRoutingInfo(cr.getDomainName());
             }
             break;
         case CellRoute.TOPIC:


### PR DESCRIPTION
Motivation:

Routing manager subscribes to notifications of route removal, however
there were three issues with this:

- Notifications were not generated for routes deleted as a result
  of cell termination.

- Routes installed by the routing manager were not removed if the
  routing manager was configured with a watch cell (unlikely this
  is used by anybody).

- Topics routes for downstream domains were not removed.

Modification:

- Let the routing table return a list of routes deleted and generate
  notifications for these.

- Rearrange routing manager listener to remove routing information
  irregardless of whether a watch cell was configured.

- Remove downstream topics and corresponding routes.

Result:

Fixes a bug in routing manager that would leave orphaned topic routes in
dCache domain.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9164/

(cherry picked from commit 367e4b8eaf719bf53bfdd8d99de47010710c646c)