### PR TITLE
srmclient: give meaningful error message if credential is missing

### DIFF
--- a/modules/srm-client/src/main/bin/srmfs
+++ b/modules/srm-client/src/main/bin/srmfs
@@ -15,6 +15,13 @@ if [ -n "$X509_USER_PROXY" ]; then
     x509_user_proxy="$X509_USER_PROXY"
 elif [ -r /tmp/x509up_u$(id -u) ]; then
     x509_user_proxy=/tmp/x509up_u$(id -u)
+else
+   (echo "Could not find X.509 proxy credential."
+    echo
+    echo "Either create a proxy credential if one does not already exist or"
+    echo "use the X509_USER_PROXY environment variable to specify the path"
+    echo "if the proxy is in a non-standard location.") >&2
+    exit 1
 fi
 
 if [ -n "$X509_CERT_DIR" ]; then


### PR DESCRIPTION
Motivation:

Currently srmfs prints a stack-trace if no credential is present.

Modification:

Update script to insist the credential exists.

Result:

Better user experience if the credential is missing.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9792/
Acked-by: Albert Rossi