### PR TITLE
pool: Fix several race conditions in migration module

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
@@ -42,6 +42,8 @@ import org.dcache.pool.repository.StickyRecord;
 import org.dcache.util.FireAndForgetTask;
 import org.dcache.util.expression.Expression;
 
+import static com.google.common.base.Preconditions.checkState;
+
 /**
  * Encapsulates a job as defined by a user command.
  *
@@ -67,6 +69,7 @@ import org.dcache.util.expression.Expression;
  *
  * Jobs can be in any of the following states:
  *
+ * NEW            Job has not been started yet
  * INITIALIZING   Initial scan of repository
  * RUNNING        Job runs (schedules new tasks)
  * SLEEPING       A task failed; no tasks are scheduled for 10 seconds
@@ -83,7 +86,7 @@ import org.dcache.util.expression.Expression;
 public class Job
     extends AbstractStateChangeListener implements TaskCompletionHandler
 {
-    enum State { INITIALIZING, RUNNING, SLEEPING, PAUSED, SUSPENDED,
+    enum State { NEW, INITIALIZING, RUNNING, SLEEPING, PAUSED, SUSPENDED,
             STOPPING, CANCELLING, CANCELLED, FINISHED, FAILED }
 
     private static final Logger _log = LoggerFactory.getLogger(Job.class);
@@ -91,7 +94,6 @@ public class Job
     private final Set<PnfsId> _queued = new LinkedHashSet<>();
     private final Map<PnfsId,Long> _sizes = new HashMap<>();
     private final Map<PnfsId,Task> _running = new HashMap<>();
-    private final Future<?> _refreshTask;
     private final BlockingQueue<Error> _errors = new ArrayBlockingQueue<>(15);
     private final Map<PoolMigrationJobCancelMessage,DelayedReply> _cancelRequests =
         new HashMap<>();
@@ -107,15 +109,14 @@ public class Job
     private volatile State _state;
     private int _concurrency;
 
+    private Future<?> _refreshTask;
+
     public Job(MigrationContext context, JobDefinition definition)
     {
-        ScheduledExecutorService executor = context.getExecutor();
-        long refreshPeriod = definition.refreshPeriod;
-
         _context = context;
         _definition = definition;
         _concurrency = 1;
-        _state = State.INITIALIZING;
+        _state = State.NEW;
 
         _taskParameters = new TaskParameters(context.getPoolStub(), context.getPnfsStub(), context.getPinManagerStub(),
                                              context.getExecutor(), definition.selectionStrategy,
@@ -124,29 +125,39 @@ public class Job
                                              definition.maintainAtime, definition.replicas);
 
         _pinPrefix = context.getPinManagerStub().getDestinationPath().getDestinationAddress().getCellName();
+    }
 
-        _refreshTask =
-            executor.scheduleWithFixedDelay(new FireAndForgetTask(() -> {
-                _definition.sourceList.refresh();
-                _definition.poolList.refresh();
-            }), 0, refreshPeriod, TimeUnit.MILLISECONDS);
+    public void start()
+    {
+        _lock.lock();
+        try {
+            checkState(_state == State.NEW);
+            _state = State.INITIALIZING;
 
-        executor.submit(new FireAndForgetTask(new Runnable() {
-                @Override
-                public void run()
-                {
-                    State state = State.FAILED;
-                    try {
-                        _context.getRepository().addListener(Job.this);
-                        populate();
-                        state = State.RUNNING;
-                    } catch (InterruptedException e) {
-                        _log.error("Migration job was interrupted");
-                    } finally {
-                        setState(state);
-                    }
+            long refreshPeriod = _definition.refreshPeriod;
+            ScheduledExecutorService executor = _context.getExecutor();
+
+            _refreshTask =
+                    executor.scheduleWithFixedDelay(new FireAndForgetTask(() -> {
+                        _definition.sourceList.refresh();
+                        _definition.poolList.refresh();
+                    }), 0, refreshPeriod, TimeUnit.MILLISECONDS);
+
+            executor.submit(new FireAndForgetTask(() -> {
+                State state = State.FAILED;
+                try {
+                    _context.getRepository().addListener(Job.this);
+                    populate();
+                    state = State.RUNNING;
+                } catch (InterruptedException e) {
+                    _log.error("Migration job was interrupted");
+                } finally {
+                    setState(state);
                 }
             }));
+        } finally {
+            _lock.unlock();
+        }
     }
 
     public JobDefinition getDefinition()
@@ -201,6 +212,8 @@ public class Job
 
             if (total > 0) {
                 switch (getState()) {
+                case NEW:
+                    break;
                 case RUNNING:
                 case SUSPENDED:
                 case CANCELLING:
@@ -480,7 +493,7 @@ public class Job
     {
         if (_state == State.CANCELLING && _running.isEmpty()) {
             setState(State.CANCELLED);
-        } else if (_state != State.INITIALIZING && !_definition.isPermanent
+        } else if (_state != State.INITIALIZING && _state != State.NEW && !_definition.isPermanent
                    && _queued.isEmpty() && _running.isEmpty()) {
             setState(State.FINISHED);
         } else if (_state == State.STOPPING && _running.isEmpty()) {

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -138,6 +138,8 @@ public class MigrationModule
     private static final Expression FALSE_EXPRESSION =
         new Expression(Token.FALSE);
 
+    private boolean _isStarted;
+
     static {
         TRUE_EXPRESSION.setType(Type.BOOLEAN);
         FALSE_EXPRESSION.setType(Type.BOOLEAN);
@@ -180,6 +182,16 @@ public class MigrationModule
     public void setPinManagerStub(CellStub stub)
     {
         _context.setPinManagerStub(stub);
+    }
+
+    /**
+     * Implements CellLifeCycleAware interface.
+     */
+    @Override
+    public synchronized void afterStart()
+    {
+        _isStarted = true;
+        _jobs.values().stream().filter(j -> j.getState() == Job.State.NEW).forEach(Job::start);
     }
 
     /** Returns the job with the given id. */
@@ -862,11 +874,16 @@ public class MigrationModule
             }
 
             if (id == null) {
-                do {
-                    id = String.valueOf(_counter++);
-                } while (_jobs.containsKey(id));
+                synchronized (MigrationModule.this) {
+                    do {
+                        id = String.valueOf(_counter++);
+                    } while (_jobs.containsKey(id));
+                }
             } else {
-                Job job = _jobs.get(id);
+                Job job;
+                synchronized (MigrationModule.this) {
+                    job = _jobs.get(id);
+                }
                 if (job != null) {
                     switch (job.getState()) {
                     case FAILED:
@@ -881,9 +898,15 @@ public class MigrationModule
 
             Job job = new Job(_context, definition);
             job.setConcurrency(concurrency);
-            _jobs.put(id, job);
 
-            _commands.put(job, commandLine);
+            synchronized (MigrationModule.this) {
+                _commands.put(job, commandLine);
+                _jobs.put(id, job);
+                if (_isStarted) {
+                    job.start();
+                }
+            }
+
             return getJobSummary(id);
         }
     }
@@ -985,18 +1008,20 @@ public class MigrationModule
         @Override
         public String call()
         {
-            Iterator<Job> i = _jobs.values().iterator();
-            while (i.hasNext()) {
-                Job job = i.next();
-                switch (job.getState()) {
-                case CANCELLED:
-                case FAILED:
-                case FINISHED:
-                    i.remove();
-                    _commands.remove(job);
-                    break;
-                default:
-                    break;
+            synchronized (MigrationModule.this) {
+                Iterator<Job> i = _jobs.values().iterator();
+                while (i.hasNext()) {
+                    Job job = i.next();
+                    switch (job.getState()) {
+                    case CANCELLED:
+                    case FAILED:
+                    case FINISHED:
+                        i.remove();
+                        _commands.remove(job);
+                        break;
+                    default:
+                        break;
+                    }
                 }
             }
             return "";
@@ -1011,8 +1036,10 @@ public class MigrationModule
         public String call() throws NoSuchElementException
         {
             StringBuilder s = new StringBuilder();
-            for (String id: _jobs.keySet()) {
-                s.append(getJobSummary(id)).append('\n');
+            synchronized (MigrationModule.this) {
+                for (String id : _jobs.keySet()) {
+                    s.append(getJobSummary(id)).append('\n');
+                }
             }
             return s.toString();
         }
@@ -1055,13 +1082,15 @@ public class MigrationModule
         public String call()
                 throws NoSuchElementException
         {
-            Job job = getJob(id);
-            String command = _commands.get(job);
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            pw.println("Command    : " + command);
-            job.getInfo(pw);
-            return sw.toString();
+            synchronized (MigrationModule.this) {
+                Job job = getJob(id);
+                String command = _commands.get(job);
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                pw.println("Command    : " + command);
+                job.getInfo(pw);
+                return sw.toString();
+            }
         }
     }
 
@@ -1099,7 +1128,7 @@ public class MigrationModule
     public synchronized void printSetup(PrintWriter pw)
     {
         pw.println("#\n# MigrationModule\n#");
-        for (Job job: _jobs.values()) {
+        _commands.forEach((job, cmd) -> {
             if (job.getDefinition().isPermanent) {
                 switch (job.getState()) {
                 case CANCELLED:
@@ -1109,11 +1138,11 @@ public class MigrationModule
                 case FINISHED:
                     break;
                 default:
-                    pw.println(_commands.get(job));
+                    pw.println(cmd);
                     break;
                 }
             }
-        }
+        });
     }
 
     public synchronized boolean isActive(PnfsId id)


### PR DESCRIPTION
Motivation:

The migration module contained several race conditions.

Modification:

- Don't leak reference to Job object to another thread from inside
  constructor.

- Add synchronization on access of job and command hash tables
  in migration module.

- Don't start jobs until cell has started.

Result:

Fixed several race conditions in the pool's migration module.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9482/

(cherry picked from commit c246de6cefbe63633ec6f0e972672b33e19dadae)