### PR TITLE
chimera: do not update ctime on atime only attribute update

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -2582,6 +2582,17 @@ class FsSqlDriver {
     private PreparedStatement generateAttributeUpdateStatement(Connection dbConnection, FsInode inode, Stat stat, int level)
 	    throws SQLException {
 
+        if (level == 0 && stat.isDefined(Stat.StatAttributes.ATIME) && stat.getDefinedAttributeses().size() == 1) {
+            /*
+             * ATIME only update. The CTIME must stay unchanged.
+             */
+            PreparedStatement preparedStatement = dbConnection.prepareStatement(
+                    "UPDATE t_inodes SET iatime=?,igeneration=igeneration+1 WHERE ipnfsid=?");
+            preparedStatement.setTimestamp(1, new Timestamp(stat.getATime()));
+            preparedStatement.setString(2, inode.toString());
+            return preparedStatement;
+        }
+
 	final String attrUpdatePrefix = level == 0
                 ? "UPDATE t_inodes SET ictime=?,igeneration=igeneration+1"
                 : "UPDATE t_level_" + level + " SET ictime=?";

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -2016,6 +2016,13 @@ public class PnfsManagerV3
                 }
             }
 
+            /*
+             * update ctime on atime update
+             */
+            if (attr.isDefined(ACCESS_TIME) && !attr.isDefined(CHANGE_TIME)) {
+                attr.setChangeTime(System.currentTimeMillis());
+            }
+
             FileAttributes updated = _nameSpaceProvider.
                     setFileAttributes(message.getSubject(),
                                       pnfsId,


### PR DESCRIPTION
Motivation:
Time ctime, mtime and atime must be updated according to folloing rules:
  - atime: only when file content is read
  - mtime: only when file content is changed
  - ctime: when file attributes are change or mtime is changed.

Modification:
treat atime-only updates as a special case and do not update ctime.

Result:
no ctime change on read (which triggers atime update)

Fixes: #2278
Acked-by: Gerd Behrmann
Target: master, 2.15, 2.14, 2.13
Require-book: no
Require-notes: no
(cherry picked from commit 8901251fc3f1a5d7dd79cb80406cfd4d7675fa19)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>