### PR TITLE
resilience: fix classification of file incomplete and other errors

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInfoMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInfoMap.java
@@ -356,6 +356,21 @@ public class PoolInfoMap {
 
     /**
      * @param writable location is writable if true, readable if false.
+     * @return all pool group pools which qualify.
+     */
+    public Set<String> getMemberPools(Integer gindex, boolean writable) {
+        read.lock();
+        try {
+            Set<Integer> members = ImmutableSet.copyOf(poolGroupToPool.get(gindex));
+            members = getValidLocations(members, writable);
+            return getPools(members);
+        } finally {
+            read.unlock();
+        }
+    }
+
+    /**
+     * @param writable location is writable if true, readable if false.
      * @return all the locations belonging to the given pool group which
      * qualify.
      */

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -454,8 +454,6 @@ public class FileOperationHandler {
         LOGGER.trace("handleVerification, {}, readable locations {}", pnfsId,
                      readableLocations);
 
-        operation.setLocations(readableLocations.size());
-
         /*
          *  If we have arrived here, we are expecting there to be an
          *  available source file.

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/FileOperationMapTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/FileOperationMapTest.java
@@ -217,9 +217,14 @@ public final class FileOperationMapTest extends TestBase {
         whenOperationFailsWithRetriableError();
         whenScanIsRun();
         whenOperationFailsWithRetriableError();
+
         /*
-         * No other source exists.  Should fail terminally.
+         * This should set retry with new source and target, but
+         * there should be no other source when it retries, and a failure
+         * should result.
          */
+        whenScanIsRun();
+        whenVerifyIsRun();
         whenScanIsRun();
         assertNull(fileOperationMap.getOperation(operation.getPnfsId()));
     }
@@ -318,10 +323,12 @@ public final class FileOperationMapTest extends TestBase {
     private void afterOperationAdded(int count) throws CacheException {
         PnfsId pnfsId = attributes.getPnfsId();
         String pool = attributes.getLocations().iterator().next();
+        String unit = attributes.getStorageClass() + "@" + attributes.getHsm();
         Integer pindex = poolInfoMap.getPoolIndex(pool);
         Integer gindex = poolInfoMap.getResilientPoolGroup(pindex);
+        Integer sindex = poolInfoMap.getGroupIndex(unit);
         FileUpdate update = new FileUpdate(pnfsId, pool,
-                                           MessageType.ADD_CACHE_LOCATION, pindex, gindex, null,
+                                           MessageType.ADD_CACHE_LOCATION, pindex, gindex, sindex,
                                            attributes);
         update.setCount(count);
         fileOperationMap.register(update);
@@ -415,5 +422,9 @@ public final class FileOperationMapTest extends TestBase {
 
     private void whenScanIsRun() throws IOException {
         fileOperationMap.scan();
+    }
+
+    private void whenVerifyIsRun() throws IOException {
+        fileOperationMap.getOperation(operation.getPnfsId()).getTask().call();
     }
 }

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
@@ -609,7 +609,7 @@ public final class FileOperationHandlerTest extends TestBase
     private void whenOperationFailsWithBrokenFileError() throws IOException {
         fileOperationMap.scan();
         fileOperationMap.updateOperation(update.pnfsId,
-                                         new CacheException(CacheException.BROKEN_ON_TAPE,
+                                         new CacheException(CacheException.FILE_CORRUPTED,
                                         "broken"));
         fileOperationMap.scan();
     }
@@ -617,7 +617,7 @@ public final class FileOperationHandlerTest extends TestBase
     private void whenOperationFailsWithNewTargetError() throws IOException {
         fileOperationMap.scan();
         fileOperationMap.updateOperation(update.pnfsId,
-                                         new CacheException(CacheException.FILE_NOT_FOUND,
+                                         new CacheException(CacheException.FILE_IN_CACHE,
                                         FORCED_FAILURE.toString()));
         fileOperationMap.scan();
     }
@@ -626,7 +626,7 @@ public final class FileOperationHandlerTest extends TestBase
         fileOperationMap.scan();
         fileOperationMap.updateOperation(update.pnfsId,
                                          new CacheException(
-                                                         CacheException.HSM_DELAY_ERROR,
+                                                         CacheException.FILE_NOT_IN_REPOSITORY,
                                                          FORCED_FAILURE.toString()));
         fileOperationMap.scan();
     }
@@ -635,7 +635,7 @@ public final class FileOperationHandlerTest extends TestBase
         fileOperationMap.scan();
         fileOperationMap.updateOperation(update.pnfsId,
                                          new CacheException(
-                                                         CacheException.SELECTED_POOL_FAILED,
+                                                         CacheException.FILE_NOT_FOUND,
                                                          "Source pool failed"));
         fileOperationMap.scan();
     }
@@ -655,7 +655,7 @@ public final class FileOperationHandlerTest extends TestBase
     }
 
     private void whenTaskIsCreatedAndCalled() {
-        task = new ResilientFileTask(update.pnfsId, false,
+        task = new ResilientFileTask(update.pnfsId, false, 0,
                                      fileOperationHandler);
         task.call();
     }


### PR DESCRIPTION
Motivation:

When a p2p copy fails because it is trying to access a source
file before the pool repository has completed processing it,
the client receives a "Source pool failure (File is incomplete)"
error.   Currently, because of the presence of "Source pool failure"
in the exception message, resilience classifies this as an error
requiring a retry using a different source.   In reality, however,
this is a transient error which can be retried using the same source.

In addition, relying on the error message for this classification
is fragile.

Modification:

Reclassify the error as retriable so that Resilience simply retries
without attempting to find a different source location.

Other classification errors have been rectified, and
reliance on the message eliminated.

A few small changes in the error post-processing
have been made, and several unit tests adjusted.

Result:

Correct behavior by resilience regarding error conditions.

Target: master
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Gerd