### PR TITLE
billing: re-implement population of aggregate tables

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/IBillingInfoAccess.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/IBillingInfoAccess.java
@@ -149,4 +149,6 @@ public interface IBillingInfoAccess {
      */
     <T> long remove(Class<T> type, String filter, String parameters,
                     Object... values);
+
+    void aggregateDaily();
 }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/datanucleus/DataNucleusBillingInfo.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/datanucleus/DataNucleusBillingInfo.java
@@ -255,4 +255,29 @@ public class DataNucleusBillingInfo extends AbstractBillingInfoAccess {
     {
         this.pmf = pmf;
     }
+
+
+    @Override
+    public void aggregateDaily()
+    {
+        executeStoredProcedure("f_billing_daily_summary()");
+    }
+
+    private void executeStoredProcedure(String name)
+    {
+        PersistenceManager pm = pmf.getPersistenceManager();
+        Transaction tx = pm.currentTransaction();
+        try {
+            tx.begin();
+            Query query = pm.newQuery("javax.jdo.query.SQL","SELECT "+name);
+            query.execute();
+            tx.commit();
+        } finally {
+            try {
+                rollbackIfActive(tx);
+            } finally {
+                pm.close();
+            }
+        }
+    }
 }

--- a/modules/dcache/src/main/resources/META-INF/persistence.xml
+++ b/modules/dcache/src/main/resources/META-INF/persistence.xml
@@ -58,6 +58,7 @@
             <property name="datanucleus.persistenceByReachabilityAtCommit" value="false"/>
             <property name="datanucleus.rdbms.stringLengthExceededAction" value="TRUNCATE"/>
             <property name="datanucleus.query.jdoql.allowAll" value="true"/>
+            <property name="datanucleus.query.sql.allowAll" value="true"/>
             <property name="javax.jdo.option.Optimistic" value="true"/>
             <property name="javax.jdo.option.NontransactionalRead" value="false"/>
             <property name="javax.jdo.option.RetainValues" value="true"/>

--- a/modules/dcache/src/main/resources/org/dcache/services/billing/cells/billing.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/cells/billing.xml
@@ -8,6 +8,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:jee="http://www.springframework.org/schema/jee"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:task="http://www.springframework.org/schema/task"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/jee
                         http://www.springframework.org/schema/jee/spring-jee.xsd
@@ -15,6 +16,8 @@
                         http://www.springframework.org/schema/beans/spring-beans.xsd
                         http://www.springframework.org/schema/context
                         http://www.springframework.org/schema/context/spring-context.xsd
+			http://www.springframework.org/schema/task
+			http://www.springframework.org/schema/task/spring-task.xsd
                         http://www.springframework.org/schema/util
                         http://www.springframework.org/schema/util/spring-util.xsd">
 
@@ -101,5 +104,12 @@
       <property name="changeLog" value="classpath:${billing.db.schema.changelog}"/>
       <property name="shouldUpdate" value="${billing.db.schema.auto}"/>
     </bean>
+
+    <task:scheduled-tasks scheduler="scheduler">
+      <task:scheduled ref="jdbc-billing-info-access" method="aggregateDaily" initial-delay="10000" fixed-delay="#{ T(java.util.concurrent.TimeUnit).DAYS.toMillis(1) }"/>
+    </task:scheduled-tasks>
+
+    <task:scheduler id="scheduler" pool-size="1"/>
   </beans>
+
 </beans>

--- a/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.16.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/db/sql/billing.changelog-2.16.xml
@@ -393,4 +393,592 @@
         </sql>
     </changeSet>
 
+    <changeSet id="9" author="litvinse"  dbms="postgresql">
+        <comment>drop aggregation triggers from fine grained tables</comment>
+
+        <sql>
+	    DROP TRIGGER tgr_update_billinginfo_rd_daily on billinginfo;
+	    DROP TRIGGER tgr_update_billinginfo_wr_daily on billinginfo;
+	    DROP TRIGGER tgr_update_billinginfo_tm_daily on billinginfo;
+            DROP TRIGGER tgr_update_billinginfo_p2p_daily on billinginfo;
+	    DROP TRIGGER tgr_update_storageinfo_wr_daily on storageinfo;
+	    DROP TRIGGER tgr_update_storageinfo_rd_daily on storageinfo;
+	    DROP TRIGGER tgr_update_hitinfo_daily on hitinfo;
+
+	    DROP FUNCTION f_update_billinginfo_wr_daily();
+	    DROP FUNCTION f_update_billinginfo_rd_daily();
+	    DROP FUNCTION f_update_billinginfo_p2p_daily();
+	    DROP FUNCTION f_update_billinginfo_tm_daily();
+	    DROP FUNCTION f_update_storageinfo_rd_daily();
+	    DROP FUNCTION f_update_storageinfo_wr_daily();
+	    DROP FUNCTION f_update_hitinfo_daily();
+
+	</sql>
+
+        <createProcedure>
+            CREATE OR REPLACE FUNCTION f_update_billinginfo_daily() RETURNS VOID
+            AS $$
+            DECLARE
+            max_date   timestamp;
+            curr_date  timestamp;
+	    start_date timestamp;
+	    read_count  numeric;
+	    read_transferred numeric;
+	    read_size  numeric;
+	    write_count numeric;
+	    write_transferred numeric;
+	    write_size  numeric;
+	    p2p_count numeric;
+	    p2p_transferred numeric;
+	    p2p_size  numeric;
+	    min_time bigint;
+	    max_time bigint;
+	    avg_time numeric;
+
+            BEGIN
+            curr_date := current_date;
+            SELECT max(date) into max_date FROM billinginfo_wr_daily;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+                  start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+	       BEGIN
+	          INSERT INTO billinginfo_wr_daily (date,count,size,transferred)
+	             VALUES (start_date,0,0,0);
+	       EXCEPTION WHEN unique_violation THEN
+	          RETURN;
+	       END;
+
+               SELECT COALESCE(sum(CASE WHEN p2p=true THEN 1 ELSE 0 END),0),
+                      COALESCE(sum(CASE WHEN p2p=true THEN transfersize ELSE 0 END),0),
+                      COALESCE(sum(CASE WHEN p2p=true THEN fullsize ELSE 0 END),0),
+                      COALESCE(sum(CASE WHEN p2p=false AND isnew=true THEN 1 ELSE 0 END),0),
+                      COALESCE(sum(CASE WHEN p2p=false AND isnew=true THEN transfersize ELSE 0 END),0),
+                      COALESCE(sum(CASE WHEN p2p=false AND isnew=true THEN fullsize ELSE 0 END),0),
+                      COALESCE(sum(CASE WHEN p2p=false AND isnew=false THEN 1 ELSE 0 END),0),
+                      COALESCE(sum(CASE WHEN p2p=false AND isnew=false THEN transfersize ELSE 0 END),0),
+                      COALESCE(sum(CASE WHEN p2p=false AND isnew=false THEN fullsize ELSE 0 END),0),
+                      COALESCE(min(CASE WHEN p2p=false THEN connectiontime END),0),
+                      COALESCE(max(CASE WHEN p2p=false THEN connectiontime END),0),
+                      COALESCE(avg(CASE WHEN p2p=false THEN connectiontime END),0)
+               INTO p2p_count, p2p_transferred, p2p_size,
+                    write_count, write_transferred, write_size,
+                    read_count, read_transferred, read_size,
+                    min_time, max_time, avg_time
+               FROM billinginfo
+               WHERE date(datestamp) = start_date
+               AND errorcode = 0;
+
+               UPDATE billinginfo_wr_daily
+               SET count=write_count,
+                               size=write_size,
+                                          transferred=write_transferred
+               WHERE date = start_date;
+
+	       BEGIN
+                  INSERT INTO billinginfo_rd_daily(date,count,size,transferred)
+                     VALUES(start_date,read_count,read_size,read_transferred);
+	       EXCEPTION WHEN unique_violation THEN
+                  --- ignore
+	       END;
+
+	       BEGIN
+                  INSERT INTO billinginfo_p2p_daily(date,count,size,transferred)
+                     VALUES(start_date,p2p_count,p2p_size,p2p_transferred);
+               EXCEPTION WHEN unique_violation THEN
+                  --- ignore
+               END;
+
+               BEGIN
+                  INSERT INTO billinginfo_tm_daily(date,count,minimum,maximum,average)
+                     VALUES(start_date,read_count+write_count,min_time,max_time,avg_time);
+               EXCEPTION WHEN unique_violation THEN
+	             --- ignore
+               END;
+
+	    END IF;
+            END;
+            $$
+            LANGUAGE plpgsql;
+        </createProcedure>
+
+        <createProcedure>
+            CREATE OR REPLACE FUNCTION f_update_storageinfo_daily() RETURNS VOID
+            AS $$
+            DECLARE
+            max_date timestamp;
+            curr_date timestamp;
+	    start_date timestamp;
+	    restore_count numeric;
+	    restore_bytes numeric;
+	    store_count numeric;
+	    store_bytes numeric;
+
+            BEGIN
+            curr_date := current_date;
+            SELECT max(date) into max_date FROM storageinfo_rd_daily;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+	          start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+	       BEGIN
+                  INSERT INTO storageinfo_rd_daily (date,count,size)
+                     VALUES (start_date,0,0);
+	       EXCEPTION WHEN unique_violation THEN
+	          RETURN;
+	       END;
+
+               SELECT COALESCE(sum(CASE WHEN action='store'   THEN 1 ELSE 0 END),0),
+                      COALESCE(sum(CASE WHEN action='store'   THEN fullsize ELSE 0 END),0),
+	              COALESCE(sum(CASE WHEN action='restore' THEN 1 ELSE 0 END),0),
+	              COALESCE(sum(CASE WHEN action='restore' THEN fullsize ELSE 0 END),0)
+               INTO store_count, store_bytes,
+	            restore_count, restore_bytes
+               FROM storageinfo
+               WHERE date(datestamp) = start_date
+               AND errorcode = 0;
+
+
+               UPDATE storageinfo_rd_daily
+               SET count=restore_count,
+                               size=restore_bytes
+               WHERE date = start_date;
+
+               BEGIN
+	          INSERT INTO storageinfo_wr_daily(date,count,size)
+                     VALUES(start_date,store_count,store_bytes);
+	       EXCEPTION WHEN unique_violation THEN
+                  --- ignore
+               END;
+
+            END IF;
+
+            END;
+            $$
+            LANGUAGE plpgsql;
+        </createProcedure>
+
+        <createProcedure>
+	    CREATE OR REPLACE FUNCTION f_update_hitinfo_daily() RETURNS VOID
+            AS $$
+            DECLARE
+            max_date timestamp;
+            curr_date timestamp;
+            start_date timestamp;
+
+            BEGIN
+            curr_date := current_date;
+            SELECT max(date) into max_date FROM hitinfo_daily;
+
+	    IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+               IF max_date IS NULL THEN
+                  start_date := curr_date - interval'1 day';
+               ELSE
+                  start_date := max_date+interval'1 day';
+               END IF;
+
+	       BEGIN
+	          INSERT INTO hitinfo_daily(date, count, notcached, cached)
+                     VALUES (start_date,0,0,0);
+	       EXCEPTION WHEN unique_violation THEN
+	          RETURN;
+	       END;
+
+               UPDATE hitinfo_daily
+               SET count=dummy.count,
+                               notcached=dummy.notcached,
+                                          cached=dummy.cached
+
+               FROM
+                  (SELECT COUNT(*) AS count,
+                          COUNT(nullif(filecached, 't')) AS notcached,
+	                   COUNT(nullif(filecached, 'f')) AS cached
+                   FROM hitinfo
+                   WHERE date(datestamp) = start_date
+                      AND errorcode=0) AS dummy
+               WHERE date = start_date;
+
+            END IF;
+            END;
+            $$
+            LANGUAGE plpgsql;
+        </createProcedure>
+
+        <createProcedure>
+	  CREATE OR REPLACE FUNCTION f_billing_daily_summary() RETURNS VOID
+                AS $$
+                BEGIN
+	           PERFORM f_update_billinginfo_daily();
+	           PERFORM f_update_storageinfo_daily();
+	           PERFORM f_update_hitinfo_daily();
+                END;
+                $$
+                LANGUAGE plpgsql;
+        </createProcedure>
+
+	<rollback>
+	    <sql>
+	      drop function f_update_hitinfo_daily();
+	      drop function f_update_storageinfo_daily();
+	      drop function f_update_billinginfo_daily();
+	      drop function f_billing_daily_summary();
+	    </sql>
+	    <createProcedure>
+                CREATE OR REPLACE FUNCTION f_update_billinginfo_wr_daily() RETURNS TRIGGER
+                AS $$
+                DECLARE
+                max_date timestamp;
+                curr_date timestamp;
+                start_date timestamp;
+                counter bigint;
+                BEGIN
+                curr_date := current_date;
+                SELECT max(date) into max_date FROM billinginfo_wr_daily;
+
+                IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+                   IF max_date IS NULL THEN
+                      start_date := curr_date - interval'1 day';
+                   ELSE
+                      start_date := max_date+interval'1 day';
+                   END IF;
+
+                   BEGIN
+                      INSERT INTO billinginfo_wr_daily (date,count,size,transferred)
+                      SELECT date(datestamp) AS d,
+                             COUNT(*), coalesce(sum(fullsize),0),
+                                       coalesce(sum(transfersize),0)
+                      FROM billinginfo
+                      WHERE datestamp BETWEEN start_date AND curr_date
+                         AND isnew='t'
+                         AND errorcode=0
+                         AND p2p='f'
+                      GROUP BY d RETURNING count INTO counter;
+
+                      IF counter is NULL THEN
+                         INSERT INTO billinginfo_wr_daily (date,count,size,transferred)
+                             VALUES (start_date,0,0,0);
+                      END IF;
+
+                      EXCEPTION WHEN       unique_violation THEN
+                         --- do nothing ---
+                   END;
+
+                END IF;
+                RETURN NULL;
+                END;
+                $$
+                LANGUAGE plpgsql;
+
+                CREATE TRIGGER tgr_update_billinginfo_wr_daily AFTER INSERT ON billinginfo
+                FOR EACH ROW EXECUTE PROCEDURE f_update_billinginfo_wr_daily();
+            </createProcedure>
+
+	    <createProcedure>
+                CREATE OR REPLACE FUNCTION f_update_billinginfo_rd_daily() RETURNS TRIGGER
+                AS $$
+                DECLARE
+                max_date timestamp;
+                curr_date timestamp;
+                start_date timestamp;
+                counter bigint;
+                BEGIN
+                curr_date := current_date;
+                SELECT max(date) into max_date FROM billinginfo_rd_daily;
+
+                IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+                   IF max_date IS NULL THEN
+                      start_date := curr_date - interval'1 day';
+                   ELSE
+                      start_date := max_date+interval'1 day';
+                   END IF;
+
+		   BEGIN
+                      INSERT INTO billinginfo_rd_daily (date,count,size,transferred)
+                      SELECT date(datestamp) AS d,
+                             COUNT(*), coalesce(sum(fullsize),0),
+                                       coalesce(sum(transfersize),0)
+                      FROM billinginfo
+                      WHERE datestamp BETWEEN start_date AND curr_date
+                          AND isnew='f'
+                          AND errorcode=0
+                          AND p2p = 'f'
+                      GROUP BY d RETURNING count INTO counter;
+
+                      IF counter is NULL THEN
+                         INSERT INTO billinginfo_rd_daily (date,count,size,transferred)
+                         VALUES (start_date,0,0,0);
+                      END IF;
+
+                      EXCEPTION WHEN       unique_violation THEN
+                         --- do nothing ---
+                   END;
+
+                END IF;
+                RETURN NULL;
+                END;
+                $$
+                LANGUAGE plpgsql;
+
+                CREATE TRIGGER tgr_update_billinginfo_rd_daily AFTER INSERT ON billinginfo
+                FOR EACH ROW EXECUTE PROCEDURE f_update_billinginfo_rd_daily();
+	    </createProcedure>
+
+	    <createProcedure>
+                CREATE OR REPLACE FUNCTION f_update_billinginfo_p2p_daily() RETURNS TRIGGER
+                AS $$
+                DECLARE
+                max_date timestamp;
+                curr_date timestamp;
+                start_date timestamp;
+                counter bigint;
+                BEGIN
+                curr_date := current_date;
+                SELECT max(date) into max_date FROM billinginfo_p2p_daily;
+
+                IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+                   IF max_date IS NULL THEN
+                      start_date := curr_date - interval'1 day';
+                   ELSE
+                      start_date := max_date+interval'1 day';
+                   END IF;
+
+                   BEGIN
+                      INSERT INTO billinginfo_p2p_daily (date,count,size,transferred)
+                      SELECT date(datestamp) AS d,
+                             COUNT(*), coalesce(sum(fullsize),0),
+                                        coalesce(sum(transfersize),0)
+                      FROM billinginfo
+                      WHERE datestamp BETWEEN start_date AND curr_date
+                          AND errorcode=0
+                          AND p2p='t'
+                      GROUP BY d RETURNING count INTO counter;
+
+                      IF counter is NULL THEN
+                         INSERT INTO billinginfo_p2p_daily (date,count,size,transferred)
+                         VALUES (start_date,0,0,0);
+                      END IF;
+
+                      EXCEPTION WHEN       unique_violation THEN
+                         --- do nothing ---
+                   END;
+
+                END IF;
+                RETURN NULL;
+                END;
+                $$
+                LANGUAGE plpgsql;
+
+                CREATE TRIGGER tgr_update_billinginfo_p2p_daily AFTER INSERT ON billinginfo
+                FOR EACH ROW EXECUTE PROCEDURE f_update_billinginfo_p2p_daily();
+	    </createProcedure>
+
+	    <createProcedure>
+                CREATE OR REPLACE FUNCTION f_update_billinginfo_tm_daily() RETURNS TRIGGER
+                AS $$
+                DECLARE
+                max_date timestamp;
+                curr_date timestamp;
+                start_date timestamp;
+                counter bigint;
+                BEGIN
+                curr_date := current_date;
+                SELECT max(date) into max_date FROM billinginfo_tm_daily;
+
+                IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+                   IF max_date IS NULL THEN
+                      start_date := curr_date - interval'1 day';
+                   ELSE
+                      start_date := max_date+interval'1 day';
+                   END IF;
+
+                   BEGIN
+                      INSERT INTO billinginfo_tm_daily (date,count,minimum,maximum,average)
+                      SELECT date(datestamp) AS d,
+                             COUNT(*), min(connectiontime),
+                                       max(connectiontime),
+                                       avg(connectiontime)
+                      FROM billinginfo
+                      WHERE datestamp BETWEEN start_date AND curr_date
+                          AND errorcode=0
+                      GROUP BY d RETURNING count INTO counter;
+
+                      IF counter is NULL THEN
+                         INSERT INTO billinginfo_tm_daily (date,count,minimum,maximum,average)
+                         VALUES (start_date,0,0,0,0);
+                      END IF;
+
+                      EXCEPTION WHEN       unique_violation THEN
+                         --- do nothing ---
+                   END;
+
+                END IF;
+                RETURN NULL;
+                END;
+                $$
+                LANGUAGE
+                plpgsql;
+
+                CREATE TRIGGER tgr_update_billinginfo_tm_daily AFTER INSERT ON billinginfo
+                FOR EACH ROW EXECUTE PROCEDURE f_update_billinginfo_tm_daily();
+	    </createProcedure>
+
+	    <createProcedure>
+                CREATE OR REPLACE FUNCTION f_update_storageinfo_rd_daily() RETURNS TRIGGER
+                AS $$
+                DECLARE
+                max_date timestamp;
+                curr_date timestamp;
+                start_date timestamp;
+                counter bigint;
+                BEGIN
+                curr_date := current_date;
+                SELECT max(date) into max_date FROM storageinfo_rd_daily;
+
+                IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+                   IF max_date IS NULL THEN
+                      start_date := curr_date - interval'1 day';
+                   ELSE
+                      start_date := max_date+interval'1 day';
+                   END IF;
+
+                   BEGIN
+                      INSERT INTO storageinfo_rd_daily (date,count,size)
+                      SELECT date(datestamp) AS d,
+                             COUNT(*), coalesce(sum(fullsize),0)
+                      FROM storageinfo
+                      WHERE datestamp BETWEEN start_date AND curr_date
+                          AND action='restore'
+                          AND errorcode=0
+                      GROUP BY d RETURNING count INTO counter;
+
+                      IF counter is NULL THEN
+                         INSERT INTO storageinfo_rd_daily (date,count,size)
+                         VALUES (start_date,0,0);
+                      END IF;
+                      EXCEPTION WHEN       unique_violation THEN
+                         --- do nothing ---
+                   END;
+                END IF;
+                RETURN NULL;
+                END;
+                $$
+                LANGUAGE plpgsql;
+
+                CREATE TRIGGER tgr_update_storageinfo_rd_daily AFTER INSERT ON storageinfo
+                FOR EACH ROW EXECUTE PROCEDURE f_update_storageinfo_rd_daily();
+	    </createProcedure>
+
+	    <createProcedure>
+                CREATE OR REPLACE FUNCTION f_update_storageinfo_wr_daily() RETURNS TRIGGER
+                AS $$
+                DECLARE
+                max_date timestamp;
+                curr_date timestamp;
+                start_date timestamp;
+                counter bigint;
+                BEGIN
+                curr_date := current_date;
+                SELECT max(date) into max_date FROM storageinfo_wr_daily;
+
+                IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+                   IF max_date IS NULL THEN
+                      start_date := curr_date - interval'1 day';
+                   ELSE
+                      start_date := max_date+interval'1 day';
+                   END IF;
+
+		   BEGIN
+                      INSERT INTO storageinfo_wr_daily (date,count,size)
+                      SELECT date(datestamp) AS d,
+                             COUNT(*), coalesce(sum(fullsize),0)
+                      FROM storageinfo
+                      WHERE datestamp BETWEEN start_date AND curr_date
+                          AND action='store'
+                          AND errorcode=0
+                      GROUP BY d RETURNING count INTO counter;
+
+                      IF counter is NULL THEN
+                         INSERT INTO storageinfo_wr_daily (date,count,size)
+                         VALUES (start_date,0,0);
+                      END IF;
+                      EXCEPTION WHEN       unique_violation THEN
+                         --- do nothing ---
+                   END;
+                END IF;
+                RETURN NULL;
+                END;
+                $$
+                LANGUAGE plpgsql;
+
+                CREATE TRIGGER tgr_update_storageinfo_wr_daily AFTER INSERT ON storageinfo
+                FOR EACH ROW EXECUTE PROCEDURE f_update_storageinfo_wr_daily();
+	    </createProcedure>
+
+	    <createProcedure>
+                CREATE OR REPLACE FUNCTION f_update_hitinfo_daily() RETURNS TRIGGER
+                AS $$
+
+                DECLARE
+                max_date timestamp;
+                curr_date timestamp;
+                start_date timestamp;
+                counter bigint;
+                BEGIN
+                curr_date := current_date;
+                SELECT max(date) into max_date FROM hitinfo_daily;
+
+                 IF max_date IS NULL OR curr_date - max_date > interval'1 days' THEN
+
+                   IF max_date IS NULL THEN
+                      start_date := curr_date - interval'1 day';
+                   ELSE
+                      start_date := max_date+interval'1 day';
+                   END IF;
+
+                   BEGIN
+                      INSERT INTO hitinfo_daily(date, count, notcached, cached)
+                      SELECT date(datestamp) AS d,
+                             COUNT(*), COUNT(nullif(filecached, 't')) AS notcached,
+                                            COUNT(nullif(filecached, 'f')) AS cached
+                      FROM hitinfo
+                      WHERE datestamp BETWEEN start_date AND curr_date
+                          AND errorcode=0
+                      GROUP BY d RETURNING count INTO counter;
+
+                      IF counter is NULL THEN
+                         INSERT INTO hitinfo_daily(date, count, notcached, cached)
+                         VALUES (start_date,0,0,0);
+                      END IF;
+                      EXCEPTION WHEN       unique_violation THEN
+                         --- do nothing ---
+                   END;
+                END IF;
+                RETURN NULL;
+                END;
+                $$
+                LANGUAGE plpgsql;
+
+                CREATE TRIGGER tgr_update_hitinfo_daily AFTER INSERT ON hitinfo
+                FOR EACH ROW EXECUTE PROCEDURE f_update_hitinfo_daily();
+	    </createProcedure>
+	</rollback>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Motivation:

Billing relied on database triggers to populate aggregate daily summary
tables on inserts in per transaction based tables. Although the triggers have
been engineered to be executed once daily to minimize their impact on insert
rate into per transaction based tables, we still encountered issues when
transaction based tables are populated concurrently.

Modification:

This patch removes on insert triggers completely replacing them with a
background thread that populates aggregate tables once a day.

Result:

Eliminated impact on insert rate into per transaction based tables.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.16
Acked-by: Gerd Behrmann <behrmann@gmail.com>
Acked-by: Paul Millar <paul.millar@desy.de>
Reviewed at https://rb.dcache.org/r/9313/
(cherry picked from commit 8e4253dd3c85bbee77dc7302e0f9af0666302554)