### PR TITLE
common: update ColumnWriter to remove any trailing whitespace

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/ColumnWriter.java
+++ b/modules/common/src/main/java/org/dcache/util/ColumnWriter.java
@@ -98,7 +98,7 @@ public class ColumnWriter
         List<Integer> spaces = new ArrayList<>(this.spaces);
 
         StringWriter result = new StringWriter();
-        try (PrintWriter out = new PrintWriter(result)) {
+        try (PrintWriter out = new NoTrailingWhitespacePrintWriter(result)) {
             String header = renderHeader(spaces, widths);
             if (!header.isEmpty()) {
                 out.println(header);

--- a/modules/common/src/main/java/org/dcache/util/NoTrailingWhitespacePrintWriter.java
+++ b/modules/common/src/main/java/org/dcache/util/NoTrailingWhitespacePrintWriter.java
@@ -1,0 +1,136 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2001 - 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+import com.google.common.base.CharMatcher;
+
+import java.io.PrintWriter;
+import java.io.Writer;
+
+/**
+ * This class provides a PrintWriter that strips off any trailing
+ * whitespace at the end of a line.  This class assumes that newlines are
+ * introduced by one of the println methods and not by using one of the append,
+ * print or write methods with the '\n' character.
+ */
+public class NoTrailingWhitespacePrintWriter extends PrintWriter
+{
+    private StringBuilder padding;
+
+    public NoTrailingWhitespacePrintWriter(Writer inner)
+    {
+        super(inner);
+    }
+
+    private StringBuilder getPadding()
+    {
+        if (padding == null) {
+            padding = new StringBuilder();
+        }
+        return padding;
+    }
+
+    private void flushPadding()
+    {
+        if (padding != null) {
+            String pad = padding.toString();
+            super.write(pad, 0, pad.length());
+            padding = null;
+        }
+    }
+
+    private int lastTrailingWhitespace(char[] buf, int off, int len)
+    {
+        int idx = -1;
+        for (int i = off+len-1; i >= off; i--) {
+            if (!CharMatcher.WHITESPACE.matches(buf [i])) {
+                break;
+            }
+            idx = i;
+        }
+        return idx;
+    }
+
+    private int lastTrailingWhitespace(String s, int off, int len)
+    {
+        int idx = -1;
+        for (int i = off+len-1; i >= off; i--) {
+            if (!CharMatcher.WHITESPACE.matches(s.charAt(i))) {
+                break;
+            }
+            idx = i;
+        }
+        return idx;
+    }
+
+    @Override
+    public void println()
+    {
+        super.println();
+        padding = null;
+    }
+
+    @Override
+    public void write(String s)
+    {
+        write(s, 0, s.length());
+    }
+
+    @Override
+    public void write(char[] buf)
+    {
+        write(buf, 0, buf.length);
+    }
+
+    @Override
+    public void write(int c)
+    {
+        if (CharMatcher.WHITESPACE.matches((char)c)) {
+            getPadding().append((char)c);
+        } else {
+            flushPadding();
+            super.write(c);
+        }
+    }
+
+    @Override
+    public void write(char buf[], int off, int len)
+    {
+        int idx = lastTrailingWhitespace(buf, off, len);
+        if (idx != 0) {
+            flushPadding();
+            super.write(buf, off, idx == -1 ? len : (idx-off));
+        }
+        if (idx > -1) {
+            getPadding().append(buf, idx, len-(idx-off));
+        }
+    }
+
+    @Override
+    public void write(String s, int off, int len)
+    {
+        int idx = lastTrailingWhitespace(s, off, len);
+        if (idx != 0) {
+            flushPadding();
+            super.write(s, off, idx == -1 ? len : (idx-off));
+        }
+        if (idx > -1) {
+            getPadding().append(s, idx, off+len);
+        }
+    }
+}

--- a/modules/common/src/test/java/org/dcache/util/NoTrailingWhitespacePrintWriterTests.java
+++ b/modules/common/src/test/java/org/dcache/util/NoTrailingWhitespacePrintWriterTests.java
@@ -1,0 +1,218 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2001 - 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class NoTrailingWhitespacePrintWriterTests
+{
+    PrintWriter writer;
+    StringWriter result;
+
+    @Before
+    public void setup()
+    {
+        result = new StringWriter();
+        writer = new NoTrailingWhitespacePrintWriter(result);
+    }
+
+    @Test
+    public void shouldAppendNoWS()
+    {
+        writer.append("HELLO");
+
+        assertThat(result.toString(), is(equalTo("HELLO")));
+    }
+
+    @Test
+    public void shouldAppendTrailingWS()
+    {
+        writer.append("HELLO ");
+
+        assertThat(result.toString(), is(equalTo("HELLO")));
+    }
+
+    @Test
+    public void shouldNotAppendOnlyWS()
+    {
+        writer.append(" ");
+
+        assertThat(result.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldAppendTrailingWSAfterAppend()
+    {
+        writer.append("HELLO ").append("WORLD");
+
+        assertThat(result.toString(), is(equalTo("HELLO WORLD")));
+    }
+
+    @Test
+    public void shouldAppendOnlyWSAfterAppend()
+    {
+        writer.append(" ").append("HELLO");
+
+        assertThat(result.toString(), is(equalTo(" HELLO")));
+    }
+
+    @Test
+    public void shouldPrintNoWS()
+    {
+        writer.print("HELLO");
+
+        assertThat(result.toString(), is(equalTo("HELLO")));
+    }
+
+    @Test
+    public void shouldPrintTrailingWS()
+    {
+        writer.print("HELLO ");
+
+        assertThat(result.toString(), is(equalTo("HELLO")));
+    }
+
+    @Test
+    public void shouldNotPrintOnlyWS()
+    {
+        writer.print(" ");
+
+        assertThat(result.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldPrintTrailingWSAfterPrint()
+    {
+        writer.print("HELLO ");
+        writer.print("WORLD");
+
+        assertThat(result.toString(), is(equalTo("HELLO WORLD")));
+    }
+
+    @Test
+    public void shouldPrintOnlyWSAfterPrint()
+    {
+        writer.print(" ");
+        writer.append("HELLO");
+
+        assertThat(result.toString(), is(equalTo(" HELLO")));
+    }
+
+    @Test
+    public void shouldSkipWSBeforePrintln()
+    {
+        writer.append("HELLO ");
+        writer.println();
+        writer.print("WORLD");
+
+        assertThat(result.toString(), is(equalTo("HELLO\nWORLD")));
+    }
+
+    @Test
+    public void shouldPrintCharSkipTrailingWS()
+    {
+        writer.print('H');
+        writer.print(' ');
+
+        assertThat(result.toString(), is(equalTo("H")));
+    }
+
+    @Test
+    public void shouldPrintCharIncludeNonTrailingWS()
+    {
+        writer.print('H');
+        writer.print(' ');
+        writer.print('W');
+
+        assertThat(result.toString(), is(equalTo("H W")));
+    }
+
+    @Test
+    public void shouldPrintCharArraySkipTrailingWS()
+    {
+        writer.print("H ".toCharArray());
+
+        assertThat(result.toString(), is(equalTo("H")));
+    }
+
+    @Test
+    public void shouldPrintCharArrayIncludeTrailingWSWithFollowingText()
+    {
+        writer.print("H ".toCharArray());
+        writer.print("W");
+
+        assertThat(result.toString(), is(equalTo("H W")));
+    }
+
+    @Test
+    public void shouldOmitOnlyWSCharArray()
+    {
+        writer.print(" ".toCharArray());
+
+        assertThat(result.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldPrintOnlyWSCharArrayWithFollowingText()
+    {
+        writer.print(" ".toCharArray());
+        writer.print("W");
+
+        assertThat(result.toString(), is(equalTo(" W")));
+    }
+
+    @Test
+    public void shouldPrintCharArrayIncludeNonTrailingWS()
+    {
+        writer.print("H W".toCharArray());
+
+        assertThat(result.toString(), is(equalTo("H W")));
+    }
+
+    @Test
+    public void shouldAppendPartialStringWithZeroOffset()
+    {
+        writer.write("HELLO", 0, 4);
+
+        assertThat(result.toString(), is(equalTo("HELL")));
+    }
+
+    @Test
+    public void shouldAppendPartialStringWithNonZeroOffset()
+    {
+        writer.write("HELLO", 1, 3);
+
+        assertThat(result.toString(), is(equalTo("ELL")));
+    }
+
+    @Test
+    public void shouldAppendPartialStringWithNonZeroOffsetRemainingString()
+    {
+        writer.write("HELLO", 1, 4);
+
+        assertThat(result.toString(), is(equalTo("ELLO")));
+    }
+}


### PR DESCRIPTION
Motivation:

Trailing whitespace can lead to ugly output as ColumnWriter ensures all
columns output the same width so if one column is too long for the
console (and is therefore wrapped), all columns are too long.

Modification:

Create a specialisation of PrintWriter that separates trailing
whitespace from other output.  The trailing whitespace (if any) is
cached.  Any text preceeding trailing whitespace (if any) triggers any
previously cached whitespace to be written before writing the
non-whitespace output.  Cached whitespace is discarded when a newline is
created.

Result:

ColumnWriter is updated so it never prints non-whitespace characters
before a newline.

Target: master
Requires-notes: yes
Requires-srm-notes: yes
Request: 2.16
Patch: https://rb.dcache.org/r/9826/
Acked-by: Gerd Behrmann