### PR TITLE
Active Transfers: substitute ? for <unknown> on html pages

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/util/BeanDataMapper.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/util/BeanDataMapper.java
@@ -1,5 +1,7 @@
 package org.dcache.webadmin.controller.util;
 
+import com.google.common.base.Strings;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -132,12 +134,15 @@ public class BeanDataMapper {
         } else {
             bean.setPnfsId(transfer.session().getPnfsId().toString());
         }
-        if (transfer.session().getPool() != null) {
-            bean.setPool(transfer.session().getPool());
+
+        String poolName = Strings.emptyToNull(transfer.session().getPool());
+        if (poolName == null || poolName.equals("<unknown>")) {
+            poolName = "N.N.";
         }
-        bean.setProcess(transfer.door().getProcess());
-        bean.setProtocol(transfer.door().getProtocolFamily(),
-                        transfer.door().getProtocolVersion());
+
+        bean.setProcess(transfer.door().getProcess().replace("<unknown>", "?"));
+        bean.setProtocol(transfer.door().getProtocolFamily().replace("<unknown>", "?"),
+                         transfer.door().getProtocolVersion().replace("<unknown>", "?"));
         bean.setReplyHost(transfer.session().getReplyHost());
         bean.setSerialId(transfer.session().getSerialId());
         if (transfer.session().getStatus() == null) {

--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -556,11 +556,11 @@ public class TransferObserverV1
         page.td("door", transfer.getCellName());
         page.td("domain", transfer.getDomainName());
         page.td("sequence", transfer.getSerialId());
-        page.td("protocol", transfer.getProtocol());
+        page.td("protocol", transfer.getProtocol().replaceAll("[<]unknown[>]", "?"));
         page.td("uid", transfer.getUserInfo().getUid());
         page.td("gid", transfer.getUserInfo().getGid());
         page.td("vomsGroup", transfer.getUserInfo().getPrimaryVOMSGroup());
-
+        
         String tmp = transfer.getProcess();
         tmp = tmp.contains("known") ? "?" : tmp;
         page.td("process", tmp);

--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -560,7 +560,7 @@ public class TransferObserverV1
         page.td("uid", transfer.getUserInfo().getUid());
         page.td("gid", transfer.getUserInfo().getGid());
         page.td("vomsGroup", transfer.getUserInfo().getPrimaryVOMSGroup());
-        
+
         String tmp = transfer.getProcess();
         tmp = tmp.contains("known") ? "?" : tmp;
         page.td("process", tmp);


### PR DESCRIPTION
Motivation:

DoorInfo and TransferInfo make the default values for owner, pool, protocol and process
"<unknown>".  While the Wicket engine automagically converts the angle brackets to
"&lt;" and "&gt;", the classic engine leaves the browser to interpret this marker
(erroneously) as an html tag.

See ticket 9056.

Modification:

Since the pool name is already handled by converting it to "N.N", and the process
by converting it to "?", we have added a similar conversion for protocol parts.

Further, we have made the webadmin pages conform to this representation as well.

Note that plain text and JSON output is not affected (only HTML).

Result:

No confusing "<unknown>" elements in the active transfer page markup.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9056
Patch: https://rb.dcache.org/r/9785
Acked-by: Paul