### PR TITLE
dcache: Add column to `dcache services` for proxy-protocol

### DIFF
--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -420,16 +420,27 @@ case "$1" in
         shift
         . ${lib}/utils.sh
         (
-            printf "DOMAIN\tSERVICE\tCELL\tREPLICABLE\n"
+            printf "DOMAIN\tSERVICE\tCELL\tPROXIED\tREPLICABLE\n"
             for domain in $(getProperty dcache.domains); do
                 for cell in $(getProperty dcache.domain.cells "$domain"); do
                     service=$(getProperty dcache.domain.service "$domain" "$cell")
+                    case "$(getScopedProperty enable.proxy-protocol "$domain" "$cell")" in
+                    true)
+                        proxied=Yes
+                        ;;
+                    false)
+                        proxied=No
+                        ;;
+                    *)
+                        proxied=-
+                        ;;
+                    esac
                     if [ "$(getScopedProperty cell.replicable "$domain" "$cell")" = "true" ]; then
                         replicable=Yes
                     else
                         replicable=No
                     fi
-                    printf "${domain}\t${service}\t${cell}\t${replicable:-true}\n"
+                    printf "${domain}\t${service}\t${cell}\t${proxied}\t${replicable}\n"
                 done
             done
         ) | column


### PR DESCRIPTION
Motivation:

Doors can be configured to support the HAProxy proxy protocol.

Modification:

Adds a column to `dcache services` output showing if proxy protocol
support is enabled for the given service.

Target: trunk
Request: 3.0
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9840/

(cherry picked from commit b78cb3a869c81e3efb48f190d352dbf11d06aad1)