### PR TITLE
alarms: reset count history on reopened alarm

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
@@ -62,21 +62,22 @@ package org.dcache.alarms.dao.impl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
 import javax.jdo.PersistenceManagerFactory;
 import javax.jdo.Query;
 import javax.jdo.Transaction;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import org.dcache.alarms.dao.AlarmJDOUtils;
 import org.dcache.alarms.dao.AlarmJDOUtils.AlarmDAOFilter;
 import org.dcache.alarms.dao.LogEntry;
 import org.dcache.alarms.dao.LogEntryDAO;
 
-import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * DataNucleus wrapper to underlying alarm store.<br>
@@ -131,6 +132,7 @@ public final class DataNucleusLogEntryStore implements LogEntryDAO, Runnable {
                 Collection<LogEntry> dup
                         = (Collection<LogEntry>) query.executeWithArray(entry.getKey());
                 logger.trace("duplicate? {}", dup);
+
                 if (dup != null && !dup.isEmpty()) {
                     if (dup.size() > 1) {
                         throw new RuntimeException
@@ -138,15 +140,33 @@ public final class DataNucleusLogEntryStore implements LogEntryDAO, Runnable {
                                  + " more than one alarm with the same id: "
                                  + entry.getKey());
                     }
+
                     LogEntry original = dup.iterator().next();
-                    original.setLastUpdate(entry.getLastUpdate());
-                    original.setReceived(original.getReceived() + 1);
-                    entry.setReceived(original.getReceived());
-                    /*
-                     * this needs to be done or else newly arriving instances will
-                     * not be tracked if this type has been closed previously
-                     */
-                    original.setClosed(false);
+                    entry.setLastUpdate(original.getLastUpdate());
+
+                    int received = original.getReceived();
+
+                    if (original.isClosed()) {
+                        /*
+                         * this needs to be done or else newly arriving instances will
+                         * not be tracked if this type has been closed previously
+                         */
+                        original.setClosed(false);
+
+                        /*
+                         * Treat the alarm as a new instance by restarting
+                         * its history.  This guarantees a new alert will
+                         * be sent and plugins called as if it were a
+                         * first occurrence.
+                         */
+                        received = 1;
+                    } else {
+                        ++received;
+                    }
+
+                    original.setReceived(received);
+                    entry.setReceived(received);
+
                     /*
                      * original is not detached so it will be updated on commit
                      */


### PR DESCRIPTION
Motivation:

9555 (master) and #9633 (2.13-2.16)

corrected the behavior of the log entry handler such that emails
(and eventually plugin calls) are triggered only on the first
occurrence of an alarm (id).

This patch finishes that correction as regards alarms which are
in the closed state.  If an alarm has been closed and not deleted,
but then occurs again, the count history (the 'received' attribute)
should be reset to 1, in order to treat this as a new (set of)
occurrences, and to guarantee a new notification will be sent.

Modification:

Reset the received value to 1 if the alarm is being reopened.

Result:

Notification and triggering of plugins will occur on reopened
alarms.

A separate patch will be needed for the stable branches.

Depends on #9633 for the stable branches.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: paul.millar@desy.de
Committed: ac50167d713d8991c4393de3a38208631b38f5d3