### PR TITLE
Set /var/log/dcache to be owned by dcache:root instead of dcache:dcache

### DIFF
--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -110,7 +110,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/share/man/man8/dcache-billing-indexer.8
 /usr/share/man/man8/dcache.8
 
-%attr(-,dcache,dcache) /var/log/dcache
+%attr(-,dcache,root) /var/log/dcache
 %attr(-,dcache,dcache) /var/lib/dcache/alarms
 %attr(-,dcache,dcache) /var/lib/dcache/config
 %attr(-,dcache,dcache) /var/lib/dcache/billing


### PR DESCRIPTION
Fixes the below error with logrotate 3.8.6 on EL7.

<pre>
considering log /var/log/dcache/PoolDomain.log
error: skipping "/var/log/dcache/PoolDomain.log" because
parent directory has insecure permissions (It's world writable or
writable by group which is not "root") Set "su" directive in config file
to tell logrotate which user/group should be used for rotation.
</pre>

The "su" directive mentioned in the error is only available on logrotate after 3.8.0 and above,  but setting "create dcache dcache" did not get logrotate working.

Signed-off-by: Johan Guldmyr <johan.guldmyr@csc.fi>