### PR TITLE
doors: Ensure that pool selection context survives between retries

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
@@ -27,22 +27,22 @@ import static org.dcache.namespace.FileAttribute.*;
  * free to either copy the file to another pool or stage it from
  * tape. These operations will cause the file attributes to be out of
  * date. In such cases PoolManager will reply with an OUT_OF_DATE
- * error code. The requestor is expected to refresh avilable file
+ * error code. The requester is expected to refresh available file
  * attributes and retry the request immediately.
  *
- * Should pool selection fail for any reason then the requestor may
+ * Should pool selection fail for any reason then the requester may
  * retry the request. In such cases PoolManager needs access to state
  * from the previous request. It is the responsibility of the
- * requestor to maintain this state and provide when retrying the
+ * requester to maintain this state and provide it when retrying the
  * request. The state is encapsulated in the request context. This
  * context should be attached to the retry request.
  *
- * The requestor should expect that a subsequent request to read the
+ * The requester should expect that a subsequent request to read the
  * file from a pool may fail. Typical reasons for such failures is
  * that the pool was disabled after pool manager selected the pool, or
  * that the name space contained stale information (such stale
  * information is cleared by pool on attempt to read the file). The
- * requestor may retry the pool selection and should reread file meta
+ * requester may retry the pool selection and should reread file meta
  * data before doing so.
  */
 public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg

--- a/modules/dcache/src/main/java/org/dcache/cells/CellStub.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/CellStub.java
@@ -551,7 +551,7 @@ public class CellStub
      * distinguishes this method from {@link Futures#transform}.
      */
     public static <T extends Message, V> ListenableFuture<V> transform(
-            ListenableFuture<T> future, Function<T, V> f)
+            ListenableFuture<T> future, Function<? super T, ? extends V> f)
     {
         return Futures.transformAsync(future,
                                       msg -> {
@@ -573,8 +573,8 @@ public class CellStub
      * returned {@code Future} will fail with the corresponding CacheException. This
      * distinguishes this method from {@link Futures#transform}.
      */
-    public static <T extends Message, V> ListenableFuture<V> transform(
-            ListenableFuture<T> future, AsyncFunction<T, V> f)
+    public static <T extends Message, V> ListenableFuture<V> transformAsync(
+            ListenableFuture<T> future, AsyncFunction<? super T, V> f)
     {
         return Futures.transformAsync(future,
                                       msg -> {
@@ -619,7 +619,7 @@ public class CellStub
     /**
      * Adapter class to turn a CellMessageAnswerable callback into a ListenableFuture.
      */
-    static class CallbackFuture<T> extends AbstractFuture<T> implements CellMessageAnswerable
+    private static class CallbackFuture<T> extends AbstractFuture<T> implements CellMessageAnswerable
     {
         private final Class<? extends T> _type;
         private final Semaphore _concurrency;

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -1,9 +1,11 @@
 package org.dcache.util;
 
+import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.AsyncFunction;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableScheduledFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -50,6 +52,7 @@ import diskCacheV111.vehicles.PnfsCreateEntryMessage;
 import diskCacheV111.vehicles.PoolAcceptFileMessage;
 import diskCacheV111.vehicles.PoolDeliverFileMessage;
 import diskCacheV111.vehicles.PoolIoFileMessage;
+import diskCacheV111.vehicles.PoolMgrSelectPoolMsg;
 import diskCacheV111.vehicles.PoolMgrSelectReadPoolMsg;
 import diskCacheV111.vehicles.PoolMgrSelectWritePoolMsg;
 import diskCacheV111.vehicles.PoolMoverKillMessage;
@@ -766,30 +769,29 @@ public class Transfer implements Comparable<Transfer>
 
         setStatusUntil("PnfsManager: Fetching storage info", reply);
 
-        return CellStub.transform(reply,
-                                  (PnfsGetFileAttributes msg) ->
-                                  {
-                                      FileAttributes attributes = msg.getFileAttributes();
-                                     /* We can only transfer regular files.
-                                      */
-                                      FileType type = attributes.getFileType();
-                                      if (type == FileType.DIR || type == FileType.SPECIAL) {
-                                          throw new NotFileCacheException("Not a regular file");
-                                      }
+        return CellStub.transformAsync(reply,
+                                       msg -> {
+                                           FileAttributes attributes = msg.getFileAttributes();
+                                           /* We can only transfer regular files.
+                                            */
+                                           FileType type = attributes.getFileType();
+                                           if (type == FileType.DIR || type == FileType.SPECIAL) {
+                                               throw new NotFileCacheException("Not a regular file");
+                                           }
 
-                                     /* I/O mode must match completeness of the file.
-                                      */
-                                      if (!attributes.getStorageInfo().isCreatedOnly()) {
-                                          setWrite(false);
-                                      } else if (allowWrite) {
-                                          setWrite(true);
-                                      } else {
-                                          throw new FileIsNewCacheException();
-                                      }
+                                           /* I/O mode must match completeness of the file.
+                                            */
+                                           if (!attributes.getStorageInfo().isCreatedOnly()) {
+                                               setWrite(false);
+                                           } else if (allowWrite) {
+                                               setWrite(true);
+                                           } else {
+                                               throw new FileIsNewCacheException();
+                                           }
 
-                                      setFileAttributes(attributes);
-                                      return immediateFuture(null);
-                                  });
+                                           setFileAttributes(attributes);
+                                           return immediateFuture(null);
+                                       });
     }
 
     /**
@@ -898,7 +900,7 @@ public class Transfer implements Comparable<Transfer>
 
     /**
      * Sets the previous read pool selection message. The message
-     * contains state that is maintained accross repeated pool
+     * contains state that is maintained across repeated pool
      * selections.
      */
     protected synchronized void setReadPoolSelectionContext(PoolMgrSelectReadPoolMsg.Context context)
@@ -932,6 +934,7 @@ public class Transfer implements Comparable<Transfer>
         FileAttributes fileAttributes = getFileAttributes();
 
         ProtocolInfo protocolInfo = getProtocolInfoForPoolManager();
+        ListenableFuture<? extends PoolMgrSelectPoolMsg> reply;
         if (isWrite()) {
             long allocated = _allocated;
             if (allocated == 0 && fileAttributes.isDefined(SIZE)) {
@@ -947,16 +950,7 @@ public class Transfer implements Comparable<Transfer>
             request.setTransferPath(getTransferPath());
             request.setIoQueueName(getIoQueue());
 
-            ListenableFuture<PoolMgrSelectWritePoolMsg> reply = _poolManager.send(request, timeout);
-            setStatusUntil("PoolManager: Selecting pool", reply);
-
-            return CellStub.transform(reply,
-                                      (PoolMgrSelectWritePoolMsg msg) -> {
-                                          setPool(msg.getPoolName());
-                                          setPoolAddress(msg.getPoolAddress());
-                                          setFileAttributes(msg.getFileAttributes());
-                                          return immediateFuture(null);
-                                      });
+            reply = _poolManager.send(request, timeout);
         } else {
             EnumSet<RequestContainerV5.RequestState> allowedStates;
             try {
@@ -979,17 +973,21 @@ public class Transfer implements Comparable<Transfer>
             request.setTransferPath(getTransferPath());
             request.setIoQueueName(getIoQueue());
 
-            ListenableFuture<PoolMgrSelectReadPoolMsg> reply = _poolManager.send(request, timeout);
-            setStatusUntil("PoolManager: Selecting pool", reply);
-            return CellStub.transform(reply,
+            reply = Futures.transform(_poolManager.send(request, timeout),
                                       (PoolMgrSelectReadPoolMsg msg) -> {
-                                          setPool(msg.getPoolName());
-                                          setPoolAddress(msg.getPoolAddress());
-                                          setFileAttributes(msg.getFileAttributes());
                                           setReadPoolSelectionContext(msg.getContext());
-                                          return immediateFuture(null);
+                                          return msg;
                                       });
         }
+
+        setStatusUntil("PoolManager: Selecting pool", reply);
+        return CellStub.transform(reply,
+                                  (PoolMgrSelectPoolMsg msg) -> {
+                                      setPool(msg.getPoolName());
+                                      setPoolAddress(msg.getPoolAddress());
+                                      setFileAttributes(msg.getFileAttributes());
+                                      return null;
+                                  });
     }
 
     /**
@@ -1050,7 +1048,7 @@ public class Transfer implements Comparable<Transfer>
 
         ListenableFuture<PoolIoFileMessage> reply = _pool.send(poolPath, message, timeout);
         setStatusUntil("Pool " + pool + ": Creating mover", reply);
-        return CellStub.transform(reply, (PoolIoFileMessage msg) -> {
+        return CellStub.transformAsync(reply, msg -> {
             setMoverId(msg.getMoverId());
             return immediateFuture(null);
         });


### PR DESCRIPTION
Motivation:

When read pool selection returns with an error the pool manager includes a
context object. The door is supposed to provide this object when it retries the
request such that pool manager can avoid retrying the same stage pool and can
keep track of the number of retries.

The Transfer class however contains a bug in which it uses the
CellStub.transformAsync method to extract attributes from the asynchronous
response. This method specifically detects error replies and throws an
exception rather than transforming the result. Thus when pool manager returns
an error, the transformation is not applied and the context is not captured.

Modification:

Use regular Futures.transform to extract the context.

Also renamed one of the CellStub.transform methods to transformAsync
to match the Guava name and allow better type inference with lambda
expressions.

Result:

Fixed a bug in which information on stage pool and number of attempts
were lost when retrying pool selection requests.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9817/

(cherry picked from commit 54ba7fe3104575e34063fb29b612c60f26e2d8d5)