### PR TITLE
pom: use project.version instead of derived dcache.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -872,7 +872,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>logback-test-config</artifactId>
-            <version>${version.dcache}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Motivation:
when referring to a submodule as dependency, use version specified by
project.version as it looks like that maven release module internally
updates project.version number, but does not updates it references and
breaks release process.

Modification:
use project.version to reference dependencies.

Result:
working release process

Acked-by: Olufemi Adeyemi
Acked-by: Gerd Behrmann
Target: master, 2.16
Require-book: no
Require-notes: no
(cherry picked from commit 2cd391fdd9cf98f9c4fd6d0c8ac6c5fc40f42f53)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>