### PR TITLE
srmclient: update ls to be more robust

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/AxisSrmFileSystem.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/AxisSrmFileSystem.java
@@ -260,7 +260,8 @@ public class AxisSrmFileSystem implements SrmFileSystem
                 throw new SRMInvalidPathException("Not a directory");
             }
             offset += count;
-            TMetaDataPathDetail[] pathDetailArray = detail.getArrayOfSubPaths().getPathDetailArray();
+            TMetaDataPathDetail[] pathDetailArray = detail.getArrayOfSubPaths() == null
+                    ? null : detail.getArrayOfSubPaths().getPathDetailArray();
             if (pathDetailArray != null) {
                 list = concat(list, pathDetailArray, TMetaDataPathDetail.class);
             }


### PR DESCRIPTION
Motivation:

The SRM server may refrain from returning an ArrayOfSubPaths if the
directory is empty.  Currently this causes an NPE.

Modification:

Check whether ArrayOfSubPaths is not specified before trying to use that
information.

Result:

Client can handle empty directories.

Target: master
Request: 2.16
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/9774/
Acked-by: Albert Rossi