### PR TITLE
srmclient: fix async stat command

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/AxisSrmFileSystem.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/AxisSrmFileSystem.java
@@ -131,7 +131,7 @@ public class AxisSrmFileSystem implements SrmFileSystem
 
     @Nonnull
     @Override
-    public TMetaDataPathDetail stat(URI surl) throws RemoteException, SRMException
+    public TMetaDataPathDetail stat(URI surl) throws RemoteException, SRMException, InterruptedException
     {
         SrmLsResponse response = srm.srmLs(
                 new SrmLsRequest(null, new ArrayOfAnyURI(new URI[]{surl}), null, null, true, false, 0, 0, 1));
@@ -143,12 +143,13 @@ public class AxisSrmFileSystem implements SrmFileSystem
         } else {
             SrmStatusOfLsRequestResponse status;
             do {
+                TimeUnit.SECONDS.sleep(2);
                 status = srm.srmStatusOfLsRequest(
                         new SrmStatusOfLsRequestRequest(null, response.getRequestToken(), 0, 1));
-            } while (response.getReturnStatus().getStatusCode() == TStatusCode.SRM_REQUEST_QUEUED ||
-                    response.getReturnStatus().getStatusCode() == TStatusCode.SRM_REQUEST_INPROGRESS);
-            TMetaDataPathDetail details = response.getDetails().getPathDetailArray(0);
-            checkBulkSuccess(response.getReturnStatus(), Collections.singletonList(details.getStatus()));
+            } while (status.getReturnStatus().getStatusCode() == TStatusCode.SRM_REQUEST_QUEUED ||
+                    status.getReturnStatus().getStatusCode() == TStatusCode.SRM_REQUEST_INPROGRESS);
+            TMetaDataPathDetail details = status.getDetails().getPathDetailArray(0);
+            checkBulkSuccess(status.getReturnStatus(), Collections.singletonList(details.getStatus()));
             return details;
         }
     }

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmFileSystem.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmFileSystem.java
@@ -49,7 +49,7 @@ public interface SrmFileSystem extends AutoCloseable
     void setCredential(X509Credential credential);
 
     @Nonnull
-    TMetaDataPathDetail stat(URI surl) throws RemoteException, SRMException;
+    TMetaDataPathDetail stat(URI surl) throws RemoteException, SRMException, InterruptedException;
 
     @Nonnull
     TPermissionMode checkPermission(URI surl) throws RemoteException, SRMException;

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -234,7 +234,7 @@ public class SrmShell extends ShellApplication
         return surls;
     }
 
-    private void cd(String path) throws URI.MalformedURIException, RemoteException, SRMException
+    private void cd(String path) throws URI.MalformedURIException, RemoteException, SRMException, InterruptedException
     {
         if (!path.endsWith("/")) {
             path = path + "/";
@@ -348,7 +348,7 @@ public class SrmShell extends ShellApplication
         String path;
 
         @Override
-        public Serializable call() throws URI.MalformedURIException, RemoteException, SRMException
+        public Serializable call() throws URI.MalformedURIException, RemoteException, SRMException, InterruptedException
         {
             if (path == null) {
                 pwd = home;
@@ -570,7 +570,7 @@ public class SrmShell extends ShellApplication
         boolean parent;
 
         @Override
-        public String call() throws RemoteException, URI.MalformedURIException, SRMException
+        public String call() throws RemoteException, URI.MalformedURIException, SRMException, InterruptedException
         {
             if (parent) {
                 recursiveMkdir(path);
@@ -580,7 +580,7 @@ public class SrmShell extends ShellApplication
             return null;
         }
 
-        private void recursiveMkdir(File path) throws RemoteException, URI.MalformedURIException, SRMException
+        private void recursiveMkdir(File path) throws RemoteException, URI.MalformedURIException, SRMException, InterruptedException
         {
             URI surl = lookup(path);
             try {


### PR DESCRIPTION
Motivation:

The stat command is broken when the server responds asynchronously: it
never terminates and it issues requests in a tight loop.

Modification:

Use status response both when testing for completion of the query and to
obtain the result.

Introduce a 2-second sleep between successive queries; this is in
keeping with the ls command.

Result:

The stat command works for servers that use asynchronous responses.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9764/
Acked-by: Anupam Ashish