### PR TITLE
httpd: Fail gracefully in case of missing options

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/InfoHttpEngine.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/InfoHttpEngine.java
@@ -35,6 +35,7 @@ import org.dcache.services.info.serialisation.XmlSerialiser;
 import org.dcache.util.Args;
 import org.dcache.vehicles.InfoGetSerialisedDataMessage;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.notNull;
 import static com.google.common.base.Throwables.propagate;
 import static com.google.common.collect.Iterables.find;
@@ -160,6 +161,7 @@ public class InfoHttpEngine implements HttpResponseEngine, CellMessageSender
     public InfoHttpEngine(String[] args)
     {
         _infoCellName = new Args(args).getOption("cell");
+        checkArgument(_infoCellName != null, "-cell option is required for InfoHttpEngine handler.");
     }
 
     @Override


### PR DESCRIPTION
Motivation:

When upgrading to dCache 2.16 with a custom httpd.conf, if one forgets to
adjust the configuration to include -cell=${httpd.service.info} in the info
handler, the httpd service throws an NPE and the info handler fails to load.

Modification:

Add a precondition check to ensure that the option was provided. Refactored
the httpd service to propagate instantiation failures and distinguish between
exceptions indicating bugs and exceptions indicating other errors.

Result:

31 maj 2016 10:09:22 (httpd) [] context:httpdSetup: line 21: Command failed
((3) java.lang.IllegalArgumentException: -cell option is required for
InfoHttpEngine handler. from ac_set_alias_$_3_16; caused by: -cell option is
required for InfoHttpEngine handler.)

Target: trunk
Request: 2.16
Require-notes: no
Require-book: no
Fixes: #2476
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9355/

(cherry picked from commit 5b92ef434694a86b2a69f89185f5ae326d60d0a8)