### PR TITLE
spacemanager: Work around for doors resubmitting PoolAcceptFileMessage

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Required;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.RecoverableDataAccessException;
 import org.springframework.dao.TransientDataAccessException;
@@ -513,6 +514,17 @@ public final class SpaceManagerService
             message.setFailedConditionally(CacheException.INVALID_ARGS, e.getMessage());
         } catch (DeadlockLoserDataAccessException e) {
             throw e;
+        } catch (DuplicateKeyException e) {
+            /* For PoolAcceptFileMessage, a duplicate key failure is most likely caused by
+             * the door resubmitting the message. We trust the door that it doesn't submit
+             * these to several pools.
+             */
+            if ((message instanceof PoolAcceptFileMessage) && !message.isReply()) {
+                LOGGER.info("Ignoring exception due to possibly duplicated PoolAcceptFileMessage: {}",
+                            e.getMessage());
+            } else {
+                throw e;
+            }
         } catch (DataAccessException e) {
             LOGGER.error("Message processing failed: {}", e.toString());
             message.setFailedConditionally(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,


### PR DESCRIPTION
Motivation:

The NFS door resubmits the PoolAcceptFileMessage blindly (i.e. with having
received a failure for the previous message), triggering a duplicate key
exception in pools.

Modification:

To provide a simple and backportable solution, this patch simply ignores the
error. Space manager trusts the door that it is really a resubmission to the
same pool.

Result:

Fixes a compatibility problem with NFS in which space manager would fail with
a duplicate key error.

Target: trunk
Request: 2.16
Rwquest: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Fixes: #2550
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9490/

(cherry picked from commit 12ab3b1486244a288224393607c69fc4e91d0f64)