### PR TITLE
resilience: remove restriction on storage unit linkage

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/PoolSelectionUnitDecorator.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/PoolSelectionUnitDecorator.java
@@ -113,10 +113,6 @@ public final class PoolSelectionUnitDecorator
     @Override
     public void addLink(String linkName, String name) {
         delegate.addLink(linkName, name);
-
-        if (active) {
-            StorageUnitInfoExtractor.validateAllStorageUnits(psu);
-        }
     }
 
     @Override
@@ -133,13 +129,6 @@ public final class PoolSelectionUnitDecorator
     public void addToUnitGroup(String uGroupName, String unitName,
                     boolean isNet) {
         delegate.addToUnitGroup(uGroupName, unitName, isNet);
-
-        if (active) {
-            StorageUnit unit = psu.getStorageUnit(unitName);
-            if (unit != null) {
-                StorageUnitInfoExtractor.validateAllStorageUnits(psu);
-            }
-        }
     }
 
     @Override
@@ -148,9 +137,6 @@ public final class PoolSelectionUnitDecorator
          *  note that this method is already called by the UniversalSpringCell
          *  on the delegate before the decorator's is invoked.
          */
-
-        StorageUnitInfoExtractor.validateAllStorageUnits(psu);
-
         active = true;
     }
 
@@ -421,12 +407,9 @@ public final class PoolSelectionUnitDecorator
      *          from its unit group.
      * </li>
      * </ol>
-     * <p>This call will run two verifications before allowing the change:
-     *          first, that a change making this unit resilient not be allowed
-     *          if this storage unit is linked to non-resilient groups; second,
-     *          a test to see that all pool groups to which it is linked can
-     *          satisfy the requirements for copies (including partitioning
-     *          by pool tags).</p>
+     * <p>This call will test to see that all resilient pool groups to which
+     *          it is linked can satisfy the requirements for copies
+     *          (including partitioning by pool tags).</p>
      */
     @Override
     public void setStorageUnit(String storageUnitKey, Integer required,
@@ -459,7 +442,6 @@ public final class PoolSelectionUnitDecorator
                 unit.setOnlyOneCopyPer(onlyOneCopyPer);
             }
 
-            StorageUnitInfoExtractor.validate(unit, psu);
             StorageUnitInfoExtractor.verifyCanBeSatisfied(unit, psu, module);
         }
 


### PR DESCRIPTION
Motivation:

The pool selection unit decorator currently enforces a constraint
on resilient storage units preventing them from being linked to
non-resilient pool groups.

This constraint is unnecessary, however, as resilience only cares
about the semantics of the unit within a given resilient group,
not outside it.

Modification:

Remove the constraint checking.

Result:

There is nothing preventing a resilient storage unit from being
linked to a non-resilient pool group.

This is not an improvement, it is actually incorrect.  It should
be backported.

(I will adjust the documentation on the wiki.)

Target: master
Request: 2.16
Acked-by: Gerd