### PR TITLE
cells: handle empty string pool value on staging in TransferObserver

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -2,6 +2,7 @@ package diskCacheV111.cells;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -153,6 +154,8 @@ public class TransferObserverV1
      *      for conversion into .txt and .html table entries.</p>
      */
     private static class TransferBean extends TransferInfo {
+        private static final long serialVersionUID = 3132576086376551676L;
+
         private final long now;
 
         public TransferBean() {
@@ -562,7 +565,7 @@ public class TransferObserverV1
         tmp = tmp.contains("known") ? "?" : tmp;
         page.td("process", tmp);
 
-        String poolName = transfer.getPool();
+        String poolName = Strings.emptyToNull(transfer.getPool());
         if (poolName == null || poolName.equals("<unknown>")) {
             poolName = "N.N.";
         }


### PR DESCRIPTION
Motivation:

Changes from 2.12 to 2.13 affecting the TransferObserverV1 class introduced a
small bug.  Previously, if the pool on the request message was either "<unknown>"
(from the DCAP door) or NULL (from all other Transfers), this was interpreted,
in the absence of a mover, to mean a staging from tape.

However, this pool value can now also be an empty string.

Modification:

Strings.emptyToNull on the pool name.  (the serial id was also missing on the
bean class).

Result:

Transfers which are staging from non-DCAP doors are correctly indicated (in yellow)
on the active transfers page, instead of showing up as "No Mover found" (in red).

Target: master
Acked-by: Olufemi
Acked-by: Paul
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13