### PR TITLE
httpd: Don't insist on using http for unauthenticated webadmin pages

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/WebAdminInterface.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/WebAdminInterface.java
@@ -11,6 +11,8 @@ import org.apache.wicket.core.request.mapper.CryptoMapper;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.protocol.https.HttpsConfig;
 import org.apache.wicket.protocol.https.HttpsMapper;
+import org.apache.wicket.protocol.https.Scheme;
+import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.Request;
 import org.apache.wicket.request.Response;
 import org.slf4j.Logger;
@@ -329,7 +331,14 @@ public class WebAdminInterface extends WebApplication implements CellMessageSend
 
         if (getAuthenticatedMode()) {
             setRootRequestMapper(new HttpsMapper(getRootRequestMapper(),
-                            new HttpsConfig(_httpPort, _httpsPort)));
+                            new HttpsConfig(_httpPort, _httpsPort)) {
+                @Override
+                protected Scheme getDesiredSchemeFor(IRequestHandler handler)
+                {
+                    Scheme desiredSchemeFor = super.getDesiredSchemeFor(handler);
+                    return desiredSchemeFor == Scheme.HTTP ? Scheme.ANY : desiredSchemeFor;
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Motivation:

Allow httpd/webadmin to be exposed through a load balancer or proxy
using https.

The HttpsMapper in wicket insists on using either HTTP or HTTPS, depending
on whether the page requires authentication or not. HTTPS requests are
redirected to HTTP if the page requested doesn't require authentication.

Modification:

Override HttpsMapper to allow both HTTP and HTTPS for any page for which
HTTP is normally requested.

Result:

Clients are not redirected from https to http in webadmin.

Target: trunk
Request: 3.0
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Albert Rossi <arossi@fnal.gov>
(cherry picked from commit 431ae2f929fcd75af774fbd2efebe763dbfbdb32)