### PR TITLE
dcache-restful-api: fix data type for cdmi_geographic_placement

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QoSMetadata.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QoSMetadata.java
@@ -1,5 +1,6 @@
 package org.dcache.restful.qos;
 
+import java.util.List;
 
 /**
  * This class represents data describing specific QoS based on CDMI specification.
@@ -7,12 +8,11 @@ package org.dcache.restful.qos;
 public class QoSMetadata {
 
     private String cdmi_data_redundancy_provided;
-
-    private String cdmi_geographic_placement_provided;
+    private List<String> cdmi_geographic_placement_provided;
     private String cdmi_latency_provided;
 
     public QoSMetadata(String cdmi_data_redundancy_provided,
-                       String cdmi_geographic_placement_provided,
+                       List<String> cdmi_geographic_placement_provided,
                        String cdmi_latency_provided) {
         this.cdmi_data_redundancy_provided = cdmi_data_redundancy_provided;
         this.cdmi_geographic_placement_provided = cdmi_geographic_placement_provided;
@@ -28,20 +28,20 @@ public class QoSMetadata {
         this.cdmi_data_redundancy_provided = cdmi_data_redundancy_provided;
     }
 
-    public String getCdmi_geographic_placement_provided() {
-        return cdmi_geographic_placement_provided;
-    }
-
-    public void setCdmi_geographic_placement_provided(String cdmi_geographic_placement_provided) {
-        this.cdmi_geographic_placement_provided = cdmi_geographic_placement_provided;
-    }
-
     public String getCdmi_latency_provided() {
         return cdmi_latency_provided;
     }
 
     public void setCdmi_latency_provided(String cdmi_latency_provided) {
         this.cdmi_latency_provided = cdmi_latency_provided;
+    }
+
+    public List<String> getCdmi_geographic_placement_provided() {
+        return cdmi_geographic_placement_provided;
+    }
+
+    public void setCdmi_geographic_placement_provided(List<String> cdmi_geographic_placement_provided) {
+        this.cdmi_geographic_placement_provided = cdmi_geographic_placement_provided;
     }
 
 }

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
@@ -39,6 +39,7 @@ public class QosManagement {
     public static final String TAPE = "tape";
     public static final String DISK_TAPE = "disk+tape";
 
+    public static List<String> cdmi_geographic_placement_provided = Arrays.asList("DE");
 
     /**
      * Get the list of available QoS for file  and directory objects corresponding to some specific quality of services supported by dCache back-end.
@@ -95,10 +96,7 @@ public class QosManagement {
             throw new InternalServerErrorException(e);
         }
 
-
         return json.toString();
-
-
     }
 
 
@@ -119,10 +117,7 @@ public class QosManagement {
     public BackendCapabilityResponse getQueriedQosForFiles(@PathParam("qosValue") String qosValue) throws CacheException {
 
         BackendCapabilityResponse backendCapabilityResponse = new BackendCapabilityResponse();
-
-
         BackendCapability backendCapability = new BackendCapability();
-
 
         try {
 
@@ -130,31 +125,26 @@ public class QosManagement {
                 throw new PermissionDeniedCacheException("Permission denied");
             }
 
-
             backendCapabilityResponse.setStatus("200");
             backendCapabilityResponse.setMessage("successful");
 
             // Set data and metadata for "DISK" QoS
             if (DISK.equals(qosValue)) {
 
-
-                QoSMetadata qoSMetadata = new QoSMetadata("1", "DE", "100");
+                QoSMetadata qoSMetadata = new QoSMetadata("1", cdmi_geographic_placement_provided, "100");
                 setBackendCapability(backendCapability, DISK, "", qoSMetadata);
-
-
             }
             // Set data and metadata for "TAPE" QoS
             else if (TAPE.equals(qosValue)) {
 
-                QoSMetadata qoSMetadata = new QoSMetadata("1", "DE", "600000");
+                QoSMetadata qoSMetadata = new QoSMetadata("1", cdmi_geographic_placement_provided, "600000");
                 setBackendCapability(backendCapability, TAPE, DISK_TAPE, qoSMetadata);
-
 
             }
             // Set data and metadata for "Disk & TAPE" QoS
             else if (DISK_TAPE.equals(qosValue)) {
 
-                QoSMetadata qoSMetadata = new QoSMetadata("2", "DE", "100");
+                QoSMetadata qoSMetadata = new QoSMetadata("2", cdmi_geographic_placement_provided, "100");
                 setBackendCapability(backendCapability, DISK_TAPE, TAPE, qoSMetadata);
 
             }
@@ -173,12 +163,9 @@ public class QosManagement {
             throw new InternalServerErrorException(e);
         }
 
-
         backendCapabilityResponse.setBackendCapability(backendCapability);
 
         return backendCapabilityResponse;
-
-
     }
 
 
@@ -194,14 +181,11 @@ public class QosManagement {
     @GET
     @Path("/directory/{qosValue : .*}")
     @Produces(MediaType.APPLICATION_JSON)
-    public BackendCapabilityResponse getQueriedQosForDirectories(@PathParam("qosValue") String qosValue
-
-    ) throws CacheException {
+    public BackendCapabilityResponse getQueriedQosForDirectories(@PathParam("qosValue") String qosValue) throws CacheException {
 
         BackendCapabilityResponse backendCapabilityResponse = new BackendCapabilityResponse();
 
         BackendCapability backendCapability = new BackendCapability();
-
 
         try {
 
@@ -212,23 +196,17 @@ public class QosManagement {
             backendCapabilityResponse.setStatus("200");
             backendCapabilityResponse.setMessage("successful");
 
-
             // Set data and metadata for "DISK" QoS
             if (DISK.equals(qosValue)) {
 
-
-                QoSMetadata qoSMetadata = new QoSMetadata("1", "DE", "100");
+                QoSMetadata qoSMetadata = new QoSMetadata("1", cdmi_geographic_placement_provided, "100");
                 setBackendCapability(backendCapability, DISK, TAPE, qoSMetadata);
-
-
             }
             // Set data and metadata for "TAPE" QoS
             else if (TAPE.equals(qosValue)) {
 
-                QoSMetadata qoSMetadata = new QoSMetadata("1", "DE", "600000");
+                QoSMetadata qoSMetadata = new QoSMetadata("1", cdmi_geographic_placement_provided, "600000");
                 setBackendCapability(backendCapability, TAPE, DISK, qoSMetadata);
-
-
             }
             // The QoS is not known or supported.
             else {
@@ -246,10 +224,7 @@ public class QosManagement {
         }
 
         backendCapabilityResponse.setBackendCapability(backendCapability);
-
         return backendCapabilityResponse;
-
-
     }
 
 
@@ -268,8 +243,6 @@ public class QosManagement {
 
         backendCapability.setTransition(transitions);
         backendCapability.setMetadata(qoSMetadata);
-
-
     }
 
 


### PR DESCRIPTION
Motivation:

     cdmi_geographic_placement should be Array of strings according to specification

Modification & Result:

Targeet: master
Require-book: no
Require-notes: no
Patch: https://rb.dcache.org/r/9520/
Acted by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>