### PR TITLE
                        chimera : fix trigger that populates data in …

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.15.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.15.xml
@@ -1846,8 +1846,8 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="24" author="behrmann" dbms="postgresql">
-        <comment>Update enstore procedures for inumber changes</comment>
+    <changeSet author="litvinse" id="24.1" dbms="postgresql">
+      <comment>Fix trigger on insert or update on t_level_4</comment>
 
         <createProcedure>
           --
@@ -1915,13 +1915,13 @@
                 INSERT INTO t_storageinfo
                VALUES (NEW.inumber,'enstore','enstore',l_entries[4]);
                   END IF;
-               --
+                   --
                    -- we assume all files coming through level4 to be CUSTODIAL-NEARLINE
-               --
+                   --
                    -- the block below is needed for files written directly by encp
                    --
               BEGIN
-                    UPDATE t_inodes SET iaccesslatency = 0, iretentionpolicy = 0 WHERE inumber = NEW.inumber;
+                    UPDATE t_inodes SET iaccess_latency = 0, iretention_policy = 0 WHERE inumber = NEW.inumber;
               END;
             ELSEIF (TG_OP = 'UPDATE')  THEN
               file_data := encode(NEW.ifiledata, 'escape');
@@ -2014,13 +2014,13 @@
                     INSERT INTO t_storageinfo
                    VALUES (NEW.ipnfsid,'enstore','enstore',l_entries[4]);
                       END IF;
-                   --
+                       --
                        -- we assume all files coming through level4 to be CUSTODIAL-NEARLINE
-                   --
+                       --
                        -- the block below is needed for files written directly by encp
                        --
                   BEGIN
-                        UPDATE t_inodes SET iaccesslatency = 0, iretentionpolicy = 0 WHERE ipnfsid = NEW.ipnfsid;
+                        UPDATE t_inodes SET iaccess_latency = 0, iretention_policy = 0 WHERE ipnfsid = NEW.ipnfsid;
                   END;
                 ELSEIF (TG_OP = 'UPDATE')  THEN
                   file_data := encode(NEW.ifiledata, 'escape');


### PR DESCRIPTION
…t_locationinfo and

                                  t_inodes on insert or update of t_level_4

                        Motivation:

                        When access latency and retention policy were moved
                        to t_inodes table they were given underscore separated
                        names, but the trigger that populates data in t_locationinfo and
                        t_inodes on insert or update of t_level_4 was not properly
                        adjusted to account for the column name change.

                        Modification:

                        Trivial fix of column names

                        Result:

                        Enstore works with dCache again

                        Release Notes:

                        Fix trigger on insert/update on t_level_4 to enable
                        Enstore client to work again.

                        RB : https://rb.dcache.org/r/9189/
                        Target: master
                        Request: 2.15
                        Require-book: no
                        Require-notes: yes
                        Acked-by: Gerd Behrmann <behrmann@gmail.com>
(cherry picked from commit 552fc76f99148b6721bef55f0ffa28e6eb32a439)