### PR TITLE
info: fix broken unit-test

### DIFF
--- a/modules/dcache-info/src/test/java/org/dcache/services/info/base/StateMaintainerTests.java
+++ b/modules/dcache-info/src/test/java/org/dcache/services/info/base/StateMaintainerTests.java
@@ -85,7 +85,14 @@ public class StateMaintainerTests
     @Test(timeout = 10_000)
     public void shouldIncrementAfterSubmittingUpdate() throws InterruptedException
     {
-        willAnswer(i -> {wait(); return null;}).given(_caretaker).processUpdate(anyObject());
+        Object monitor = new Object();
+
+        willAnswer(a -> {
+                synchronized (monitor) {
+                    monitor.wait();
+                }
+                return null;
+            }).given(_caretaker).processUpdate(anyObject());
 
         _maintainer.enqueueUpdate(new StateUpdate());
 


### PR DESCRIPTION
Motivation:

A unit test occationally fails, despite the underlying code being OK.

Modification:

Fix faulty wait call outside the corresponding monitor.

Result:

Test shouldn't fail any more.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/9493/
Acked-by: Gerd Behrmann