### PR TITLE
webdav: Fix initialization of html template

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/AdminReloadingTemplate.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/AdminReloadingTemplate.java
@@ -35,7 +35,6 @@ public class AdminReloadingTemplate extends ReloadableTemplate implements CellCo
     public AdminReloadingTemplate(Resource resource) throws IOException
     {
         super(resource);
-        reload();
     }
 
     @Command(name="reload template", hint="refresh HTML template from file")

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/AutoReloadingTemplate.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/AutoReloadingTemplate.java
@@ -20,7 +20,6 @@ package org.dcache.webdav;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
-import org.stringtemplate.v4.STErrorListener;
 import org.stringtemplate.v4.STGroup;
 
 import java.io.IOException;

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/ReloadableTemplateFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/ReloadableTemplateFactory.java
@@ -19,22 +19,18 @@ package org.dcache.webdav;
 
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Required;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.core.io.Resource;
-
-import org.dcache.cells.UniversalSpringCell.BeanPostProcessorAware;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * Factory for creating the reloadable template.
  */
-public class ReloadableTemplateFactory implements FactoryBean, BeanPostProcessorAware
+public class ReloadableTemplateFactory implements FactoryBean
 {
     private Resource _templateResource;
     private boolean _isAutoReloadEnabled;
     private String _templateName;
-    private BeanPostProcessor _processor;
 
     @Override
     public Object getObject() throws Exception
@@ -42,8 +38,8 @@ public class ReloadableTemplateFactory implements FactoryBean, BeanPostProcessor
         ReloadableTemplate t = _isAutoReloadEnabled
                 ? new AutoReloadingTemplate(_templateResource)
                 : new AdminReloadingTemplate(_templateResource);
-        t = (ReloadableTemplate) _processor.postProcessBeforeInitialization(t, _templateName);
         t.setTemplateName(_templateName);
+        t.reload();
         return t;
     }
 
@@ -75,11 +71,5 @@ public class ReloadableTemplateFactory implements FactoryBean, BeanPostProcessor
     public void setWorkaroundTemplate(String name)
     {
         _templateName = requireNonNull(name);
-    }
-
-    @Override
-    public void setBeanPostProcessor(BeanPostProcessor processor)
-    {
-        _processor = processor;
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
@@ -135,11 +135,6 @@ public class UniversalSpringCell
     private static final Class<?>[] TERMINAL_TYPES = new Class<?>[] { Class.class, ApplicationContext.class };
     private static final Class<?>[] HIDDEN_TYPES = new Class<?>[] { ApplicationContext.class, AutoCloseable.class };
 
-    public interface BeanPostProcessorAware
-    {
-        void setBeanPostProcessor(BeanPostProcessor processor);
-    }
-
     /**
      * Environment map this cell was instantiated in.
      */
@@ -930,31 +925,6 @@ public class UniversalSpringCell
     }
 
     /**
-     * Add a message sender. Message senders can send cell messages
-     * via a cell endpoint.
-     */
-    public void addMessageSender(CellMessageSender bean)
-    {
-        bean.setCellEndpoint(this);
-    }
-
-    /**
-     * Add provider of CellInfo to a CellInfoAware bean.
-     */
-    public void addCellInfoAware(CellInfoAware bean)
-    {
-        bean.setCellInfoSupplier(this::getCellInfo);
-    }
-
-    /**
-     * Add the cell's identity
-     */
-    public void addCellIdentity(CellIdentityAware bean)
-    {
-        bean.setCellAddress(getNucleus().getThisAddress());
-    }
-
-    /**
      * Registers a setup provider. Setup providers contribute to the
      * result of the <code>save</code> method.
      */
@@ -984,42 +954,6 @@ public class UniversalSpringCell
                                                   String beanName)
         throws BeansException
     {
-        if (bean instanceof BeanPostProcessorAware) {
-            ((BeanPostProcessorAware)bean).setBeanPostProcessor(this);
-        }
-
-        if (bean instanceof CellCommandListener) {
-            addCommandListener(bean);
-        }
-
-        if (bean instanceof CellInfoProvider) {
-            addInfoProviderBean((CellInfoProvider) bean, beanName);
-        }
-
-        if (bean instanceof CellMessageReceiver) {
-            addMessageReceiver((CellMessageReceiver) bean);
-        }
-
-        if (bean instanceof CellMessageSender) {
-            addMessageSender((CellMessageSender) bean);
-        }
-
-        if (bean instanceof CellInfoAware) {
-            addCellInfoAware((CellInfoAware) bean);
-        }
-
-        if (bean instanceof CellIdentityAware) {
-            addCellIdentity((CellIdentityAware) bean);
-        }
-
-        if (bean instanceof CellSetupProvider) {
-            addSetupProviderBean((CellSetupProvider) bean, beanName);
-        }
-
-        if (bean instanceof CellLifeCycleAware) {
-            addLifeCycleAwareBean((CellLifeCycleAware) bean, beanName);
-        }
-
         if (bean instanceof EnvironmentAware) {
             ((EnvironmentAware) bean).setEnvironment(_environment);
         }
@@ -1032,12 +966,20 @@ public class UniversalSpringCell
             ((DomainContextAware) bean).setDomainContext(getDomainContext());
         }
 
-        if (bean instanceof CellEventListener) {
-            addCellEventListener((CellEventListener) bean);
-        }
-
         if (bean instanceof CuratorFrameworkAware) {
             ((CuratorFrameworkAware) bean).setCuratorFramework(getCuratorFramework());
+        }
+
+        if (bean instanceof CellIdentityAware) {
+            ((CellIdentityAware) bean).setCellAddress(getNucleus().getThisAddress());
+        }
+
+        if (bean instanceof CellInfoAware) {
+            ((CellInfoAware) bean).setCellInfoSupplier(this::getCellInfo);
+        }
+
+        if (bean instanceof CellMessageSender) {
+            ((CellMessageSender) bean).setCellEndpoint(this);
         }
 
         return bean;
@@ -1048,6 +990,30 @@ public class UniversalSpringCell
                                                  String beanName)
         throws BeansException
     {
+        if (bean instanceof CellCommandListener) {
+            addCommandListener(bean);
+        }
+
+        if (bean instanceof CellInfoProvider) {
+            addInfoProviderBean((CellInfoProvider) bean, beanName);
+        }
+
+        if (bean instanceof CellMessageReceiver) {
+            addMessageReceiver((CellMessageReceiver) bean);
+        }
+
+        if (bean instanceof CellSetupProvider) {
+            addSetupProviderBean((CellSetupProvider) bean, beanName);
+        }
+
+        if (bean instanceof CellLifeCycleAware) {
+            addLifeCycleAwareBean((CellLifeCycleAware) bean, beanName);
+        }
+
+        if (bean instanceof CellEventListener) {
+            addCellEventListener((CellEventListener) bean);
+        }
+
         return bean;
     }
 


### PR DESCRIPTION
Motivation:

08 Oct 2016 22:15:30 (WebDAVS-dav-ipv4) [door:WebDAVS-dav-ipv4@webdavs-piggyDomain:AAU+YDA4TWA] template 'errorpage' not found in templategroup: /usr/share/dcache/webdav/templates/html.stg
08 Oct 2016 22:15:30 (WebDAVS-dav-ipv4) [door:WebDAVS-dav-ipv4@webdavs-piggyDomain:AAU+YDA60eg] template 'errorpage' not found in templategroup: /usr/share/dcache/webdav/templates/html.stg
08 Oct 2016 22:15:30 (WebDAVS-dav-ipv4) [door:WebDAVS-dav-ipv4@webdavs-piggyDomain:AAU+YDA7fcg] template 'errorpage' not found in templategroup: /usr/share/dcache/webdav/templates/html.stg
08 Oct 2016 22:15:30 (WebDAVS-dav-ipv4) [door:WebDAVS-dav-ipv4@webdavs-piggyDomain:AAU+YDA7y+g] template 'errorpage' not found in templategroup: /usr/share/dcache/webdav/templates/html.stg
08 Oct 2016 22:15:30 (WebDAVS-dav-ipv4) [door:WebDAVS-dav-ipv4@webdavs-piggyDomain:AAU+YDA81Yg] template 'errorpage' not found in templategroup: /usr/share/dcache/webdav/templates/html.stg
08 Oct 2016 22:15:30 (WebDAVS-dav-ipv4) [door:WebDAVS-dav-ipv4@webdavs-piggyDomain:AAU+YDA9M0g] template 'errorpage' not found in templategroup: /usr/share/dcache/webdav/templates/html.stg

Modification:

Ensure that the reload method is called after the template name has
been set.

Remove the need for invoking the bean post processor directly by letting those
post processing steps in universal spring cell that simply register the bean in
external lists happen after the initialization callbacks. That step is also
applied to beans created by a factory.

The post processing that injects something into the bean is still executed before
the initialization callbacks.

Removed the Aware interface for the bean post processor - first of all, it was
incorrectly implemented as it only exposed the universal spring cell as a bean
post processor, despite there being many other registered post processors in
spring. Second, it is quite easy for a bean to get a reference to its
BeanFactory (either through an @Autowirable annotation or by implementing one
of Spring's Aware interfaces); using the BeanFactory, one can ask it to apply
all registered post processors on a custom bean.

Result:

Fixed an unreleased bug in WebDAV door that caused it to fail to load the errorpage
template.

Target: trunk
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Request: 3.0

Reviewed at https://rb.dcache.org/r/9824/

(cherry picked from commit 9204dc39fe2bdf64308b47db36cc43094cb6876c)