### PR TITLE
srmclient: clean shutdown srmfs after transfer

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmTransferAgent.java
@@ -131,9 +131,10 @@ public class SrmTransferAgent extends AbstractFileTransferAgent
     }
 
     @Override
-    public void close()
+    public void close() throws Exception
     {
         MoreExecutors.shutdownAndAwaitTermination(_srmExecutor, 500, TimeUnit.MILLISECONDS);
+        agent.close();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

A clean shutdown is not possible after making a transfer.

Modification:

Ensure transfer agent is shutdown when the SRM agent is shutdown.

Result:

srmfs shuts down cleanly even after making a transfer.

Target: master
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/9803/
Acked-by: Tigran Mkrtchyan