### PR TITLE
resilience: fix error in file operation updating

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
@@ -571,6 +571,30 @@ public final class FileOperation {
         this.task = task;
     }
 
+    /**
+     * <p>When another operation for this file/pnfsid is to be
+     *    queued, we simply overwrite the appropriate fields on
+     *    this one.</p>
+     */
+    void updateOperation(FileOperation operation) {
+        if (operation.storageUnit != NIL) {
+            storageUnit = operation.storageUnit;
+        }
+
+        if (operation.checkSticky) {
+            checkSticky = true;
+        }
+
+        /*
+         *  The incoming count can be safely added to this one;
+         *  if the count exceeds the necessary number of operations
+         *  to achieve what this operation must, the count will
+         *  be zeroed out anyway when the correct replica state
+         *  is reached.
+         */
+        opCount += operation.opCount;
+    }
+
     boolean updateOperation(CacheException error) {
         synchronized (this) {
             if (isInTerminalState()) {

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
@@ -1082,7 +1082,7 @@ public class FileOperationMap extends RunnableModule {
         FileOperation present = index.get(pnfsId);
 
         if (present != null) {
-            present.incrementCount();
+            present.updateOperation(operation);
             return false;
         }
 

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -317,7 +317,7 @@ public final class FileUpdate {
          * exist.  Force the pnfsId operation into the table if the
          * storage unit matches the modified one.
          */
-        if (action == SelectionAction.MODIFY && unitIndex.equals(storageUnit)) {
+        if (unitIndex.equals(storageUnit)) {
             /*
              * The maximum number of steps required to redistribute all files
              * would be (required - 1) removes + (required - 1) copies.


### PR DESCRIPTION
Motivation:

File operations run concurrently, but are serialized with respect to
pnfsid.  For any logical file, only one copy or remove is thus allowed
to run at a given time.

When several pool scans intersect over their sets of pnfsids, the
first scan to have created the file operation remains the "parent",
but the operation is updated.  Currently, this merely involved
incrementing the operation count, i.e., the number of times it
should attempt to run.

This, however, neglects passing on some important data which
may be held by subsequent scan calls, in particular, whether
the scan involves a specific storage unit, and whether it
also forces the checking of the source sticky bit.  In addition,
in the case of tag distribution, the count calculation done
during the preliminary phase must also be reflected.

Modification:

Change the update call to incorporate the updating of these
attributes/values.

Note that the dependency on MODIFY for determining whether
the operation involves the file's storage unit has been
eliminated in favor of just checking that the unit value
is set.

Result:

Correct behavior on file operation update.

Target: master
Request: 2.16
Acked-by: Gerd