### PR TITLE
nfs: Fix race condition in transfer startup

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -855,6 +855,8 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         private final Inode _nfsInode;
 
+        private ListenableFuture<Void> _redirectFuture;
+
         NfsTransfer(PnfsHandler pnfs, Inode nfsInode, Subject ioSubject) {
             super(pnfs, Subjects.ROOT, ioSubject,  new FsPath("/"));
             _nfsInode = nfsInode;
@@ -879,23 +881,24 @@ public class NFSv41Door extends AbstractCellComponent implements
                 InterruptedException, ExecutionException,
                 TimeoutException, CacheException {
 
-            ListenableFuture<Void> redirectFuture;
-             synchronized (this) {
-                /*
-                 * Check try to re-run the selection if no pool selected yet.
-                 * Restart/ping mover if not running yet.
-                 */
-                if (getPool() == null) {
-                    // we did not select a pool
-                     redirectFuture = selectPoolAndStartMoverAsync(queue, RETRY_POLICY);
-                } else {
-                    // we may re-send the request, but pool will handle it
-                    redirectFuture = startMoverAsync(queue, NFS_REQUEST_BLOCKING);
-                 }
-             }
+            synchronized (this) {
+                if (_redirectFuture == null || _redirectFuture.isDone()) {
+                    /*
+                     * Check try to re-run the selection if no pool selected yet.
+                     * Restart/ping mover if not running yet.
+                     */
+                    if (getPool() == null) {
+                        // we did not select a pool
+                        _redirectFuture = selectPoolAndStartMoverAsync(queue, RETRY_POLICY);
+                    } else {
+                        // we may re-send the request, but pool will handle it
+                        _redirectFuture = startMoverAsync(queue, NFS_REQUEST_BLOCKING);
+                    }
+                }
+            }
 
             Stopwatch sw = Stopwatch.createStarted();
-            redirectFuture.get(NFS_REQUEST_BLOCKING, TimeUnit.MILLISECONDS);
+            _redirectFuture.get(NFS_REQUEST_BLOCKING, TimeUnit.MILLISECONDS);
             _log.debug("mover ready: pool={} moverid={}", getPool(), getMoverId());
 
             return  waitForRedirect(NFS_REQUEST_BLOCKING - sw.elapsed(TimeUnit.MILLISECONDS));


### PR DESCRIPTION
Motivation:

The NFS door has a fast 100 ms timeout on pool selection, mover startup and
redirect. If this times out, the client is asked to delay and resubmit the
request. The door will continue the procedure asynchronously though until
the configure retry policy expires.

When the client resubmits the request, the door unconditionally starts another
asynchronous operation, either a full pool selection or just mover creation. It
will do this even when the previous asynchronous operation is still running.
This can lead to a situation in which two asynchronous pool selection are
active and may result in two write movers being created on two different pools.

Modification:

Keep track of the running asynchronous operation and only start a new one if the
previous one has completed.

Result:

Fixed a race condition in the NFS door that could result in the creation of
multiple inconsistent copies of a file being uploaded.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9491/

(cherry picked from commit 9f991f46dc1b0c4d94e1eeb63b125eaabcf51963)
(cherry picked from commit 45c4db949c386d0c197eb4f6da1a48fb440e2561)