### PR TITLE
pnfsmanager: Move flush notification out of chimera transaction

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -1,5 +1,6 @@
 package diskCacheV111.namespace;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.FutureCallback;
@@ -1636,7 +1637,8 @@ public class PnfsManagerV3
         sendMessage(new CellMessage(_cacheModificationRelay, message));
     }
 
-    public void processPnfsMessage(CellMessage message, PnfsMessage pnfsMessage)
+    @VisibleForTesting
+    void processPnfsMessage(CellMessage message, PnfsMessage pnfsMessage)
     {
         long ctime = System.currentTimeMillis();
         try {
@@ -1663,10 +1665,7 @@ public class PnfsManagerV3
             _log.info("{} processed in {} ms", pnfsMessage.getClass(), duration);
         }
 
-        if (pnfsMessage.getReplyRequired()) {
-            message.revertDirection();
-            sendMessage(message);
-        }
+        postProcessMessage(message, pnfsMessage);
     }
 
     @Transactional
@@ -1701,7 +1700,7 @@ public class PnfsManagerV3
         } else if (pnfsMessage instanceof PnfsSetChecksumMessage) {
             setChecksum((PnfsSetChecksumMessage) pnfsMessage);
         } else if (pnfsMessage instanceof PoolFileFlushedMessage) {
-            processFlushMessage(message, (PoolFileFlushedMessage) pnfsMessage);
+            processFlushMessage((PoolFileFlushedMessage) pnfsMessage);
         } else if (pnfsMessage instanceof PnfsGetParentMessage) {
             getParent((PnfsGetParentMessage) pnfsMessage);
         } else if (pnfsMessage instanceof PnfsListDirectoryMessage) {
@@ -1720,7 +1719,58 @@ public class PnfsManagerV3
         return true;
     }
 
-    public void processFlushMessage(CellMessage envelope, PoolFileFlushedMessage pnfsMessage)
+    private void postProcessMessage(CellMessage envelope, PnfsMessage message)
+    {
+        if (message instanceof PoolFileFlushedMessage && message.getReturnCode() == 0) {
+            postProcessFlush(envelope, (PoolFileFlushedMessage) message);
+        } else if (message.getReplyRequired()) {
+            envelope.revertDirection();
+            sendMessage(envelope);
+        }
+    }
+
+    private void postProcessFlush(CellMessage envelope, PoolFileFlushedMessage pnfsMessage)
+    {
+        long timeout = envelope.getAdjustedTtl() - envelope.getLocalAge();
+
+        /* Asynchronously notify flush notification targets about the flush. */
+        PoolFileFlushedMessage notification =
+                new PoolFileFlushedMessage(pnfsMessage.getPoolName(), pnfsMessage.getPnfsId(),
+                                           pnfsMessage.getFileAttributes());
+        List<ListenableFuture<PoolFileFlushedMessage>> futures = new ArrayList<>();
+        for (String address : _flushNotificationTargets) {
+            futures.add(_stub.send(new CellPath(address), notification, timeout));
+        }
+
+        /* Only generate positive reply if all notifications succeeded. */
+        Futures.addCallback(Futures.allAsList(futures),
+                            new FutureCallback<List<PoolFileFlushedMessage>>()
+                            {
+                                @Override
+                                public void onSuccess(List<PoolFileFlushedMessage> result)
+                                {
+                                    pnfsMessage.setSucceeded();
+                                    reply();
+                                }
+
+                                @Override
+                                public void onFailure(Throwable t)
+                                {
+                                    pnfsMessage.setFailed(CacheException.DEFAULT_ERROR_CODE,
+                                                          "PNFS manager failed while notifying other " +
+                                                          "components about the flush: " + t.getMessage());
+                                    reply();
+                                }
+
+                                private void reply()
+                                {
+                                    envelope.revertDirection();
+                                    sendMessage(envelope);
+                                }
+                            });
+    }
+
+    public void processFlushMessage(PoolFileFlushedMessage pnfsMessage)
     {
         try {
             // Note: no Restriction check as message sent autonomously by pool.
@@ -1729,47 +1779,6 @@ public class PnfsManagerV3
             _nameSpaceProvider.setFileAttributes(pnfsMessage.getSubject(),
                                                  pnfsMessage.getPnfsId(), attributesToUpdate,
                                                  EnumSet.noneOf(FileAttribute.class));
-
-            long timeout = envelope.getAdjustedTtl() - envelope.getLocalAge();
-
-            /* Asynchronously notify flush notification targets about the flush. */
-            PoolFileFlushedMessage notification =
-                    new PoolFileFlushedMessage(pnfsMessage.getPoolName(), pnfsMessage.getPnfsId(),
-                                               pnfsMessage.getFileAttributes());
-            List<ListenableFuture<PoolFileFlushedMessage>> futures = new ArrayList<>();
-            for (String address : _flushNotificationTargets) {
-                futures.add(_stub.send(new CellPath(address), notification, timeout));
-            }
-
-            /* Prevent the caller from generating a reply. */
-            pnfsMessage.setReplyRequired(false);
-
-            /* Only generate positive reply if all notifications succeeded. */
-            Futures.addCallback(Futures.allAsList(futures),
-                                new FutureCallback<List<PoolFileFlushedMessage>>()
-                                {
-                                    @Override
-                                    public void onSuccess(List<PoolFileFlushedMessage> result)
-                                    {
-                                        pnfsMessage.setSucceeded();
-                                        reply();
-                                    }
-
-                                    @Override
-                                    public void onFailure(Throwable t)
-                                    {
-                                        pnfsMessage.setFailed(CacheException.DEFAULT_ERROR_CODE,
-                                                              "PNFS manager failed while notifying other " +
-                                                              "components about the flush: " + t.getMessage());
-                                        reply();
-                                    }
-
-                                    private void reply()
-                                    {
-                                        envelope.revertDirection();
-                                        sendMessage(envelope);
-                                    }
-                                });
         } catch (CacheException e) {
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {


### PR DESCRIPTION
Motivation:

Upon receiving a flush message, pnfsmanager adds the tape location to
chimera and then generates asynchronous flush notifications for space
manager. These flush notifications are submitted asynchronously so
the transaction doesn't block, but there is no reason to send them
from within the transaction. Worse, the transaction commit may fail
and in that case we should not send the flush notifications to space
manager.

Modifiction:

Adds a post processing step for pnfs messages. The flush notification
is generated during post processing.

Result:

Reduces transaction length of flush processing in pnfs manager.

Target: trunk
Request: 2.15
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9296/

(cherry picked from commit f4dcb5bade1039e90731b70b6c60c1c29a6e82a9)