### PR TITLE
doors: Allow setting an empty list of login broker tags

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
@@ -132,7 +132,7 @@ public class LoginBrokerPublisher
                           "by these tags.")
     class SetTagCommand implements Callable<String>
     {
-        @Argument
+        @Argument(required = false)
         String[] tags;
 
         @Override


### PR DESCRIPTION
Motivation:

Doors are tagged for particular purposes (srm, glue, etc). Login broker
publisher allows the tags to be updated at runtime. The command currently
does not accept an empty list of tags.

Modification:

Allow an empty list of tags to be specified.

Result:

Fixed a bug in the `lb set tags` command in doors that prevented setting
an empty list of tags.

Target: trunk
Require-notes: yes
Require-book: no
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9839/

(cherry picked from commit 9a83eb35cb467b99b0dbcc55c522d69df6e7b3a2)