### PR TITLE
commons: fix Args string parsing and toString method

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/Args.java
+++ b/modules/common/src/main/java/org/dcache/util/Args.java
@@ -92,9 +92,13 @@ public class Args implements Serializable
 
     public static CharSequence quote(String raw)
     {
-        StringBuilder sb = new StringBuilder();
-        quote(raw, sb);
-        return sb;
+        if (raw.isEmpty()) {
+            return "''";
+        } else {
+            StringBuilder sb = new StringBuilder();
+            quote(raw, sb);
+            return sb;
+        }
     }
 
     public Args removeOptions(String... names)
@@ -308,6 +312,9 @@ public class Args implements Serializable
                 break;
             case '=':
                 out.append("\\=");
+                break;
+            case '-':
+                out.append("\\-");
                 break;
             case ' ':
                 out.append("\\ ");
@@ -590,6 +597,7 @@ public class Args implements Serializable
                 case '"':
                 case ' ':
                 case '-':
+                case '=':
                 case '\\':
                     word.append(c);
                     break;

--- a/modules/common/src/test/java/org/dcache/util/ArgsTest.java
+++ b/modules/common/src/test/java/org/dcache/util/ArgsTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 
 import java.util.NoSuchElementException;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 public class ArgsTest {
@@ -619,5 +621,45 @@ public class ArgsTest {
         assertEquals(2, args.argc());
         assertEquals(arg1, args.argv(0));
         assertEquals(arg2, args.argv(1));
+    }
+
+    @Test
+    public void testParsingToStringOutputWithEqualsArgument()
+    {
+        Args original = new Args("bar=baz");
+        Args parsed = new Args(original.toString());
+        assertThat(parsed, is(equalTo(original)));
+    }
+
+    @Test
+    public void testParsingToStringOutputWithEqualsOptionKey()
+    {
+        Args original = new Args("-foo\\=bar=baz");
+        Args parsed = new Args(original.toString());
+        assertThat(parsed, is(equalTo(original)));
+    }
+
+    @Test
+    public void testParsingToStringOutputWithEqualsOptionValue()
+    {
+        Args original = new Args("-foo=bar=baz");
+        Args parsed = new Args(original.toString());
+        assertThat(parsed, is(equalTo(original)));
+    }
+
+    @Test
+    public void testParsingToStringOutputWithDashArgument()
+    {
+        Args original = new Args("\\-foo");
+        Args parsed = new Args(original.toString());
+        assertThat(parsed, is(equalTo(original)));
+    }
+
+    @Test
+    public void testParsingToStringOutputWithEmptyArgument()
+    {
+        Args original = new Args("\"\"");
+        Args parsed = new Args(original.toString());
+        assertThat(parsed, is(equalTo(original)));
     }
 }


### PR DESCRIPTION
Motivation:

The \s admin command uses the toString method to serialise the requested
so that the remote cell may correctly parse it.  This does not always
work: '=' characters in arguments are escaped but not unescaped;
arguments that start with a '-' character are not escaped; empty words
are lost.

Modification:

Bring quoting/escaping and unescaping into alignment; make sure empty
words are not lost.

Note that Args#toString needlessly escapes characters under some
circumstances.  While this is mildly undesireable, this patch does not
address this issue with the hope that this reduces the risk when
back-porting.

Result:

\s command works more as people might expect.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Fixes: #2744
Fixes: #2130
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9046
Patch: https://rb.dcache.org/r/9716/
Acked-by: Tigran Mkrtchyan