### PR TITLE
zookeeper: avoid one race in shutdown

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/zookeeper/service/ZooKeeperCell.java
+++ b/modules/dcache/src/main/java/org/dcache/zookeeper/service/ZooKeeperCell.java
@@ -141,11 +141,14 @@ public class ZooKeeperCell extends AbstractCell
     @Override
     public void cleanUp()
     {
-        if (cnxnFactory != null) {
-            cnxnFactory.shutdown();
-        }
         if (zkServer != null) {
             zkServer.shutdown();
+        }
+        // Must shutdown zkServer before shutting down cnxnFactory since
+        // zkServer.shutdown flushes any pending messages while
+        // cnxnFactory.shutdown closes the network sockets.
+        if (cnxnFactory != null) {
+            cnxnFactory.shutdown();
         }
         if (txnLog != null) {
             try {


### PR DESCRIPTION
Motivation:

On shutdown, we currently see exceptions like:

    java.nio.channels.CancelledKeyException: null
        at sun.nio.ch.SelectionKeyImpl.ensureValid(SelectionKeyImpl.java:73) ~[na:1.8.0_101]
        at sun.nio.ch.SelectionKeyImpl.interestOps(SelectionKeyImpl.java:77) ~[na:1.8.0_101]
        at org.apache.zookeeper.server.NIOServerCnxn.sendBuffer(NIOServerCnxn.java:151) [zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.server.NIOServerCnxn.sendResponse(NIOServerCnxn.java:1081) [zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.server.FinalRequestProcessor.processRequest(FinalRequestProcessor.java:404) [zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.server.SyncRequestProcessor.flush(SyncRequestProcessor.java:200) [zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.server.SyncRequestProcessor.run(SyncRequestProcessor.java:131) [zookeeper-3.4.6.jar:3.4.6-1569965]

This is triggered by shutting down the connection factory (which closes all
connections) before zookeeper.

Modification:

Reorder the shutdown sequence in ZooKeeperCell

Result:

One less stacktrace on shutdown.

Target: master
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/9650/
Acked-by: Gerd Behrmann