### PR TITLE
cells: Remove race in routing manager

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/CoreRoutingManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/CoreRoutingManager.java
@@ -465,14 +465,10 @@ public class CoreRoutingManager
         case CellRoute.DOMAIN:
             updateTopicRoutes(cr.getDomainName(), Collections.emptyList());
             updateQueueRoutes(cr.getDomainName(), Collections.emptyList());
-            getTunnelInfo(target)
-                    .map(CellTunnelInfo::getTunnel)
-                    .ifPresent(address -> {
-                        coreTunnels.remove(address);
-                        satelliteTunnels.remove(address);
-                        legacyTunnels.remove(address);
-                        delayedDefaultRoutes.remove(new CellRoute(null, address, CellRoute.DEFAULT));
-                    });
+            coreTunnels.remove(target);
+            satelliteTunnels.remove(target);
+            legacyTunnels.remove(target);
+            delayedDefaultRoutes.remove(new CellRoute(null, target, CellRoute.DEFAULT));
             break;
         case CellRoute.TOPIC:
             String topic = cr.getCellName();


### PR DESCRIPTION
Motivation:

Routing manager monitors when routes beeing added and removed. It updates
internal data structures accordingly. When adding a route it looks up the
corresponding tunnel for information about whether the remote is a satellite or
core domain. In route removal this code was copied, however there is no
guarantee that the tunnel still exists at this point and thus we may not clean
the information from the internal data structures.

Modification:

We don't need to look up the tunnel information on remove as all we need
to know is the tunnel address.

Result:

Fixed a race that could lead to corrupted state in the routing manager.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9748/

(cherry picked from commit d5f1fdb00e66a45a037e33cef4ee8986333a9c65)