### PR TITLE
ftp: Fix regression in resolving path

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1757,7 +1757,7 @@ public abstract class AbstractFtpDoorV1
 
     private FsPath absolutePath(String path) throws FTPCommandException
     {
-        FsPath absolutePath = _doorRootPath.chroot(_cwd + "/" + path);
+        FsPath absolutePath = path.startsWith("/") ? _doorRootPath.chroot(path) : _doorRootPath.chroot(_cwd + "/" + path);
         if (absolutePath.hasPrefix(_userRootPath)) {
             return absolutePath;
         }


### PR DESCRIPTION
Motivation:

A regression introduced when refactoring FsPath causes the FTP
door to append any path to the current working directory, even
if the path is absolute.

Modification:

Check whether the path is relative before concatenating it with
the current working directory.

Result:

Unreleased regression resolved.

Target: trunk
Request: 2.16
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9349/

(cherry picked from commit f748eba241ea6f316b10ee8fdf3d8985b6c87543)