### PR TITLE
resilience: fail when source retry is requested with only one possibl…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/LocationSelector.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/LocationSelector.java
@@ -96,10 +96,14 @@ public final class LocationSelector {
                     Set<String> locations) throws Exception {
         LOGGER.trace("selecting source for {}", operation);
         if (locations.size() == 1) {
+            if (!operation.getTried().isEmpty()) {
+                throw new Exception(String.format("Cannot find a new source "
+                                                + "because only one exists:  %s.",
+                                    locations));
+            }
             return locations.iterator().next();
-        } else {
-            return selectSource(locations, operation.getTried());
         }
+        return selectSource(locations, operation.getTried());
     }
 
     public String selectCopyTarget(FileOperation operation, Integer gindex,


### PR DESCRIPTION
…e source

Motivation:

When a source is selected by resilience for copying, a check
is also made to see that it is not taken from among the
locations that have already been (unsuccessfully) tried.

The current code, however, does not do this in the case where
only one location exists.

Modification:

Always check for the tried locations.  In the case of a single
location, throw an exception.

Result:

No more bug.

Target: master
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Gerd