### PR TITLE
xrootd: Upgrade to xrootd4j 3.2.1

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/AbstractXrootdRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/AbstractXrootdRequestHandler.java
@@ -17,15 +17,9 @@
  */
 package org.dcache.xrootd;
 
-import com.google.common.net.InetAddresses;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.haproxy.HAProxyMessage;
-import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.net.InetSocketAddress;
-import java.util.Objects;
 
 import org.dcache.xrootd.core.XrootdException;
 import org.dcache.xrootd.core.XrootdRequestHandler;
@@ -42,51 +36,6 @@ public class AbstractXrootdRequestHandler extends XrootdRequestHandler
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractXrootdRequestHandler.class);
 
-    private boolean _isHealthCheck;
-
-    private InetSocketAddress _localAddress;
-
-    private InetSocketAddress _remoteAddress;
-
-    @Override
-    public void channelActive(ChannelHandlerContext ctx) throws Exception
-    {
-        _localAddress = (InetSocketAddress) ctx.channel().localAddress();
-        _remoteAddress = (InetSocketAddress) ctx.channel().remoteAddress();
-    }
-
-    @Override
-    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception
-    {
-        if (msg instanceof HAProxyMessage) {
-            HAProxyMessage proxyMessage = (HAProxyMessage) msg;
-            switch (proxyMessage.command()) {
-            case LOCAL:
-                _isHealthCheck = true;
-                break;
-            case PROXY:
-                String sourceAddress = proxyMessage.sourceAddress();
-                String destinationAddress = proxyMessage.destinationAddress();
-                InetSocketAddress localAddress = (InetSocketAddress) ctx.channel().localAddress();
-                if (proxyMessage.proxiedProtocol() == HAProxyProxiedProtocol.TCP4 ||
-                    proxyMessage.proxiedProtocol() == HAProxyProxiedProtocol.TCP6) {
-                    if (Objects.equals(destinationAddress, localAddress.getAddress().getHostAddress())) {
-                        /* Workaround for what looks like a bug in HAProxy - health checks should
-                         * generate a LOCAL command, but it appears they do actually use PROXY.
-                         */
-                        _isHealthCheck = true;
-                    } else {
-                        _localAddress = new InetSocketAddress(InetAddresses.forString(destinationAddress), proxyMessage.destinationPort());
-                        _remoteAddress = new InetSocketAddress(InetAddresses.forString(sourceAddress), proxyMessage.sourcePort());
-                    }
-                }
-                break;
-            }
-        } else {
-            super.channelRead(ctx, msg);
-        }
-    }
-
     @Override
     protected XrootdResponse<ProtocolRequest> doOnProtocolRequest(ChannelHandlerContext ctx, ProtocolRequest msg)
             throws XrootdException
@@ -101,7 +50,7 @@ public class AbstractXrootdRequestHandler extends XrootdRequestHandler
          * whether the file exists or not.
          */
         return new LocateResponse(msg, new LocateResponse.InfoElement(
-                getLocalAddress(), LocateResponse.Node.SERVER, LocateResponse.Access.READ));
+                getDestinationAddress(), LocateResponse.Node.SERVER, LocateResponse.Access.READ));
     }
 
     @Override
@@ -118,20 +67,5 @@ public class AbstractXrootdRequestHandler extends XrootdRequestHandler
                                        Math.min(APPID_PREFIX_LENGTH + APPID_MSG_LENGTH, data.length())));
         }
         return new SetResponse(request, "");
-    }
-
-    protected InetSocketAddress getLocalAddress()
-    {
-        return _localAddress;
-    }
-
-    protected InetSocketAddress getRemoteAddress()
-    {
-        return _remoteAddress;
-    }
-
-    protected boolean isHealthCheck()
-    {
-        return _isHealthCheck;
     }
 }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -18,7 +18,6 @@
 package org.dcache.xrootd.door;
 
 import com.google.common.net.InetAddresses;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,8 +140,8 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
          * introduces an artificial 1 second delay when processing such a response.
          */
 
-        InetSocketAddress localAddress = getLocalAddress();
-        InetSocketAddress remoteAddress = getRemoteAddress();
+        InetSocketAddress localAddress = getDestinationAddress();
+        InetSocketAddress remoteAddress = getSourceAddress();
 
         FilePerm neededPerm = req.getRequiredPermission();
 
@@ -245,7 +244,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
     {
         String path = req.getPath();
         try {
-            InetSocketAddress client = getRemoteAddress();
+            InetSocketAddress client = getSourceAddress();
             return new StatResponse(req, _door.getFileStatus(createFullPath(path), req.getSubject(), _authz,
                                                              client.getAddress().getHostAddress()));
         } catch (FileNotFoundCacheException e) {
@@ -704,7 +703,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
         public StatListCallback(DirListRequest request, FsPath dirPath, ChannelHandlerContext context)
         {
             super(request, context);
-            _client = getRemoteAddress().getAddress().getHostAddress();
+            _client = getSourceAddress().getAddress().getHostAddress();
             _dirPath = dirPath;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.3.11.v20160721</version.jetty>
         <version.wicket>7.4.0</version.wicket>
-        <version.xrootd4j>3.2.0</version.xrootd4j>
+        <version.xrootd4j>3.2.2</version.xrootd4j>
         <version.jersey>2.22.2</version.jersey>
         <version.dcache-view>1.0.2</version.dcache-view>
         <version.netty>4.1.5.Final</version.netty>


### PR DESCRIPTION
Changes:

04c6bde9a98268a87edd86e01d9cfd6c206e2e52 xrootd4j: Propagate channel activation event
e870e4eb47d21e926af67976d5fddabfdc12a68a xrootd4j: Enable HAProxy aware authorization
609a55c57ce23eaedd6b53dc9bccc25aa73bc690 xrootd4j: Move HAProxy processing to xrootd4j library

Fixes a problem with using the alice token plugin behind
HAProxy.

Target: trunk
Request: 3.0
Require-notes: no
Require-book: no
Acked-by: Anupam Ashish <anupam.ashish@desy.de>

Reviewed at https://rb.dcache.org/r/9833/

Reviewed at https://rb.dcache.org/r/9835/

(cherry picked from commit 5484c3f7dd54d797f9e67d07b87231f9c8db2a2c)