### PR TITLE
pool: Fix race condition in request scheduler

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/IoRequestState.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/IoRequestState.java
@@ -6,6 +6,7 @@ package org.dcache.pool.classic;
  * @since 1.9.11
  */
 public enum IoRequestState {
+    NEW,
     QUEUED,
     RUNNING,
     DONE,

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
@@ -1,5 +1,6 @@
 package org.dcache.pool.classic;
 
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,13 +58,13 @@ public class MoverRequestScheduler implements Runnable {
     private final BlockingQueue<PrioritizedRequest> _queue;
 
     private final Map<Integer, PrioritizedRequest> _jobs =
-        new ConcurrentHashMap<>();
+        new ConcurrentHashMap<>(128);
 
     /**
      * requests by door unique request string
      */
     private final Map<String, PrioritizedRequest> _moverByRequests
-            = new ConcurrentHashMap<>();
+            = new ConcurrentHashMap<>(128);
 
     /**
      * ID of the current queue. Used to identify queue in {@link
@@ -122,37 +123,66 @@ public class MoverRequestScheduler implements Runnable {
      * @param priority
      * @return mover id
      */
-    public synchronized int getOrCreateMover(MoverSupplier moverSupplier, String doorUniqueId, IoPriority priority) throws CacheException {
+    public int getOrCreateMover(MoverSupplier moverSupplier, String doorUniqueId,
+                                IoPriority priority) throws CacheException
+    {
         checkState(!_shutdown);
 
-        PrioritizedRequest request = _moverByRequests.get(doorUniqueId);
-        if (request != null) {
+        try {
+            /* Create the request if it doesn't already exists.
+             */
+            PrioritizedRequest request =
+                    _moverByRequests.computeIfAbsent(doorUniqueId,
+                                                     key -> {
+                                                         try {
+                                                             return createRequest(moverSupplier, key, priority);
+                                                         } catch (CacheException e) {
+                                                             throw new RuntimeException(e);
+                                                         }
+                                                     });
+
+            /* If not already queued, submit it.
+             */
+            if (request.queue()) {
+                if (submit(request)) {
+                    /* There was a free slot in the queue so we submit directly to execution.
+                     */
+                    sendToExecution(request);
+                } else if (_semaphore.getMaxPermits() <= 0) {
+                    _log.warn("A task was added to queue '{}', however the queue is not " +
+                              "configured to execute any tasks.", _name);
+                }
+            }
+
             return request.getId();
+        } catch (RuntimeException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), CacheException.class);
+            throw e;
         }
+    }
 
-        int id = _queueId << 24 | nextId();
+    private PrioritizedRequest createRequest(MoverSupplier moverSupplier,
+                                             String doorUniqueId,
+                                             IoPriority priority) throws CacheException
+    {
+        return new PrioritizedRequest(_queueId << 24 | nextId(),
+                                      doorUniqueId,
+                                      moverSupplier.createMover(),
+                                      priority);
+    }
 
-        if (_semaphore.getMaxPermits() <= 0) {
-            _log.warn("A task was added to queue '{}', however the queue is not configured to execute any tasks.", _name);
+    private synchronized boolean submit(PrioritizedRequest request)
+    {
+        if (_jobs.put(request.getId(), request) != null) {
+            throw new RuntimeException("Duplicate mover id detected. Please report to support@dcache.org.");
         }
-
-        Mover<?> mover = moverSupplier.createMover();
-        request = new PrioritizedRequest(id, doorUniqueId, mover, priority);
-
-        _jobs.put(id, request);
-        _moverByRequests.put(doorUniqueId, request);
 
         if (_semaphore.tryAcquire()) {
-            /*
-             * there is a free slot in the queue - use it!
-             */
-            sendToExecution(request);
+            return true;
         } else {
             _queue.add(request);
+            return false;
         }
-
-
-        return id;
     }
 
     private synchronized int nextId() {
@@ -306,7 +336,7 @@ public class MoverRequestScheduler implements Runnable {
      * Set maximal number of concurrently running jobs by this scheduler. All
      * pending jobs will be executed.
      *
-     * @param max
+     * @param maxJobs
      */
     public void setMaxActiveJobs(int maxJobs) {
         _semaphore.setMaxPermits(maxJobs);
@@ -428,7 +458,7 @@ public class MoverRequestScheduler implements Runnable {
             _priority = p;
             _ctime = System.nanoTime();
             _submitTime = System.currentTimeMillis();
-            _state = QUEUED;
+            _state = NEW;
             _doorUniqueId = doorUniqueId;
             _cdc = new CDC();
         }
@@ -489,6 +519,15 @@ public class MoverRequestScheduler implements Runnable {
                                  _mover.getPathToDoor().getDestinationAddress().toString(), _mover.getClientId(),
                                  _mover.getFileAttributes().getPnfsId(), _mover.getBytesTransferred(),
                                  _mover.getTransferTime(), _mover.getLastTransferred());
+        }
+
+        public synchronized boolean queue()
+        {
+            if (_state == NEW) {
+                _state = QUEUED;
+                return true;
+            }
+            return false;
         }
 
         public synchronized void transfer(CompletionHandler<Void,Void> completionHandler) {

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
@@ -139,6 +139,9 @@ public class MoverRequestScheduler implements Runnable {
         Mover<?> mover = moverSupplier.createMover();
         request = new PrioritizedRequest(id, doorUniqueId, mover, priority);
 
+        _jobs.put(id, request);
+        _moverByRequests.put(doorUniqueId, request);
+
         if (_semaphore.tryAcquire()) {
             /*
              * there is a free slot in the queue - use it!
@@ -148,8 +151,6 @@ public class MoverRequestScheduler implements Runnable {
             _queue.add(request);
         }
 
-        _jobs.put(id, request);
-        _moverByRequests.put(doorUniqueId, request);
 
         return id;
     }


### PR DESCRIPTION
Motivation:

The mover request scheduler has some complicated logic combining various
concurrent collections and the java monitor lock. Insertion happens while
holding the monitor lock to ensure that the statistics obtained from the sizes
of the various collections is accurate.  Removal on the other happens at
various stages of processing without holding a lock.

Insertion happens into the request queue before the mover is added to the two
job maps.  This presents a race in which the mover could finish processing and
subsequently be removed from the maps before the insertion thread managed to
add them. The result would be a request in the maps that no longer exists.

The same race exists when the queue is bypassed and the mover is submitted
directly for execution.

Modification:

Insert the movers into the maps before inserting them into the queue.

Result:

Fixed a race condition in which a mover that had already finished executing
would stay in the list of movers and appear as active.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9291/

Reviewed at https://rb.dcache.org/r/9291/

(cherry picked from commit 358dc91668462ef1cfd9249efa95eac35ca94724)