### PR TITLE
common: include filename in error message

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
@@ -449,6 +449,9 @@ public class UniversalSpringCell
                             lineCount + ": " + e.getMessage());
                 }
             }
+        } catch (IOException e) {
+            throw new IOException("Failed to read " + setup + ": " +
+                    e.getMessage(), e);
         } finally {
             try {
                 br.close();


### PR DESCRIPTION
Motivation:

If there is an IOException when reading the setup file, the corresponding
filename is not included in the message.  This may make diagnosing the
problem harder for the admin.

Modification:

Wrap the IOException to include the filename.

Result:

More useful error messages

Target: master
Requires-notes: yes
Requires-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/9587/
Acked-by: Gerd Behrmann

Conflicts:
	modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java