### PR TITLE
billing: Fix NoClassDefFoundError when invoking dcache billing command

### DIFF
--- a/skel/share/lib/billing.sh
+++ b/skel/share/lib/billing.sh
@@ -2,7 +2,8 @@
 billing_indexer() # $* = arguments
 {
     CLASSPATH="$(printLimitedClassPath slf4j-api logback-classic logback-core logback-console-config \
-        jul-to-slf4j commons-compress gson spring-core guava dcache-common common-cli cells dcache-core)" \
+        jul-to-slf4j commons-compress gson spring-core guava dcache-common common-cli cells dcache-core \
+        curator-client)" \
         quickJava \
           "-Ddcache.home=${DCACHE_HOME}" \
           "-Ddcache.paths.defaults=${DCACHE_DEFAULTS}" \


### PR DESCRIPTION
Motivation:

$ dcache billing 0000099A014C0DE146C49BBDC3467BDD51C0
ERROR - Uncaught exception java.lang.NoClassDefFoundError: org/apache/curator/RetryPolicy

Modification:

Add curator-client to list of jar files.

Result:

No NoClassDefFoundError.

Target: trunk
Request: 2.16
Require-notes: no
Require-book: no
Fixes: #2482
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9354/

(cherry picked from commit 6cf3f9566be94eba40f6e9c495dd859e6e2e51f7)