### PR TITLE
spacemanger: Fix interception of PoolAcceptFileMessage

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -1073,9 +1073,7 @@ public final class SpaceManagerService
         Subject subject = selectWritePool.getSubject();
 
         if (defaultSpaceToken != null) {
-            LOGGER.trace("selectPool: file is not " +
-                         "found, found default space " +
-                         "token, calling insertFile()");
+            LOGGER.trace("selectPool: file is not found, using default space token");
             Space space;
             try {
                 space = db.getSpace(Long.parseLong(defaultSpaceToken));
@@ -1092,20 +1090,19 @@ public final class SpaceManagerService
             if (!fileAttributes.isDefined(FileAttribute.ACCESS_LATENCY)) {
                 fileAttributes.setAccessLatency(space.getAccessLatency());
             } else if (fileAttributes.getAccessLatency() != space.getAccessLatency()) {
-                throw new SpaceException("Access latency conflicts with access latency defined by space reservation.");
+                throw new SpaceException("Access latency conflicts with access latency defined by default space reservation.");
             }
             if (!fileAttributes.isDefined(FileAttribute.RETENTION_POLICY)) {
                 fileAttributes.setRetentionPolicy(space.getRetentionPolicy());
             } else if (fileAttributes.getRetentionPolicy() != space.getRetentionPolicy()) {
                 throw new SpaceException(
-                        "Retention policy conflicts with retention policy defined by space reservation.");
+                        "Retention policy conflicts with retention policy defined by default space reservation.");
             }
 
             if (space.getDescription() != null) {
                 storageInfo.setKey("SpaceTokenDescription", space.getDescription());
             }
-            LOGGER.trace("selectPool: found linkGroup = {}, " +
-                         "forwarding message", linkGroupName);
+            LOGGER.trace("selectPool: found linkGroup = {}, forwarding message", linkGroupName);
         } else if (allowUnreservedUploadsToLinkGroups) {
             LOGGER.trace("Upload outside a reservation, identifying appropriate linkgroup");
 

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolManagerHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolManagerHandler.java
@@ -111,9 +111,23 @@ public class RemotePoolManagerHandler implements SerializablePoolManagerHandler
         }
 
         @Override
-        public boolean equals(SerializablePoolManagerHandler.Version other)
+        public boolean equals(Object o)
         {
-            return other instanceof Version && ((Version) other).destination.equals(destination);
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Version version = (Version) o;
+            return destination.equals(version.destination);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return destination.hashCode();
         }
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/RendezvousPoolManagerHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/RendezvousPoolManagerHandler.java
@@ -164,11 +164,23 @@ public class RendezvousPoolManagerHandler implements SerializablePoolManagerHand
         }
 
         @Override
-        public boolean equals(SerializablePoolManagerHandler.Version other)
+        public boolean equals(Object o)
         {
-            return other instanceof Version &&
-                   ((Version) other).serviceAddress.equals(serviceAddress) &&
-                   ((Version) other).backends.equals(backends);
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Version version = (Version) o;
+            return serviceAddress.equals(version.serviceAddress) && backends.equals(version.backends);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return 31 * serviceAddress.hashCode() + backends.hashCode();
         }
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/SerializablePoolManagerHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/SerializablePoolManagerHandler.java
@@ -41,6 +41,7 @@ public interface SerializablePoolManagerHandler extends PoolManagerHandler, Seri
      */
     interface Version extends Serializable
     {
-        boolean equals(Version version);
+        @Override
+        boolean equals(Object object);
     }
 }


### PR DESCRIPTION
Motivation:

Some weeks ago we updated pool manager to no longer intercept
PoolIoFileMessage. Unfortunately space manager inherited that
change and thus failed to intercept that message, thus breaking
space management.

Modification:

Stop inheriting from the RemotePoolManagerHandler as this bug
clearly shows that sharing this code is introducing a false
coupling.

Ensure that the message it now sent via space manager.

Also cleaned up the definition of the Version#equals method.

Result:

Fixed an unreleased regression. The fix breaks backwards compatibility with
previous 3.0 deployments.

Target: trunk
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/9836/

(cherry picked from commit 9d55e4d562f4b695f7465e8aef9da1e5be67c85a)