### PR TITLE
Disable OCSP by default

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -664,8 +664,13 @@ dcache.authn.crl-mode=REQUIRE
 #
 #	   Do not use OCSP.
 #
+#
+# Although OCSP lookups are cached for an hour, the refresh when the cache expires blocks new
+# client requests. In case of networks problems such refresh would block connections until the
+# TCP connection of the refresh times out.  For this reason the default is IGNORE.
+#
 (one-of?REQUIRE|IF_AVAILABLE|IGNORE)\
-dcache.authn.ocsp-mode=IF_AVAILABLE
+dcache.authn.ocsp-mode=IGNORE
 
 
 # ---- Flags to disable ciphers


### PR DESCRIPTION
Motivation:

Even when OCSP support is set to IF_VALID, I non-responding OCSP server
can bring down a dCache because caNl wait for the OCSP server to respond.

We have been requested to adjust our default setting to disable OCSP
as WLCG isn't ready to rely on OCSP for production.

Modification:

Change the default for dcache.authn.ocsp-mode to IGNORE.

Result:

OCSP support is disabled by default.

Target: trunk
Request: 2.16
Require-notes: yes
Require-book: yes
Fixes: #2474
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9351/

(cherry picked from commit 74f09171b7125f04cc3c12d651a57d995864a572)