### PR TITLE
resilience: remove pool from operation table when it has been removed…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
@@ -79,6 +79,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
+import org.dcache.alarms.AlarmMarkerFactory;
+import org.dcache.alarms.PredefinedAlarm;
 import org.dcache.resilience.data.PoolOperation.NextAction;
 import org.dcache.resilience.data.PoolOperation.State;
 import org.dcache.resilience.handlers.PoolOperationHandler;
@@ -825,7 +827,15 @@ public class PoolOperationMap extends RunnableModule {
         operation.psuAction = SelectionAction.NONE;
         operation.forceScan = false;
         operation.resetChildren();
-        idle.put(pool, operation);
+        if (poolInfoMap.isResilientPool(pool)) {
+            idle.put(pool, operation);
+        } else if (operation.state == State.FAILED) {
+            LOGGER.error(AlarmMarkerFactory.getMarker(
+                            PredefinedAlarm.FAILED_REPLICATION, pool),
+                            "{} was removed from resilient group but final scan "
+                                            + "failed: {}.", pool,
+                            new ExceptionMessage(operation.exception));
+        }
     }
 
     /**


### PR DESCRIPTION
… from a resilient group

Motivation:

The pool operation list in Resilience exposes only potential operations on resilient pools.
If a pool should be removed from a resilient group, it should no longer appear in this list.

Modification:

When a pool scan completes, check to see if the pool is still resilient before
putting it back on the idle queue.

Note that when a pool is removed from a resilient group, the pool is scheduled to
be scanned, so the easiest way to ensure map consistency is lazily, rather than
checking the map periodically.

Result:

Stray pools which were once but are no longer resilient no longer stick around in
the operation map and thus disappear from the "pool ls" listing.

Target: master
Request: 2.16
Acked-by: Gerd