### PR TITLE
srmclient: add initial support for glob expansion

### DIFF
--- a/modules/common-cli/src/main/java/dmg/util/command/ExpandWith.java
+++ b/modules/common-cli/src/main/java/dmg/util/command/ExpandWith.java
@@ -1,0 +1,38 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dmg.util.command;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a particular field supports glob expansion through some
+ * GlobExpander class.  The annotated field must be an array and must also be
+ * an @Argument.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ExpandWith
+{
+    /**
+     * @return Class to instantiate that will expand glob arguments.
+     */
+    Class<? extends GlobExpander<String>> value();
+}

--- a/modules/common-cli/src/main/java/dmg/util/command/GlobExpander.java
+++ b/modules/common-cli/src/main/java/dmg/util/command/GlobExpander.java
@@ -1,0 +1,38 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dmg.util.command;
+
+import java.util.List;
+
+import org.dcache.util.Glob;
+
+/**
+ * A class that implements this interface can expand a supplied glob
+ * into a list of zero or more items.  Typically, a class implementing this
+ * interface represents some namespace.
+ */
+public interface GlobExpander<T>
+{
+    /**
+     * Provide a list of items that match the supplied pattern.
+     * @param glob the pattern to select matching items.
+     * @return the result of expanding {@literal argument}, or an empty list
+     * if no matches were found.
+     */
+    List<T> expand(Glob glob);
+}

--- a/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
+++ b/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
@@ -62,10 +62,12 @@ public abstract class TextHelpPrinter implements AnnotatedCommandHelpPrinter
                 public boolean apply(Field field)
                 {
                     Argument argument = field.getAnnotation(Argument.class);
+                    ExpandWith expandWith = field.getAnnotation(ExpandWith.class);
+
                     /* Arguments that are not required might have a default value and should thus
                      * be included in the help output.
                      */
-                    return argument != null && (!argument.usage().isEmpty() || !argument.required());
+                    return argument != null && (expandWith != null || !argument.usage().isEmpty() || !argument.required());
                 }
             };
 
@@ -287,6 +289,9 @@ public abstract class TextHelpPrinter implements AnnotatedCommandHelpPrinter
                 String help = argument.usage();
                 if (!argument.required()) {
                     help = Joiner.on(' ').join(help, getDefaultDescription(instance, field));
+                }
+                if (field.getAnnotation(ExpandWith.class) != null) {
+                    help = Joiner.on(' ').join(help, "Glob patterns will be expanded.");
                 }
                 if (!help.isEmpty()) {
                     writer.append(Strings.wrap("              ", help, WIDTH));

--- a/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
+++ b/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
@@ -18,6 +18,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,13 +32,16 @@ import dmg.util.CommandThrowableException;
 import dmg.util.command.AnnotatedCommandHelpPrinter;
 import dmg.util.command.AnsiHelpPrinter;
 import dmg.util.command.Argument;
+import dmg.util.command.GlobExpander;
 import dmg.util.command.Command;
 import dmg.util.command.CommandLine;
+import dmg.util.command.ExpandWith;
 import dmg.util.command.HelpFormat;
 import dmg.util.command.Option;
 import dmg.util.command.PlainHelpPrinter;
 
 import org.dcache.util.Args;
+import org.dcache.util.Glob;
 import org.dcache.util.ReflectionUtils;
 
 import static com.google.common.collect.Iterables.*;
@@ -203,13 +208,17 @@ public class AnnotatedCommandExecutor implements CommandExecutor
         }
     }
 
-    private static Handler createFieldHandler(Field field, Argument argument)
+    private Handler createFieldHandler(Field field, Argument argument)
     {
         Class<?> type = field.getType();
         if (type.isArray()) {
             Function<String,Object> typeConverter =
                     createTypeConverter(type.getComponentType());
-            return new MultiValuedArgumentHandler(field, typeConverter, argument);
+            if (field.getAnnotation(ExpandWith.class) == null) {
+                return new MultiValuedArgumentHandler(field, typeConverter, argument);
+            } else {
+                return new ExpandingMultiValuedArgumentHandler(field, typeConverter, argument);
+            }
         } else {
             Function<String,Object> typeConverter = createTypeConverter(type);
             return new ArgumentHandler(field, typeConverter, argument);
@@ -228,7 +237,7 @@ public class AnnotatedCommandExecutor implements CommandExecutor
         }
     }
 
-    private static List<Handler> createFieldHandlers(Command command, Class<? extends Callable<?>> clazz)
+    private List<Handler> createFieldHandlers(Command command, Class<? extends Callable<?>> clazz)
     {
         Set<String> optionNames = new HashSet<>();
 
@@ -378,6 +387,7 @@ public class AnnotatedCommandExecutor implements CommandExecutor
     private abstract static class FieldHandler implements Handler
     {
         protected final Field _field;
+        protected Object _command;
 
         public FieldHandler(Field field)
         {
@@ -388,12 +398,13 @@ public class AnnotatedCommandExecutor implements CommandExecutor
         protected abstract Object getValue(Args args);
 
         @Override
-        public void apply(Object object, Args args)
+        public void apply(Object command, Args args)
                 throws IllegalAccessException
         {
+            _command = command;
             Object value = getValue(args);
             if (value != null) {
-                _field.set(object, value);
+                _field.set(command, value);
             }
         }
     }
@@ -442,8 +453,8 @@ public class AnnotatedCommandExecutor implements CommandExecutor
      */
     private static class MultiValuedArgumentHandler extends FieldHandler
     {
-        private final Function<String,Object> _typeConverter;
-        private final Argument _argument;
+        protected final Function<String,Object> _typeConverter;
+        protected final Argument _argument;
 
         public MultiValuedArgumentHandler(Field field,
                                           Function<String, Object> typeConverter,
@@ -471,17 +482,125 @@ public class AnnotatedCommandExecutor implements CommandExecutor
             int index = _argument.index();
 
             if (index < args.argc()) {
-                Class<?> type = _field.getType().getComponentType();
-                Object values = Array.newInstance(type, args.argc() - index);
-                for (int i = index; i < args.argc(); i++) {
-                    Object value = _typeConverter.apply(args.argv(i));
-                    Array.set(values, i - index, value);
-                }
-                return values;
+                return buildArray(args);
             } else if (_argument.required()) {
                 throw new IllegalArgumentException("Argument " + (index + 1) + " is required");
             }
             return null;
+        }
+
+        protected Object buildArray(Args args)
+        {
+            int index = _argument.index();
+
+            Class<?> type = _field.getType().getComponentType();
+            Object values = Array.newInstance(type, args.argc() - index);
+            for (int i = index; i < args.argc(); i++) {
+                Object value = _typeConverter.apply(args.argv(i));
+                Array.set(values, i - index, value);
+            }
+            return values;
+        }
+    }
+
+    /**
+     * Map arguments to an array after expanding any that are Globs.
+     */
+    private class ExpandingMultiValuedArgumentHandler extends MultiValuedArgumentHandler
+    {
+        private final ExpandWith _expand;
+
+        public ExpandingMultiValuedArgumentHandler(Field field,
+                                          Function<String, Object> typeConverter,
+                                          Argument argument)
+        {
+            super(field, typeConverter, argument);
+            _expand = field.getAnnotation(ExpandWith.class);
+        }
+
+        private GlobExpander<String> createNonstaticExpander(Object parent)
+                throws InstantiationException,
+                IllegalAccessException, IllegalArgumentException,
+                InvocationTargetException
+        {
+            try {
+                Constructor<? extends GlobExpander<String>> constructor =
+                        _expand.value().getDeclaredConstructor(parent.getClass());
+                constructor.setAccessible(true);
+                return constructor.newInstance(parent);
+            } catch (NoSuchMethodException e) {
+                return null;
+            }
+        }
+
+        private GlobExpander<String> createStaticExpander()
+                throws NoSuchMethodException, InstantiationException,
+                IllegalAccessException, IllegalArgumentException,
+                InvocationTargetException
+        {
+            Constructor<? extends GlobExpander<String>> constructor =
+                    _expand.value().getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        }
+
+        private GlobExpander<String> createExpander()
+        {
+            GlobExpander<String> expander;
+            try {
+                expander = createNonstaticExpander(_command); // as subclass of @Command class
+                if (expander == null) {
+                    expander = createNonstaticExpander(_parent); // as sibling of @Command class
+                }
+                if (expander == null) {
+                    expander = createStaticExpander(); // as static method
+                }
+                if (expander == null) {
+                    throw new IllegalArgumentException("Cannot find constructor for " + _expand.value());
+                }
+            } catch (InstantiationException | NoSuchMethodException | IllegalAccessException |
+                    IllegalArgumentException | InvocationTargetException e) {
+                throw new RuntimeException("Unable to build GlobExpander: " +
+                        e.toString(), e);
+            }
+            return expander;
+        }
+
+        private Object asArrayForField(List<String> values)
+        {
+            Class<?> type = _field.getType().getComponentType();
+            Object array = Array.newInstance(type, values.size());
+            for (int i = 0; i < values.size(); i++) {
+                Array.set(array, i, _typeConverter.apply(values.get(i)));
+            }
+            return array;
+        }
+
+        @Override
+        protected Object buildArray(Args args)
+        {
+            GlobExpander<String> expander = null;
+
+            List<String> values = new ArrayList<>();
+            for (int i = _argument.index(); i < args.argc(); i++) {
+                String argument = args.argv(i);
+
+                if (Glob.isGlob(argument)) {
+                    if (expander == null) {
+                        expander = createExpander();
+                    }
+                    List<String> expansion = expander.expand(new Glob(argument));
+                    if (expansion.isEmpty()) {
+                        values.add(argument);
+                    } else {
+                        values.addAll(expansion);
+                    }
+                } else {
+                    values.add(argument);
+                }
+            }
+
+            return asArrayForField(values);
         }
     }
 


### PR DESCRIPTION
Motivation:

Glob arguments provide a convenient and familiar mechanism to specify a
group of similarly named files.  Support for specifying a set of files
through glob is currently missing in srmfs.

Modification:

Introduce GlobExpander interface through which a class declares it can
expand a Glob.  Add support for ExpandWith annotation, which allows the
declaration that some GlobExpander class is to be used to expand any
supplied glob value(s).  The ExpandWith annotation is currently limited
to Arguments but future patches may extend this to support Options, too.
The GlobExpander class named in ExpandWith annotation may be either a
subclass of the command (i.e., command-specific), a sibling of the
command (allowing it to be shared between commands), or any static
class.

A GlobExpander object is created only if any of the ExpandWith annotated
arguments is a glob.  This instance is used to expand all glob arguments
of the command, but not retained beyond that.

This patch also updates SrmShell to make use of this framework.  It adds
two concrete GlobExpander classes: one that uses the local filesystem
and one that uses the srm namespace.  The srm namespace glob expanding
employs caching so that expansion triggers at most a single srmLs per
directory.  Various local filesystem and srm filesystem commands are
updated to make use of these GlobExpanders.

Result:

Specifying glob patterns is now supported for the "check permission",
"get permission", "lrm", "lrmdir", "rm" and "rmdir" commands.

Target: master
Request: 3.0
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9801/
Acked-by: Gerd Behrmann