### PR TITLE
chimera: fix writing into file level

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -862,7 +862,7 @@ class FsSqlDriver {
                                  ps.setBinaryStream(9, new ByteArrayInputStream(data, offset, len), len);
                              });
             } else {
-                _jdbc.update("UPDATE t_level_" + level + " SET ifiledata=?,isize=? WHERE ino=?",
+                _jdbc.update("UPDATE t_level_" + level + " SET ifiledata=?,isize=? WHERE inumber=?",
                              ps -> {
                                  ps.setBinaryStream(1, new ByteArrayInputStream(data, offset, len), len);
                                  ps.setLong(2, len);

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -1182,4 +1182,19 @@ public class BasicTest extends ChimeraTestCaseHelper {
         _fs.createFile(_rootInode, "aDir", 0, 0, 0755 | UnixPermission.S_IFDIR, UnixPermission.S_IFDIR);
     }
 
+    @Test
+    public void testLevelCreation() throws ChimeraFsException {
+
+        FsInode file = _fs.createFile(_rootInode, "aFile", 0, 0, 0755 | UnixPermission.S_IFREG, UnixPermission.S_IFREG);
+        FsInode level = _fs.createFileLevel(file, 2);
+
+        byte[] data = "some random data".getBytes(StandardCharsets.UTF_8);
+        int n = level.write(0, data, 0, data.length);
+        assertEquals("incorrect number of bytes", data.length, n);
+
+        byte[] moreData = "some more random data".getBytes(StandardCharsets.UTF_8);
+        n = level.write(0, moreData, 0, moreData.length);
+        assertEquals("incorrect number of bytes", moreData.length, n);
+
+    }
 }


### PR DESCRIPTION
Motivation:

14 May 2016 00:43:11 (PnfsManager) [dcache-photon17-08 PnfsFlag 0000A46614130D18483ABAF9FA374DD59B07] Exception in setFileAttributes: {}
org.dcache.chimera.IOHimeraFsException: PreparedStatementCallback; bad SQL grammar [UPDATE t_level_2 SET ifiledata=?,isize=? WHERE ino=?]; nested excepti
on is org.postgresql.util.PSQLException: ERROR: column "ino" does not exist
Position: 50
at org.dcache.chimera.JdbcFs.inTransaction(JdbcFs.java:210) ~[chimera-2.15.5.jar:2.15.5]
at org.dcache.chimera.JdbcFs.write(JdbcFs.java:1012) ~[chimera-2.15.5.jar:2.15.5]
at sun.reflect.GeneratedMethodAccessor290.invoke(Unknown Source) ~[na:na]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_92]
at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_92]
at org.dcache.commons.stats.MonitoringProxy.invoke(MonitoringProxy.java:54) ~[dcache-common-2.15.5.jar:2.15.5]
....

Modification:
fix sql statement to use correct field. Added unit test

Result:
exception is gone.

Fixes: #2407
Acked-by: Albert Rossi
Target: master, 2.15
Require-book: no
Require-notes: no
(cherry picked from commit 4236e4aa89b8a534b6266d8fcd1c9ac405b073c0)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>