### PR TITLE
admin: Send requests to a fully qualified address once connected to a cell

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -617,7 +617,7 @@ public class UserAdminShell
                                           }, MoreExecutors.directExecutor(), CONNECT_PROBE_MESSAGE_TIMEOUT_MS);
                 CellAddressCore remote = future.get();
                 if (path.hops() == 1 && path.getDestinationAddress().isLocalAddress()) {
-                    return new Position(remote.toString(), path);
+                    return new Position(remote.toString(), new CellPath(remote));
                 } else {
                     return new Position(cell, path);
                 }


### PR DESCRIPTION
Motivation:

The admin shell was written before the introduction of named queues.
After replacing well known cells with named queues, there may now be
more than one cell accepting messages from the same named queue. Once
connected to a cell, we thus have to use the fully qualified cell
address to ensure all messages are sent to the connected cell.

Modification:

Use the cell address are returned from the ping we use to verify that
the cell exists.

Result:

Fixed a problem in which connecting the admin shell to a named queue
caused messages to be sent to one of several consumers rather than the
one cell than the admin prompt would indicate as the connected cell.

Target: trunk
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Anupam Ashish <anupam.ashish@desy.de>

Reviewed at https://rb.dcache.org/r/9829/

(cherry picked from commit e576407c4251b0b546e0180060a7d73b732211b5)