### PR TITLE
doors: Ensure that pool selection context survives between retries

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
+++ b/modules/dcache/src/main/java/diskCacheV111/vehicles/PoolMgrSelectReadPoolMsg.java
@@ -27,22 +27,22 @@ import static org.dcache.namespace.FileAttribute.*;
  * free to either copy the file to another pool or stage it from
  * tape. These operations will cause the file attributes to be out of
  * date. In such cases PoolManager will reply with an OUT_OF_DATE
- * error code. The requestor is expected to refresh avilable file
+ * error code. The requester is expected to refresh available file
  * attributes and retry the request immediately.
  *
- * Should pool selection fail for any reason then the requestor may
+ * Should pool selection fail for any reason then the requester may
  * retry the request. In such cases PoolManager needs access to state
  * from the previous request. It is the responsibility of the
- * requestor to maintain this state and provide when retrying the
+ * requester to maintain this state and provide it when retrying the
  * request. The state is encapsulated in the request context. This
  * context should be attached to the retry request.
  *
- * The requestor should expect that a subsequent request to read the
+ * The requester should expect that a subsequent request to read the
  * file from a pool may fail. Typical reasons for such failures is
  * that the pool was disabled after pool manager selected the pool, or
  * that the name space contained stale information (such stale
  * information is cleared by pool on attempt to read the file). The
- * requestor may retry the pool selection and should reread file meta
+ * requester may retry the pool selection and should reread file meta
  * data before doing so.
  */
 public class PoolMgrSelectReadPoolMsg extends PoolMgrSelectPoolMsg

--- a/modules/dcache/src/main/java/org/dcache/cells/CellStub.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/CellStub.java
@@ -558,7 +558,7 @@ public class CellStub
      * distinguishes this method from {@link Futures#transform}.
      */
     public static <T extends Message, V> ListenableFuture<V> transform(
-            ListenableFuture<T> future, Function<T, V> f)
+            ListenableFuture<T> future, Function<? super T, ? extends V> f)
     {
         return Futures.transform(future,
                                  new AsyncFunction<T, V>() {
@@ -584,8 +584,8 @@ public class CellStub
      * returned {@code Future} will fail with the corresponding CacheException. This
      * distinguishes this method from {@link Futures#transform}.
      */
-    public static <T extends Message, V> ListenableFuture<V> transform(
-            ListenableFuture<T> future, AsyncFunction<T, V> f)
+    public static <T extends Message, V> ListenableFuture<V> transformAsync(
+            ListenableFuture<T> future, AsyncFunction<? super T, V> f)
     {
         return Futures.transform(future,
                                  new AsyncFunction<T, V>() {
@@ -634,7 +634,7 @@ public class CellStub
     /**
      * Adapter class to turn a CellMessageAnswerable callback into a ListenableFuture.
      */
-    static class CallbackFuture<T> extends AbstractFuture<T> implements CellMessageAnswerable
+    private static class CallbackFuture<T> extends AbstractFuture<T> implements CellMessageAnswerable
     {
         private final Class<? extends T> _type;
         private final Semaphore _concurrency;


### PR DESCRIPTION
Motivation:

When read pool selection returns with an error the pool manager includes a
context object. The door is supposed to provide this object when it retries the
request such that pool manager can avoid retrying the same stage pool and can
keep track of the number of retries.

The Transfer class however contains a bug in which it uses the
CellStub.transformAsync method to extract attributes from the asynchronous
response. This method specifically detects error replies and throws an
exception rather than transforming the result. Thus when pool manager returns
an error, the transformation is not applied and the context is not captured.

Modification:

Use regular Futures.transform to extract the context.

Also renamed one of the CellStub.transform methods to transformAsync
to match the Guava name and allow better type inference with lambda
expressions.

Result:

Fixed a bug in which information on stage pool and number of attempts
were lost when retrying pool selection requests.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9817/

(cherry picked from commit 54ba7fe3104575e34063fb29b612c60f26e2d8d5)
(cherry picked from commit a3a68b7def8da6aaa3c1b20b7857a580ca9c5846)