### PR TITLE
dcache: Generate proper exit code for check-config command

### DIFF
--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -988,9 +988,12 @@ case "$1" in
     check-config)
         shift
         . ${lib}/utils.sh
-        bootLoader check-config | while read line; do
+
+        out=$(bootLoader check-config) && rc=0 || rc=$?
+        echo "$out" | while read line; do
             printpi "$line" "^[^:]*:[^:]*:"
         done
+        exit $rc
         ;;
 
     property)


### PR DESCRIPTION
Motivation:

The check-config command generates exit code 1 for warnings and
exit code 2 for errors, however this exit code is lost when the
dcache script pipes the output through a formatting function.

Modification:

Capture the exit code and use it when exiting the dcache script.

Result:

Fixed a regression in which the exit code of check-config would
always be zero even when errors were detected.

Target: trunk
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9733/

(cherry picked from commit d0c35361e5b3a8d378f3496cf269cb088c70651e)