### PR TITLE
srmclient: do not rely on -f option of readlink

### DIFF
--- a/modules/srm-client/pom.xml
+++ b/modules/srm-client/pom.xml
@@ -13,6 +13,11 @@
 
     <name>SRM Client</name>
 
+    <properties>
+        <raw-files>${project.basedir}/src/main</raw-files>
+        <filtered-files>${project.build.directory}/filtered-files</filtered-files>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -59,6 +64,46 @@
                     <source>1.7</source>
                     <target>1.7</target>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                          <!-- The scripts need some variable substitution.
+
+                             The assembly plugin however only supports
+                             ${} substitution and that conflicts with
+                             shell variables and dCache configuration
+                             properties.
+
+                             Therefore we use the resource plugin to
+                             make a filtered copy of the skel and use
+                             those files in the assembly whenever we
+                             need a filtered file. -->
+                        <id>copy-resources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${filtered-files}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${raw-files}</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                            <delimiters>
+                                <delimiter>@</delimiter>
+                            </delimiters>
+                            <useDefaultDelimiters>false</useDefaultDelimiters>
+                            <filters>
+                                <filter>${project.basedir}/src/main/assembly/filter.properties</filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -139,7 +184,6 @@
                             </execution>
                         </executions>
                     </plugin>
-
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/modules/srm-client/src/main/assembly/dir.xml
+++ b/modules/srm-client/src/main/assembly/dir.xml
@@ -11,7 +11,7 @@
 
     <fileSets>
         <fileSet>
-            <directory>${project.basedir}/src/main/bin</directory>
+            <directory>${filtered-files}/bin</directory>
             <outputDirectory>usr/bin</outputDirectory>
             <fileMode>775</fileMode>
             <excludes>
@@ -23,12 +23,12 @@
             </excludes>
         </fileSet>
         <fileSet>
-            <directory>${project.basedir}/src/main/lib</directory>
+            <directory>${filtered-files}/lib</directory>
             <outputDirectory>usr/share/srm/lib</outputDirectory>
             <fileMode>775</fileMode>
         </fileSet>
         <fileSet>
-            <directory>${project.basedir}/src/main/conf</directory>
+            <directory>${filtered-files}/conf</directory>
             <outputDirectory>usr/share/srm/conf</outputDirectory>
             <includes>
                 <include>logback*.xml</include>

--- a/modules/srm-client/src/main/assembly/filter.properties
+++ b/modules/srm-client/src/main/assembly/filter.properties
@@ -1,0 +1,34 @@
+INIT_SCRIPT=                                                                           \n\
+printCanonicalPath() # in $1 = path                                                    \n\
+{                                                                                      \n\
+    local link                                                                         \n\
+    local ret                                                                          \n\
+    link="$1"                                                                          \n\
+    if readlink -f / > /dev/null 2>&1; then                                            \n\
+        readlink -f $link                                                              \n\
+    else                                                                               \n\
+        ret="$(cd $(dirname $link); pwd -P)/$(basename $link)"                         \n\
+        while [ -h "$ret" ]; do                                                        \n\
+            link="$(readlink "$ret")"                                                  \n\
+            if [ -z "${link##/*}" ]; then                                              \n\
+                ret="${link}"                                                          \n\
+            else                                                                       \n\
+                link=$(dirname $ret)/${link}                                           \n\
+                ret="$(cd $(dirname $link); pwd -P)/$(basename $link)"                 \n\
+            fi                                                                         \n\
+        done                                                                           \n\
+        echo "$ret"                                                                    \n\
+    fi                                                                                 \n\
+}                                                                                      \n\
+                                                                                       \n\
+if [ -z "$SRM_PATH" ]; then                                                            \n\
+    SRM_PATH="$(cd "$(dirname "$(printCanonicalPath "$0")")/../share/srm"; pwd -P)"    \n\
+fi                                                                                     \n\
+                                                                                       \n\
+if [ ! -d "$SRM_PATH" ]; then                                                          \n\
+    echo "${SRM_PATH} is not a directory"                                              \n\
+    exit 2                                                                             \n\
+fi                                                                                     \n\
+                                                                                       \n\
+export SRM_PATH                                                                        \n\
+

--- a/modules/srm-client/src/main/assembly/tar.xml
+++ b/modules/srm-client/src/main/assembly/tar.xml
@@ -11,7 +11,7 @@
 
     <fileSets>
         <fileSet>
-            <directory>${project.basedir}/src/main/bin</directory>
+            <directory>${filtered-files}/bin</directory>
             <outputDirectory>bin</outputDirectory>
             <fileMode>755</fileMode>
             <directoryMode>755</directoryMode>
@@ -24,13 +24,13 @@
             </excludes>
         </fileSet>
         <fileSet>
-            <directory>${project.basedir}/src/main/lib</directory>
+            <directory>${filtered-files}/lib</directory>
             <outputDirectory>share/srm/lib</outputDirectory>
             <fileMode>755</fileMode>
             <directoryMode>755</directoryMode>
         </fileSet>
         <fileSet>
-            <directory>${project.basedir}/src/main/conf</directory>
+            <directory>${filtered-files}/conf</directory>
             <outputDirectory>share/srm/conf</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>

--- a/modules/srm-client/src/main/bin/adler32
+++ b/modules/srm-client/src/main/bin/adler32
@@ -1,15 +1,6 @@
 #! /bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
-
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
+@INIT_SCRIPT@
 
 for jar in $SRM_PATH/lib/*.jar
 do

--- a/modules/srm-client/src/main/bin/delegation
+++ b/modules/srm-client/src/main/bin/delegation
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-jar_dir=$(cd $(dirname $(readlink -f $0))/../share/srm/lib; pwd)
+@INIT_SCRIPT@
 
-conf_dir=$(cd $jar_dir/../conf;pwd)
+conf_dir="$SRM_PATH/conf"
 
 if [ "$1" = "-debug" ]; then
     logbackDefn=-Dlogback.configurationFile=$conf_dir/logback-all.xml
@@ -17,7 +17,7 @@ else
     x509_user_proxy=/tmp/x509up_u$(id -u)
 fi
 
-CLASSPATH="$jar_dir/*" java -Dlog=${DELEGATION_LOG:-warn} \
+CLASSPATH="$SRM_PATH/lib/*" java -Dlog=${DELEGATION_LOG:-warn} \
     -client \
     -Djava.awt.headless=true \
     -DwantLog4jSetup=n \

--- a/modules/srm-client/src/main/bin/srm-abort-files
+++ b/modules/srm-client/src/main/bin/srm-abort-files
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -abortFiles $*
+"${SRM_PATH}/lib/srm" -abortFiles "$@"

--- a/modules/srm-client/src/main/bin/srm-abort-request
+++ b/modules/srm-client/src/main/bin/srm-abort-request
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -abortRequest $*
+"${SRM_PATH}/lib/srm" -abortRequest "$@"

--- a/modules/srm-client/src/main/bin/srm-advisory-delete
+++ b/modules/srm-client/src/main/bin/srm-advisory-delete
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -advisoryDelete $*
+"${SRM_PATH}/lib/srm" -advisoryDelete "$@"

--- a/modules/srm-client/src/main/bin/srm-bring-online
+++ b/modules/srm-client/src/main/bin/srm-bring-online
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -bringOnline $*
+"${SRM_PATH}/lib/srm" -bringOnline "$@"

--- a/modules/srm-client/src/main/bin/srm-check-permissions
+++ b/modules/srm-client/src/main/bin/srm-check-permissions
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -checkPermissions $*
+"${SRM_PATH}/lib/srm" -checkPermissions "$@"

--- a/modules/srm-client/src/main/bin/srm-extend-file-lifetime
+++ b/modules/srm-client/src/main/bin/srm-extend-file-lifetime
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -extendFileLifetime $*
+"${SRM_PATH}/lib/srm" -extendFileLifetime "$@"

--- a/modules/srm-client/src/main/bin/srm-get-metadata
+++ b/modules/srm-client/src/main/bin/srm-get-metadata
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -getFileMetaData $*
+"${SRM_PATH}/lib/srm" -getFileMetaData "$@"

--- a/modules/srm-client/src/main/bin/srm-get-permissions
+++ b/modules/srm-client/src/main/bin/srm-get-permissions
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -getPermissions $*
+"${SRM_PATH}/lib/srm" -getPermissions "$@"

--- a/modules/srm-client/src/main/bin/srm-get-request-status
+++ b/modules/srm-client/src/main/bin/srm-get-request-status
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -getRequestStatus $*
+"${SRM_PATH}/lib/srm" -getRequestStatus "$@"

--- a/modules/srm-client/src/main/bin/srm-get-request-summary
+++ b/modules/srm-client/src/main/bin/srm-get-request-summary
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -getRequestSummary $*
+"${SRM_PATH}/lib/srm" -getRequestSummary "$@"

--- a/modules/srm-client/src/main/bin/srm-get-request-tokens
+++ b/modules/srm-client/src/main/bin/srm-get-request-tokens
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -getRequestTokens $*
+"${SRM_PATH}/lib/srm" -getRequestTokens "$@"

--- a/modules/srm-client/src/main/bin/srm-get-space-metadata
+++ b/modules/srm-client/src/main/bin/srm-get-space-metadata
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -getSpaceMetaData $*
+"${SRM_PATH}/lib/srm" -getSpaceMetaData "$@"

--- a/modules/srm-client/src/main/bin/srm-get-space-tokens
+++ b/modules/srm-client/src/main/bin/srm-get-space-tokens
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -getSpaceTokens $*
+"${SRM_PATH}/lib/srm" -getSpaceTokens "$@"

--- a/modules/srm-client/src/main/bin/srm-release-files
+++ b/modules/srm-client/src/main/bin/srm-release-files
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -releaseFiles $*
+"${SRM_PATH}/lib/srm" -releaseFiles "$@"

--- a/modules/srm-client/src/main/bin/srm-release-space
+++ b/modules/srm-client/src/main/bin/srm-release-space
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -releaseSpace $*
+"${SRM_PATH}/lib/srm" -releaseSpace "$@"

--- a/modules/srm-client/src/main/bin/srm-reserve-space
+++ b/modules/srm-client/src/main/bin/srm-reserve-space
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -reserveSpace $*
+"${SRM_PATH}/lib/srm" -reserveSpace "$@"

--- a/modules/srm-client/src/main/bin/srm-set-permissions
+++ b/modules/srm-client/src/main/bin/srm-set-permissions
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -setPermissions $*
+"${SRM_PATH}/lib/srm" -setPermissions "$@"

--- a/modules/srm-client/src/main/bin/srm-storage-element-info
+++ b/modules/srm-client/src/main/bin/srm-storage-element-info
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -getStorageElementInfo $*
+"${SRM_PATH}/lib/srm" -getStorageElementInfo "$@"

--- a/modules/srm-client/src/main/bin/srmcp
+++ b/modules/srm-client/src/main/bin/srmcp
@@ -1,15 +1,6 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
-
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
+@INIT_SCRIPT@
 
 args=$*
 

--- a/modules/srm-client/src/main/bin/srmfs
+++ b/modules/srm-client/src/main/bin/srmfs
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-jar_dir=$(cd $(dirname $(readlink -f $0))/../share/srm/lib; pwd)
+@INIT_SCRIPT@
 
-conf_dir=$(cd $jar_dir/../conf;pwd)
+conf_dir=$SRM_PATH/conf
 
 if [ "$1" = "-debug" ]; then
     logbackDefn=-Dlogback.configurationFile=$conf_dir/logback-all.xml
@@ -25,7 +25,7 @@ else
    x509_user_trusted_certs=/etc/grid-security/certificates
 fi
 
-CLASSPATH="$jar_dir/*" java -Dlog=${DELEGATION_LOG:-warn} \
+CLASSPATH="$SRM_PATH/lib/*" java -Dlog=${DELEGATION_LOG:-warn} \
     -client \
     -Djava.awt.headless=true \
     -DwantLog4jSetup=n \

--- a/modules/srm-client/src/main/bin/srmls
+++ b/modules/srm-client/src/main/bin/srmls
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -ls $*
+"${SRM_PATH}/lib/srm" -ls "$@"

--- a/modules/srm-client/src/main/bin/srmmkdir
+++ b/modules/srm-client/src/main/bin/srmmkdir
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -mkdir $*
+"${SRM_PATH}/lib/srm" -mkdir "$@"

--- a/modules/srm-client/src/main/bin/srmmv
+++ b/modules/srm-client/src/main/bin/srmmv
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -mv $*
+"${SRM_PATH}/lib/srm" -mv "$@"

--- a/modules/srm-client/src/main/bin/srmping
+++ b/modules/srm-client/src/main/bin/srmping
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -ping $*
+"${SRM_PATH}/lib/srm" -ping "$@"

--- a/modules/srm-client/src/main/bin/srmrm
+++ b/modules/srm-client/src/main/bin/srmrm
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -rm $*
+"${SRM_PATH}/lib/srm" -rm "$@"

--- a/modules/srm-client/src/main/bin/srmrmdir
+++ b/modules/srm-client/src/main/bin/srmrmdir
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -rmdir $*
+"${SRM_PATH}/lib/srm" -rmdir "$@"

--- a/modules/srm-client/src/main/bin/srmstage
+++ b/modules/srm-client/src/main/bin/srmstage
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-if [ -z "$SRM_PATH" ]; then
-    SRM_PATH="$(cd $(dirname $(readlink -f $0))/../share/srm;pwd)"
-fi
+@INIT_SCRIPT@
 
-if [ ! -d "$SRM_PATH" ]; then
-    echo "${SRM_PATH} is not a directory"
-    exit 2
-fi
-
-export SRM_PATH
-
-"${SRM_PATH}/lib/srm" -stage $*
+"${SRM_PATH}/lib/srm" -stage "$@"


### PR DESCRIPTION
Motivation:

Mac OS-X BSD has an implementation of `readlink` that doesn't support
the `-f` option.  The recent commit that fixed support for
ScientificLinux-7 used `readlink -f` to identify the location of jar
files, which resulted in breaking srmclient for OS-X.

Modification:

Copy the function from dcache script that canonicalises a path to avoid
any symbolic links.  Since the common part of the scripts is now
substantial, this has been factored out and injected as part of the
build process.

Result:

srm-client works again for mac clients.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9591/
Acked-by: Gerd Behrmann