### PR TITLE
Upgrade to CANL 2.1 and BC 1.50

### DIFF
--- a/modules/common-security/pom.xml
+++ b/modules/common-security/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
+            <artifactId>${bouncycastle.bcprov}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/modules/common-security/src/main/java/org/dcache/gsi/ClientGsiEngine.java
+++ b/modules/common-security/src/main/java/org/dcache/gsi/ClientGsiEngine.java
@@ -21,9 +21,7 @@ import com.google.common.io.ByteSource;
 import eu.emi.security.authn.x509.X509Credential;
 import eu.emi.security.authn.x509.proxy.ProxyGenerator;
 import eu.emi.security.authn.x509.proxy.ProxyRequestOptions;
-import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.jce.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -74,18 +72,16 @@ public class ClientGsiEngine extends InterceptingSSLEngine
 
     private class GotCsr implements Callback
     {
-        private int len = 0;
         private ByteSource data;
 
         @Override
         public void call(ByteBuffer buffer) throws SSLException
         {
             // read csr
-            len += buffer.position();
             ByteSource chunk = ByteSource.wrap(buffer.array()).slice(buffer.arrayOffset(), buffer.position());
             ByteSource source = (data == null) ? chunk : ByteSource.concat(data, chunk);
-            try (ASN1InputStream in = new ASN1InputStream(source.openStream(), len, true)) {
-                PKCS10CertificationRequest csr = new PKCS10CertificationRequest((ASN1Sequence) in.readObject());
+            try {
+                PKCS10CertificationRequest csr = new PKCS10CertificationRequest(source.read());
 
                 // generate proxy
                 ProxyRequestOptions options = new ProxyRequestOptions(credential.getCertificateChain(), csr);

--- a/modules/common-security/src/main/java/org/dcache/gsi/ServerGsiEngine.java
+++ b/modules/common-security/src/main/java/org/dcache/gsi/ServerGsiEngine.java
@@ -148,7 +148,7 @@ public class ServerGsiEngine extends InterceptingSSLEngine
         return super.wrap(srcs, offset, length, dst);
     }
 
-    private ByteBuffer getCertRequest() throws SSLPeerUnverifiedException, GeneralSecurityException
+    private ByteBuffer getCertRequest() throws IOException, GeneralSecurityException
     {
         X509Certificate[] chain = CertificateUtils.convertToX509Chain(getSession().getPeerCertificates());
         int bits = ((RSAPublicKey) chain[0].getPublicKey()).getModulus().bitLength();
@@ -211,7 +211,7 @@ public class ServerGsiEngine extends InterceptingSSLEngine
             if (buffer.get(0) == DELEGATION_CHAR) {
                 try {
                     sendThenReceive(getCertRequest(), new GotDelegatedCredentials());
-                } catch (GeneralSecurityException e) {
+                } catch (IOException | GeneralSecurityException e) {
                     throw new SSLException("GSI delegation failed: " + e.toString(), e);
                 }
             }

--- a/modules/dcache-srm/src/main/java/org/dcache/gridsite/DelegationService.java
+++ b/modules/dcache-srm/src/main/java/org/dcache/gridsite/DelegationService.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Required;
 import javax.security.auth.Subject;
 
 import java.security.cert.CertPath;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.Map;
@@ -105,8 +106,7 @@ public class DelegationService implements CellMessageReceiver
                    id);
 
         CertPath path = getFirst(subject.getPublicCredentials(CertPath.class), null);
-        CredentialDelegation delegation =
-                factory.newDelegation(id, (Collection<X509Certificate>) path.getCertificates());
+        CredentialDelegation delegation = factory.newDelegation(id, path);
 
         delegations.add(delegation);
 
@@ -131,8 +131,7 @@ public class DelegationService implements CellMessageReceiver
         assertThat(credentials.has(id), "no delegated credential", id);
 
         CertPath certPath = getFirst(request.getSubject().getPublicCredentials(CertPath.class), null);
-        CredentialDelegation delegation =
-                factory.newDelegation(id, (Collection<X509Certificate>) certPath.getCertificates());
+        CredentialDelegation delegation = factory.newDelegation(id, certPath);
 
         delegations.add(delegation);
 

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/ShellCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/ShellCommand.java
@@ -89,7 +89,7 @@ public class ShellCommand implements Command
     }
 
     @Override
-    public void destroy()
+    public void destroy() throws Exception
     {
         if (delegate != null) {
             delegate.destroy();

--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
@@ -4,9 +4,9 @@ import com.google.common.net.InetAddresses;
 import eu.emi.security.authn.x509.impl.OpensslNameUtils;
 import eu.emi.security.authn.x509.proxy.ProxyChainInfo;
 import eu.emi.security.authn.x509.proxy.ProxyUtils;
+import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DEREncodable;
 import org.bouncycastle.asn1.DERObjectIdentifier;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.PolicyInformation;
@@ -124,7 +124,7 @@ public class X509Plugin implements GPlazmaAuthenticationPlugin
     }
 
 
-    private List<DEREncodable> listPolicies(X509Certificate eec)
+    private List<ASN1Encodable> listPolicies(X509Certificate eec)
             throws AuthenticationException
     {
         byte[] encoded;
@@ -140,10 +140,10 @@ public class X509Plugin implements GPlazmaAuthenticationPlugin
             return Collections.emptyList();
         }
 
-        Enumeration<DEREncodable> policySource = ASN1Sequence.getInstance(encoded).getObjects();
-        List<DEREncodable> policies = new ArrayList();
+        Enumeration<ASN1Encodable> policySource = ASN1Sequence.getInstance(encoded).getObjects();
+        List<ASN1Encodable> policies = new ArrayList<>();
         while (policySource.hasMoreElements()) {
-            DEREncodable policy = policySource.nextElement();
+            ASN1Encodable policy = policySource.nextElement();
             if (!policy.equals(ANY_POLICY)) {
                 policies.add(policy);
             }

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
@@ -8,7 +8,11 @@ import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Sequence;
-
+import org.bouncycastle.asn1.x509.AttributeCertificate;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.italiangrid.voms.VOMSAttribute;
+import org.italiangrid.voms.asn1.VOMSACUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sun.security.rsa.RSAPublicKeyImpl;
@@ -52,18 +56,10 @@ import org.dcache.gplazma.monitor.LoginResult.SetDiff;
 import org.dcache.gplazma.util.CertPaths;
 
 import static java.util.concurrent.TimeUnit.*;
-
-import org.bouncycastle.asn1.x509.AttributeCertificate;
-import org.bouncycastle.asn1.x509.X509Extension;
-import org.bouncycastle.asn1.x509.X509Extensions;
-import org.italiangrid.voms.VOMSAttribute;
-
 import static org.dcache.gplazma.configuration.ConfigurationItemControl.*;
 import static org.dcache.gplazma.monitor.LoginMonitor.Result.FAIL;
 import static org.dcache.gplazma.monitor.LoginMonitor.Result.SUCCESS;
 import static org.dcache.utils.Bytes.toHexString;
-
-import org.italiangrid.voms.asn1.VOMSACUtils;
 
 
 
@@ -498,7 +494,7 @@ public class LoginResultPrinter
         sb.append(attribute.getIssuer().getName(X500Principal.RFC2253)).append('\n');
         sb.append("  +--Validity: ").append(validityStatementFor(certificate)).append('\n');
 
-        X509Extensions extensions = certificate.getAcinfo().getExtensions();
+        Extensions extensions = certificate.getAcinfo().getExtensions();
         if (extensions != null) {
             ASN1ObjectIdentifier[] ids = extensions.getExtensionOIDs();
             if (ids != null && ids.length != 0) {
@@ -507,7 +503,7 @@ public class LoginResultPrinter
                 int index = 1;
                 for (ASN1ObjectIdentifier id : ids) {
                     boolean isLast = index == ids.length;
-                    X509Extension e = extensions.getExtension(id);
+                    Extension e = extensions.getExtension(id);
                     String padding = isLast ? "  |       " : "  |    |  ";
                     sb.append(extensionInfoFor(id, e, attribute, padding));
                     index++;
@@ -527,7 +523,7 @@ public class LoginResultPrinter
     }
 
     private static StringBuilder extensionInfoFor(ASN1ObjectIdentifier id,
-            X509Extension extension, VOMSAttribute attribute, String padding)
+            Extension extension, VOMSAttribute attribute, String padding)
     {
         StringBuilder sb = new StringBuilder();
         if (VOMS_CERTIFICATES_OID.equals(id.toString())) {

--- a/modules/srm-client/src/main/java/org/dcache/srm/DelegationShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/DelegationShell.java
@@ -27,9 +27,9 @@ import org.apache.axis.SimpleTargetedChain;
 import org.apache.axis.client.Call;
 import org.apache.axis.client.Stub;
 import org.apache.axis.configuration.SimpleProvider;
-import org.bouncycastle.jce.PKCS10CertificationRequest;
-import org.bouncycastle.openssl.PEMReader;
+import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.PEMWriter;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.xml.rpc.ServiceException;
@@ -638,7 +638,7 @@ public class DelegationShell extends ShellApplication
 
         private PKCS10CertificationRequest fromPEM(String data) throws IOException
         {
-            PEMReader reader = new PEMReader(new StringReader(data));
+            PEMParser reader = new PEMParser(new StringReader(data));
             return (PKCS10CertificationRequest)reader.readObject();
         }
     }

--- a/modules/srm-common/src/main/java/org/dcache/srm/client/GsiConnectionSocketFactory.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/client/GsiConnectionSocketFactory.java
@@ -24,8 +24,8 @@ import org.apache.http.HttpHost;
 import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
 import org.apache.http.protocol.HttpContext;
 import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.jce.PKCS10CertificationRequest;
+import org.bouncycastle.asn1.pkcs.CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -93,7 +93,8 @@ public class GsiConnectionSocketFactory implements LayeredConnectionSocketFactor
                 try {
                     // read csr
                     ASN1InputStream dIn = new ASN1InputStream(socket.getInputStream());
-                    PKCS10CertificationRequest csr = new PKCS10CertificationRequest((ASN1Sequence) dIn.readObject());
+                    PKCS10CertificationRequest csr =
+                            new PKCS10CertificationRequest(CertificationRequest.getInstance(dIn.readObject()));
 
                     // generate proxy
                     ProxyRequestOptions options = new ProxyRequestOptions(credential.getCertificateChain(), csr);

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/BouncyCastleCredentialDelegation.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/BouncyCastleCredentialDelegation.java
@@ -18,41 +18,23 @@
 package org.dcache.gridsite;
 
 import eu.emi.security.authn.x509.X509Credential;
+import eu.emi.security.authn.x509.impl.CertificateUtils;
 import eu.emi.security.authn.x509.impl.KeyAndCertCredential;
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1Object;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.ASN1StreamParser;
-import org.bouncycastle.asn1.DERObject;
-import org.bouncycastle.asn1.DERPrintableString;
-import org.bouncycastle.asn1.DERSequence;
-import org.bouncycastle.asn1.DERSet;
-import org.bouncycastle.asn1.x509.X509CertificateStructure;
-import org.bouncycastle.asn1.x509.X509Name;
-import org.bouncycastle.jce.PKCS10CertificationRequest;
-import org.bouncycastle.jce.provider.X509CertificateObject;
+import eu.emi.security.authn.x509.proxy.ProxyCSRGenerator;
+import eu.emi.security.authn.x509.proxy.ProxyCertificateOptions;
 import org.bouncycastle.openssl.PEMWriter;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.security.auth.x500.X500Principal;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyStoreException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.List;
 import java.util.stream.Stream;
 
 import org.dcache.delegation.gridsite2.DelegationException;
@@ -65,23 +47,21 @@ public class BouncyCastleCredentialDelegation implements CredentialDelegation
     private static final Logger LOG = LoggerFactory.getLogger(BouncyCastleCredentialDelegation.class);
 
     private final DelegationIdentity _id;
-    private final Collection<X509Certificate> _certificates;
-    private final X509Certificate _first;
+    private final X509Certificate[] _certificates;
     private final String _pemRequest;
 
     protected final KeyPair _keyPair;
 
 
-    BouncyCastleCredentialDelegation(KeyPair keypair, DelegationIdentity id, Collection<X509Certificate> certificates)
+    BouncyCastleCredentialDelegation(KeyPair keypair, DelegationIdentity id, X509Certificate[] certificates)
             throws DelegationException
     {
         _id = id;
         _certificates = certificates;
-        _first = certificates.iterator().next();
         _keyPair = keypair;
 
         try {
-            _pemRequest = pemEncode(createRequest(_first, keypair));
+            _pemRequest = pemEncode(createRequest(certificates, keypair));
         } catch (GeneralSecurityException e) {
             LOG.error("Failed to create CSR: {}", e.toString());
             throw new DelegationException("cannot create certificate-signing" +
@@ -93,50 +73,13 @@ public class BouncyCastleCredentialDelegation implements CredentialDelegation
         }
     }
 
-    private static PKCS10CertificationRequest createRequest(X509Certificate cert,
+    private static PKCS10CertificationRequest createRequest(X509Certificate[] chain,
             KeyPair keyPair) throws GeneralSecurityException
     {
-        return new PKCS10CertificationRequest(cert.getSigAlgName(),
-                buildProxyDN(cert.getSubjectX500Principal()),
-                keyPair.getPublic(), null, keyPair.getPrivate());
-    }
-
-    private static X509Name buildProxyDN(X500Principal principal)
-            throws GeneralSecurityException
-    {
-        ASN1StreamParser parser = new ASN1StreamParser(principal.getEncoded());
-
-        DERSequence seq;
-        try {
-            ASN1Encodable object = parser.readObject().getDERObject();
-            if (!(object instanceof DERSequence)) {
-                throw new IOException("not a DER-encoded ASN.1 sequence");
-            }
-            seq = (DERSequence) object;
-        } catch (IOException e) {
-            throw new GeneralSecurityException("failed to parse DN: " +
-                    e.getMessage());
-        }
-
-        List<ASN1Encodable> rdn = new ArrayList<>(seq.size()+1);
-        for(Enumeration e = seq.getObjects(); e.hasMoreElements();) {
-            rdn.add((ASN1Encodable) e.nextElement());
-        }
-
-        DERSequence atv = new DERSequence(new ASN1Object[]{X509Name.CN,
-            new DERPrintableString("proxy")});
-        rdn.add(new DERSet(atv));
-
-        ASN1Encodable[] rdnArray = rdn.toArray(new ASN1Encodable[rdn.size()]);
-        return new X509Name(new DERSequence(rdnArray));
-    }
-
-    private static X509Certificate loadCertificate(InputStream in) throws IOException,
-            GeneralSecurityException
-    {
-        DERObject certInfo = new ASN1InputStream(in).readObject();
-        ASN1Sequence seq = ASN1Sequence.getInstance(certInfo);
-        return new X509CertificateObject(new X509CertificateStructure(seq));
+        ProxyCertificateOptions options = new ProxyCertificateOptions(chain);
+        options.setPublicKey(keyPair.getPublic());
+        options.setLimited(true);
+        return ProxyCSRGenerator.generate(options, keyPair.getPrivate()).getCSR();
     }
 
     private static String pemEncode(Object item) throws IOException
@@ -164,18 +107,17 @@ public class BouncyCastleCredentialDelegation implements CredentialDelegation
     public X509Credential acceptCertificate(String encodedCertificate) throws DelegationException
     {
         X509Certificate certificate;
-
         try {
-            certificate = pemDecodeCertificate(encodedCertificate);
-        } catch (CertificateException e) {
+            certificate = CertificateUtils.loadCertificate(
+                    new ByteArrayInputStream(encodedCertificate.getBytes(StandardCharsets.UTF_8)),
+                    CertificateUtils.Encoding.PEM);
+        } catch (IOException e) {
             LOG.debug("Bad certificate: {}", e.getMessage());
-            throw new DelegationException("Supplied certificate is " +
-                    "unacceptable: " + e.getMessage());
+            throw new DelegationException("Supplied certificate is unacceptable: " + e.getMessage());
         }
 
         X509Certificate[] newCertificates =
-                Stream.concat(Stream.of(certificate), _certificates.stream())
-                        .map(BouncyCastleCredentialDelegation::asBcCertificate)
+                Stream.concat(Stream.of(certificate), Stream.of(_certificates))
                         .toArray(X509Certificate[]::new);
         try {
             return new KeyAndCertCredential(_keyPair.getPrivate(), newCertificates);
@@ -183,41 +125,5 @@ public class BouncyCastleCredentialDelegation implements CredentialDelegation
             LOG.error("Failed to create delegated credential: {}", e.getMessage());
             throw new DelegationException("Unable to create delegated credential: " + e.getMessage());
         }
-    }
-
-    private static X509Certificate asBcCertificate(X509Certificate c)
-    {
-        if (c instanceof X509CertificateObject) {
-            return c;
-        } else {
-            try (ByteArrayInputStream in = new ByteArrayInputStream(c.getEncoded())) {
-                return loadCertificate(in);
-            } catch (GeneralSecurityException | IOException e) {
-                throw new RuntimeException("failed to convert certificate: " + e.getMessage());
-            }
-        }
-    }
-
-    private static X509Certificate pemDecodeCertificate(String encoded)
-            throws CertificateException
-    {
-        byte[] data;
-
-        try {
-            data = encoded.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException ignored) {
-            throw new RuntimeException("UTF-8 not supported");
-        }
-        InputStream in = new ByteArrayInputStream(data, 0, data.length);
-
-        CertificateFactory cf;
-        try {
-            cf = CertificateFactory.getInstance("X.509");
-        } catch (CertificateException e) {
-            throw new RuntimeException("Failed to find CertificateFactory" +
-                    " for X.509: " + e.getMessage());
-        }
-
-        return (X509Certificate) cf.generateCertificate(in);
     }
 }

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/CredentialDelegationFactory.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/CredentialDelegationFactory.java
@@ -17,8 +17,7 @@
  */
 package org.dcache.gridsite;
 
-import java.security.cert.X509Certificate;
-import java.util.Collection;
+import java.security.cert.CertPath;
 
 import org.dcache.delegation.gridsite2.DelegationException;
 
@@ -32,6 +31,5 @@ public interface CredentialDelegationFactory
     /**
      * Return a fluent interface for building a CredentialDelegation object.
      */
-    CredentialDelegation newDelegation(DelegationIdentity id,
-            Collection<X509Certificate> certificates) throws DelegationException;
+    CredentialDelegation newDelegation(DelegationIdentity id, CertPath certPath) throws DelegationException;
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseRequestCredentialStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseRequestCredentialStorage.java
@@ -258,8 +258,7 @@ public class DatabaseRequestCredentialStorage implements RequestCredentialStorag
            if (credential != null) {
                CredentialsUtils.saveProxyCredentials(credentialFileName, credential);
            }
-       } catch(IOException | UnrecoverableKeyException | NoSuchAlgorithmException | KeyStoreException |
-               NoSuchProviderException | CertificateException e) {
+       } catch (IOException e) {
            logger.error(e.toString());
        }
    }

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.3.8.v20160314</version.jetty>
         <version.wicket>7.3.0</version.wicket>
-        <version.xrootd4j>3.0.5</version.xrootd4j>
+        <version.xrootd4j>3.1.1</version.xrootd4j>
         <version.jersey>2.22.2</version.jersey>
         <version.dcache-view>1.0.0</version.dcache-view>
         <version.dcache>${project.version}</version.dcache>
@@ -99,8 +99,8 @@
 
                1.43     bcprov-jdk16    JDK v1.6; used by JGlobus-1.8.x
          -->
-        <bouncycastle.bcprov>bcprov-jdk16</bouncycastle.bcprov>
-        <bouncycastle.version>1.46</bouncycastle.version>
+        <bouncycastle.bcprov>bcprov-jdk15on</bouncycastle.bcprov>
+        <bouncycastle.version>1.50</bouncycastle.version>
         <datanucleus-core.version>4.1.8</datanucleus-core.version>
         <datanucleus.plugin.version>4.0.2</datanucleus.plugin.version>
     </properties>
@@ -204,22 +204,22 @@
             <dependency>
                 <groupId>eu.eu-emi.security</groupId>
                 <artifactId>canl</artifactId>
-                <version>1.3.3</version>
+                <version>2.1.2</version>
             </dependency>
             <dependency>
                 <groupId>org.italiangrid</groupId>
                 <artifactId>voms-api-java</artifactId>
-                <version>3.0.5</version>
+                <version>3.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.glite.authz</groupId>
                 <artifactId>pep-common</artifactId>
-                <version>2.3.0</version>
+                <version>2.3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.glite.authz</groupId>
                 <artifactId>pep-java</artifactId>
-                <version>2.2.0</version>
+                <version>2.3.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-httpclient</groupId>
@@ -481,13 +481,7 @@
             <dependency>
                 <groupId>org.apache.sshd</groupId>
                 <artifactId>sshd-core</artifactId>
-                <!-- Version 0.9.0 contains a bug that prevents upgrade (see
-                     https://issues.apache.org/jira/browse/SSHD-258?jql=project%20%3D%20SSHD%20AND%20issuetype%20%3D%20Bug%20AND%20text%20~%20%220.9.0%22).
-
-                     Version 0.10.0 and beyond require a version of BouncyCastle newer
-                     than what works with JGlobus.
-                  -->
-                <version>0.8.0</version>
+                <version>1.2.0</version>
             </dependency>
             <dependency>
                 <!-- Newer versions have two problems. A performance regression causes it to block on non-responding network
@@ -660,13 +654,7 @@
             <dependency>
                 <groupId>org.dcache</groupId>
                 <artifactId>xrootd4j-authz-plugin-alice</artifactId>
-                <version>1.0.4</version>
-                <exclusions>
-                  <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk16</artifactId>
-                  </exclusion>
-                </exclusions>
+                <version>1.1.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Requires updating (or allows to update) Apache SSHD, Argus client and VOMS
library.

Target: trunk
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9589/

(cherry picked from commit c68b78162c6a96f8d7bd5f082a7bf2d09ed8785b)