### PR TITLE
chimera: Fix IllegalStateException in inode cache

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ExtendedInode.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ExtendedInode.java
@@ -151,7 +151,7 @@ public class ExtendedInode extends FsInode
             FsInode actualParent = super.getParent();
             parent = Optional.fromNullable(actualParent != null ? new ExtendedInode(getFs(), actualParent) : null);
         }
-        return parent.get();
+        return parent.orNull();
     }
 
     public ImmutableMap<String,byte[]> getTags() throws ChimeraFsException


### PR DESCRIPTION
Motivation:

11 Aug 2016 22:45:02 (PnfsManager) [A+Q:12038615:srm2:ls:-1996682928:-1996682927 SRM-madhatter PnfsListDirectory] java.lang.IllegalStateException: Optional.get() cannot be called on an absent value
java.lang.IllegalStateException: Optional.get() cannot be called on an absent value
at com.google.common.base.Absent.get(Absent.java:49) ~[guava-19.0.jar:na]
at org.dcache.chimera.namespace.ExtendedInode.getParent(ExtendedInode.java:142) ~[dcache-chimera-2.15.10.jar:2.15.10]
at org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor.getDirStorageInfo(ChimeraOsmStorageInfoExtractor.java:76) ~[dcache-chimera-2.15.10.jar:2.15.10]
at org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor.getFileStorageInfo(ChimeraOsmStorageInfoExtractor.java:45) ~[dcache-chimera-2.15.10.jar:2.15.10]
at org.dcache.chimera.namespace.ChimeraHsmStorageInfoExtractor.getStorageInfo(ChimeraHsmStorageInfoExtractor.java:163) ~[dcache-chimera-2.15.10.jar:2.15.10]
at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.getFileAttributes(ChimeraNameSpaceProvider.java:844) ~[dcache-chimera-2.15.10.jar:2.15.10]
at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.list(ChimeraNameSpaceProvider.java:1053) ~[dcache-chimera-2.15.10.jar:2.15.10]
at diskCacheV111.namespace.PnfsManagerV3.listDirectory(PnfsManagerV3.java:1545) [dcache-core-2.15.10.jar:2.15.10]
at diskCacheV111.namespace.PnfsManagerV3.processMessageTransactionally_aroundBody16(PnfsManagerV3.java:1743) [dcache-core-2.15.10.jar:2.15.10]
at diskCacheV111.namespace.PnfsManagerV3$AjcClosure17.run(PnfsManagerV3.java:1) [dcache-core-2.15.10.jar:2.15.10]
at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96cproceed(AbstractTransactionAspect.aj:66) [spring-aspects-4.2.4.RELEASE.jar:4.2.4.RELEASE]
at org.springframework.transaction.aspectj.AbstractTransactionAspect$AbstractTransactionAspect$1.proceedWithInvocation(AbstractTransactionAspect.aj:72) [spring-aspects-4.2.4.RELEASE.jar:4.2.4.RELEASE]
at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:281) [spring-tx-4.2.4.RELEASE.jar:4.2.4.RELEASE]
at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96c(AbstractTransactionAspect.aj:70) [spring-aspects-4.2.4.RELEASE.jar:4.2.4.RELEASE]
at diskCacheV111.namespace.PnfsManagerV3.processMessageTransactionally(PnfsManagerV3.java:1710) [dcache-core-2.15.10.jar:2.15.10]
at diskCacheV111.namespace.PnfsManagerV3.processPnfsMessage(PnfsManagerV3.java:1681) [dcache-core-2.15.10.jar:2.15.10]
at diskCacheV111.namespace.PnfsManagerV3$ProcessThread.run(PnfsManagerV3.java:1591) [dcache-core-2.15.10.jar:2.15.10]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_91]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_91]
at java.lang.Thread.run(Thread.java:745) [na:1.8.0_91]

Modification:

Propagate the null parent (i.e. when calling getParent on the root inode).

Result:

Fixed an IllegalStateException in Chimera.

Target: trunk
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9035
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9670/

(cherry picked from commit ef5ff6abb9d141a9181fa5864fb6e246e7833a2d)