### PR TITLE
cells: Backport fixes for cell shutdown

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Maps;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Longs;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.retry.RetryOneTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +38,7 @@ class CellGlue
 
     private final String _cellDomainName;
     private final ConcurrentMap<String, CellNucleus> _cellList = Maps.newConcurrentMap();
+    private final ConcurrentMap<String, CellNucleus> _publicCellList = Maps.newConcurrentMap();
     private final Set<CellNucleus> _killedCells = Collections.newSetFromMap(
             Maps.<CellNucleus, Boolean>newConcurrentMap());
     private final Map<String, List<CellEventListener>> _cellEventListener =
@@ -89,19 +89,28 @@ class CellGlue
         return _masterThreadGroup;
     }
 
-    void addCell(String name, CellNucleus cell)
+    void registerCell(CellNucleus cell)
             throws IllegalArgumentException
     {
+        if (cell.getThisCell() instanceof SystemCell) {
+            checkState(_systemNucleus == null);
+            _systemNucleus = cell;
+        }
+
+        String name = cell.getCellName();
         if (_cellList.putIfAbsent(name, cell) != null) {
             throw new IllegalArgumentException("Name Mismatch ( cell " + name + " exist )");
         }
         sendToAll(new CellEvent(name, CellEvent.CELL_CREATED_EVENT));
     }
 
-    void setSystemNucleus(CellNucleus nucleus)
+    void publishCell(CellNucleus cell)
+            throws IllegalArgumentException
     {
-        checkState(_systemNucleus == null);
-        _systemNucleus = nucleus;
+        String name = cell.getCellName();
+        if (_publicCellList.putIfAbsent(name, cell) != null) {
+            throw new IllegalArgumentException("Name Mismatch ( cell " + name + " exist )");
+        }
     }
 
     CellNucleus getSystemNucleus()
@@ -132,7 +141,7 @@ class CellGlue
     public void routeAdd(CellRoute route)
     {
         CellAddressCore target = route.getTarget();
-        if (target.getCellDomainName().equals(getCellDomainName()) && !_cellList.containsKey(target.getCellName())) {
+        if (target.getCellDomainName().equals(getCellDomainName()) && !_publicCellList.containsKey(target.getCellName())) {
             throw new IllegalArgumentException("No such cell: " + target);
         }
         _routingTable.add(route);
@@ -158,7 +167,7 @@ class CellGlue
     List<CellTunnelInfo> getCellTunnelInfos()
     {
         List<CellTunnelInfo> v = new ArrayList<>();
-        for (CellNucleus cellNucleus : _cellList.values()) {
+        for (CellNucleus cellNucleus : _publicCellList.values()) {
             Cell c = cellNucleus.getThisCell();
             if (c instanceof CellTunnel) {
                 v.add(((CellTunnel) c).getCellTunnelInfo());
@@ -240,7 +249,7 @@ class CellGlue
             throws IllegalArgumentException
     {
         CellNucleus nucleus = _cellList.get(cellName);
-        if (nucleus == null || _killedCells.contains(nucleus)) {
+        if (nucleus == null) {
             throw new IllegalArgumentException("Cell Not Found : " + cellName);
         }
         _kill(sender, nucleus, 0);
@@ -307,28 +316,30 @@ class CellGlue
     synchronized void destroy(CellNucleus nucleus)
     {
         _cellEventListener.remove(nucleus.getCellName());
+        _publicCellList.remove(nucleus.getCellName());
         _cellList.remove(nucleus.getCellName());
         _killedCells.remove(nucleus);
         LOGGER.trace("destroy : sendToAll : killed {}", nucleus.getCellName());
         notifyAll();
     }
 
-    private void _kill(CellNucleus source, final CellNucleus destination, long to)
+    private synchronized void _kill(CellNucleus source, final CellNucleus destination, long to)
     {
+        /* Mark the cell as being killed to prevent it from being killed more
+         * than once and to block certain operations while it is being killed.
+         */
+        String cellToKill = destination.getCellName();
+        if (_cellList.get(cellToKill) != destination || !_killedCells.add(destination)) {
+            return;
+        }
+
         /* Remove routes to this cell first to allow it to be drained cleanly.
          */
         for (CellRoute route : _routingTable.delete(destination.getThisAddress())) {
             sendToAll(new CellEvent(route, CellEvent.CELL_ROUTE_DELETED_EVENT));
         }
 
-        /* Mark the cell as being killed to prevent it from being killed more
-         * than once and to block certain operations while it is being killed.
-         */
-        String cellToKill = destination.getCellName();
-        if (!_killedCells.add(destination)) {
-            LOGGER.trace("Cell is being killed: {}", cellToKill);
-            return;
-        }
+        _publicCellList.remove(cellToKill, destination);
 
         /* Post the obituary.
          */
@@ -482,8 +493,8 @@ class CellGlue
 
     private boolean deliverLocally(CellMessage msg, CellAddressCore address)
     {
-        CellNucleus destNucleus = _cellList.get(address.getCellName());
-        if (destNucleus != null && !_killedCells.contains(destNucleus)) {
+        CellNucleus destNucleus = _publicCellList.get(address.getCellName());
+        if (destNucleus != null) {
             /* Is the message addressed to the cell or is the cell merely a router.
              */
             CellPath destinationPath = msg.getDestinationPath();

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
@@ -43,6 +43,7 @@ import java.util.StringTokenizer;
 import java.util.TreeSet;
 import java.util.Vector;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 
@@ -1056,6 +1057,8 @@ public class CellShell extends CommandInterpreter
                                        });
                }
                return "created : " + cell;
+           } catch (CancellationException e) {
+               throw new CommandThrowableException("Startup of " + cellName + " was cancelled.", e);
            } catch (InvocationTargetException e) {
                throw Throwables.propagate(e.getTargetException());
            } catch (ExecutionException e) {


### PR DESCRIPTION
Motivation:

We have observed problems at NDGF in which we clearly had two location manager
connectors running (as they alternated creating tunnels with different name
prefixes), yet only one was visible in the 'ps' command. The theory is that
we hid a race in the pool startup in which if the cell is killed while startup
is still running, the prepareRemoval callback may be called before the startup
callbacks have returned.

We have also seen

31 Aug 2016 09:19:24 (lm) [] Uncaught exception in thread Thread-150
java.lang.IllegalStateException: null
        at com.google.common.base.Preconditions.checkState(Preconditions.java:159) ~[guava-19.0.jar:na]
        at dmg.cells.nucleus.CellNucleus.shutdown(CellNucleus.java:937) ~[cells-2.16.10.jar:2.16.10]
        at dmg.cells.nucleus.CellGlue.lambda$_kill$1(CellGlue.java:341) ~[cells-2.16.10.jar:2.16.10]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_92]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_92]
        at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_92]

This indicates duplicate attempts to kill a cell which the code in 2.16 does
not tollerate.

Those problems are fixed on master.

Modification:

Backport the relevant parts from master:

- Two step registration of a cell in the cell glue such that it is
  registered as soon as the cell nucleus is created rather than when
  it has started. This ensures that it is visible in 'ps' and that
  it will be properly killed upon shutdown.

- Protection in cell glue against duplicate kills - a cell is only
  killed once.

- Fix of a race in iterating of deferred tasks.

- Block in shutdown for startup to complete before proceeding; interrupt
  startup if it appears to be slow.

- Wait for the timeout task to complete.

Result:

Fixed several cell shutdown related bugs. One manifestation of these bugs is that
tunnel connections appear to fail.

Target: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9702/