### PR TITLE
resilience: fix the way removal of a pool from a resilient group is h…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
@@ -90,7 +90,6 @@ import org.dcache.resilience.util.ExceptionMessage;
 import org.dcache.resilience.util.Operation;
 import org.dcache.resilience.util.OperationHistory;
 import org.dcache.resilience.util.OperationStatistics;
-import org.dcache.resilience.util.PoolSelectionUnitDecorator.SelectionAction;
 import org.dcache.resilience.util.ResilientFileTask;
 import org.dcache.util.RunnableModule;
 import org.dcache.vehicles.FileAttributes;
@@ -549,9 +548,7 @@ public class FileOperationMap extends RunnableModule {
          * <p>Task is submitted to an appropriate executor service.</p>
          */
         private void submit(FileOperation operation) {
-            int remove = SelectionAction.REMOVE.ordinal();
             operation.setTask(new ResilientFileTask(operation.getPnfsId(),
-                            operation.getSelectionAction() == remove,
                             operation.getRetried(),
                             operationHandler));
             operation.setState(FileOperation.RUNNING);

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -326,14 +326,17 @@ public final class FileUpdate {
             return true;
         }
 
-        Collection<String> locations = attributes.getLocations();
-
+        Collection<String> locations
+                        = poolInfoMap.getMemberLocations(group,
+                                                         attributes.getLocations());
         /*
-         * On removing a pool from a group, the pool must
-         * be considered as if it were DOWN.
+         * This indicates that all the locations for the file do not belong
+         * to the given pool group.  This could happen if all locations
+         * that were once part of the group are removed.  In this case,
+         * the operation is a NOP.
          */
-        if (action == SelectionAction.REMOVE) {
-            locations.remove(pool);
+        if (locations.isEmpty()) {
+            return false;
         }
 
         /*

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperation.java
@@ -86,17 +86,17 @@ public final class PoolOperation {
         DOWN_TO_UP     // CANCEL ANY CURRENT DOWN AND PROMOTE TO WAITING
     }
 
-    boolean forceScan;     // Overrides non-handling of restarts
-    long lastUpdate;
-    long lastScan;
-    Integer group;         // Only set when the psuAction != NONE
-    Integer unit;          // Only set when the psuAction == MODIFY
-    State state;
-    SelectionAction psuAction;
+    boolean                 forceScan;     // Overrides non-handling of restarts
+    long                    lastUpdate;
+    long                    lastScan;
+    Integer                 group;         // Only set when the psuAction != NONE
+    Integer                 unit;          // Only set when the psuAction == MODIFY
+    State                   state;
+    SelectionAction         psuAction;
     PoolStatusForResilience lastStatus;
     PoolStatusForResilience currStatus;
-    PoolScanTask task;
-    CacheException exception;
+    PoolScanTask            task;
+    CacheException          exception;
 
     private int children;
     private int completed;

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/LocationSelector.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/LocationSelector.java
@@ -87,11 +87,6 @@ public final class LocationSelector {
     private PoolInfoMap poolInfoMap;
     private PoolSelectionStrategy poolSelectionStrategy;
 
-    public Set<String> getReadableMemberLocations(Integer gindex,
-                    Collection<String> locations) {
-        return poolInfoMap.getMemberPools(gindex, locations, false);
-    }
-
     public String selectCopySource(FileOperation operation,
                     Set<String> locations) throws LocationSelectionException {
         LOGGER.trace("selecting source for {}", operation);

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/ResilientFileTask.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/ResilientFileTask.java
@@ -98,7 +98,6 @@ public final class ResilientFileTask implements Cancellable, Callable<Void> {
 
     private final PnfsId               pnfsId;
     private final FileOperationHandler handler;
-    private final boolean              suppressAlarm;
     private final int                  retry;
 
     private Task   migrationTask;
@@ -125,12 +124,11 @@ public final class ResilientFileTask implements Cancellable, Callable<Void> {
         return String.format("%.3f", delta);
     }
 
-    public ResilientFileTask(PnfsId pnfsId, boolean suppressAlarm, int retry,
+    public ResilientFileTask(PnfsId pnfsId, int retry,
                              FileOperationHandler handler) {
         this.pnfsId = pnfsId;
         this.retry = retry;
         this.handler = handler;
-        this.suppressAlarm = suppressAlarm;
         type = Type.VOID;
         cancelled = false;
         inVerify = 0L;
@@ -164,7 +162,7 @@ public final class ResilientFileTask implements Cancellable, Callable<Void> {
         }
 
         startSubTask = System.currentTimeMillis();
-        type = handler.handleVerification(attributes, suppressAlarm);
+        type = handler.handleVerification(attributes);
         inVerify = System.currentTimeMillis() - startSubTask;
 
         switch (type) {

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
@@ -100,7 +100,6 @@ public final class FileOperationHandlerTest extends TestBase
     String               storageUnit;
     Integer              originalTarget;
     Integer              originalSource;
-    boolean suppressAlarm = false;
     boolean rmMessageFailure = false;
 
     @Override
@@ -569,7 +568,6 @@ public final class FileOperationHandlerTest extends TestBase
         } else {
             update = new FileUpdate(pnfsId, null, type, false);
         }
-        suppressAlarm = action == SelectionAction.REMOVE;
     }
 
     private void shutPoolDown(String pool) {
@@ -655,13 +653,12 @@ public final class FileOperationHandlerTest extends TestBase
     }
 
     private void whenTaskIsCreatedAndCalled() {
-        task = new ResilientFileTask(update.pnfsId, false, 0,
+        task = new ResilientFileTask(update.pnfsId, 0,
                                      fileOperationHandler);
         task.call();
     }
 
     private void whenVerifyIsRun() {
-        verifyType = fileOperationHandler.handleVerification(attributes,
-                                                             suppressAlarm).name();
+        verifyType = fileOperationHandler.handleVerification(attributes).name();
     }
 }

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/util/LocationSelectorTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/util/LocationSelectorTest.java
@@ -244,8 +244,8 @@ public final class LocationSelectorTest extends TestBase {
     }
 
     private void whenReadableMemberLocationsAreRequested() {
-        collection = locationSelector.getReadableMemberLocations(group,
-                        attributes.getLocations());
+        collection = poolInfoMap.getMemberLocations(group, attributes.getLocations());
+        collection = poolInfoMap.getReadableLocations(collection);
     }
 
     private void whenRemoveTargetIsSelected() {


### PR DESCRIPTION
…andled

Motivation:

When a pool is removed from a resilient group, the resilience system
should take appropriate action.  This depends upon the (altered)
composition of the pool group and the presence of replicas on other
pools in the group.

If replicas held by the removed group are still present on other
pools in the group, then an attempt to compensate by making the
missing copy elsewhere (just as if the pool were DOWN) should occur.

When, however, all copies of that replica have been removed from
the group (because other pools have been removed), then no action
should occur.

These conditions are both currently being handled, but in a manner
which is fragile.  The latter, in particular, is checking an enum
value which may not be present because the operation is not being
properly updated (another patch will be posted that fixes the more
general issue which affects other areas of the code as well) when
another request to handle the same pnfsid occurs.  It is also
neglecting to do a relevant check earlier (which could
avoid unnecessarily creating or updating an operation to begin with).

Modification:

Eliminate the dependency on the REMOVE value of the SelectionAction
enum (a later patch will eliminate this enum entirely).  Check,
instead, the intersection of attribute locations with the pools
that are actually members of the group in question.  The FileUpdate
now pre-empts the operation when this intersection is null; this
is rechecked in the later verification method (instead of the
suppressAlarm flag).  Some refactoring of the PoolInfoMap methods was
done to make the various calls to find countable, readable and
valid members DRY.

Result:

The remove triggers consistent behavior which survives incoming
operation updates because it depends only on the current state
of the pool group.

Target: master
Request: 2.16
Acked-by: Gerd