### PR TITLE
dcache-webadmin: synchronize client-side filtering with server-side s…

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/SortableBasePage.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/basepage/SortableBasePage.java
@@ -9,6 +9,8 @@ import java.util.concurrent.TimeUnit;
 
 public abstract class SortableBasePage extends BasePage {
 
+    public static final String FILTER_EVENT = "row-filter-change";
+
     private static final long serialVersionUID = 4235195090469174433L;
 
     /**
@@ -29,6 +31,9 @@ public abstract class SortableBasePage extends BasePage {
               .append("var options1 = {\n")
               .append("    additionalFilterTriggers: [$('.quickfind-" + id + "')],\n")
               .append("    clearFiltersControls: [$('.cleanfilters-" + id + "')],\n")
+              .append("    filteredRows: function() {\n")
+              .append("        $(document).trigger('row-filter-change');\n")
+              .append("    }\n")
               .append("}\n")
               .append("$('.sortable-" + id + "').tableFilter(options1);\n");
         response.render(OnLoadHeaderItem.forScript(script.toString()));

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poollist/PoolList.java
@@ -37,6 +37,28 @@ public class PoolList extends SortableBasePage {
     private SelectOption _selectedOption;
     private static final Logger _log = LoggerFactory.getLogger(PoolList.class);
 
+    private class PoolSpaceTableSelectAll extends SelectAllPanel {
+        private static final long serialVersionUID = -1886067539481596863L;
+
+        public PoolSpaceTableSelectAll(String id, Button submit) {
+            super(id, "space", submit);
+        }
+
+        @Override
+        protected void setSubmitCalled() {
+            submitFormCalled = true;
+        }
+
+        @Override
+        protected void setSelectionForAll(Boolean selected) {
+            for (PoolSpaceBean bean : _poolBeans) {
+                if (!isHidden(bean)) {
+                    bean.setSelected(selected);
+                }
+            }
+        }
+    }
+
     /*
      * necessary so that submit uses the current list instance
      */
@@ -119,22 +141,7 @@ public class PoolList extends SortableBasePage {
         public PoolUsageForm(String id) {
             super(id);
             Button submit = new Button("submit");
-            SelectAllPanel selectAllPanel = new SelectAllPanel("selectAllPanel", submit) {
-                private static final long serialVersionUID = -1886067539481596863L;
-
-                @Override
-                protected void setSubmitCalled() {
-                    submitFormCalled = true;
-                }
-
-                @Override
-                protected void setSelectionForAll(Boolean selected) {
-                    for (PoolSpaceBean bean : _poolBeans) {
-                        bean.setSelected(selected);
-                    }
-                }
-            };
-            this.add(selectAllPanel);
+            this.add(new PoolSpaceTableSelectAll("selectAllPanel", submit));
         }
 
         @Override

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/panels/selectall/SelectAllPanel.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/panels/selectall/SelectAllPanel.java
@@ -59,32 +59,115 @@ documents or software obtained from this server.
  */
 package org.dcache.webadmin.view.panels.selectall;
 
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AbstractDefaultAjaxBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes.Method;
+import org.apache.wicket.ajax.attributes.CallbackParameter;
 import org.apache.wicket.authroles.authorization.strategies.role.metadata.MetaDataRoleAuthorizationStrategy;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnEventHeaderItem;
 import org.apache.wicket.markup.html.form.Button;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.http.WebRequest;
+import org.apache.wicket.util.string.StringValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.dcache.webadmin.view.beans.PoolCommandBean;
+import org.dcache.webadmin.view.beans.PoolSpaceBean;
 import org.dcache.webadmin.view.panels.basepanel.BasePanel;
 import org.dcache.webadmin.view.util.Role;
 
+import static org.dcache.webadmin.view.pages.basepage.SortableBasePage.FILTER_EVENT;
+
 /**
- * Encapsulates the triad of select all, deselect all and submit buttons.
- * The submit and selection functionality depends on the concrete class.
+ * <p>Encapsulates the triad of select all, deselect all and submit buttons.
+ * The submit and selection functionality depends on the concrete class.</p>
  *
- * @author arossi
+ * <p>Also provides AJAX callback for synchronizing the filtered (hidden)
+ * rows with the select/deselect all button functions.</p>
  */
 public abstract class SelectAllPanel extends BasePanel {
 
     private static final long serialVersionUID = 8704591801936459097L;
 
-    public SelectAllPanel(String id, Button submit) {
-        super(id);
-        Button selectAll = new SelectAllButton("selectAllButton");
-        Button deselectAll = new DeselectAllButton("deselectAllButton");
-        MetaDataRoleAuthorizationStrategy.authorize(submit, RENDER, Role.ADMIN);
-        MetaDataRoleAuthorizationStrategy.authorize(selectAll, RENDER, Role.ADMIN);
-        MetaDataRoleAuthorizationStrategy.authorize(deselectAll, RENDER, Role.ADMIN);
-        add(submit);
-        add(selectAll);
-        add(deselectAll);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SelectAllPanel.class);
+
+    /**
+     * <p>Behavior which reacts to a special event triggered by
+     *    the picnet filter.  It determines which rows have been
+     *    hidden by the filter and sends the name identifiers to the
+     *    server via Http POST.</p>
+     */
+    class PicnetPostHiddenRowsBehavior extends AbstractDefaultAjaxBehavior {
+        /**
+         * <p>Builds the callback script to send to the client.</p>
+         */
+        @Override
+        public void renderHead(Component component, IHeaderResponse response) {
+            super.renderHead(component, response);
+            StringBuilder script = new StringBuilder();
+            appendHiddenRows(script);
+            response.render(OnEventHeaderItem.forScript("document",
+                                                        FILTER_EVENT,
+                                                        script.toString()));
+        }
+
+        /**
+         * <p>Processes the POST by updating the set of hidden rows.</p>
+         */
+        @Override
+        protected void respond(AjaxRequestTarget target) {
+            RequestCycle cycle = RequestCycle.get();
+            WebRequest webRequest = (WebRequest) cycle.getRequest();
+            StringValue value = webRequest.getPostParameters()
+                                          .getParameterValue("document.hiddenRows");
+            setHiddenRows(value.toString(""));
+        }
+
+        @Override
+        protected void updateAjaxAttributes(AjaxRequestAttributes attributes) {
+            super.updateAjaxAttributes(attributes);
+            attributes.setMethod(Method.POST);
+        }
+
+        String getCallback() {
+            return behavior.getCallbackFunctionBody
+                            (CallbackParameter.explicit("document.hiddenRows"))
+                           .toString();
+        }
+
+        /**
+         * <p>Searches for rows in the table marked by picnet as 'filtermatch = false'
+         * and returns the text of the columns with the key classes.  This is
+         * assigned to a document-level variable "hiddenRows".</p>
+         *
+         * @param script builder representing full script
+         */
+        private void appendHiddenRows(StringBuilder script) {
+            script.append("document.hiddenRows = $('.sortable-").append(tableId)
+                  .append("').find(\"tr\").filter(function() {\n")
+                  .append("return $(this).attr( \"filtermatch\" ) === \"false\";\n")
+                  .append("}).map(function() {\n")
+                  .append("return $(this).find('.key1').text() + $(this).find('.key2').text();")
+                  .append("}).get();\n");
+        }
+
+        private void setHiddenRows(String commaDelimitedList) {
+            String[] list = commaDelimitedList.split("[,]");
+            synchronized (hidden) {
+                hidden.clear();
+                for (String key : list) {
+                    hidden.add(key);
+                }
+            }
+            LOGGER.debug("setHiddenRows, now {}.", hidden);
+        }
     }
 
     private class SelectAllButton extends Button {
@@ -93,6 +176,15 @@ public abstract class SelectAllPanel extends BasePanel {
         public SelectAllButton(String id) {
             super(id);
             this.setDefaultFormProcessing(false);
+
+        }
+
+        @Override
+        public void renderHead(IHeaderResponse response) {
+            super.renderHead(response);
+            response.render(OnEventHeaderItem.forScript("selectAll",
+                                                        "click",
+                                                        behavior.getCallback()));
         }
 
         @Override
@@ -111,9 +203,53 @@ public abstract class SelectAllPanel extends BasePanel {
         }
 
         @Override
+        public void renderHead(IHeaderResponse response) {
+            super.renderHead(response);
+            response.render(OnEventHeaderItem.forScript("deselectAll",
+                                                        "click",
+                                                        behavior.getCallback()));
+        }
+
+        @Override
         public void onSubmit() {
             setSubmitCalled();
             setSelectionForAll(Boolean.FALSE);
+        }
+    }
+
+    final PicnetPostHiddenRowsBehavior behavior = new PicnetPostHiddenRowsBehavior();
+    final private Set<String> hidden = new HashSet<>();
+    final private String tableId;
+
+    public SelectAllPanel(String id, String tableId, Button submit) {
+        super(id);
+        this.tableId = tableId;
+        Button selectAll = new SelectAllButton("selectAllButton");
+        Button deselectAll = new DeselectAllButton("deselectAllButton");
+        MetaDataRoleAuthorizationStrategy.authorize(submit, RENDER, Role.ADMIN);
+        MetaDataRoleAuthorizationStrategy.authorize(selectAll, RENDER, Role.ADMIN);
+        MetaDataRoleAuthorizationStrategy.authorize(deselectAll, RENDER, Role.ADMIN);
+        add(submit);
+        add(selectAll);
+        add(deselectAll);
+        add(behavior);
+    }
+
+    protected boolean isHidden(PoolSpaceBean bean) {
+        synchronized (hidden) {
+            String key = bean.getName() + bean.getDomainName();
+            boolean isHidden = hidden.contains(key);
+            LOGGER.debug("{}, hidden = {}.", key, isHidden);
+            return isHidden;
+        }
+    }
+
+    protected boolean isHidden(PoolCommandBean bean) {
+        synchronized (hidden) {
+            String key = bean.getName() + bean.getDomain();
+            boolean isHidden = hidden.contains(key);
+            LOGGER.debug("{}, hidden = {}.", key, isHidden);
+            return isHidden;
         }
     }
 

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/pages/pooladmin/PoolAdmin.html
@@ -18,12 +18,10 @@
             </h1>
             <div>
                 <span wicket:id="feedback"></span>
+                <span wicket:id="selectAllPanel"></span>
                 <input
-                    wicket:id="commandText"
-                    type="text" /> <input
-                    type="submit"
-                    wicket:message="value:submitButton"
-                    wicket:id="submit" />
+                        wicket:id="commandText"
+                        type="text" />
                 <div class="clear">&nbsp;</div>
                 <span wicket:id="lastCommand"></span>
             </div>
@@ -40,14 +38,6 @@
                 </ul>
             </span>
             <div class="clear">&nbsp;</div>
-            <input
-                type="submit"
-                wicket:id="selectAllButton"
-                wicket:message="value:selectAllButton" /> <input
-                type="submit"
-                wicket:id="deselectAllButton"
-                wicket:message="value:deselectAllButton" />
-            <br><br>
             <wicket:message key="poolAdmin.quickfind"></wicket:message>
             &nbsp;
             <input
@@ -74,9 +64,9 @@
                         <td id="poolAdminLine"><input
                             type="checkbox"
                             wicket:id="poolAdmin.poolselected"></input></td>
-                        <td id="poolAdminLine"><span
+                        <td class="key1" id="poolAdminLine"><span
                                 wicket:id="poolAdmin.poolnamevalue"></span></td>
-                        <td id="poolAdminLine"><span
+                        <td class="key2" id="poolAdminLine"><span
                                 wicket:id="poolAdmin.pooldomainvalue"></span></td>
                         <td id="poolAdminLine"><span
                                 wicket:id="poolAdmin.poolresponsevalue"></span></td>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poollist/PoolListPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/poollist/PoolListPanel.html
@@ -43,8 +43,8 @@
                     <td wicket:id="PoolPanel.checkboxRow"><input
                         type="checkbox"
                         wicket:id="PoolPanel.selected" /></td>
-                    <td><span wicket:id="PoolPanel.name"></span></td>
-                    <td><span wicket:id="PoolPanel.domainName"></span></td>
+                    <td class="key1"><span wicket:id="PoolPanel.name"></span></td>
+                    <td class="key1"><span wicket:id="PoolPanel.domainName"></span></td>
                     <td><span wicket:id="PoolPanel.poolMode"></span></td>
                     <td><span wicket:id="PoolPanel.totalSpace"></span></td>
                     <td><span wicket:id="PoolPanel.freeSpace"></span></td>

--- a/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/selectall/SelectAllPanel.html
+++ b/modules/dcache-webadmin/src/main/resources/org/dcache/webadmin/view/panels/selectall/SelectAllPanel.html
@@ -2,13 +2,15 @@
 <wicket:head>
 </wicket:head>
 <body>
-    <wicket:panel>
+    <wicket:panel id="selectAllPanel">
             <input
                 type="submit"
+                id="selectAll"
                 wicket:id="selectAllButton"
                 wicket:message="value:selectAllButton" />
             <input
                 type="submit"
+                id="deselectAll"
                 wicket:id="deselectAllButton"
                 wicket:message="value:deselectAllButton" />
             <div>&nbsp;</div>


### PR DESCRIPTION
…election of rows on pages using picnet table filters

Motivation:

Pages that expose tables (Wicket repeaters) filtered using the JQuery picnet table
filter library, and that have admin functionality which makes use of table row
selection (via checkbox) in connection with issuing admin commands, currently
present a potentially dangerous problem.  If one filters the table (and hides
rows), those hidden rows are nevertheless unknown to the server, which is
reponsible for implementing the "select all" and "deselect all" buttons by
marking the selected state on the model object.  This leads to totally
unexpected behavior, in that the user believes only the filtered rows
to have been selected, when in reality all were.

What is necessary to solve this problem is to communicate the filtered
state of the tables from the client to the server in connection with
the buttons which do the select/deselect all.

Modification:

1.  An ad hoc event (table-filter-changed) is triggered by binding
    a function to the picnet filteredRows option.
2.  An Ajax behavior is added which adds to the header a
    handler which collects the ids of the hidden rows and assigns
    them to a variable on the document in response to this
    new event.
3.  The buttons responsible for calling select/deselect all
    now pass to the server (i.e., the behavior listener above)
    the value of this variable on the 'click' event via HTTP POST.

Result:

Selection/Deselection of hidden rows is now prevented.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: tigran.mkrtchyan@desy.de