### PR TITLE
httpd: restore original fields and format to the TransferObserverV1 a…

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/ActiveTransfersBean.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/beans/ActiveTransfersBean.java
@@ -63,6 +63,6 @@ public class ActiveTransfersBean extends TransferInfo {
     }
 
     public String getTimeWaiting() {
-        return timeWaiting(System.currentTimeMillis());
+        return timeWaiting(System.currentTimeMillis(), true);
     }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
@@ -59,9 +59,9 @@ documents or software obtained from this server.
  */
 package diskCacheV111.util;
 
-import javax.security.auth.Subject;
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
+import javax.security.auth.Subject;
 
 import org.dcache.util.TimeUtils.DurationParser;
 
@@ -73,15 +73,30 @@ import org.dcache.util.TimeUtils.DurationParser;
 public class TransferInfo implements Serializable {
     private static final long serialVersionUID = 7303353263666911507L;
 
-    protected static String getTimeString(long time) {
+    protected static String getTimeString(long time, boolean display) {
         DurationParser durations = new DurationParser(time,
                                                       TimeUnit.MILLISECONDS).parseAll();
 
-        return String.format("%d+%02d:%02d:%02d",
-                             durations.get(TimeUnit.DAYS),
-                             durations.get(TimeUnit.HOURS),
-                             durations.get(TimeUnit.MINUTES),
-                             durations.get(TimeUnit.SECONDS));
+        if (display) {
+            return String.format("%d+%02d:%02d:%02d",
+                            durations.get(TimeUnit.DAYS),
+                            durations.get(TimeUnit.HOURS),
+                            durations.get(TimeUnit.MINUTES),
+                            durations.get(TimeUnit.SECONDS));
+        }
+
+        if (durations.get(TimeUnit.DAYS) > 0) {
+            return String.format("%d d %02d:%02d:%02d",
+                            durations.get(TimeUnit.DAYS),
+                            durations.get(TimeUnit.HOURS),
+                            durations.get(TimeUnit.MINUTES),
+                            durations.get(TimeUnit.SECONDS));
+        }
+
+        return String.format("%02d:%02d:%02d",
+                        durations.get(TimeUnit.HOURS),
+                        durations.get(TimeUnit.MINUTES),
+                        durations.get(TimeUnit.SECONDS));
     }
 
     protected String cellName   = "";
@@ -266,15 +281,15 @@ public class TransferInfo implements Serializable {
         this.waitingSince = waitingSince;
     }
 
-    protected String timeRunning(long now) {
-        return getTimeString(now - moverStart);
+    protected String timeRunning(long now, boolean display) {
+        return getTimeString(now - moverStart, display);
     }
 
-    protected String timeElapsedSinceSubmitted(long now) {
-        return getTimeString(now - moverSubmit);
+    protected String timeElapsedSinceSubmitted(long now, boolean display) {
+        return getTimeString(now - moverSubmit, display);
     }
 
-    protected String timeWaiting(long now) {
-        return getTimeString(now - waitingSince);
+    protected String timeWaiting(long now, boolean display) {
+        return getTimeString(now - waitingSince, display);
     }
 }


### PR DESCRIPTION
…scii output

Motivation:

A previous patch 9258 introduced several changes to the ascii (text) output
for active transfer information.  As this is consumed by scripts, it is
better to leave it as it was for backward compatibility.

Modification:

Restore the original number of fields and the formatting of several of the
strings to what it was before that patch.

Result:

Backward compatibility is maintained.

Target: master
Request: 2.16
Require-notes: no
Require-book: no
Acked-by: Gerd