### PR TITLE
srm,statistics: Parameterize billing service name

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -1428,8 +1428,8 @@ public final class Storage
                                            config.getPath(surl).toString(),
                                            callbacks,
                                            _pnfsStub,
+                                           _billingStub,
                                            getCellAddress(),
-                                           getCellEndpoint(),
                                            _executor);
         } catch (SRMInvalidPathException e) {
             callbacks.notFound(e.getMessage());

--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -1350,9 +1350,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
     private void resetBillingStatistics() {
         _log.info("Resetting Billing statistics");
-        CellMessage m =
-                new CellMessage(new CellAddressCore("billing"), RESET_POOL_STATISTICS);
-        _nucleus.sendMessage(m, true, true);
+        _billing.notify(RESET_POOL_STATISTICS);
     }
     //
     // structur expected from 'billing' : get pool statistics


### PR DESCRIPTION
Motivation:

Several services still had the name of the billing service hard-coded. In
particular remove records generated by the SRM were submitted to the 'billing'
queue rather the the 'BillingTopic' topic.

Modification:

Inject the proper cell stubs.

Result:

Several services were updated to respect the configurable name of the
billing service rather than a hard-coded name.

Target: trunk
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9786/

(cherry picked from commit 3f56a0eefd58feb62d3335844e10caeab2857074)