### PR TITLE
srmclient: add support in srmfs for uploading and downloading files

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/AbstractFileTransfer.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/AbstractFileTransfer.java
@@ -1,0 +1,72 @@
+package org.dcache.srm.shell;
+
+import com.google.common.util.concurrent.SettableFuture;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Useful base class to represent a transfer.  This implements the callback
+ * support and cancellation.
+ */
+public abstract class AbstractFileTransfer implements FileTransfer
+{
+    private final SettableFuture<Void> future = SettableFuture.create();
+
+    @Override
+    public void addListener(Runnable listener, Executor executor)
+    {
+        future.addListener(listener, executor);
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning)
+    {
+        return future.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public Void get() throws InterruptedException, ExecutionException
+    {
+        return future.get();
+    }
+
+    @Override
+    public Void get(long timeout, TimeUnit unit) throws InterruptedException,
+            TimeoutException, ExecutionException
+    {
+        return future.get(timeout, unit);
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+        return future.isCancelled();
+    }
+
+    @Override
+    public boolean isDone()
+    {
+        return future.isDone();
+    }
+
+    /**
+     * Subclass should call this method to mark that the transfer has
+     * finished.
+     */
+    protected synchronized void succeeded()
+    {
+        future.set(null);
+    }
+
+    /**
+     * Subclass should call this method to mark that the transfer has
+     * failed.
+     */
+    protected synchronized void failed(Throwable reason)
+    {
+        future.setException(reason);
+    }
+}

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/AbstractFileTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/AbstractFileTransferAgent.java
@@ -1,0 +1,62 @@
+package org.dcache.srm.shell;
+
+import org.apache.axis.types.URI;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A simple FileTransferAgent that doesn't support anything.
+ */
+public abstract class AbstractFileTransferAgent implements FileTransferAgent
+{
+    @Override
+    public void start()
+    {
+        // Nothing needed.
+    }
+
+    /**
+     * The options that may be configured and their current values.
+     */
+    @Override
+    public Map<String,String> getOptions()
+    {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Alter an option.
+     */
+    @Override
+    public void setOption(String key, String value)
+    {
+        throw new IllegalArgumentException("No such option \"" + key + "\"");
+    }
+
+
+    @Override
+    public FileTransfer download(URI source, File destination)
+    {
+        return null; // URI schema not supported.
+    }
+
+    @Override
+    public FileTransfer upload(File source, URI destination)
+    {
+        return null; // URI schema not supported.
+    }
+
+    @Override
+    public Map<String, Integer> getSupportedProtocols()
+    {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        // Nothing needed.
+    }
+}

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/CredentialAware.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/CredentialAware.java
@@ -1,0 +1,11 @@
+package org.dcache.srm.shell;
+
+import eu.emi.security.authn.x509.X509Credential;
+
+/**
+ *  Indicates that the class needs an X509 credential to work.
+ */
+public interface CredentialAware
+{
+    public void setCredential(X509Credential credential);
+}

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/ExtendableFileTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/ExtendableFileTransferAgent.java
@@ -1,0 +1,146 @@
+package org.dcache.srm.shell;
+
+import com.google.common.collect.ImmutableMap;
+import eu.emi.security.authn.x509.X509Credential;
+import org.apache.axis.types.URI;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+
+/**
+ * A FileTransferAgent that delegates the actual activity to some other
+ * FileTransferAgent based on Java SPI.  This class also supports the
+ * MultiProtocolFileTransfer interface by injecting itself as the
+ * FileTransferAgent the transfer should use.
+ */
+public class ExtendableFileTransferAgent implements FileTransferAgent, CredentialAware
+{
+    private final ServiceLoader<FileTransferAgent> agents =
+            ServiceLoader.load(FileTransferAgent.class);
+
+    private ImmutableMap<String,FileTransferAgent> _protocolAgent;
+    private ImmutableMap<String,Integer> _protocolPriority;
+    private X509Credential _credential;
+
+    @Override
+    public void setCredential(X509Credential credential)
+    {
+        _credential = credential;
+    }
+
+    @Override
+    public String getTransportName()
+    {
+        return "multi-protocol";
+    }
+
+    @Override
+    public Map<String,String> getOptions()
+    {
+        Map<String,String> options = new HashMap<>();
+
+        for (FileTransferAgent agent : agents) {
+            String name = agent.getTransportName();
+
+            if (name != null) {
+                for (Map.Entry<String,String> e : agent.getOptions().entrySet()) {
+                    options.put(name+"."+e.getKey(), e.getValue());
+                }
+            }
+        }
+
+        return options;
+    }
+
+    @Override
+    public void setOption(String key, String value)
+    {
+        int index = key.indexOf('.');
+        if (index == -1 || index == 0 || index == key.length()-1) {
+            throw new IllegalArgumentException("Unknown key: " + key);
+        }
+
+        String transport = key.substring(0, index);
+
+        for (FileTransferAgent agent : agents) {
+            if (transport.equals(agent.getTransportName())) {
+                agent.setOption(key.substring(index+1), value);
+                return;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown key: " + key);
+    }
+
+    @Override
+    public void start()
+    {
+        for (FileTransferAgent agent : agents) {
+            if (agent instanceof CredentialAware) {
+                ((CredentialAware)agent).setCredential(_credential);
+            }
+
+            agent.start();
+        }
+
+        buildProtocols();
+    }
+
+    private void buildProtocols()
+    {
+        Map<String,FileTransferAgent> protocolAgent = new HashMap<>();
+        Map<String,Integer> protocolPriority = new HashMap<>();
+
+        for (FileTransferAgent agent : agents) {
+            for (Map.Entry<String,Integer> e : agent.getSupportedProtocols().entrySet()) {
+                String protocol = e.getKey();
+                int priority = e.getValue();
+                Integer existing = protocolPriority.get(protocol);
+                if (existing == null || existing < priority) {
+                    protocolPriority.put(protocol, priority);
+                    protocolAgent.put(protocol, agent);
+                }
+            }
+        }
+
+        _protocolAgent = ImmutableMap.copyOf(protocolAgent);
+        _protocolPriority = ImmutableMap.copyOf(protocolPriority);
+    }
+
+    @Override
+    public FileTransfer download(URI source, File destination)
+    {
+        FileTransferAgent agent = _protocolAgent.get(source.getScheme());
+        if (agent == null) {
+            throw new IllegalArgumentException("Scheme " + source.getScheme() + " not supported.");
+        }
+        return agent.download(source, destination);
+    }
+
+    @Override
+    public FileTransfer upload(File source, URI destination)
+    {
+        FileTransferAgent agent = _protocolAgent.get(destination.getScheme());
+        if (agent == null) {
+            throw new IllegalArgumentException("Scheme " + destination.getScheme() + " not supported.");
+        }
+        return agent.upload(source, destination);
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        for (FileTransferAgent agent : agents) {
+            agent.close();
+        }
+    }
+
+    @Override
+    public Map<String,Integer> getSupportedProtocols()
+    {
+        return _protocolPriority;
+    }
+}

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/FileTransfer.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/FileTransfer.java
@@ -1,0 +1,13 @@
+package org.dcache.srm.shell;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+
+/**
+ * A class that implements FileTransfer acts as a facade for a specific
+ * file transfer.
+ */
+public interface FileTransfer extends ListenableFuture<Void>
+{
+    String getStatus();
+}

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/FileTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/FileTransferAgent.java
@@ -1,0 +1,62 @@
+package org.dcache.srm.shell;
+
+import org.apache.axis.types.URI;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * A concrete class that implements FileTransferAgent organises the
+ * transfer of a file between some URL and some local file.
+ */
+public interface FileTransferAgent extends AutoCloseable
+{
+    /**
+     * Called precisely once, before download, upload or
+     * getSupportedProtocols.
+     */
+    void start();
+
+    /**
+     * A name for this transport.  The value should be lower-case and unique
+     * in the set of transports.  Return null if this FileTransferAgent should
+     * not be exposed to the end user.
+     */
+    String getTransportName();
+
+    /**
+     * The options that may be configured and their current values.
+     */
+    @Nonnull
+    Map<String,String> getOptions();
+
+    /**
+     * Alter an option.
+     */
+    void setOption(String key, String value);
+
+    /**
+     * Download a file to a locally-attached storage medium
+     * (e.g., harddisk) from some remote location.
+     * @return the facade for this transfer or null if the URI cannot be handled
+     * by this agent.
+     */
+    FileTransfer download(URI source, File destination);
+
+    /**
+     * Upload a file from a locally-attached storage medium
+     * (e.g., harddisk) to some remote location.
+     * @return the facade for this transfer or null if the URI cannot be handled
+     * by this agent.
+     */
+    FileTransfer upload(File source, URI destination);
+
+    /**
+     * Provide a list of transfer protocols with corresponding priority.
+     * The higher the integer value, the greater the priority with which the
+     * protocol should be selected.
+     */
+    Map<String,Integer> getSupportedProtocols();
+}

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/GridFTPTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/GridFTPTransferAgent.java
@@ -1,0 +1,623 @@
+package org.dcache.srm.shell;
+
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import eu.emi.security.authn.x509.CrlCheckingMode;
+import eu.emi.security.authn.x509.NamespaceCheckingMode;
+import eu.emi.security.authn.x509.OCSPCheckingMode;
+import eu.emi.security.authn.x509.X509Credential;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.axis.types.URI;
+
+import org.dcache.ftp.client.Buffer;
+import org.dcache.ftp.client.ChecksumAlgorithm;
+import org.dcache.ftp.client.DataChannelAuthentication;
+import org.dcache.ftp.client.DataSinkStream;
+import org.dcache.ftp.client.DataSourceStream;
+import org.dcache.ftp.client.GridFTPClient;
+import org.dcache.ftp.client.GridFTPSession;
+import org.dcache.ftp.client.RetrieveOptions;
+import org.dcache.ftp.client.exception.ClientException;
+import org.dcache.ftp.client.exception.ServerException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.text.NumberFormat;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.dcache.dss.ClientGsiEngineDssContextFactory;
+import org.dcache.ssl.CanlContextFactory;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+
+/**
+ * A FileTransferAgent that supports the {@literal gsiftp} protocol.
+ */
+public class GridFTPTransferAgent extends AbstractFileTransferAgent implements CredentialAware
+{
+    private static final int MAX_CONCURRENT_TRANSFERS = 10;
+    private static final ChecksumAlgorithm ADLER32 = new ChecksumAlgorithm("ADLER32");
+
+    private final ExecutorService _executor = Executors.newFixedThreadPool(MAX_CONCURRENT_TRANSFERS);
+
+    private Entity _dataInitiator = Entity.CLIENT;
+    private TransferMode _transferMode = TransferMode.STREAM;
+    private ChecksumMode _checksumHandling = ChecksumMode.IF_AVAILABLE;
+    private X509Credential _credential;
+    private String _caPath = "/etc/grid-security/certificates";
+    private CrlCheckingMode _crlChecking = CrlCheckingMode.IF_VALID;
+    private NamespaceCheckingMode _namespace = NamespaceCheckingMode.EUGRIDPMA_GLOBUS;
+    private OCSPCheckingMode _ocsp = OCSPCheckingMode.IF_AVAILABLE;
+    private CanlContextFactory _sslContextFactory;
+    private ClientGsiEngineDssContextFactory _dssContextFactory;
+
+    enum TransferMode {
+        EMODE, STREAM;
+    }
+
+    enum Entity {
+        CLIENT, SERVER;
+    }
+
+    enum ChecksumMode {
+        IF_AVAILABLE, REQUIRE, IGNORE;
+    }
+
+    private void updateCanlContextFactory()
+    {
+        _sslContextFactory = CanlContextFactory.custom()
+                .withCertificateAuthorityPath(_caPath)
+                .withCrlCheckingMode(_crlChecking)
+                .withNamespaceMode(_namespace)
+                .withOcspCheckingMode(_ocsp)
+                .withLazy(true)
+                .build();
+        updateDssContextFactory();
+    }
+
+    private void updateDssContextFactory()
+    {
+        _dssContextFactory = new ClientGsiEngineDssContextFactory(_sslContextFactory,
+                _credential, new String[0], true, true);
+    }
+
+    @Override
+    public void setCredential(X509Credential credential)
+    {
+        _credential = credential;
+    }
+
+    @Override
+    public String getTransportName()
+    {
+        return "gridftp";
+    }
+
+    @Override
+    public Map<String,String> getOptions()
+    {
+        ImmutableMap.Builder<String,String> builder = ImmutableMap.builder();
+
+        builder.put("data.connection-initiator", _dataInitiator.name());
+        builder.put("data.mode", _transferMode.name());
+        builder.put("checksum-verification", _checksumHandling.name());
+        builder.put("security.ca-path", _caPath);
+        builder.put("security.crl-checking", _crlChecking.name());
+        builder.put("security.OCSP", _ocsp.name());
+        builder.put("security.ca-namespace", _namespace.name());
+
+        return builder.build();
+    }
+
+    @Override
+    public void setOption(String key, String value)
+    {
+        switch (key) {
+        case "data.connection-initiator":
+            _dataInitiator = Entity.valueOf(value);
+            break;
+
+        case "data.mode":
+            _transferMode = TransferMode.valueOf(value);
+            break;
+
+        case "checksum-verification":
+            _checksumHandling = ChecksumMode.valueOf(value);
+            break;
+
+        case "security.ca-path":
+            File path = new File(value);
+            checkArgument(path.isAbsolute(), "Absolute path required");
+            checkArgument(path.isDirectory(), "Path is not a directory");
+            try {
+                _caPath = path.getCanonicalPath();
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Unable to set path: " + e.getMessage());
+            }
+            updateCanlContextFactory();
+            break;
+
+        case "security.crl-checking":
+            _crlChecking = CrlCheckingMode.valueOf(value);
+            updateCanlContextFactory();
+            break;
+
+        case "security.OCSP":
+            _ocsp = OCSPCheckingMode.valueOf(value);
+            updateCanlContextFactory();
+            break;
+
+        case "security.ca-namespace":
+            _namespace = NamespaceCheckingMode.valueOf(value);
+            updateCanlContextFactory();
+            break;
+
+        default:
+            throw new IllegalArgumentException("No such option \"" + key + "\"");
+        }
+    }
+
+    @Override
+    public void start()
+    {
+        updateCanlContextFactory();
+    }
+
+    @Override
+    public void close()
+    {
+        MoreExecutors.shutdownAndAwaitTermination(_executor, 500, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public Map<String,Integer> getSupportedProtocols()
+    {
+        return Collections.singletonMap("gsiftp", 100);
+    }
+
+    @Override
+    public FileTransfer download(URI source, File destination)
+    {
+        if (source.getScheme().equals("gsiftp")) {
+            GridFTPDownload transfer = new GridFTPDownload(source, destination);
+            transfer.start();
+            return transfer;
+        }
+
+        return null;
+    }
+
+    @Override
+    public FileTransfer upload(File source, URI destination)
+    {
+        if (destination.getScheme().equals("gsiftp")) {
+            GridFTPUpload transfer = new GridFTPUpload(source, destination);
+            transfer.start();
+            return transfer;
+        }
+
+        return null;
+    }
+
+    private abstract class GridFTPTransfer extends AbstractFileTransfer
+    {
+        private final Entity dataInitiator = GridFTPTransferAgent.this._dataInitiator;
+        private final TransferMode transferMode = GridFTPTransferAgent.this._transferMode;
+        private final ChecksumMode checksumHandling = GridFTPTransferAgent.this._checksumHandling;
+
+        private final URI _remote;
+        private final File _localFile;
+
+        private long _bytesTransferred;
+        private long _size;
+        protected GridFTPClient _client;
+        protected volatile String _status;
+
+        GridFTPTransfer(URI remote, File localFile)
+        {
+            _remote = remote;
+            _localFile = localFile;
+
+            Futures.addCallback(this, new FutureCallback(){
+                @Override
+                public void onSuccess(Object result)
+                {
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    if (t instanceof CancellationException) {
+                        onCancel();
+                    }
+                }
+            });
+
+        }
+
+        protected void onCancel()
+        {
+            try {
+                if (_client != null) {
+                    _client.abort();
+                }
+                _status = "cancelled";
+            } catch (IOException | ServerException e) {
+                _status = "cancel failed [" + e.toString() + "]";
+            }
+        }
+
+        @Override
+        public String getStatus()
+        {
+            return _status;
+        }
+
+        protected void incrementBytesTransferred(int increment)
+        {
+            _bytesTransferred += increment;
+        }
+
+        protected long getBytesTransferred()
+        {
+            return _bytesTransferred;
+        }
+
+        protected URI getRemote()
+        {
+            return _remote;
+        }
+
+        protected ChecksumMode getChecksumHandling()
+        {
+            return checksumHandling;
+        }
+
+        private int getPort()
+        {
+            int port = _remote.getPort();
+            return port == -1 ? 2811 : port;
+        }
+
+        protected String getRemotePath()
+        {
+            return _remote.getPath();
+        }
+
+        protected File getLocalFile()
+        {
+            return _localFile;
+        }
+
+        protected void setTargetSize(long size)
+        {
+            _size = size;
+        }
+
+        protected long getTargetSize()
+        {
+            return _size;
+        }
+
+        protected String percent()
+        {
+            return NumberFormat.getPercentInstance().format(((double)_bytesTransferred)/_size);
+        }
+
+        protected boolean isPassive()
+        {
+            return transferMode == TransferMode.STREAM && dataInitiator == Entity.CLIENT;
+        }
+
+        protected GridFTPClient buildClient() throws IOException, ServerException, ClientException
+        {
+            GridFTPClient client = new GridFTPClient(_remote.getHost(), getPort());
+            client.setUsageInformation("srmfs", "0.0.1");
+            client.setType(GridFTPSession.TYPE_IMAGE);
+            client.authenticate(_dssContextFactory);
+
+            if (client.isFeatureSupported("DCAU")) {
+                client.setDataChannelAuthentication(DataChannelAuthentication.NONE);
+            }
+
+            client.setLocalNoDataChannelAuthentication();
+
+            if (transferMode == TransferMode.EMODE) {
+                client.setMode(GridFTPSession.MODE_EBLOCK);
+                client.setOptions(new RetrieveOptions(1));
+            } else {
+                client.setMode(GridFTPSession.MODE_STREAM);
+
+                if (!client.isFeatureSupported("GETPUT")) {
+                    switch (dataInitiator) {
+                    case CLIENT:
+                        client.setPassive();
+                        client.setLocalActive();
+                        break;
+                    case SERVER:
+                        client.setLocalPassive();
+                        client.setActive();
+                        break;
+                    }
+                }
+            }
+
+            return client;
+        }
+
+        protected void start()
+        {
+            _executor.submit(new Runnable(){
+                @Override
+                public void run()
+                {
+                    try {
+                        _status = "Connecting to FTP server.";
+                        _client = buildClient();
+
+                        doTransfer();
+
+                        _status = "Succeeded.";
+                        succeeded();
+                    } catch (IOException e) {
+                        Throwable cause = Throwables.getRootCause(e);
+                        _status = "Transfer failed: " + cause.getMessage();
+                        failed(cause);
+                    } catch (ServerException e) {
+                        Throwable cause = Throwables.getRootCause(e);
+                        _status = "Transfer failed (server exception): " + cause.getMessage();
+                        failed(cause);
+                    } catch (ClientException e) {
+                        Throwable cause = Throwables.getRootCause(e);
+                        _status = "Transfer failed (client exception): " + cause.getMessage();
+                        failed(cause);
+                    } finally {
+                        try {
+                            _client.close();
+                        } catch (IOException|ServerException e) {
+                            //FIXME: we ignore errors sent back when saying BYE.
+                        }
+                    }
+                }
+            });
+        }
+
+        protected String getRemoteChecksum() throws IOException
+        {
+            switch (getChecksumHandling()) {
+            case REQUIRE:
+                try {
+                    return _client.checksum(ADLER32, 0, -1, getRemotePath());
+                } catch (IOException | ServerException e) {
+                    throw new IOException("Unable to fetch remote checksum: " + e.getMessage());
+                }
+
+            case IGNORE:
+                return null;
+
+            case IF_AVAILABLE:
+                try {
+                    return _client.checksum(ADLER32, 0, -1, getRemotePath());
+                } catch (IOException | ServerException e) {
+                    return null;
+                }
+
+            default:
+                throw new RuntimeException("No further options");
+            }
+        }
+
+
+        protected abstract void doTransfer() throws IOException, ClientException, ServerException;
+    }
+
+    /**
+     * Represents a file being uploaded via GridFTP.
+     */
+    private class GridFTPUpload extends GridFTPTransfer
+    {
+        public GridFTPUpload(File source, URI destination)
+        {
+            super(destination, source);
+            setTargetSize(getLocalFile().length());
+        }
+
+        @Override
+        protected void doTransfer() throws IOException, ClientException, ServerException
+        {
+            _status = "Preparing for upload.";
+            MonitoringFileDataSource source = new MonitoringFileDataSource();
+
+            if (_client.isFeatureSupported("GETPUT")) {
+                _client.put2(getRemotePath(), isPassive(), source, null);
+            } else {
+                _client.put(getRemotePath(), source, null);
+            }
+
+            String localChecksum = source.getHash();
+            String remoteChecksum = getRemoteChecksum();
+
+            if (remoteChecksum != null && !localChecksum.equals(remoteChecksum)) {
+                throw new IOException("checksum mismatch: " + remoteChecksum + " != " + localChecksum);
+            }
+        }
+
+        @Override
+        protected void incrementBytesTransferred(int count)
+        {
+            super.incrementBytesTransferred(count);
+            _status = "Sent " + percent() + " of " + getTargetSize() + " bytes.";
+        }
+
+        private class MonitoringFileDataSource extends DataSourceStream
+        {
+            private final Hasher hasher;
+            private HashCode hashcode;
+
+            MonitoringFileDataSource() throws FileNotFoundException
+            {
+                super(new FileInputStream(getLocalFile()));
+                switch (GridFTPUpload.this.getChecksumHandling()) {
+                case IF_AVAILABLE:
+                case REQUIRE:
+                    hasher = Hashing.adler32().newHasher();
+                    break;
+                case IGNORE:
+                    hasher = null;
+                    break;
+                default:
+                    throw new RuntimeException("Unknown ChecksumHandling");
+                }
+            }
+
+            @Override
+            public Buffer read() throws IOException
+            {
+                Buffer buffer = super.read();
+                if (buffer != null) {
+                    incrementBytesTransferred(buffer.getLength());
+
+                    if (hasher != null) {
+                        hasher.putBytes(buffer.getBuffer(), 0, buffer.getLength());
+                    }
+                }
+                return buffer;
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                if (hashcode != null) {
+                    throw new IllegalStateException("Attempt to close already closed DataSource");
+                }
+                if (hasher != null) {
+                    hashcode = hasher.hash();
+                }
+                super.close();
+            }
+
+            public String getHash()
+            {
+                if (hashcode == null) {
+                    return null;
+                }
+
+                // We cannot use HashCode#toString as that returns a little-endian hex string.
+                int nibbles = hashcode.bits() >> 3;
+                return Strings.padStart(Integer.toHexString(hashcode.asInt()), nibbles, '0');
+            }
+        }
+    }
+
+    /**
+     * Represents downloading a file via GridFTP.
+     */
+    private class GridFTPDownload extends GridFTPTransfer
+    {
+        public GridFTPDownload(URI source, File destination)
+        {
+            super(source, destination);
+        }
+
+        @Override
+        protected void doTransfer() throws IOException, ServerException, ClientException
+        {
+            _status = "Querying file size.";
+            setTargetSize(_client.getSize(getRemotePath()));
+
+            _status = "Preparing for download.";
+            MonitoringFileDataSink sink = new MonitoringFileDataSink();
+            if (_client.isFeatureSupported("GETPUT")) {
+                _client.get2(getRemotePath(), isPassive(), sink, null);
+            } else {
+                _client.get(getRemotePath(), sink, null);
+            }
+
+            String localChecksum = sink.getHash();
+            String remoteChecksum = getRemoteChecksum();
+
+            if (remoteChecksum != null && !remoteChecksum.equals(localChecksum)) {
+                throw new IOException("checksum mismatch: " + remoteChecksum + " != " + localChecksum);
+            }
+        }
+
+        @Override
+        protected void incrementBytesTransferred(int count)
+        {
+            super.incrementBytesTransferred(count);
+            _status = "Recieved " + percent() + " of " + getTargetSize() + " bytes.";
+        }
+
+        private class MonitoringFileDataSink extends DataSinkStream
+        {
+            private final Hasher hasher;
+            private HashCode hashcode;
+
+            MonitoringFileDataSink() throws FileNotFoundException
+            {
+                super(new FileOutputStream(getLocalFile()));
+
+                switch (GridFTPDownload.this.getChecksumHandling()) {
+                case IF_AVAILABLE:
+                case REQUIRE:
+                    hasher = Hashing.adler32().newHasher();
+                    break;
+                case IGNORE:
+                    hasher = null;
+                    break;
+                default:
+                    throw new RuntimeException("Unknown ChecksumHandling");
+                }
+            }
+
+            @Override
+            public void write(Buffer out) throws IOException
+            {
+                if (hasher != null) {
+                    hasher.putBytes(out.getBuffer(), 0, out.getLength());
+                }
+                incrementBytesTransferred(out.getLength());
+                super.write(out);
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                if (hashcode != null) {
+                    throw new IllegalStateException("Attempt to close already closed DataSink");
+                }
+                if (hasher != null) {
+                    hashcode = hasher.hash();
+                }
+                super.close();
+            }
+
+            public String getHash()
+            {
+                if (hashcode == null) {
+                    return null;
+                }
+
+                // We cannot use HashCode#toString as that returns a little-endian hex string.
+                int nibbles = hashcode.bits() >> 3;
+                return Strings.padStart(Integer.toHexString(hashcode.asInt()), nibbles, '0');
+            }
+        }
+    }
+}

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmFileSystem.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmFileSystem.java
@@ -18,12 +18,15 @@
 package org.dcache.srm.shell;
 
 import org.apache.axis.types.URI;
+import org.ietf.jgss.GSSCredential;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import java.io.File;
 import java.rmi.RemoteException;
+import java.util.Map;
 
 import org.dcache.srm.SRMException;
 import org.dcache.srm.v2_2.SrmPingResponse;
@@ -36,10 +39,15 @@ import org.dcache.srm.v2_2.TPermissionReturn;
 import org.dcache.srm.v2_2.TRetentionPolicy;
 import org.dcache.srm.v2_2.TSURLPermissionReturn;
 import org.dcache.srm.v2_2.TSupportedTransferProtocol;
+import eu.emi.security.authn.x509.X509Credential;
 
 @ParametersAreNonnullByDefault
-public interface SrmFileSystem
+public interface SrmFileSystem extends AutoCloseable
 {
+    void start();
+
+    void setCredential(X509Credential credential);
+
     @Nonnull
     TMetaDataPathDetail stat(URI surl) throws RemoteException, SRMException;
 
@@ -88,4 +96,15 @@ public interface SrmFileSystem
 
     @Nonnull
     TMetaDataSpace getSpaceMetaData(String spaceTokens) throws RemoteException, SRMException;
+
+    @Nullable
+    FileTransfer get(URI surl, File target);
+
+    @Nullable
+    FileTransfer put(File source, URI surl);
+
+    @Nonnull
+    Map<String,String> getTransportOptions();
+
+    void setTransportOption(String key, String value);
 }

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmTransferAgent.java
@@ -1,0 +1,776 @@
+package org.dcache.srm.shell;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Ordering;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.axis.types.URI;
+import org.apache.axis.types.UnsignedLong;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.rmi.RemoteException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.dcache.srm.SRMException;
+import org.dcache.srm.v2_2.ArrayOfAnyURI;
+import org.dcache.srm.v2_2.ArrayOfString;
+import org.dcache.srm.v2_2.ArrayOfTGetFileRequest;
+import org.dcache.srm.v2_2.ArrayOfTGetRequestFileStatus;
+import org.dcache.srm.v2_2.ArrayOfTPutFileRequest;
+import org.dcache.srm.v2_2.ArrayOfTPutRequestFileStatus;
+import org.dcache.srm.v2_2.ArrayOfTSURLReturnStatus;
+import org.dcache.srm.v2_2.ISRM;
+import org.dcache.srm.v2_2.SrmAbortRequestRequest;
+import org.dcache.srm.v2_2.SrmAbortRequestResponse;
+import org.dcache.srm.v2_2.SrmPrepareToGetRequest;
+import org.dcache.srm.v2_2.SrmPrepareToGetResponse;
+import org.dcache.srm.v2_2.SrmPrepareToPutRequest;
+import org.dcache.srm.v2_2.SrmPrepareToPutResponse;
+import org.dcache.srm.v2_2.SrmPutDoneRequest;
+import org.dcache.srm.v2_2.SrmPutDoneResponse;
+import org.dcache.srm.v2_2.SrmReleaseFilesRequest;
+import org.dcache.srm.v2_2.SrmReleaseFilesResponse;
+import org.dcache.srm.v2_2.SrmStatusOfGetRequestRequest;
+import org.dcache.srm.v2_2.SrmStatusOfGetRequestResponse;
+import org.dcache.srm.v2_2.SrmStatusOfPutRequestRequest;
+import org.dcache.srm.v2_2.SrmStatusOfPutRequestResponse;
+import org.dcache.srm.v2_2.TAccessLatency;
+import org.dcache.srm.v2_2.TAccessPattern;
+import org.dcache.srm.v2_2.TConnectionType;
+import org.dcache.srm.v2_2.TDirOption;
+import org.dcache.srm.v2_2.TGetFileRequest;
+import org.dcache.srm.v2_2.TGetRequestFileStatus;
+import org.dcache.srm.v2_2.TOverwriteMode;
+import org.dcache.srm.v2_2.TPutFileRequest;
+import org.dcache.srm.v2_2.TPutRequestFileStatus;
+import org.dcache.srm.v2_2.TRetentionPolicy;
+import org.dcache.srm.v2_2.TRetentionPolicyInfo;
+import org.dcache.srm.v2_2.TSURLReturnStatus;
+import org.dcache.srm.v2_2.TStatusCode;
+import org.dcache.srm.v2_2.TTransferParameters;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static org.dcache.srm.shell.TStatusCodes.checkSuccess;
+
+/**
+ *  Support for transferring a file using SRM.
+ */
+public class SrmTransferAgent extends AbstractFileTransferAgent
+{
+    private final ScheduledExecutorService _srmExecutor = Executors.newSingleThreadScheduledExecutor();
+
+    private ISRM srm;
+    private FileTransferAgent agent;
+    private ImmutableList<String> protocols;
+
+    public void setSrm(ISRM srm)
+    {
+        this.srm = checkNotNull(srm);
+    }
+
+    public void setFileTransferAgent(FileTransferAgent agent)
+    {
+        this.agent = checkNotNull(agent);
+    }
+
+    @Nonnull
+    @Override
+    public Map<String,String> getOptions()
+    {
+        return agent.getOptions();
+    }
+
+    /**
+     * Alter an option.
+     */
+    @Override
+    public void setOption(String key, String value)
+    {
+        agent.setOption(key, value);
+    }
+
+
+    protected synchronized ImmutableList<String> getProtocolPreference()
+    {
+        if (protocols == null) {
+            protocols = buildProtocolPreference(agent);
+        }
+
+        return protocols;
+    }
+
+    private static ImmutableList<String> buildProtocolPreference(FileTransferAgent agent)
+    {
+        Ordering<Map.Entry<String,Integer>> order = Ordering.natural().
+                onResultOf(new Function<Map.Entry<String,Integer>, Integer>(){
+                    @Override
+                    public Integer apply(Map.Entry<String,Integer> input)
+                    {
+                        return input.getValue();
+                    }
+                }).reverse();
+
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+
+        for (Map.Entry<String,Integer> entry : order.sortedCopy(agent.getSupportedProtocols().entrySet())) {
+            builder.add(entry.getKey());
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void close()
+    {
+        MoreExecutors.shutdownAndAwaitTermination(_srmExecutor, 500, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public FileTransfer download(URI source, File destination)
+    {
+        if (source.getScheme().equals("srm")) {
+            GetTransfer transfer = new GetTransfer(source, destination);
+            transfer.start();
+            return transfer;
+        }
+
+        return null;
+    }
+
+    @Override
+    public FileTransfer upload(File source, URI destination)
+    {
+        if (destination.getScheme().equals("srm")) {
+            PutTransfer transfer = new PutTransfer(source, destination);
+            transfer.start();
+            return transfer;
+        }
+
+        return null;
+    }
+
+    @Override
+    public String getTransportName()
+    {
+        return "srm";
+    }
+
+    /**
+     * Base class for uploads and downloads.
+     */
+    abstract private class AbstractSRMTransfer extends AbstractFileTransfer
+    {
+        private final URI _surl;
+        private final File _localFile;
+
+        protected String _description = "awaiting initiation";
+        private String _token;
+        private FileTransfer _transfer;
+
+        AbstractSRMTransfer(URI surl, File localFile)
+        {
+            _surl = surl;
+            _localFile = localFile;
+
+            Futures.addCallback(this, new FutureCallback(){
+                @Override
+                public void onSuccess(Object result)
+                {
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    if (t instanceof CancellationException) {
+                        onCancel();
+                    }
+                }
+            });
+        }
+
+        private void onCancel()
+        {
+            FileTransfer transfer = getTransfer();
+            if (transfer != null) {
+                transfer.cancel(true);
+            } else {
+                abortRequest();
+            }
+        }
+
+        @Override
+        public String getStatus()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.append(_surl).append(": ");
+
+            if (_transfer == null) {
+                sb.append(_description);
+            } else {
+                sb.append(_transfer.getStatus());
+            }
+
+            return sb.toString();
+        }
+
+        public ArrayOfString getProtocolPreference()
+        {
+            ImmutableList<String> protocols = SrmTransferAgent.this.getProtocolPreference();
+            return new ArrayOfString(protocols.toArray(new String[protocols.size()]));
+        }
+
+        public void setTransfer(FileTransfer transfer)
+        {
+            _transfer = transfer;
+        }
+
+        public FileTransfer getTransfer()
+        {
+            return _transfer;
+        }
+
+        protected void setRequestToken(String token)
+        {
+            _token = token;
+        }
+
+        public String getRequestToken()
+        {
+            return _token;
+        }
+
+        public URI getSurl()
+        {
+            return _surl;
+        }
+
+        public File getLocalFile()
+        {
+            return _localFile;
+        }
+
+        public void setDescription(String description)
+        {
+            _description = description;
+        }
+
+        protected void fail(RemoteException e)
+        {
+            setDescription("Problem contacting remote server : " + e.toString());
+        }
+
+        protected void fail(SRMException e)
+        {
+            setDescription(e.getMessage() == null ? "Unspecified problem" : e.getMessage());
+        }
+
+        protected void abortRequest()
+        {
+            String token = getRequestToken();
+            if (token != null) {
+                try {
+                    SrmAbortRequestRequest request = new SrmAbortRequestRequest(token, null);
+                    SrmAbortRequestResponse response = srm.srmAbortRequest(request);
+                    checkSuccess(response.getReturnStatus(), TStatusCode.SRM_SUCCESS);
+                } catch (RemoteException e) {
+                    setDescription(_description + ", failed to abort request: " +
+                            e.getMessage());
+                } catch (SRMException e) {
+                    setDescription(_description + ", failed to abort request: " +
+                            "[" + e.getStatusCode() + "] " + e.getMessage());
+                }
+            }
+        }
+
+        class FailOnBugTask implements Runnable
+        {
+            private final Runnable _inner;
+
+            FailOnBugTask(Runnable inner)
+            {
+                _inner = inner;
+            }
+
+            @Override
+            public void run()
+            {
+                try {
+                    _inner.run();
+                } catch (RuntimeException e) {
+                    setDescription("bug detected: " + e.toString());
+                    e.printStackTrace();
+                }
+            }
+        }
+
+
+    }
+
+    /**
+     * Class for handling downloads specifically.
+     */
+    public class PutTransfer extends AbstractSRMTransfer
+    {
+        public PutTransfer(File source, URI target)
+        {
+            super(target, source);
+        }
+
+        private void start()
+        {
+            _srmExecutor.execute(new FailOnBugTask(new Runnable(){
+                @Override
+                public void run()
+                {
+                    prepareToPut();
+                }
+            }));
+        }
+
+        private void prepareToPut()
+        {
+            setDescription("requesting transfer URL.");
+
+            ArrayOfTPutFileRequest fileRequests = new ArrayOfTPutFileRequest(new TPutFileRequest[]{
+                new TPutFileRequest(getSurl(), new UnsignedLong(getLocalFile().length())),
+            });
+            TTransferParameters params = new TTransferParameters(TAccessPattern.TRANSFER_MODE,
+                    TConnectionType.WAN, null, getProtocolPreference());
+
+            // FIXME: make target ALRP configurable
+            TRetentionPolicyInfo retention = new TRetentionPolicyInfo(TRetentionPolicy.REPLICA,
+                    TAccessLatency.ONLINE);
+
+            // FIXME: add user-description to allow rediscovery of ongoing requests
+            // FIXME: add overwrite option
+            // FIXME: add space-token option
+            SrmPrepareToPutRequest request = new SrmPrepareToPutRequest(
+                    null, fileRequests, null, TOverwriteMode.NEVER, null,
+                    (int)TimeUnit.DAYS.toSeconds(1), null, null, null, null,
+                    retention, params);
+
+            try {
+                SrmPrepareToPutResponse response = srm.srmPrepareToPut(request);
+                setRequestToken(response.getRequestToken());
+
+
+                TStatusCode requestStatus = response.getReturnStatus().getStatusCode();
+                if (requestStatus != TStatusCode.SRM_REQUEST_QUEUED &&
+                        requestStatus != TStatusCode.SRM_REQUEST_INPROGRESS &&
+                        requestStatus != TStatusCode.SRM_SUCCESS) {
+                    if (response.getArrayOfFileStatuses() != null) {
+                        TPutRequestFileStatus file = getFileStatus(response.getArrayOfFileStatuses());
+                        throw new SRMException(file.getStatus().getExplanation());
+                    } else {
+                        throw new SRMException(response.getReturnStatus().getExplanation());
+                    }
+                }
+
+                TPutRequestFileStatus file = getFileStatus(response.getArrayOfFileStatuses());
+
+                TStatusCode requestStatusCode = response.getReturnStatus().getStatusCode();
+
+                if (requestStatusCode == TStatusCode.SRM_REQUEST_QUEUED ||
+                        requestStatusCode == TStatusCode.SRM_REQUEST_INPROGRESS) {
+
+                    TStatusCode fileStatusCode = file.getStatus().getStatusCode();
+                    if (fileStatusCode != requestStatusCode) {
+                        throw new SRMException("mismatch between file and response status: " +
+                                fileStatusCode + " != " + requestStatusCode);
+                    }
+
+                    setDescription("waiting to request status update.");
+                    int delay = max(min(file.getEstimatedWaitTime(), 60), 1);
+                    _srmExecutor.schedule(new FailOnBugTask(new Runnable() {
+                        @Override
+                        public void run()
+                        {
+                            statusOfPrepareToPut();
+                        }
+                    }), delay, TimeUnit.SECONDS);
+                } else {
+                    checkSuccess(file.getStatus(), TStatusCode.SRM_SPACE_AVAILABLE);
+                    initiateTransfer(file.getTransferURL());
+                }
+            } catch (RemoteException e) {
+                fail(e);
+                abortRequest();
+                failed(e);
+            } catch (SRMException e) {
+                fail(e);
+                abortRequest();
+                failed(e);
+            }
+        }
+
+        private void statusOfPrepareToPut()
+        {
+            setDescription("request status update.");
+            SrmStatusOfPutRequestRequest request =
+                    new SrmStatusOfPutRequestRequest(getRequestToken(), null,
+                            new ArrayOfAnyURI(new URI[]{getSurl()}));
+            try {
+                SrmStatusOfPutRequestResponse response = srm.srmStatusOfPutRequest(request);
+
+                checkSuccess(response.getReturnStatus(), TStatusCode.SRM_REQUEST_QUEUED,
+                        TStatusCode.SRM_REQUEST_INPROGRESS, TStatusCode.SRM_SUCCESS);
+
+                TStatusCode requestStatusCode = response.getReturnStatus().getStatusCode();
+                TPutRequestFileStatus file = getFileStatus(response.getArrayOfFileStatuses());
+
+                if (requestStatusCode == TStatusCode.SRM_REQUEST_QUEUED ||
+                        requestStatusCode == TStatusCode.SRM_REQUEST_INPROGRESS) {
+                    TStatusCode fileStatusCode = file.getStatus().getStatusCode();
+                    if (fileStatusCode != requestStatusCode) {
+                        throw new SRMException("mismatch between file and response status: " +
+                                fileStatusCode + " != " + requestStatusCode);
+                    }
+
+                    setDescription("waiting to request status update.");
+
+                    int delay = Math.max(Math.min(file.getEstimatedWaitTime(), 60), 1);
+                    _srmExecutor.schedule(new FailOnBugTask(new Runnable() {
+                        @Override
+                        public void run()
+                        {
+                            statusOfPrepareToPut();
+                        }
+                    }), delay, TimeUnit.SECONDS);
+                } else {
+                    checkSuccess(file.getStatus(), TStatusCode.SRM_SPACE_AVAILABLE);
+                    initiateTransfer(file.getTransferURL());
+                }
+            } catch (RemoteException e) {
+                fail(e);
+                abortRequest();
+                failed(e);
+            } catch (SRMException e) {
+                fail(e);
+                abortRequest();
+                failed(e);
+            }
+        }
+
+        private void initiateTransfer(URI turl)
+        {
+            FileTransfer transfer = agent.upload(getLocalFile(), turl);
+
+            if (transfer == null) {
+                setDescription("unable to transfer from " + turl);
+                abortRequest();
+            } else {
+                setDescription("preparing for transfer using " + turl);
+                setTransfer(transfer);
+                Futures.addCallback(transfer, new FutureCallback<Void>(){
+                    @Override
+                    public void onSuccess(Void result)
+                    {
+                        setDescription("file transfer complete.");
+                        setTransfer(null);
+                        putDone();
+                        succeeded();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t)
+                    {
+                        setDescription(t.getMessage());
+                        setTransfer(null);
+                        abortRequest();
+                        failed(t);
+                    }
+                }, _srmExecutor);
+            }
+        }
+
+        private void putDone()
+        {
+            SrmPutDoneRequest request = new SrmPutDoneRequest(getRequestToken(),
+                    null, new ArrayOfAnyURI(new URI[]{getSurl()}));
+
+            try {
+                SrmPutDoneResponse response = srm.srmPutDone(request);
+                checkSuccess(response.getReturnStatus(), TStatusCode.SRM_SUCCESS);
+                TSURLReturnStatus status = getSURLStatus(response.getArrayOfFileStatuses());
+                checkSuccess(status.getStatus(), TStatusCode.SRM_SUCCESS);
+            } catch (RemoteException e) {
+                setDescription(_description + ", failed to release lock: " +
+                        e.getMessage());
+            } catch (SRMException e) {
+                setDescription(_description + ", failed to finalise upload: " +
+                        "[" + e.getStatusCode() + "] " + e.getMessage());
+            }
+        }
+
+        @Nonnull
+        private TPutRequestFileStatus getFileStatus(ArrayOfTPutRequestFileStatus container) throws SRMException
+        {
+            checkForFailure(container != null, "bad reply: null array-container of RequestFileStatus.");
+
+            TPutRequestFileStatus[] statusArray = container.getStatusArray();
+
+            checkForFailure(statusArray != null, "bad reply: null RequestFileStatus array.");
+
+            if (statusArray.length != 1) {
+                throw new SRMException("bad reply: RequestFileStatus array with length " + statusArray.length + ".");
+            }
+
+            TPutRequestFileStatus status = statusArray[0];
+
+            checkForFailure(status != null, "bad reply: RequestFileStatus array with null element.");
+
+            return status;
+        }
+
+        @Nonnull
+        private TSURLReturnStatus getSURLStatus(ArrayOfTSURLReturnStatus container) throws SRMException
+        {
+            checkForFailure(container != null, "bad reply: null array-container of SURLReturnStatus.");
+
+            TSURLReturnStatus[] statusArray = container.getStatusArray();
+
+            checkForFailure(statusArray != null, "bad reply: null SURLReturnStatus.");
+
+            if (statusArray.length != 1) {
+                throw new SRMException("bad reply: SURLReturnStatus array with length " + statusArray.length + ".");
+            }
+
+            TSURLReturnStatus status = statusArray[0];
+
+            checkForFailure(status != null, "bad reply: SURLReturnStatus array will null element");
+
+            return status;
+        }
+    }
+
+
+    /**
+     * Class for handling downloads specifically.
+     */
+    public class GetTransfer extends AbstractSRMTransfer
+    {
+        public GetTransfer(URI source, File target)
+        {
+            super(source, target);
+        }
+
+        private void start()
+        {
+            _srmExecutor.execute(new FailOnBugTask(new Runnable(){
+                @Override
+                public void run()
+                {
+                    prepareToGet();
+                }
+            }));
+        }
+
+        private void prepareToGet()
+        {
+            setDescription("requesting transfer URL.");
+
+            ArrayOfTGetFileRequest fileRequests = new ArrayOfTGetFileRequest(new TGetFileRequest[]{
+                new TGetFileRequest(getSurl(), new TDirOption(false, false, 0)),
+            });
+            TTransferParameters params = new TTransferParameters(TAccessPattern.TRANSFER_MODE,
+                    TConnectionType.WAN, null, getProtocolPreference());
+
+            // FIXME: add user-description to allow rediscovery of ongoing requests
+            SrmPrepareToGetRequest request = new SrmPrepareToGetRequest(
+                    null, fileRequests, null, null, null, (int)TimeUnit.DAYS.toSeconds(1), -1, null,
+                    null, params);
+
+            try {
+                SrmPrepareToGetResponse response = srm.srmPrepareToGet(request);
+                setRequestToken(response.getRequestToken());
+
+                checkSuccess(response.getReturnStatus(), TStatusCode.SRM_REQUEST_QUEUED,
+                        TStatusCode.SRM_REQUEST_INPROGRESS, TStatusCode.SRM_SUCCESS);
+
+                TGetRequestFileStatus file = getFileStatus(response.getArrayOfFileStatuses());
+
+                TStatusCode requestStatusCode = response.getReturnStatus().getStatusCode();
+
+                if (requestStatusCode == TStatusCode.SRM_REQUEST_QUEUED ||
+                        requestStatusCode == TStatusCode.SRM_REQUEST_INPROGRESS) {
+
+                    TStatusCode fileStatusCode = file.getStatus().getStatusCode();
+                    if (fileStatusCode != requestStatusCode) {
+                        throw new SRMException("mismatch between file and response status: " +
+                                fileStatusCode + " != " + requestStatusCode);
+                    }
+
+                    setDescription("waiting to request status update.");
+                    int delay = max(min(file.getEstimatedWaitTime(), 60), 1);
+                    _srmExecutor.schedule(new FailOnBugTask(new Runnable() {
+                        @Override
+                        public void run()
+                        {
+                            statusOfPrepareToGet();
+                        }
+                    }), delay, TimeUnit.SECONDS);
+                } else {
+                    checkSuccess(file.getStatus(), TStatusCode.SRM_FILE_PINNED);
+                    initiateTransfer(file.getTransferURL());
+                }
+            } catch (RemoteException e) {
+                fail(e);
+                releaseFiles();
+                failed(e);
+            } catch (SRMException e) {
+                fail(e);
+                releaseFiles();
+                failed(e);
+            }
+        }
+
+        @Nonnull
+        private TGetRequestFileStatus getFileStatus(ArrayOfTGetRequestFileStatus fileStatus) throws SRMException
+        {
+            checkForFailure(fileStatus != null, "bad reply: null array-container of RequestFileStatus.");
+
+            TGetRequestFileStatus[] statuses = fileStatus.getStatusArray();
+
+            checkForFailure(statuses != null, "bad reply: null RequestFileStatus array.");
+
+            if (statuses.length != 1) {
+                throw new SRMException("bad reply: RequestFileStatus array with length " + statuses.length + ".");
+            }
+
+            TGetRequestFileStatus status = statuses[0];
+
+            checkForFailure(status != null, "bad reply: RequestFileStatus array with null element.");
+
+            return status;
+        }
+
+        private void statusOfPrepareToGet()
+        {
+            setDescription("request status update.");
+            SrmStatusOfGetRequestRequest request =
+                    new SrmStatusOfGetRequestRequest(getRequestToken(), null,
+                            new ArrayOfAnyURI(new URI[]{getSurl()}));
+            try {
+                SrmStatusOfGetRequestResponse response = srm.srmStatusOfGetRequest(request);
+
+                checkSuccess(response.getReturnStatus(), TStatusCode.SRM_REQUEST_QUEUED,
+                        TStatusCode.SRM_REQUEST_INPROGRESS, TStatusCode.SRM_SUCCESS);
+
+                TStatusCode requestStatusCode = response.getReturnStatus().getStatusCode();
+                TGetRequestFileStatus file = getFileStatus(response.getArrayOfFileStatuses());
+
+                if (requestStatusCode == TStatusCode.SRM_REQUEST_QUEUED ||
+                        requestStatusCode == TStatusCode.SRM_REQUEST_INPROGRESS) {
+                    TStatusCode fileStatusCode = file.getStatus().getStatusCode();
+                    if (fileStatusCode != requestStatusCode) {
+                        throw new SRMException("mismatch between file and response status: " +
+                                fileStatusCode + " != " + requestStatusCode);
+                    }
+
+                    setDescription("waiting to request status update.");
+
+                    int delay = Math.max(Math.min(file.getEstimatedWaitTime(), 60), 1);
+                    _srmExecutor.schedule(new FailOnBugTask(new Runnable() {
+                        @Override
+                        public void run()
+                        {
+                            statusOfPrepareToGet();
+                        }
+                    }), delay, TimeUnit.SECONDS);
+                } else {
+                    checkSuccess(file.getStatus(), TStatusCode.SRM_FILE_PINNED);
+                    initiateTransfer(file.getTransferURL());
+                }
+            } catch (RemoteException e) {
+                fail(e);
+                releaseFiles();
+                failed(e);
+            } catch (SRMException e) {
+                fail(e);
+                releaseFiles();
+                failed(e);
+            }
+        }
+
+        private void initiateTransfer(URI turl)
+        {
+            FileTransfer transfer = agent.download(turl, getLocalFile());
+
+            if (transfer == null) {
+                setDescription("unable to transfer from " + turl);
+                releaseFiles();
+            } else {
+                setDescription("preparing for transfer using " + turl);
+                setTransfer(transfer);
+                Futures.addCallback(transfer, new FutureCallback<Void>(){
+                    @Override
+                    public void onSuccess(Void result)
+                    {
+                        setDescription("file transfer complete.");
+                        setTransfer(null);
+                        releaseFiles();
+                        succeeded();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t)
+                    {
+                        setDescription(t.getMessage());
+                        setTransfer(null);
+                        releaseFiles();
+                        failed(t);
+                    }
+                }, _srmExecutor);
+            }
+        }
+
+        private void releaseFiles()
+        {
+            if (getRequestToken() == null) {
+                return;
+            }
+
+            String transferDescription = _description;
+
+            String description = transferDescription;
+            if (description.endsWith(".")) {
+                description = description.substring(0, description.length()-1);
+            }
+            setDescription(description + ", finalising transfer");
+
+            SrmReleaseFilesRequest request = new SrmReleaseFilesRequest(getRequestToken(),
+                    null, new ArrayOfAnyURI(new URI[]{getSurl()}), false);
+
+            try {
+                SrmReleaseFilesResponse response = srm.srmReleaseFiles(request);
+                checkSuccess(response.getReturnStatus(), TStatusCode.SRM_SUCCESS);
+                setDescription(transferDescription);
+            } catch (SRMException e) {
+                setDescription(_description + " but failed to release lock: " +
+                        "[" + e.getStatusCode() + "] " + e.getMessage());
+            } catch (RemoteException e) {
+                setDescription(_description + " but failed to release lock: " +
+                        e.getMessage());
+            }
+        }
+    }
+
+    private void checkForFailure(boolean isOk, String message) throws SRMException
+    {
+        if (!isOk) {
+            throw new SRMException(message);
+        }
+    }
+}

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/TStatusCodes.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/TStatusCodes.java
@@ -1,0 +1,108 @@
+package org.dcache.srm.shell;
+
+import org.dcache.srm.SRMAbortedException;
+import org.dcache.srm.SRMAuthorizationException;
+import org.dcache.srm.SRMDuplicationException;
+import org.dcache.srm.SRMExceedAllocationException;
+import org.dcache.srm.SRMException;
+import org.dcache.srm.SRMFileUnvailableException;
+import org.dcache.srm.SRMInternalErrorException;
+import org.dcache.srm.SRMInvalidPathException;
+import org.dcache.srm.SRMInvalidRequestException;
+import org.dcache.srm.SRMNoFreeSpaceException;
+import org.dcache.srm.SRMNonEmptyDirectoryException;
+import org.dcache.srm.SRMNotSupportedException;
+import org.dcache.srm.SRMOtherException;
+import org.dcache.srm.SRMReleasedException;
+import org.dcache.srm.SRMRequestTimedOutException;
+import org.dcache.srm.SRMSpaceLifetimeExpiredException;
+import org.dcache.srm.SRMTooManyResultsException;
+import org.dcache.srm.v2_2.TReturnStatus;
+import org.dcache.srm.v2_2.TStatusCode;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Utility methods for TStatusCode class.
+ */
+public class TStatusCodes
+{
+    private TStatusCodes()
+    {
+        // Utility class: prevent initialisation
+    }
+
+    public static void checkSuccess(TReturnStatus returnStatus, TStatusCode... success) throws SRMException
+    {
+        TStatusCode statusCode = returnStatus.getStatusCode();
+        String explanation = returnStatus.getExplanation();
+        if (asList(success).contains(statusCode)) {
+            return;
+        }
+        if (statusCode == TStatusCode.SRM_FAILURE) {
+            throw new SRMException(explanation);
+        } else if (statusCode == TStatusCode.SRM_PARTIAL_SUCCESS) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_AUTHENTICATION_FAILURE) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_AUTHORIZATION_FAILURE) {
+            throw new SRMAuthorizationException(explanation);
+        } else if (statusCode == TStatusCode.SRM_INVALID_REQUEST) {
+            throw new SRMInvalidRequestException(explanation);
+        } else if (statusCode == TStatusCode.SRM_INVALID_PATH) {
+            throw new SRMInvalidPathException(explanation);
+        } else if (statusCode == TStatusCode.SRM_FILE_LIFETIME_EXPIRED) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_SPACE_LIFETIME_EXPIRED) {
+            throw new SRMSpaceLifetimeExpiredException(explanation);
+        } else if (statusCode == TStatusCode.SRM_EXCEED_ALLOCATION) {
+            throw new SRMExceedAllocationException(explanation);
+        } else if (statusCode == TStatusCode.SRM_NO_USER_SPACE) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_NO_FREE_SPACE) {
+            throw new SRMNoFreeSpaceException(explanation);
+        } else if (statusCode == TStatusCode.SRM_DUPLICATION_ERROR) {
+            throw new SRMDuplicationException(explanation);
+        } else if (statusCode == TStatusCode.SRM_NON_EMPTY_DIRECTORY) {
+            throw new SRMNonEmptyDirectoryException(explanation);
+        } else if (statusCode == TStatusCode.SRM_TOO_MANY_RESULTS) {
+            throw new SRMTooManyResultsException(explanation);
+        } else if (statusCode == TStatusCode.SRM_INTERNAL_ERROR) {
+            throw new SRMInternalErrorException(explanation);
+        } else if (statusCode == TStatusCode.SRM_FATAL_INTERNAL_ERROR) {
+            throw new SRMInternalErrorException(explanation);
+        } else if (statusCode == TStatusCode.SRM_NOT_SUPPORTED) {
+            throw new SRMNotSupportedException(explanation);
+        } else if (statusCode == TStatusCode.SRM_REQUEST_QUEUED) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_REQUEST_INPROGRESS) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_ABORTED) {
+            throw new SRMAbortedException(explanation);
+        } else if (statusCode == TStatusCode.SRM_RELEASED) {
+            throw new SRMReleasedException(explanation);
+        } else if (statusCode == TStatusCode.SRM_FILE_PINNED) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_FILE_IN_CACHE) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_SPACE_AVAILABLE) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_LOWER_SPACE_GRANTED) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_REQUEST_TIMED_OUT) {
+            throw new SRMRequestTimedOutException(explanation);
+        } else if (statusCode == TStatusCode.SRM_LAST_COPY) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_FILE_BUSY) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_FILE_LOST) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else if (statusCode == TStatusCode.SRM_FILE_UNAVAILABLE) {
+            throw new SRMFileUnvailableException(explanation);
+        } else if (statusCode == TStatusCode.SRM_CUSTOM_STATUS) {
+            throw new SRMOtherException(statusCode, explanation);
+        } else {
+            throw new SRMOtherException(statusCode, explanation);
+        }
+    }
+}

--- a/modules/srm-client/src/main/resources/META-INF/services/org.dcache.srm.shell.FileTransferAgent
+++ b/modules/srm-client/src/main/resources/META-INF/services/org.dcache.srm.shell.FileTransferAgent
@@ -1,0 +1,1 @@
+org.dcache.srm.shell.GridFTPTransferAgent


### PR DESCRIPTION
This patch adds the 'get' and 'put' commands to fetch and upload a
file.  This is achieved using several abstractions.

First, classes that support uploading and downloading data implement
the FileTransferAgent.  Currently this is limited to a class that
supports GridFTP transfers, but additional transports (such as
http/https) would be easy to add.

The ExtendableFileTransferAgent uses SPI to discover FileTransferAgent
classes and iterates over them until one them handles the request. It
is expected that at most one FileTransferAgent can handle a transfer
request, so the iteration order does not matter.

The necessary SRM interactions to conduct a transfer is also contained
within a FileTransferAgent, albeit one that needs access to the
ExtendableFileTransferAgent to do the actual transfer, once the TURL is
known.

File transfers are conducted in the background.  Commands are available
to query the current status, list known transfers and cancel a specific
transfer.  Completed transfers are listed separately and a command
exists to clear the completed transfers.

The patch also introduces the idea of notifications.  These are pending
messages that are shown when the current command completes, similar to
how other shells handle asynchronous notification.

The patch also supports setting transport-specific options.  Currently
this is only used by the GridFTP transfer agent.

Target: master
Request: 2.16
Require-notes: yes
Require-book: yes
Patch: https://rb.dcache.org/r/8302
Acked-by Gerd Behrmann