### PR TITLE
ftp: improve compatibility with Apache Commons FtpClient

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1943,6 +1943,12 @@ public abstract class AbstractFtpDoorV1
         reply(sr.toString());
     }
 
+    /**
+     * Apache Commons FTPClient uses the output of SYST to determine how
+     * to parse the output from the LIST command.  Any response with the
+     * keyword "UNIX" ensures the client parses LIST output as if it is the
+     * output from "ls -l", as will including the phrase "Type: L8".
+     */
     @Help("SYST - Return system type.")
     public void ftp_syst(String arg)
     {
@@ -3356,6 +3362,21 @@ public abstract class AbstractFtpDoorV1
         }
     }
 
+    /**
+     * Provide a directory listing in some unspecified format.  Historically
+     * Unix-like systems returned the output from "ls -l" and some clients
+     * attempt to parse the output on this basis.  Below we document the
+     * format expectations of various clients.
+     * <p>
+     * <b>Apache Commons FTPClient</b> Although FTPClient supports MLSD & MLST,
+     * it doesn't provide this transparently; therefore clients using FTPClient
+     * may well issue a LIST command and attempt to parse the response.
+     * FTPClient has an option to request the server shows all files; enabling
+     * this option results in the client issuing the non-standard option "-a";
+     * e.g., "LIST -a". FTPClient uses the output from the SYST command to
+     * determine how to parse the LIST response.
+     * @see ftp_syst
+     */
     @Help("LIST [<SP> <path>] - Returns information on <path> or the current working directory.")
     public void ftp_list(String arg)
         throws FTPCommandException
@@ -3363,6 +3384,10 @@ public abstract class AbstractFtpDoorV1
         checkLoggedIn();
 
         Args args = new Args(arg);
+
+        args.removeOptions("a"); // Remove any '-a', dCache always shows all files.
+
+        // REVISIT: do any clients require shortList output?
         boolean listLong =
             args.options().isEmpty() || args.hasOption("l");
         if (args.argc() == 0) {


### PR DESCRIPTION
Motivation:

The Apache Commons FtpClient can issue the LIST command with the
non-standard "-a" option.  Currently this triggers dCache to switch
output format from the long ("ls -l"-like) to the short ("ls"-like)
response.  Unfortunately, FtpClient only parses the long format.

Modification:

Accept and ignore the "-a" option.

Result:

dCache is more compatible with Apache Commons FtpClient.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/9605/
Acked-by: Albert Rossi