### PR TITLE
gplazma2-argus: Update to Argus client 2.2.0 to fix dependency on VOMS library

### DIFF
--- a/modules/gplazma2-argus/src/main/java/org/dcache/gplazma/plugins/ArgusPepRequestFactory.java
+++ b/modules/gplazma2-argus/src/main/java/org/dcache/gplazma/plugins/ArgusPepRequestFactory.java
@@ -8,7 +8,7 @@ import org.glite.authz.common.model.Resource;
 import org.glite.authz.common.model.Subject;
 import org.glite.authz.pep.profile.AuthorizationProfile;
 
-import static org.glite.authz.common.profile.AuthorizationProfileConstants.*;
+import static org.glite.authz.common.profile.CommonXACMLAuthorizationProfileConstants.*;
 
 public class ArgusPepRequestFactory {
 

--- a/pom.xml
+++ b/pom.xml
@@ -216,12 +216,12 @@
             <dependency>
                 <groupId>org.glite.authz</groupId>
                 <artifactId>pep-common</artifactId>
-                <version>2.1.1</version>
+                <version>2.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.glite.authz</groupId>
                 <artifactId>pep-java</artifactId>
-                <version>2.0.2</version>
+                <version>2.2.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Motivation:

The Argus library that was used in dCache relied upon an older VOMS library no
longer used in dCache. Thus the Argus plugin fails to load with a
ClassNotFoundException.

Modification:

Upgrade the Argus library being used to a version that uses the same major
version of the VOMS library.

Result:

Fixed a problem with the gPlazma argus plugin that caused it to fail with a
ClassNotFoundException.

Target: trunk
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Olufemi Adeyemi <olufemi.segun.adeyemi@desy.de>

Reviewed at https://rb.dcache.org/r/9525/

(cherry picked from commit 874661c787f1dc02f8e49d95a5968580ddf151a8)