### PR TITLE
cells: Do not subscribe to topics in per-session door instances

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -132,8 +132,9 @@ public class LoginManager
             int listenPort = Integer.parseInt(_args.argv(0));
             String loginCell = _args.argv(1);
 
-            Args childArgs = new Args(argString.replaceFirst("(^|\\s)-export(=true|=false)?($|\\s)", " -hasSiteUniqueName$2 "));
-            childArgs.shift();
+            Args childArgs = new Args(argString
+                                              .replaceFirst("(^|\\s)-export(=true|=false)?($|\\s)", " -hasSiteUniqueName$2 ")
+                                              .replaceFirst("(^|\\s)-subscribe=\\S*", ""));            childArgs.shift();
             childArgs.shift();
 
             _protocol = checkProtocol(_args.getOpt("prot"));


### PR DESCRIPTION
Motivation:

LoginManager starts a door instance per connection. It passes along the
cell arguments, which causes each instance to subscribe to the topics
of LoginManager too. This causes far too much routing chatter.

Modification:

Filter out the subscribe option just as we do we the export option.

Result:

Fixed a problem causing FTP and DCAP per connection instances to subscribe
to topics they should not subscribe to. This reduces overhead caused by
routing updates.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Jürgen Starek <juergen.starek@desy.de>

Reviewed at https://rb.dcache.org/r/9174/

(cherry picked from commit 3595a50a7c831f3fbad40cbdf411216f5852da80)
(cherry picked from commit 07350e6673795c213c4fa0a5d5d25928f40e73f0)