### PR TITLE
webdav: fix Unauthorized vs Forbidden response

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
@@ -79,7 +79,7 @@ public class DcacheDirectoryResource
         } catch (FileNotFoundCacheException e) {
             return Collections.emptyList();
         } catch (PermissionDeniedCacheException e) {
-            throw new UnauthorizedException(e.getMessage(), e, this);
+            throw WebDavExceptions.permissionDenied(e.getMessage(), e, this);
         } catch (CacheException | InterruptedException e) {
             throw new WebDavException(e.getMessage(), e, this);
         }
@@ -105,7 +105,7 @@ public class DcacheDirectoryResource
             // transferred entity's size.
             throw new BadRequestException(this, "Connection closed prematurely, entity smaller than expected.");
         } catch (PermissionDeniedCacheException e) {
-            throw new NotAuthorizedException(this);
+            throw WebDavExceptions.permissionDenied(this);
         } catch (FileExistsCacheException e) {
             throw new ConflictException(this);
         } catch (CacheException e) {
@@ -129,7 +129,7 @@ public class DcacheDirectoryResource
             }
             writer.flush();
         } catch (PermissionDeniedCacheException e) {
-            throw new NotAuthorizedException(this);
+            throw WebDavExceptions.permissionDenied(this);
         } catch (CacheException | InterruptedException e) {
             throw new WebDavException(e.getMessage(), e, this);
         } catch (UnsupportedEncodingException e) {
@@ -163,7 +163,7 @@ public class DcacheDirectoryResource
         try {
             _factory.deleteDirectory(_attributes.getPnfsId(), _path);
         } catch (PermissionDeniedCacheException e) {
-            throw new NotAuthorizedException(this);
+            throw WebDavExceptions.permissionDenied(this);
         } catch (CacheException e) {
             throw new WebDavException(e.getMessage(), e, this);
         }
@@ -176,7 +176,7 @@ public class DcacheDirectoryResource
         try {
             return _factory.makeDirectory(_attributes, _path.child(newName));
         } catch (PermissionDeniedCacheException e) {
-            throw new NotAuthorizedException(this);
+            throw WebDavExceptions.permissionDenied(this);
         } catch (CacheException e) {
             throw new WebDavException(e.getMessage(), e, this);
         }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheFileResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheFileResource.java
@@ -121,7 +121,7 @@ public class DcacheFileResource
             // the client has already disconnected.
             throw new WebDavException("Failed to send entity: client closed connection", e, this);
         } catch (PermissionDeniedCacheException e) {
-            throw new NotAuthorizedException(this);
+            throw WebDavExceptions.permissionDenied(this);
         } catch (FileNotFoundCacheException | NotInTrashCacheException e) {
             throw new ForbiddenException(e.getMessage(), e, this);
         } catch (CacheException e) {
@@ -174,7 +174,7 @@ public class DcacheFileResource
             }
             return null;
         } catch (PermissionDeniedCacheException e) {
-            throw new UnauthorizedException(e.getMessage(), e, this);
+            throw WebDavExceptions.permissionDenied(e.getMessage(), e, this);
         } catch (CacheException | InterruptedException e) {
             throw new WebDavException(e.getMessage(), e, this);
         } catch (URISyntaxException e) {
@@ -189,7 +189,7 @@ public class DcacheFileResource
         try {
             _factory.deleteFile(_attributes, _path);
         } catch (PermissionDeniedCacheException e) {
-            throw new NotAuthorizedException(this);
+            throw WebDavExceptions.permissionDenied(this);
         } catch (CacheException e) {
             throw new WebDavException(e.getMessage(), e, this);
         }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -601,7 +601,7 @@ public class DcacheResourceFactory
                 }
             }
         } catch (PermissionDeniedCacheException e) {
-            throw new UnauthorizedException(e.getMessage(), e, new InaccessibleResource(path));
+            throw WebDavExceptions.permissionDenied(e.getMessage(), e, new InaccessibleResource(path));
         } catch (CacheException e) {
             throw new WebDavException(e.getMessage(), e, new InaccessibleResource(path));
         }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/WebDavExceptions.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/WebDavExceptions.java
@@ -1,0 +1,65 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.webdav;
+
+import io.milton.resource.Resource;
+
+import javax.security.auth.Subject;
+
+import java.security.AccessController;
+
+import org.dcache.auth.Subjects;
+
+/**
+ *
+ */
+public class WebDavExceptions
+{
+    private WebDavExceptions()
+    {
+    }
+
+    /**
+     * Returns either an UnauthorizedException or a ForbiddenException depending
+     * on whether the user is authenticated.
+     */
+    public static WebDavException permissionDenied(Resource resource)
+    {
+        Subject subject = Subject.getSubject(AccessController.getContext());
+        if (Subjects.isNobody(subject)) {
+            return new UnauthorizedException(resource);
+        } else {
+            return new ForbiddenException(resource);
+        }
+    }
+
+    /**
+     * Returns either an UnauthorizedException or a ForbiddenException depending
+     * on whether the user is authenticated.
+     */
+    public static WebDavException permissionDenied(String message, Throwable cause, Resource resource)
+    {
+        Subject subject = Subject.getSubject(AccessController.getContext());
+        if (Subjects.isNobody(subject)) {
+            return new UnauthorizedException(message, cause, resource);
+        } else {
+            return new ForbiddenException(message, cause, resource);
+        }
+    }
+}

--- a/packages/system-test/src/main/bin/test
+++ b/packages/system-test/src/main/bin/test
@@ -219,8 +219,7 @@ def http(source, dest, *args)
   tmp1 = makeTempName
   runExpectingStatus(401, @curl, args, "-o", "/dev/null", "-L", "-T", source, "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
 
-  # FIXME: following request should return 403 Forbidden since user is known
-  runExpectingStatus(401, @curl, args, "-o", "/dev/null", "-u", "readonly:password", "-L", "-T", source, "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(403, @curl, args, "-o", "/dev/null", "-u", "readonly:password", "-L", "-T", source, "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
 
   run(@curl, args, "-f", "-o", "/dev/null", "-u", "#{Etc.getlogin}:password", "-L", "-T", source, "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
 
@@ -230,8 +229,7 @@ def http(source, dest, *args)
 
   runExpectingStatus(401, @curl, args, "-X", "DELETE", "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
 
-  # FIXME: following request should return 403 Forbidden since the user is known
-  runExpectingStatus(401, @curl, args, "-u", "readonly:password", "-X", "DELETE", "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(403, @curl, args, "-u", "readonly:password", "-X", "DELETE", "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
 
   run(@curl, args, "-f", "-u", "#{Etc.getlogin}:password", "-X", "DELETE", "http://#{@options.host}:2880/#{@options.dir}/#{tmp1}")
   runExpectingStatus(404, @curl, args, "-u", "#{Etc.getlogin}:password", "-X", "DELETE",
@@ -245,8 +243,7 @@ def httpNoAnonymous(source, dest, *args)
   tmp1 = makeTempName
   runExpectingStatus(401, @curl, args, "-o", "/dev/null", "-L", "-T", source, "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
 
-  # FIXME: following request should return 403 Forbidden since the user is known
-  runExpectingStatus(401, @curl, args, "-o", "/dev/null", "-u", "readonly:password", "-L", "-T", source, "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
+  runExpectingStatus(403, @curl, args, "-o", "/dev/null", "-u", "readonly:password", "-L", "-T", source, "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
   run(@curl, args, "-f", "-o", "/dev/null", "-u", "#{Etc.getlogin}:password", "-L", "-T", source, "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
 
   runExpectingStatus(401, @curl, args, "-L", "-o", dest, "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
@@ -255,8 +252,7 @@ def httpNoAnonymous(source, dest, *args)
 
   runExpectingStatus(401, @curl, args, "-X", "DELETE", "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
 
-  # FIXME: following request should return 403 Forbidden since the user is known
-  runExpectingStatus(401, @curl, args, "-u", "readonly:password", "-X", "DELETE",
+  runExpectingStatus(403, @curl, args, "-u", "readonly:password", "-X", "DELETE",
       "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
   run(@curl, args, "-f", "-u", "#{Etc.getlogin}:password", "-X", "DELETE", "http://#{@options.host}:2882/#{@options.dir}/#{tmp1}")
   runExpectingStatus(404, @curl, args, "-u", "#{Etc.getlogin}:password", "-X", "DELETE",
@@ -271,8 +267,7 @@ def https(source, dest, *args)
   runExpectingStatus(401, @curl, args, "-L", "-T", source,
                      "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
 
-  # FIXME: following request should return 403 Forbidden since the user is known
-  runExpectingStatus(401, @curl, args, "-u", "readonly:password", "-L", "-T", source,
+  runExpectingStatus(403, @curl, args, "-u", "readonly:password", "-L", "-T", source,
                      "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
   run(@curl, args, "-u", "#{Etc.getlogin}:password", "-L", "-T", source,
       "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
@@ -283,8 +278,7 @@ def https(source, dest, *args)
   runExpectingStatus(401, @curl, args, "-X", "DELETE",
       "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
 
-  # FIXME: following request should return 403 Forbidden since the user is known
-  runExpectingStatus(401, @curl, args, "-u", "readonly:password", "-X", "DELETE",
+  runExpectingStatus(403, @curl, args, "-u", "readonly:password", "-X", "DELETE",
       "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")
   run(@curl, args, "-u", "#{Etc.getlogin}:password", "-X", "DELETE",
       "https://#{@options.host}:2881/#{@options.dir}/#{tmp1}")


### PR DESCRIPTION
Motivation:

The status code 401 Unauthorized indicates that there is an
authentication error; 403 Forbidden indicates there is a permissions
problem.  For more details, see:

    http://www.dirv.me/blog/2011/07/18/understanding-403-forbidden

We may translate this to permission denied and Subject is NOBODY then
return 401 (please try again, but with Authorization header), otherwise
return 403 (please don't try again, instead someone to adjust
permissions within dCache).

Currently WebDAV door return 401 on permission problems even when the
user is authenticated.  This results in clients prompting users to
reauthenticate whenever the client makes a request that is denied for
authorisation reasons.

Modification:

Add helper method to return the correct exception; update code to make
use of this helper method.

Result:

Clients can handle objects that they don't have permission to access.

It may be that some users were using that dCache returns the wrong
status-code as a mechanism to clear the browser's BASIC credential cache
(e.g., to "log out").  With this patch, that is not possible and users
must use the facilities the web-browser provides.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9722/
Acked-by: Gerd Behrmann