### PR TITLE
srm: add hint to escape IDs

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/SrmCommandLineInterface.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SrmCommandLineInterface.java
@@ -131,7 +131,7 @@ public class SrmCommandLineInterface
         this.config = configuration;
     }
 
-    public static final String fh_cancel = " Syntax: cancel <id> ";
+    public static final String fh_cancel = " Syntax: cancel <id>. Note that <id> may need escaping.";
     public static final String hh_cancel = " <id> ";
 
     public String ac_cancel_$_1(Args args)
@@ -250,7 +250,9 @@ public class SrmCommandLineInterface
         @Option(name = "l", usage = "Show more details.")
         boolean verbose;
 
-        @Argument(usage = "Request ID", metaVar = "id", required = false)
+        @Argument(usage = "The request ID.  Note that IDs that start with '-' " +
+                "must be escaped; e.g., 'ls \\-1234', 'ls \"-1234\"' or " +
+                "'ls -- -1234'", metaVar = "id", required = false)
         Long id;
 
         @Override
@@ -543,7 +545,7 @@ public class SrmCommandLineInterface
     }
 
     public static final String fh_set_job_priority = " Syntax: set priority <requestId> <priority>" +
-            "will set priority for the requestid";
+            "will set priority for the requestid.  Note that <requestId> may require escaping.";
     public static final String hh_set_job_priority = " <requestId> <priority>";
 
     public String ac_set_job_priority_$_2(Args args)


### PR DESCRIPTION
Motivation:

Admins don't always appreciate that the - character indicates an option
and so any argument that start with a - require escaping.

Modification:

Add a hint to describe the necessity to include escaping.

Result:

Fewer support tickets.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9005
Patch: https://rb.dcache.org/r/9505/
Acked-by: Gerd Behrmann
Requires-notes: no
Requires-book: no