### PR TITLE
restful-api: make exception and error handling resful

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/DcacheRestApplication.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/DcacheRestApplication.java
@@ -2,7 +2,6 @@ package org.dcache.restful;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-import org.dcache.restful.resources.namespace.FileResources;
 import org.glassfish.jersey.message.GZipEncoder;
 import org.glassfish.jersey.message.filtering.EntityFilteringFeature;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -10,6 +9,7 @@ import org.glassfish.jersey.server.filter.EncodingFilter;
 
 import org.dcache.restful.filters.ResponseHeaderFilter;
 import org.dcache.restful.providers.ObjectMapperProvider;
+import org.dcache.restful.resources.namespace.FileResources;
 
 /**
  *

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/errorHandling/RestAPIExceptionHandler.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/errorHandling/RestAPIExceptionHandler.java
@@ -1,0 +1,43 @@
+package org.dcache.restful.errorHandling;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.ErrorHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ *
+ */
+public class RestAPIExceptionHandler extends ErrorHandler
+{
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request,
+                       HttpServletResponse response) throws IOException
+    {
+        int code = response.getStatus();
+        String message = HttpStatus.getMessage(code);
+        String xHttp = request.getHeader("X-Requested-With");
+
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+        response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+        response.setHeader("content-type", "application/json");
+
+        if (Objects.equals(xHttp, "XMLHttpRequest") && code == 401) {
+            response.setHeader("X-Requested-With", "handled");
+            response.setHeader("WWW-Authenticate", "");
+        }
+
+        response.getWriter()
+                .append("{\"errors\": [{\"status\" : ")
+                .append(String.valueOf(code))
+                .append(", \"message\": \"")
+                .append(message)
+                .append("\"}]}");
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -205,4 +205,3 @@ public class FileResources {
 
 
 }
-

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -165,13 +165,11 @@
                                                                value-ref="pnfs-stub"/>
                                                         <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).PM}"
                                                                value-ref="pool-monitor"/>
-
                                                     </map>
                                                 </constructor-arg>
                                             </bean>
                                         </property>
                                     </bean>
-                                    <bean class="org.eclipse.jetty.server.handler.DefaultHandler"/>
                                 </list>
                             </property>
                         </bean>
@@ -253,6 +251,7 @@
                               '${frontend.limits.low-resource-idle-time.unit}')}" />
                     <property name="maxLowResourcesTime" value="180000"/>
                 </bean>
+                <bean class="org.dcache.restful.errorHandling.RestAPIExceptionHandler"/>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
Motivation:

1. The current error and exception handling inside the resful-api rely on the default
error handling in jetty. Unfornately, the side-effect of this is that the error message
are in html format.

2. The NotAuthorizedException response include 401 status code with `WWW-Authenticate`
header field. The cause browser to prompt for login and this is not suitable for
dcache-view (web-app).

Modification:

1. Create error handling package for restful-api, this handles both checked and
unchecked exceptions and convert the exception object to desirable JSON format.

2. Handle and support a request with header "X-Requested-With": "XMLHttpRequest". This
remove the WWW-Authenticate header field causing the browser to prompt for login. Even
though this is not a standard way of responding with 401, the standard behaviour is
still supported whenever the X-Requested-With header is not set to `XMLHttpRequest`
in the request.

Result:

1. proper error handling in JSON format
2. Prompt login can now be averted in dcache-veiw

Target: trunk
Require-notes: no
Require-book: no
Request: 2.16
Acked-by: Gerd Behrmann <behrmann@ndgf.org>

Review at https://rb.dcache.org/r/9457/

(cherry picked from commit 197009c7e471d369f23472706ff3aefa9507269d)