### PR TITLE
cells: Add safe guards to connector create and process update events

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
@@ -169,22 +169,22 @@ public class LocationManager extends CellAdapter
         public void update(PathChildrenCacheEvent event)
         {
             LOGGER.info("{}", event);
-            String domain = ZKPaths.getNodeFromPath(event.getData().getPath());
             String cell;
             switch (event.getType()) {
             case CHILD_REMOVED:
-                cell = connectors.remove(domain);
+                cell = connectors.remove(ZKPaths.getNodeFromPath(event.getData().getPath()));
                 if (cell != null) {
                     getNucleus().kill(cell);
                 }
                 break;
             case CHILD_UPDATED:
-                cell = connectors.remove(domain);
+                cell = connectors.remove(ZKPaths.getNodeFromPath(event.getData().getPath()));
                 if (cell != null) {
                     getNucleus().kill(cell);
                 }
                 // fall through
             case CHILD_ADDED:
+                String domain = ZKPaths.getNodeFromPath(event.getData().getPath());
                 try {
                     if (shouldConnectTo(domain)) {
                         cell = connectors.remove(domain);


### PR DESCRIPTION
Motivation:

We have observed problems with two connectors running to the same
core domain.

Modification:

First of all, this patch fixes a bug in which update events from the
path and children cache were not processed. These should however not
be responsible for the problems observed.

Second, baring insight into why two connetors ran at the same time,
this patch adds a number of safe guards to kill the old connector
with a suitable log message. Also increased the log level of the
events being generated by zookeeper.

Result:

Added debugging code to help pinpoint problems observed with tunnel
connections.

Target: trunk
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9861/

(cherry picked from commit ede86ad03a7fb7aa1707bb260b0ca4a6e8f7f2a2)