### PR TITLE
dcap: expose dcap client version limit

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -1,8 +1,10 @@
 package diskCacheV111.doors;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
+import com.google.common.net.InetAddresses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -269,16 +271,28 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
          */
         Version(String versionString)
         {
-            StringTokenizer st = new StringTokenizer(versionString,".");
-            _major = Integer.parseInt(st.nextToken());
-            _minor = Integer.parseInt(st.nextToken());
-            if (st.hasMoreTokens()) {
-                st = new StringTokenizer(st.nextToken(), "-");
-                _bugfix = Integer.parseInt(st.nextToken());
-                _package = st.hasMoreTokens() ? st.nextToken() : null;
-            } else {
-                _bugfix = null;
-                _package = null;
+            List<String> values = Splitter.on('.').limit(3).splitToList(versionString);
+            if (values.size() < 2) {
+                throw new IllegalArgumentException("Versions requires at least one dot.");
+            }
+            try {
+                _major = Integer.parseInt(values.get(0));
+                _minor = Integer.parseInt(values.get(1));
+                if (values.size() > 2) {
+                    int idx = values.get(2).indexOf('-');
+                    if (idx == -1) {
+                        _bugfix = Integer.parseInt(values.get(2));
+                        _package = null;
+                    } else {
+                        _bugfix = Integer.parseInt(values.get(2).substring(0, idx));
+                        _package = values.get(2).substring(idx+1);
+                    }
+                } else {
+                    _bugfix = null;
+                    _package = null;
+                }
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("invalid integer: " + e.getMessage());
             }
         }
 
@@ -414,25 +428,24 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
             throw new CommandException("Invalid client version number", e);
         }
 
-        _log.debug("Client Version : {}", _version);
-        if (_settings.getMinClientVersion().matches(_version) > 0 ||
-                _settings.getMaxClientVersion().matches(_version) < 0) {
-            String error = "Client version rejected : "+_version;
-            _log.error(error);
-            throw new
-            CommandExitException(error , 1 );
-        }
-        String yourName = args.getName() ;
-        if( yourName.equals("server") ) {
-            _ourName = "client";
-        }
-
         /*
           replace current values if alternatives are provided
         */
         _pid = args.getOption("pid", _pid);
         _uid = args.getIntOption("uid", _uid);
         _gid = args.getIntOption("gid", _gid);
+
+        _log.debug("Client Version : {}", _version);
+        if (_settings.getMinClientVersion().matches(_version) > 0 ||
+                _settings.getMaxClientVersion().matches(_version) < 0) {
+            _log.error("Client {} (proc \"{}\" running with uid:{} gid:{}) rejected: bad client version: {}",
+                    InetAddresses.toAddrString(_clientAddress), _pid, _uid, _gid, _version);
+            throw new CommandExitException("Client version rejected : "+_version, 1);
+        }
+        String yourName = args.getName() ;
+        if( yourName.equals("server") ) {
+            _ourName = "client";
+        }
 
         return "0 0 "+_ourName+" welcome "+_version.getMajor()+" "+_version.getMinor();
     }

--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DcapDoorSettings.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DcapDoorSettings.java
@@ -18,10 +18,11 @@
  */
 package diskCacheV111.doors;
 
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 
 import java.util.Collections;
-import java.util.StringTokenizer;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.CheckStagePermission;
@@ -148,13 +149,19 @@ public class DcapDoorSettings
 
         if (clientVersion != null) {
             try {
-                StringTokenizer st = new StringTokenizer(clientVersion, ":");
-                minClientVersion  = new DCapDoorInterpreterV3.Version(st.nextToken());
-                if (st.countTokens() > 0) {
-                    maxClientVersion  = new DCapDoorInterpreterV3.Version(st.nextToken());
+                List<String> values = Splitter.on(':').limit(2).trimResults().splitToList(clientVersion);
+                if (values.get(0).isEmpty()) {
+                    throw new IllegalArgumentException("missing minimum version");
                 }
-            } catch (NumberFormatException e) {
-                _log.error("Client Version : syntax error (limits ignored) : {} : {}", clientVersion, e.toString());
+                minClientVersion  = new DCapDoorInterpreterV3.Version(values.get(0));
+                if (values.size() > 1) {
+                    if (values.get(1).isEmpty()) {
+                        throw new IllegalArgumentException("missing maximum version");
+                    }
+                    maxClientVersion  = new DCapDoorInterpreterV3.Version(values.get(1));
+                }
+            } catch (IllegalArgumentException e) {
+                _log.error("Ignoring client version limits: syntax error with '{}': {}", clientVersion, e.getMessage());
             }
         }
 

--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -142,6 +142,44 @@ dcap.loginbroker.version=1.3.0
 dcap.loginbroker.address = ${dcap.net.listen}
 dcap.loginbroker.port = ${dcap.net.port}
 
+#  ---- Limit dcap client version
+#
+#  The door can reject clients based on their version.  The
+#  dcap.limit.client-version describes which client versions will be
+#  accepted.  The value has the form:
+#
+#     [<MIN VERSION>[:<MAX VERSION>]]
+#
+#  Both min- and max- versions have the format:
+#
+#      <major>.<minor>[.<bug-fix>[-<package>]]
+#
+#  If <MIN VERSION> is specified then then client must be this version
+#  or newer.  If <MAX VERSION> is specified then clients must be this
+#  version or older.  If both a minimum and maximum version is
+#  specified then a client version must match both values.
+#
+#  If <bug-fix> number or <package> string are omitted then the
+#  version will match all unspecified elements; e.g., a version of
+#  "2.48" matches v2.48.0-1, v2.48.0-2, v2.48.1-1, ..., and a version
+#  of "2.48.16" matches client versions of v2.48.16-1, v2.48.16-2, ...
+#
+#  For example, with a value of:
+#
+#      2.48
+#
+#  the dcap door will reject clients older than v2.48.0; if the value
+#  is:
+#
+#      2.48.3 : 2.999
+#
+#  then the dcap door will reject clients older than v2.48.3, and
+#  reject clients with version v2.1000.0 or newer.
+#
+#  If the value is empty then all client versions are accepted.
+#
+dcap.limits.client-version =
+
 #
 #   Document which TCP ports are opened
 #

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -41,6 +41,7 @@ check -strong dcap.authz.mover-queue-overwrite
 check dcap.mover.queue
 check dcap.net.listen
 check -strong dcache.paths.share
+check dcap.limits.client-version
 
 exec file:${dcache.paths.share}/cells/stage.fragment dcap doors
 
@@ -115,5 +116,6 @@ create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
              -io-queue=${dcap.mover.queue} \
              -io-queue-overwrite=${dcap.authz.mover-queue-overwrite} \
              -anonymous-access=${dcap.authz.anonymous-operations} \
+             -clientVersion=\"${dcap.limits.client-version}\" \
              ${arguments-${dcap.authn.protocol}} \
              "


### PR DESCRIPTION
Motivation:

We have 'rogue' versions of dcap that contain a bug that causes the
client to make unsatisfiable requests to a pool with no way for dCache
to reject the request: the client will simply retry.  With centralised
software deployment (such as CVMFS) sites are unable to control which
version of a library an application is linked.  Therefore the only
practical way to protect dCache from such clients is to allow the door
to reject such broken clients as early as possible.

Modification:

Expose the existing client version limits as a configuration property.
The default is to allow all dcap client versions, unchanged from the
previous behaviour.

Result:

The admin has the ability to ban broken dcap client.

Target: master
Requires-notes: yes
Requires-book: yes
Request: 3.0
Patch: https://rb.dcache.org/r/9870/
Acked-by: Gerd Behrmann