### PR TITLE
pool: Fix regression in mover set max active command

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -1947,7 +1947,7 @@ public class PoolV4
     private String mover_set_max_active(MoverRequestScheduler js, int active)
             throws IllegalArgumentException
     {
-        checkArgument(active > 0, "<maxActiveMovers> must be >= 0");
+        checkArgument(active >= 0, "<maxActiveMovers> must be >= 0");
         js.setMaxActiveJobs(active);
 
         return "Max Active Io Movers set to " + active;


### PR DESCRIPTION
Motivation:

One may set a queue to not process any jobs at all, but a regression
prevents setting the limit to 0.

Modification:

Allow setting the maximum active movers to zero.

Result:

Fixed a regression preventing to set the limits of a mover queue to
zero.

Target: trunk
Request: 2.16
Request: 2.15
Request: 2.14
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9478/

(cherry picked from commit ca6c53119f6a4d12421936e016b40544d86f54c8)