### PR TITLE
cells: Ensure that newly created threads are non-daemon normal priority threads

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -3,6 +3,7 @@ package dmg.cells.nucleus;
 import com.google.common.collect.Maps;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Longs;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,13 +76,44 @@ class CellGlue
         _domainAddress = new CellAddressCore("*", _cellDomainName);
         _masterThreadGroup = new ThreadGroup("Master-Thread-Group");
         _killerThreadGroup = new ThreadGroup("Killer-Thread-Group");
-        ThreadFactory killerThreadFactory = r -> new Thread(_killerThreadGroup, r);
+        ThreadFactory killerThreadFactory =
+                new ThreadFactoryBuilder().setNameFormat("killer-%d").setThreadFactory(r -> newThread(_killerThreadGroup, r)).build();
         _killerExecutor = Executors.newCachedThreadPool(killerThreadFactory);
         _emergencyKillerExecutor = new ThreadPoolExecutor(1, 1,
                                                           0L, TimeUnit.MILLISECONDS,
                                                           new LinkedBlockingQueue<>(),
                                                           killerThreadFactory);
         _emergencyKillerExecutor.prestartCoreThread();
+    }
+
+    static Thread newThread(ThreadGroup threadGroup, Runnable r)
+    {
+        Thread thread = new Thread(threadGroup, r);
+        /* By default threads inherit the daemon status and priority from the creating
+         * thread. Thus we reset them.
+         */
+        if (thread.isDaemon()) {
+            thread.setDaemon(false);
+        }
+        if (thread.getPriority() != Thread.NORM_PRIORITY) {
+            thread.setPriority(Thread.NORM_PRIORITY);
+        }
+        return thread;
+    }
+
+    static Thread newThread(ThreadGroup threadGroup, Runnable r, String name)
+    {
+        Thread thread = new Thread(threadGroup, r, name);
+        /* By default threads inherit the daemon status and priority from the creating
+         * thread. Thus we reset them.
+         */
+        if (thread.isDaemon()) {
+            thread.setDaemon(false);
+        }
+        if (thread.getPriority() != Thread.NORM_PRIORITY) {
+            thread.setPriority(Thread.NORM_PRIORITY);
+        }
+        return thread;
     }
 
     ThreadGroup getMasterThreadGroup()

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -818,7 +818,7 @@ public class CellNucleus implements ThreadFactory
     @Nonnull
     public Thread newThread(@Nonnull Runnable target, @Nonnull String name)
     {
-        return new Thread(_threads, wrapLoggingContext(target), name);
+        return CellGlue.newThread(_threads, wrapLoggingContext(target), name);
     }
 
     //


### PR DESCRIPTION
Motivation:

CellNucleus is a thread factory. This factory is used by the message executor
used for message delivery and curator callbacks. The factory creates threads
using the regular Thread constructor - this constructor uses the daemon status
and priority of the creating thread as defaults for the new thread.

When a cell has been idle for a while, the threads of the message executor are
terminated. If a curator notification is generated, this notification is
scheduled on the message executor of the target cell. This will cause a new
thread to be allocated in the message excutor, now with the daemon status and
priority of the internal curator notification thread - this thread happens to
be daemon thread.

Other threads, such as the connector thread of the location manager connector,
created from the message thread, as well as message executors of new cells
being created, will now inherit this daemon status. Consequently we may end
up with threads marked as daemon threads that were not intended to be daemon
threads. This has been observed in a heap dump.

Modification:

Explicitly reset the daemon status and priority of newly created threads. The
code is copied directly from the JDKs DefaultThreadFactory.

Result:

Fixed a problem in which threads could inappropriately be created as daemon threads,
causing problems in killing those threads when the cell shuts down.

Target: trunk
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9745/

(cherry picked from commit bd87c3de71eb3fe065bebc47f4aab7ab548fb277)