### PR TITLE
pool: Fix race in pool initialization

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCache.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCache.java
@@ -490,7 +490,7 @@ public class MetaDataCache
     public void init() throws CacheException
     {
         for (PnfsId id: _inner.index(IndexOption.ALLOW_REPAIR)) {
-            _entries.put(id, new Monitor(id));
+            _entries.putIfAbsent(id, new Monitor(id));
         }
     }
 


### PR DESCRIPTION
Motivation:

Since 2.15, pools can eagerly load the meta data of files being opened
even before the initial index has been build. If this happens, the
cache entry may be overwritten, breaking the invariant that the cache
always returns the same entry.

Modification:

Only add a new entry if it doesn't already exist.

Result:

Fixed a race condition in pool startup that could lead to invalid link
counts, resulting in premature deletion of files still open.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9364/

(cherry picked from commit ff48c27bdf2580ce1ae5087bc9ba93d8560237f8)