### PR TITLE
zookeeper: Document ports used by embedded zookeeper

### DIFF
--- a/skel/share/defaults/zookeeper.properties
+++ b/skel/share/defaults/zookeeper.properties
@@ -82,3 +82,7 @@ zookeeper.max-session-timeout.unit = SECONDS
 
 # Maximum number of client connections.
 zookeeper.max-client-connections = 1000
+
+
+#  Document which TCP ports are opened
+(immutable)zookeeper.net.ports.tcp=${zookeeper.net.port}


### PR DESCRIPTION
Motivation:

The `dcache ports` command did not output the port zookeper listen on.

Modification:

Define zookeeper.net.ports.tcp.

Result:

`dcache ports` shows zookeeper.

Target: trunk
Request: 2.16
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/9350/

Reviewed at https://rb.dcache.org/r/9350/

(cherry picked from commit 1b7fb03ba50b26447dc336940144feb536f460ea)