### PR TITLE
srmclient: fix error message for ls

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/TStatusCodes.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/TStatusCodes.java
@@ -32,6 +32,28 @@ public class TStatusCodes
         // Utility class: prevent initialisation
     }
 
+    /**
+     * Check the status of a bulk operation.  If the result is PARTIAL_SUCCESS
+     * or FAILURE then also check the result at the file level.
+     */
+    public static void checkBulkSuccess(TReturnStatus requestStatus,
+            Iterable<TReturnStatus> fileStatuses) throws SRMException
+    {
+        TStatusCode code = requestStatus.getStatusCode();
+        if (code == TStatusCode.SRM_FAILURE || code == TStatusCode.SRM_PARTIAL_SUCCESS) {
+            for (TReturnStatus status : fileStatuses) {
+                checkSuccess(status);
+            }
+        } else {
+            checkSuccess(requestStatus);
+        }
+    }
+
+    public static void checkSuccess(TReturnStatus returnStatus) throws SRMException
+    {
+        checkSuccess(returnStatus, TStatusCode.SRM_SUCCESS);
+    }
+
     public static void checkSuccess(TReturnStatus returnStatus, TStatusCode... success) throws SRMException
     {
         TStatusCode statusCode = returnStatus.getStatusCode();


### PR DESCRIPTION
Motivation:

The stat and ls command failures report only the request-level error
message.  This provides no useful information on why this particular
file failed.

Modification:

Use the file-level message when reporting a problem.

Result:

Better error messages.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9734/
Acked-by: Gerd Behrmann