### PR TITLE
nfs: fix NPE when remove sent to billing

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/DCacheAwareJdbcFs.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/DCacheAwareJdbcFs.java
@@ -189,7 +189,8 @@ public class DCacheAwareJdbcFs extends JdbcFs implements CellMessageSender {
         infoRemove.setPnfsId(new PnfsId(inode.getId()));
         infoRemove.setFileSize(0L);
         infoRemove.setBillingPath("parent:[" + directory.getId() + "]/" + name);
-        infoRemove.setClient(Subjects.getOrigin(subject).getAddress().getHostAddress());
+        // FIXME: in some cases subject is not set
+        infoRemove.setClient(subject == null? "0.0.0.0" : Subjects.getOrigin(subject).getAddress().getHostAddress());
         infoRemove.setClientChain(infoRemove.getClient());
 
         billingStub.notify(infoRemove);


### PR DESCRIPTION
Motivation:
Removal notification relays on the fact that user subject is always set.
Nevertheless, subject propagation is implemented only for NFSv4.

Modification:
Avoid calling 'null' subject. This is a workaround until a proper fix will
be implemented.

Result:
no NPE on removal over NFSv3

Fixes: #2358
Ticket: #8952
Acked-by: Gerd Behrmann
Target: master, 2.15
Require-book: no
Require-notes: yes
(cherry picked from commit d0001ae69cc55ebc09c64b26d5f3a6eca11da7d9)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>