### PR TITLE
webdav: avoid NPE if client fails to send a User-Agent header

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/owncloud/OwncloudClients.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/owncloud/OwncloudClients.java
@@ -33,6 +33,6 @@ public class OwncloudClients
     {
         String userAgent = request.getHeader(HttpHeader.USER_AGENT.toString());
 
-        return userAgent.contains(OWNCLOUD_USERAGENT);
+        return userAgent != null && userAgent.contains(OWNCLOUD_USERAGENT);
     }
 }


### PR DESCRIPTION
Motivation:

Not all user-agents send a User-Agent header in their requests, yet
dCache webdav door fails with a NPE if not.  Duplicity is apparently
one such client.

Modification:

Update code to check if user-agent is the OwnCloud sync-client to be
robust against a client not sending the header.

Result:

No more NPEs.

Target: master
Request: 2.16
Request: 2.15
Patch: https://rb.dcache.org/r/9444/
Acked-by: Gerd Behrmann
Ticket: http://rt.dcache.org/Ticket/Display.html?id=8998