### PR TITLE
pool: Suppress two stack traces in nearline storage handling

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1049,8 +1049,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
                 if (cause instanceof InterruptedException || cause instanceof CancellationException) {
                     cause = new TimeoutCacheException("Stage was cancelled.", cause);
                 }
-                LOGGER.warn("Stage of {} failed with {}.",
-                            pnfsId, cause);
+                LOGGER.warn("Stage of {} failed with {}.", pnfsId, cause.toString());
             }
             descriptor.close();
             if (cause instanceof CacheException) {
@@ -1104,7 +1103,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             if (cause instanceof InterruptedException || cause instanceof CancellationException) {
                 cause = new TimeoutCacheException("Stage was cancelled.", cause);
             }
-            LOGGER.warn("Remove of {} failed with {}.", uri, cause);
+            LOGGER.warn("Remove of {} failed with {}.", uri, cause.toString());
             removeRequests.removeAndCallback(uri, cause);
         }
 


### PR DESCRIPTION
Motivation:

A trivial bug caused stack traces to be logged upon failure to
stage and delete from nearline storage.

Modification:

Don't log the stack trace.

Result:

A bug that caused stack traces to be logged on the pool after
stage or deletion failure from nearline storage has been fixed.

Target: trunk
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9853/

(cherry picked from commit 0b782a5bedb6433629f07b85fb268f6198375a2c)