### PR TITLE
common: add support for UserNamePrincipal as user:<name>

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/Subjects.java
+++ b/modules/common/src/main/java/org/dcache/auth/Subjects.java
@@ -480,6 +480,9 @@ public class Subjects
                 case "name":
                     principal = new LoginNamePrincipal(value);
                     break;
+                case "user":
+                    principal = new UserNamePrincipal(value);
+                    break;
                 default:
                     try {
                         Class principalClass = Class.forName(type);

--- a/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
+++ b/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
@@ -168,7 +168,7 @@ public class Gplazma2LoginStrategy
             "the result was obtained.\n\n" +
             "Examples:\n" +
             "  explain login \"dn:/C=DE/O=GermanGrid/OU=DESY/CN=testUser\" fqan:/test\n" +
-            "  explain login name:testuser\n";
+            "  explain login user:testuser\n";
     public static final String hh_explain_login = "<principal> [<principal> ...] # explain the result of login";
     public String ac_explain_login_$_1_99(Args args)
     {

--- a/modules/dcache/src/main/java/org/dcache/services/login/LoginCLI.java
+++ b/modules/dcache/src/main/java/org/dcache/services/login/LoginCLI.java
@@ -37,16 +37,17 @@ public class LoginCLI
             + "either the login succeeds or fails.  If the login succeeds then the set\n"
             + "of identities is shown.\n"
             + "\n"
-            + "Each supplied principal has the form <type>:<value> (e.g. 'name:paul').\n"
+            + "Each supplied principal has the form <type>:<value> (e.g. 'user:paul').\n"
             + "If a principal has spaces then surround the declaration with quote-marks\n"
             + "(e.g., \"dn:/C=DE/O=ACME/CN=Example certificate\").\n"
             + "\n"
             + "Valid principal types are:\n"
             + "\n"
-            + "    name      a user-requested username\n"
-            + "    kerberos  a kerberos principal (e.g. paul@EXAMPLE.ORG)\n"
             + "    dn        the distinguished name from an X509 certificate\n"
-            + "    fqan      an FQAN, the first is taken as the primary FQAN\n";
+            + "    fqan      an FQAN, the first is taken as the primary FQAN\n"
+            + "    kerberos  a kerberos principal (e.g. paul@EXAMPLE.ORG)\n"
+            + "    name      the desired username when authentication without a password\n"
+            + "    user      the authenticated username\n";
     public static final String hh_test_login = "<principal> [<principal> ...] # show result of login";
     public String ac_test_login_$_1_99(Args args) {
         Subject subject = Subjects.subjectFromArgs(args.getArguments());

--- a/modules/gplazma2-banfile/src/main/scala/org/dcache/gplazma/plugins/BanFilePlugin.scala
+++ b/modules/gplazma2-banfile/src/main/scala/org/dcache/gplazma/plugins/BanFilePlugin.scala
@@ -44,10 +44,10 @@ class BanFilePlugin(properties : Properties) extends GPlazmaAccountPlugin with F
    *   alias <alias>=<full qualified classname>
    *   ban <full qualified classname or alias>:<principal string>
    * e.g.,
-   *   alias username=org.dcache.auth.LoginNamePrincipal
+   *   alias username=org.dcache.auth.UserNamePrincipal
    *   ban username:Someuser
    * or
-   *   ban org.dcache.auth.LoginNamePrincipal:Someuser
+   *   ban org.dcache.auth.UserNamePrincipal:Someuser
    *
    * @return a set of banned principals
    */


### PR DESCRIPTION
Motivation:

The gPlazma "explain login" and "test login" commands and the ban
gPlazma plugin use a common format for describing principals.
Unfortunately, this failed to include the option of specifying the
authenticated username principal UserNamePrincipal.

The prevents admins from obtaining meaningful results from gPlazma
commands when testing the behaviour of non-X.509 and non-Kerberos based
authentication.

It could also lead to admins believing they have banned a user without
that being effective, if they use the existing "login" prefix.

Modification:

Include the "user" prefix to create a UserNamePrincipal.  Documentation
is updated to reflect this new principal.

Result:

Admins are able to test their gPlazma configuration correctly.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9059
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9794/
Acked-by: Albert Rossi

Conflicts:
	modules/common/src/main/java/org/dcache/auth/Subjects.java

Conflicts:
	modules/common/src/main/java/org/dcache/auth/Subjects.java