### PR TITLE
chimera: do not update ctime on atime only attribute update

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
@@ -329,6 +329,12 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
 
         if (stat.isDefined(Stat.StatAttribute.ATIME)) {
             pStat.setATime(stat.getATime());
+            /*
+             * update ctime on atime update
+             */
+            if (!stat.isDefined(Stat.StatAttribute.CTIME)) {
+                pStat.setCTime(System.currentTimeMillis());
+            }
         }
         if (stat.isDefined(Stat.StatAttribute.CTIME)) {
             pStat.setCTime(stat.getCTime());

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -1848,6 +1848,13 @@ public class PnfsManagerV3
                 }
             }
 
+            /*
+             * update ctime on atime update
+             */
+            if (attr.isDefined(ACCESS_TIME) && !attr.isDefined(CHANGE_TIME)) {
+                attr.setChangeTime(System.currentTimeMillis());
+            }
+
             FileAttributes updated = _nameSpaceProvider.
                     setFileAttributes(message.getSubject(),
                                       pnfsId,


### PR DESCRIPTION
Motivation:
Time ctime, mtime and atime must be updated according to folloing rules:
  - atime: only when file content is read
  - mtime: only when file content is changed
  - ctime: when file attributes are change or mtime is changed.

Modification:
treat atime-only updates as a special case and do not update ctime.

Result:
no ctime change on read (which triggers atime update)

Fixes: #2278
Acked-by: Gerd Behrmann
Target: master, 2.15, 2.14, 2.13
Require-book: no
Require-notes: no
(cherry picked from commit 8901251fc3f1a5d7dd79cb80406cfd4d7675fa19)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>