### PR TITLE
frontend/dcache-restful-api: remove www-authenticate header

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/errorHandling/RestAPIExceptionHandler.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/errorHandling/RestAPIExceptionHandler.java
@@ -8,7 +8,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.util.Objects;
 
 /**
  *
@@ -21,15 +20,13 @@ public class RestAPIExceptionHandler extends ErrorHandler
     {
         int code = response.getStatus();
         String message = HttpStatus.getMessage(code);
-        String xHttp = request.getHeader("X-Requested-With");
 
         response.setHeader("Access-Control-Allow-Origin", "*");
         response.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
         response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
         response.setHeader("content-type", "application/json");
 
-        if (Objects.equals(xHttp, "XMLHttpRequest") && code == 401) {
-            response.setHeader("X-Requested-With", "handled");
+        if (code == 401) {
             response.setHeader("WWW-Authenticate", "");
         }
 


### PR DESCRIPTION
Motivation:

The inconsistency in browser behaviour on how to handle an ajax call
have some detrimental effect in developing a more reliable and user
friendly web app.

Some browsers set and send all the request headers at once while others
send some basic headers first then later send all the headers set in the
request. Since dcache-rest-api rely on header: X-Requested-with which is
a signal telling the rest-api not to send the Www-authenticate header.
Unfornately some browser don't send this during the first flightof the
request. Therefore a 401 with www-authenticate response header is send
to the browser (which is not desirable).

Modification:

1. Set `www-authenticate` header to an empty string when (only) 401 response
is hit, which in return remove the header.
2. (At least for now) no need for X-Requested-with header.

Result:

This end the problem with prompt login by the browser.

Target: trunk
Request: 2.16
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Review at https://rb.dcache.org/r/9518/

(cherry picked from commit 4a57c27e1d21839a2866a0ac68980805c8de3117)