### PR TITLE
srm: Suppress message delivery failures for credential service announcements

### DIFF
--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -40,7 +40,7 @@
   <bean id="noroutetocell" class="org.dcache.cells.LogNoRouteToCellExceptionReceiver">
       <description>Undeliverable message logger</description>
       <property name="excludedDestinations"
-                value="${srm.loginbroker.update-topic},${srm.credential-service.topic}"/>
+                value="${srm.loginbroker.update-topic},${srm.loginbroker.request-topic},${srm.credential-service.topic}"/>
   </bean>
 
   <bean id="pool-manager-stub" class="org.dcache.cells.CellStub">

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -15,7 +15,7 @@ srm.cell.name=SRM-${host.name}
 #  using their fully qualified cell address.
 (one-of?true|false)srm.cell.export=true
 
-srm.cell.subscribe=${srm.loginbroker.update-topic},${srm.loginbroker.request-topic},${srm.credential-service.topic}
+srm.cell.subscribe=${srm.loginbroker.update-topic},${srm.loginbroker.request-topic}
 
 # Cell message processing limits
 (deprecated)srm.cell.limits.message.threads.max = 10


### PR DESCRIPTION
Motivation:

Delivery failures on topics are usually suppressed (only logged at debug level),
but this wasn't done for credential service announcements in the SRM.

Modification:

Add the credential service topic to the list of addresses for which delivery
failures are suppressed. On the other hand, there is no reason for the SRM
itself to subscribe to this topic as it isn't using the credential service
client.

Result:

Fixed a bug that caused delivery failures of credential service announcements
to be logged.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Jürgen Starek <juergen.starek@desy.de>

Reviewed at https://rb.dcache.org/r/9175/

(cherry picked from commit 6d8a4beab6ecd28963c03068f1517618d97fad8c)