### PR TITLE
webdav: fixed broken HTTP Basic Authentication

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/AuthenticationHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/AuthenticationHandler.java
@@ -118,6 +118,7 @@ public class AuthenticationHandler extends HandlerWrapper {
                 LOG.warn("{} for path {} and user {}", e.getMessage(), request.getPathInfo(),
                         NetLoggerBuilder.describeSubject(subject));
                 if (Subjects.isNobody(subject)) {
+                    response.setHeader("WWW-Authenticate", "Basic realm=\"" + getRealm() + "\"");
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
                 } else {
                     response.sendError(HttpServletResponse.SC_FORBIDDEN);

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -255,6 +255,7 @@
         <property name="loginStrategy" ref="login-strategy"/>
         <property name="readOnly" value="${webdav.authz.readonly}"/>
         <property name="enableBasicAuthentication" value="${webdav.authn.basic}"/>
+        <property name="realm" value="${webdav.authn.realm}"/>
         <property name="pathMapper" ref="path-mapper"/>
         <property name="uploadPath" value="${webdav.authz.upload-directory}"/>
     </bean>

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -549,6 +549,10 @@ webdav.templates.html=file:${dcache.paths.share}/webdav/templates/html.stg
 #  See dcache.authn.ciphers for details.
 webdav.authn.ciphers = ${dcache.authn.ciphers}
 
+# Set Http Webdav authentication realm
+webdav.authn.realm = ${dcache.description}
+
+
 #OwnCloud handling activation flag
 (one-of?true|false)webdav.enable.owncloud=true
 


### PR DESCRIPTION
Http Basic Authentication was broken and was not triggering a browser
login prompt. This resulted in authorization denied.

It was caused by the missing "WWW-Authenticate" header. Also, setting
the realm from webdav.xml.

Ticket: http://rt.dcache.org/Ticket/Display.html?id=8963
Fixes: #2398
Acked-by:
Target: trunk
Require-book: no
Require-notes: yes
Request: 2.15
Patch: https://rb.dcache.org/r/9257/