### PR TITLE
billing: Removing erroneous stack trace output

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/text/Indexer.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/text/Indexer.java
@@ -231,7 +231,6 @@ public class Indexer
                     parseDefaultTimestamp(year, line);
                     out.append(String.valueOf(year)).append('.');
                 } catch (DateTimeParseException ignore) {
-                    ignore.printStackTrace();
                 }
                 out.println(line);
             }


### PR DESCRIPTION
Motivation:

The billing indexer tries to prepend each output line with the year if the billing
line is missing the year. This relies on detecting a parse error on the date field.

Modification:

Remove an erroneous calling to output a strack trace when an exception that should
be ignored is caught.

Result:

Removed erroneous output of a stack trace when using the 'dcache billing' command
with a non-default date format in the billing file.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9615/

(cherry picked from commit 2954441c367a2ccc147b9602d31e14d0c4147b75)