### PR TITLE
resilience: eliminate unnecessary update calls and fix synchronizatio…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -212,13 +212,6 @@ public class FileOperationHandler {
                     throws CacheException {
         LOGGER.trace("handleLocationUpdate {}", data);
 
-        if (fileOpMap.updateCount(data.pnfsId)) {
-            LOGGER.debug("Update of {}: operation already registered, "
-                                         + "count incremented.",
-                         data.pnfsId);
-            return false;
-        }
-
         if (data.pool == null) {
             LOGGER.debug("Update of {} with no location; file has likely "
                                          + "been deleted from namespace.",
@@ -273,13 +266,6 @@ public class FileOperationHandler {
     public boolean handleScannedLocation(FileUpdate data, Integer storageUnit)
                     throws CacheException {
         LOGGER.trace("handleScannedLocation {}", data);
-
-        if (fileOpMap.updateCount(data.pnfsId)) {
-            LOGGER.trace("Update of {}: operation already registered, "
-                                         + "count incremented.",
-                         data.pnfsId);
-            return false;
-        }
 
         /*
          * These must be true during a pool scan.

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/FileOperationMapTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/FileOperationMapTest.java
@@ -366,7 +366,7 @@ public final class FileOperationMapTest extends TestBase {
     }
 
     private void givenAnotherLocationForPnfsId() {
-        fileOperationMap.updateCount(operation.getPnfsId());
+        fileOperationMap.getOperation(operation.getPnfsId()).incrementCount();
     }
 
     private void setMocks() {


### PR DESCRIPTION
…n of file op registration

Motivation:

Patch 9451 made adjustments to the way a duplicated
file operation updates the extant one.  It did so
in the FileOperationMap's 'add' method.

However, the two entry points for a new file operation
were also pre-checking the existence of the operation
before actually processing the update.  This was
being done in order to avoid the database call to
get file attributes.

Now that the logic of the update has changed slightly,
this simple counter increment is not correct.

Moreover, the lack of synchronization (the underlying
call to the index fetches from a ConcurrentMap) was
based on the idea that we would not get into serious
trouble if simultaneous calls were sliced such
that both actually end up adding an operation (the
second overwriting the first).

However, it is possible for this to confuse the
operation counts on simultaneous pool scans (it
happens rarely, but recent testing revealed a few
instances).

Modification:

First, the extra call (and its updateCount method)
have been eliminated.  Testing shows that there
is no significant performance loss in doing so.
In fact, the collision is most likely to occur
between two handleScanned calls, and the ingest
rates there are already masked by the slower
select query.

Second, the add method has now made the check-and-add
sequence into an atomic critical section, as it
normally should have been.  Once again, testing
reveals no noticeable drop in performance.

Result:

Correct update code, and race condition eliminated.

Target: master
Request: 2.16
Acked-by: Gerd