### PR TITLE
Active Transfers: substitute ? for <unknown> on html pages

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/util/BeanDataMapper.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/util/BeanDataMapper.java
@@ -1,5 +1,7 @@
 package org.dcache.webadmin.controller.util;
 
+import com.google.common.base.Strings;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -132,12 +134,16 @@ public class BeanDataMapper {
         } else {
             bean.setPnfsId(transfer.session().getPnfsId().toString());
         }
-        if (transfer.session().getPool() != null) {
-            bean.setPool(transfer.session().getPool());
+
+        String poolName = Strings.emptyToNull(transfer.session().getPool());
+        if (poolName == null || poolName.equals("<unknown>")) {
+            poolName = "N.N.";
         }
-        bean.setProcess(transfer.door().getProcess());
-        bean.setProtocolFamily(transfer.door().getProtocolFamily());
-        bean.setProtocolVersion(transfer.door().getProtocolVersion());
+
+        bean.setPool(poolName);
+        bean.setProcess(transfer.door().getProcess().replace("<unknown>", "?"));
+        bean.setProtocolFamily(transfer.door().getProtocolFamily().replace("<unknown>", "?"));
+        bean.setProtocolVersion(transfer.door().getProtocolVersion().replace("<unknown>", "?"));
         bean.setReplyHost(transfer.session().getReplyHost());
         bean.setSerialId(transfer.session().getSerialId());
         if (transfer.session().getStatus() == null) {

--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -612,8 +612,8 @@ public class TransferObserverV1
         page.td("door", transfer.door().getCellName());
         page.td("domain", transfer.door().getDomainName());
         page.td("sequence", transfer.session().getSerialId());
-        page.td("protocol", transfer.door().getProtocolFamily() +
-                     "-" + transfer.door().getProtocolVersion());
+        page.td("protocol", transfer.door().getProtocolFamily().replace("[<]unknown[>]", "?") +
+                     "-" + transfer.door().getProtocolVersion().replace("[<]unknown[>]", "?"));
 
         String tmp = transfer.door().getOwner() ;
         tmp = tmp.contains("known") ? "?" : _fieldMap.mapOwner(tmp) ;


### PR DESCRIPTION
Motivation:

DoorInfo and TransferInfo make the default values for owner, pool, protocol and process
"<unknown>".  While the Wicket engine automagically converts the angle brackets to
"&lt;" and "&gt;", the classic engine leaves the browser to interpret this marker
(erroneously) as an html tag.

See ticket 9056.

Modification:

Since the pool name is already handled by converting it to "N.N", and the process
by converting it to "?", we have added a similar conversion for protocol parts.

Further, we have made the webadmin pages conform to this representation as well.

Note that plain text and JSON output is not affected (only HTML).

Result:

No confusing "<unknown>" elements in the active transfer page markup.

Target: master
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9056
Patch: https://rb.dcache.org/r/9785
Acked-by: Paul