### PR TITLE
cleaner: Send notifications concurrently

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
@@ -3,6 +3,9 @@ package org.dcache.chimera.namespace;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.FutureFallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -31,6 +34,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
@@ -50,7 +56,10 @@ import org.dcache.services.hsmcleaner.RequestTracker;
 import org.dcache.util.Args;
 import org.dcache.util.CacheExceptionFactory;
 
+import static com.google.common.util.concurrent.Futures.allAsList;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
 
 /**
  * @author Irina Kozlova
@@ -452,24 +461,24 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
                 "WHERE itype=2 AND NOT EXISTS (SELECT 1 FROM t_locationinfo_trash t2 WHERE t2.ipnfsid=t1.ipnfsid AND t2.itype <> 2)";
         for (String id : _db.queryForList(QUERY, String.class)) {
             try {
-                sendDeleteNotifications(id);
-            } catch (CacheException e) {
-                _log.warn(e.getMessage());
+                sendDeleteNotifications(new PnfsId(id)).get();
+                _db.update("DELETE FROM t_locationinfo_trash WHERE ipnfsid=? AND itype=2", id);
+            } catch (ExecutionException e) {
+                _log.warn(e.getCause().getMessage());
             }
         }
     }
 
-    private void sendDeleteNotifications(String id) throws InterruptedException, CacheException
+    private ListenableFuture<List<PnfsDeleteEntryNotificationMessage>> sendDeleteNotifications(PnfsId pnfsId)
     {
-        PnfsId pnfsId = new PnfsId(id);
-        for (CellPath address : _deleteNotificationTargets) {
-            try {
-                _notificationStub.sendAndWait(address, new PnfsDeleteEntryNotificationMessage(pnfsId));
-            } catch (CacheException e) {
-                throw new CacheException("Failed to notify " + address + " about deletion of " + id + ": " + e.getMessage(), e);
-            }
-        }
-        _db.update("DELETE FROM t_locationinfo_trash WHERE ipnfsid=? AND itype=2", id);
+        BiFunction<CellPath, Throwable, CacheException> failureFor =
+                (path, e) -> new CacheException("Failed to notify " + path + " about deletion of " + pnfsId + ": " + e.getMessage(), e);
+        return allAsList(
+                Arrays.stream(_deleteNotificationTargets)
+                        .map(a -> Futures.withFallback(
+                                _notificationStub.send(a, new PnfsDeleteEntryNotificationMessage(pnfsId)),
+                                e -> immediateFailedFuture(failureFor.apply(a, e))))
+                        .collect(toList()));
     }
 
     /**


### PR DESCRIPTION
Motivation:

Cleaner can send notifications to other services, typically pinmanager,
replica manager and space manager.

Modification:

This patch changes the logic to send the notifications concurently to
all receivers.

Result:

Faster notifications.

Target: trunk
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13

Reviewed at https://rb.dcache.org/r/9838/

(cherry picked from commit f02a23afc897811ce566199ad4a769fd25cd4ab8)
(cherry picked from commit dc23d883ee665b7666d9b024fbe07ed8aba0975e)