### PR TITLE
dcache-nearline-plugin-archetype: Include correct service loader definition

### DIFF
--- a/archetypes/dcache-nearline-plugin-archetype/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/dcache-nearline-plugin-archetype/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -47,7 +47,7 @@
         <fileSet filtered="true" encoding="UTF-8">
             <directory>src/main/resources</directory>
             <includes>
-                <include>**/org.dcache.xrootd.plugins.ChannelHandlerProvider</include>
+                <include>**/org.dcache.pool.nearline.spi.NearlineStorageProvider</include>
             </includes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
Result:

Fixes a cut'n'paste error that caused the service loader definition
to be excluded from the generated plugin project.

Target: trunk
Request: 2.16
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9528/

(cherry picked from commit 574cf496afec0ffc66dff89378f27d806c07ddaa)