### PR TITLE
dcap: fix Kerberos dcap if principal contains a '-'

### DIFF
--- a/modules/common-security/src/main/java/org/dcache/dss/KerberosDssContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/KerberosDssContextFactory.java
@@ -31,6 +31,8 @@ import org.ietf.jgss.Oid;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+import org.dcache.util.Args;
+
 public class KerberosDssContextFactory implements DssContextFactory
 {
     private final Function<GSSName, GSSContext> createInitialContext =
@@ -88,9 +90,14 @@ public class KerberosDssContextFactory implements DssContextFactory
         }
     }
 
-    public KerberosDssContextFactory(String principal) throws GSSException
+    public KerberosDssContextFactory(String args) throws GSSException
     {
-        this(principal, Optional.<String>absent());
+        this(new Args(args));
+    }
+
+    public KerberosDssContextFactory(Args args) throws GSSException
+    {
+        this(args.argv(0), Optional.<String>absent());
     }
 
     public KerberosDssContextFactory(String principal, String peerName) throws GSSException


### PR DESCRIPTION
Motivation:

A recent patch revealed a works-by-accident bug when creating an
instance of the context factory.  Such factories must have a constructor
that accepts a string argument.  Whereas the GSI context factory parses
the supplied string using Args, support for Kerberos uses the string
directly.  This used to work because Args#toString didn't escape
characters that are likely to exist in a principal.

Modification:

Use Args to parse the supplied string.  The first argument is extracted
as the Kerberos principal.

Result:

Kerberos dcap works again for hosts containing a '-' character.

Target: master
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9062
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9843/
Acked-by: Gerd Behrmann