### PR TITLE
poolmanager,spacemanager: Do not reply to pool manager query replies

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -429,11 +429,17 @@ public final class SpaceManagerService
 
     public Reply messageArrived(CellMessage envelope, PoolMgrGetHandler message)
     {
+        if (message.isReply()) {
+            return null;
+        }
         return new FutureReply<>(forward(envelope, message));
     }
 
     public Reply messageArrived(CellMessage envelope, PoolMgrGetUpdatedHandler message)
     {
+        if (message.isReply()) {
+            return null;
+        }
         PoolMgrGetUpdatedHandler messageToForward =
                 new PoolMgrGetUpdatedHandler(SpaceManagerHandler.extractWrappedVersion(message.getVersion()));
         ListenableFuture<PoolMgrGetHandler> result = forward(envelope, messageToForward);

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerHandlerPublisher.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerHandlerPublisher.java
@@ -220,6 +220,9 @@ public class PoolManagerHandlerPublisher
     public PoolMgrGetHandler messageArrived(PoolMgrGetHandler message)
     {
         checkPublicationTimestamp();
+        if (message.isReply()) {
+            return null;
+        }
         message.setHandler(handler);
         return message;
     }
@@ -227,6 +230,9 @@ public class PoolManagerHandlerPublisher
     public DelayedReply messageArrived(CellMessage envelope, PoolMgrGetUpdatedHandler message)
     {
         checkPublicationTimestamp();
+        if (message.isReply()) {
+            return null;
+        }
         SerializablePoolManagerHandler handler = this.handler;
         UpdateRequest request = new UpdateRequest(envelope, message);
         requests.add(request);


### PR DESCRIPTION
Motivation:

Pool manager and space manager both accept PoolMgrGetHandler and
PoolMgrGetUpdatedHandler messages. They currently reply to these requests even
if the message is itself a reply. Such a situation may occur if the reply
received by space manager from pool manager is delivered after space manager
has timed out; in that case the reply gets delivered to the regular message
handler like any other request. Space manager would forward this request to
pool manager, who would then reply immediately as the versions mismatch (pool
manager vs space manager version). When space manager receives the reply to
that request, it would return it as a reply to its requestor, which itself
would be pool manager. Pool manager too would then receive this as a regular
request and the process repeats.

Modification:

Filter out reply message in the message handlers.

Result:

Fixed an unreleased regression in how pool manager handlers are requested.

Target: trunk
Request: 3.0
Require-notes: no
Require-book: no
Acked-by: Dmitry Litvintsev <litvinse@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9842/

(cherry picked from commit 20fdc8130b4666f18aed9d5788d051ac2f675020)