### PR TITLE
billing: Strip format string from attribute name

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/billing/text/BillingParserBuilder.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/text/BillingParserBuilder.java
@@ -294,7 +294,8 @@ public class BillingParserBuilder
         while (matcher.find()) {
             String expression = matcher.group(1);
             if (!isIf(expression) && !isElse(expression) && !isEndIf(expression)) {
-                attributes.add(expression);
+                int pos = expression.indexOf(';');
+                attributes.add(pos > -1 ? expression.substring(0, pos) : expression);
             }
         }
         return attributes;


### PR DESCRIPTION
Motivation:

When specifying a format string, the attribute name in the json
or yaml output include the format string, eg.

  date;format="yyyy-MM-dd'T'HH:mm:ssXSSSZ": 2016-09-28T14:58:21+02451+0200

Modification:

Strip the format string from the attribute name.

Result:

Fixed a problem in the output of the 'dcache billing' command using
JSON or YAML when the billing format includes a custom date format.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9784/

(cherry picked from commit 25292750d89d2b35058ec65ee2ea42c29e1dc122)