### PR TITLE
srmclient: refrain from adding default port to SURL in srmcp

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
@@ -115,6 +115,7 @@ import org.dcache.srm.request.FileStorageType;
 import org.dcache.srm.request.OverwriteMode;
 import org.dcache.srm.request.RetentionPolicy;
 import org.dcache.srm.util.RequestStatusTool;
+import org.dcache.srm.util.SrmUrl;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ArrayOfTCopyFileRequest;
 import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
@@ -163,9 +164,11 @@ public class SRMCopyClientV2 extends SRMClient implements Runnable {
     public void connect() throws Exception {
         java.net.URI srmUrl;
         if ( configuration.isPushmode()  ) {
-            srmUrl = from[0];
+            srmUrl = SrmUrl.withDefaultPort(from [0],
+                configuration.getDefaultSrmPortNumber());
         } else {
-            srmUrl = to[0];
+            srmUrl = SrmUrl.withDefaultPort(to [0],
+                configuration.getDefaultSrmPortNumber());
         }
         srmv2 = new SRMClientV2(srmUrl,
                                 getCredential(),

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMDispatcher.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMDispatcher.java
@@ -667,10 +667,8 @@ public class SRMDispatcher {
                 from_urls                = new java.net.URI[number_of_sources];
                 to_urls                  = new java.net.URI[number_of_sources];
                 for(int i=0;i<number_of_sources;++i) {
-                    from_urls[i] = SrmUrl.createWithDefaultPort(from[i],
-                                                                configuration.getDefaultSrmPortNumber());
-                    to_urls[i]   = SrmUrl.createWithDefaultPort(to[i],
-                                                                configuration.getDefaultSrmPortNumber());
+                    from_urls[i] = new URI(from [i]);
+                    to_urls[i]   = new URI(to[i]);
                 }
             }
             else {
@@ -679,8 +677,7 @@ public class SRMDispatcher {
                 String to             = configuration.getTo();
                 from_urls             = new java.net.URI[number_of_sources];
                 for (int i=0;i<number_of_sources;++i) {
-                    from_urls[i] = SrmUrl.createWithDefaultPort(from[i],
-                                                                configuration.getDefaultSrmPortNumber());
+                    from_urls[i] = new URI(from [i]);
                 }
                 to_urls = new java.net.URI[number_of_sources];
                 if (number_of_sources >1) {
@@ -690,13 +687,11 @@ public class SRMDispatcher {
                         if(lastSlash != -1) {
                             file = file.substring(lastSlash);
                         }
-                        to_urls[i] = SrmUrl.createWithDefaultPort(to + "/" + file,
-                                                                  configuration.getDefaultSrmPortNumber());
+                        to_urls[i] = new URI(to + "/" + file);
                     }
                 }
                 else {
-                    to_urls[0] =  SrmUrl.createWithDefaultPort(to,
-                                                               configuration.getDefaultSrmPortNumber());
+                    to_urls[0] =  new URI(to);
                 }
             }
             int fromType = getUrlType(from_urls[0]);
@@ -830,9 +825,8 @@ public class SRMDispatcher {
         String host = urls[0].getHost();
         int port = urls[0].getPort();
         if(type == SRM_URL  || ((type & SUPPORTED_PROTOCOL_URL) == SUPPORTED_PROTOCOL_URL)) {
-            if( host == null || host.equals("") ||
-                    port < 0) {
-                String error = "illegal source url for multiple sources mode"+urls[0];
+            if( host == null || host.equals("")) {
+                String error = "illegal source url for multiple sources mode "+urls[0];
                 esay(error);
                 throw new IllegalArgumentException(error );
             }

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV2.java
@@ -82,6 +82,7 @@ import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.request.AccessLatency;
 import org.dcache.srm.request.RetentionPolicy;
 import org.dcache.srm.util.RequestStatusTool;
+import org.dcache.srm.util.SrmUrl;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ArrayOfString;
 import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
@@ -129,7 +130,8 @@ public class SRMGetClientV2 extends SRMClient implements Runnable {
 
     @Override
     public void connect() throws Exception {
-        java.net.URI srmUrl = from[0];
+        java.net.URI srmUrl = SrmUrl.withDefaultPort(from [0],
+                configuration.getDefaultSrmPortNumber());
         srmv2 = new SRMClientV2(srmUrl,
                                 getCredential(),
                                 configuration.getRetry_timeout(),

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMPutClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMPutClientV2.java
@@ -85,6 +85,7 @@ import org.dcache.srm.request.AccessLatency;
 import org.dcache.srm.request.FileStorageType;
 import org.dcache.srm.request.RetentionPolicy;
 import org.dcache.srm.util.RequestStatusTool;
+import org.dcache.srm.util.SrmUrl;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ArrayOfString;
 import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
@@ -141,7 +142,8 @@ public class SRMPutClientV2 extends SRMClient implements Runnable {
 
     @Override
     public void connect() throws Exception {
-        java.net.URI srmUrl = to[0];
+        java.net.URI srmUrl = SrmUrl.withDefaultPort(to [0],
+                configuration.getDefaultSrmPortNumber());
         srmv2 = new SRMClientV2(srmUrl,
                                 getCredential(),
                                 configuration.getRetry_timeout(),


### PR DESCRIPTION
Motivation:

There is an inconsistency in how srmclient handles user-supplied SURLs
that have no port number: in almost all clients these are passed on
as-is to the SRM endpoint but with srmcp, the default port number is
added.

Currently dCache distinguishes between SURLs that have a port number and
those that do not; therefore srmrm srm://srm.example.org/file-1 will not
abort an upload issued with srmcp file:///path/to/local-file
srm://srm.example.org/file-1.

Modification:

The port number is only needed to connect to the SRM endpoint.
Therefore, the default port number is added when connecting.  The SURLs
are otherwise left as supplied by the user.

An erronous test is modified to allow port-less SURLs.

Result:

A user can use srmcp to upload to a port-less SURL.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9760
Acked-by: Tigran Mkrtchyan