### PR TITLE
pool: Lower log level of certain failures to create mover

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -40,6 +40,7 @@ import diskCacheV111.util.FileCorruptedCacheException;
 import diskCacheV111.util.FileInCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FileNotInCacheException;
+import diskCacheV111.util.LockedCacheException;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.DCapProtocolInfo;
@@ -762,6 +763,12 @@ public class PoolV4
         try {
             message.setMoverId(queueIoRequest(envelope, message));
             message.setSucceeded();
+        } catch (FileNotInCacheException | FileInCacheException e) {
+            _log.warn(e.getMessage());
+            message.setFailed(e.getRc(), e.getMessage());
+        } catch (LockedCacheException e) {
+            _log.info(e.getMessage());
+            message.setFailed(e.getRc(), e.getMessage());
         } catch (CacheException e) {
             _log.error(e.getMessage());
             message.setFailed(e.getRc(), e.getMessage());


### PR DESCRIPTION
Motivation:

Some error conditions when creating movers are expected to happen under
certain conditions and dCache is designed to transparently recover from
these. There is no reason to fill the logs with errors for such cases.

Modification:

Lowers the log level of a number of exceptions that may happen during
mover creation.

Result:

Fixed a problem in which certain harmless error during mover creation were
logged as errors.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/9391/

(cherry picked from commit 586e62f60fb94fe30d5fc11080da6fe6357f3711)
(cherry picked from commit bb3fa821b3df5a73f204e787955a4911558c381b)