### PR TITLE
poolmanager: Log pool name rather than SelectPool object id

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -863,7 +863,7 @@ public class RequestContainerV5
                 return _poolCandidate.name();
             } else if (_p2pDestinationPool != null) {
                 return (_p2pSourcePool == null ? POOL_UNKNOWN_STRING : _p2pSourcePool)
-                    + "->" + _p2pDestinationPool;
+                    + "->" + _p2pDestinationPool.name();
             } else {
                 return POOL_UNKNOWN_STRING;
             }
@@ -1898,8 +1898,7 @@ public class RequestContainerV5
                _bestPool = e.getPool();
                _parameter = _poolSelector.getCurrentPartition();
                if (e.shouldTryAlternatives()) {
-                   _log.info("[read] {} ({})",
-                             e.getMessage(), _bestPool);
+                   _log.info("[read] {} ({})", e.getMessage(), _bestPool.name());
                    return RT_COST_EXCEEDED;
                }
            } catch (CacheException e) {


### PR DESCRIPTION
Motivation:

    00006E1C59C4AA144C7FB16E9C55780E23D5@0.0.0.0/0-*/* m=1 r=0 [org.dcache.poolmanager.SelectedPool@f580842->org.dcache.poolmanager.SelectedPool@117f2c55] [Pool2Pool 10.23 19:12:07] {0,}

Modification:

Be explicit about logging the pool name when that is the intention.

Result:

Fixes an unreleased regression in which pool manager would about a binary
object identifier in `rc ls`.

Target: trunk
Request: 3.0
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9855/

(cherry picked from commit 01efa18dc45ccee91eeb84c1fb9d38bc53e1fc8d)