### PR TITLE
srm: Fix regression in SRM startup

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
@@ -97,6 +97,9 @@ import java.util.regex.Pattern;
 import diskCacheV111.srm.FileMetaData;
 import diskCacheV111.srm.RequestStatus;
 
+import dmg.cells.nucleus.AbstractCellComponent;
+import dmg.cells.nucleus.CellLifeCycleAware;
+
 import org.dcache.commons.stats.MonitoringProxy;
 import org.dcache.commons.stats.RequestCounters;
 import org.dcache.commons.stats.RequestExecutionTimeGauges;
@@ -140,7 +143,8 @@ import static java.util.Arrays.asList;
  *
  * @author  timur
  */
-public class SRM {
+public class SRM implements CellLifeCycleAware
+{
     private static final Logger logger = LoggerFactory.getLogger(SRM.class);
     private final InetAddress host;
     private final Configuration configuration;
@@ -306,7 +310,6 @@ public class SRM {
         try {
             JobStorageFactory.initJobStorageFactory(databaseFactory);
             databaseFactory.init();
-            databaseFactory.restoreJobsOnSrmStart(schedulers);
         } catch (RuntimeException e) {
             try {
                 databaseFactory.shutdown();
@@ -315,6 +318,17 @@ public class SRM {
             }
             throw e;
         }
+    }
+
+    @Override
+    public void afterStart()
+    {
+        databaseFactory.restoreJobsOnSrmStart(schedulers);
+    }
+
+    @Override
+    public void beforeStop()
+    {
     }
 
     public void stop() throws InterruptedException


### PR DESCRIPTION
Motivation:

A change in 2.15 added cell lifecycle notifications. During startup
the cell is not available for communication with other cells. This
causes a regression in the SRM as it tries to restored requests during
startup and these requests may have expired. In that case the SRM tries
to clean up temporary upload directories in the name space, but this
blocks due to the cell communication not being available.

Modification:

Move the job restore until a phase after the cell has started.

Result:

Fixes a regression in the SRM that caused it to hang during startup.
Fixes #2354.

Target: trunk
Request: 2.15
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/9198/

(cherry picked from commit aedd9663b0273fec7d95ab280ea9451c77a59ea2)