### PR TITLE
cells: Fix lost interrupt exception

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/network/LocationManagerConnector.java
+++ b/modules/cells/src/main/java/dmg/cells/network/LocationManagerConnector.java
@@ -73,6 +73,8 @@ public class LocationManagerConnector
             throw new IOException("Unsupported address type: " + _address, e);
         } catch (UnresolvedAddressException e) {
             throw new IOException("Unable to resolve " + _address, e);
+        } catch (InterruptedIOException e) {
+            throw e;
         } catch (IOException e) {
             throw new IOException("Failed to connect to " + _address + ": " + e.toString(), e);
         }


### PR DESCRIPTION
Motivation:

The location manager connector relies on a thread interrupt during shutdown, yet
at least in one case the interrupt could get wrapped in a regular IOException
and thus not cause the connector thread to shut down.

Modification:

Explicitly catch InterruptedIOException.

Result:

Fixed a problem in which the tunnel connector cell would fail to shut down.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9746/

(cherry picked from commit 54b3a9c553005957f5b119e57f487312ca56cb59)