### PR TITLE
script: Do not claim success if meta data conversion failed

### DIFF
--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -274,7 +274,7 @@ poolConvertMeta() # $1 = domain, $2 = cell, $3 = type
         fail 2 "Cannot convert pool '$name', as it is already of type $src."
     fi
 
-    CLASSPATH="$classpath" quickJava org.dcache.pool.repository.MetaDataStoreCopyTool "$path" "$src" "$3"
+    CLASSPATH="$classpath" quickJava org.dcache.pool.repository.MetaDataStoreCopyTool "$path" "$src" "$3" || fail 1
 
     printp ""\
            "The pool meta data database of '$name' was converted from


### PR DESCRIPTION
Motivation:

Although the dcache script runs with `set -e`, this does not seem
to be preserved in subshells.

As a consequence, failure to convert the meta data of a pool is
follow by output claiming the data was converted successfully.

Modification:

Fail the script if the conversion failed.

Result:

Fixed a problem in which failure to convert pool meta data was
misreported.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9404/

(cherry picked from commit 5180b992f585278c1c54b532d49c0327eb30d8e8)