### PR TITLE
srmclient: provide better error message if credential has expired

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -151,7 +151,7 @@ public class SrmShell extends ShellApplication
         } catch (SRMException e) {
             System.err.println(uri + " failed request: " + e.getMessage());
             System.exit(1);
-        } catch (MalformedURLException e) {
+        } catch (IOException e) {
             System.err.println(e.getMessage());
             System.exit(1);
         }

--- a/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
@@ -175,7 +175,7 @@ public class SRMClientV2 implements ISRM {
         this.retries = numberofretries;
         this.user_cred = user_cred;
         if (user_cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new IOException("credentials have expired");
+            throw new IOException("X.509 credentials have expired");
         }
         host = srmurl.getHost();
         host = InetAddress.getByName(host).getCanonicalHostName();


### PR DESCRIPTION
Motivation:

srmfs will show a stack-trace if the user's credential has expired.
This is not intuative nor user-friendly.

Modification:

Catch the exception and log it with the error message.  The message
is updated to make it more explicit what has gone wrong.

Result:

Users attempting to use srmfs with expired credentials see a
more descriptive message without any stack-trace.

Target: master
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/9794/
Acked-by: Albert Rossi