### PR TITLE
pool: Fix several race conditions in migration module

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -137,6 +137,8 @@ public class MigrationModule
     private final static Expression FALSE_EXPRESSION =
         new Expression(Token.FALSE);
 
+    private boolean _isStarted;
+
     static {
         TRUE_EXPRESSION.setType(Type.BOOLEAN);
         FALSE_EXPRESSION.setType(Type.BOOLEAN);
@@ -179,6 +181,16 @@ public class MigrationModule
     public void setPinManagerStub(CellStub stub)
     {
         _context.setPinManagerStub(stub);
+    }
+
+    /**
+     * Implements CellLifeCycleAware interface.
+     */
+    @Override
+    public synchronized void afterStart()
+    {
+        _isStarted = true;
+        _jobs.values().stream().filter(j -> j.getState() == Job.State.NEW).forEach(Job::start);
     }
 
     /** Returns the job with the given id. */
@@ -861,11 +873,16 @@ public class MigrationModule
             }
 
             if (id == null) {
-                do {
-                    id = String.valueOf(_counter++);
-                } while (_jobs.containsKey(id));
+                synchronized (MigrationModule.this) {
+                    do {
+                        id = String.valueOf(_counter++);
+                    } while (_jobs.containsKey(id));
+                }
             } else {
-                Job job = _jobs.get(id);
+                Job job;
+                synchronized (MigrationModule.this) {
+                    job = _jobs.get(id);
+                }
                 if (job != null) {
                     switch (job.getState()) {
                     case FAILED:
@@ -880,9 +897,15 @@ public class MigrationModule
 
             Job job = new Job(_context, definition);
             job.setConcurrency(concurrency);
-            _jobs.put(id, job);
 
-            _commands.put(job, commandLine);
+            synchronized (MigrationModule.this) {
+                _commands.put(job, commandLine);
+                _jobs.put(id, job);
+                if (_isStarted) {
+                    job.start();
+                }
+            }
+
             return getJobSummary(id);
         }
     }
@@ -984,18 +1007,20 @@ public class MigrationModule
         @Override
         public String call()
         {
-            Iterator<Job> i = _jobs.values().iterator();
-            while (i.hasNext()) {
-                Job job = i.next();
-                switch (job.getState()) {
-                case CANCELLED:
-                case FAILED:
-                case FINISHED:
-                    i.remove();
-                    _commands.remove(job);
-                    break;
-                default:
-                    break;
+            synchronized (MigrationModule.this) {
+                Iterator<Job> i = _jobs.values().iterator();
+                while (i.hasNext()) {
+                    Job job = i.next();
+                    switch (job.getState()) {
+                    case CANCELLED:
+                    case FAILED:
+                    case FINISHED:
+                        i.remove();
+                        _commands.remove(job);
+                        break;
+                    default:
+                        break;
+                    }
                 }
             }
             return "";
@@ -1010,8 +1035,10 @@ public class MigrationModule
         public String call() throws NoSuchElementException
         {
             StringBuilder s = new StringBuilder();
-            for (String id: _jobs.keySet()) {
-                s.append(getJobSummary(id)).append('\n');
+            synchronized (MigrationModule.this) {
+                for (String id : _jobs.keySet()) {
+                    s.append(getJobSummary(id)).append('\n');
+                }
             }
             return s.toString();
         }
@@ -1054,13 +1081,15 @@ public class MigrationModule
         public String call()
                 throws NoSuchElementException
         {
-            Job job = getJob(id);
-            String command = _commands.get(job);
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            pw.println("Command    : " + command);
-            job.getInfo(pw);
-            return sw.toString();
+            synchronized (MigrationModule.this) {
+                Job job = getJob(id);
+                String command = _commands.get(job);
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                pw.println("Command    : " + command);
+                job.getInfo(pw);
+                return sw.toString();
+            }
         }
     }
 
@@ -1098,7 +1127,7 @@ public class MigrationModule
     public synchronized void printSetup(PrintWriter pw)
     {
         pw.println("#\n# MigrationModule\n#");
-        for (Job job: _jobs.values()) {
+        _commands.forEach((job, cmd) -> {
             if (job.getDefinition().isPermanent) {
                 switch (job.getState()) {
                 case CANCELLED:
@@ -1108,11 +1137,11 @@ public class MigrationModule
                 case FINISHED:
                     break;
                 default:
-                    pw.println(_commands.get(job));
+                    pw.println(cmd);
                     break;
                 }
             }
-        }
+        });
     }
 
     public synchronized boolean isActive(PnfsId id)


### PR DESCRIPTION
Motivation:

The migration module contained several race conditions.

Modification:

- Don't leak reference to Job object to another thread from inside
  constructor.

- Add synchronization on access of job and command hash tables
  in migration module.

- Don't start jobs until cell has started.

Result:

Fixed several race conditions in the pool's migration module.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9482/

(cherry picked from commit c246de6cefbe63633ec6f0e972672b33e19dadae)
(cherry picked from commit 54bfb03a235c3ca10131b642a332c1c06d39a483)