### PR TITLE
pnfsmanager: fix atime update regression

### DIFF
--- a/modules/dcache-chimera/src/test/java/diskCacheV111/namespace/PnfsManagerTest.java
+++ b/modules/dcache-chimera/src/test/java/diskCacheV111/namespace/PnfsManagerTest.java
@@ -590,6 +590,38 @@ public class PnfsManagerTest
         assertNotExists("/test");
     }
 
+    @Test
+    public void testUpdateAtimeOnGetFileAttributes() throws ChimeraFsException {
+
+        FsInode inode = _fs.createFile("/file1");
+        Stat stat_before = inode.stat();
+        _pnfsManager.setAtimeGap(0);
+
+        PnfsGetFileAttributes message = new PnfsGetFileAttributes(new PnfsId(inode.toString()), SOME_ATTRIBUTES);
+        message.setUpdateAtime(true);
+
+        _pnfsManager.getFileAttributes(message);
+        Stat stat_after = inode.stat();
+
+        assertTrue("atime is not updated", stat_after.getATime() != stat_before.getATime());
+    }
+
+    @Test
+    public void testNoAtimeUpdateOnGetFileAttributesNegativeGap() throws ChimeraFsException {
+
+        FsInode inode = _fs.createFile("/file1");
+        Stat stat_before = inode.stat();
+        _pnfsManager.setAtimeGap(-1);
+
+        PnfsGetFileAttributes message = new PnfsGetFileAttributes(new PnfsId(inode.toString()), SOME_ATTRIBUTES);
+        message.setUpdateAtime(true);
+
+        _pnfsManager.getFileAttributes(message);
+        Stat stat_after = inode.stat();
+
+        assertTrue("atime is updated, but shouldn't", stat_after.getATime() == stat_before.getATime());
+    }
+
     private void assertNotExists(String path) throws ChimeraFsException
     {
         try {

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -268,7 +268,11 @@ public class PnfsManagerV3
 
     @Required
     public void setAtimeGap(long gap) {
-        _atimeGap = TimeUnit.SECONDS.toMillis(gap);
+        if (gap < 0) {
+            _atimeGap = -1;
+        } else {
+            _atimeGap = TimeUnit.SECONDS.toMillis(gap);
+        }
     }
 
     @Required
@@ -1775,7 +1779,7 @@ public class PnfsManagerV3
             PnfsId pnfsId = populatePnfsId(message);
             checkMask(message);
             Set<FileAttribute> requested = message.getRequestedAttributes();
-            if (message.getUpdateAtime() && _atimeGap != -1) {
+            if (message.getUpdateAtime() && _atimeGap >= 0) {
                 requested.add(ACCESS_TIME);
             }
             if(requested.contains(FileAttribute.STORAGEINFO)) {
@@ -1810,7 +1814,7 @@ public class PnfsManagerV3
 
             message.setFileAttributes(attrs);
             message.setSucceeded();
-            if (message.getUpdateAtime() && _atimeGap != -1) {
+            if (message.getUpdateAtime() && _atimeGap >= 0) {
                 long now = System.currentTimeMillis();
                 if (attrs.getFileType() == FileType.REGULAR && Math.abs(now - attrs.getAccessTime()) > _atimeGap) {
                     FileAttributes atimeUpdateAttr = new FileAttributes();


### PR DESCRIPTION
Motivation:
Setting atime-gap to -1 (default value) should disable file's last access
time updates. Nevertheless, this was not the case and atime update was always
enabled.

The main reason of disabling atime update is to reduce the load on DB.

Modification:
Fix atime condition check from != -1 to >= 0 as

TimeUnit.SECONDS.toMillis(-1) return -1000.

Result:
File's last access time can be disabled as described in the documentation.

Fixes: #2390
Acked-by: Gerd Behrmann
Target: master, 2.15, 2.14, 2.13, 2.12
Require-book: no
Require-notes: yes
(cherry picked from commit 487095d9e0f9b2b322349f2d06b958e606d15ed8)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>