### PR TITLE
httpd: Enable X-Forwarded-For processing in httpd

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/jetty/ConnectorFactoryBean.java
+++ b/modules/dcache/src/main/java/org/dcache/util/jetty/ConnectorFactoryBean.java
@@ -21,6 +21,7 @@ import eu.emi.security.authn.x509.CrlCheckingMode;
 import eu.emi.security.authn.x509.NamespaceCheckingMode;
 import eu.emi.security.authn.x509.OCSPCheckingMode;
 import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.ProxyConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
@@ -68,6 +69,7 @@ public class ConnectorFactoryBean implements FactoryBean<ServerConnector>
     private KeyPairCache keyPairCache;
 
     private boolean isProxyConnectionEnabled;
+    private boolean isForwardedHeaderProcessingEnabled;
 
     private Protocol protocol;
 
@@ -315,6 +317,16 @@ public class ConnectorFactoryBean implements FactoryBean<ServerConnector>
         isProxyConnectionEnabled = proxyConnectionEnabled;
     }
 
+    public boolean isForwardedHeaderProcessingEnabled()
+    {
+        return isForwardedHeaderProcessingEnabled;
+    }
+
+    public void setForwardedHeaderProcessingEnabled(boolean forwardedHeaderProcessingEnabled)
+    {
+        isForwardedHeaderProcessingEnabled = forwardedHeaderProcessingEnabled;
+    }
+
     private SslContextFactory createContextFactory() throws Exception
     {
         CanlContextFactory factory = new CanlContextFactory();
@@ -359,6 +371,10 @@ public class ConnectorFactoryBean implements FactoryBean<ServerConnector>
             httpConnectionFactory.getHttpConfiguration().addCustomizer(new SecureRequestCustomizer());
             httpConnectionFactory.getHttpConfiguration().addCustomizer(new GsiRequestCustomizer());
             break;
+        }
+
+        if (isForwardedHeaderProcessingEnabled) {
+            httpConnectionFactory.getHttpConfiguration().addCustomizer(new ForwardedRequestCustomizer());
         }
 
         List<ConnectionFactory> factories = new ArrayList<>();

--- a/modules/dcache/src/main/resources/org/dcache/services/httpd/httpd.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/httpd/httpd.xml
@@ -62,6 +62,7 @@
         <property name="idleTimeout" value="${httpd.limits.idle-time}"/>
         <property name="idleTimeoutUnit" value="${httpd.limits.idle-time.unit}"/>
         <property name="proxyConnectionEnabled" value="${httpd.enable.proxy-protocol}"/>
+        <property name="forwardedHeaderProcessingEnabled" value="${httpd.enable.forwarded-header}"/>
     </bean>
 
     <bean id="plain-connector" parent="connector" depends-on="jetty">

--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -59,6 +59,25 @@ httpd.watch = ${dcache.topic.watched}
 #
 (one-of?true|false)httpd.enable.proxy-protocol = false
 
+# ----- Whether to process X-Forwarded-For headers
+#
+# HTTP reverse proxies typically and HTTP aware load balancers can often
+# be configured to inject X-Forwarded-For headers to reveal information
+# about the original request the client made to the proxy.
+#
+# These X-Forwarded-For headers serve a similar role as the proxy protocol
+# described above. Being HTTP specific, the header does however reveal
+# additional information, such as whether the original connection used
+# HTTP or HTTPS. This is particularly important for the Webadmin interface.
+#
+# In contrast to the proxy protocol setting above, enabling processing of
+# the X-Forwarded-For header does not prevent direct access (without a
+# proxy), however be aware that this should only be allowed from trusted
+# clients; an opponent may mask his or her identity by injecting false
+# information through this header.
+#
+(one-of?true|false)httpd.enable.forwarded-header = false
+
 #
 #     Specifies the host for the connector;
 #     see further comments for dcache.net.listen in dcache.properties

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -15,6 +15,7 @@ check -strong httpd.setup
 check -strong httpd.enable.authn
 check -strong httpd.enable.plots.pool-queue
 check -strong httpd.enable.proxy-protocol
+check -strong httpd.enable.forwarded-header
 check httpd.watch
 
 check httpd.statistics.location


### PR DESCRIPTION
Motivation:

To allow httpd/webadmin to be used behind a load balancer or proxy.

Modification:

Add a flag to enable processing of the X-Forwarded- headers in Jetty.

Result:

Added httpd.enable.forwarded-header. If set to true, httpd recognizes
X-Forwarded-For headers, allowing it generate correct redirects when used
behind a proxy.

E.g. with HaProxy, one can configure TLS offloading including authentication
and authorizatino for httpd as:

listen httpd
        bind :::9443 v4v6 level user v4v6 ssl ca-file /etc/grid-security/certificates.pem crt /etc/grid-security/haproxy.pem verify required
        mode http
        balance source
        acl subject-is-allowed ssl_c_s_dn() -f /etc/grid-security/subjects
        http-request deny unless subject-is-allowed
        option forwardfor
        reqadd X-Forwarded-Proto:\ https
        reqadd X-Forwarded-Port:\ 9443
        server piggy   <backend-ip>:2288 check send-proxy

Note 'balance source' since webadmin does not allow clustering of the
session store. Also note that this setup doesn't allow the x.509
login feature to work in webadmin.

Target: trunk
Require-notes: yes
Require-book: no
Request: 3.0
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/9851/

(cherry picked from commit b1b2af95a1685d7a00619b2876b8e3ca46b701ba)