### PR TITLE
pool: Suppress logging of delivery failure of DoorTransferFinished

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -28,6 +28,7 @@
 
   <bean id="noroutetocell" class="org.dcache.cells.LogNoRouteToCellExceptionReceiver">
       <property name="excludedDestinations" value="${pool.destination.heartbeat}"/>
+      <property name="excludedMessages" value="diskCacheV111.vehicles.DoorTransferFinishedMessage"/>
   </bean>
 
   <!-- The lock protects the pool from being accessed by multiple


### PR DESCRIPTION
Motivation:

If FTP clients (in particular) disconnect mid-transfer, pools log
a DoorTransferFinished delivery failure as the door is gone.

We used to suppress this failure, but a regression in 2.13 reintroduced
this error message.

Modification:

Add DoorTransferFinishedMessage to the list of messages for which not
to log delivery failures in pools.

Result:

Suppress log messages like these in pools:

15:26:15 [pool_write-0] [door:GFTP-Gerds-MacBook-Pro-AAUx2-_eHFg@dCacheDomain *] Failed to deliver DoorTransferFinishedMessage message <1462195575577:2549> to [PoolManager@dCacheDomain:SpaceManager@dCacheDomain:>GFTP-Gerds-MacBook-Pro-AAUx2-_eHFg@dCacheDomain]: Route for >GFTP-Gerds-MacBook-Pro-AAUx2-_eHFg@dCacheDomain< not found at >dCacheDomain<

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9246/

Reviewed at https://rb.dcache.org/r/9246/

(cherry picked from commit 373a3b9e2da18ea5febd3b8dc6cc432f96df59e4)
(cherry picked from commit 9cc60901d3a7673389413e09ecbf84120f0094e2)