### PR TITLE
srm: Fix job expiration during service startup

### DIFF
--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -609,6 +609,7 @@
     <constructor-arg ref="storage"/>
     <property name="schedulers" ref="schedulers"/>
     <property name="requestCredentialStorage" ref="srm-credential-store"/>
+    <property name="executor" ref="scheduledExecutor"/>
   </bean>
 
   <bean id="srm-cli" class="org.dcache.srm.SrmCommandLineInterface">


### PR DESCRIPTION
Motivation:

Job expiration was implemented as part of the SharedMemoryCacheJobStorage.
This was done because in a Terracotta based setup only this component knew
if a job was local to this instance.

Upon startup, the expiration jobs are scheduled during job storage
initialization. This means that jobs may be marked as expired even before they
have been processed by the restart logic, thus resulting in wrong job counts.
Since 2.15 cell communication is also not enabled until after cell startup
has completed, and thus upload expiration fails due to failure to communicate
with PnfsManager.

Modification:

Since we no longer support Terracotta, the expiration can be moved out of
the job storage and into the main SRM class.

Result:

Fixed race conditions during SRM startup that could lead to failures to
expire jobs and to wrong job counts in the SRM schedulers.

Target: trunk
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Fixes: #2477
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9369/

(cherry picked from commit 61d13ef39c81009693a32a450f0e8edb1356bc7f)
(cherry picked from commit c39599a4d38bf8f3c00a9710008f452cf5aa8c23)
(cherry picked from commit e7135f5fc36df901e799bf3d29fd0455c63da552)