### PR TITLE
srmclient: add initial support for glob expansion

### DIFF
--- a/modules/common-cli/src/main/java/dmg/util/command/ExpandWith.java
+++ b/modules/common-cli/src/main/java/dmg/util/command/ExpandWith.java
@@ -1,0 +1,38 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dmg.util.command;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a particular field supports glob expansion through some
+ * GlobExpander class.  The annotated field must be an array and must also be
+ * an @Argument.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ExpandWith
+{
+    /**
+     * @return Class to instantiate that will expand glob arguments.
+     */
+    Class<? extends GlobExpander<String>> value();
+}

--- a/modules/common-cli/src/main/java/dmg/util/command/GlobExpander.java
+++ b/modules/common-cli/src/main/java/dmg/util/command/GlobExpander.java
@@ -1,0 +1,38 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dmg.util.command;
+
+import java.util.List;
+
+import org.dcache.util.Glob;
+
+/**
+ * A class that implements this interface can expand a supplied glob
+ * into a list of zero or more items.  Typically, a class implementing this
+ * interface represents some namespace.
+ */
+public interface GlobExpander<T>
+{
+    /**
+     * Provide a list of items that match the supplied pattern.
+     * @param glob the pattern to select matching items.
+     * @return the result of expanding {@literal argument}, or an empty list
+     * if no matches were found.
+     */
+    List<T> expand(Glob glob);
+}

--- a/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
+++ b/modules/common-cli/src/main/java/dmg/util/command/TextHelpPrinter.java
@@ -61,10 +61,12 @@ public abstract class TextHelpPrinter implements AnnotatedCommandHelpPrinter
                 public boolean apply(Field field)
                 {
                     Argument argument = field.getAnnotation(Argument.class);
+                    ExpandWith expandWith = field.getAnnotation(ExpandWith.class);
+
                     /* Arguments that are not required might have a default value and should thus
                      * be included in the help output.
                      */
-                    return argument != null && (!argument.usage().isEmpty() || !argument.required());
+                    return argument != null && (expandWith != null || !argument.usage().isEmpty() || !argument.required());
                 }
             };
 
@@ -282,6 +284,9 @@ public abstract class TextHelpPrinter implements AnnotatedCommandHelpPrinter
                 String help = argument.usage();
                 if (!argument.required()) {
                     help = Joiner.on(' ').join(help, getDefaultDescription(instance, field));
+                }
+                if (field.getAnnotation(ExpandWith.class) != null) {
+                    help = Joiner.on(' ').join(help, "Glob patterns will be expanded.");
                 }
                 if (!help.isEmpty()) {
                     writer.append(Strings.wrap("              ", help, 65));


### PR DESCRIPTION
Motivation:

Glob arguments provide a convenient and familiar mechanism to specify a
group of similarly named files.  Support for specifying a set of files
through glob is currently missing in srmfs.

Modification:

Introduce GlobExpander interface through which a class declares it can
expand a Glob.  Add support for ExpandWith annotation, which allows the
declaration that some GlobExpander class is to be used to expand any
supplied glob value(s).  The ExpandWith annotation is currently limited
to Arguments but future patches may extend this to support Options, too.
The GlobExpander class named in ExpandWith annotation may be either a
subclass of the command (i.e., command-specific), a sibling of the
command (allowing it to be shared between commands), or any static
class.

A GlobExpander object is created only if any of the ExpandWith annotated
arguments is a glob.  This instance is used to expand all glob arguments
of the command, but not retained beyond that.

This patch also updates SrmShell to make use of this framework.  It adds
two concrete GlobExpander classes: one that uses the local filesystem
and one that uses the srm namespace.  The srm namespace glob expanding
employs caching so that expansion triggers at most a single srmLs per
directory.  Various local filesystem and srm filesystem commands are
updated to make use of these GlobExpanders.

Result:

Specifying glob patterns is now supported for the "check permission",
"get permission", "lrm", "lrmdir", "rm" and "rmdir" commands.

Target: master
Request: 3.0
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9801/
Acked-by: Gerd Behrmann