### PR TITLE
resilience: fix several related bugs in transition checking when sche…

### DIFF
--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolInfoChangeHandlerTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolInfoChangeHandlerTest.java
@@ -68,6 +68,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import diskCacheV111.pools.PoolV2Mode;
 import diskCacheV111.util.CacheException;
 import org.dcache.resilience.TestBase;
 import org.dcache.resilience.TestSynchronousExecutor;
@@ -113,6 +114,14 @@ public class PoolInfoChangeHandlerTest extends TestBase {
         wirePoolOperationMap();
         wirePoolOperationHandler();
         poolOperationMap.loadPools();
+
+        poolInfoMap.getResilientPools().stream()
+                   .forEach((p) -> {
+                            PoolV2Mode mode = new PoolV2Mode(PoolV2Mode.ENABLED);
+                            PoolStateUpdate update = new PoolStateUpdate(p, mode);
+                            poolInfoMap.updatePoolStatus(update);
+                            poolOperationMap.update(update);
+                   });
 
         ResilienceMessageHandler handler = new ResilienceMessageHandler();
         handler.setCounters(counters);
@@ -397,6 +406,7 @@ public class PoolInfoChangeHandlerTest extends TestBase {
     private void whenPoolIsWaitingToBeScanned(String pool) {
         PoolOperation operation = new PoolOperation();
         operation.state = State.WAITING;
+        operation.currStatus = PoolStatusForResilience.ENABLED;
         poolOperationMap.waiting.put(pool, operation);
     }
 

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolOperationMapTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolOperationMapTest.java
@@ -379,7 +379,7 @@ public class PoolOperationMapTest extends TestBase {
     }
 
     private boolean givenForcedScanOf(String pool) {
-        return poolOperationMap.scan(poolInfoMap.getPoolState(pool));
+        return poolOperationMap.scan(poolInfoMap.getPoolState(pool), true);
     }
 
     private void givenPnfsCountOfPoolIs(int count) {


### PR DESCRIPTION
…duling scans

Motivation:

When a pool changes state, resilience uses an implicit transition table to
determine whether a scan is necessary or not.

However, there are several other paths leading to scanning.

1.  The periodic pool sweeps.
2.  A change in pool groups or storage units.
3.  A manually initiated scan.

Currently, 2) and 3) share the same logic.  This is incorrect.  Except
for pools which are not yet initialized, 3) should never be rejected
(it is a forced scan in the truest sense).  At the same time, there
are distinct differences between whether 2) has to do with a pool
or pool group change or a storage unit change.

Modification:

Distinguish properly between the various cases.  This means that
considerations of whether the pool is down and has already been
scanned, or is excluded, should be bypassed for (3), and also
for a redistribution of pool tag constraints on the storage unit,
but should be enforced otherwise.  (In the latter case we skip
the checks because this is really a form of 'rebalancing' rather
than the creation of missing copies or the removal of extra ones.)

Result:

Correct scan scheduling behavior.

Target: master
Request: 2.16
Acked-by: Gerd