### PR TITLE
dcache-webadmin: disable saving table filter settings to browser cookies

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/WebAdminInterface.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/WebAdminInterface.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellPath;
-
 import org.dcache.auth.LoginStrategy;
 import org.dcache.cells.CellStub;
 import org.dcache.services.login.RemoteLoginStrategy;

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/SortableBasePage.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/SortableBasePage.java
@@ -19,13 +19,15 @@ public abstract class SortableBasePage extends BasePage {
     }
 
     protected void addFilterSelectScript(String id, IHeaderResponse response) {
-        response.render(OnLoadHeaderItem
-                        .forScript("                $('.sortable-" + id + "').tablesorter();\n"
-                                 + "                // Initialise Plugin\n"
-                                 + "                var options1 = {\n"
-                                 + "                    additionalFilterTriggers: [$('.quickfind-" + id + "')],\n"
-                                 + "                    clearFiltersControls: [$('.cleanfilters-" + id + "')],\n"
-                                 + "                };\n"
-                                 + "                $('.sortable-" + id + "').tableFilter(options1);\n"));
+        StringBuilder script = new StringBuilder();
+        script.append("picnet.ui.filter.GenericListFilterOptions.prototype['enableCookies']")
+              .append( " = false;\n")
+              .append("$('.sortable-" + id + "').tablesorter();\n")
+              .append("var options1 = {\n")
+              .append("    additionalFilterTriggers: [$('.quickfind-" + id + "')],\n")
+              .append("    clearFiltersControls: [$('.cleanfilters-" + id + "')],\n")
+              .append("}\n")
+              .append("$('.sortable-" + id + "').tableFilter(options1);\n");
+        response.render(OnLoadHeaderItem.forScript(script.toString()));
     }
 }


### PR DESCRIPTION
Motivation:

On pages displaying tables that are filtered using the JQuery picnet library,
the presence of a filter in a particular table column will reappear on other
pages having tables with similar columns.   This applies to both navigation
from one page to the next in a single tab and with refreshing pages in
different tabs.

This behavior is confusing and unexpected, and could potentially cause
commands to be issued (on the pages with admin activation) which were
not intended.

The reason this occurs is because the picnet library stores and reloads
filter settings from a browser cookie, marking them positionally.

Modification:

Rather than trying to modify the way the JQuery library behaves, we
have opted simply to disable this feature.

The disadvantage of doing so is that now with page reloads and
form submissions the filters are cleared.   This is not a major
problem because the clearing takes place after the submission,
so commands will be properly issued.

We experimented with allowing this to be an option/property,
but making the saved filter settings play correctly with the
"select all" buttons (see the following patch #9677)
would have entailed holding information in different
places (in the page when disabled, in the session when enabled)
on the server side.   We did not deem this complication
worth the effort.

Result:

Tables on different pages exposed simultaneously in different
browser tabs are now filtered independently.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: tigran.mkrtchyan@desy.de