### PR TITLE
srm: make out-of-date historic data deletion more robust

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
@@ -434,7 +434,13 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
         long lifetime =
                 TimeUnit.DAYS.toMillis(configuration.getKeepRequestHistoryPeriod());
         long timestamp = System.currentTimeMillis() - lifetime;
-        jdbcTemplate.update("DELETE FROM " + getTableName() + " WHERE CREATIONTIME + LIFETIME < ?", timestamp);
+        try {
+            jdbcTemplate.update("DELETE FROM " + getTableName() + " WHERE CREATIONTIME + LIFETIME < ?", timestamp);
+        } catch (DataAccessException e) {
+            logger.warn("Failed to remove out-of-date historic data from {}: {}", getTableName(), e.toString());
+        } catch (RuntimeException e) {
+            logger.error("Bug detected", e);
+        }
     }
 
     protected PreparedStatement getPreparedStatement(


### PR DESCRIPTION
Motivation:

The SRM periodically (every 10 minutes, by default) deletes out-of-date
historic data (older than 10 days by default) using a scheduled task.
If this task throws any exception (e.g., any problem issuing the DELETE
SQL query) then subsequent invocations are suppressed.

Modification:

Catch any RuntimeException and log it appropriately.

Result:

Problems evicting out-of-date historic data are logged and the process
is robust against temporary database problems.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9033
Patch: https://rb.dcache.org/r/9666/