### PR TITLE
pools: restore correct command names

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/StorageClassContainer.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/StorageClassContainer.java
@@ -258,7 +258,7 @@ public class StorageClassContainer
             append("\n");
     }
 
-    @Command(name = "queue setIncluded",
+    @Command(name = "queue activate",
             description = "Move a file from FAILED to ACTIVE.")
     class ActivateFileCommand implements Callable<String>
     {
@@ -277,7 +277,7 @@ public class StorageClassContainer
         }
     }
 
-    @Command(name = "queue setIncluded class",
+    @Command(name = "queue activate class",
             description = "Move files of a storage class from FAILED to ACTIVE.")
     class ActivateClassCommand implements Callable<String>
     {


### PR DESCRIPTION
Motivation:

Refactoring done in conjunction with commit 69cc5b9224282eabadc842fe5c930049373770d6
accidentally altered two command names in the pool StorageClassContainer.

Modification:

Restored to original name.

Result:

Commands are correctly named.

Target: master
Request: 2.16
Require-notes: yes
Require-book: no
Fixes: #2518
Acked-by: Gerd
Acked-by: Paul