### PR TITLE
restful: add ability to discover information about current user

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/UserAttributes.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/UserAttributes.java
@@ -1,0 +1,77 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.restful.providers;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class to hold information for a JSON response querying information
+ * about a user.
+ */
+public class UserAttributes
+{
+    public enum AuthenticationStatus {ANONYMOUS, AUTHENTICATED};
+
+    /**
+     * Whether the current user has authenticated with the system.
+     * ANONYMOUS indicates that the user supplied no credentials or that
+     * the credentials failed to authenticate the user (e.g., wrong password).
+     *
+     */
+    private AuthenticationStatus status;
+
+    /**
+     * The UID of the user, if the user has status AUTHENTICATED, null
+     * otherwise.
+     */
+    private Long uid;
+
+    private List<Long> gids;
+
+    public AuthenticationStatus getStatus()
+    {
+        return status;
+    }
+
+    public void setStatus(AuthenticationStatus status)
+    {
+        this.status = Objects.requireNonNull(status);
+    }
+
+    public Long getUid()
+    {
+        return uid;
+    }
+
+    public void setUid(Long uid)
+    {
+        this.uid = uid;
+    }
+
+    public List<Long> getGids()
+    {
+        return gids;
+    }
+
+    public void setGids(List<Long> gids)
+    {
+        this.gids = gids;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/identity/UserResource.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/identity/UserResource.java
@@ -1,0 +1,67 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.restful.resources.identity;
+
+import jersey.repackaged.com.google.common.collect.Lists;
+
+import javax.security.auth.Subject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.dcache.auth.Subjects;
+import org.dcache.restful.providers.UserAttributes;
+import org.dcache.restful.util.ServletContextHandlerAttributes;
+
+/**
+ * Provide services related to the identity the user is currently
+ * operating.
+ */
+@Path("/user")
+public class UserResource
+{
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public UserAttributes getUserAttributes()
+    {
+        UserAttributes user = new UserAttributes();
+
+        Subject subject = ServletContextHandlerAttributes.getSubject();
+        if (Subjects.isNobody(subject)) {
+            user.setStatus(UserAttributes.AuthenticationStatus.ANONYMOUS);
+            user.setUid(null);
+            user.setGids(null);
+        } else {
+            user.setStatus(UserAttributes.AuthenticationStatus.AUTHENTICATED);
+            user.setUid(Subjects.getUid(subject));
+            List<Long> gids = Arrays.stream(Subjects.getGids(subject))
+                    .boxed()
+                    .collect(Collectors.toList());
+            user.setGids(gids);
+        }
+
+        return user;
+    }
+}


### PR DESCRIPTION
Motivation:

Currently, the restful interface provides no reliable way to discover if
the credentials supplied by the user resulted in that user being
authenticated: failure to authenticate may result in the user being
Subjects.NOBODY and that user may be able to interact with dCache.

Modification:

Add the /api/v1/user endpoint.  GET requests to this endpoint return a
JSON summary of how the user within dCache.

Result:

Clients can discover information such as whether or not a
username+password combination is valid and which uid and gid(s) the user
has.

Target: master
Patch: https://rb.dcache.org/r/9409/
Acked-by: Gerd Behrmann
Request: 2.16
Require-notes: yes
Require-book: yes