### PR TITLE
billing: fix issue with database change rollback

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.16.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.16.xml
@@ -60,7 +60,7 @@
 	</rollback>
     </changeSet>
 
-    <changeSet id="8" author="litvinse">
+    <changeSet id="8.1" author="litvinse">
         <preConditions onError="WARN" onFail="WARN">
             <sqlCheck expectedResult="CREATE LANGUAGE">CREATE LANGUAGE plpgsql</sqlCheck>
         </preConditions>
@@ -391,6 +391,7 @@
             $$
             LANGUAGE plpgsql;
         </sql>
+        <rollback/>
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
Motivation:

Commit a7730edd2c55fe4aac231c26941238b9ef7975d9 lacked a rollback statement preventing dcache from downgrading.

Modification:

Added empty rollback section to trigger changeset and renamed "8" -> "8.1".

Result:

Restored ability to rollback database change.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.16
Fixes: #2454
Acked-by: Gerd Behrmann <behrmann@gmail.com>

Reviewed at https://rb.dcache.org/r/9332/
(cherry picked from commit 8cd3d3e8aafd835b6d15c465a90ec6c578c51835)