### PR TITLE
cells: Fix NPE during shutdown

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -199,7 +199,6 @@ public class CellNucleus implements ThreadFactory
     {
         if (__cellGlue != null) {
             __cellGlue.shutdown();
-            __cellGlue = null;
         }
     }
 


### PR DESCRIPTION
Motivation:

java.lang.NullPointerException: null
        at dmg.cells.nucleus.CellNucleus.shutdown(CellNucleus.java:971) ~[cells-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
        at dmg.cells.nucleus.CellGlue.lambda$_kill$10(CellGlue.java:341) ~[cells-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_60]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_60]
        at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_60]

Modification:

The problem is that clearing out the static cell glue reference from within
SystemCell#cleanup leaves a race in that the CellNucleus of SystemCell will
unregister SystemCell from the cell glue after cleanup returns. The solution
is not to clean the cell glue reference - since this is during shutdown,
nothing bad should happen from not cleaning the reference.

Result:

One less NPE.

Target: trunk
Request: 2.16
Require-notes: no
Require-book: no
Fixes: #2469
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9348/

(cherry picked from commit 93c223ed030ceb0aa768d156a4bbfade8b12ae96)