### PR TITLE
cells: IOException is not a bug in create command

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
@@ -197,6 +197,8 @@ public class CellAdapter
      * starts the delivery of messages to this cell and
      * executes the auto and defined Setup context.
      * (&lt;cellName&gt;Setup and "!&lt;setupContextName&gt;)
+     * Failures to start the cell due to external influences are indicated by
+     * a CommandException; all other exceptions are treated as bugs.
      */
     public ListenableFuture<Void> start()
     {

--- a/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
@@ -75,7 +75,6 @@ import dmg.cells.nucleus.CellSetupProvider;
 import dmg.cells.nucleus.DomainContextAware;
 import dmg.cells.nucleus.EnvironmentAware;
 import dmg.cells.services.SetupInfoMessage;
-import dmg.cells.zookeeper.CellCuratorFramework;
 import dmg.util.CommandException;
 import dmg.util.CommandThrowableException;
 import dmg.util.command.Argument;
@@ -286,7 +285,7 @@ public class UniversalSpringCell
     }
 
     private synchronized void executeSetup()
-        throws IOException, CommandException
+        throws CommandException
     {
         executeSetupContext();
 
@@ -298,6 +297,9 @@ public class UniversalSpringCell
                     providers.add(provider);
                 }
                 execFile(_setupFile);
+            } catch (IOException e) {
+                throw new CommandException("Failed to load " + _setupFile.toPath() +
+                        ": " + e.getMessage(), e);
             } finally {
                 for (CellSetupProvider provider : Lists.reverse(providers)) {
                     provider.afterSetup();


### PR DESCRIPTION
Motivation:

The 'create' command in CellShell creates a new cell.  This can fail
because of an IOException, triggered by the inability to read a setup
file.  This is currently reported as a bug, which is wrong.

Modification:

Create a CommandException from any IOException.  This allows such errors
to reported as a simple problem, rather than as a bug.

Result:

Slightly less confused admins.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9026
Acked-by: Olufemi Adeyemi
Acked-by: Gerd Behrmann
Patch: https://rb.dcache.org/r/9588/

Conflicts:
	modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java