### PR TITLE
dcache-restful-api: RestfulAPI for QoS(CDMI) CHANGE current QoS for t…

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/ServletContextHandlerAttributes.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/ServletContextHandlerAttributes.java
@@ -13,11 +13,11 @@ import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.RemotePoolMonitor;
 import org.dcache.util.list.ListDirectoryHandler;
 
-public class ServletContextHandlerAttributes
-{
+public class ServletContextHandlerAttributes {
     public final static String DL = "org.dcache.restful";
     public final static String CS = "org.dcache.restful.CS";
     public final static String PM = "org.dcache.restful.PM";
+    public final static String PinMngStub = "org.dcache.restful.PinMngStub";
 
     public static Subject getSubject()
     {
@@ -46,5 +46,12 @@ public class ServletContextHandlerAttributes
     public static RemotePoolMonitor getRemotePoolMonitor(ServletContext ctx)
     {
         return (RemotePoolMonitor) (ctx.getAttribute(PM));
+    }
+
+    public static CellStub getPinManager(ServletContext ctx)
+    {
+        CellStub cellStub = (CellStub) (ctx.getAttribute(PinMngStub));
+        return cellStub;
+
     }
 }

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -100,6 +100,12 @@
 	class="org.dcache.util.ConfigurationMapFactoryBean">
       <property name="prefix" value="frontend.custom-response-header"/>
   </bean>
+    <bean id="pinManagerStub" class="org.dcache.cells.CellStub">
+        <description>Pin manager cell stub</description>
+        <property name="timeout" value="${frontend.service.pinmanager.timeout}"/>
+        <property name="timeoutUnit" value="${frontend.service.pinmanager.timeout.unit}"/>
+        <property name="destination" value="${frontend.service.pinmanager}"/>
+    </bean>
 
     <bean id="handlers" class="org.eclipse.jetty.server.handler.HandlerList">
         <description>List of handlers for HTTP requests</description>
@@ -165,6 +171,9 @@
                                                                value-ref="pnfs-stub"/>
                                                         <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).PM}"
                                                                value-ref="pool-monitor"/>
+                                                        <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).PinMngStub}"
+                                                               value-ref= "pinManagerStub"/>
+
                                                     </map>
                                                 </constructor-arg>
                                             </bean>

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -42,6 +42,14 @@ frontend.cell.subscribe=${frontend.pool-monitor.topic}
 # Cell address of pnfsmanager service
 frontend.service.pnfsmanager=${dcache.service.pnfsmanager}
 
+# Cell address of pinmanager service
+frontend.service.pinmanager=${dcache.service.pinmanager}
+
+# Timeout for pinmanager requests
+frontend.service.pinmanager.timeout=300000
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pinmanager.timeout.unit=MILLISECONDS
+
+
 # Timeout for pnfsmanager requests
 frontend.service.pnfsmanager.timeout = 120000
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pnfsmanager.timeout.unit=MILLISECONDS


### PR DESCRIPTION
…he specified file

Motivation:

    Provides call to change the current Qos

Modification & Result:

   changeQosStatus()  is added

Target: master
Require-book: no
Require-notes: no
Patch: https://rb.dcache.org/r/9517/
Acted by: Jürgen Starek <juergen.starek@desy.de>