### PR TITLE
zookeeper: Add automatic purging of old snapshots

### DIFF
--- a/skel/share/defaults/zookeeper.properties
+++ b/skel/share/defaults/zookeeper.properties
@@ -63,6 +63,22 @@ zookeeper.data-dir = ${dcache.paths.zookeeper}
 # cache.
 zookeeper.data-log-dir = ${zookeeper.data-dir}
 
+# Automatic cleaning of snapshots
+#
+# Snapshots stored in the data directory will accumulate unless cleaned periodically.
+# Automatic cleaning can be achieved with the auto purge functionality.
+#
+
+# How many snapshots to retain in the data directory.
+#
+# If more snapshots exists, the oldest are deleted.
+zookeeper.auto-purge.snap-retain-count = 3
+
+# How often to run the auto purge procedure. Set to 0 to disable automatic purging.
+zookeeper.auto-purge.purge-interval = 3
+(one-of?HOURS|DAYS)\
+zookeeper.auto-purge.purge-interval.unit = HOURS
+
 # The basic time unit used by ZooKeeper. It is used to do heartbeats.
 zookeeper.tick-time = 2
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\

--- a/skel/share/services/zookeeper.batch
+++ b/skel/share/services/zookeeper.batch
@@ -20,6 +20,9 @@ check -strong zookeeper.min-session-timeout.unit
 check zookeeper.max-session-timeout
 check -strong zookeeper.max-session-timeout.unit
 check -strong zookeeper.max-client-connections
+check -strong zookeeper.auto-purge.snap-retain-count
+check -strong zookeeper.auto-purge.purge-interval
+check -strong zookeeper.auto-purge.purge-interval.unit
 
 create org.dcache.zookeeper.service.ZooKeeperCell ${zookeeper.cell.name} \
           "-consume=${zookeeper.cell.consume} \
@@ -33,4 +36,7 @@ create org.dcache.zookeeper.service.ZooKeeperCell ${zookeeper.cell.name} \
            -max-session-timeout-unit=${zookeeper.max-session-timeout.unit} \
            -max-client-connections=${zookeeper.max-client-connections} \
            -listen=${zookeeper.net.listen} \
-           -port=${zookeeper.net.port}"
+           -port=${zookeeper.net.port} \
+           -autoPurgeRetainCount=${zookeeper.auto-purge.snap-retain-count} \
+           -autoPurgeInterval=${zookeeper.auto-purge.purge-interval} \
+           -autoPurgeIntervalUnit=${zookeeper.auto-purge.purge-interval.unit}"


### PR DESCRIPTION
Motivation:

ZooKeeper data snapshots accumulate on disk unless periodically removed.

Modification:

Enables automatic purging for the embedded zookeeper service.

Result:

Adds zookeeper.auto-purge.snap-retain-count and zookeeper.auto-purge.purge-interval
configuration properties to configure auto purging of ZooKeeper snapshot
files.

Target: trunk
Request: 2.16
Require-notes: yes
Require-book: yes
Fixes: #2442
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9336/

(cherry picked from commit 89be067283805263096a251616e173e8b2259296)