### PR TITLE
cells: Fix local delivery to queues

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -421,7 +421,7 @@ class CellGlue
                  */
                 for (CellRoute route : _routingTable.findTopicRoutes(address)) {
                     CellAddressCore target = route.getTarget();
-                    boolean isLocalSubscriber = !target.getCellName().equals("*");
+                    boolean isLocalSubscriber = !target.isDomainAddress();
                     if (isLocalSubscriber || resolveRemotely) {
                         CellMessage m = msg.clone();
                         if (isLocalSubscriber) {
@@ -472,7 +472,8 @@ class CellGlue
 
             /* Alias routes rewrite the address.
              */
-            if (route.getRouteType() == CellRoute.ALIAS) {
+            if (route.getRouteType() == CellRoute.ALIAS ||
+                route.getRouteType() == CellRoute.QUEUE && !address.isDomainAddress()) {
                 destination.replaceCurrent(address);
                 hasDestinationChanged = true;
             }


### PR DESCRIPTION
Motivation:

Cells may consume messages from named queues. When they do, a
queue route is installed that routes messages sent to the queue
to the consuming cell.

This fails because the routing logic delivers the message as
if to a tunnel. Thus the message isn't corrcectly decoded before
delivery to the cell, resulting in a null pointer exception.

This was not discovered earlier as delivery will succeed if the
cell has the same name as the queue - in that case delivery is
directly to the cell rather than through the queue route.

Modification:

Add the same kind of destination address rewriting logic already
used for alias and topic routes. This causes the message to
delivered as a message event rather than a routing event.

Result:

Fixed a bug in which delivery of messages to cells would fail
if the cell name was different from the cell service name.

Target: trunk
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/9427/

(cherry picked from commit 9e9a2abec6d5fe169eb06b5bcfb5c62b1caa7538)