### PR TITLE
dcap: fix Kerberos dcap if principal contains a '-'

### DIFF
--- a/modules/javatunnel/src/main/java/javatunnel/GssTunnel.java
+++ b/modules/javatunnel/src/main/java/javatunnel/GssTunnel.java
@@ -22,12 +22,13 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetAddress;
 import java.net.Socket;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.dcache.util.Args;
 
 
 class GssTunnel extends TunnelConverter {
@@ -50,8 +51,12 @@ class GssTunnel extends TunnelConverter {
     protected GssTunnel() {}
 
     // Creates a new instance of GssTunnel
-    public GssTunnel(String principalStr ) {
-    	_principalStr   = principalStr;
+    public GssTunnel(String args) {
+        this(new Args(args));
+    }
+
+    public GssTunnel(Args args) {
+        _principalStr = args.argv(0);
     }
 
     public GssTunnel(String principalStr, boolean init) throws GSSException {


### PR DESCRIPTION
Motivation:

A recent patch revealed a works-by-accident bug when creating an
instance of the context factory.  Such factories must have a constructor
that accepts a string argument.  Whereas the GSI context factory parses
the supplied string using Args, support for Kerberos uses the string
directly.  This used to work because Args#toString didn't escape
characters that are likely to exist in a principal.

Modification:

Use Args to parse the supplied string.  The first argument is extracted
as the Kerberos principal.

Result:

Kerberos dcap works again for hosts containing a '-' character.

Target: master
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9062
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9843/
Acked-by: Gerd Behrmann

Conflicts:
	modules/common-security/src/main/java/org/dcache/dss/KerberosDssContextFactory.java