### PR TITLE
frontend: always fail request if wrong credentials are presented

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -81,6 +81,7 @@
           </bean>
 	  </list>
       </property>
+      <property name="fallbackToAnonymous" value="false"/>
       <property name="anonymousAccess" value="${frontend.authz.anonymous-operations}"/>
   </bean>
 


### PR DESCRIPTION
Motivation:

Current behaviour is to treat a failed login in WebDAV, frontend and
dcap doors as if the user presented no credentials (i.e., an anonymous
request).  For frontend, this is undesirable as we wish to have
standard-compliant response to incorrect credentials; i.e., 401 status
code in the response.

Modification:

Update UnionLoginStrategy to support a switch to disable treating a
failed login as an unauthenticated request.  Update frontend to disable
the switch.

Result:

For the frontend, if the user supplies incorrect credentials then their
request will always fail.

Target: master
Patch: https://rb.dcache.org/r/9413
Acked-by: Gerd Behrmann
Request: 2.16
Requires-notes: yes
Requires-book: no