### PR TITLE
cells: IOException is not a bug in create command

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
@@ -183,6 +183,8 @@ public class CellAdapter
      * This method has to be called if the
      * constructor has been used with the startNow
      * argument set to 'false'.
+     * Failures to start the cell due to external influences are indicated by
+     * a CommandException; all other exceptions are treated as bugs.
      */
     public synchronized void start()
     {

--- a/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
@@ -321,8 +321,7 @@ public class UniversalSpringCell
         }
     }
 
-    private void executeSetup()
-        throws IOException, CommandException
+    private void executeSetup() throws CommandException
     {
         executeDefinedSetup();
 
@@ -331,7 +330,12 @@ public class UniversalSpringCell
                 provider.beforeSetup();
             }
 
-            execFile(_setupFile);
+            try {
+                execFile(_setupFile);
+            } catch (IOException e) {
+                throw new CommandException("Failed to load " + _setupFile.toPath() +
+                        ": " + e.getMessage(), e);
+            }
 
             for (CellSetupProvider provider: _setupProviders.values()) {
                 provider.afterSetup();
@@ -568,7 +572,7 @@ public class UniversalSpringCell
             boolean confirmed;
 
             @Override
-            public String call() throws IOException, CommandException, IllegalArgumentException
+            public String call() throws CommandException, IllegalArgumentException
             {
                 checkArgument(confirmed, "Required option is missing.");
                 if (_setupFile != null && !_setupFile.exists()) {


### PR DESCRIPTION
Motivation:

The 'create' command in CellShell creates a new cell.  This can fail
because of an IOException, triggered by the inability to read a setup
file.  This is currently reported as a bug, which is wrong.

Modification:

Create a CommandException from any IOException.  This allows such errors
to reported as a simple problem, rather than as a bug.

Result:

Slightly less confused admins.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9026
Acked-by: Olufemi Adeyemi
Acked-by: Gerd Behrmann
Patch: https://rb.dcache.org/r/9588/

Conflicts:
	modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java

Conflicts:
	modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java

Conflicts:
	modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java