### PR TITLE
billing: Expose property to subscribe to topics

### DIFF
--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -29,6 +29,16 @@ billing.cell.consume=${billing.cell.consume-when-export-is-${billing.cell.export
 (immutable)billing.cell.consume-when-export-is-true=${billing.cell.name}
 (immutable)billing.cell.consume-when-export-is-false=
 
+#  ---- Topics to subscribe to
+#
+#   A service can subscribe to messages published on a topic. Other service
+#   can send messages to such a topic. A topic an unqualified cell address,
+#   that is, an address without a domain name.
+#
+#   This property contains a comma separated list of topics to subscribe to.
+#
+billing.cell.subscribe=
+
 #  ---- Disable billing to plain text file
 #
 #   Controls whether dCache activity is logged as plain text files.  If

--- a/skel/share/services/billing.batch
+++ b/skel/share/services/billing.batch
@@ -42,5 +42,6 @@ onerror shutdown
 create org.dcache.cells.UniversalSpringCell ${billing.cell.name} \
         "classpath:org/dcache/services/billing/cells/billing.xml \
         -profiles=db-${billing.enable.db} \
+        -subscribe=${billing.cell.subscribe} \
         -consume=${billing.cell.consume} \
         -billingCellName=${billing.cell.name}.alias"


### PR DESCRIPTION
Motivation:

In some deployments it is useful to have more than one billing service.
In such a deployment one may want all instances to log the same billing
messages. This may be achieved by treating 'billing' as a topic rather
than a named queue.

Modification:

Expose billing.cell.subscribe to allow subscription to topics.

Result:

Added the billing.cell.subscribe property to allow the billing service
to subscribe to publish subscribe topics. This is useful for deployments
with multiple billing services.

Asking for back-port as NDGF specifically requested this.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9596/

(cherry picked from commit 76cde04b0d3fb63eb3fffe3ab66c8ef8f2c505b8)