### PR TITLE
resilience: fix alarm log level

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileTaskCompletionHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileTaskCompletionHandler.java
@@ -119,7 +119,7 @@ public final class FileTaskCompletionHandler implements TaskCompletionHandler {
                                 maxRetries), e);
         }
 
-        LOGGER.trace(AlarmMarkerFactory.getMarker(
+        LOGGER.error(AlarmMarkerFactory.getMarker(
                                         PredefinedAlarm.FAILED_REPLICATION,
                                         pnfsId.toString()),
                         ABORT_REPLICATION_LOG_MESSAGE, pnfsId,


### PR DESCRIPTION
The log level on this alarm was obviously set back to trace
(after a debugging session) by mistake.

The patch just changes it back from TRACE to ERROR.

Target: master
Request: 2.16
Acked-by: Paul