### PR TITLE
transferObserverV1: replace Args with Joiner to construct transfers.t…

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -1,5 +1,6 @@
 package diskCacheV111.cells;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
@@ -540,7 +541,9 @@ public class TransferObserverV1
                     args.add(String.valueOf(now - mover.getStartTime()));
                 }
             }
-            sb.append(new Args(args)).append('\n');
+            
+            Joiner.on(" ").appendTo(sb, args);
+            sb.append('\n');
         }
         return sb.toString();
     }


### PR DESCRIPTION
…xt linesMotivation:

In 2.10, the method which constructs the text output for the transfers list was changed
to use the dCache Args utility in order to encapsulate the appending of spaces between elements.

However, https://rb.dcache.org/r/9716/ added some escaping to the Args class in order to
make the \s command in the admin shell behave correctly.

http://rt.dcache.org/Ticket/Display.html?id=9055 now reports that this escaping is also
appearing in the transfers.txt output, breaking backwards compatibility.

Modification:

Use Guava Joiner instead of Args (more appropriate in any case).

Result:

Backward compatibility is restored.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9055
Patch: https://rb.dcache.org/r/9780
Require-notes: yes
Require-book: no
Acked-by: Dmitry
Acked-by: Paul