### PR TITLE
transfermanager: fix querying of 3rd-party transfer

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -259,7 +259,13 @@ public abstract class TransferManager extends AbstractCellComponent
         return message;
     }
 
-    public Object messageArrived(TransferStatusQueryMessage message)
+    // TransferStatusQueryMessage is a subclass of
+    // TransferManagerMessage, so the code relies on the
+    // messageArrived dispatch invoking the method with the most
+    // specific signature.  The unused "CellMessage envelope" argument
+    // of this method is required because two-argument methods are
+    // called preferentially.
+    public Object messageArrived(CellMessage envelope, TransferStatusQueryMessage message)
     {
         TransferManagerHandler handler = getHandler(message.getId());
 


### PR DESCRIPTION
Motivation:

Initiating a 3rd-party transfer via WebDAV shows NPE in transfer
manager.  Although the transfer succeeds, the progress reports contain
badly formed information.

This problem is a result of a regression introduced with commit
dbf3bf3c, where a seemingly innocuous change altered how the cell
message was routed.  When delivering a message, the dispatcher is
meant to select the `messageArrived` method with the most specific
(most sub-classed) signature.  Prior to dbf3bf3c this happened.

Modification:

Revert the change in the method signature.  Although this is not an
ideal change, it is the least dangerous change for back-porting to
2.16

Result:

WebDAV initiated 3rd-party transfers now provide valid progress
reports.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9593/
Acked-by: Gerd Behrmann