### PR TITLE
pnfsmanager: Fix chimera.db.password.file support

### DIFF
--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -62,13 +62,7 @@
 
   <bean id="liquibase" class="org.dcache.util.SpringLiquibase">
       <description>Database schema manager</description>
-      <property name="dataSource">
-          <bean class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-              <property name="url" value="${pnfsmanager.db.url}"/>
-              <property name="username" value="${pnfsmanager.db.user}"/>
-              <property name="password" value="${pnfsmanager.db.password}"/>
-          </bean>
-      </property>
+      <property name="dataSource" ref="chimera-data-source"/>
       <property name="changeLog" value="classpath:${pnfsmanager.db.schema.changelog}"/>
       <property name="shouldUpdate" value="${pnfsmanager.db.schema.auto}"/>
   </bean>


### PR DESCRIPTION
Motivation:

chimera.db.password.file does not work for PnfsManager.

Modification:

PnfsManager contained two data sources, one for liquibase and one for Chimera.
The former did not support chimera.db.password.file. The fix now uses a single
data-source just like in subsequent releases.

Result:

Fixed a problem in pnfsmanager that prevented the use of
chimera.db.password.file.

Target: 2.10
Request: 2.10
Require-notes: yes
Require-book: no
Fixes: #2352
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9373/