### PR TITLE
pool: Avoid reverse DNS lookup in HTTP mover

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
@@ -134,7 +134,7 @@ public class HttpTransferService extends NettyTransferService<HttpProtocolInfo>
                 NetworkUtils.getLocalAddress(protocolInfo.getSocketAddress().getAddress());
         return new URI(PROTOCOL_HTTP,
                 null,
-                localIP.getCanonicalHostName(),
+                localIP.getHostAddress(),
                 port,
                 path,
                 UUID_QUERY_PARAM + QUERY_PARAM_ASSIGN + uuid.toString(),


### PR DESCRIPTION
Motivation:

When creating an HTTP mover, the mover does a reverse DNS lookup to determine
its own FQDN. Since reverse DNS lookups are not cached in dCache, this limits
throughput and may even cause a pool to become unresponsive due to movers
sometimes being created on the mover message thread.

Modification:

Use the IP address in the HTTP redirect, thus avoid the reverse DNS lookup.

Result:

Fixes an issue with pools becoming unresponsive in case of slow DNS reverse
lookups. The fix causes HTTP redirects to be by address rather than name.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=7509
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9288/

(cherry picked from commit 79192a2146e15e8f9a1cd13f98ea9f32e1e4753a)