### PR TITLE
pnfsmanager: Revert "Use a single shared request queue for threads"

### DIFF
--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -31,6 +31,7 @@
       <property name="listThreads" value="${pnfsmanager.limits.list-threads}"/>
       <property name="cacheModificationRelay" value="${pnfsmanager.destination.cache-notification}"/>
       <property name="logSlowThreshold" value="${pnfsmanager.limits.log-slow-threshold}"/>
+      <property name="folding" value="${pnfsmanager.enable.folding}"/>
       <property name="directoryListLimit" value="${pnfsmanager.limits.list-chunk-size}"/>
       <property name="permissionHandler" ref="permission-handler"/>
       <property name="nameSpaceProvider" ref="name-space-provider"/>

--- a/modules/dcache-chimera/src/test/java/diskCacheV111/namespace/PnfsManagerTest.java
+++ b/modules/dcache-chimera/src/test/java/diskCacheV111/namespace/PnfsManagerTest.java
@@ -45,6 +45,7 @@ import org.dcache.chimera.FileNotFoundHimeraFsException;
 import org.dcache.chimera.FileSystemProvider;
 import org.dcache.chimera.FsFactory;
 import org.dcache.chimera.FsInode;
+import org.dcache.chimera.JdbcFs;
 import org.dcache.chimera.UnixPermission;
 import org.dcache.chimera.namespace.ChimeraNameSpaceProvider;
 import org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor;
@@ -128,6 +129,7 @@ public class PnfsManagerTest
         _pnfsManager.setLogSlowThreshold(0);
         _pnfsManager.setNameSpaceProvider(chimera);
         _pnfsManager.setQueueMaxSize(0);
+        _pnfsManager.setFolding(true);
         _pnfsManager.setDirectoryListLimit(100);
         _pnfsManager.init();
 

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -23,6 +23,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -85,6 +86,7 @@ import org.dcache.auth.attributes.Restriction;
 import org.dcache.auth.attributes.Restrictions;
 import org.dcache.cells.CellStub;
 import org.dcache.chimera.UnixPermission;
+import org.dcache.commons.stats.RequestCounters;
 import org.dcache.commons.stats.RequestExecutionTimeGauges;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.namespace.FileType;
@@ -123,6 +125,8 @@ public class PnfsManagerV3
 
     private final RequestExecutionTimeGauges<Class<? extends PnfsMessage>> _gauges =
         new RequestExecutionTimeGauges<>("PnfsManagerV3");
+    private final RequestCounters<Class<?>> _foldedCounters =
+        new RequestCounters<>("PnfsManagerV3.Folded");
 
     /**
      * Cache of path prefix to database IDs mappings.
@@ -152,14 +156,19 @@ public class PnfsManagerV3
     private long _logSlowThreshold;
 
     /**
+     * Whether to use folding.
+     */
+    private boolean _canFold;
+
+    /**
      * Queues for list operations. There is one queue per thread
      * group.
      */
     private BlockingQueue<CellMessage>[] _listQueues;
 
     /**
-     * Queues for non-listing messages. There is one queue per thread
-     * group.
+     * Tasks queues used for messages that do not operate on cache
+     * locations.
      */
     private BlockingQueue<CellMessage>[] _fifos;
 
@@ -267,6 +276,12 @@ public class PnfsManagerV3
     }
 
     @Required
+    public void setFolding(boolean folding)
+    {
+        _canFold = folding;
+    }
+
+    @Required
     public void setDirectoryListLimit(int limit)
     {
         _directoryListLimit = limit;
@@ -291,19 +306,22 @@ public class PnfsManagerV3
     {
         _stub = new CellStub(getCellEndpoint());
 
-        _fifos = new BlockingQueue[_threadGroups];
-        _log.info("Starting {} threads", _threads * _threadGroups);
-        for (int i = 0; i < _threadGroups; i++) {
+        _fifos = new BlockingQueue[_threads * _threadGroups];
+        _log.info("Starting {} threads", _fifos.length);
+        for (int i = 0; i < _fifos.length; i++) {
             if (_queueMaxSize > 0) {
                 _fifos[i] = new LinkedBlockingQueue<>(_queueMaxSize);
             } else {
                 _fifos[i] = new LinkedBlockingQueue<>();
             }
-            for (int j = 0; j < _threads; j++) {
-                executor.execute(new ProcessThread(_fifos[i]));
-            }
+            executor.execute(new ProcessThread(_fifos[i]));
         }
 
+        /* Start list-threads threads per thread group for list
+         * processing. We use a shared queue per thread group, as
+         * list operations are read only and thus there is no need
+         * to serialize the operations.
+         */
         _listQueues = new BlockingQueue[_threadGroups];
         for (int i = 0; i < _threadGroups; i++) {
             _listQueues[i] = new LinkedBlockingQueue<>();
@@ -353,14 +371,24 @@ public class PnfsManagerV3
             pw.println("    [" + i + "] " + _listQueues[i].size());
         }
         pw.println();
-        pw.println("Message queues (" + _fifos.length + ")");
+        pw.println("Threads (" + _fifos.length + ") Queue");
         for (int i = 0; i < _fifos.length; i++) {
-            pw.println( "    [" + i + "] " +  _fifos[i].size());
+            pw.println( "    ["+i+"] "+_fifos[i].size() ) ;
+        }
+        pw.println();
+        pw.println("Thread groups (" + _threadGroups + ")");
+        for (int i = 0; i < _threadGroups; i++) {
+            int total = 0;
+            for (int j = 0; j < _threads; j++) {
+                total += _fifos[i * _threads + j].size();
+            }
+            pw.println("    [" + i + "] " + total);
         }
         pw.println();
 
         pw.println( "Statistics:" ) ;
         pw.println(_gauges.toString());
+        pw.println(_foldedCounters.toString());
     }
 
     public static final String hh_pnfsidof     = "<globalPath>" ;
@@ -676,17 +704,17 @@ public class PnfsManagerV3
         + "        dumthreadqueus prints the context of\n"
         + "        thread[s] queue[s] into the error log file";
 
-    public static final String hh_dumpthreadqueues = "[<group>]";
+    public static final String hh_dumpthreadqueues = "[<threadId>]";
 
     public String ac_dumpthreadqueues_$_0_1(Args args)
     {
         if (args.argc() > 0) {
-            int group = Integer.parseInt(args.argv(0));
-            dumpThreadQueue(group);
+            int threadId = Integer.parseInt(args.argv(0));
+            dumpThreadQueue(threadId);
             return "dumped";
         }
-        for (int group = 0; group < _fifos.length; ++group) {
-            dumpThreadQueue(group);
+        for (int threadId = 0; threadId < _fifos.length; ++threadId) {
+            dumpThreadQueue(threadId);
         }
         return "dumped";
     }
@@ -1538,7 +1566,7 @@ public class PnfsManagerV3
 
     private class ProcessThread implements Runnable
     {
-        private final BlockingQueue<CellMessage> _fifo;
+        private final BlockingQueue<CellMessage> _fifo ;
 
         private ProcessThread(BlockingQueue<CellMessage> fifo)
         {
@@ -1565,16 +1593,41 @@ public class PnfsManagerV3
                         }
 
                         processPnfsMessage(message, pnfs);
+                        fold(pnfs);
                     } catch (Throwable e) {
                         _log.warn("processPnfsMessage: {} : {}", Thread.currentThread().getName(), e);
                     } finally {
                         CDC.clearMessageContext();
                     }
                 }
-                /* Poison any other threads reading from the same queue */
-                _fifo.offer(SHUTDOWN_SENTINEL);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+            }
+        }
+
+        protected void fold(PnfsMessage message)
+        {
+            if (_canFold && message.getReturnCode() == 0) {
+                Iterator<CellMessage> i = _fifo.iterator();
+                while (i.hasNext()) {
+                    CellMessage envelope = i.next();
+                    PnfsMessage other =
+                        (PnfsMessage) envelope.getMessageObject();
+
+                    if (other.invalidates(message)) {
+                        break;
+                    }
+
+                    if (other.fold(message)) {
+                        _log.info("Folded {}", other.getClass().getSimpleName());
+                        _foldedCounters.incrementRequests(message.getClass());
+
+                        i.remove();
+                        envelope.revertDirection();
+
+                        sendMessage(envelope);
+                    }
+                }
             }
         }
     }
@@ -1615,19 +1668,27 @@ public class PnfsManagerV3
         PnfsId pnfsId = message.getPnfsId();
         String path = message.getPnfsPath();
 
-        int group;
+        int index;
         if (pnfsId != null) {
-            group = pnfsIdToThreadGroup(pnfsId);
-            _log.info("Using thread group [{}] {}", pnfsId, group);
+            index =
+                pnfsIdToThreadGroup(pnfsId) * _threads +
+                (int) (Math.abs((long) pnfsId.hashCode()) % _threads);
+            _log.info("Using thread [{}] {}", pnfsId, index);
         } else if (path != null) {
-            group = pathToThreadGroup(path);
-            _log.info("Using thread group [{}] {}", path, group);
+            index =
+                pathToThreadGroup(path) * _threads +
+                (int) (Math.abs((long) path.hashCode()) % _threads);
+            _log.info("Using thread [{}] {}", path, index);
         } else {
-            group = _random.nextInt(_fifos.length);
-            _log.info("Using random thread group {}", group);
+            index = _random.nextInt(_fifos.length);
+            _log.info("Using random thread {}", index);
         }
 
-        if (!_fifos[group].offer(envelope)) {
+        /*
+         * try to add a message into queue.
+         * tell requester, that queue is full
+         */
+        if (!_fifos[index].offer(envelope)) {
             throw new MissingResourceCacheException("PnfsManager queue limit exceeded");
         }
     }

--- a/skel/share/defaults/pnfsmanager.properties
+++ b/skel/share/defaults/pnfsmanager.properties
@@ -85,6 +85,15 @@ pnfsmanager.limits.log-slow-threshold=0
 #
 pnfsmanager.limits.queue-length = 0
 
+#  ---- PnfsManager message folding
+#
+#   Whether to use message folding in PnfsManager. When message folding
+#   is enabled, the PnfsManager will try to fold or collapse processing of
+#   identical messages. This can reduce the load on PNFS or Chimera if a
+#   large number of simultaneous requests on the same objects are performed.
+#
+(one-of?true|false)pnfsmanager.enable.folding = true
+
 #  ---- Inherit file ownership when creating files and directories
 #
 #   By default new files and directories receive will be owned by the
@@ -201,5 +210,3 @@ pnfsmanager.db.schema.auto=${dcache.db.schema.auto}
 #  Updating the atimes less often (or not at all) may have performance benefits.
 #
 pnfsmanager.atime-gap=-1
-
-(obsolete)pnfsmanager.enable.folding = No longer supported

--- a/skel/share/services/pnfsmanager.batch
+++ b/skel/share/services/pnfsmanager.batch
@@ -5,6 +5,7 @@ onerror shutdown
 check -strong pnfsmanager.plugins.storage-info-extractor
 check -strong pnfsmanager.enable.inherit-file-ownership
 check -strong pnfsmanager.enable.full-path-permission-check
+check -strong pnfsmanager.enable.folding
 check -strong pnfsmanager.enable.acl
 check -strong pnfsmanager.default-retention-policy
 check -strong pnfsmanager.default-access-latency


### PR DESCRIPTION
Motivation:

We originally removed the multiple request queues in pnfsmanager to instead
feed all threads from a single queue. This would avoid the balancing issues
of having multiple queues and was done because we no longer need to
serialize operations on chimera objects as we have proper transactional
isolation now. We failed to take into account that several threads updating
common chimera objects would be serialized by the database due to locking,
potentially limiting the throughput of PnfsManager.

Modification:

This reverts commit c299bb80890c6431aab678112878546ffefe4dfb and thus
reintroduces the concept of multiple queues.

Result:

Reintroduces multiple pnfs manager queues - one per thread - to avoid possible
lock contention in chimera. Reintroduces request folding.

Target: trunk
Request: 2.15
Require-notes: yes
Require-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9297/

(cherry picked from commit b36c76f4d61137893a5b0aee4032c5d1747edaa9)