### PR TITLE
frontend: reinstate support for truly anonymous access

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -73,14 +73,22 @@
   </bean>
 
   <bean id="login-strategy" class="org.dcache.webdav.AnonymousUserLoginStrategy">
-      <description>Processes login requests</description>
-      <property name="nonAnonymousStrategy">
-          <bean class="org.dcache.services.login.RemoteLoginStrategy">
-              <property name="cellStub" ref="login-stub"/>
-          </bean>
-      </property>
+      <description>Processes login for user 'anonymous'</description>
       <property name="anonymousAccess" value="${frontend.authz.anonymous-operations}"/>
       <property name="username" value="anonymous"/>
+      <property name="nonAnonymousStrategy">
+          <bean id="union-login-strategy" class="org.dcache.auth.UnionLoginStrategy">
+              <description>Process anonymous login requests</description>
+              <property name="loginStrategies">
+                  <list>
+                      <bean class="org.dcache.services.login.RemoteLoginStrategy">
+                          <property name="cellStub" ref="login-stub"/>
+                      </bean>
+                  </list>
+              </property>
+              <property name="anonymousAccess" value="${frontend.authz.anonymous-operations}"/>
+          </bean>
+      </property>
   </bean>
 
   <bean id="cache-login-strategy" class="org.dcache.auth.CachingLoginStrategy">


### PR DESCRIPTION
Motivation:

dCache includes the concept of the anonymous user: one who has presented
no (accepted) credential when authenticating.  Support for such users is
configurable.  Commit 942cca1f added support in the frontend for the
user 'anonymous' being treated as the anonymous user as a work-around
for browser limitations.  Unfortunately, this patch broke support for
truly anonymous users.

Modification:

Reinstate the use of UnionLoginStrategy, which adds support for
anonymous access.

Result:

Fix regression where users accessing dCache through the frontend and who
supply no credential have no access to dCache, despite dCache being
configured to accept such access.

Target: master
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9827/
Acked-by: Olufemi Adeyemi