### PR TITLE
dcache-restful-api/pinmanager: modify  current QoS fom disk+tape to tape

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCountPinsMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCountPinsMessage.java
@@ -1,0 +1,39 @@
+package org.dcache.pinmanager;
+
+
+import diskCacheV111.util.PnfsId;
+import diskCacheV111.vehicles.Message;
+
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+
+public class PinManagerCountPinsMessage extends Message {
+
+
+    private static final long serialVersionUID = 7314454233774958888L;
+    private final PnfsId _pnfsId;
+
+    private int count;
+
+
+    public PinManagerCountPinsMessage(PnfsId pnfsId) {
+        _pnfsId = checkNotNull(pnfsId);
+    }
+
+
+    public int getCount() {
+        return count;
+    }
+
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+
+    public PnfsId getPnfsId() {
+        return _pnfsId;
+    }
+
+}

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/QueryRequestProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/QueryRequestProcessor.java
@@ -1,0 +1,34 @@
+package org.dcache.pinmanager;
+
+
+import dmg.cells.nucleus.CellMessageReceiver;
+
+import org.springframework.beans.factory.annotation.Required;
+
+import diskCacheV111.util.CacheException;
+
+
+/**
+ * Process request to get the count of pins.
+ *
+ */
+public class QueryRequestProcessor
+        implements CellMessageReceiver {
+
+    private PinDao _dao;
+
+    @Required
+    public void setDao(PinDao dao) {
+        _dao = dao;
+    }
+
+
+    public PinManagerCountPinsMessage
+    messageArrived(PinManagerCountPinsMessage message)
+            throws CacheException {
+        message.setCount(_dao.count(_dao.where().pnfsId(message.getPnfsId())));
+        return message;
+    }
+
+
+}

--- a/modules/dcache/src/main/resources/org/dcache/pinmanager/pinmanager.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pinmanager/pinmanager.xml
@@ -85,6 +85,12 @@
       <property name="authorizationPolicy" ref="pdp"/>
   </bean>
 
+
+    <bean id="query-pin-processor" class="org.dcache.pinmanager.QueryRequestProcessor">
+        <description>Processes unpin requests</description>
+        <property name="dao" ref="dao"/>
+    </bean>
+
   <bean id="move-pin-processor" class="org.dcache.pinmanager.MovePinRequestProcessor">
       <description>Processes pin extension requests</description>
       <property name="dao" ref="dao"/>


### PR DESCRIPTION
Motivation:

 According to CDMI/QosS specification  QoS  of a file object  could be changed from disk+tape (nearline+online) to tape (nearline).
In dCache this could be mapped  to unpin command, which unpins a previously pinned file.
 Nevertheless the same  file could be pinned by different  requestors (user, doors for example SRM door).
Therefore even if file is unpinned by the QOS requestor  it still could be pinned by others and the locality of the file will be NEARLINE+ONLINE.

One of the solutions is to check the number of pins for a file.

Modifications

New `PinMangerQueryQosPinsMessage`  and `QueryQosPinsRequestProcessor`  have been added to pinmanager module,
so that we can query the number of pins for a file.

Result

Users can see the change of QoS from disk+tape to tape.

Target: master
Require-book: no
Require-notes: no
Patch: https://rb.dcache.org/r/9566/
Acted-by: Gerd Behrmann <behrmann@ndgf.org>