### PR TITLE
srmclient: fix -debug mode

### DIFF
--- a/modules/srm-client/src/main/conf/logback-all.xml
+++ b/modules/srm-client/src/main/conf/logback-all.xml
@@ -9,10 +9,7 @@
     <appender-ref ref="stdout"/>
   </root>
 
-  <logger name="org.apache.client.Call" level="DEBUG"/>
-  <logger name="org.apache.axis.transport.http.HTTPSender" level="DEBUG"/>
-  <logger name="org.globus.axis.axis.transport" level="DEBUG"/>
-  <logger name="org.apache.client.Call" level="DEBUG"/>
+  <logger name="org.apache.axis.client.Call" level="DEBUG"/>
   <logger name="org.apache.axis.transport.http.HTTPSender" level="DEBUG"/>
   <logger name="org.globus.axis.axis.transport" level="DEBUG"/>
   <logger name="org.dcache.ftp.client.dc.AbstractDataChannel" level="DEBUG"/>
@@ -91,4 +88,7 @@
   <logger name="org.dcache.ftp.client.vanilla.Reply" level="DEBUG"/>
   <logger name="org.dcache.ftp.client.vanilla.TransferMonitor" level="DEBUG"/>
   <logger name="org.dcache.ftp.client.vanilla.TransferState" level="DEBUG"/>
+  <logger name="org.dcache.srm.client.SRMClientV2" level="DEBUG"/>
+  <logger name="org.dcache.srm.client.HttpClientSender" level="DEBUG"/>
+  <logger name="org.dcache.srm.client.FlexibleCredentialSSLConnectionSocketFactory" level="DEBUG"/>
 </configuration>


### PR DESCRIPTION
Motivation:

The -debug option of delegation and srmfs failed to show information
about SOAP traffic.

Modification:

Update logback-all.xml file to remove duplicate entries, sort entries,
and fix typo in Axis client entry.

Result:

The -debug option provides much more useful output.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9744/
Acked-by: Gerd Behrmann