### PR TITLE
srmmanager: Make scheduler ID configurable and compatible with older versions

### DIFF
--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srmmanager.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srmmanager.xml
@@ -450,7 +450,7 @@
           init-method="start" destroy-method="stop">
         <description>Scheduler for GET operations</description>
 
-        <constructor-arg value="get_${srmmanager.cell.name}"/>
+        <constructor-arg value="get_${srmmanager.scheduler-id}"/>
         <constructor-arg value="org.dcache.srm.request.GetFileRequest"/>
 
         <property name="schedulingStrategyProvider" ref="scheduling-strategy-provider"/>
@@ -465,7 +465,7 @@
           init-method="start" destroy-method="stop">
         <description>Scheduler for LS operations</description>
 
-        <constructor-arg value="ls_${srmmanager.cell.name}"/>
+        <constructor-arg value="ls_${srmmanager.scheduler-id}"/>
         <constructor-arg value="org.dcache.srm.request.LsFileRequest"/>
 
         <property name="schedulingStrategyProvider" ref="scheduling-strategy-provider"/>
@@ -479,7 +479,7 @@
           init-method="start" destroy-method="stop">
         <description>Scheduler for BRING-ONLINE operations</description>
 
-        <constructor-arg value="bring_online_${srmmanager.cell.name}"/>
+        <constructor-arg value="bring_online_${srmmanager.scheduler-id}"/>
         <constructor-arg value="org.dcache.srm.request.BringOnlineFileRequest"/>
 
         <property name="schedulingStrategyProvider" ref="scheduling-strategy-provider"/>
@@ -493,7 +493,7 @@
           init-method="start" destroy-method="stop">
         <description>Scheduler for PUT operations</description>
 
-        <constructor-arg value="put_${srmmanager.cell.name}"/>
+        <constructor-arg value="put_${srmmanager.scheduler-id}"/>
         <constructor-arg value="org.dcache.srm.request.PutFileRequest"/>
 
         <property name="schedulingStrategyProvider" ref="scheduling-strategy-provider"/>
@@ -507,7 +507,7 @@
           init-method="start" destroy-method="stop">
         <description>Scheduler for COPY operations</description>
 
-        <constructor-arg value="copy_${srmmanager.cell.name}"/>
+        <constructor-arg value="copy_${srmmanager.scheduler-id}"/>
         <constructor-arg value="org.dcache.srm.request.Job"/>
 
         <property name="schedulingStrategyProvider" ref="scheduling-strategy-provider"/>
@@ -520,7 +520,7 @@
           init-method="start" destroy-method="stop">
         <description>Scheduler for RESERVE-SPACE operations</description>
 
-        <constructor-arg value="reserve_space_${srmmanager.cell.name}"/>
+        <constructor-arg value="reserve_space_${srmmanager.scheduler-id}"/>
         <constructor-arg value="org.dcache.srm.request.ReserveSpaceRequest"/>
 
         <property name="schedulingStrategyProvider" ref="scheduling-strategy-provider"/>

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -588,6 +588,7 @@ public class Scheduler <T extends Job>
         formatter.format("\n");
         formatter.format("    Scheduling strategy             : %s\n", schedulingStrategyName);
         formatter.format("    Transfer strategy               : %s\n", transferStrategyName);
+        formatter.format("    Scheduler ID                    : %s\n", id);
     }
 
     private static void printQueue(StringBuilder sb, Collection<Long> queue)

--- a/skel/share/defaults/srmmanager.properties
+++ b/skel/share/defaults/srmmanager.properties
@@ -134,6 +134,13 @@ srmmanager.net.local-hosts=${srmmanager.net.host}
 #
 (one-of?SSL|GSI)srmmanager.client-transport = GSI
 
+# ---- Unique identifier amongst all instances of a logical srmmanager service
+#
+# Database records are tagged with an identifier derived from this value. If a logical
+# srmmanager service is replicated with a shared database, each instance must have a
+# unique value for this property.
+#
+srmmanager.scheduler-id=SRM-${host.name}
 
 # ---- Database host name
 #


### PR DESCRIPTION
Motivation:

SrmManager tags all records with a scheduler ID and only processes those with its
own tag. In replicated setups, each instance sharing a database must have its
own scheduler ID. Furthermore, when upgrading from an earlier version, one should
try to maintain the scheduler ID to ensure that old transfers get cleaned up.

Modification:

Introduced the srmmanager.scheduler-id property and let it default to
SRM-${host.name} for compatibility with older versions. This also likely makes
it unique in replicated deployments.

Result:

Introduced the srmmanager.scheduler-id property.

Target: trunk
Request: 2.16
Require-notes: yes
Reqiure-book: yes
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9333/

(cherry picked from commit f7511cbf0280dc840cc2923bd9de779635c66070)