### PR TITLE
SrmShell.java: changed 'rw--' to 'rw-' in case TPermissionMode._RW

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -261,7 +261,7 @@ public class SrmShell extends ShellApplication
         case TPermissionMode._RX:
             return "rx-";
         case TPermissionMode._RW:
-            return "rw--";
+            return "rw-";
         case TPermissionMode._RWX:
             return "rwx";
         default:


### PR DESCRIPTION
I was searching for directory right code to investigate why we have a directory that spontaneously changes from 755 to 770 every now and then. Then I stumbled upon what appears to be a coding typo. I have no idea if it is related to our bug, but I'd like to bring it to your attention anyway.