### PR TITLE
billing: additional fixes to insert triggers

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.6.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.6.xml
@@ -402,195 +402,301 @@
                       oldColumnName="totaltime"
                       tableName="billinginfo_tm_daily"/>
     </changeSet>
-    <changeSet id="6.4.1" author="arossi" context="billing">
+    <changeSet id="6.4.1.2" author="litvinse">
         <preConditions onError="WARN" onFail="WARN">
             <sqlCheck expectedResult="CREATE LANGUAGE">CREATE LANGUAGE plpgsql</sqlCheck>
         </preConditions>
         <comment>change updates in triggers to select and single insert every 24 hours</comment>
-        <sql splitStatements="false">CREATE OR REPLACE FUNCTION f_update_billinginfo_wr_daily() RETURNS TRIGGER
+        <sql splitStatements="false">
+            CREATE OR REPLACE FUNCTION f_update_billinginfo_wr_daily() RETURNS TRIGGER
             AS $$
             DECLARE
             max_date timestamp;
             curr_date timestamp;
+	    start_date timestamp;
+	    counter bigint;
             BEGIN
             curr_date := current_date;
             SELECT max(date) into max_date FROM billinginfo_wr_daily;
-            IF max_date IS NULL THEN
-                INSERT INTO
-                billinginfo_wr_daily (date,count,size,transferred) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0),
-                coalesce(sum(transfersize),0)
-                from billinginfo where datestamp between curr_date-interval'24 hours' and curr_date
-                and isnew='t' and errorcode=0 and (p2p='f' or p2p is null) group by d;
-            ELSIF curr_date - max_date > interval'1 days' THEN
-                INSERT INTO
-                billinginfo_wr_daily (date,count,size,transferred) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0),
-                coalesce(sum(transfersize),0)
-                from billinginfo where datestamp between max_date+interval'1 day' and curr_date
-                and isnew='t' and errorcode=0 and p2p != 't' group by d;
-            END IF;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+                  start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+               INSERT INTO billinginfo_wr_daily (date,count,size,transferred)
+               SELECT date(datestamp) AS d,
+                      COUNT(*), coalesce(sum(fullsize),0),
+                                coalesce(sum(transfersize),0)
+               FROM billinginfo
+               WHERE datestamp BETWEEN start_date AND curr_date
+                  AND isnew='t'
+                  AND errorcode=0
+                  AND p2p='f'
+               GROUP BY d RETURNING count INTO counter;
+
+	       IF counter is NULL THEN
+	          INSERT INTO billinginfo_wr_daily (date,count,size,transferred)
+                  VALUES (start_date,0,0,0);
+               END IF;
+
+	    END IF;
+
             RETURN NULL;
             END;
             $$
             LANGUAGE plpgsql;
         </sql>
-        <sql splitStatements="false">CREATE OR REPLACE FUNCTION f_update_billinginfo_rd_daily() RETURNS TRIGGER
+        <sql splitStatements="false">
+            CREATE OR REPLACE FUNCTION f_update_billinginfo_rd_daily() RETURNS TRIGGER
             AS $$
             DECLARE
             max_date timestamp;
             curr_date timestamp;
+            start_date timestamp;
+	    counter bigint;
             BEGIN
             curr_date := current_date;
             SELECT max(date) into max_date FROM billinginfo_rd_daily;
-            IF max_date IS NULL THEN
-                INSERT INTO
-                billinginfo_rd_daily (date,count,size,transferred) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0),
-                coalesce(sum(transfersize),0)
-                from billinginfo where datestamp between curr_date-interval'24 hours' and curr_date
-                and isnew='f' and errorcode=0 and (p2p='f' or p2p is null) group by d;
-            ELSIF curr_date - max_date > interval'1 days' THEN
-                INSERT INTO
-                billinginfo_rd_daily (date,count,size,transferred) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0),
-                coalesce(sum(transfersize),0)
-                from billinginfo where datestamp between max_date+interval'1 day' and curr_date
-                and isnew='f' and errorcode=0 and p2p != 't' group by d;
-            END IF;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+                  start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+               INSERT INTO billinginfo_rd_daily (date,count,size,transferred)
+               SELECT date(datestamp) AS d,
+                      COUNT(*), coalesce(sum(fullsize),0),
+                                coalesce(sum(transfersize),0)
+               FROM billinginfo
+               WHERE datestamp BETWEEN start_date AND curr_date
+                   AND isnew='f'
+                   AND errorcode=0
+                   AND p2p = 'f'
+               GROUP BY d RETURNING count INTO counter;
+
+               IF counter is NULL THEN
+                  INSERT INTO billinginfo_rd_daily (date,count,size,transferred)
+                  VALUES (start_date,0,0,0);
+               END IF;
+
+	    END IF;
+
             RETURN NULL;
             END;
             $$
             LANGUAGE plpgsql;
         </sql>
-        <sql splitStatements="false">CREATE OR REPLACE FUNCTION f_update_billinginfo_p2p_daily() RETURNS TRIGGER
+        <sql splitStatements="false">
+	    CREATE OR REPLACE FUNCTION f_update_billinginfo_p2p_daily() RETURNS TRIGGER
             AS $$
             DECLARE
             max_date timestamp;
             curr_date timestamp;
+            start_date timestamp;
+	    counter bigint;
             BEGIN
             curr_date := current_date;
             SELECT max(date) into max_date FROM billinginfo_p2p_daily;
-            IF max_date IS NULL THEN
-                INSERT INTO
-                billinginfo_p2p_daily (date,count,size,transferred) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0),
-                coalesce(sum(transfersize),0)
-                from billinginfo where datestamp between curr_date-interval'24 hours' and curr_date
-                and errorcode=0 and p2p='t' group by d;
-            ELSIF curr_date - max_date > interval'1 days' THEN
-                INSERT INTO
-                billinginfo_p2p_daily (date,count,size,transferred) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0),
-                coalesce(sum(transfersize),0)
-                from billinginfo where datestamp between max_date+interval'1 day' and curr_date
-                and errorcode=0 and p2p='t' group by d;
-            END IF;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+	          start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+               INSERT INTO billinginfo_p2p_daily (date,count,size,transferred)
+               SELECT date(datestamp) AS d,
+                      COUNT(*), coalesce(sum(fullsize),0),
+                                coalesce(sum(transfersize),0)
+               FROM billinginfo
+               WHERE datestamp BETWEEN start_date AND curr_date
+                   AND errorcode=0
+                   AND p2p='t'
+               GROUP BY d RETURNING count INTO counter;
+
+               IF counter is NULL THEN
+                  INSERT INTO billinginfo_p2p_daily (date,count,size,transferred)
+                  VALUES (start_date,0,0,0);
+               END IF;
+
+	    END IF;
+
             RETURN NULL;
             END;
             $$
             LANGUAGE plpgsql;
         </sql>
-        <sql splitStatements="false">CREATE OR REPLACE FUNCTION f_update_billinginfo_tm_daily() RETURNS TRIGGER
+        <sql splitStatements="false">
+	    CREATE OR REPLACE FUNCTION f_update_billinginfo_tm_daily() RETURNS TRIGGER
             AS $$
             DECLARE
             max_date timestamp;
             curr_date timestamp;
+	    start_date timestamp;
+	    counter bigint;
             BEGIN
             curr_date := current_date;
             SELECT max(date) into max_date FROM billinginfo_tm_daily;
-            IF max_date IS NULL THEN
-                INSERT INTO
-                billinginfo_tm_daily (date,count,minimum,maximum,average) select date(datestamp) as d,
-                count(*),
-                min(connectiontime),max(connectiontime), avg(connectiontime)
-                from billinginfo where datestamp between curr_date-interval'24 hours' and curr_date
-                and errorcode=0 group by d;
-            ELSIF curr_date - max_date > interval'1 days' THEN
-                INSERT INTO
-                billinginfo_tm_daily (date,count,minimum,maximum,average) select date(datestamp) as d,
-                count(*),
-                min(connectiontime),max(connectiontime), avg(connectiontime)
-                from billinginfo where datestamp between max_date+interval'1 day' and curr_date
-                and errorcode=0 group by d;
-            END IF;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+	          start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+               INSERT INTO billinginfo_tm_daily (date,count,minimum,maximum,average)
+               SELECT date(datestamp) AS d,
+                      COUNT(*), min(connectiontime),
+                                max(connectiontime),
+                                avg(connectiontime)
+               FROM billinginfo
+               WHERE datestamp BETWEEN start_date AND curr_date
+                   AND errorcode=0
+               GROUP BY d RETURNING count INTO counter;
+
+               IF counter is NULL THEN
+                  INSERT INTO billinginfo_tm_daily (date,count,minimum,maximum,average)
+                  VALUES (start_date,0,0,0,0);
+               END IF;
+
+	    END IF;
+
             RETURN NULL;
             END;
             $$
             LANGUAGE
             plpgsql;
         </sql>
-        <sql splitStatements="false">CREATE OR REPLACE FUNCTION f_update_storageinfo_rd_daily() RETURNS TRIGGER
+        <sql splitStatements="false">
+            CREATE OR REPLACE FUNCTION f_update_storageinfo_rd_daily() RETURNS TRIGGER
             AS $$
             DECLARE
             max_date timestamp;
             curr_date timestamp;
+	    start_date timestamp;
+	    counter bigint;
             BEGIN
             curr_date := current_date;
             SELECT max(date) into max_date FROM storageinfo_rd_daily;
-            IF max_date IS NULL THEN
-                INSERT INTO storageinfo_rd_daily (date,count,size) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0)
-                from storageinfo where datestamp between curr_date-interval'24 hours' and curr_date
-                and action='restore' and errorcode=0 group by d;
-            ELSIF curr_date - max_date > interval'1 days' THEN
-                INSERT INTO storageinfo_rd_daily (date,count,size) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0)
-                from storageinfo where datestamp between max_date+interval'1 day' and curr_date
-                and action='restore' and errorcode=0 group by d;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+	          start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+               INSERT INTO storageinfo_rd_daily (date,count,size)
+               SELECT date(datestamp) AS d,
+                      COUNT(*), coalesce(sum(fullsize),0)
+               FROM storageinfo
+               WHERE datestamp BETWEEN start_date AND curr_date
+                   AND action='restore'
+                   AND errorcode=0
+               GROUP BY d RETURNING count INTO counter;
+
+               IF counter is NULL THEN
+                  INSERT INTO storageinfo_rd_daily (date,count,size)
+                  VALUES (start_date,0,0);
+               END IF;
+
             END IF;
+
             RETURN NULL;
             END;
             $$
             LANGUAGE plpgsql;
         </sql>
-        <sql splitStatements="false">CREATE OR REPLACE FUNCTION f_update_storageinfo_wr_daily() RETURNS TRIGGER
+        <sql splitStatements="false">
+	    CREATE OR REPLACE FUNCTION f_update_storageinfo_wr_daily() RETURNS TRIGGER
             AS $$
             DECLARE
             max_date timestamp;
             curr_date timestamp;
+	    start_date timestamp;
+	    counter bigint;
             BEGIN
             curr_date := current_date;
             SELECT max(date) into max_date FROM storageinfo_wr_daily;
-            IF max_date IS NULL THEN
-                INSERT INTO storageinfo_wr_daily (date,count,size) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0)
-                from storageinfo where datestamp between curr_date-interval'24 hours' and curr_date
-                and action='store' and errorcode=0 group by d;
-            ELSIF curr_date - max_date > interval'1 days' THEN
-                INSERT INTO storageinfo_wr_daily (date,count,size) select date(datestamp) as d,
-                count(*), coalesce(sum(fullsize),0)
-                from storageinfo where datestamp between max_date+interval'1 day' and curr_date
-                and action='store' and errorcode=0 group by d;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+	          start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+               INSERT INTO storageinfo_wr_daily (date,count,size)
+               SELECT date(datestamp) AS d,
+                      COUNT(*), coalesce(sum(fullsize),0)
+               FROM storageinfo
+               WHERE datestamp BETWEEN start_date AND curr_date
+                   AND action='store'
+                   AND errorcode=0
+               GROUP BY d RETURNING count INTO counter;
+
+               IF counter is NULL THEN
+                  INSERT INTO storageinfo_wr_daily (date,count,size)
+                  VALUES (start_date,0,0);
+               END IF;
+
             END IF;
+
             RETURN NULL;
             END;
             $$
             LANGUAGE plpgsql;
         </sql>
-        <sql splitStatements="false">CREATE OR REPLACE FUNCTION f_update_hitinfo_daily() RETURNS TRIGGER
+        <sql splitStatements="false">
+	  CREATE OR REPLACE FUNCTION f_update_hitinfo_daily() RETURNS TRIGGER
             AS $$
+
             DECLARE
             max_date timestamp;
             curr_date timestamp;
+            start_date timestamp;
+	    counter bigint;
             BEGIN
             curr_date := current_date;
             SELECT max(date) into max_date FROM hitinfo_daily;
-            IF max_date IS NULL THEN
-                INSERT INTO hitinfo_daily(date, count, notcached, cached) select date(datestamp) as d,
-                count(*),
-                count(nullif(filecached, 't')) as notcached, count(nullif(filecached,'f')) as cached
-                from hitinfo where datestamp
-                between curr_date-interval'24 hours' and curr_date
-                and errorcode=0 group by d;
-            ELSIF curr_date - max_date > interval'1 days' THEN
-                INSERT INTO hitinfo_daily(date, count, notcached, cached) select date(datestamp) as d,
-                count(*),
-                count(nullif(filecached, 't')) as notcached, count(nullif(filecached, 'f')) as cached
-                from hitinfo where datestamp
-                between max_date+interval'1 day' and curr_date
-                and errorcode=0 group by d;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+                  start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+               INSERT INTO hitinfo_daily(date, count, notcached, cached)
+               SELECT date(datestamp) AS d,
+                      COUNT(*), COUNT(nullif(filecached, 't')) AS notcached,
+                                     COUNT(nullif(filecached, 'f')) AS cached
+               FROM hitinfo
+               WHERE datestamp BETWEEN start_date AND curr_date
+                   AND errorcode=0
+               GROUP BY d RETURNING count INTO counter;
+
+               IF counter is NULL THEN
+                  INSERT INTO hitinfo_daily(date, count, notcached, cached)
+                  VALUES (start_date,0,0,0);
+               END IF;
+
             END IF;
+
             RETURN NULL;
             END;
             $$


### PR DESCRIPTION
Motivation:

Patch https://rb.dcache.org/r/9222/ fixed issue only partially.
A case when no entries exist in a daily tables was not covered.
Additionally, wrong date was inserted when a zero entry is made
(it has to be previous date not current date)

Modification:

This patch fixes this issue and refactors triggers to be more DRY.

Result:

Inserts have been shown to be fast on heavy loaded system. Particularly
corner cases were tested by truncating summary tables.

RB : https://rb.dcache.org/r/9273/
Acked-by: Al Rossi <arossi@fnal.gov>

Request: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12

Require-book: no
Require-notes: no
(cherry picked from commit 84480cf83e1c8cf1d652e7ab6e005ba1dd7a57a8)