### PR TITLE
                chimera : fix trigger that populates data in t_locati…

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
@@ -188,8 +188,8 @@
         </rollback>
     </changeSet>
 
-    <changeSet author="tigran" id="24" dbms="postgresql">
-
+    <changeSet author="litvinse" id="24.1" dbms="postgresql">
+      <comment>Fix trigger on insert or update on t_level_4</comment>
 	<createProcedure>
 	  DROP TRIGGER IF EXISTS tgr_enstore_location ON t_level_4;
 
@@ -220,7 +220,7 @@
                -- the block below is needed for files written directly by encp
                --
 	      BEGIN
-                UPDATE t_inodes SET iaccesslatency = 0, iretentionpolicy = 0 WHERE ipnfsid = NEW.ipnfsid;
+                UPDATE t_inodes SET iaccess_latency = 0, iretention_policy = 0 WHERE ipnfsid = NEW.ipnfsid;
 	      END;
 	    ELSEIF (TG_OP = 'UPDATE')  THEN
 	      file_data := encode(NEW.ifiledata, 'escape');


### PR DESCRIPTION
…oninfo and

                          t_inodes on insert or update of t_level_4

                Motivation:

                When access latency and retention policy were moved
                to t_inodes table they were given underscore separated
                names, but the trigger that populates data in t_locationinfo and
                t_inodes on insert or update of t_level_4 was not properly
                adjusted to account for the column name change.

                Modification:

                Trivial fix of column names

                Result:

                Enstore works with dCache again

                Release Notes:

                Fix trigger on insert/update on t_level_4 to enable
                Enstore client to work again.

                RB : https://rb.dcache.org/r/9181/
                Target: master
                Request: 2.14
                Require-book: no
                Require-notes: yes
                Acked-by: Gerd Behrmann <behrmann@gmail.com>

commit c46963b15c16d117e91ea76599924df6c8ff304b
Author: Dmitry Litvintsev <litvinse@fnal.gov>
Date:   Tue Apr 5 16:19:26 2016 -0500

            chimera : fix trigger that populates data in t_locationinfo and
                      t_inodes on insert or update of t_level_4

            Motivation:

            When access latency and retention policy were moved
            to t_inodes table they were given underscore separated
            names, but the trigger that populates data in t_locationinfo and
            t_inodes on insert or update of t_level_4 was not properly
            adjusted to account for the column name change.

            Modification:

            Trivial fix of column names

            Result:

            Enstore works with dCache again

            Release Notes:

            Fix trigger on insert/update on t_level_4 to enable
            Enstore client to work again.

            Target: master
            Request: 2.14
            Require-book: no
            Require-notes: yes
            Acked-by:

commit 4896e44407558c0874694b0d8d6f695f73fc1c18
Author: Dmitry Litvintsev <litvinse@fnal.gov>
Date:   Tue Apr 5 11:11:02 2016 -0500

        chimera : fix trigger that populates data in t_locationinfo and
                  t_inodes on insert or update of t_level_4

        Motivation:

        When access latency and retention policy were moved
        to t_inodes table they were given underscore separated
        names, but the trigger that populates data in t_locationinfo and
        t_inodes on insert or update of t_level_4 was not properly
        adjusted to account for the column name change.

        Modification:

        Trivial fix of column names

        Result:

        Enstore works with dCache again

        Release Notes:

        Fix trigger on insert/update on t_level_4 to enable
        Enstore client to work again.

        Target: master
        Request: 2.14
        Request: 2.15
        Require-book: no
        Require-notes: yes
        Acked-by:
(cherry picked from commit 9692cb8661dfb267ed239fa8bcf6a808600922f9)