### PR TITLE
srmclient: support SIGKILL

### DIFF
--- a/modules/srm-client/src/main/bin/adler32
+++ b/modules/srm-client/src/main/bin/adler32
@@ -31,4 +31,4 @@ if [ "$DEBUG" = "true" ]
 then
 	echo $cmd
 fi
-$cmd
+exec $cmd

--- a/modules/srm-client/src/main/bin/delegation
+++ b/modules/srm-client/src/main/bin/delegation
@@ -17,7 +17,7 @@ else
     x509_user_proxy=/tmp/x509up_u$(id -u)
 fi
 
-CLASSPATH="$SRM_PATH/lib/*" java -Dlog=${DELEGATION_LOG:-warn} \
+CLASSPATH="$SRM_PATH/lib/*" exec java -Dlog=${DELEGATION_LOG:-warn} \
     -client \
     -Djava.awt.headless=true \
     -DwantLog4jSetup=n \
@@ -25,4 +25,5 @@ CLASSPATH="$SRM_PATH/lib/*" java -Dlog=${DELEGATION_LOG:-warn} \
     -XX:+TieredCompilation \
     -XX:TieredStopAtLevel=0 \
     ${SRM_JAVA_OPTIONS} \
-    org.dcache.srm.DelegationShell -x509_user_proxy="$x509_user_proxy" "$@"
+    org.dcache.srm.DelegationShell \
+    -x509_user_proxy="$x509_user_proxy" "$@"

--- a/modules/srm-client/src/main/bin/gridftpcopy
+++ b/modules/srm-client/src/main/bin/gridftpcopy
@@ -58,4 +58,4 @@ if [ "$DEBUG" = "true" ]
 then
 	echo $cmd
 fi
-$cmd
+exec $cmd

--- a/modules/srm-client/src/main/bin/gridftplist
+++ b/modules/srm-client/src/main/bin/gridftplist
@@ -57,4 +57,4 @@ if [ "$DEBUG" = "true" ]
 then
 	echo $cmd
 fi
-$cmd
+exec $cmd

--- a/modules/srm-client/src/main/bin/srm-abort-files
+++ b/modules/srm-client/src/main/bin/srm-abort-files
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -abortFiles "$@"
+exec "${SRM_PATH}/lib/srm" -abortFiles "$@"

--- a/modules/srm-client/src/main/bin/srm-abort-request
+++ b/modules/srm-client/src/main/bin/srm-abort-request
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -abortRequest "$@"
+exec "${SRM_PATH}/lib/srm" -abortRequest "$@"

--- a/modules/srm-client/src/main/bin/srm-advisory-delete
+++ b/modules/srm-client/src/main/bin/srm-advisory-delete
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -advisoryDelete "$@"
+exec "${SRM_PATH}/lib/srm" -advisoryDelete "$@"

--- a/modules/srm-client/src/main/bin/srm-bring-online
+++ b/modules/srm-client/src/main/bin/srm-bring-online
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -bringOnline "$@"
+exec "${SRM_PATH}/lib/srm" -bringOnline "$@"

--- a/modules/srm-client/src/main/bin/srm-check-permissions
+++ b/modules/srm-client/src/main/bin/srm-check-permissions
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -checkPermissions "$@"
+exec "${SRM_PATH}/lib/srm" -checkPermissions "$@"

--- a/modules/srm-client/src/main/bin/srm-extend-file-lifetime
+++ b/modules/srm-client/src/main/bin/srm-extend-file-lifetime
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -extendFileLifetime "$@"
+exec "${SRM_PATH}/lib/srm" -extendFileLifetime "$@"

--- a/modules/srm-client/src/main/bin/srm-get-metadata
+++ b/modules/srm-client/src/main/bin/srm-get-metadata
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -getFileMetaData "$@"
+exec "${SRM_PATH}/lib/srm" -getFileMetaData "$@"

--- a/modules/srm-client/src/main/bin/srm-get-permissions
+++ b/modules/srm-client/src/main/bin/srm-get-permissions
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -getPermissions "$@"
+exec "${SRM_PATH}/lib/srm" -getPermissions "$@"

--- a/modules/srm-client/src/main/bin/srm-get-request-status
+++ b/modules/srm-client/src/main/bin/srm-get-request-status
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -getRequestStatus "$@"
+exec "${SRM_PATH}/lib/srm" -getRequestStatus "$@"

--- a/modules/srm-client/src/main/bin/srm-get-request-summary
+++ b/modules/srm-client/src/main/bin/srm-get-request-summary
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -getRequestSummary "$@"
+exec "${SRM_PATH}/lib/srm" -getRequestSummary "$@"

--- a/modules/srm-client/src/main/bin/srm-get-request-tokens
+++ b/modules/srm-client/src/main/bin/srm-get-request-tokens
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -getRequestTokens "$@"
+exec "${SRM_PATH}/lib/srm" -getRequestTokens "$@"

--- a/modules/srm-client/src/main/bin/srm-get-space-metadata
+++ b/modules/srm-client/src/main/bin/srm-get-space-metadata
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -getSpaceMetaData "$@"
+exec "${SRM_PATH}/lib/srm" -getSpaceMetaData "$@"

--- a/modules/srm-client/src/main/bin/srm-release-files
+++ b/modules/srm-client/src/main/bin/srm-release-files
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -releaseFiles "$@"
+exec "${SRM_PATH}/lib/srm" -releaseFiles "$@"

--- a/modules/srm-client/src/main/bin/srm-release-space
+++ b/modules/srm-client/src/main/bin/srm-release-space
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -releaseSpace "$@"
+exec "${SRM_PATH}/lib/srm" -releaseSpace "$@"

--- a/modules/srm-client/src/main/bin/srm-reserve-space
+++ b/modules/srm-client/src/main/bin/srm-reserve-space
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -reserveSpace "$@"
+exec "${SRM_PATH}/lib/srm" -reserveSpace "$@"

--- a/modules/srm-client/src/main/bin/srm-set-permissions
+++ b/modules/srm-client/src/main/bin/srm-set-permissions
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -setPermissions "$@"
+exec "${SRM_PATH}/lib/srm" -setPermissions "$@"

--- a/modules/srm-client/src/main/bin/srm-storage-element-info
+++ b/modules/srm-client/src/main/bin/srm-storage-element-info
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -getStorageElementInfo "$@"
+exec "${SRM_PATH}/lib/srm" -getStorageElementInfo "$@"

--- a/modules/srm-client/src/main/bin/srmcp
+++ b/modules/srm-client/src/main/bin/srmcp
@@ -112,10 +112,8 @@ first=${#fargs[0]}
 cmd=""
 if [ "${skip}" -eq 0 ]
     then
-    if [ ${length} -lt 2 ]
-	then
-	"${SRM_PATH}/lib/srm" -copy $*
-	exit 1
+    if [ ${length} -lt 2 ]; then
+	exec "${SRM_PATH}/lib/srm" -copy "$@"
     else
 	i=0
 	src_protocols=
@@ -207,14 +205,12 @@ if [ "${skip}" -eq 0 ]
 		    error ${src_protocol} ${dst_protocol}
 		fi
 	    fi
-	    $cmd
-	    rc=$?
-	    exit $rc
+	    exec $cmd
 	fi
     fi
 else
     if [ "$delegationMakesSense" = 1 ] && [ "$haveDelegate" = 0 ]; then
         delegate=-delegate=true
     fi
-    "${SRM_PATH}/lib/srm" -copy $delegate "$@"
+    exec "${SRM_PATH}/lib/srm" -copy $delegate "$@"
 fi

--- a/modules/srm-client/src/main/bin/srmfs
+++ b/modules/srm-client/src/main/bin/srmfs
@@ -25,7 +25,7 @@ else
    x509_user_trusted_certs=/etc/grid-security/certificates
 fi
 
-CLASSPATH="$SRM_PATH/lib/*" java -Dlog=${DELEGATION_LOG:-warn} \
+CLASSPATH="$SRM_PATH/lib/*" exec java -Dlog=${DELEGATION_LOG:-warn} \
     -client \
     -Djava.awt.headless=true \
     -DwantLog4jSetup=n \

--- a/modules/srm-client/src/main/bin/srmls
+++ b/modules/srm-client/src/main/bin/srmls
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -ls "$@"
+exec "${SRM_PATH}/lib/srm" -ls "$@"

--- a/modules/srm-client/src/main/bin/srmmkdir
+++ b/modules/srm-client/src/main/bin/srmmkdir
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -mkdir "$@"
+exec "${SRM_PATH}/lib/srm" -mkdir "$@"

--- a/modules/srm-client/src/main/bin/srmmv
+++ b/modules/srm-client/src/main/bin/srmmv
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -mv "$@"
+exec "${SRM_PATH}/lib/srm" -mv "$@"

--- a/modules/srm-client/src/main/bin/srmping
+++ b/modules/srm-client/src/main/bin/srmping
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -ping "$@"
+exec "${SRM_PATH}/lib/srm" -ping "$@"

--- a/modules/srm-client/src/main/bin/srmrm
+++ b/modules/srm-client/src/main/bin/srmrm
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -rm "$@"
+exec "${SRM_PATH}/lib/srm" -rm "$@"

--- a/modules/srm-client/src/main/bin/srmrmdir
+++ b/modules/srm-client/src/main/bin/srmrmdir
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -rmdir "$@"
+exec "${SRM_PATH}/lib/srm" -rmdir "$@"

--- a/modules/srm-client/src/main/bin/srmstage
+++ b/modules/srm-client/src/main/bin/srmstage
@@ -2,4 +2,4 @@
 
 @INIT_SCRIPT@
 
-"${SRM_PATH}/lib/srm" -stage "$@"
+exec "${SRM_PATH}/lib/srm" -stage "$@"

--- a/modules/srm-client/src/main/lib/srm
+++ b/modules/srm-client/src/main/lib/srm
@@ -157,5 +157,5 @@ if [ "$DEBUG" = "true" ]; then
     echo
     echo $cmd
 fi
-CLASSPATH="$SRM_CP" $cmd
+CLASSPATH="$SRM_CP" exec $cmd
 


### PR DESCRIPTION
Motivation:

Sending an srmclient command a SIGKILL doesn't kill that activity.  This
is because (at least) bash does not propagate a SIGKILL to child
activity.

Modification:

Use 'exec' so that the actual java command receives the signal.  This
ensures that the correct process dies.

Result:

SIGKILL works as expected.

Target: master
Request: 2.16
Requires-book: no
Requires-notes: yes
Patch: https://rb.dcache.org/r/9753/
Acked-by: Gerd Behrmann