### PR TITLE
commons: log bugs with stack-trace and instructions

### DIFF
--- a/modules/common-cli/src/main/java/org/dcache/util/cli/ShellApplication.java
+++ b/modules/common-cli/src/main/java/org/dcache/util/cli/ShellApplication.java
@@ -13,12 +13,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.io.Serializable;
+import java.io.StringWriter;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import dmg.util.CommandException;
 import dmg.util.CommandExitException;
+import dmg.util.CommandPanicException;
 import dmg.util.CommandSyntaxException;
 import dmg.util.CommandThrowableException;
 import dmg.util.command.Command;
@@ -160,6 +163,13 @@ public abstract class ShellApplication implements Closeable
             out = sb.toString();
         } catch (CommandExitException e) {
             throw e;
+        } catch (CommandPanicException e) {
+            Ansi sb = Ansi.ansi();
+            sb.fg(RED).a("Bug detected! ").reset().a("Please email the following details to <support@dcache.org>:\n");
+            Throwable t = e.getCause() == null ? e : e.getCause();
+            StringWriter sw = new StringWriter();
+            t.printStackTrace(new PrintWriter(sw));
+            out = sb.a(sw.toString()).toString();
         } catch (Exception e) {
             out = Ansi.ansi().fg(RED).a(e.getMessage()).reset().toString();
         }


### PR DESCRIPTION
Motivation:

The ShellApplication framework is used as the basis for the deletation
and srmfs commands (srm-client) and chimera (distributed as part of
dCache).  Currently, any bug is logged simply with as the Exception's
toString value.  This does not convey that the user found a bug, what
the user should do, or provide sufficient information to debug the
problem.

Modification:

Provide user with explicit instructions to contact us, and supply
sufficient information to make debugging possible.

Result:

We should recieve feedback on bugs with enough information to fix 'em.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9774/
Acked-by: Albert Rossi