### PR TITLE
cells: Do not call shutdown from message thread

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -910,7 +910,7 @@ public class CellNucleus implements ThreadFactory
         return Futures.catchingAsync(
                 _messageExecutor.submit(wrapLoggingContext(this::doStart)), Exception.class,
                 e -> {
-                    shutdown(new KillEvent(new CellPath(_cellName), 0));
+                    __cellGlue.kill(this);
                     throw e;
                 });
     }


### PR DESCRIPTION
Motivation:

If cell startup fails, the cell nucleus invokes cell shutdown. It currently
does this from the message thread pool, but since that thread pool is shut
down while shutting down the cell, this will cause shutdown to first block
and evetually output a warning.

Modification:

Kill the cell through cell glue, thus executing the kill on the apprioriate
kill executor.

Result:

Fixed a problem causing erroneous errors while failure to start a cell.

Target: trunk
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9653/

(cherry picked from commit 740f86374f5429409a1fb3e7a0eb640a5e2bebcb)