### PR TITLE
poolmanager: Fix incorrect correction of pool cost

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -1034,7 +1034,6 @@ public class RequestContainerV5
                 }
                 m.revertDirection();
                 sendMessage(m);
-                _poolMonitor.messageToCostModule(m);
                 if (!rpm.getSkipCostUpdate()) {
                     _poolMonitor.messageToCostModule(m);
                 }


### PR DESCRIPTION
Motivation:

Pool manager anticipates changes in pool load by adjusting cost estimates after
pool selection.

Modification:

For read pool selection the cost adjustment was applied twice. Now it is only
applied once.

Result:

Fixed a bug in pool manager affecting pool cost estimates.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9570/

(cherry picked from commit 7bcf59280d79e019806072aafff9083142a39738)