### PR TITLE
pool: Fix mover leak

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
@@ -281,6 +281,7 @@ public class MoverRequestScheduler implements Runnable {
                             {
                                 request.done();
                                 _jobs.remove(request.getId());
+                                _moverByRequests.remove(request.getDoorUniqueId());
                             }
 
                         });


### PR DESCRIPTION
Motivation:

A regression causes the pool to leak movers when these are cancelled while
still being queued.

Modification:

Remove the mover from the deduplication map.

Result:

Fixed a regression that caused pools to leak movers if these are cancelled
while still being queued.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/9477/

(cherry picked from commit 9b7b6799633216c114bc42627c0f086f272187d6)
(cherry picked from commit 79cfa235f92df66edd70583408ad24d3da252d8f)