### PR TITLE
pool: Fix synchronization regression in jtm

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/JobTimeoutManager.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/JobTimeoutManager.java
@@ -152,10 +152,12 @@ public class JobTimeoutManager
     public class JtmGoCommand implements Callable<String>
     {
         @Override
-        public synchronized String call()
+        public String call()
                 throws IllegalMonitorStateException
         {
-            notifyAll();
+            synchronized (JobTimeoutManager.this) {
+                JobTimeoutManager.this.notifyAll();
+            }
             return "";
         }
     }
@@ -212,7 +214,7 @@ public class JobTimeoutManager
         long  total;
 
         @Override
-        public synchronized String call() throws IllegalArgumentException
+        public String call() throws IllegalArgumentException
         {
             if (queueName == null) {
                 for (SchedulerEntry entry: _schedulers) {


### PR DESCRIPTION
Motivation:

A regression in the job timeout manager broke the `jtm go` command.

Modification:

Synchronize and notify the proper object.

Result:

Fixed a regression rendering the `jtm go` command nonfunctional.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/9476/

(cherry picked from commit c03c4893c7f6a055e68bf2c0e6783123dc9de782)