### PR TITLE
dcache-restful-api: RestfulAPI for QoS(CDMI)

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/DcacheRestApplication.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/DcacheRestApplication.java
@@ -2,6 +2,7 @@ package org.dcache.restful;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import org.dcache.restful.qos.QosManagement;
 import org.glassfish.jersey.message.GZipEncoder;
 import org.glassfish.jersey.message.filtering.EntityFilteringFeature;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -24,6 +25,8 @@ public class DcacheRestApplication extends ResourceConfig
 
         //register application resources controller
         register(FileResources.class);
+        register(QosManagement.class);
+
 
         //register filters
         register(ResponseHeaderFilter.class);

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/BackendCapability.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/BackendCapability.java
@@ -1,0 +1,45 @@
+package org.dcache.restful.qos;
+
+
+import java.util.List;
+
+/**
+ * Data describing specific QoS.
+ */
+public class BackendCapability {
+
+
+    private String name;
+
+    private List<String> transition;
+
+    private QoSMetadata metadata;
+
+
+    public QoSMetadata getMetadata() {
+        return this.metadata;
+    }
+
+    public void setMetadata(QoSMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+
+    public List<String> getTransition() {
+        return transition;
+    }
+
+    public void setTransition(List<String> transitions) {
+        this.transition = transitions;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/BackendCapabilityResponse.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/BackendCapabilityResponse.java
@@ -1,0 +1,36 @@
+package org.dcache.restful.qos;
+
+/**
+ * QoS response object
+ */
+public class BackendCapabilityResponse {
+
+    private String status;
+    private String message;
+
+    private BackendCapability backendCapability;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public BackendCapability getBackendCapability() {
+        return backendCapability;
+    }
+
+    public void setBackendCapability(BackendCapability backendCapability) {
+        this.backendCapability = backendCapability;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/BackendCapabilityResponse.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/BackendCapabilityResponse.java
@@ -1,36 +1,41 @@
 package org.dcache.restful.qos;
-
 /**
  * QoS response object
  */
 public class BackendCapabilityResponse {
-
-    private String status;
-    private String message;
-
+    private String status = "200";
+    private String message = "successful";
+    private String qos;
+    private String target;
     private BackendCapability backendCapability;
-
     public String getStatus() {
         return status;
     }
-
     public void setStatus(String status) {
         this.status = status;
     }
-
     public String getMessage() {
         return message;
     }
-
     public void setMessage(String message) {
         this.message = message;
     }
-
     public BackendCapability getBackendCapability() {
         return backendCapability;
     }
-
     public void setBackendCapability(BackendCapability backendCapability) {
         this.backendCapability = backendCapability;
+    }
+    public String getQos() {
+        return qos;
+    }
+    public void setQoS(String qos) {
+        this.qos = qos;
+    }
+    public String getTargetQoS() {
+        return target;
+    }
+    public void setTargetQoS(String targetQoS) {
+        this.target = targetQoS;
     }
 }

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QoSMetadata.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QoSMetadata.java
@@ -1,0 +1,47 @@
+package org.dcache.restful.qos;
+
+
+/**
+ * This class represents data describing specific QoS based on CDMI specification.
+ */
+public class QoSMetadata {
+
+    private String cdmi_data_redundancy_provided;
+
+    private String cdmi_geographic_placement_provided;
+    private String cdmi_latency_provided;
+
+    public QoSMetadata(String cdmi_data_redundancy_provided,
+                       String cdmi_geographic_placement_provided,
+                       String cdmi_latency_provided) {
+        this.cdmi_data_redundancy_provided = cdmi_data_redundancy_provided;
+        this.cdmi_geographic_placement_provided = cdmi_geographic_placement_provided;
+        this.cdmi_latency_provided = cdmi_latency_provided;
+    }
+
+    //TODO clean up (underscores)
+    public String getCdmi_data_redundancy_provided() {
+        return cdmi_data_redundancy_provided;
+    }
+
+    public void setCdmi_data_redundancy_provided(String cdmi_data_redundancy_provided) {
+        this.cdmi_data_redundancy_provided = cdmi_data_redundancy_provided;
+    }
+
+    public String getCdmi_geographic_placement_provided() {
+        return cdmi_geographic_placement_provided;
+    }
+
+    public void setCdmi_geographic_placement_provided(String cdmi_geographic_placement_provided) {
+        this.cdmi_geographic_placement_provided = cdmi_geographic_placement_provided;
+    }
+
+    public String getCdmi_latency_provided() {
+        return cdmi_latency_provided;
+    }
+
+    public void setCdmi_latency_provided(String cdmi_latency_provided) {
+        this.cdmi_latency_provided = cdmi_latency_provided;
+    }
+
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
@@ -1,0 +1,276 @@
+package org.dcache.restful.qos;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.PathParam;
+
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ForbiddenException;
+
+import javax.ws.rs.core.MediaType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.PermissionDeniedCacheException;
+
+import org.dcache.auth.Subjects;
+import org.dcache.restful.util.ServletContextHandlerAttributes;
+
+
+/**
+ * RestFul API for querying and manipulating QoS
+ */
+
+
+@Path("/qos-management/qos/")
+public class QosManagement {
+
+    private static final String DISK = "disk";
+    private static final String TAPE = "tape";
+    private static final String DISK_TAPE = "disk+tape";
+
+
+    /**
+     * Get the list of available QoS for file  and directory objects corresponding to some specific quality of services supported by dCache back-end.
+     * For example, storage requirements such as flexible allocation of disk or tape storage space.
+     *
+     * @param qosValue specific object (file | directory)
+     * @return JSONObject List of available QoS
+     * @throws CacheException
+     */
+
+    @GET
+    @Path("{qosValue : .*}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getQosList(@PathParam("qosValue") String qosValue) throws CacheException {
+
+        JSONObject json = new JSONObject();
+
+
+        try {
+
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new PermissionDeniedCacheException("Permission denied");
+            }
+
+            // query the lis of available QoS for file objects
+            if ("file".equals(qosValue)) {
+
+                JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE, DISK_TAPE));
+                json.put("name", list);
+
+            }
+            // query the lis of available QoS for directory objects
+            else if ("directory".equals(qosValue.trim())) {
+
+                JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE));
+                json.put("name", list);
+
+
+            } else {
+                throw new NotFoundException();
+
+            }
+
+            json.put("status", "200");
+            json.put("message", "successful");
+
+        } catch (PermissionDeniedCacheException e) {
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new NotAuthorizedException(e);
+            } else {
+                throw new ForbiddenException(e);
+            }
+        } catch (CacheException e) {
+            throw new InternalServerErrorException(e);
+        }
+
+
+        return json.toString();
+
+
+    }
+
+
+    /**
+     * Query data for specified QoS for file objects.
+     * All QoS objects for file objects are specified by "name", "transition" attributes.
+     * If present, the QoS objects should also contain data system metadata values which are described in the following sections.
+     *
+     * @param qosValue specific QoS {disk|tape|disk+tape}
+     * @return BackendCapabilityDisk  detailed description of the QoS
+     * @throws CacheException
+     */
+
+
+    @GET
+    @Path("/file/{qosValue : .*}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public BackendCapabilityResponse getQueriedQosForFiles(@PathParam("qosValue") String qosValue) throws CacheException {
+
+        BackendCapabilityResponse backendCapabilityResponse = new BackendCapabilityResponse();
+
+
+        BackendCapability backendCapability = new BackendCapability();
+
+
+        try {
+
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new PermissionDeniedCacheException("Permission denied");
+            }
+
+
+            backendCapabilityResponse.setStatus("200");
+            backendCapabilityResponse.setMessage("successful");
+
+            // Set data and metadata for "DISK" QoS
+            if (DISK.equals(qosValue)) {
+
+
+                QoSMetadata qoSMetadata = new QoSMetadata("1", "DE", "100");
+                setBackendCapability(backendCapability, DISK, "", qoSMetadata);
+
+
+            }
+            // Set data and metadata for "TAPE" QoS
+            else if (TAPE.equals(qosValue)) {
+
+                QoSMetadata qoSMetadata = new QoSMetadata("1", "DE", "600000");
+                setBackendCapability(backendCapability, TAPE, DISK_TAPE, qoSMetadata);
+
+
+            }
+            // Set data and metadata for "Disk & TAPE" QoS
+            else if (DISK_TAPE.equals(qosValue)) {
+
+                QoSMetadata qoSMetadata = new QoSMetadata("2", "DE", "100");
+                setBackendCapability(backendCapability, DISK_TAPE, TAPE, qoSMetadata);
+
+            }
+            // The QoS is not known or supported.
+            else {
+                throw new NotFoundException();
+            }
+
+        } catch (PermissionDeniedCacheException e) {
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new NotAuthorizedException(e);
+            } else {
+                throw new ForbiddenException(e);
+            }
+        } catch (CacheException e) {
+            throw new InternalServerErrorException(e);
+        }
+
+
+        backendCapabilityResponse.setBackendCapability(backendCapability);
+
+        return backendCapabilityResponse;
+
+
+    }
+
+
+    /**
+     * Query data for specified QoS for directory objects.
+     *
+     * @param qosValue specific QoS {disk|tape}
+     * @return BackendCapabilityDisk  detailed description of the QoS
+     * @throws CacheException
+     */
+
+
+    @GET
+    @Path("/directory/{qosValue : .*}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public BackendCapabilityResponse getQueriedQosForDirectories(@PathParam("qosValue") String qosValue
+
+    ) throws CacheException {
+
+        BackendCapabilityResponse backendCapabilityResponse = new BackendCapabilityResponse();
+
+        BackendCapability backendCapability = new BackendCapability();
+
+
+        try {
+
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new PermissionDeniedCacheException("Permission denied");
+            }
+
+            backendCapabilityResponse.setStatus("200");
+            backendCapabilityResponse.setMessage("successful");
+
+
+            // Set data and metadata for "DISK" QoS
+            if (DISK.equals(qosValue)) {
+
+
+                QoSMetadata qoSMetadata = new QoSMetadata("1", "DE", "100");
+                setBackendCapability(backendCapability, DISK, TAPE, qoSMetadata);
+
+
+            }
+            // Set data and metadata for "TAPE" QoS
+            else if (TAPE.equals(qosValue)) {
+
+                QoSMetadata qoSMetadata = new QoSMetadata("1", "DE", "600000");
+                setBackendCapability(backendCapability, TAPE, DISK, qoSMetadata);
+
+
+            }
+            // The QoS is not known or supported.
+            else {
+                throw new NotFoundException();
+            }
+
+        } catch (PermissionDeniedCacheException e) {
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new NotAuthorizedException(e);
+            } else {
+                throw new ForbiddenException(e);
+            }
+        } catch (CacheException e) {
+            throw new InternalServerErrorException(e);
+        }
+
+        backendCapabilityResponse.setBackendCapability(backendCapability);
+
+        return backendCapabilityResponse;
+
+
+    }
+
+
+    public void setBackendCapability(BackendCapability backendCapability,
+                                     String name,
+                                     String transition,
+                                     QoSMetadata qoSMetadata) {
+
+        backendCapability.setName(name);
+        List<String> transitions = new ArrayList<>();
+
+        //TODO optimise
+        if (!"".equals(transition)) {
+            transitions.add(transition);
+        }
+
+        backendCapability.setTransition(transitions);
+        backendCapability.setMetadata(qoSMetadata);
+
+
+    }
+
+
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
@@ -35,9 +35,9 @@ import org.dcache.restful.util.ServletContextHandlerAttributes;
 @Path("/qos-management/qos/")
 public class QosManagement {
 
-    private static final String DISK = "disk";
-    private static final String TAPE = "tape";
-    private static final String DISK_TAPE = "disk+tape";
+    public static final String DISK = "disk";
+    public static final String TAPE = "tape";
+    public static final String DISK_TAPE = "disk+tape";
 
 
     /**

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java
@@ -1,0 +1,161 @@
+package org.dcache.restful.qos;
+
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.servlet.ServletContext;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Produces;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.BadRequestException;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileNotFoundCacheException;
+import diskCacheV111.util.FsPath;
+import diskCacheV111.util.PermissionDeniedCacheException;
+import diskCacheV111.util.PnfsHandler;
+
+import org.dcache.auth.Subjects;
+import org.dcache.namespace.FileAttribute;
+import org.dcache.restful.util.ServletContextHandlerAttributes;
+import org.dcache.vehicles.FileAttributes;
+
+/**
+ * Created by sahakya on 7/5/16.
+ */
+
+@Path("/qos-management/namespace")
+public class QosManagementNamespace {
+
+    @Context
+    ServletContext ctx;
+
+    /**
+     * Gets the current status of the object, (including transition status), for the object specified by path.
+     *
+     * @param requestPath path to a file
+     * @return JSONObject current QoS status
+     * @throws CacheException
+     */
+    @GET
+    @Path("{requestPath : .*}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String getQosStatus(@PathParam("requestPath") String requestPath) throws CacheException {
+
+        JSONObject jsonResponse = new JSONObject();
+
+
+        try {
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new PermissionDeniedCacheException("Permission denied");
+            }
+
+            //TODO  get QoS for the specified file
+            getPath(requestPath);
+
+
+        } catch (PermissionDeniedCacheException e) {
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new NotAuthorizedException(e);
+            } else {
+                throw new ForbiddenException(e);
+            }
+        } catch (FileNotFoundCacheException e) {
+            throw new NotFoundException(e);
+        } catch (CacheException e) {
+            throw new InternalServerErrorException(e);
+        }
+
+        jsonResponse.put("status", "200");
+        jsonResponse.put("message", "successful");
+        jsonResponse.put("current_qos", "-");
+        return jsonResponse.toString();
+
+    }
+
+    /**
+     * Starts a object transition to the specified QoS.
+     *
+     * @param requestPath path to a file
+     * @param requestPath requestQuery
+     * @return JSONObject current QoS status
+     * @throws CacheException
+     */
+    @POST
+    @Path("{requestPath : .*}")
+    @Consumes({MediaType.APPLICATION_JSON})
+    @Produces(MediaType.APPLICATION_JSON)
+    public String changeQosStatus(@PathParam("requestPath") String requestPath, String requestQuery) throws CacheException {
+
+
+        JSONObject jsonResponse = new JSONObject(requestQuery);
+
+        try {
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new PermissionDeniedCacheException("Permission denied");
+            }
+
+            JSONObject jsonRequest = new JSONObject(requestQuery);
+            String currentQos = (String) jsonRequest.get("current_qos").toString();
+            String target_Qos = (String) jsonRequest.get("target_Qos").toString();
+
+
+            //TODO  get QoS (locality) for the specified file
+            getPath(requestPath);
+
+        } catch (PermissionDeniedCacheException e) {
+            if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+                throw new NotAuthorizedException(e);
+            } else {
+                throw new ForbiddenException(e);
+            }
+        } catch (FileNotFoundCacheException e) {
+            throw new NotFoundException(e);
+        } catch (CacheException e) {
+            throw new InternalServerErrorException(e);
+        } catch (BadRequestException | JSONException e) {
+            throw new BadRequestException(e);
+        }
+
+        jsonResponse.put("status", "200");
+        jsonResponse.put("message", "Transition was successful");
+        return jsonResponse.toString();
+
+    }
+
+    //TODO  get QoS (locality) for the specified file
+    public FileAttributes getPath(String requestPath) throws CacheException {
+
+
+        PnfsHandler handler = ServletContextHandlerAttributes.getPnfsHandler(ctx);
+        FsPath path;
+        if (requestPath == null || requestPath.isEmpty()) {
+            path = FsPath.ROOT;
+        } else {
+            path = FsPath.create(FsPath.ROOT + requestPath);
+        }
+        Set<FileAttribute> attributes = EnumSet.allOf(FileAttribute.class);
+
+        FileAttributes namespaceAttrributes = handler.getFileAttributes(path, attributes);
+
+
+        return namespaceAttrributes;
+    }
+
+
+}


### PR DESCRIPTION
Motivation:

Users should be provided by possibility to  request certain QoS attributes to be associated with data objects (files) and containers (directories).

The following restful calls will be available for the user

1.GET /api/v1/qos-management/qos/file - Get the list of Quality of Services (QoS) for a file
2.GET /api/v1/qos-management /qos/directory - Get the list of QoS for a directory
3.GET /api/v1/qos-management/qos/file/{disk/tape/disk+tape} - Get data describing a specific QoS for a file
4.GET /api/v1/qos-management/qos/dir/{tape/disk} - Get data describing a specific QoS for a directory

Modification & Result:

The following classes has been added to qos pacakge

1. QoSMetadata - Data describing specific qos, please see CDMI specification for more details.
2. BackendCapability - Data describing specific QoS.
3. QosManagement - Get the list of available QoS for file objects corresponding to some specific quality of services supported by dCache back-end.
4. draft version of POST /api/v1/qos-management/namespace/{path}
Target: master
Require-book: no
Require-notes: no
Patch: https://rb.dcache.org/r/9513/
Acted by: Paul Millar <paul.millar@desy.de>