### PR TITLE
cells: Remove delayed default route if tunnel shuts down

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/CoreRoutingManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/CoreRoutingManager.java
@@ -451,7 +451,6 @@ public class CoreRoutingManager
             }
             break;
         case CellRoute.DEFAULT:
-            LOG.info("Default route {} was added", cr);
             break;
         }
     }
@@ -461,16 +460,18 @@ public class CoreRoutingManager
     {
         CellRoute cr = (CellRoute) ce.getSource();
         CellAddressCore target = cr.getTarget();
+        LOG.info("Got 'route deleted' event: {}", cr);
         switch (cr.getRouteType()) {
         case CellRoute.DOMAIN:
             updateTopicRoutes(cr.getDomainName(), Collections.emptyList());
             updateQueueRoutes(cr.getDomainName(), Collections.emptyList());
             getTunnelInfo(target)
                     .map(CellTunnelInfo::getTunnel)
-                    .ifPresent(name -> {
-                        coreTunnels.remove(name);
-                        satelliteTunnels.remove(name);
-                        legacyTunnels.remove(name);
+                    .ifPresent(address -> {
+                        coreTunnels.remove(address);
+                        satelliteTunnels.remove(address);
+                        legacyTunnels.remove(address);
+                        delayedDefaultRoutes.remove(new CellRoute(null, address, CellRoute.DEFAULT));
                     });
             break;
         case CellRoute.TOPIC:


### PR DESCRIPTION
Motivation:

Routing manager delays installation of a second default route to allow
all satellites to connect to the core first. If the tunnel shuts down
before the default route is installed, the routing manager will try
to install the route anyway. The result is a default route to a
non-existing tunnel.

Modification:

Remove the delayed default route if the corresponding domain route
is removed.

Result:

Fixed a race in which a default route could be installed for a tunnel
that no longer exists.

Target: trunk
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Anupam Ashish <anupam.ashish@desy.de>

Reviewed at https://rb.dcache.org/r/9738/

(cherry picked from commit e0b11957e6b213175cfa6791dee970ad335b2a51)