### PR TITLE
http: avoid dns reverse lookup on HttpProtocolInfo#toString()

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/HttpProtocolInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/HttpProtocolInfo.java
@@ -146,7 +146,7 @@ public class HttpProtocolInfo implements IpProtocolInfo
   {
     StringBuilder sb = new StringBuilder() ;
     sb.append(getVersionString()) ;
-    sb.append(':').append(_clientSocketAddress.getAddress().getHostName());
+    sb.append(':').append(_clientSocketAddress.getAddress().getHostAddress());
     sb.append(':').append(_clientSocketAddress.getPort()) ;
     sb.append(':').append(httpDoorCellName);
     sb.append(':').append(httpDoorDomainName);


### PR DESCRIPTION
Motivation:

 - billing performance depends on DNS server
 - not secure.

Modification:
 use Inetaddress#getHostAddress() instead of Inetaddress#getHostName()

Result:
no extra dns lookups.
billing file will contain ip address

Acked-by:
Target: master, 2.15, 2.14, 2.13
Require-book: no
Require-notes: yes
(cherry picked from commit 72a9d68a646fd112aef7b81f02bc20330869eb27)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>