### PR TITLE
cells: Fix race in cell shutdown

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -938,14 +938,14 @@ public class CellNucleus implements ThreadFactory
         try {
             checkState(_state == State.NEW);
             _state = State.PRE_STARTUP;
-            _startup = _messageExecutor.submit(wrapLoggingContext(this::doStart), null);
+            _startup = _messageExecutor.submit(wrapLoggingContext(this::doStart));
         } finally {
             _lifeCycleMonitor.leave();
         }
         return Futures.nonCancellationPropagating(_startup);
     }
 
-    private void doStart()
+    private Void doStart() throws Exception
     {
         try {
             checkState(_state == State.PRE_STARTUP);
@@ -958,11 +958,11 @@ public class CellNucleus implements ThreadFactory
             _cell.postStartup(event);
             setState(State.RUNNING);
         } catch (Throwable e) {
-            Thread t = Thread.currentThread();
-            t.getUncaughtExceptionHandler().uncaughtException(t, e);
             setState(State.FAILED);
             __cellGlue.kill(CellNucleus.this);
+            throw e;
         }
+        return null;
     }
 
     void shutdown(KillEvent event)

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -1,7 +1,6 @@
 package dmg.cells.nucleus;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Monitor;
@@ -19,7 +18,6 @@ import javax.annotation.Nonnull;
 import java.io.FileNotFoundException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -27,9 +25,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
@@ -72,18 +67,26 @@ public class CellNucleus implements ThreadFactory
 
     private enum State
     {
-        NEW(INITIAL),
-        STARTING(ACTIVE),
-        RUNNING(ACTIVE),
-        FAILED(REMOVING),
-        STOPPING(REMOVING),
-        TERMINATED(DEAD);
+        NEW(INITIAL,         false),
+        PRE_STARTUP(ACTIVE,  true),
+        POST_STARTUP(ACTIVE, true),
+        RUNNING(ACTIVE,      false),
+        FAILED(REMOVING,     false),
+        STOPPING(REMOVING,   false),
+        TERMINATED(DEAD,     false);
 
+        /** State included in CellInfo. */
         int externalState;
 
-        State(int externalState)
+        /**
+         * Whether the cell is currently processing startup callbacks.
+         */
+        boolean isStarting;
+
+        State(int externalState, boolean isStarting)
         {
             this.externalState = externalState;
+            this.isStarting = isStarting;
         }
     }
 
@@ -140,7 +143,7 @@ public class CellNucleus implements ThreadFactory
         @Override
         public boolean isSatisfied()
         {
-            return _state != State.STARTING;
+            return !_state.isStarting;
         }
     };
 
@@ -934,8 +937,8 @@ public class CellNucleus implements ThreadFactory
         _lifeCycleMonitor.enter();
         try {
             checkState(_state == State.NEW);
+            _state = State.PRE_STARTUP;
             _startup = _messageExecutor.submit(wrapLoggingContext(this::doStart), null);
-            _state = State.STARTING;
         } finally {
             _lifeCycleMonitor.leave();
         }
@@ -945,13 +948,15 @@ public class CellNucleus implements ThreadFactory
     private void doStart()
     {
         try {
+            checkState(_state == State.PRE_STARTUP);
             _timeoutTask = _timer.scheduleWithFixedDelay(wrapLoggingContext(this::executeMaintenanceTasks),
                                                          20, 20, TimeUnit.SECONDS);
             StartEvent event = new StartEvent(new CellPath(_cellName), 0);
             _cell.prepareStartup(event);
-            setState(State.RUNNING);
+            setState(State.POST_STARTUP);
             __cellGlue.publishCell(this);
             _cell.postStartup(event);
+            setState(State.RUNNING);
         } catch (Throwable e) {
             Thread t = Thread.currentThread();
             t.getUncaughtExceptionHandler().uncaughtException(t, e);
@@ -973,7 +978,8 @@ public class CellNucleus implements ThreadFactory
                     _startup.cancel(true);
                     _lifeCycleMonitor.waitForUninterruptibly(isNotStarting);
                 }
-                checkState(_state == State.NEW || _state == State.RUNNING || _state == State.FAILED);
+                State state = _state;
+                checkState(state == State.NEW || state == State.RUNNING || state == State.FAILED);
                 _state = State.STOPPING;
             } finally {
                 _lifeCycleMonitor.leave();


### PR DESCRIPTION
Motivation:

The nucleus state is not fine grained enough to track the state needed for
various steps of the cell. On one hand the cell needs to know when it has been
published - for that reason it sets the state to RUNNING when preStartup
returns. On the other hand, shutdown needs to know when the startup callbacks
have finished, and thus it needs to know the postStartup is done. It currently
cannot do this, which means we still have a race in which a cell can shut down
before it has started.

The consequence is that we may still have tunnel connectors running even though
the cell no longer exists.

Modification:

Split the STARTING state into PRE_STARTUP and POST_STARTUP states to better
track the state of the cell. Dropped the FAILED state; the cell is put directly
into STOPPING if startup fails.

Result:

Fixed a problem with phantom tunnel connectors causing tunnel connections between
satellite and core domains to be reestablished every 10 seconds or so. This
problem should have been fixed in 2.16.12, but the fix was buggy.

Target: trunk
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.desy>

Reviewed at https://rb.dcache.org/r/9737/

(cherry picked from commit c6358e3d7a3b48500a9751ab4fddf257d68d04f9)