### PR TITLE
billing: Make billing indexer work with custom format strings

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/text/BillingParserBuilder.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/text/BillingParserBuilder.java
@@ -276,6 +276,10 @@ public class BillingParserBuilder
      */
     private static String toGroupName(String attribute)
     {
+        int pos = attribute.indexOf(';');
+        if (pos > -1) {
+            attribute = attribute.substring(0, pos);
+        }
         return attribute.replace("X", "XX").replace(".", "X");
     }
 


### PR DESCRIPTION
Motivation:

Using a custom format string for the date field causes the indexer to fail:

named capturing group is missing trailing '>' near index 32
\Q{ "billing_time":"\E(?<date;format="yyyy-MM-dd'T'HH:mm:ssXSSSZ">.*?)\Q", "cell_name":"\E(?<cellNameXcell>.*?)\Q", "domain_name":"\E(?<cellNameXdomain>.*?)\Q", "bill_type":"\E(?<type>\w+)\Q", "dn":"\E(?<owner>.*?)\Q", "uid":"\E(?<uid>-?\d+)\Q", "gid":"\E(?<gid>-?\d+)\Q", "remote_host":"\E(?<clientChain>.*?)\Q", "pnfsid":"\E(?<pnfsid>[0-9A-F]{24}(?:[0-9A-F]{12})?)\Q", "size":"\E(?<filesize>-?\d+)\Q", "file_path":"\E(?<path>.*?)\Q", "sunit":"\E(?:(?<storageXstorageClass>.*?)\Q@\E(?<storageXhsm>.*?)|\Q<Unknown>\E)\Q", "transfer_time":"\E(?<transactionTime>-?\d+)\Q", "queue_time":"\E(?<queuingTime>-?\d+)\Q", "error_code":"\E(?<rc>-?\d+)\Q", "error_msg":"\E(?<message>.*?)\Q" }\E

Modification:

Strip the formatting string from the group name.

Result:

Fixed a bug in the billing indexer that caused it to fail when using custom date format
strings in the billing format.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9782/

(cherry picked from commit 67dea34fb170d715ca5f051c9f2914536df91727)