### PR TITLE
alarms: add ndc info to alarm info

### DIFF
--- a/modules/common/src/main/java/org/dcache/commons/util/NDC.java
+++ b/modules/common/src/main/java/org/dcache/commons/util/NDC.java
@@ -1,16 +1,8 @@
 package org.dcache.commons.util;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import org.slf4j.MDC;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Strings.nullToEmpty;
+import java.util.Map;
 
 /**
  * The class emulates the Nested Diagnostic Context of Log4j.
@@ -128,5 +120,9 @@ public class NDC
         }
 
         return top;
+    }
+
+    public static String ndcFromMdc(Map<String, String> mdc) {
+        return mdc.get(KEY_NDC);
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/alarms/logback/LoggingEventConverter.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/logback/LoggingEventConverter.java
@@ -72,13 +72,13 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 import dmg.cells.nucleus.CDC;
-
 import org.dcache.alarms.Alarm;
 import org.dcache.alarms.AlarmDefinition;
 import org.dcache.alarms.AlarmDefinitionsMap;
 import org.dcache.alarms.AlarmMarkerFactory;
 import org.dcache.alarms.PredefinedAlarm;
 import org.dcache.alarms.dao.LogEntry;
+import org.dcache.commons.util.NDC;
 import org.dcache.util.NetworkUtils;
 
 /**
@@ -195,11 +195,17 @@ final class LoggingEventConverter {
             domain = mdc.get(CDC.MDC_DOMAIN);
         }
 
+        String info = event.getFormattedMessage();
+        String ndc = NDC.ndcFromMdc(mdc);
+        if (ndc != null && !ndc.isEmpty()) {
+            info = "[" + ndc + "] " + info;
+        }
+
         LogEntry entry = new LogEntry();
+        entry.setInfo(info);
         Long timestamp = event.getTimeStamp();
         entry.setFirstArrived(timestamp);
         entry.setLastUpdate(timestamp);
-        entry.setInfo(event.getFormattedMessage());
         entry.setHost(host);
         entry.setDomain(domain);
         entry.setService(service);

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -172,7 +172,7 @@ alarms.email.buffer-size=1
 
 #  ---- Pattern to use to encode email alert.
 #
-alarms.email.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %X{type} \\(%X{host}\\)\\(%X{service}\\)\\(%X{domain}\\) %m%n
+alarms.email.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %X{type} \\(%X{host}\\)\\(%X{service}\\)\\(%X{domain}\\)\\(%X{org.dcache.ndc}\\) %m%n
 
 #  ---- Level of priority serving as threshold for logging history entry.
 #       All alerts at this level or above are logged to the history file.
@@ -180,7 +180,7 @@ alarms.email.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %X{type} \\(%X{host}\\)\\
 
 #  ---- Pattern to use to encode history log entry.
 #
-alarms.history.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %X{type} \\(%X{host}\\)\\(%X{service}\\)\\(%X{domain}\\) %m%n
+alarms.history.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %X{type} \\(%X{host}\\)\\(%X{service}\\)\\(%X{domain}\\)\\(%X{org.dcache.ndc}\\) %m%n
 
 #  ---- Path of history log file
 #


### PR DESCRIPTION
Motivation:

Sometimes information, like the pnfsid, is missing from a logging
message which we promote to alarm, but the information is present
in the MDC (NDC):

rw-stkendca13a-5Domain.log:20 Jul 2016 09:30:40 (rw-stkendca13a-5) [b55b5e9b-baa0-4613-b56c-e10c32d71d19 000013A9AA57B8684A4AA5E407F9A0F5E795] HSM script failed (script reported: 1: ...

This information can be usefully displayed in the
webadmin table for diagnostic purposes.

Modification:

Instead of appending the information on the client end (to the
event message), we allow the server-end to do so.

Result:

The missing diagnostic info is displayed in the table.

While not a bug, the improvement is minimally invasive, affects
only the displayed element, and would be useful to have.
Hence I am requesting a backport.
I leave it to the reviewers' discretion.

Target: master
Acked-by: Paul