### PR TITLE
httpd: Update cell info view for named queues and make srmmanager monitored

### DIFF
--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -24,6 +24,7 @@ httpd.service.gplazma=${dcache.service.gplazma}
 httpd.service.pnfsmanager=${dcache.service.pnfsmanager}
 httpd.service.poolmanager=${dcache.service.poolmanager}
 httpd.service.spacemanager=${dcache.service.spacemanager}
+httpd.service.srmmanager=${dcache.service.srmmanager}
 httpd.enable.space-reservation=${dcache.enable.space-reservation}
 
 httpd.loginbroker.update-topic=${dcache.loginbroker.update-topic}
@@ -32,6 +33,11 @@ httpd.loginbroker.request-topic=${dcache.loginbroker.request-topic}
 httpd.pool-monitor-topic=${dcache.pool-monitor.topic}
 
 httpd.net.port = 2288
+
+# Cell addresses to monitor. Only supported by the old httpd pages. Simple names
+# are expected to be named queues or topics and httpd adds recipients of these
+# addresses to the list of cells to monitor.
+httpd.watch=${httpd.service.pnfsmanager} ${httpd.service.poolmanager} ${httpd.service.gplazma} ${httpd.service.srmmanager}
 
 #
 #     For authenticated pages (all admin pages in the webadmin servlet are

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -14,6 +14,7 @@ check httpd.cell.subscribe
 check -strong httpd.setup
 check -strong httpd.enable.authn
 check -strong httpd.enable.plots.pool-queue
+check httpd.watch
 
 check httpd.statistics.location
 
@@ -258,9 +259,7 @@ create diskCacheV111.services.web.PoolInfoObserverV3 ${httpd.cell.name}PoolColle
 
 onerror shutdown
 create diskCacheV111.cells.WebCollectorV3 ${httpd.cell.name}Collector \
-    "PnfsManager \
-     PoolManager \
-     gPlazma \
+    "${httpd.watch} \
      -subscribe=${httpd.cell.subscribe} \
      -replyObject"
 


### PR DESCRIPTION
Motivation:

We no longer have well-known cells in dCache. Instead we got named queues that
may have more than one consumer.

Modification:

Update the collector of httpd to send ping messages to simple names to
first resolve them to fully qualified cell addresses. By repeating the
ping message, all possible receivers will be detected and monitored.

Adds srmmanager to the monitored services.

Result:

Adds the httpd.watch property to allow the list of monitored cells to be
configured.

Target: trunk
Require-notes: yes
Require-book: yes
Request: 2.16
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9337/

(cherry picked from commit 870a5b7aac7f6fa54ee3badc6ea15ef77cdd8d7e)