### PR TITLE
pool: Make final state update after upload atomic

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
@@ -356,9 +356,10 @@ class WriteHandleImpl implements ReplicaDescriptor
 
             registerFileAttributesInNameSpace();
 
-            _entry.setFileAttributes(_fileAttributes);
-            setToTargetState();
-
+            synchronized (_entry) {
+                _entry.setFileAttributes(_fileAttributes);
+                setToTargetState();
+            }
             setState(HandleState.COMMITTED);
         } catch (CacheException e) {
             /* If any of the PNFS operations return FILE_NOT_FOUND,


### PR DESCRIPTION
Motivation:

Several bits of meta data is updated on a pool after upload. There is a race
between doors/replica/resilience discovering a replica location in chimera and
the pool updating the meta data on the pool to a non-transient state. If the
pool looses this race, the file access by the doors is denied. The requestor
transparantly retries the operation, but in particular for resilience this
happens relatively often if the pool is loaded and meta data update slows down.

Modification:

Fixing the race entirely is difficult without introducing other problems, but
this patch makes the state update atomic, reducing the window of opportunity
for the door/replica/resilience to win the race.

Result:

Hopefully reduced lock conflicts under high resilience load.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Albert Rossir <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/9394/

(cherry picked from commit 61ee15f577515fcd95848285083d4caeadcb282d)