### PR TITLE
cells: Fix race when adding routes

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -141,10 +142,13 @@ class CellGlue
     public void routeAdd(CellRoute route)
     {
         CellAddressCore target = route.getTarget();
-        if (target.getCellDomainName().equals(getCellDomainName()) && !_publicCellList.containsKey(target.getCellName())) {
-            throw new IllegalArgumentException("No such cell: " + target);
+        synchronized (this) {
+            if (target.getCellDomainName().equals(getCellDomainName()) &&
+                !_publicCellList.containsKey(target.getCellName())) {
+                throw new IllegalArgumentException("No such cell: " + target);
+            }
+            _routingTable.add(route);
         }
-        _routingTable.add(route);
         sendToAll(new CellEvent(route, CellEvent.CELL_ROUTE_ADDED_EVENT));
     }
 
@@ -323,23 +327,34 @@ class CellGlue
         notifyAll();
     }
 
-    private synchronized void _kill(CellNucleus source, final CellNucleus destination, long to)
+    private void _kill(CellNucleus source, final CellNucleus destination, long to)
     {
-        /* Mark the cell as being killed to prevent it from being killed more
-         * than once and to block certain operations while it is being killed.
-         */
         String cellToKill = destination.getCellName();
-        if (_cellList.get(cellToKill) != destination || !_killedCells.add(destination)) {
-            return;
+        Collection<CellRoute> routes;
+
+        synchronized (this) {
+            /* Mark the cell as being killed to prevent it from being killed more
+             * than once and to block certain operations while it is being killed.
+             */
+            if (_cellList.get(cellToKill) != destination || !_killedCells.add(destination)) {
+                return;
+            }
+
+            /* Remove routes to this cell first to reduce the chance that
+             * we try to route to a no longer existing cell...
+             */
+            routes = _routingTable.delete(destination.getThisAddress());
+
+            /* ... then remove the cell to prevent further messages to be sent to it.
+             */
+            _publicCellList.remove(cellToKill, destination);
         }
 
-        /* Remove routes to this cell first to allow it to be drained cleanly.
+        /* Notify others about the route removal.
          */
-        for (CellRoute route : _routingTable.delete(destination.getThisAddress())) {
+        for (CellRoute route : routes) {
             sendToAll(new CellEvent(route, CellEvent.CELL_ROUTE_DELETED_EVENT));
         }
-
-        _publicCellList.remove(cellToKill, destination);
 
         /* Post the obituary.
          */


### PR DESCRIPTION
Motvation:

Upon shutting down a cell, routes to that cell are removed. Upon
adding routes, the existence of the target cell is checked. There
is however a race in this check with the cell shutting down.

Modification:

Synchronize cell glue when adding a route to prevent concurrent
removal of a cell.

Limited the synchronization in the kill method to avoid invoking
callbacks while holding the cell glue lock.

Result:

Fixed a race condition in which routes to non-existing cells could
be installed.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9739/

(cherry picked from commit 1509b2b6d0e1bfba7f155ff261de533318f406b5)