### PR TITLE
webdav: fix thrown NPE when CORS is set

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
@@ -80,7 +80,7 @@ public class MiltonHandler
                     "to be part of the URL.", s);
             checkArgument(uri.toURL().getPath().isEmpty(), "The URL: %s is invalid. Remove the \"path\" part of the " +
                     "URL.", s);
-            checkArgument(uri.toURL().getQuery().isEmpty(), "The URL: %s is invalid. Remove the query-path part of " +
+            checkArgument(uri.toURL().getQuery() == null, "The URL: %s is invalid. Remove the query-path part of " +
                     "the URL.", s);
             checkArgument(uri.toURL().getRef() == null, "URL: %s is invalid. Reason: no reference or fragment " +
                     "allowed in the URL.", s);


### PR DESCRIPTION
Motivation:

When webdav.allowed.client.origins is set, the checkOrigin method is used to
check if the url met the neccessary criteria. One of the criteria is to ensure
that the url doesn't have a query part. The getQuery method of the url class
used to do this will be null if there is no query, and isEmpty of null will
throw a NulPointerExpection.

Modification:

change uri.toURL().getQuery().isEmpty() to uri.toURL().getQuery() == null

Result:

No more NPE.

Target: trunk
Request: 3.0
Require-book: no
Require-notes: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9858/

(cherry picked from commit 9d286e714212af073de1a1510e81b07a16922cb2)