### PR TITLE
pool: Fix race condition in request scheduler

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SimpleIoScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SimpleIoScheduler.java
@@ -126,6 +126,8 @@ public class SimpleIoScheduler implements IoScheduler, Runnable {
 
         final PrioritizedRequest wrapper = new PrioritizedRequest(id, mover, priority);
 
+        _jobs.put(id, wrapper);
+
         if (_semaphore.tryAcquire()) {
             /*
              * there is a free slot in the queue - use it!
@@ -134,8 +136,6 @@ public class SimpleIoScheduler implements IoScheduler, Runnable {
         } else {
             _queue.add(wrapper);
         }
-
-        _jobs.put(id, wrapper);
 
         return id;
     }


### PR DESCRIPTION
Motivation:

The mover request scheduler has some complicated logic combining various
concurrent collections and the java monitor lock. Insertion happens while
holding the monitor lock to ensure that the statistics obtained from the sizes
of the various collections is accurate.  Removal on the other happens at
various stages of processing without holding a lock.

Insertion happens into the request queue before the mover is added to the two
job maps.  This presents a race in which the mover could finish processing and
subsequently be removed from the maps before the insertion thread managed to
add them. The result would be a request in the maps that no longer exists.

The same race exists when the queue is bypassed and the mover is submitted
directly for execution.

Modification:

Insert the movers into the maps before inserting them into the queue.

Result:

Fixed a race condition in which a mover that had already finished executing
would stay in the list of movers and appear as active.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Patch: https://rb.dcache.org/r/9291/

Reviewed at https://rb.dcache.org/r/9291/

(cherry picked from commit 358dc91668462ef1cfd9249efa95eac35ca94724)