### PR TITLE
srm: Include session identifier in error message when srmRm aborts an upload

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmRm.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmRm.java
@@ -17,6 +17,7 @@ import org.dcache.srm.SRMUser;
 import org.dcache.srm.request.GetFileRequest;
 import org.dcache.srm.request.PutFileRequest;
 import org.dcache.srm.scheduler.IllegalStateTransition;
+import org.dcache.srm.util.JDC;
 import org.dcache.srm.v2_2.ArrayOfTSURLReturnStatus;
 import org.dcache.srm.v2_2.SrmRmRequest;
 import org.dcache.srm.v2_2.SrmRmResponse;
@@ -116,7 +117,7 @@ public class SrmRm
             URI surl = URI.create(surls[i].toString());
             for (PutFileRequest request : srm.getActiveFileRequests(PutFileRequest.class, surl)) {
                 try {
-                    request.abort("Upload aborted because the file was deleted by another request.");
+                    request.abort("Upload aborted because the file was deleted by request " + JDC.getSession() + ".");
                     returnStatus.setStatus(new TReturnStatus(TStatusCode.SRM_SUCCESS, "Upload was aborted."));
                 } catch (IllegalStateTransition e) {
                     // The request likely aborted or finished before we could abort it


### PR DESCRIPTION
Motivation:

We often see "Upload aborted because the file was deleted by another request." in
billing logs with no way for us to know who and from which host the remove request
came.

Modification:

Include the session id in the error message. The session ID itself doesn't reveal
anything, however an admin can use the ID to find the remove request in the SRM
access log.

Result:

Modified the error and billing message used when an srmRm request aborts an upload.
The message now includes the session ID of the remove request. This session ID
may be used to identify the request in the access log.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9586/

(cherry picked from commit 27c8720e153785e312b5aff98b98b6bb796bec82)