### PR TITLE
common: fix ChecksumType.toString()

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/ChecksumType.java
+++ b/modules/common/src/main/java/org/dcache/util/ChecksumType.java
@@ -90,4 +90,10 @@ public enum ChecksumType
     {
         return (bits + 3) / 4;
     }
+
+    @Override
+    public String toString()
+    {
+        return getName();
+    }
 }

--- a/modules/common/src/test/java/org/dcache/util/ChecksumTypeTests.java
+++ b/modules/common/src/test/java/org/dcache/util/ChecksumTypeTests.java
@@ -6,7 +6,7 @@ import static org.dcache.util.ChecksumType.ADLER32;
 import static org.dcache.util.ChecksumType.MD5_TYPE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-
+import static org.junit.Assert.assertEquals;
 
 /**
  *  Tests for the ChecksumType
@@ -36,4 +36,12 @@ public class ChecksumTypeTests
     {
         assertThat(MD5_TYPE.getNibbles(), equalTo(32));
     }
+
+    @Test
+    public void shouldReturnSimpleNameOnToString() {
+        for(ChecksumType checksumType: ChecksumType.values()) {
+            assertEquals(checksumType.getName(), checksumType.toString());
+        }
+    }
+
 }


### PR DESCRIPTION
Motivation:
default Enum.toString() returns Enum.name(), which is string of enum, e.g.

MD5_TYPE.toString() -> "MD5_TYPE".

Nevertheless, by converting string form into ChecksumType, we expect
checksum algorithm name. This happens when we read configuration files
and have to create corresponding objects.

Modification:
add ChecksumType.toString() to return type name.

Result:
The correct string form is produced, which is used by various dcache
admin commands and configuration files.

Ticket: #8941
Acked-by: Gerd Behrmann
Target: master, 2.15, 2.14, 2.13, (2.12, 2.11, 2.12).
Require-book: no
Require-notes: no
(cherry picked from commit 047e1d11f749305b72285e1fa1e501b3a54156b8)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>