### PR TITLE
srm: Resolve message thead blocking issues with SRM third party copy

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -562,41 +562,40 @@ public final class Storage
         Long callerId = msg.getId();
         _log.debug("handleTransferManagerMessage for callerId="+callerId);
 
-        TransferInfo info = callerIdToHandler.get(callerId);
+        TransferInfo info = callerIdToHandler.remove(callerId);
         if (info == null) {
             _log.error("TransferInfo for callerId="+callerId+"not found");
             return;
         }
 
-        if (msg instanceof TransferCompleteMessage ) {
-            info.callbacks.copyComplete();
-            _log.debug("removing TransferInfo for callerId="+callerId);
-            callerIdToHandler.remove(callerId);
-        } else if (msg instanceof TransferFailedMessage) {
-            Object error =  msg.getErrorObject();
-            if (error instanceof CacheException) {
-                error = ((CacheException) error).getMessage();
-            }
-            SRMException e;
-            switch (msg.getReturnCode()) {
-            case CacheException.PERMISSION_DENIED:
-                e = new SRMAuthorizationException(String.format("Access denied: %s", error));
-                break;
-            case CacheException.FILE_NOT_FOUND:
-                e = new SRMInvalidPathException(String.valueOf(error));
-                break;
-            case CacheException.THIRD_PARTY_TRANSFER_FAILED:
-                e = new SRMException("Transfer failed: " + error);
-                break;
-            default:
-                e = new SRMException(String.format("Transfer failed: %s [%d]",
-                                                   error, msg.getReturnCode()));
-            }
-            info.callbacks.copyFailed(e);
+        _log.debug("removed TransferInfo for callerId={}", callerId);
 
-            _log.debug("removing TransferInfo for callerId="+callerId);
-            callerIdToHandler.remove(callerId);
-        }
+        _executor.execute(() -> {
+            if (msg instanceof TransferCompleteMessage) {
+                info.callbacks.copyComplete();
+            } else if (msg instanceof TransferFailedMessage) {
+                Object error = msg.getErrorObject();
+                if (error instanceof CacheException) {
+                    error = ((CacheException) error).getMessage();
+                }
+                SRMException e;
+                switch (msg.getReturnCode()) {
+                case CacheException.PERMISSION_DENIED:
+                    e = new SRMAuthorizationException(String.format("Access denied: %s", error));
+                    break;
+                case CacheException.FILE_NOT_FOUND:
+                    e = new SRMInvalidPathException(String.valueOf(error));
+                    break;
+                case CacheException.THIRD_PARTY_TRANSFER_FAILED:
+                    e = new SRMException("Transfer failed: " + error);
+                    break;
+                default:
+                    e = new SRMException(String.format("Transfer failed: %s [%d]",
+                                                       error, msg.getReturnCode()));
+                }
+                info.callbacks.copyFailed(e);
+            }
+        });
     }
 
     public void messageArrived(PnfsCreateUploadPath msg)

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
@@ -85,6 +85,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.dcache.srm.SRM;
@@ -527,12 +528,13 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
     public void turlArrived(String surl, String turl, String remoteRequestId,
             String remoteFileId, Long size)
     {
+        Collection<Long> fileRequestIds;
         synchronized (remoteSurlToFileReqIds) {
-            Collection<Long> fileRequestIds = remoteSurlToFileReqIds.get(surl);
-            if (fileRequestIds == null || fileRequestIds.isEmpty()) {
-                LOG.error("turlArrived for unknown SURL = "+surl+" !!!!!!!");
-                return;
-            }
+            fileRequestIds = remoteSurlToFileReqIds.removeAll(surl);
+        }
+        if (fileRequestIds.isEmpty()) {
+            LOG.error("turlArrived for unknown SURL = {} !!!!!!!", surl);
+        } else {
             for (long id : fileRequestIds) {
                 CopyFileRequest cfr = getFileRequest(id);
                 if (getQosPlugin() != null && cfr.getQOSTicket() != null) {
@@ -559,15 +561,13 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
                     }
                 } catch (IllegalStateException | IllegalArgumentException |
                         IllegalStateTransition | InterruptedException e) {
-                    LOG.error("failed to schedule CopyFileRequest {}: {}", cfr,
-                            e.toString());
+                    LOG.error("failed to schedule CopyFileRequest {}: {}", cfr, e.toString());
                     try {
                         cfr.setState(State.FAILED, "Failed to schedule request: " + e.getMessage());
                     } catch (IllegalStateTransition ist) {
-                        LOG.error("Illegal State Transition : {}" + ist.getMessage());
+                        LOG.error("Illegal State Transition : {}", ist.getMessage());
                     }
                 }
-                remoteSurlToFileReqIds.remove(surl, id);
             }
         }
     }
@@ -575,28 +575,24 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
     public void turlRetrievalFailed(String surl, String reason,
             String remoteRequestId, String remoteFileId)
     {
+        Collection<Long> fileRequestSet;
         synchronized (remoteSurlToFileReqIds) {
-            Collection<Long> fileRequestSet = remoteSurlToFileReqIds.get(surl);
-            if (fileRequestSet == null || fileRequestSet.isEmpty()) {
-                LOG.error("turlArrived for unknown SURL = "+surl);
-                return;
-            }
+            fileRequestSet = remoteSurlToFileReqIds.removeAll(surl);
+        }
+        if (fileRequestSet.isEmpty()) {
+            LOG.error("turlArrived for unknown SURL = {}", surl);
+        } else {
             for (long id : fileRequestSet) {
                 CopyFileRequest cfr = getFileRequest(id);
-
                 try {
-                    String type = isSourceSrm() && !isSourceLocal() ? "source"
-                            : "destination";
-                    String error = "retrieval of " + type +
-                            " TURL failed with error " + reason;
+                    String type = isSourceSrm() && !isSourceLocal() ? "source" : "destination";
+                    String error = "retrieval of " + type + " TURL failed with error " + reason;
                     LOG.error(error);
                     cfr.setState(State.FAILED, error);
                 } catch (IllegalStateTransition ist) {
-                    LOG.error("Illegal State Transition : " + ist.getMessage());
+                    LOG.error("Illegal State Transition : {}", ist.getMessage());
                 }
                 cfr.saveJob();
-
-                remoteSurlToFileReqIds.remove(surl, id);
             }
         }
         remoteFileRequestDone(surl, remoteRequestId, remoteFileId);
@@ -604,54 +600,50 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
 
     public void turlsRetrievalFailed(Object reason)
     {
+        ArrayList<Map.Entry<String, Long>> entries;
         synchronized (remoteSurlToFileReqIds) {
-            for (String surl : remoteSurlToFileReqIds.keySet()) {
-                for (long id : remoteSurlToFileReqIds.get(surl)) {
-                    CopyFileRequest cfr = getFileRequest(id);
-                    try {
-                        String type = isSourceSrm() && !isSourceLocal() ? "source"
-                            : "destination";
-                        String error = "retrieval of " + type +
-                                " TURL failed with error " + reason;
-                        LOG.error(error);
-                        cfr.setState(State.FAILED, error);
-                    } catch (IllegalStateTransition ist) {
-                        LOG.error("Illegal State Transition : " + ist.getMessage());
-                    }
-                    cfr.saveJob();
-                    remoteSurlToFileReqIds.remove(surl, id);
-                }
+            entries = new ArrayList<>(remoteSurlToFileReqIds.entries());
+            remoteSurlToFileReqIds.clear();
+        }
+        for (Map.Entry<String, Long> entry : entries) {
+            String surl = entry.getKey();
+            long id = entry.getValue();
+            CopyFileRequest cfr = getFileRequest(id);
+            try {
+                String type = isSourceSrm() && !isSourceLocal() ? "source" : "destination";
+                String error = "retrieval of " + type + " TURL failed with error " + reason;
+                LOG.error(error);
+                cfr.setState(State.FAILED, error);
+            } catch (IllegalStateTransition ist) {
+                LOG.error("Illegal State Transition : {}", ist.getMessage());
             }
+            cfr.saveJob();
         }
     }
 
-    public void remoteFileRequestDone(String surl, String requestId,
-            String fileId)
+    public void remoteFileRequestDone(String surl, String requestId, String fileId)
     {
-        synchronized (remoteSurlToFileReqIds) {
-            try {
-                Scheduler<?> scheduler = Scheduler.getScheduler(schedulerId);
-                RequestCredential credential = RequestCredential.getRequestCredential(credentialId);
-                String caCertificatePath = getConfiguration().getCaCertificatePath();
-                if (isSourceSrm() && !isSourceLocal()) {
-                   RemoteTurlGetterV2.staticReleaseFile(credential,
-                                                        surl, requestId,
-                                                        0,
-                                                        0,
-                                                        caCertificatePath,
-                                                        clientTransport);
-                } else {
-                    RemoteTurlPutterV2.staticPutDone(credential,
-                                                     surl, requestId,
-                                                     0,
-                                                     0,
-                                                     caCertificatePath,
-                                                     clientTransport);
-                }
-            } catch (Exception e) {
-                LOG.error("set remote file status to done failed, surl={}, " +
-                         "requestId={}, fileId={}", surl, requestId, fileId);
+        try {
+            RequestCredential credential = RequestCredential.getRequestCredential(credentialId);
+            String caCertificatePath = getConfiguration().getCaCertificatePath();
+            if (isSourceSrm() && !isSourceLocal()) {
+               RemoteTurlGetterV2.staticReleaseFile(credential,
+                                                    surl, requestId,
+                                                    0,
+                                                    0,
+                                                    caCertificatePath,
+                                                    clientTransport);
+            } else {
+                RemoteTurlPutterV2.staticPutDone(credential,
+                                                 surl, requestId,
+                                                 0,
+                                                 0,
+                                                 caCertificatePath,
+                                                 clientTransport);
             }
+        } catch (Exception e) {
+            LOG.error("set remote file status to done failed, surl={}, " +
+                     "requestId={}, fileId={}", surl, requestId, fileId);
         }
     }
 


### PR DESCRIPTION
Motivation:

There are two issues with SRM third pary copies:

- The callback from the Storage class happens on the cell message thread
  rather than the dedicated executor used for callbacks.

- The CopyRequest class synchronizes on an internal multimap which will
  serialize the final release of TURLs in the request.

Modification:

- Use the executor for callbacks.

- Reduce for how long we lock the problematic map.

Result:

Fixed issues in which the use of SRM third party copy operations could cause
the SRM cell to become unresponsive, possibly even run out of memory.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9492/

(cherry picked from commit b20cc35d073d2a9a5bc6e35d70f7ab7c72dca401)