### PR TITLE
dcache-webadmin: disable AJAX autorefresh on pages using picnet table…

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/SortableBasePage.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/SortableBasePage.java
@@ -3,6 +3,9 @@ package org.dcache.webadmin.view.pages.basepage;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.head.OnLoadHeaderItem;
+import org.apache.wicket.markup.html.form.Form;
+
+import java.util.concurrent.TimeUnit;
 
 public abstract class SortableBasePage extends BasePage {
 
@@ -27,5 +30,13 @@ public abstract class SortableBasePage extends BasePage {
                                  + "                    clearFiltersControls: [$('.cleanfilters-" + id + "')],\n"
                                  + "                };\n"
                                  + "                $('.sortable-" + id + "').tableFilter(options1);\n"));
+    }
+
+    @Override
+    protected void addAutoRefreshToForm(Form<?> form,
+                                        long refresh,
+                                        TimeUnit unit) {
+        _log.info("addAutoRefreshToForm not supported for SortableBasePage {}.",
+                   this);
     }
 }

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/cellservices/CellServices.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/cellservices/CellServices.java
@@ -25,7 +25,7 @@ public class CellServices extends SortableBasePage {
     private static final Logger _log = LoggerFactory.getLogger(CellServices.class);
 
     public CellServices() {
-        Form<?> form = getAutoRefreshingForm("cellServicesForm");
+        Form<?> form = new Form<Void>("cellServicesForm");
         form.add(new FeedbackPanel("feedback"));
         CellServicesPanel cellServicesPanel = new CellServicesPanel("cellServicesPanel",
                 new PropertyModel(this, "cellBeans"));

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.java
@@ -55,7 +55,7 @@ public class PoolAdmin extends SortableBasePage implements AuthenticatedWebPage 
     }
 
     private void addMarkup() {
-        Form<?> poolAdminForm = getAutoRefreshingForm("poolAdminForm");
+        Form<?> poolAdminForm = new Form<Void>("poolAdminForm");
         poolAdminForm.add(new FeedbackPanel("feedback"));
         TextField<Object> commandInput = new TextField<>("commandText",
                 new PropertyModel<>(this, "_command"));

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolgroupview/PoolGroupView.java
@@ -66,7 +66,7 @@ public class PoolGroupView extends SortableBasePage {
     }
 
     private void addMarkup() {
-        Form poolGroups = getAutoRefreshingForm("poolGroupsForm");
+        Form poolGroups = new Form<Void>("poolGroupsForm");
         poolGroups.add(new FeedbackPanel("feedback"));
         poolGroups.add(new LayoutHeaderPanel("layoutHeaderPanel"));
         poolGroups.add(createListview());

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
@@ -14,10 +14,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.pools.PoolV2Mode;
-
 import org.dcache.webadmin.controller.PoolSpaceService;
 import org.dcache.webadmin.controller.exceptions.PoolSpaceServiceException;
 import org.dcache.webadmin.view.beans.PoolSpaceBean;
@@ -40,12 +38,6 @@ public class PoolList extends SortableBasePage {
     private static final Logger _log = LoggerFactory.getLogger(PoolList.class);
 
     /*
-     * set to false when using the Junit FormTester; otherwise, the autorefreshing
-     * form produces incorrect results
-     */
-    public static boolean autorefresh = true;
-
-    /*
      * necessary so that submit uses the current list instance
      */
     private boolean submitFormCalled = false;
@@ -59,9 +51,6 @@ public class PoolList extends SortableBasePage {
                 new PropertyModel(this, "_poolBeans"), true);
         poolListPanel.setPoolListPage(this);
         poolUsageForm.add(poolListPanel);
-        if (autorefresh) {
-            addAutoRefreshToForm(poolUsageForm, 1, TimeUnit.MINUTES);
-        }
         add(poolUsageForm);
     }
 

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolqueues/PoolQueues.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolqueues/PoolQueues.java
@@ -28,7 +28,7 @@ public class PoolQueues extends SortableBasePage {
     private static final long serialVersionUID = -6482302256752371950L;
 
     public PoolQueues() {
-        Form<?> form = getAutoRefreshingForm("poolQueuesForm");
+        Form<?> form = new Form<Void>("poolQueuesForm");
         form.add(new PoolQueuesPanel("poolQueuesPanel",
                         new PropertyModel<PoolGroupBean>(this, "allPoolsGroup")));
         add(form);

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/spacetokens/SpaceTokens.java
@@ -44,7 +44,7 @@ public class SpaceTokens extends SortableBasePage {
     }
 
     private void createMarkup() {
-        Form<?> form = getAutoRefreshingForm("spaceTokensForm");
+        Form<?> form = new Form<Void>("spaceTokensForm");
         form.add(new FeedbackPanel("feedback"));
         form.add(new LinkGroupListView("linkGroupView", new PropertyModel(this,
                 "tokenInfo")));

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/tapetransferqueue/TapeTransferQueue.java
@@ -30,7 +30,7 @@ public class TapeTransferQueue extends SortableBasePage {
     final List<RestoreBean> _restoreBeans;
 
     public TapeTransferQueue() {
-        Form<?> form = getAutoRefreshingForm("tapeTransferQueueForm");
+        Form<?> form = new Form<Void>("tapeTransferQueueForm");
         form.add(new FeedbackPanel("feedback"));
         _restoreBeans = getRestoreBeans();
         ListView<RestoreBean> listview =

--- a/modules/dcache-webadmin/src/test/java/org/dcache/webadmin/view/pages/poollist/PoolListTest.java
+++ b/modules/dcache-webadmin/src/test/java/org/dcache/webadmin/view/pages/poollist/PoolListTest.java
@@ -42,7 +42,6 @@ public class PoolListTest {
         _poolSpaceService = new StandardPoolSpaceService(daoFactory);
         authenticatedWebApp.setPoolSpaceService(_poolSpaceService);
         _tester = new WicketTester(authenticatedWebApp);
-        PoolList.autorefresh = false;
         _tester.startPage(PoolList.class);
     }
 


### PR DESCRIPTION
… filter library

Motivation:

We have known for a while that there is a basic incompatibility between
the way the picnet filter library handles filtering and the autorefreshing
of a webpage via the Wicket AJAX command.  The problem does not seem
solvable short of altering the picnet library.

(If we were to commit to Wicket, the proper thing to do would be to
replace all these repeaters with the data tables used on other pages,
and remove dependency on the picnet library; our continued use of
Wicket, however, being uncertain ...)

Modification:

Disable autorefresh on the pages where the tables are filtered using
picnet (JQuery).  Pages displaying plots (billing, pool queues),
active transfers and alarms are unaffected.

Result:

There is no interference from autorefresh (which makes the
filter boxes disappear and/or resets the filter).

Downside:  The services, pools, and tape transfer pages must be manually refreshed.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: tigran.mkrtchyan@desy.de