### PR TITLE
cells: Fix RejectedExecutionException during shutdown

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
@@ -79,13 +79,10 @@ public class      SystemCell
     @Override
     protected void startUp()
     {
-        /**
-         * We start the curator here to get the right context for the curator threads.
+        /* We start the curator here to get the right context for the curator threads.
          */
-        CuratorFramework curatorFramework = _nucleus.getCuratorFramework();
-        if (curatorFramework != null) {
-            curatorFramework.start();
-        }
+        CellNucleus.startCurator();
+
         _cellShell.addCommandListener(this);
         _cellShell.addCommandListener(new LogbackShell());
         _cellShell.addCommandListener(new FilterShell(_nucleus.getLoggingThresholds()));

--- a/modules/cells/src/main/java/dmg/cells/zookeeper/CellCuratorFramework.java
+++ b/modules/cells/src/main/java/dmg/cells/zookeeper/CellCuratorFramework.java
@@ -75,6 +75,7 @@ import java.util.concurrent.TimeUnit;
 
 import dmg.cells.nucleus.CDC;
 
+import org.dcache.util.BoundedExecutor;
 import org.dcache.util.SequentialExecutor;
 
 /**
@@ -84,7 +85,7 @@ import org.dcache.util.SequentialExecutor;
 public class CellCuratorFramework implements CuratorFramework
 {
     private final CuratorFramework inner;
-    private final Executor executor;
+    private final BoundedExecutor executor;
 
     public CellCuratorFramework(CuratorFramework inner, Executor executor)
     {
@@ -121,13 +122,12 @@ public class CellCuratorFramework implements CuratorFramework
     @Override
     public void start()
     {
-        inner.start();
     }
 
     @Override
     public void close()
     {
-        inner.close();
+        executor.shutdown();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Commit 20725411a7f80e23ef69256be83d121201c35e59 already tried to fix the
following:

13 Aug 2016 12:34:05 (System) [] Background exception was not retry-able or retry gave up
java.util.concurrent.RejectedExecutionException: Executor has been shut down.
        at org.dcache.util.BoundedExecutor.execute(BoundedExecutor.java:140) ~[dcache-common-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
        at org.dcache.util.BoundedExecutor.execute(BoundedExecutor.java:147) ~[dcache-common-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
        at dmg.cells.zookeeper.CellCuratorFramework$1.execute(CellCuratorFramework.java:99) ~[cells-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
        at org.apache.curator.framework.imps.Backgrounding$1.processResult(Backgrounding.java:141) ~[curator-framework-2.11.0.jar:na]
        at org.apache.curator.framework.imps.CuratorFrameworkImpl.sendToBackgroundCallback(CuratorFrameworkImpl.java:749) [curator-framework-2.11.0.jar:na]
        at org.apache.curator.framework.imps.CuratorFrameworkImpl.processBackgroundOperation(CuratorFrameworkImpl.java:522) [curator-framework-2.11.0.jar:na]
        at org.apache.curator.framework.imps.GetChildrenBuilderImpl$2.processResult(GetChildrenBuilderImpl.java:177) [curator-framework-2.11.0.jar:na]
        at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:590) [zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:498) [zookeeper-3.4.6.jar:3.4.6-1569965]

Modification:

The fix was incomplete as the executor used by the Curator decorator is itself
a decorator around the cell's message executor. Since the executor decorator is
not shut down, the fix doesn't work.

The cell nucleus now starts and closes the Curator decorator without this being
propagated to the decorated Curator client. This allows the decorator to shut
down its executor, thus allowing the exception to be rejected.

Result:

Fixed a RejectedExecutionException that could occur during shutdown.

Target: trunk
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9628/

(cherry picked from commit 618c3b6909191c54218a32aeb7529e4b708c3ea0)