### PR TITLE
cells: Add support for marking shell commands deprecated

### DIFF
--- a/modules/cells/src/main/java/dmg/util/command/AcCommandExecutor.java
+++ b/modules/cells/src/main/java/dmg/util/command/AcCommandExecutor.java
@@ -28,10 +28,17 @@ class AcCommandExecutor implements CommandExecutor
     private Field _fullHelp;
     private Field _helpHint;
     private Field _acls;
+    private boolean _isDeprecated;
 
     public AcCommandExecutor(Object listener)
     {
         _listener = listener;
+    }
+
+    @Override
+    public boolean isDeprecated()
+    {
+        return _isDeprecated;
     }
 
     public void setMethod(Method m, int mn, int mx)
@@ -39,6 +46,7 @@ class AcCommandExecutor implements CommandExecutor
         _method = m;
         _minArgs = mn;
         _maxArgs = mx;
+        _isDeprecated = m.getDeclaredAnnotation(Deprecated.class) != null;
     }
 
     public void setFullHelpField(Field f) {

--- a/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
+++ b/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
@@ -262,6 +262,11 @@ public abstract class TextHelpPrinter implements AnnotatedCommandHelpPrinter
         writer.append(Strings.wrap("       ", literal(command.name()) + " " + getSignature(clazz), WIDTH));
         writer.println();
 
+        if (clazz.getDeclaredAnnotation(Deprecated.class) != null) {
+            writer.append(Strings.wrap("       ", "This command is deprecated and will be removed in a future release.", WIDTH));
+            writer.println();
+        }
+
         if (!command.description().isEmpty()) {
             writer.println(heading("DESCRIPTION"));
             writer.append(Strings.wrap("       ", command.description(), WIDTH));

--- a/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
+++ b/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
@@ -68,6 +68,7 @@ public class AnnotatedCommandExecutor implements CommandExecutor
     private final Command _command;
     private final Constructor<? extends Callable<? extends Serializable>> _constructor;
     private final List<Handler> _handlers;
+    private final boolean _isDeprecated;
 
     public AnnotatedCommandExecutor(Object parent, Command command,
                                     Constructor<? extends Callable<? extends Serializable>> constructor)
@@ -75,7 +76,15 @@ public class AnnotatedCommandExecutor implements CommandExecutor
         _parent = parent;
         _command = command;
         _constructor = constructor;
-        _handlers = createFieldHandlers(command, _constructor.getDeclaringClass());
+        Class<? extends Callable<? extends Serializable>> commandClass = _constructor.getDeclaringClass();
+        _handlers = createFieldHandlers(command, commandClass);
+        _isDeprecated = commandClass.getDeclaredAnnotation(Deprecated.class) != null;
+    }
+
+    @Override
+    public boolean isDeprecated()
+    {
+        return _isDeprecated;
     }
 
     @Override

--- a/modules/common-cli/src/main/java/org/dcache/util/cli/CommandExecutor.java
+++ b/modules/common-cli/src/main/java/org/dcache/util/cli/CommandExecutor.java
@@ -14,6 +14,11 @@ import org.dcache.util.Args;
 public interface CommandExecutor
 {
     /**
+     * Returns true if and only if the command is marked as deprecated.
+     */
+    boolean isDeprecated();
+
+    /**
      * Returns true if and only if the command has any ACLs.
      */
     boolean hasACLs();

--- a/modules/common-cli/src/main/java/org/dcache/util/cli/CommandInterpreter.java
+++ b/modules/common-cli/src/main/java/org/dcache/util/cli/CommandInterpreter.java
@@ -246,7 +246,7 @@ public class CommandInterpreter
 
         public void dumpHelpHint(String top, StringBuilder sb, HelpFormat format)
         {
-            if (_commandExecutor != null) {
+            if (_commandExecutor != null && !_commandExecutor.isDeprecated()) {
                 String hint = _commandExecutor.getHelpHint(format);
                 if (hint != null) {
                     sb.append(top).append(hint).append("\n");


### PR DESCRIPTION
Motivation:

To deprecate admin shell commands that still work but are no longer
shown in help output.

Modification:

Extend command help printer to recognize deprecated commands. Deprecated
commands are not included in the command list, but the full help information
is available. For annotated commands the help output warns that the command
is deprecated.

Result:

No user visible changes.

Target: trunk
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9109/