### PR TITLE
alarms: only send email on first alarm occurrence

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
@@ -62,23 +62,21 @@ package org.dcache.alarms.dao.impl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
 import javax.jdo.PersistenceManagerFactory;
 import javax.jdo.Query;
 import javax.jdo.Transaction;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
-
 import org.dcache.alarms.dao.AlarmJDOUtils;
 import org.dcache.alarms.dao.AlarmJDOUtils.AlarmDAOFilter;
 import org.dcache.alarms.dao.LogEntry;
 import org.dcache.alarms.dao.LogEntryDAO;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.*;
 
 /**
  * DataNucleus wrapper to underlying alarm store.<br>
@@ -143,6 +141,7 @@ public final class DataNucleusLogEntryStore implements LogEntryDAO, Runnable {
                     LogEntry original = dup.iterator().next();
                     original.setLastUpdate(entry.getLastUpdate());
                     original.setReceived(original.getReceived() + 1);
+                    entry.setReceived(original.getReceived());
                     /*
                      * this needs to be done or else newly arriving instances will
                      * not be tracked if this type has been closed previously

--- a/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/logback/LogEntryHandler.java
@@ -119,6 +119,14 @@ public class LogEntryHandler {
                 event.getMDCPropertyMap().put(MDC_TYPE, entry.getType());
 
                 /*
+                 * Store the alarm.
+                 *
+                 * If this is a duplicate, the store will increment
+                 * the received field.
+                 */
+                store.put(entry);
+
+                /*
                  * The history log parses out all alerts above a certain
                  * priority. This is just a convenience for sifting messages
                  * from the normal domain log and recording them them using the
@@ -130,14 +138,13 @@ public class LogEntryHandler {
                 }
 
                 /*
-                 * Remote messages which are indeed alarms/alerts can be sent as
-                 * email.
+                 * Post-process if this is a new alarm.
                  */
-                if (emailEnabled && priority >= emailThreshold.ordinal()) {
-                    emailAppender.doAppend(event);
+                if (entry.getReceived() == 1) {
+                    if (emailEnabled && priority >= emailThreshold.ordinal()) {
+                        emailAppender.doAppend(event);
+                    }
                 }
-
-                store.put(entry);
             } else if (!storeOnlyAlarms) {
                 store.put(entry);
             }


### PR DESCRIPTION
Motivation:

extensions to process alarms, also modified the handling of alarms such
that this post-processing, as well as email, occurs only on the first
instance of potentially duplicate alarms.   This behavior is currently
not enforced for the stable branches with respect to alarm emails.

Modification:

Backport the change which affects the handling of alarm emails.

Result:

Alarm email notifications are sent only on the first occurrence
of given alarm (i.e., for that alarm instance's unique ID).

Target: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: litvinse@fnal.gov