### PR TITLE
gplazma2-xacml: remove erroneous creation of placeholder extensions

### DIFF
--- a/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
+++ b/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
@@ -415,26 +415,6 @@ public final class XACMLPlugin implements GPlazmaAuthenticationPlugin
             }
         }
 
-        /*
-         * generate placeholder extensions from principals
-         * note that the set is ordered so the extensions extracted from
-         * the credentials are given precedence
-         */
-        if (extensions.isEmpty()) {
-            /* REVISIT: This only gets executed if the public credentials do not contain
-             * a chert chain. Shouldn't this plugin fail in such cases? At least the
-             * OGF interoperability profile for XACML doesn't indicate that none DN values
-             * are allowed for the subject x509 id attribute.
-             */
-            for (Principal principal: identifiedPrincipals) {
-                VomsExtensions vomsExtensions =
-                        new VomsExtensions(principal.getName(), null, null, null, null, null, false);
-                logger.debug(" {} authenticate, adding voms extensions = {}",
-                            this, vomsExtensions);
-                extensions.add(vomsExtensions);
-            }
-        }
-
         logger.debug("VOMS extensions found: {}", extensions);
 
         checkAuthentication(!extensions.isEmpty(), "no subjects found to map");


### PR DESCRIPTION
Motivation:

Currently the XACML plugin tries to create extension sets which are 'degenerate',
in the sense that it is an x509 subject but no VOMS attributes.  This should
only be done for x509 principals.   The extractExtensionsFromChain method takes
care of these cases, so it is not necessary to repeat the procedure in the
calling method (authenticate).  What is more, there is a bug here in that
non-DN subjects are also processed this way.

Modification:

Remove the offending code, and allow the case where there are no x509 (Globus)
principals among the identified principals to raise an AuthenticationException.

Result:

No bizarre error messages in gPlazma such as:

"xacml SUFFICIENT:FAIL (no mapping for: [VomsExtensions[X509Subject='131.225.100.228',
X509SubjectIssuer='null', fqan='null', primary=false, VO='null', VOMSSubject='null',
VOMSSubjectIssuer='null']]) => OK"

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: tigran.mkrtchyan@desy.de
Acked-by: paul.millar@desy.de