### PR TITLE
fix regression from 859431218e3d7cdddcf906144c1b8928bb625fed

### DIFF
--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -843,7 +843,7 @@ case "$1" in
                     for cell in $(getProperty dcache.domain.cells "$domain"); do
                         if [ $# -eq 0 ] || matchesAny "$cell@$domain" "$@"; then
                             if hasManagedDatabase "$domain" "$cell"; then
-                                printf "-- %s: \n" "$cell@$domain"
+                                printf -- "-- %s: \n" "$cell@$domain"
                                 liquibase "$domain" "$cell" updateSQL
                             fi
                         fi


### PR DESCRIPTION
Commit 859431218e3d7cdddcf906144c1b8928bb625fed introduced a regression and
breaks dcache database showUpdateSQL because at printf(1) doesn’t allow “--”
alone.

Target: master
Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>
(cherry picked from commit 5ed88b3e553a44a57c46a404057a21574bf4d110)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
PR: #2323 