### PR TITLE
cells: Remove resubmission to event thread in location manager

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
@@ -241,11 +241,11 @@ public class LocationManager extends CellAdapter
             case CORE:
                 checkArgument(this.args.argc() >= 1, "Listening port is required.");
                 client = new CoreClient();
-                coreDomains.onChange(event -> invokeOnMessageThread(() -> client.update(event)));
+                coreDomains.onChange(client::update);
                 break;
             default:
                 client = new Client();
-                coreDomains.onChange(event -> invokeOnMessageThread(() -> client.update(event)));
+                coreDomains.onChange(client::update);
                 break;
             }
         } else {


### PR DESCRIPTION
Motivation:

Location manager contains what appears to be unnecessary resubmission
of zookeeper events to the event thread - zookeeper notifications are
already delivered on the cell event thread.

Modification:

Process the events directly. I can only speculate that the old code
was necessary in an earlier version of the code.

Result:

Should not have any user visible changes, but just in case I ask for
this to be merged into 3.0.

Target: trunk
Request: 3.0
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.deZ

Reviewed at https://rb.dcache.org/r/9862/

(cherry picked from commit 26ce471a962e8157133297301f35f46f01a18863)