### PR TITLE
cells: Avoid bouncing message on no-route errors in System cell

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellAddressCore.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellAddressCore.java
@@ -114,4 +114,9 @@ public final class CellAddressCore implements Cloneable, Serializable, Comparabl
                 .compare(_domain, other._domain)
                 .result();
     }
+
+    public boolean isDomainAddress()
+    {
+        return _cell.equals("*");
+    }
 }

--- a/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
@@ -277,8 +277,7 @@ public class      SystemCell
             return ;
         }
         Object obj  = msg.getMessageObject() ;
-        Serializable reply = null; // dummy value needed for Java, not used.
-        boolean processed = false;
+        Serializable reply;
 
         if(obj instanceof String) {
            String command = (String) obj;
@@ -291,7 +290,6 @@ public class      SystemCell
            } else {
                reply = _cellShell.objectCommand2(command);
            }
-           processed = true;
         }else if( obj instanceof AuthorizedString ){
            AuthorizedString as = (AuthorizedString)obj ;
            String command = as.toString() ;
@@ -300,22 +298,19 @@ public class      SystemCell
            }
            _log.info( "Command(p="+as.getAuthorizedPrincipal()+") : "+command ) ;
            reply = _cellShell.objectCommand2( command ) ;
-           processed = true;
+        } else {
+            return;
         }
 
-        if(processed) {
-            _log.debug("Reply : {}", reply);
-            _packetsAnswered++;
-        }
+       _log.debug("Reply : {}", reply);
+       _packetsAnswered++;
 
         try {
-            if (processed && reply instanceof Reply) {
-                ((Reply)reply).deliver(this, msg);
+            if (reply instanceof Reply) {
+                ((Reply) reply).deliver(this, msg);
             } else {
                 msg.revertDirection();
-                if(processed) {
-                    msg.setMessageObject(reply);
-                }
+                msg.setMessageObject(reply);
                 sendMessage(msg);
                 _log.debug("Sending : {}", msg);
             }


### PR DESCRIPTION
Motivation:

One can observe bouncing NoRouteToCellException messages in System cell.  These
happen when System cell sends a message (typically a reply) to another cell but
that other cell isn't reachable. In that case a NoRouteToCellException is sent
back to System cell, but System cell doesn't recognize this kind of message. In
contrast to other cells, System cell just returns that message to the sender -
the sender in this case however is a domain (a * address) and thus delivery of
that message fails too. This then repeats forever.

Modification:

Let System cell drop messages it doesn't recognize. This is similar to what other
cells do.

Result:

Fixes a bouncing message bug in System cell.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9212/