### PR TITLE
doors: Include IO queue in pool selection request

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -665,6 +665,7 @@ public abstract class AbstractFtpDoorV1
             setPoolStub(_poolStub);
             setBillingStub(_billingStub);
             setAllocation(_allo);
+            setIoQueue(_settings.getIoQueueName());
 
             _offset = offset;
             _size = size;
@@ -3072,7 +3073,7 @@ public abstract class AbstractFtpDoorV1
              * transfer a few times.
              */
             transfer.createAdapter();
-            transfer.selectPoolAndStartMoverAsync(_settings.getIoQueueName(), _readRetryPolicy);
+            transfer.selectPoolAndStartMoverAsync(_readRetryPolicy);
         } catch (PermissionDeniedCacheException e) {
             transfer.abort(550, "Permission denied");
         } catch (CacheException e) {
@@ -3196,7 +3197,7 @@ public abstract class AbstractFtpDoorV1
             }
 
             transfer.createAdapter();
-            transfer.selectPoolAndStartMoverAsync(_settings.getIoQueueName(), _writeRetryPolicy);
+            transfer.selectPoolAndStartMoverAsync(_writeRetryPolicy);
         } catch (IOException e) {
             transfer.abort(451, "Operation failed: " + e.getMessage());
         } catch (PermissionDeniedCacheException e) {

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -469,6 +469,7 @@ public class NFSv41Door extends AbstractCellComponent implements
                         transfer.setPoolManagerStub(_poolManagerStub);
                         transfer.setPnfsId(pnfsId);
                         transfer.setClientAddress(remote);
+                        transfer.setIoQueue(_ioQueue);
 
                         /*
                          * Bind transfer to open-state.
@@ -509,7 +510,7 @@ public class NFSv41Door extends AbstractCellComponent implements
                         throw new NfsIoException("lost file " + inode.getId());
                     }
 
-                    PoolDS ds = transfer.getPoolDataServer(_ioQueue, NFS_REQUEST_BLOCKING);
+                    PoolDS ds = transfer.getPoolDataServer(NFS_REQUEST_BLOCKING);
                     deviceid = ds.getDeviceId();
                 }
             }
@@ -859,7 +860,7 @@ public class NFSv41Door extends AbstractCellComponent implements
             return _nfsInode;
         }
 
-        PoolDS  getPoolDataServer(String queue, long timeout) throws
+        PoolDS  getPoolDataServer(long timeout) throws
                 InterruptedException, ExecutionException,
                 TimeoutException, CacheException {
 
@@ -874,10 +875,10 @@ public class NFSv41Door extends AbstractCellComponent implements
 
                         _log.debug("looking for {} pool for {}", (isWrite() ? "write" : "read"), getPnfsId());
 
-                        _redirectFuture = selectPoolAndStartMoverAsync(queue, RETRY_POLICY);
+                        _redirectFuture = selectPoolAndStartMoverAsync(RETRY_POLICY);
                     } else {
                         // we may re-send the request, but pool will handle it
-                        _redirectFuture = startMoverAsync(queue, NFS_REQUEST_BLOCKING);
+                        _redirectFuture = startMoverAsync(NFS_REQUEST_BLOCKING);
                     }
                 }
             }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -662,7 +662,7 @@ public class DcacheResourceFactory
             try {
                 transfer.setLength(length);
                 try {
-                    transfer.selectPoolAndStartMover(_ioQueue, _retryPolicy);
+                    transfer.selectPoolAndStartMover(_retryPolicy);
                     String uri = transfer.waitForRedirect(_moverTimeout, _moverTimeoutUnit);
                     if (uri == null) {
                         throw new TimeoutCacheException("Server is busy (internal timeout)");
@@ -709,7 +709,7 @@ public class DcacheResourceFactory
             transfer.createNameSpaceEntry();
             try {
                 transfer.setLength(length);
-                transfer.selectPoolAndStartMover(_ioQueue, _retryPolicy);
+                transfer.selectPoolAndStartMover(_retryPolicy);
                 uri = transfer.waitForRedirect(_moverTimeout, _moverTimeoutUnit);
                 if (uri == null) {
                     throw new TimeoutCacheException("Server is busy (internal timeout)");
@@ -1039,7 +1039,7 @@ public class DcacheResourceFactory
             transfer.setProxyTransfer(isProxyTransfer);
             transfer.readNameSpaceEntry(false);
             try {
-                transfer.selectPoolAndStartMover(_ioQueue, _retryPolicy);
+                transfer.selectPoolAndStartMover(_retryPolicy);
                 uri = transfer.waitForRedirect(_moverTimeout, _moverTimeoutUnit);
                 if (uri == null) {
                     throw new TimeoutCacheException("Server is busy (internal timeout)");
@@ -1188,6 +1188,7 @@ public class DcacheResourceFactory
         transfer.setPoolManagerStub(_poolManagerStub);
         transfer.setPoolStub(_poolStub);
         transfer.setBillingStub(_billingStub);
+        transfer.setIoQueue(_ioQueue);
         List<InetSocketAddress> addresses = Subjects.getOrigin(subject).getClientChain().stream().
                 map(a -> new InetSocketAddress(a, PROTOCOL_INFO_UNKNOWN_PORT)).
                 collect(Collectors.toList());

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -343,6 +343,7 @@ public class XrootdDoor
         transfer.setClientAddress(client);
         transfer.setUUID(uuid);
         transfer.setDoorAddress(local);
+        transfer.setIoQueue(_ioQueue);
         transfer.setFileHandle(_handleCounter.getAndIncrement());
         return transfer;
     }
@@ -364,7 +365,7 @@ public class XrootdDoor
         _transfers.put(handle, transfer);
         try {
             transfer.readNameSpaceEntry(false);
-            transfer.selectPoolAndStartMover(_ioQueue, RETRY_POLICY);
+            transfer.selectPoolAndStartMover(RETRY_POLICY);
             address = transfer.waitForRedirect(_moverTimeout, _moverTimeoutUnit);
             if (address == null) {
                 throw new CacheException(transfer.getPool() + " failed to open TCP socket");
@@ -415,7 +416,7 @@ public class XrootdDoor
                 transfer.createNameSpaceEntry();
             }
             try {
-                transfer.selectPoolAndStartMover(_ioQueue, RETRY_POLICY);
+                transfer.selectPoolAndStartMover(RETRY_POLICY);
 
                 address = transfer.waitForRedirect(_moverTimeout, _moverTimeoutUnit);
                 if (address == null) {

--- a/modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java
@@ -335,6 +335,7 @@ public class CopyManager extends AbstractCellComponent
             _source.setPoolStub(_poolStub);
             _source.setDomainName(getCellDomainName());
             _source.setCellName(getCellName());
+            _source.setIoQueue("p2p");
             // _source.setClientAddress();
             // _source.setBillingStub();
             // _source.setCheckStagePermission();
@@ -343,6 +344,7 @@ public class CopyManager extends AbstractCellComponent
             _target.setPoolStub(_poolStub);
             _target.setDomainName(getCellDomainName());
             _target.setCellName(getCellName());
+            _target.setIoQueue("pp");
             // _target.setClientAddress();
             // _target.setBillingStub();
 
@@ -357,11 +359,11 @@ public class CopyManager extends AbstractCellComponent
 
                 _target.setProtocolInfo(createTargetProtocolInfo(_target));
                 _target.setLength(_source.getLength());
-                _target.selectPoolAndStartMover("pp", new TransferRetryPolicy(1, 0, _poolManager.getTimeoutInMillis()));
+                _target.selectPoolAndStartMover(new TransferRetryPolicy(1, 0, _poolManager.getTimeoutInMillis()));
                 _target.waitForRedirect(timeout);
 
                 _source.setProtocolInfo(createSourceProtocolInfo(_target.getRedirect(), _target.getId()));
-                _source.selectPoolAndStartMover("p2p", new TransferRetryPolicy(1, 0, _poolManager.getTimeoutInMillis()));
+                _source.selectPoolAndStartMover(new TransferRetryPolicy(1, 0, _poolManager.getTimeoutInMillis()));
 
                 if (!_source.waitForMover(timeout)) {
                     throw new TimeoutCacheException("copy: wait for DoorTransferFinishedMessage expired");

--- a/modules/dcache/src/main/java/org/dcache/util/AsynchronousRedirectedTransfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/AsynchronousRedirectedTransfer.java
@@ -52,9 +52,9 @@ public abstract class AsynchronousRedirectedTransfer<T> extends Transfer
     }
 
     @Override
-    public ListenableFuture<Void> selectPoolAndStartMoverAsync(String queue, TransferRetryPolicy policy)
+    public ListenableFuture<Void> selectPoolAndStartMoverAsync(TransferRetryPolicy policy)
     {
-        return monitor.setQueueFuture(super.selectPoolAndStartMoverAsync(queue, policy));
+        return monitor.setQueueFuture(super.selectPoolAndStartMoverAsync(policy));
     }
 
     /**


### PR DESCRIPTION
Motivation:

Pool manager contains 'magic' to adjust cost estimates when selecting a pool.
This magic relies on the pool manager knowing which queue the request will be
submitted to. Most doors do however not include this information in the
request.

Modification:

Include the io queue in the pool selection request.

Result:

Fixed a bug that cost pool manager to adjust cost estimates on the wrong
mover queue when selecting pools.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9708/

(cherry picked from commit d56eee290930c6c96b5a1c5f23081d9d8d620f24)