### PR TITLE
resilience: repair (subtle) bug in target selection

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -579,7 +579,7 @@ public class FileOperationHandler {
                 Integer pool = operation.getTarget();
                 if (pool == null || !poolInfoMap.isPoolViable(pool, true)) {
                     target = locationSelector.selectRemoveTarget(operation,
-                                                                 locations, tags);
+                                    readableLocations, tags);
                 }
                 LOGGER.trace("target to remove: {}", target);
             } else if (missing > 0) {
@@ -593,7 +593,7 @@ public class FileOperationHandler {
                 pool = operation.getTarget();
                 if (pool == null || !poolInfoMap.isPoolViable(pool, true)) {
                     target = locationSelector.selectCopyTarget(operation, gindex,
-                                                               locations, tags);
+                                    readableLocations, tags);
                 }
                 LOGGER.trace("target to copy: {}", target);
             } else {


### PR DESCRIPTION
Motivation:

When a target is selected for copy (and remove), a number of
different conditions must pertain:

    it must be from the resilient group;
    it must not already contain the file in question;
    it must be writable;
    it must meet the tag exclusion requirements.

With respect to the latter, the requirements of the storage unit
are checked against the tag values of the potential locations
in such a way as to exclude values already possessed by
existing locations.

Currently, values for all existing locations are being included.
This is a bug.

Modification:

The obvious solution is not to include all
the location tags, just those for the readable
locations.  And in fact it makes sense to do
this for the selection of targets to be removed
as well.

Result:

While the impossible scenario remains what it is
(it's a group issue), the second one is solved.

This bug is so subtle I doubt we would need to
give specific details on the release notes
other than to say a minor bug in target selection
for a corner case has been resolved.

Target: master
Request: 2.16
Acked-by: Gerd