### PR TITLE
srm: Fix job expiration during service startup

### DIFF
--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -585,6 +585,7 @@
     <property name="schedulers" ref="schedulers"/>
     <property name="requestCredentialStorage" ref="srm-credential-store"/>
     <property name="srmUserPersistenceManager" ref="user-manager"/>
+    <property name="executor" ref="scheduledExecutor"/>
   </bean>
 
   <bean id="srm-cli" class="org.dcache.srm.SrmCommandLineInterface">

--- a/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
@@ -87,10 +87,15 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -165,6 +170,8 @@ public class SRM implements CellLifeCycleAware
     private SchedulerContainer schedulers;
     private DatabaseJobStorageFactory databaseFactory;
     private SRMUserPersistenceManager manager;
+    private ScheduledExecutorService executor;
+    private final List<Future<?>> tasks = new ArrayList<>();
 
     private static SRM srm;
 
@@ -284,6 +291,12 @@ public class SRM implements CellLifeCycleAware
         this.manager = checkNotNull(manager);
     }
 
+    @Required
+    public void setExecutor(java.util.concurrent.ScheduledExecutorService executor)
+    {
+        this.executor = checkNotNull(executor);
+    }
+
     public static final synchronized void setSRM(SRM srm)
     {
         SRM.srm = srm;
@@ -324,11 +337,23 @@ public class SRM implements CellLifeCycleAware
     public void afterStart()
     {
         databaseFactory.restoreJobsOnSrmStart(schedulers);
+
+        /* Schedule expiration of active jobs individually for each job storage to
+         * break expiration into smaller tasks.
+         */
+        for (JobStorage<?> jobStorage : databaseFactory.getJobStorages().values()) {
+            tasks.add(executor.scheduleWithFixedDelay(() -> {
+                for (Job job : jobStorage.getActiveJobs()) {
+                    job.checkExpiration();
+                }
+            }, 509, 509, TimeUnit.SECONDS));
+        }
     }
 
     @Override
     public void beforeStop()
     {
+        tasks.forEach(f -> f.cancel(false));
     }
 
     public void stop() throws InterruptedException
@@ -1287,4 +1312,5 @@ public class SRM implements CellLifeCycleAware
     {
         return Iterables.filter(getActiveJobs(type), request -> request.isTouchingSurl(surl));
     }
+
 }


### PR DESCRIPTION
Motivation:

Job expiration was implemented as part of the SharedMemoryCacheJobStorage.
This was done because in a Terracotta based setup only this component knew
if a job was local to this instance.

Upon startup, the expiration jobs are scheduled during job storage
initialization. This means that jobs may be marked as expired even before they
have been processed by the restart logic, thus resulting in wrong job counts.
Since 2.15 cell communication is also not enabled until after cell startup
has completed, and thus upload expiration fails due to failure to communicate
with PnfsManager.

Modification:

Since we no longer support Terracotta, the expiration can be moved out of
the job storage and into the main SRM class.

Result:

Fixed race conditions during SRM startup that could lead to failures to
expire jobs and to wrong job counts in the SRM schedulers.

Target: trunk
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Fixes: #2477
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9369/

(cherry picked from commit 61d13ef39c81009693a32a450f0e8edb1356bc7f)