### PR TITLE
resilience: fix incomplete behavior for pools intentionally marked "e…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
@@ -1299,10 +1299,9 @@ public final class ResilienceCommands implements CellCommandListener {
                                     + "exclusion will cancel any running "
                                     + "operations.  The pool will not be included "
                                     + "in periodic, forced, or status-change "
-                                    + "scans, though it will still "
-                                    + "appear to its pool group as a member "
-                                    + "in whatever state the pool manager "
-                                    + "knows about.")
+                                    + "scans; locations on it are still considered "
+                                    + "valid regarding replica count, but "
+                                    + "cannot be used as copy sources.")
     class PoolOpExcludeCommand extends PoolOpActivateCommand {
         PoolOpExcludeCommand() {
             super(false);

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -338,14 +338,16 @@ public final class FileUpdate {
 
         /*
          *  Check the constraints.
+         *  Countable means readable OR intentionally excluded locations.
+         *  If there are copies missing only from excluded locations,
+         *  do nothing.
          */
-        int readable = locationSelector.getReadableMemberLocations(group,
-                                                                   locations).size();
-        count = constraints.getRequired() - readable;
+        int countable = poolInfoMap.getCountableLocations(locations);
+        count = constraints.getRequired() - countable;
         LOGGER.debug("validateForAction ({} needs {} replicas, locations {}, "
-                                     + "{} readable; difference = {}.",
+                                     + "{} countable; difference = {}.",
                      pnfsId, constraints.getRequired(),
-                     locations, readable, count);
+                     locations, countable, count);
 
         if (count == 0) {
             LOGGER.debug("{}, requirements are already met.", pnfsId);

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInfoMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInfoMap.java
@@ -579,6 +579,22 @@ public class PoolInfoMap {
         return tags;
     }
 
+    public int getCountableLocations(Collection<String> locations) {
+        read.lock();
+        int countable = 0;
+        try {
+            for (String location : locations) {
+                PoolInformation info = poolInfo.get(getPoolIndex(location));
+                if (info != null && info.isInitialized() && info.isCountable()) {
+                    ++countable;
+                }
+            }
+        } finally {
+            read.unlock();
+        }
+        return countable;
+    }
+
     public Set<Integer> getValidLocations(Collection<Integer> locations,
                                           boolean writable) {
         read.lock();

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
@@ -82,6 +82,7 @@ import diskCacheV111.util.PnfsId;
 import org.dcache.resilience.data.PoolOperation.NextAction;
 import org.dcache.resilience.data.PoolOperation.State;
 import org.dcache.resilience.handlers.PoolOperationHandler;
+import org.dcache.resilience.util.CheckpointUtils;
 import org.dcache.resilience.util.ExceptionMessage;
 import org.dcache.resilience.util.MapInitializer;
 import org.dcache.resilience.util.Operation;
@@ -155,12 +156,23 @@ public class PoolOperationMap extends RunnableModule {
     private PoolOperationHandler    handler;
     private FileOperationMap        fileOperationMap; // needed for cancellation
 
+    private String                  excludedPoolsFile;
+
     private int                 downGracePeriod;
     private TimeUnit            downGracePeriodUnit;
     private int                 restartGracePeriod;
     private TimeUnit            restartGracePeriodUnit;
     private int                 maxConcurrentRunning;
     private OperationStatistics counters;
+
+    public void saveExcluded() {
+        lock.lock();
+        try {
+            CheckpointUtils.save(excludedPoolsFile, idle);
+        } finally {
+            lock.unlock();
+        }
+    }
 
     /**
      * <p>Called by the admin interface.</p>
@@ -356,6 +368,12 @@ public class PoolOperationMap extends RunnableModule {
             lock.unlock();
         }
 
+        CheckpointUtils.load(excludedPoolsFile).stream().forEach((p) -> {
+            PoolFilter filter = new PoolFilter();
+            filter.setPools(p);
+            setIncluded(filter, false);
+        });
+
         return removed;
     }
 
@@ -496,6 +514,10 @@ public class PoolOperationMap extends RunnableModule {
         this.downGracePeriodUnit = downGracePeriodUnit;
     }
 
+    public void setExcludedPoolsFile(String excludedPoolsFile) {
+        this.excludedPoolsFile = excludedPoolsFile;
+    }
+
     public void setHandler(PoolOperationHandler handler) {
         this.handler = handler;
     }
@@ -583,11 +605,6 @@ public class PoolOperationMap extends RunnableModule {
             }
 
             switch (nextAction) {
-                case DEACTIVATE:
-                    queue.remove(update.pool);
-                    operation.state = State.INACTIVE;
-                    reset(update.pool, operation);
-                    break;
                 case DOWN_TO_UP:
                 case UP_TO_DOWN:
                     if (operation.state == State.WAITING) {
@@ -829,8 +846,7 @@ public class PoolOperationMap extends RunnableModule {
                 String pool = entry.getKey();
                 PoolOperation operation = entry.getValue();
 
-                if (operation.state == State.EXCLUDED ||
-                                operation.state == State.INACTIVE) {
+                if (operation.state == State.EXCLUDED) {
                     continue;
                 }
 
@@ -973,6 +989,12 @@ public class PoolOperationMap extends RunnableModule {
                         update(poolInfoMap.getPoolState(k));
                         visited.add(k);
                     }
+                    /*
+                     *  mark the pool information so that other operations
+                     *  know this pool is temporarily in limbo.
+                     */
+                    poolInfoMap.getPoolInformation(poolInfoMap.getPoolIndex(k))
+                               .setExcluded(!include);
                 }
             }
         });

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolStatusForResilience.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolStatusForResilience.java
@@ -68,9 +68,7 @@ public enum PoolStatusForResilience {
     UNINITIALIZED,      // no info yet
     DOWN,               // equivalent to disabled -strict, or dead
     ENABLED,            // equivalent to enabled
-    READ_ONLY,          // equivalent to disabled -readOnly
-    DOWN_IGNORE,        // DOWN for pool with resilience suppressed
-    UP_IGNORE;          // READ_ONLY/ENABLED for pool with resilience suppressed
+    READ_ONLY;          // equivalent to disabled -readOnly
 
     final static int[] notReadable = { PoolV2Mode.DISABLED_DEAD,
                                        PoolV2Mode.DISABLED_STRICT,
@@ -113,14 +111,6 @@ public enum PoolStatusForResilience {
             if ((mode & mask) == mask) {
                 state = DOWN;
                 break;
-            }
-        }
-
-        if (!poolMode.isResilienceEnabled()) {
-            if (state == DOWN) {
-                state = DOWN_IGNORE;
-            } else {
-                state = UP_IGNORE;
             }
         }
 

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -456,7 +456,8 @@ public class FileOperationHandler {
 
         /*
          *  If we have arrived here, we are expecting there to be an
-         *  available source file.
+         *  available source file.  So we need the strictly readable
+         *  locations, not just "countable" ones.
          */
         if (readableLocations.size() == 0
                         && operation.getRetentionPolicy()
@@ -550,7 +551,13 @@ public class FileOperationHandler {
 
         StorageUnitConstraints constraints
                         = poolInfoMap.getStorageUnitConstraints(sindex);
-        int missing = constraints.getRequired() - readableLocations.size();
+        /*
+         *  Countable means readable OR intentionally excluded locations.
+         *  If there are copies missing only from excluded locations,
+         *  do nothing.
+         */
+        int missing = constraints.getRequired()
+                        - poolInfoMap.getCountableLocations(locations);
 
         Collection<String> tags = constraints.getOneCopyPer();
 

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/PoolInfoChangeHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/PoolInfoChangeHandler.java
@@ -215,6 +215,7 @@ public final class PoolInfoChangeHandler implements CellMessageReceiver {
             .map(poolInfoMap::getPoolState)
             .forEach(resilienceMessageHandler::handleInternalMessage);
 
+        poolOperationMap.saveExcluded();
         lastRefresh = System.currentTimeMillis();
 
         LOGGER.trace("DIFF:\n{}", diff);

--- a/modules/dcache-resilience/src/main/resources/org/dcache/resilience/resilience.xml
+++ b/modules/dcache-resilience/src/main/resources/org/dcache/resilience/resilience.xml
@@ -199,6 +199,7 @@
       <property name="counters" ref="Counters"/>
       <property name="downGracePeriod" value="${resilience.limits.pool.down-grace-period}"/>
       <property name="downGracePeriodUnit" value="${resilience.limits.pool.down-grace-period.unit}"/>
+      <property name="excludedPoolsFile" value="${resilience.home}/excluded-pools"/>
       <property name="handler" ref="PoolOpHandler"/>
       <property name="maxConcurrentRunning" value="${resilience.limits.pool.scan-threads}"/>
       <property name="rescanWindow" value="${resilience.watchdog.scan.window}"/>

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestBase.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestBase.java
@@ -98,6 +98,7 @@ public abstract class TestBase implements Cancellable {
     protected static final Exception FORCED_FAILURE
                     = new Exception("Forced failure for test purposes");
     protected static final String    CHKPTFILE      = "/tmp/checkpoint-file";
+    protected static final String    POOLSFILE      = "/tmp/excluded-pools";
 
     /*
      *  Real instances.
@@ -528,6 +529,7 @@ public abstract class TestBase implements Cancellable {
         poolOperationMap.setCounters(counters);
         poolOperationMap.setPoolInfoMap(poolInfoMap);
         poolOperationMap.setHandler(poolOperationHandler);
+        poolOperationMap.setExcludedPoolsFile(POOLSFILE);
     }
 
     private void setLongTaskExecutor() {

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolStatusTransitionTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolStatusTransitionTest.java
@@ -67,17 +67,15 @@ import java.util.List;
 
 import diskCacheV111.pools.PoolV2Mode;
 import org.dcache.resilience.data.PoolOperation.NextAction;
+import org.dcache.resilience.data.PoolOperation.State;
 
-import static org.dcache.resilience.data.PoolOperation.NextAction.DEACTIVATE;
 import static org.dcache.resilience.data.PoolOperation.NextAction.DOWN_TO_UP;
 import static org.dcache.resilience.data.PoolOperation.NextAction.NOP;
 import static org.dcache.resilience.data.PoolOperation.NextAction.UP_TO_DOWN;
 import static org.dcache.resilience.data.PoolStatusForResilience.DOWN;
-import static org.dcache.resilience.data.PoolStatusForResilience.DOWN_IGNORE;
 import static org.dcache.resilience.data.PoolStatusForResilience.ENABLED;
 import static org.dcache.resilience.data.PoolStatusForResilience.READ_ONLY;
 import static org.dcache.resilience.data.PoolStatusForResilience.UNINITIALIZED;
-import static org.dcache.resilience.data.PoolStatusForResilience.UP_IGNORE;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -110,23 +108,23 @@ public final class PoolStatusTransitionTest {
 
     static void generateOracles() {
         oracles.add(new TestOracle(DOWN, DOWN, DOWN, NOP));
-        oracles.add(new TestOracle(UNINITIALIZED, DOWN_IGNORE, DOWN, DEACTIVATE));
-        oracles.add(new TestOracle(UNINITIALIZED, UP_IGNORE, READ_ONLY, DEACTIVATE));
+        oracles.add(new TestOracle(UNINITIALIZED, DOWN, DOWN, NOP));
+        oracles.add(new TestOracle(UNINITIALIZED, DOWN, ENABLED, NOP));
         oracles.add(new TestOracle(DOWN, READ_ONLY, READ_ONLY, DOWN_TO_UP));
         oracles.add(new TestOracle(DOWN, ENABLED, ENABLED, DOWN_TO_UP));
         oracles.add(new TestOracle(READ_ONLY, DOWN, DOWN, UP_TO_DOWN));
-        oracles.add(new TestOracle(UNINITIALIZED, DOWN_IGNORE, DOWN, DEACTIVATE));
-        oracles.add(new TestOracle(UNINITIALIZED, UP_IGNORE, READ_ONLY, DEACTIVATE));
+        oracles.add(new TestOracle(UNINITIALIZED, DOWN, DOWN, NOP));
+        oracles.add(new TestOracle(UNINITIALIZED, READ_ONLY, ENABLED, NOP));
         oracles.add(new TestOracle(READ_ONLY, READ_ONLY, READ_ONLY, NOP));
         oracles.add(new TestOracle(READ_ONLY, ENABLED, ENABLED, NOP));
         oracles.add(new TestOracle(ENABLED, DOWN, DOWN, UP_TO_DOWN));
-        oracles.add(new TestOracle(UNINITIALIZED, DOWN_IGNORE, DOWN, DEACTIVATE));
-        oracles.add(new TestOracle(UNINITIALIZED, UP_IGNORE, ENABLED, DEACTIVATE));
+        oracles.add(new TestOracle(UNINITIALIZED, DOWN, DOWN, NOP));
+        oracles.add(new TestOracle(UNINITIALIZED, ENABLED, ENABLED, NOP));
         oracles.add(new TestOracle(ENABLED, READ_ONLY, READ_ONLY, NOP));
         oracles.add(new TestOracle(ENABLED, ENABLED, ENABLED, NOP));
         oracles.add(new TestOracle(UNINITIALIZED, DOWN, DOWN, UP_TO_DOWN));
-        oracles.add(new TestOracle(UNINITIALIZED, DOWN_IGNORE, DOWN, DEACTIVATE));
-        oracles.add(new TestOracle(UNINITIALIZED, UP_IGNORE, UNINITIALIZED, DEACTIVATE));
+        oracles.add(new TestOracle(UNINITIALIZED, DOWN, DOWN, NOP));
+        oracles.add(new TestOracle(UNINITIALIZED, ENABLED, ENABLED, NOP));
         oracles.add(new TestOracle(UNINITIALIZED, READ_ONLY, READ_ONLY, NOP));
         oracles.add(new TestOracle(UNINITIALIZED, ENABLED, ENABLED, NOP));
     }
@@ -143,14 +141,14 @@ public final class PoolStatusTransitionTest {
     }
 
     @Test
-    public void case01ActionShouldBeDeactivateForDownFollowedByDownResilienceOff() {
+    public void case01ActionShouldBeNOPForDownFollowedByDownResilienceOff() {
         givenUpdateWithPoolModeEqualToDown();
         givenUpdateWithPoolModeEqualToDownButResilienceOff();
         assertThatTestCaseObeysOracle(1);
     }
 
     @Test
-    public void case02ActionShouldBeDeactivateForDownFollowedByUpResilienceOff() {
+    public void case02ActionShouldBeNOPForDownFollowedByUpResilienceOff() {
         givenUpdateWithPoolModeEqualToDown();
         givenUpdateWithPoolModeEnabledButResilienceOff();
         assertThatTestCaseObeysOracle(2);
@@ -178,14 +176,14 @@ public final class PoolStatusTransitionTest {
     }
 
     @Test
-    public void case06ActionShouldBeDeactivateForReadableFollowedByDownResilienceOff() {
+    public void case06ActionShouldBeNOPForReadableFollowedByDownResilienceOff() {
         givenUpdateWithPoolModeReadOnly();
         givenUpdateWithPoolModeEqualToDownButResilienceOff();
         assertThatTestCaseObeysOracle(6);
     }
 
     @Test
-    public void case07ActionShouldBeDeactivateForReadableFollowedByUpResilienceOff() {
+    public void case07ActionShouldBeNOPForReadableFollowedByUpResilienceOff() {
         givenUpdateWithPoolModeReadOnly();
         givenUpdateWithPoolModeEnabledButResilienceOff();
         assertThatTestCaseObeysOracle(7);
@@ -213,14 +211,14 @@ public final class PoolStatusTransitionTest {
     }
 
     @Test
-    public void case11ActionShouldBeDeactivateForWritableFollowedByDownResilienceOff() {
+    public void case11ActionShouldBeNOPForWritableFollowedByDownResilienceOff() {
         givenUpdateWithPoolModeEnabled();
         givenUpdateWithPoolModeEqualToDownButResilienceOff();
         assertThatTestCaseObeysOracle(11);
     }
 
     @Test
-    public void case12ActionShouldBeDeactivateForWritableFollowedByUpResilienceOff() {
+    public void case12ActionShouldBeNOPForWritableFollowedByUpResilienceOff() {
         givenUpdateWithPoolModeEnabled();
         givenUpdateWithPoolModeEnabledButResilienceOff();
         assertThatTestCaseObeysOracle(12);
@@ -247,13 +245,13 @@ public final class PoolStatusTransitionTest {
     }
 
     @Test
-    public void case16ActionShouldBeDeactivateForUninitializedFollowedByDownResilienceOff() {
+    public void case16ActionShouldBeNOPForUninitializedFollowedByDownResilienceOff() {
         givenUpdateWithPoolModeEqualToDownButResilienceOff();
         assertThatTestCaseObeysOracle(16);
     }
 
     @Test
-    public void case17ActionShouldBeDeactivateForUninitializedFollowedByUpResilienceOff() {
+    public void case17ActionShouldBeNOPForUninitializedFollowedByUpResilienceOff() {
         givenUpdateWithPoolModeEnabledButResilienceOff();
         assertThatTestCaseObeysOracle(17);
     }
@@ -284,7 +282,7 @@ public final class PoolStatusTransitionTest {
 
     private void givenPoolModeOf(int mode, boolean enabled) {
         this.mode = new PoolV2Mode(mode);
-        this.mode.setResilienceEnabled(enabled);
+        operation.state = enabled ? State.WAITING : State.EXCLUDED;
     }
 
     private void givenUpdateWithPoolModeEnabled() {


### PR DESCRIPTION
…xcluded"

Motivation:

Under normal operation, the Resilience service should be expected
to handle gracefully situations where a pool with many files, for
one reason or another, goes off line.  Such an incident, even if
the "grace period" value is set to 0, in initiating a large scan,
should not bring the system down.  Obversely, should the pool
come back on line, any such scan should be (and is) immediately canceled,
and the pool rescheduled for a scan to remove unnecessary copies.
Under most circumstances, the Resilience service should not require
any manual intervention or adjustment in this regard.

Nevertheless, admins may still feel the need to have a safety procedure
whereby pools can be excluded temporarily from being handled by
the Resilience service.  This may be used, for instance, if
one decides to rebalance a resilient pool group (resilience should
be disabled there first).  Such a feature was provided in the
old Replica Manager via the "pool set <pool> OFFLINE" command.

The Resilience redesign intended to keep this feature; however,
its current implementation is both unnecessarily redundant and
confusing, as well as being partly erroneous.  So as it stands,
this feature is actually broken, not just awkward to use:

Currently, there are two separate commands to "deactivate" resilience
on a pool, – on the pool itself,

\s poolname pool suppress resilience on/off

and in the Resilience service,

\s Resilience pool exclude/include <expression>

The reason for the first was to take advantage of the fact that one
could save this setting so it survives a pool restart.  But if
a pool is discovered to be unreachable, one also needs a way to
"shut off" resilience for it (if so desired) inside the Resilience
service; hence, the second command.

The two states as a consequence also had to be kept distinct.
The first required modifying the PoolV2Mode object to carry that
information, as well as the pool configuration code.

For obvious reasons, this situation is suboptimal.

But the exclusion/deactivation of a pool in the new system also does
not behave as one would expect (on the basis of the Replica Manager)
in the sense that, while blocking scans of the pool on state changes
or periodic checks, the locations on that pool are still considered
offline and will result as "missing" if a replica check is initiated
on another pool sharing files with it.  This behavior, at least
from the standpoint of the original, is wrong.

Modification:

1.  The pool suppress resilience command, and corresponding INACTIVE
    state handling have all been eliminated.
2.  The pool exclude command now also marks the pool information in
    such as way as to distinguish between 'readable' and 'countable'
    files; handling of resilience requests takes this into account.
3.  To compensate for the loss of the ability to save state on the pool,
    resilience itself now writes out to a file (during the periodic
    update from pool monitor) any pools that are set to EXCLUDED,
    and reads these back in a (re)start.

Note that the PoolV2Mode changes originally introduced to support
INACTIVE have been left in place in order to be backward
compatible with pools on which this patch is not applied.

Unit tests have been adjusted to reflect the new semantics.

Result:

Simpler/unified control over this feature, and behavior as
expected on the basis of past usage.

Target: master
Request: 2.16
Require-notes: yes
Require-book: yes
Acked-by: Gerd