### PR TITLE
resilience: allow file consumer to propagate Exception

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
@@ -86,7 +86,6 @@ import org.dcache.resilience.handlers.PoolTaskCompletionHandler;
 import org.dcache.resilience.util.CacheExceptionUtils;
 import org.dcache.resilience.util.CacheExceptionUtils.FailureType;
 import org.dcache.resilience.util.CheckpointUtils;
-import org.dcache.resilience.util.ExceptionMessage;
 import org.dcache.resilience.util.Operation;
 import org.dcache.resilience.util.OperationHistory;
 import org.dcache.resilience.util.OperationStatistics;
@@ -871,10 +870,6 @@ public class FileOperationMap extends RunnableModule {
             }
         } catch (InterruptedException e) {
             LOGGER.trace("Consumer was interrupted.");
-        } catch (Exception e) {
-            LOGGER.error("Consumer thread failed, "
-                            + "resilience is no longer running: {}.",
-                            new ExceptionMessage(e));
         }
 
         LOGGER.info("Exiting pnfs operation consumer.");


### PR DESCRIPTION
Motivation:

The file consumer thread is currently catching Exception.
The rationale for this was to allow for "file ctrl start"
to be used to try to recover functioning.

It is, however, preferable to just allow the error to
propagate, since the Runtime exceptions represent bugs
anyway.

Modification:

Remove the catch clause from the run method.

Result:

Clearer indication of bug in log, and fail-fast
behavior.

Target: master
Request: 2.16
Acked-by: Gerd