### PR TITLE
srm: Fix listing of completed list requests

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/SrmCommandLineInterface.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SrmCommandLineInterface.java
@@ -463,15 +463,15 @@ public class SrmCommandLineInterface
         }
 
         private void listLatestCompletedLsRequests(StringBuilder sb, int maxCount) throws DataAccessException {
-            listRequests(sb, srm.getLsRequestStorage().getLatestCompletedJobIds(maxCount), ReserveSpaceRequest.class);
+            listRequests(sb, srm.getLsRequestStorage().getLatestCompletedJobIds(maxCount), LsRequest.class);
         }
 
         private void listLatestFailedLsRequests(StringBuilder sb, int maxCount) throws DataAccessException {
-            listRequests(sb, srm.getLsRequestStorage().getLatestFailedJobIds(maxCount), ReserveSpaceRequest.class);
+            listRequests(sb, srm.getLsRequestStorage().getLatestFailedJobIds(maxCount), LsRequest.class);
         }
 
         private void listLatestCancelledLsRequests(StringBuilder sb, int maxCount) throws DataAccessException {
-            listRequests(sb, srm.getLsRequestStorage().getLatestCanceledJobIds(maxCount), ReserveSpaceRequest.class);
+            listRequests(sb, srm.getLsRequestStorage().getLatestCanceledJobIds(maxCount), LsRequest.class);
         }
 
         private <T extends Job> void listRequests(StringBuilder sb,

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/LsRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/LsRequest.java
@@ -26,6 +26,8 @@ import org.dcache.srm.v2_2.TRequestType;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.util.TimeUtils.relativeTimestamp;
+
 public final class LsRequest extends ContainerRequest<LsFileRequest> {
     private final static Logger logger =
             LoggerFactory.getLogger(LsRequest.class);
@@ -436,27 +438,30 @@ public final class LsRequest extends ContainerRequest<LsFileRequest> {
 
         @Override
         public void toString(StringBuilder sb, boolean longformat) {
-                sb.append(getMethod()).append("Request #").append(getId()).append(" created by ").append(getUser());
-                sb.append(" state = ").append(getState());
-                sb.append("\n SURL(s) : ");
-                for (LsFileRequest fr: getFileRequests()) {
-                        sb.append(fr.getSurlString()).append(" ");
+            sb.append(getNameForRequestType()).append(" id:").append(getId());
+            sb.append(" files:").append(getFileRequests().size());
+            sb.append(" state:").append(getState());
+            TStatusCode code = getStatusCode();
+            if (code != null) {
+                sb.append(" status:").append(code);
+            }
+            sb.append(" by:").append(getUser().getDisplayName());
+            if (longformat) {
+                sb.append('\n');
+                long now = System.currentTimeMillis();
+                sb.append("   Submitted: ").append(relativeTimestamp(getCreationTime(), now)).append('\n');
+                sb.append("   Expires: ").append(relativeTimestamp(getCreationTime() + getLifetime(), now)).append('\n');
+                sb.append("   Count      : ").append(getCount()).append('\n');
+                sb.append("   Offset     : ").append(getOffset()).append('\n');
+                sb.append("   LongFormat : ").append(getLongFormat()).append('\n');
+                sb.append("   NumOfLevels: ").append(getNumOfLevels()).append('\n');
+                sb.append("   History:\n");
+                sb.append(getHistory("   "));
+                for (LsFileRequest fr:getFileRequests()) {
+                    sb.append("\n");
+                    fr.toString(sb, "   ", true);
                 }
-                sb.append("\n count      : ").append(getCount());
-                sb.append("\n offset     : ").append(getOffset());
-                sb.append("\n longFormat : ").append(getLongFormat());
-                sb.append("\n numOfLevels: ").append(getNumOfLevels());
-                if(longformat) {
-                        sb.append("\n status code=").append(getStatusCode());
-                        sb.append("\n error message=").append(getErrorMessage());
-                        sb.append("\n History of State Transitions: \n");
-                        sb.append(getHistory());
-                        for (LsFileRequest fr: getFileRequests()) {
-                                fr.toString(sb,longformat);
-                        }
-                } else {
-                    sb.append(" number of surls in request:").append(getFileRequests().size());
-                }
+            }
         }
 
     /**


### PR DESCRIPTION
Motivation:

The `ls -completed=n` command has been observed to fail with
SRMInvalidRequestException.

Modification:

This was caused by a copu'n'paste error in the job type to load. The
code tried to load reservation jobs instead of list jobs. This has
been fixed.

Also changed the formatting of the list request to match that of other
container requests.

Result:

Fixed a problem in which `ls -completed` in the srm/srmmanager service
would produce an SRMInvalidRequestException error in the log file. The
output format of listing list requests has been changed to match that
of other requests.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Request: 2.12
Request: 2.11
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9358/

(cherry picked from commit ec6df2f9489b4e0adc75da8b51b768908be30229)