### PR TITLE
srm: Log correct request token in access log

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
@@ -462,12 +462,13 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
                 return toGetRequestSummaryResponse(futureMap);
             }
             default: {
-                CellPath address = mapRequest(request);
-                ListenableFuture<SrmResponse> future =
-                        (address == null)
-                        ? srmManagerStub.send(toMessage.apply(request), SrmResponse.class)
-                        : srmManagerStub.send(address, toMessage.apply(request), SrmResponse.class);
-                return mapResponse(future.get());
+                try (MappedRequest mapped = mapRequest(request)) {
+                    ListenableFuture<SrmResponse> future =
+                            (mapped == null)
+                            ? srmManagerStub.send(toMessage.apply(request), SrmResponse.class)
+                            : srmManagerStub.send(mapped.getBackend(), toMessage.apply(mapped.getRequest()), SrmResponse.class);
+                    return mapResponse(future.get());
+                }
             }
             }
         } catch (ExecutionException e) {
@@ -668,7 +669,54 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
         return new CellPath(new String(data.getData(), US_ASCII));
     }
 
-    private CellPath mapRequest(Object request) throws SRMInternalErrorException
+    /**
+     * Encapsulates the result of mapping a request to a backend.
+     *
+     * The request is modified inline to reflect the internal request token. This
+     * avoids copying the request, however the modification must be undone by
+     * closing this MappedRequest once the mapped request is no longer needed.
+     */
+    private class MappedRequest implements AutoCloseable
+    {
+        private final Object request;
+
+        private final CellPath backend;
+
+        private final Field field;
+
+        private final String token;
+
+        MappedRequest(Object request, CellPath backend, Field field, String token) throws IllegalAccessException
+        {
+            this.request = request;
+            this.backend = backend;
+            this.field = field;
+            this.token = token;
+            field.set(request, backendTokenOf(token));
+        }
+
+        CellPath getBackend()
+        {
+            return backend;
+        }
+
+        Object getRequest()
+        {
+            return request;
+        }
+
+        @Override
+        public void close()
+        {
+            try {
+                field.set(request, token);
+            } catch (IllegalAccessException e) {
+                Throwables.propagate(e);
+            }
+        }
+    }
+
+    private MappedRequest mapRequest(Object request) throws SRMInternalErrorException
     {
         Optional<Field> field = requestTokenFieldCache.getUnchecked(request.getClass());
         if (field.isPresent()) {
@@ -676,12 +724,11 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
                 Field f = field.get();
                 String token = (String) f.get(request);
                 if (hasPrefix(token)) {
-                    f.set(request, backendTokenOf(token));
                     CellPath path = backendOf(token);
                     if (path == null) {
                         throw new SRMInternalErrorException("SRM backend serving this request token is currently offline.");
                     }
-                    return path;
+                    return new MappedRequest(request, path, f, token);
                 }
             } catch (IllegalAccessException e) {
                 Throwables.propagate(e);


### PR DESCRIPTION
Motivation:

srm maps request tokens between frontend and backend tokens by adding or
stripping a backend id. The access log contains a request token extracted from
either the request or response.  If extracted from the request, the token lacks
the backend id prefix.

Modification:

The problem is that the request is modified inline to avoid copying it. Thus when
the access log is updated, the request being used is the modified request.

This patch solves the problem by restoring the original token after a response
has been reeived from the backend.

Result:

Fixed a regression that caused the SRM request token of some requests to be
logged without the backend identifier in the access log.

Target: trunk
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9852/

(cherry picked from commit 73919be57a13667ddc0977126bdeb0f5e244e209)