### PR TITLE
pool: Fix regression breaking hopping mananger

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
@@ -47,14 +47,8 @@ import static org.dcache.namespace.FileAttribute.*;
  */
 public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg
 {
-    private static final EnumSet<FileAttribute> NEEDED_ATTRIBUTES;
-
-    static {
-        EnumSet<FileAttribute> attributes =
-                EnumSet.of(PNFSID, STORAGEINFO, STORAGECLASS, CACHECLASS, HSM, LOCATIONS, SIZE, ACCESS_LATENCY, RETENTION_POLICY);
-        attributes.addAll(Pool2PoolTransferMsg.NEEDED_ATTRIBUTES);
-        NEEDED_ATTRIBUTES = attributes;
-    }
+    private static final EnumSet<FileAttribute> REQUIRED_ATTRIBUTES =
+            EnumSet.of(PNFSID, STORAGEINFO, STORAGECLASS, CACHECLASS, HSM, LOCATIONS, SIZE, ACCESS_LATENCY, RETENTION_POLICY);
 
     private static final long serialVersionUID = -2126253028981131441L;
 
@@ -85,7 +79,9 @@ public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg
 
     public static EnumSet<FileAttribute> getRequiredAttributes()
     {
-        return NEEDED_ATTRIBUTES.clone();
+        EnumSet<FileAttribute> attributes = REQUIRED_ATTRIBUTES.clone();
+        attributes.addAll(Pool2PoolTransferMsg.NEEDED_ATTRIBUTES);
+        return attributes;
     }
 
     public Context getContext()

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -112,6 +112,7 @@ import org.dcache.vehicles.FileAttributes;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static org.dcache.namespace.FileAttribute.CHECKSUM;
 
 public class PoolV4
     extends AbstractCellComponent
@@ -837,6 +838,14 @@ public class PoolV4
             FileAttributes attributes = new FileAttributes();
             attributes.setPnfsId(pnfsId);
             attributes.setStorageInfo(storageInfo);
+            attributes.setStorageClass(fileAttributes.getStorageClass());
+            if (fileAttributes.isDefined(CHECKSUM)) {
+                attributes.setChecksums(fileAttributes.getChecksums());
+            }
+            attributes.setSize(fileAttributes.getSize());
+            attributes.setCacheClass(fileAttributes.getCacheClass());
+            attributes.setHsm(fileAttributes.getHsm());
+            attributes.setFlags(fileAttributes.getFlags());
             attributes.setLocations(Collections.singleton(_poolName));
             attributes.setSize(fileAttributes.getSize());
             attributes.setAccessLatency(fileAttributes.getAccessLatency());


### PR DESCRIPTION
Motivation:

When setting pool.destination.replication, pools generate the error:

01 Apr 2016 19:23:24 (pool73_1) [] Unexpected failure during state change notification
java.lang.IllegalArgumentException: Required attributes are missing.
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:122) ~[guava-18.0.jar:na]
    at diskCacheV111.vehicles.PoolMgrGetPoolMsg.<init>(PoolMgrGetPoolMsg.java:27) ~[dcache-vehicles-2.13.28.jar:2.13.28]
    at diskCacheV111.vehicles.PoolMgrSelectPoolMsg.<init>(PoolMgrSelectPoolMsg.java:37) ~[dcache-core-2.13.28.jar:2.13.28]
    at diskCacheV111.vehicles.PoolMgrSelectReadPoolMsg.<init>(PoolMgrSelectReadPoolMsg.java:81) ~[dcache-core-2.13.28.jar:2.13.28]
    at diskCacheV111.vehicles.PoolMgrSelectReadPoolMsg.<init>(PoolMgrSelectReadPoolMsg.java:67) ~[dcache-core-2.13.28.jar:2.13.28]
    at diskCacheV111.vehicles.PoolMgrReplicateFileMsg.<init>(PoolMgrReplicateFileMsg.java:25) ~[dcache-core-2.13.28.jar:2.13.28]
    at org.dcache.pool.classic.PoolV4$ReplicationHandler._initiateReplication(PoolV4.java:844) ~[dcache-core-2.13.28.jar:2.13.28]
    at org.dcache.pool.classic.PoolV4$ReplicationHandler.initiateReplication(PoolV4.java:815) ~[dcache-core-2.13.28.jar:2.13.28]
    at org.dcache.pool.classic.PoolV4$ReplicationHandler.stateChanged(PoolV4.java:792) ~[dcache-core-2.13.28.jar:2.13.28]
    at org.dcache.pool.repository.v5.StateChangeListeners.lambda$stateChanged$32(StateChangeListeners.java:66) ~[dcache-core-2.13.28.jar:2.13.28]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_77]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_77]
    at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_77]

Modification:

Inject the missing attribute in the message. Adjust pre-condition in the
message since there is a difference between required attributes and used
attributes as the P2P companion fetches missing attributes. This is important
for this feature as there is no guarantee that the pool has a cached copy of
the checkum.

Result:

Fixes a regression in pools causing it to fail with an IllegalArgumentException
when replication manager is enabled.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8938

Reviewed at https://rb.dcache.org/r/9166/

(cherry picked from commit 6c344851c7835fdb641a2d6cd3dda2dfc1216819)
(cherry picked from commit 0aa69547ac56089a7330c42c6493afcd5d184453)