### PR TITLE
cells: Fix tunnel shutdown order

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
@@ -205,8 +205,7 @@ public class      SystemCell
            try {
                _nucleus.kill(cellName);
            } catch (IllegalArgumentException e) {
-               _log.info("Problem killing : {} -> {}",
-                         cellName, e.getMessage());
+               _log.trace("Problem killing : {} -> {}", cellName, e.getMessage());
            }
        }
 

--- a/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
@@ -1025,7 +1025,7 @@ public class LocationManager extends CellAdapter {
           }
           String cellArgs = port + " " + cellClass + " " + protocol + " -lm=" + getCellName();
           _log.info(" LocationManager starting acceptor with {}", cellArgs);
-          LoginManager c = new LoginManager(cellName, cellArgs);
+          LoginManager c = new LoginManager(cellName, "System", cellArgs);
           c.start();
           _log.info("Created : {}", c);
       }

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -114,7 +114,12 @@ public class LoginManager
      */
     public LoginManager(String name, String argString)
     {
-        super(name, argString);
+        this(name, "Generic", argString);
+    }
+
+    public LoginManager(String name, String cellType, String argString)
+    {
+        super(name, cellType, argString);
         _nucleus = getNucleus();
         _args = getArgs();
     }
@@ -708,7 +713,10 @@ public class LoginManager
         {
             for (Object child : _children.values()) {
                 if (child instanceof CellAdapter) {
-                    getNucleus().kill(((CellAdapter) child).getCellName());
+                    try {
+                        getNucleus().kill(((CellAdapter) child).getCellName());
+                    } catch (IllegalArgumentException ignored) {
+                    }
                 }
             }
         }


### PR DESCRIPTION
Motivation:

LoginManager kills its children during shutdown, yet LocationManager uses
a LoginManager for tunnels marked as a Generic cell. Thus even though
tunnels are marked as System cells, the LoginManager gets killed early
during shutdown and kills the tunnels early too.

Modification:

Mark the LoginManager used to manage tunnels as a System cell.

Result:

Fixes a problem during shutdown in which communication tunnels between
domains were shut down too early.

Target: master
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9209/

Reviewed at https://rb.dcache.org/r/9209/

(cherry picked from commit d555a0e5d7a191f264a90a1ceed8593b90a6d619)