### PR TITLE
srm: remove trailing dot from reverse lookup result

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -2517,6 +2517,12 @@ public final class Storage
                 for (List<String> hosts: map.values()) {
                     host = hosts.get(0);
                 }
+
+                // Remove trailing dot: it can harm
+                // at least X.509 CN/subjectAltName:DNS comparisons
+                if (host.endsWith(".")) {
+                    host = host.substring(0, host.length() - 1);
+                }
                 return host;
             } catch (NamingException e) {
                 throw new UnknownHostException(e.getMessage());


### PR DESCRIPTION
Worlds tends to use DNS names without trailing dots in URLs,
X.509 certificates and other places.  We have at least one
example where trailing dot creates problem: certificate name
comparison for URLs we generate, since GT folks are reluctant
to omit it in their name comparisons,
  https://github.com/globus/globus-toolkit/issues/58

All-work-by: Alexander Rogovskiy <a.rogovsky@grid.kiae.ru>
Signed-off-by: Eygene Ryabinkin <rea@grid.kiae.ru>
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
(cherry picked from commit 8aff8524e0fbfb9ec5c1c3e3075cfcf65c163795)