### PR TITLE
srmclient: print friendly message on SRMException

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -148,6 +148,9 @@ public class SrmShell extends ShellApplication
 
         try (SrmShell shell = new SrmShell(uri, args)) {
             shell.start(args);
+        } catch (SRMException e) {
+            System.err.println(uri + " failed request: " + e.getMessage());
+            System.exit(1);
         } catch (MalformedURLException e) {
             System.err.println(e.getMessage());
             System.exit(1);


### PR DESCRIPTION
Motivation:

If the server fails a request then SRMException is thrown.  This
is treated as a bug and a stack-trace is shown.  This isn't
user friendly

Modification:

Catch SRMException and print a reasonable message

Result:

Remote failures are shown in a concised and reasonable fashion.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9771/
Acked-by: Albert Rossi
Acked-by: Olufemi Adeyemi