### PR TITLE
resilience: finish the renaming of 'pnfs(id) operation' to 'file oper…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
@@ -393,21 +393,21 @@ public final class ResilienceCommands implements CellCommandListener {
                                         + "on = turn checkpointing on; "
                                         + "info = information (default); "
                                         + "reset = reset properties; "
-                                        + "start = (re)start processing of pnfs operations; "
-                                        + "shutdown = stop all processing of pnfs operations; "
+                                        + "start = (re)start processing of file operations; "
+                                        + "shutdown = stop all processing of file operations; "
                                         + "run = checkpoint to disk immediately." )
         String arg = "INFO";
 
         @Option(name = "checkpoint",
                         usage = "With reset mode (one of checkpoint|sweep). "
                                         + "Interval length between checkpointing "
-                                        + "of the pnfs operation data.")
+                                        + "of the file operation data.")
         Long checkpoint;
 
         @Option(name = "sweep",
                         usage = "With reset mode (one of checkpoint|sweep). "
                                         + "Minimal interval between sweeps of "
-                                        + "the pnfs operations.")
+                                        + "the file operations.")
         Long sweep;
 
         @Option(name = "unit",
@@ -508,7 +508,7 @@ public final class ResilienceCommands implements CellCommandListener {
                                       fileOperationMap.getCheckpointExpiry(),
                                       fileOperationMap.getCheckpointExpiryUnit(),
                                       fileOperationMap.getCheckpointFilePath()));
-            counters.getPnfsSweepInfo(info);
+            counters.getFileOpSweepInfo(info);
             counters.getCheckpointInfo(info);
             return info.toString();
         }
@@ -523,7 +523,7 @@ public final class ResilienceCommands implements CellCommandListener {
         @Option(name = "state",
                         valueSpec = "WAITING|RUNNING",
                         separator = ",",
-                        usage = "Cancel operations for pnfsids matching this "
+                        usage = "Cancel operations for files matching this "
                                         + "comma-delimited set of operation states; "
                                         + "default is both.")
         String[] state;
@@ -549,12 +549,12 @@ public final class ResilienceCommands implements CellCommandListener {
 
         @Option(name = "retentionPolicy",
                         valueSpec = "REPLICA|CUSTODIAL ",
-                        usage = "Cancel only operations for pnfsids with this "
+                        usage = "Cancel only operations for files with this "
                                         + "policy.")
         String retentionPolicy;
 
         @Option(name = "storageUnit",
-                        usage = "Cancel only operations for pnfsids with this "
+                        usage = "Cancel only operations for files with this "
                                         + "storage unit/group.")
         String storageUnit;
 
@@ -630,7 +630,7 @@ public final class ResilienceCommands implements CellCommandListener {
 
             fileOperationMap.cancel(filter);
 
-            return "Issued cancel command to cancel pnfs operations.";
+            return "Issued cancel command to cancel file operations.";
         }
     }
 
@@ -693,19 +693,19 @@ public final class ResilienceCommands implements CellCommandListener {
     class FileOpLsCommand extends ResilienceCommand {
         @Option(name = "retentionPolicy",
                         valueSpec = "REPLICA|CUSTODIAL",
-                        usage = "List only operations for pnfsids with this "
+                        usage = "List only operations for files with this "
                                         + "policy.")
         String retentionPolicy;
 
         @Option(name = "storageUnit",
-                        usage = "List only operations for pnfsids with this "
+                        usage = "List only operations for files with this "
                                         + "storage unit/group.")
         String storageUnit;
 
         @Option(name = "state",
                         valueSpec = "WAITING|RUNNING",
                         separator = ",",
-                        usage = "List only operations for pnfsids matching this "
+                        usage = "List only operations for files matching this "
                                         + "comma-delimited set of operation states; "
                                         + "default is both.")
         String[] state = {"WAITING", "RUNNING"};
@@ -758,7 +758,7 @@ public final class ResilienceCommands implements CellCommandListener {
                         usage = "List only activities for this comma-delimited "
                                         + "list of pnfsids. No argument lists all "
                                         + "operations; use '$' to return just "
-                                        + "the number of pnfsid entries; '$@' to "
+                                        + "the number of entries; '$@' to "
                                         + "return the op counts by pool.")
         String pnfsids;
 
@@ -789,7 +789,7 @@ public final class ResilienceCommands implements CellCommandListener {
                     return total + " matching pnfsids";
                 }
 
-                return String.format("%s matching pnfsids."
+                return String.format("%s matching operations."
                                 + "\n\nOperation counts per pool:\n%s",
                                 total, builder.toString());
             }
@@ -1238,7 +1238,7 @@ public final class ResilienceCommands implements CellCommandListener {
         String lastScanAfter;
 
         @Option(name = "includeChildren",
-                        usage = "Cancel pnfsId operations whose parents match "
+                        usage = "Cancel file operations whose parents match "
                                         + "the pool pattern.  Note that this "
                                         + "option automatically sets 'forceRemoval' "
                                         + "to true on the child operation cancel. "
@@ -1285,7 +1285,7 @@ public final class ResilienceCommands implements CellCommandListener {
 
             if (includeChildren) {
                 fileOperationMap.cancel(filter);
-                sb.append("  Also issued cancel command to pnfsId operations.");
+                sb.append("  Also issued cancel command to file operations.");
             }
 
             return sb.toString();
@@ -1428,7 +1428,7 @@ public final class ResilienceCommands implements CellCommandListener {
 
         @Argument(usage = "Regular expression for pool(s) on which to "
                                         + "conduct the adjustment of "
-                                        + "all pnfsids.")
+                                        + "all files.")
         String pools;
 
         @Override

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
@@ -877,10 +877,10 @@ public class FileOperationMap extends RunnableModule {
                             new ExceptionMessage(e));
         }
 
-        LOGGER.info("Exiting pnfs operation consumer.");
+        LOGGER.info("Exiting file operation consumer.");
         clear();
 
-        LOGGER.info("Pnfs operation queues and index cleared.");
+        LOGGER.info("File operation queues and index cleared.");
     }
 
     /**
@@ -900,7 +900,7 @@ public class FileOperationMap extends RunnableModule {
     }
 
     /**
-     *  <p>"Pnfs sweep:" the main queue update sequence (run by the consumer).</p>
+     *  <p>"File operation sweep:" the main queue update sequence (run by the consumer).</p>
      */
     @VisibleForTesting
     public void scan() {
@@ -908,7 +908,7 @@ public class FileOperationMap extends RunnableModule {
         terminalOperationProcessor.processTerminated();
         waitingOperationProcessor.processWaiting();
         long end = System.currentTimeMillis();
-        counters.recordPnfsSweep(end, end - start);
+        counters.recordFileOpSweep(end, end - start);
     }
 
     public void setCheckpointExpiry(long checkpointExpiry) {

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -82,7 +82,7 @@ import org.dcache.vehicles.FileAttributes;
 
 /**
  * <p>A transient encapsulation of pertinent configuration data regarding
- *      a pnfs location.</p>
+ *      a file location.</p>
  *
  * <p>Implements verification/validation methods to determine if the update
  *      should be registered in the operation map or not.</p>
@@ -314,7 +314,7 @@ public final class FileUpdate {
 
         /*
          * Files may be in need of migration even if the correct number
-         * exist.  Force the pnfsId operation into the table if the
+         * exist.  Force the file operation into the table if the
          * storage unit matches the modified one.
          */
         if (action == SelectionAction.MODIFY && unitIndex.equals(storageUnit)) {

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInfoMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInfoMap.java
@@ -109,7 +109,7 @@ import org.dcache.vehicles.FileAttributes;
  *      operation.</p>
  *
  * <p>The reason for doing this is to be able to store most of the pool info
- *      associated with a given pnfs or pool operation in progress as index
+ *      associated with a given file or pool operation in progress as index
  *      references, allowing the {@link FileOperation} to use 4-byte rather
  *       than 8-byte 'references'.</p>
  *

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
@@ -590,7 +590,7 @@ public class PoolOperationMap extends RunnableModule {
                 /*
                  *  NOTE:  there is a need to cancel children here,
                  *  even though the task is being canceled because
-                 *  of a change of status, so that all waiting pnfsid tasks
+                 *  of a change of status, so that all waiting file tasks
                  *  would eventually find the available replica count changed
                  *  and act accordingly.  The problem is with possible
                  *  inconsistencies in the child counts for the operation,

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/db/LocalNamespaceAccess.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/db/LocalNamespaceAccess.java
@@ -112,7 +112,7 @@ public class LocalNamespaceAccess implements NamespaceAccess {
     private static final Logger LOGGER = LoggerFactory.getLogger(LocalNamespaceAccess.class);
 
     /**
-     * <p>Handler for processing pnfs operations.</p>
+     * <p>Handler for processing file operations.</p>
      */
     protected FileOperationHandler handler;
 

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -414,7 +414,7 @@ public class FileOperationHandler {
 
         /*
          *  Note that the location-dependent checks are run on this thread
-         *  instead of being pre-checked by the PnfsOperationMap consumer thread
+         *  instead of being pre-checked by the FileOperationMap consumer thread
          *  because they require a call to the database.
          */
         try {

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/ResilienceMessageHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/ResilienceMessageHandler.java
@@ -82,7 +82,7 @@ import org.dcache.resilience.util.OperationStatistics;
 import org.dcache.vehicles.CorruptFileMessage;
 
 /**
- * <p>Processes external messages in order to trigger Pnfs-based operations.
+ * <p>Processes external messages in order to trigger file operations.
  *      Also handles internal callbacks indicated the change of
  *      pool status/mode.</p>
  */
@@ -100,7 +100,7 @@ public final class ResilienceMessageHandler implements CellMessageReceiver{
     /**
      * <p>Pool status changes are detected internally during the
      *      comparison of pool monitor states.  The change is rerouted
-     *      here as a loopback to conform with the way external pnfs updates
+     *      here as a loopback to conform with the way external file updates
      *      are handled.</p>
      *
      * <p>Pools that have not yet been fully initialized are skipped.</p>

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/LocationSelector.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/LocationSelector.java
@@ -78,7 +78,7 @@ import org.dcache.resilience.data.PoolInfoMap;
  * <p>Manages the selection of locations from the underlying pool map
  *      information.  Encapsulates the logic involved in extracting
  *      sets of valid readable or writable pools in connection with
- *      the verify, copy and remove phases of the pnfs operation.</p>
+ *      the verify, copy and remove phases of the file operation.</p>
  */
 public final class LocationSelector {
     private static final Logger LOGGER = LoggerFactory.getLogger(
@@ -154,7 +154,7 @@ public final class LocationSelector {
 
     /**
      * <p>Filters first the writable pools in the pool group which do
-     *      not yet have a copy of this pnfsid, then applies any tag-induced
+     *      not yet have a copy of this file, then applies any tag-induced
      *      partitioning on the basis of the tags of copies that already exist.
      *      From that list, it then chooses the pool using the
      *      configured poolSelectionStrategy.</p>
@@ -164,8 +164,7 @@ public final class LocationSelector {
                     Collection<String> locations, Set<Integer> tried,
                     Collection<String> oneCopyPer) throws LocationSelectionException {
         /*
-         *  Writable locations in the pool group without a copy of this
-         *  pnfsId.
+         *  Writable locations in the pool group without a copy of this file.
          */
         Set<String> possible = getEligibleCopyTargets(gindex, locations, tried);
 
@@ -213,7 +212,7 @@ public final class LocationSelector {
 
     /**
      * <p>Filters first the writable pools in the pool group which contain a
-     *      copy of this pnfsid, then applies any tag-induced partitioning on
+     *      copy of this file, then applies any tag-induced partitioning on
      *      the basis of the tags of copies that already exist to select a
      *      maximally constrained pool.  If more than one pool has the same
      *      weight, one of them is chosen randomly.</p>

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/MapInitializer.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/MapInitializer.java
@@ -121,7 +121,7 @@ public final class MapInitializer implements Runnable {
         poolInfoChangeHandler.stopWatchdog();
 
         if (fileOperationMap.isRunning()) {
-            LOGGER.info("Shutting down pnfs operation map.");
+            LOGGER.info("Shutting down file operation map.");
             fileOperationMap.shutdown();
         }
 
@@ -180,10 +180,10 @@ public final class MapInitializer implements Runnable {
         LOGGER.info("Pool maps initialized; delivering backlog.");
         messageGuard.enable();
 
-        LOGGER.info("Messages are now activated; starting pnfs consumer.");
+        LOGGER.info("Messages are now activated; starting file operation consumer.");
         fileOperationMap.initialize();
 
-        LOGGER.info("Pnfs consumer is running; activating admin commands.");
+        LOGGER.info("File operation consumer is running; activating admin commands.");
         synchronized (this) {
             initialized = System.currentTimeMillis();
         }

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/OperationStatistics.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/OperationStatistics.java
@@ -118,8 +118,8 @@ public final class OperationStatistics {
 
     private static final String LASTSTART = "Running since: %s\n";
     private static final String UPTIME    = "Uptime %s days, %s hours, %s minutes, %s seconds\n\n";
-    private static final String LASTSWP   = "Last pnfs sweep at %s\n";
-    private static final String LASTSWPD  = "Last pnfs sweep took %s seconds\n";
+    private static final String LASTSWP   = "Last file operation sweep at %s\n";
+    private static final String LASTSWPD  = "Last file operation sweep took %s seconds\n";
     private static final String LASTCHK   = "Last checkpoint at %s\n";
     private static final String LASTCHKD  = "Last checkpoint took %s seconds\n";
     private static final String LASTCHKCT = "Last checkpoint saved %s records\n";
@@ -197,8 +197,8 @@ public final class OperationStatistics {
     private long lastCheckpoint         = started.getTime();
     private long lastCheckpointDuration = 0;
 
-    private long lastPnfsSweep          = started.getTime();
-    private long lastPnfsSweepDuration  = 0;
+    private long lastFileOpSweep = started.getTime();
+    private long lastFileOpSweepDuration = 0;
 
     private File statisticsPath;
     private boolean toFile = false;
@@ -222,11 +222,10 @@ public final class OperationStatistics {
         builder.append(String.format(LASTCHKCT, latest.get()));
     }
 
-    public void getPnfsSweepInfo(StringBuilder info) {
-        info.append(String.format(LASTSWP, new Date(lastPnfsSweep)));
+    public void getFileOpSweepInfo(StringBuilder info) {
+        info.append(String.format(LASTSWP, new Date(lastFileOpSweep)));
         info.append(String.format(LASTSWPD,
-                        TimeUnit.MILLISECONDS.toSeconds(
-                                        lastPnfsSweepDuration)));
+                        TimeUnit.MILLISECONDS.toSeconds(lastFileOpSweepDuration)));
     }
 
     public void increment(String source, String target, Type type, long size) {
@@ -321,7 +320,7 @@ public final class OperationStatistics {
         StringBuilder builder = new StringBuilder();
 
         getRunning(builder);
-        getPnfsSweepInfo(builder);
+        getFileOpSweepInfo(builder);
         getCheckpointInfo(builder);
         builder.append("\n");
         printSummary(builder);
@@ -384,9 +383,9 @@ public final class OperationStatistics {
         resetLatestCounts();
     }
 
-    public void recordPnfsSweep(long ended, long duration) {
-        lastPnfsSweep = ended;
-        lastPnfsSweepDuration = duration;
+    public void recordFileOpSweep(long ended, long duration) {
+        lastFileOpSweep = ended;
+        lastFileOpSweepDuration = duration;
     }
 
     public void recordTaskStatistics(ResilientFileTask task,
@@ -495,7 +494,7 @@ public final class OperationStatistics {
         if (!statisticsPath.exists()) {
             try (FileWriter fw = new FileWriter(statisticsPath, true)) {
                 fw.write(String.format(FORMAT_FILE, "CHECKPOINT", "NEWLOC",
-                                "HZ", "CHNG", "PNFSOP", "HZ", "CHNG", "FAILED",
+                                "HZ", "CHNG", "FILEOP", "HZ", "CHNG", "FAILED",
                                 "CHCKPTD"));
                 fw.flush();
             } catch (FileNotFoundException e) {

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/SimplePersistentBacklogHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/SimplePersistentBacklogHandler.java
@@ -162,7 +162,7 @@ public final class SimplePersistentBacklogHandler
         }
 
         /**
-         * <p>Only pnfs-based messages are stored.</p>
+         * <p>Only file operation messages are stored.</p>
          */
         private void saveToBacklog(Serializable message) {
             String pnfsid;

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolFilterTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolFilterTest.java
@@ -85,56 +85,56 @@ public final class PoolFilterTest extends TestBase {
     }
 
     @Test
-    public void shouldMatchPnfsOperationWhenParentMatchesParentPool()
+    public void shouldMatchFileOperationWhenParentMatchesParentPool()
                     throws CacheException {
         givenFilterWith("resilient_pool-0", null, null, true, false, false, null, null,
                         null, null);
-        givenPnfsOperationWith("resilient_pool-0", null, null);
+        givenFileOperationWith("resilient_pool-0", null, null);
         assertTrue(filter.matches(fileOperation, poolInfoMap));
     }
 
     @Test
-    public void shouldMatchPnfsOperationWhenSourceMatchesSourcePool()
+    public void shouldMatchFileOperationWhenSourceMatchesSourcePool()
                     throws CacheException {
         givenFilterWith("resilient_pool-0", null, null, false, true, false, null, null,
                         null, null);
-        givenPnfsOperationWith(null, "resilient_pool-0", null);
+        givenFileOperationWith(null, "resilient_pool-0", null);
         assertTrue(filter.matches(fileOperation, poolInfoMap));
     }
 
     @Test
-    public void shouldMatchPnfsOperationWhenTargetMatchesTargetPool()
+    public void shouldMatchFileOperationWhenTargetMatchesTargetPool()
                     throws CacheException {
         givenFilterWith("resilient_pool-0", null, null, false, false, true, null, null,
                         null, null);
-        givenPnfsOperationWith(null, null, "resilient_pool-0");
+        givenFileOperationWith(null, null, "resilient_pool-0");
         assertTrue(filter.matches(fileOperation, poolInfoMap));
     }
 
     @Test
-    public void shouldNotMatchPnfsOperationWhenParentDoesNotMatchParentPool()
+    public void shouldNotMatchFileOperationWhenParentDoesNotMatchParentPool()
                     throws CacheException {
         givenFilterWith("resilient_pool-0", null, null, true, false, false, null, null,
                         null, null);
-        givenPnfsOperationWith(null, null, null);
+        givenFileOperationWith(null, null, null);
         assertFalse(filter.matches(fileOperation, poolInfoMap));
     }
 
     @Test
-    public void shouldNotMatchPnfsOperationWhenSourceDoesNotMatchSourcePool()
+    public void shouldNotMatchFileOperationWhenSourceDoesNotMatchSourcePool()
                     throws CacheException {
         givenFilterWith("resilient_pool-0", null, null, false, true, false, null, null,
                         null, null);
-        givenPnfsOperationWith(null, null, null);
+        givenFileOperationWith(null, null, null);
         assertFalse(filter.matches(fileOperation, poolInfoMap));
     }
 
     @Test
-    public void shouldNotMatchPnfsOperationWhenTargetDoesNotMatchTargetPool()
+    public void shouldNotMatchFileOperationWhenTargetDoesNotMatchTargetPool()
                     throws CacheException {
         givenFilterWith("resilient_pool-0", null, null, false, false, true, null, null,
                         null, null);
-        givenPnfsOperationWith(null, null, null);
+        givenFileOperationWith(null, null, null);
         assertFalse(filter.matches(fileOperation, poolInfoMap));
     }
 
@@ -293,7 +293,7 @@ public final class PoolFilterTest extends TestBase {
         }
     }
 
-    private void givenPnfsOperationWith(String parent, String source, String target)
+    private void givenFileOperationWith(String parent, String source, String target)
                     throws CacheException {
         fileOperation = new FileOperation(aReplicaOnlineFileWithNoTags().getPnfsId(), 1, 2L);
 

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolOperationMapTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolOperationMapTest.java
@@ -282,7 +282,7 @@ public class PoolOperationMapTest extends TestBase {
         givenRescanWindowInHoursIs(10);
         givenPoolIsDown("resilient_pool-3");
         givenPoolIsRestarted("resilient_pool-3");
-        givenPnfsCountOfPoolIs(4);
+        givenFileCountOfPoolIs(4);
         whenQueuesAreScanned();
         assertTrue(poolOperationMap.running.containsKey(pool));
         assertFalse(poolOperationMap.idle.containsKey(pool));
@@ -296,7 +296,7 @@ public class PoolOperationMapTest extends TestBase {
         givenRescanWindowInHoursIs(10);
         givenPoolIsDown("resilient_pool-3");
         givenPoolIsRestarted("resilient_pool-3");
-        givenPnfsCountOfPoolIs(4);
+        givenFileCountOfPoolIs(4);
         whenQueuesAreScanned();
         assertTrue(poolOperationMap.running.containsKey(pool));
         assertFalse(poolOperationMap.idle.containsKey(pool));
@@ -310,7 +310,7 @@ public class PoolOperationMapTest extends TestBase {
         givenRescanWindowInHoursIs(10);
         givenPoolIsDown("resilient_pool-3");
         givenPoolIsRestarted("resilient_pool-3");
-        givenPnfsCountOfPoolIs(4);
+        givenFileCountOfPoolIs(4);
         whenQueuesAreScanned();
         assertTrue(poolOperationMap.running.containsKey(pool));
         assertFalse(poolOperationMap.idle.containsKey(pool));
@@ -325,7 +325,7 @@ public class PoolOperationMapTest extends TestBase {
         givenRescanWindowInHoursIs(10);
         givenPoolIsDown("resilient_pool-3");
         givenPoolIsRestarted("resilient_pool-3");
-        givenPnfsCountOfPoolIs(0);
+        givenFileCountOfPoolIs(0);
         whenQueuesAreScanned();
         assertTrue(poolOperationMap.running.containsKey(pool));
         assertFalse(poolOperationMap.idle.containsKey(pool));
@@ -339,7 +339,7 @@ public class PoolOperationMapTest extends TestBase {
         givenRescanWindowInHoursIs(10);
         givenPoolIsDown("resilient_pool-3");
         givenPoolIsRestarted("resilient_pool-3");
-        givenPnfsCountOfPoolIs(4);
+        givenFileCountOfPoolIs(4);
         whenQueuesAreScanned();
         assertTrue(poolOperationMap.running.containsKey(pool));
         assertFalse(poolOperationMap.idle.containsKey(pool));
@@ -354,7 +354,7 @@ public class PoolOperationMapTest extends TestBase {
         givenRescanWindowInHoursIs(10);
         givenPoolIsDown("resilient_pool-3");
         givenPoolIsRestarted("resilient_pool-3");
-        givenPnfsCountOfPoolIs(0);
+        givenFileCountOfPoolIs(0);
         whenQueuesAreScanned();
         assertTrue(poolOperationMap.running.containsKey(pool));
         assertFalse(poolOperationMap.idle.containsKey(pool));
@@ -382,7 +382,7 @@ public class PoolOperationMapTest extends TestBase {
         return poolOperationMap.scan(poolInfoMap.getPoolState(pool));
     }
 
-    private void givenPnfsCountOfPoolIs(int count) {
+    private void givenFileCountOfPoolIs(int count) {
         children = count;
     }
 

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/PoolOperationHandlerTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/PoolOperationHandlerTest.java
@@ -124,7 +124,7 @@ public class PoolOperationHandlerTest extends TestBase {
         givenMinimumReplicasOnPool();
         givenARestartStatusChangeFor(pool);
         whenPoolOpScanIsRun();
-        theResultingNumberOfPnfsOperationsSubmittedWas(0);
+        theResultingNumberOfFileOperationsSubmittedWas(0);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class PoolOperationHandlerTest extends TestBase {
          * (the inaccessible handler is invoked later, during
          * the verification phase)
          */
-        theResultingNumberOfPnfsOperationsSubmittedWas(10);
+        theResultingNumberOfFileOperationsSubmittedWas(10);
     }
 
     @Test
@@ -150,7 +150,7 @@ public class PoolOperationHandlerTest extends TestBase {
         /*
          *  5 REPLICA ONLINE, 5 CUSTODIAL ONLINE
          */
-        theResultingNumberOfPnfsOperationsSubmittedWas(10);
+        theResultingNumberOfFileOperationsSubmittedWas(10);
     }
 
     @Test
@@ -162,7 +162,7 @@ public class PoolOperationHandlerTest extends TestBase {
         /*
          * 2 REPLICA ONLINE, 2 CUSTODIAL ONLINE
          */
-        theResultingNumberOfPnfsOperationsSubmittedWas(4);
+        theResultingNumberOfFileOperationsSubmittedWas(4);
     }
 
     @Test
@@ -174,7 +174,7 @@ public class PoolOperationHandlerTest extends TestBase {
         /*
          * 2 REPLICA ONLINE, 2 CUSTODIAL ONLINE
          */
-        theResultingNumberOfPnfsOperationsSubmittedWas(4);
+        theResultingNumberOfFileOperationsSubmittedWas(4);
     }
 
     @Test
@@ -187,7 +187,7 @@ public class PoolOperationHandlerTest extends TestBase {
         /*
          * 3 REPLICA ONLINE, 3 CUSTODIAL ONLINE
          */
-        theResultingNumberOfPnfsOperationsSubmittedWas(6);
+        theResultingNumberOfFileOperationsSubmittedWas(6);
     }
 
     @Test
@@ -278,7 +278,7 @@ public class PoolOperationHandlerTest extends TestBase {
         });
     }
 
-    private void theResultingNumberOfPnfsOperationsSubmittedWas(int submitted) {
+    private void theResultingNumberOfFileOperationsSubmittedWas(int submitted) {
         FileFilter filter = new FileFilter();
         filter.setState(ImmutableSet.of("WAITING"));
         assertEquals(submitted, fileOperationMap.count(filter, new StringBuilder()));

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/ResilienceMessageHandlerTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/ResilienceMessageHandlerTest.java
@@ -137,7 +137,7 @@ public final class ResilienceMessageHandlerTest extends TestBase {
         handler.processBackloggedMessage(message);
         /*
          *  Without artificially altering the call structure of the
-         *  handler, verification of the actual pnfsOperationHandler method
+         *  handler, verification of the actual FileOperationHandler method
          * call is not possible here as the message handler creates an
          * anonymous struct-type object on the fly to pass as parameter.
          */
@@ -156,7 +156,7 @@ public final class ResilienceMessageHandlerTest extends TestBase {
         handler.processBackloggedMessage(message);
         /*
          *  Without artificially altering the call structure of the
-         *  handler, verification of the actual pnfsOperationHandler method
+         *  handler, verification of the actual FileOperationHandler method
          * call is not possible here as the message handler creates an
          * anonymous struct-type object on the fly to pass as parameter.
          */


### PR DESCRIPTION
…ation'

Motivation:

After the initial commit of Resilience, some classes were renamed to use "File"
rather than "Pnfs" as a more proper designation.  Some fields and methods
were neglected, however, along with literals in comments and admin command
instructions.

Modification:

Change all such instances.

Result:

Consistency. Only the the admin command changes are visible to the user.

Target: master
Request: 2.16
Acked-by: Gerd