### PR TITLE
doors: Abort transfer if file is deleted during pool selection

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -1221,6 +1221,7 @@ public class Transfer implements Comparable<Transfer>
                             return retryWhen(immediateFuture(null));
                         case CacheException.FILE_IN_CACHE:
                         case CacheException.INVALID_ARGS:
+                        case CacheException.FILE_NOT_FOUND:
                             return immediateFailedFuture(t);
                         case CacheException.NO_POOL_CONFIGURED:
                             _log.error(t.getMessage());


### PR DESCRIPTION
Motivation:

If a file is deleted during pool selection, the Transfer class gets
caught in the retry loop (until the limit is reached) as it doesn't
recognize the failure as a permanent error.

Modification:

Abort the transfer if the file is deleted.

Result:

Fixed an issue in which doors could get temporarily stuck in a
retry loop if the file was deleted during pool selection.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9681/

(cherry picked from commit f2b6b24f4dcfabba38d5139987b2079774d3b999)