### PR TITLE
srm: Delay announcing credential service after cell start

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/CredentialService.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/CredentialService.java
@@ -105,17 +105,24 @@ public class CredentialService
     {
         try {
             _delegationEndpoint = new URI("https", null, _host, _httpsPort, "/srm/delegation", null, null);
-            _task = _executor.scheduleAtFixedRate(this::publish, 0, 30, SECONDS);
         } catch (URISyntaxException e) {
             LOGGER.error("Failed to create delegation endpoint: {}", e);
             throw Throwables.propagate(e);
         }
     }
 
+    @Override
+    public void afterStart()
+    {
+        _task = _executor.scheduleAtFixedRate(this::publish, 0, 30, SECONDS);
+    }
+
     @PreDestroy
     public void stop()
     {
-        _task.cancel(false);
+        if (_task != null) {
+            _task.cancel(false);
+        }
     }
 
     public SrmRequestCredentialMessage messageArrived(SrmRequestCredentialMessage message)


### PR DESCRIPTION
Motivation:

The credential service embedded in SRM announces its pressence by broadcast on
a topic. Currently this announcement is sent the first time before the cell
startup has completed. If there is no subscriber for this topic a delivery
failure is returned to the SRM, but since the cell hasn't finished starting the
failure cannot be delivered and an error is logged instead.

Modification:

Delay the announcement until the SRM has started.

Result:

Resolved an issue that caused delivery failure of credential service announcements
to be logged at SRM startup.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9170/

(cherry picked from commit 817da9b94fb2ff5a27d54d03cfebe88abd3a350e)