### PR TITLE
pool: Report file in transient state as locked when setting sticky flag

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheRepositoryV5.java
@@ -715,10 +715,10 @@ public class CacheRepositoryV5
                 case FROM_CLIENT:
                 case FROM_STORE:
                 case FROM_POOL:
-                    throw new FileNotInCacheException("File is incomplete");
+                    throw new LockedCacheException("File is incomplete");
                 case REMOVED:
                 case DESTROYED:
-                    throw new FileNotInCacheException("File has been removed");
+                    throw new LockedCacheException("File has been removed");
                 case BROKEN:
                 case PRECIOUS:
                 case CACHED:


### PR DESCRIPTION
Motivation:

When setting the sticky flag of a file in a transient state, the pool failed
with a FileNotInCacheException rather than LockedCacheException like other
operations.

Modification:

Fail with LockedCacheException instead.

Result:

No user visible changes, but requesting backport as this affects the resilience
service.

Target: trunk
Require-notes: no
Require-book: no
Request: 2.16
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/9424/

(cherry picked from commit 7e0baec7bfd6c26c2ff549b6b0b7098d2c4d5074)