### PR TITLE
httpd: change condition from numeric inequality to non-null check on …

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -582,7 +582,7 @@ public class TransferObserverV1
             }
         } else {
             page.td("state", transfer.getMoverStatus());
-            if (transfer.getMoverStart() > 0L) {
+            if (transfer.getMoverStart() != null) {
                 page.td("transferred", transfer.getBytesTransferred() / 1024);
             } else {
                 page.td("transferred", "-");


### PR DESCRIPTION
…TransferInfo value

Motivation:

When transfer info from a door is received, some values may not be set
if there is no mover.  These will then be null (including numeric objects).

One condition check in the TransferObserver1 was erroneously treating
one of these fields as an initialized primitive value.

Modification:

Change the condition to a non-null check.

Result:

No NullPointerException if the value is not set.

Target: master
Request: 2.16
Acked-by: Gerd