### PR TITLE
pool: avoid NPE when querying status of a 3rd-party HTTP transfer

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -163,7 +163,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     // checksums that don't overlap with the on-transfer checksum.
     private ChecksumChannel _remoteSuppliedChecksumChannel;
 
-    private MoverChannel<RemoteHttpDataTransferProtocolInfo> _channel;
+    private volatile MoverChannel<RemoteHttpDataTransferProtocolInfo> _channel;
     private Checksum _remoteSuppliedChecksum;
 
     private CloseableHttpClient _client;
@@ -558,19 +558,22 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     @Override
     public long getLastTransferred()
     {
-        return _channel.getLastTransferred();
+        MoverChannel<RemoteHttpDataTransferProtocolInfo> channel = _channel;
+        return channel == null ? System.currentTimeMillis() : channel.getLastTransferred();
     }
 
     @Override
     public long getBytesTransferred()
     {
-        return _channel.getBytesTransferred();
+        MoverChannel<RemoteHttpDataTransferProtocolInfo> channel = _channel;
+        return channel == null ? 0 : channel.getBytesTransferred();
     }
 
     @Override
     public long getTransferTime()
     {
-        return _channel.getTransferTime();
+        MoverChannel<RemoteHttpDataTransferProtocolInfo> channel = _channel;
+        return channel == null ? 0 : channel.getTransferTime();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

An NullPointerException is thrown if the transfer's status is queried
before the transfer is initiated.  This can happen if the pool queues
the request and the transfermanager queries the current status of the
transfer.

Modification:

Update code to be robust against the MoveChannel not existing.

Result:

No more NPE

Target: master
Patch: https://rb.dcache.org/r/9483/
Acked-by: Gerd Behrmann
Fixes: #2596
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13