### PR TITLE
webdav: Fix error reporting when client is unauthorized

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -601,9 +601,9 @@ public class DcacheResourceFactory
                 }
             }
         } catch (PermissionDeniedCacheException e) {
-            throw new UnauthorizedException(e.getMessage(), e, null);
+            throw new UnauthorizedException(e.getMessage(), e, new InaccessibleResource(path));
         } catch (CacheException e) {
-            throw new WebDavException(e.getMessage(), e, null);
+            throw new WebDavException(e.getMessage(), e, new InaccessibleResource(path));
         }
     }
 

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/InaccessibleResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/InaccessibleResource.java
@@ -1,0 +1,91 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dcache.webdav;
+
+import io.milton.http.Auth;
+import io.milton.http.Request;
+import io.milton.resource.Resource;
+
+import java.util.Date;
+
+import diskCacheV111.util.FsPath;
+
+/**
+ * Base class for resource objects for dCache files in the Milton
+ * WebDAV frame work.
+ */
+public class InaccessibleResource
+    implements Comparable<InaccessibleResource>, Resource
+{
+    private final FsPath _path;
+
+    public InaccessibleResource(FsPath path)
+    {
+        _path = path;
+    }
+
+    @Override
+    public Object authenticate(String user, String password)
+    {
+        return user;
+    }
+
+    @Override
+    public boolean authorise(Request request, Request.Method method, Auth auth)
+    {
+        return true;
+    }
+
+    @Override
+    public String checkRedirect(Request request)
+    {
+        return null;
+    }
+
+    @Override
+    public Date getModifiedDate()
+    {
+        return null;
+    }
+
+    @Override
+    public String getName()
+    {
+        return _path.name();
+    }
+
+    @Override
+    public String getRealm()
+    {
+        return "dCache";
+    }
+
+    @Override
+    public String getUniqueId()
+    {
+        return null;
+    }
+
+    @Override
+    public int compareTo(InaccessibleResource that)
+    {
+        return getName().compareTo(that.getName());
+    }
+}


### PR DESCRIPTION
Motivation:

28 maj 2016 22:44:12 (WebDAV-Gerds-MacBook-Pro) [] //localhost:2880/private/test-1464468242-1
java.lang.RuntimeException: Can't generate challenge because resource is null, so can't get realm
        at io.milton.http.http11.auth.BasicAuthHandler.appendChallenges(BasicAuthHandler.java:75) ~[milton-server-ce-2.7.1.5.jar:na]
        at io.milton.http.AuthenticationService.getChallenges(AuthenticationService.java:146) ~[milton-server-ce-2.7.1.5.jar:na]
        at org.dcache.webdav.DcacheResponseHandler.respondUnauthorised(DcacheResponseHandler.java:134) ~[dcache-webdav-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
        at io.milton.http.AbstractWrappingResponseHandler.respondUnauthorised(AbstractWrappingResponseHandler.java:124) ~[milton-server-ce-2.7.1.5.jar:na]
        at org.dcache.webdav.DcacheStandardFilter.process(DcacheStandardFilter.java:74) ~[dcache-webdav-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]

Modification:

A couple of exceptions were thrown with null resources, causing this problem. Added
an InaccessibleResource class to provide to the exception for these cases.

Result:

Fixed a problem in which accessing a file for which the client was not authorized would
generate a 200 OK reply with an empty body rather than the expected error page.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Fixes: #2461
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9371/

(cherry picked from commit 0d2f9c06875e2232c192e269e165cc109b5d4ee3)