### PR TITLE
pool: Fix regressions in meta data utilities

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/DummyFileStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/DummyFileStore.java
@@ -1,0 +1,71 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.pool.repository;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+import diskCacheV111.util.PnfsId;
+
+/**
+ * File store to be used with meta data utilities. Returns the same temporary file for
+ * all PNFS IDs.
+ */
+class DummyFileStore implements FileStore
+{
+    public final File file;
+
+    DummyFileStore() throws IOException
+    {
+        file = File.createTempFile("dcache-yaml-tool", null);
+        file.deleteOnExit();
+    }
+
+    @Override
+    public File get(PnfsId id)
+    {
+        return file;
+    }
+
+    @Override
+    public Set<PnfsId> index()
+    {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public long getFreeSpace()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getTotalSpace()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isOk()
+    {
+        return false;
+    }
+}

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStore.java
@@ -1,5 +1,6 @@
 package org.dcache.pool.repository;
 
+import java.io.Closeable;
 import java.util.Set;
 
 import diskCacheV111.util.CacheException;
@@ -13,7 +14,7 @@ import diskCacheV111.util.PnfsId;
  * the interface is used as an abstraction over both meta data storage
  * and file storage.
  */
-public interface MetaDataStore
+public interface MetaDataStore extends Closeable
 {
     enum IndexOption
     {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreCopyTool.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreCopyTool.java
@@ -38,30 +38,31 @@ public class MetaDataStoreCopyTool
 
         File poolDir = new File(args[0]);
         FileStore fileStore = new DummyFileStore();
-        MetaDataStore fromStore =
-            createStore(Class.forName(args[1]).asSubclass(MetaDataStore.class), fileStore, poolDir, true);
-        MetaDataStore toStore =
-            createStore(Class.forName(args[2]).asSubclass(MetaDataStore.class), fileStore, poolDir, false);
-        fromStore.init();
-        toStore.init();
+        try (MetaDataStore fromStore =
+                     createStore(Class.forName(args[1]).asSubclass(MetaDataStore.class), fileStore, poolDir, true);
+             MetaDataStore toStore =
+                     createStore(Class.forName(args[2]).asSubclass(MetaDataStore.class), fileStore, poolDir, false)) {
+            fromStore.init();
+            toStore.init();
 
-        if (!toStore.index(MetaDataStore.IndexOption.META_ONLY).isEmpty()) {
-            System.err.println("ERROR: Target store is not empty");
-            System.exit(1);
-        }
-
-        Collection<PnfsId> ids = fromStore.index(MetaDataStore.IndexOption.META_ONLY);
-        int size = ids.size();
-        int count = 1;
-        for (PnfsId id: ids) {
-            _log.info("Copying {} ({} of {})", id, count, size);
-            MetaDataRecord entry = fromStore.get(id);
-            if (entry == null) {
-                System.err.println("Failed to load " + id);
+            if (!toStore.index(MetaDataStore.IndexOption.META_ONLY).isEmpty()) {
+                System.err.println("ERROR: Target store is not empty");
                 System.exit(1);
             }
-            toStore.copy(entry);
-            count++;
+
+            Collection<PnfsId> ids = fromStore.index(MetaDataStore.IndexOption.META_ONLY);
+            int size = ids.size();
+            int count = 1;
+            for (PnfsId id : ids) {
+                _log.info("Copying {} ({} of {})", id, count, size);
+                MetaDataRecord entry = fromStore.get(id);
+                if (entry == null) {
+                    System.err.println("Failed to load " + id);
+                    System.exit(1);
+                }
+                toStore.copy(entry);
+                count++;
+            }
         }
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreYamlTool.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreYamlTool.java
@@ -39,64 +39,65 @@ public class MetaDataStoreYamlTool
 
         File poolDir = new File(args[0]);
         FileStore fileStore = new DummyFileStore();
-        MetaDataStore metaStore =
-            createStore(Class.forName(args[1]).asSubclass(MetaDataStore.class), fileStore, poolDir);
-        metaStore.init();
+        try (MetaDataStore metaStore =
+                     createStore(Class.forName(args[1]).asSubclass(MetaDataStore.class), fileStore, poolDir)) {
+            metaStore.init();
 
-        PrintWriter out = new PrintWriter(System.out);
-        PrintWriter error = new PrintWriter(System.err);
-        for (PnfsId id: metaStore.index(MetaDataStore.IndexOption.META_ONLY)) {
-            try {
-                MetaDataRecord record = metaStore.get(id);
-                if (record == null) {
-                    continue;
-                }
-                FileAttributes attributes = record.getFileAttributes();
+            PrintWriter out = new PrintWriter(System.out);
+            PrintWriter error = new PrintWriter(System.err);
+            for (PnfsId id : metaStore.index(MetaDataStore.IndexOption.META_ONLY)) {
+                try {
+                    MetaDataRecord record = metaStore.get(id);
+                    if (record == null) {
+                        continue;
+                    }
+                    FileAttributes attributes = record.getFileAttributes();
 
-                out.format("%s:\n", id);
-                out.format("  state: %s\n", record.getState());
-                out.format("  sticky:\n");
-                for (StickyRecord sticky : record.stickyRecords()) {
-                    out.format("    %s: %d\n", sticky.owner(), sticky.expire());
-                }
-                if (attributes.isDefined(FileAttribute.STORAGECLASS)) {
-                    out.format("  storageclass: %s\n", attributes.getStorageClass());
-                }
-                if (attributes.isDefined(FileAttribute.CACHECLASS)) {
-                    out.format("  cacheclass: %s\n", attributes.getCacheClass());
-                }
-                if (attributes.isDefined(FileAttribute.STORAGEINFO)) {
-                    StorageInfo info = attributes.getStorageInfo();
-                    out.format("  bitfileid: %s\n", info.getBitfileId());
-                    out.format("  locations:\n");
-                    for (URI location : info.locations()) {
-                        out.format("    - %s\n", location);
+                    out.format("%s:\n", id);
+                    out.format("  state: %s\n", record.getState());
+                    out.format("  sticky:\n");
+                    for (StickyRecord sticky : record.stickyRecords()) {
+                        out.format("    %s: %d\n", sticky.owner(), sticky.expire());
                     }
-                }
-                if (attributes.isDefined(FileAttribute.HSM)) {
-                    out.format("  hsm: %s\n", attributes.getHsm());
-                }
-                if (attributes.isDefined(FileAttribute.SIZE)) {
-                    out.format("  filesize: %s\n", attributes.getSize());
-                }
-                if (attributes.isDefined(FileAttribute.FLAGS)) {
-                    out.format("  map:\n");
-                    for (Map.Entry<String, String> entry : attributes.getFlags().entrySet()) {
-                        out.format("    %s: %s\n", entry.getKey(), entry.getValue());
+                    if (attributes.isDefined(FileAttribute.STORAGECLASS)) {
+                        out.format("  storageclass: %s\n", attributes.getStorageClass());
                     }
+                    if (attributes.isDefined(FileAttribute.CACHECLASS)) {
+                        out.format("  cacheclass: %s\n", attributes.getCacheClass());
+                    }
+                    if (attributes.isDefined(FileAttribute.STORAGEINFO)) {
+                        StorageInfo info = attributes.getStorageInfo();
+                        out.format("  bitfileid: %s\n", info.getBitfileId());
+                        out.format("  locations:\n");
+                        for (URI location : info.locations()) {
+                            out.format("    - %s\n", location);
+                        }
+                    }
+                    if (attributes.isDefined(FileAttribute.HSM)) {
+                        out.format("  hsm: %s\n", attributes.getHsm());
+                    }
+                    if (attributes.isDefined(FileAttribute.SIZE)) {
+                        out.format("  filesize: %s\n", attributes.getSize());
+                    }
+                    if (attributes.isDefined(FileAttribute.FLAGS)) {
+                        out.format("  map:\n");
+                        for (Map.Entry<String, String> entry : attributes.getFlags().entrySet()) {
+                            out.format("    %s: %s\n", entry.getKey(), entry.getValue());
+                        }
+                    }
+                    if (attributes.isDefined(FileAttribute.RETENTION_POLICY)) {
+                        out.format("  retentionpolicy: %s\n", attributes.getRetentionPolicy());
+                    }
+                    if (attributes.isDefined(FileAttribute.ACCESS_LATENCY)) {
+                        out.format("  accesslatency: %s\n", attributes.getAccessLatency());
+                    }
+                } catch (CacheException e) {
+                    error.println("Failed to read " + id + ": " + e.getMessage());
                 }
-                if (attributes.isDefined(FileAttribute.RETENTION_POLICY)) {
-                    out.format("  retentionpolicy: %s\n", attributes.getRetentionPolicy());
-                }
-                if (attributes.isDefined(FileAttribute.ACCESS_LATENCY)) {
-                    out.format("  accesslatency: %s\n", attributes.getAccessLatency());
-                }
-            } catch (CacheException e) {
-                error.println("Failed to read " + id + ": " + e.getMessage());
             }
+            out.flush();
+            error.flush();
         }
-        out.flush();
-        error.flush();
     }
 
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreYamlTool.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataStoreYamlTool.java
@@ -38,7 +38,7 @@ public class MetaDataStoreYamlTool
         }
 
         File poolDir = new File(args[0]);
-        FileStore fileStore = new FlatFileStore(poolDir);
+        FileStore fileStore = new DummyFileStore();
         MetaDataStore metaStore =
             createStore(Class.forName(args[1]).asSubclass(MetaDataStore.class), fileStore, poolDir);
         metaStore.init();
@@ -97,5 +97,6 @@ public class MetaDataStoreYamlTool
         }
         out.flush();
         error.flush();
-   }
+    }
+
 }


### PR DESCRIPTION
Motivation:

Recent refactoring has left the meta data utilities with several
undesirable features:

- They only act upon entries for which a data file exists - even though
  this was originally considered a feature, it makes it difficult to
  use the utilities for forensic analysis on a clone of the meta data.
  It also slows down the utilities.

- The copy utility would open the source repository in read write mode.
  This is particularly bad for the berkeley db as it will perform background
  cleaning of the db if not opened in read only mode.

Modification:

Adds a dummy file store whos only purpose is to provide a file that
exists, allowing the meta data stores to return the meta data without
the actual data files being present.

Opens the source store in read only mode.

Adds a consistency check to the copy tool to avoid a null pointer
exception.

Result:

Fixes a couple of regressions in the pool meta data utilities. The `dcache pool
convert` command now opens the source database in read-only mode, preventing
that the source is modified. Both the `dcache pool yaml` and `dcache pool
convert` commands now work without accessing the data files, making them faster
and allowing them to be used without the data files being present.

Target: trunk
Request: 2.16
Request: 2.15
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9361/

(cherry picked from commit cc2eb798560574699ed24492315fc8e0d4a05ee7)