### PR TITLE
pool: Don't log illegal state exception on migration job cancellation as a bug

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -968,7 +968,7 @@ public class MigrationModule
         String id;
 
         @Override
-        public String call() throws NoSuchElementException
+        public String call() throws NoSuchElementException, IllegalStateException
         {
             Job job = getJob(id);
             job.cancel(force);


### PR DESCRIPTION
Motivation:

When cancelling a job in a state that doesn't allow cancellation, an illegal
state exception is thrown. This is currently logged as a bug.

Modification:

Declare the exception such that it is not logged as a bug.

Result:

Avoids logging an exception on migration module cancellation as a bug.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9274/

(cherry picked from commit 0ca62f6de1b6f33ed91ed786a1357f3957e1c81d)