### PR TITLE
dcap: fix regression in handling old version

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -579,15 +579,11 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
         try {
             int major = Integer.parseInt(args.argv(2));
             int minor = Integer.parseInt(args.argv(3));
-            Integer bugfix = null;
-            String patch = null;
-            if (args.argc() > 2) {
-                bugfix = Integer.parseInt(args.argv(4));
-                patch = args.argv(5);
-            }
+            Integer bugfix = args.argc() > 4 ? Integer.parseInt(args.argv(4)) : null;
+            String patch = args.argv(5);
             _version = new Version(major, minor, bugfix, patch);
         } catch (NumberFormatException e) {
-            _log.error("Syntax error in client version number : {}", e.toString());
+            _log.error("Syntax error in client version number {} : {}", args, e.toString());
             throw new CommandException("Invalid client version number", e);
         }
 


### PR DESCRIPTION
Motivation:

A recent patch introduced a regression where client "hello" messages
were incorrectly parsed.  This results in the dcap door logging a line
like:

    Syntax error in client version number : java.lang.NumberFormatException: null

This error is ignored by the client, allowing files to be read albeit as
the anonymous user, but prevents staging of files.

Modification:

Correctly parse hello messages.

Result:

The dcap doors allows reading, writing and staging of data as expected.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9071
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/9867/
Acked-by: Albert Rossi