### PR TITLE
dcap: expose dcap client version limit

### DIFF
--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -152,6 +152,44 @@ dcap.loginbroker.family.gsi=gsidcap
 dcap.loginbroker.family.kerberos=dcap
 dcap.loginbroker.version=1.3.0
 
+#  ---- Limit dcap client version
+#
+#  The door can reject clients based on their version.  The
+#  dcap.limit.client-version describes which client versions will be
+#  accepted.  The value has the form:
+#
+#     [<MIN VERSION>[:<MAX VERSION>]]
+#
+#  Both min- and max- versions have the format:
+#
+#      <major>.<minor>[.<bug-fix>[-<package>]]
+#
+#  If <MIN VERSION> is specified then then client must be this version
+#  or newer.  If <MAX VERSION> is specified then clients must be this
+#  version or older.  If both a minimum and maximum version is
+#  specified then a client version must match both values.
+#
+#  If <bug-fix> number or <package> string are omitted then the
+#  version will match all unspecified elements; e.g., a version of
+#  "2.48" matches v2.48.0-1, v2.48.0-2, v2.48.1-1, ..., and a version
+#  of "2.48.16" matches client versions of v2.48.16-1, v2.48.16-2, ...
+#
+#  For example, with a value of:
+#
+#      2.48
+#
+#  the dcap door will reject clients older than v2.48.0; if the value
+#  is:
+#
+#      2.48.3 : 2.999
+#
+#  then the dcap door will reject clients older than v2.48.3, and
+#  reject clients with version v2.1000.0 or newer.
+#
+#  If the value is empty then all client versions are accepted.
+#
+dcap.limits.client-version =
+
 #
 #   Document which TCP ports are opened
 #

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -39,6 +39,7 @@ check -strong dcap.authz.mover-queue-overwrite
 check dcap.mover.queue
 check dcap.net.listen
 check -strong dcache.paths.share
+check dcap.limits.client-version
 
 exec file:${dcache.paths.share}/cells/stage.fragment dcap doors
 
@@ -112,5 +113,6 @@ create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
              -io-queue=${dcap.mover.queue} \
              -io-queue-overwrite=${dcap.authz.mover-queue-overwrite} \
              -anonymous-access=${dcap.authz.anonymous-operations} \
+             -clientVersion=\"${dcap.limits.client-version}\" \
              ${arguments-${dcap.authn.protocol}} \
              "


### PR DESCRIPTION
Motivation:

We have 'rogue' versions of dcap that contain a bug that causes the
client to make unsatisfiable requests to a pool with no way for dCache
to reject the request: the client will simply retry.  With centralised
software deployment (such as CVMFS) sites are unable to control which
version of a library an application is linked.  Therefore the only
practical way to protect dCache from such clients is to allow the door
to reject such broken clients as early as possible.

Modification:

Expose the existing client version limits as a configuration property.
The default is to allow all dcap client versions, unchanged from the
previous behaviour.

This patch also fixes a bug when checking the client version is less
than the maximum client version.  This causes various problems,
particularly for one Tier-1 with staging.

Result:

The admin has the ability to ban broken dcap client.

Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9071
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/9871/
Acked-by: Gerd Behrmann

Conflicts:
	modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
	modules/dcache-dcap/src/main/java/diskCacheV111/doors/DcapDoorSettings.java