### PR TITLE
cells: Fix tunnel shutdown order

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
@@ -181,8 +181,7 @@ public class      SystemCell
            try {
                _nucleus.kill(cellName);
            } catch (IllegalArgumentException e) {
-               _log.info("Problem killing : {} -> {}",
-                         cellName, e.getMessage());
+               _log.trace("Problem killing : {} -> {}", cellName, e.getMessage());
            }
        }
 

--- a/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
@@ -1007,7 +1007,7 @@ public class LocationManager extends CellAdapter {
 
       private void startListener( int port , String securityContext ) throws Exception {
          String cellName  = "l*" ;
-         String inetClass = "dmg.cells.services.login.LoginManager" ;
+         String inetClass = "dmg.cells.services.login.SystemLoginManager" ;
          String cellClass = "dmg.cells.network.LocationMgrTunnel" ;
          String protocol;
          if( ( securityContext          == null ) ||

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -113,8 +113,12 @@ public class LoginManager
      */
     public LoginManager(String name, String argString) throws Exception
     {
-        super(name, argString);
+        this(name, "Generic", argString);
+    }
 
+    public LoginManager(String name, String cellType, String argString) throws Exception
+    {
+        super(name, cellType, argString);
         _nucleus = getNucleus();
         _args = getArgs();
         try {
@@ -714,7 +718,10 @@ public class LoginManager
         {
             for (Object child : _children.values()) {
                 if (child instanceof CellAdapter) {
-                    getNucleus().kill(((CellAdapter) child).getCellName());
+                    try {
+                        getNucleus().kill(((CellAdapter) child).getCellName());
+                    } catch (IllegalArgumentException ignored) {
+                    }
                 }
             }
         }

--- a/modules/cells/src/main/java/dmg/cells/services/login/SystemLoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/SystemLoginManager.java
@@ -1,0 +1,27 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dmg.cells.services.login;
+
+public class SystemLoginManager extends LoginManager
+{
+    public SystemLoginManager(String name, String argString) throws Exception
+    {
+        super(name, "System", argString);
+    }
+}


### PR DESCRIPTION
Motivation:

LoginManager kills its children during shutdown, yet LocationManager uses
a LoginManager for tunnels marked as a Generic cell. Thus even though
tunnels are marked as System cells, the LoginManager gets killed early
during shutdown and kills the tunnels early too.

Modification:

Mark the LoginManager used to manage tunnels as a System cell.

Result:

Fixes a problem during shutdown in which communication tunnels between
domains were shut down too early.

Target: master
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9209/

Reviewed at https://rb.dcache.org/r/9209/

(cherry picked from commit d555a0e5d7a191f264a90a1ceed8593b90a6d619)
(cherry picked from commit 4ceeabe792659350c44956fc377f5a073232aa11)
(cherry picked from commit 3559ff96bb2e911a84e467102839fa944ebda365)