### PR TITLE
pool: Ensure that post transfer service shuts down before repository

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.pool.classic;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +28,7 @@ import java.io.InterruptedIOException;
 import java.nio.channels.CompletionHandler;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
@@ -179,6 +181,6 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
 
     public void shutdown()
     {
-        _executor.shutdown();
+        MoreExecutors.shutdownAndAwaitTermination(_executor, 10, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
Motivation:

java.lang.IllegalStateException: Attempt to use non-open Environment object().
	at com.sleepycat.je.Environment.checkHandleIsValid(Environment.java:2450) ~[je-6.4.25.jar:6.4.25]
	at com.sleepycat.je.Environment.beginTransactionInternal(Environment.java:1415) ~[je-6.4.25.jar:6.4.25]
	at com.sleepycat.je.Environment.beginTransaction(Environment.java:1387) ~[je-6.4.25.jar:6.4.25]
	at org.dcache.pool.repository.meta.db.AbstractBerkeleyDBReplicaStore.beginTransaction(AbstractBerkeleyDBReplicaStore.java:181) ~[dcache-core-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
	at org.dcache.pool.repository.meta.db.CacheRepositoryEntryImpl.update(CacheRepositoryEntryImpl.java:259) ~[dcache-core-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
	at org.dcache.pool.repository.ReplicaStoreCache$Monitor.update(ReplicaStoreCache.java:347) ~[dcache-core-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
	at org.dcache.pool.repository.v5.WriteHandleImpl.fail(WriteHandleImpl.java:403) ~[dcache-core-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
	at org.dcache.pool.repository.v5.WriteHandleImpl.close(WriteHandleImpl.java:432) ~[dcache-core-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
	at org.dcache.pool.classic.DefaultPostTransferService.lambda$execute$35(DefaultPostTransferService.java:91) ~[dcache-core-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
	at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) ~[dcache-common-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
	at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149) ~[dcache-core-2.17.0-SNAPSHOT.jar:2.17.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_101]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_101]
	at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_101]

Modification:

The exception is caused by post-transfer-service not blocking while shutting down its
executor. Thus Spring will proceed with shutting down the repository and thus berkeley
db while the post transfer service is still active.

The solution is to make the shutdown method of the post-transfer-service blocking.

The present solution is suboptimal as during post-transfer the pool will try to
register files with pnfs manager while the pool is unable to receive the replies
as it is in the middle of shutting down. The present patch is however simple and
easy to backport.

Result:

An problem during pool shutdown causing exception about the use of a non-open Berkeley
DB environment has been fixed.

Target: trunk
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9697/

(cherry picked from commit f509447b990a022b2017bc6b37926750799cdefb)