### PR TITLE
pool: Fix documentation error for -storage option of rep ls command

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -172,9 +172,9 @@ public class RepositoryInterpreter
         "                 u  : files in use\n"+
         "                 nc : files which are not cached\n" +
         "                 e  : files which error condition\n" +
-        "              -si=<glob>   # select only replicas\n" +
-        "                             of files with storage-\n" +
-        "                             info that matches <glob>\n" +
+        "              -storage=<glob>   # select only replicas\n" +
+        "                                  of files with storage-\n" +
+        "                                  info that matches <glob>\n" +
         "              -s[=kmgt] [-sum]       # statistics\n" +
         "                 k  : data amount in KBytes\n"+
         "                 m  : data amount in MBytes\n"+


### PR DESCRIPTION
Motivation:

There was still one reference to the unpublished -si option.

Modification:

Fix the documentation.

Result:

A minor documentation error for the `rep ls` command was fixed.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9417/

(cherry picked from commit 219b9700ac429a9d3ce4bd86202b94ed50c19457)