### PR TITLE
webadmin: silence warning about future change in wicket

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/celladmin/CellAdmin.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/celladmin/CellAdmin.java
@@ -68,7 +68,7 @@ public class CellAdmin extends BasePage implements AuthenticatedWebPage {
         cells.setRequired(true);
         cells.setOutputMarkupId(true);
         cellAdminForm.add(cells);
-        domains.add(new AjaxFormComponentUpdatingBehavior("onchange") {
+        domains.add(new AjaxFormComponentUpdatingBehavior("change") {
 
             private static final long serialVersionUID = 7202016450667815788L;
 


### PR DESCRIPTION
Motivation:

Wicket issues warnings like:

16 Aug 2016 11:24:50 (httpd) [] Since version 6.0.0 Wicket uses JavaScript event registration so there is no need of the leading 'on' in the event name 'onchange'. Please use just 'change'. Wicket 8.x won't manipulate the provided event names so the leading 'on' may break your application.

While we are currently using wicket 7, the warnings clutter the log
files.

Modification:

Switch to using the 'change' event name.

Result:

Slightly less spam in our log files.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9646/
Acked-by: Gerd Behrmann