### PR TITLE
srmclient: avoid stack-trace if lcd with incorrect path

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -451,7 +451,7 @@ public class SrmShell extends ShellApplication
         String path;
 
         @Override
-        public Serializable call() throws IOException
+        public Serializable call() throws IllegalArgumentException, IOException
         {
             Path newPath = lcwd.resolve(path).normalize();
 


### PR DESCRIPTION
Motivation:

Providing an incorrect directory with the lcd command results in a
stack-trace.

Modification:

Declare IllegalArgumentException as an expected exception.

Result:

No longer present the user with a stack-trace if the user issues an lcd
command with an incorrect directory.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9802/
Acked-by: Olufemi Adeyemi