### PR TITLE
common: do not markup ellipses as a user-value

### DIFF
--- a/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
+++ b/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
@@ -198,7 +198,7 @@ public abstract class TextHelpPrinter implements AnnotatedCommandHelpPrinter
                 signature.append("[").append(metaVar).append("]");
             }
             if (field.getType().isArray()) {
-                signature.append(value("..."));
+                signature.append("...");
             }
             signature.append(" ");
         }
@@ -222,7 +222,7 @@ public abstract class TextHelpPrinter implements AnnotatedCommandHelpPrinter
                 signature.append("[").append(metaVar).append("]");
             }
             if (field.getType().isArray()) {
-                signature.append(value("..."));
+                signature.append("...");
             }
             signature.append(" ");
         }


### PR DESCRIPTION
Motivation:

Stylistically, the text help printer supports output that distinguishes
between user-input and structual elements in the output.  This currently
results in user-input text being underlined.

The ellipsis in an argument's representation (that denote accepting
multiple arguments) are marked up as user-input.  This developer finds
it easier to parse if ellipses are not marked up as a user-value; that
it is, instead, an non-marked-up structural element.

Modification:

No longer markup ellipses.

Result:

Easier to parse help text.

Target: master
Request: 2.16
Requires-notes: yes
Requires-srm-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9825/
Acked-by: Olufemi Adeyemi