### PR TITLE
cells: Allow local delivery of messages through queue routes

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -994,7 +994,7 @@ public class CellNucleus implements ThreadFactory
         __cellGlue.routeDelete(route);
     }
     CellRoute routeFind(CellAddressCore addr) {
-        return __cellGlue.getRoutingTable().find(addr);
+        return __cellGlue.getRoutingTable().find(addr, true);
     }
     public CellRoutingTable getRoutingTable() { return __cellGlue.getRoutingTable(); }
     public CellRoute [] getRoutingList() { return __cellGlue.getRoutingList(); }


### PR DESCRIPTION
Motivation:

The cells framework has two boolean flags to restrict local and remote delivery
of messages.  The current implementation would skip the use of routes if remote
delivery was disabled (with the exception of topic routes). This causes
messages to named queues to fail to be delivered to local consumers if remote
delivery is disabled. This is the case when the message was received from a
core domain.

Modification:

Restructure the routing loop such that only delivery through routes to domain
targets are suppressed. This is the same logic also used for topic routes.

Result:

Fixed an issue with message delivery to named queues affecting consumers
whose cell name is different from the queue name.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9438/

(cherry picked from commit e4f1b42cdf1a057ae51cb978f9572c29294425b5)