### PR TITLE
pool: Don't use transient error for a broken file

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/util/FileCorruptedCacheException.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/util/FileCorruptedCacheException.java
@@ -25,7 +25,7 @@ import org.dcache.util.Checksum;
 
 /**
  * Signals that the file size or checksum of a file does not match the expected
- * checksum or file size.
+ * checksum or file size, or that a file or replica is otherwise corrupted.
  *
  * Note that expected and actual file size or checksum stored in the exception
  * are not preserved by cells message passing.

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/util/LockedCacheException.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/util/LockedCacheException.java
@@ -1,7 +1,9 @@
 package diskCacheV111.util;
 
 /**
- * Thrown when accessing a locked resource.
+ * Thrown when accessing a locked resource. This is typically a transient
+ * error and retrying later maybe allow the operation to succeed without
+ * administrative intervention.
  */
 public class LockedCacheException extends CacheException
 {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -26,6 +26,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.util.DiskSpace;
+import diskCacheV111.util.FileCorruptedCacheException;
 import diskCacheV111.util.FileInCacheException;
 import diskCacheV111.util.FileNotInCacheException;
 import diskCacheV111.util.LockedCacheException;
@@ -620,7 +621,7 @@ public class CacheRepositoryV5
                 case FROM_POOL:
                     throw new LockedCacheException("File is incomplete");
                 case BROKEN:
-                    throw new LockedCacheException("File is broken");
+                    throw new FileCorruptedCacheException("File is broken");
                 case REMOVED:
                 case DESTROYED:
                     throw new LockedCacheException("File has been removed");


### PR DESCRIPTION
Motivation:

Opening a broken replica is not a transient error, yet we report that the
replica is locked which usually indicates that retrying will eventually allow
the request to succeed.

Modification:

Use FileCorruptedCacheException instead - we use the same error message in
other places when we try to access a broken replica.

Result:

Minimal user visible impact, but useful for resilience as it needs to know
which errors are transient and which are not. Hence the backport request.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.16
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9403/

(cherry picked from commit 73bb943c989b2bd93e36b5b5d8362db26478e852)