### PR TITLE
srm: Do not expose TURL before request is ready

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
@@ -298,8 +298,9 @@ public final class GetFileRequest extends FileRequest<GetRequest> {
             throw new SRMInvalidRequestException("wrong surl format");
         }
 
+        TReturnStatus returnStatus = getReturnStatus();
         String turlstring = getTurlString();
-        if(turlstring != null) {
+        if(turlstring != null && TStatusCode.SRM_FILE_PINNED.equals(returnStatus.getStatusCode())) {
             try {
             fileStatus.setTransferURL(new org.apache.axis.types.URI(turlstring));
             } catch (org.apache.axis.types.URI.MalformedURIException e) {
@@ -313,7 +314,7 @@ public final class GetFileRequest extends FileRequest<GetRequest> {
             fileStatus.setRemainingPinTime((int)(getRemainingLifetime()/1000));
         }
         fileStatus.setEstimatedWaitTime(getContainerRequest().getRetryDeltaTime());
-        fileStatus.setStatus(getReturnStatus());
+        fileStatus.setStatus(returnStatus);
 
         return fileStatus;
     }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
@@ -261,8 +261,10 @@ public final class PutFileRequest extends FileRequest<PutRequest> {
         fileStatus.setSURL(anSurl);
         //fileStatus.set
 
+        TReturnStatus returnStatus = getReturnStatus();
+
         String turlstring = getTurlString();
-        if(turlstring != null) {
+        if(turlstring != null && TStatusCode.SRM_SPACE_AVAILABLE.equals(returnStatus.getStatusCode())) {
             org.apache.axis.types.URI transferURL;
             try {
                 transferURL = new org.apache.axis.types.URI(turlstring);
@@ -275,7 +277,6 @@ public final class PutFileRequest extends FileRequest<PutRequest> {
         }
         fileStatus.setEstimatedWaitTime(getContainerRequest().getRetryDeltaTime());
         fileStatus.setRemainingPinLifetime((int)getRemainingLifetime()/1000);
-        TReturnStatus returnStatus = getReturnStatus();
         if(TStatusCode.SRM_SPACE_LIFETIME_EXPIRED.equals(returnStatus.getStatusCode())) {
             //SRM_SPACE_LIFETIME_EXPIRED is illeal on the file level,
             // but we use it to correctly calculate the request level status


### PR DESCRIPTION
Motivation:

The SRM may decide delay finalizing an upload or download request due to
scheduling constraints. The code did however expose the TURL in the status
response even though the status code indidcated the request was still
queued.

A client could misuse this to transfer the file early - something our own
client does.

Modification:

Do not expose the TURL until the transfer has been scheduled.

Target: trunk
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Request: 2.10
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9280/

(cherry picked from commit de98dbe61317d543f533de1a229b189c5f28fced)