### PR TITLE
dcache: Fix detection of message errors in poolmanager and admin

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -344,7 +344,7 @@ public class UserAdminShell
      */
     private ListenableFuture<Stream<String>> getPools(String poolGroup)
     {
-        return transform(
+        return CellStub.transform(
                 _poolManager.send(new PoolManagerGetPoolsByPoolGroupMessage(singletonList(poolGroup))),
                 (PoolManagerGetPoolsByPoolGroupMessage m) ->
                         m.getPools().stream().map(PoolManagerPoolInformation::getName));

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/Rebalancer.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/Rebalancer.java
@@ -67,7 +67,7 @@ public class Rebalancer
     {
         return allAsList(pools.stream()
                                  .map(pool -> new CellPath(pool.getName()))
-                                 .map(path -> _poolStub.send(path, new PoolMigrationJobCancelMessage(JOB_NAME, true)))
+                                 .map(path -> CellStub.transform(_poolStub.send(path, new PoolMigrationJobCancelMessage(JOB_NAME, true)), m -> m))
                                  .collect(toList()));
     }
 


### PR DESCRIPTION
Motivation:

While cells itself carries errors as Exception replies, dCache's Message
base class carries errors as a non-zero return code in the Message.

We have various utility methods in CellStub that can detect these error
and throw them as exceptions, however in some cases we use the generic
versions in the Guava Futures class that does not detect the errors.

Modification:

Use the proper CellStub version.

This is a temporary fix that is easy to backport. The entire architecture
is messy and we should find alternative solutions.

Result:

Fixed a bug in admin and in the pool manager rebalancer component that
caused these to not detect certain error replies from other components.

Target: trunk
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9818/

(cherry picked from commit 08d69d6328380f93a3e5452c64a64f5af8d9ce25)