### PR TITLE
cells: Fix logging formatting string

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -625,7 +625,7 @@ class CellGlue
                 try {
                     destNucleus.addToEventQueue(new MessageEvent(msg.decode()));
                 } catch (SerializationException e) {
-                    LOGGER.error("Received malformed message from %s with UOID %s and session [%s]: %s",
+                    LOGGER.error("Received malformed message from {} with UOID {} and session [{}]: {}",
                                  msg.getSourcePath(), msg.getUOID(), msg.getSession(), e.getMessage());
                     sendException(msg, address.toString());
                 }


### PR DESCRIPTION
Motivation:

28 apr. 2016 08:17:30 (c-dCacheDomain-AAUxhXqMwxA-AAUxhXqNctg) [] Received malformed message from %s with UOID %s and session [%s]: %s

Modification:

Fix the formatting string.

Result:

Fixed an issue that would cause log messages in which placeholders had
not been replaced with actual values.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9236/

(cherry picked from commit cc6f17cc0ea3c825bba298791459af566520fc29)