### PR TITLE
billing: Wrap cellName attribute to allow access to the cell and domain components

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/cells/BillingCell.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/cells/BillingCell.java
@@ -26,7 +26,7 @@ import diskCacheV111.vehicles.InfoMessage;
 import diskCacheV111.vehicles.MoverInfoMessage;
 import diskCacheV111.vehicles.PnfsFileInfoMessage;
 import diskCacheV111.vehicles.StorageInfo;
-import diskCacheV111.vehicles.StringTemplateInfoMessageVisitor;
+import org.dcache.services.billing.text.StringTemplateInfoMessageVisitor;
 import diskCacheV111.vehicles.WarningPnfsFileInfoMessage;
 
 import dmg.cells.nucleus.CellCommandListener;

--- a/modules/dcache/src/main/java/org/dcache/services/billing/text/CellAddressWrapper.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/text/CellAddressWrapper.java
@@ -16,15 +16,42 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+package org.dcache.services.billing.text;
 
-package diskCacheV111.vehicles;
+import dmg.cells.nucleus.CellAddressCore;
 
-public interface InfoMessageVisitor
+public class CellAddressWrapper
 {
-    void visit(DoorRequestInfoMessage message);
-    void visit(MoverInfoMessage message);
-    void visit(PoolHitInfoMessage message);
-    void visit(RemoveFileInfoMessage message);
-    void visit(StorageInfoMessage message);
-    void visit(WarningPnfsFileInfoMessage message);
+    private final CellAddressCore address;
+
+    public CellAddressWrapper(String address)
+    {
+        this.address = new CellAddressCore(address);
+    }
+
+    public String getCell()
+    {
+        return address.getCellName();
+    }
+
+    public String getDomain()
+    {
+        return address.getCellDomainName();
+    }
+
+    public boolean isDomainAddress()
+    {
+        return address.isDomainAddress();
+    }
+
+    public boolean isQualified()
+    {
+        return !address.isLocalAddress();
+    }
+
+    @Override
+    public String toString()
+    {
+        return address.isLocalAddress() ? address.getCellName() : address.toString();
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/text/StringTemplateInfoMessageVisitor.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/text/StringTemplateInfoMessageVisitor.java
@@ -1,6 +1,7 @@
-/* dCache - http://www.dcache.org/
+/*
+ * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2015 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -15,11 +16,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package diskCacheV111.vehicles;
+package org.dcache.services.billing.text;
 
 import org.stringtemplate.v4.ST;
 
 import java.util.Date;
+
+import diskCacheV111.vehicles.DoorRequestInfoMessage;
+import diskCacheV111.vehicles.InfoMessage;
+import diskCacheV111.vehicles.InfoMessageVisitor;
+import diskCacheV111.vehicles.MoverInfoMessage;
+import diskCacheV111.vehicles.PnfsFileInfoMessage;
+import diskCacheV111.vehicles.PoolHitInfoMessage;
+import diskCacheV111.vehicles.RemoveFileInfoMessage;
+import diskCacheV111.vehicles.StorageInfoMessage;
+import diskCacheV111.vehicles.WarningPnfsFileInfoMessage;
 
 import org.dcache.auth.SubjectWrapper;
 
@@ -38,7 +49,7 @@ public class StringTemplateInfoMessageVisitor implements InfoMessageVisitor
         template.add("queuingTime", message.getTimeQueued());
         template.add("message", message.getMessage());
         template.add("type", message.getMessageType());
-        template.add("cellName", message.getCellName());
+        template.add("cellName", new CellAddressWrapper(message.getCellName()));
         template.add("cellType", message.getCellType());
         template.add("rc", message.getResultCode());
         template.add("subject", new SubjectWrapper(message.getSubject()));

--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -103,7 +103,7 @@ billing.text.dir = ${dcache.paths.billing}
 #   ---------   ----        -----------
 #
 #   date        Date        Time stamp of mesage
-#   cellName    String      Name of cell submitting the message
+#   cellName    CellAddress Address of cell submitting the message
 #   cellType    String      Type of cell submitting the message
 #   session     String      Session identifier for transfer
 #   type        String      Request type
@@ -245,6 +245,15 @@ billing.text.dir = ${dcache.paths.billing}
 #   domain         String
 #   id             String       String form of PNFS ID
 #   bytes          byte[]       Binary form of PNFS ID
+#
+# Type: CellAddress
+# ------------
+#
+#   Field          Type         Description
+#   -----          ----         -----------
+#   cell           String       Name of the dCache cell
+#   domain         String       Name of the dCache domain
+#   isQualified    Boolean      True when the address has a domain name, false otherwise
 #
 
 


### PR DESCRIPTION
Motivation:

The billing info message contains the cell name attribute. This is usually the full
cell address. Sometimes it is convenient to be able to factor out this address into
its components.

Modification:

Wrap the cell name in a CellAddressWrapper to expose the cell, name and isQualified
sub-attributes.

Result:

The billing formatting strings have been extended to allow the cell name and cell
domain name of the cell address to be addressed directly, e.g. $cellName.cell$ and
$cellName.domain$. Existing formatting strings are not affected by this change.

Requesting backport as NDGF has asked for this to allow output in JSON format.

Target: trunk
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9606/

(cherry picked from commit a2fd0be43648e5a9c3415220456c1b50ccdfd000)