### PR TITLE
PoolManager : stage protection, fix error in stage.fragment

### DIFF
--- a/skel/share/cells/stage.fragment
+++ b/skel/share/cells/stage.fragment
@@ -8,7 +8,7 @@ end
 onerror shutdown
 check ${0}.authz.staging.pep
 onerror continue
-eval "${0}.authz.staging.pep" "${1}" !=
-exec env stage-disable-pep.exe -ifok
+eval ${${0}.authz.staging.pep} "${1}" ==
+exec env stage-disable-pep.exe -ifnotok
 onerror shutdown
 


### PR DESCRIPTION
Motivation:

It has been noticed that setting properties:
  dcache.authz.staging.pep=PoolManager
  dcache.authz.staging=/path/to/stage/configuration/file.conf
did not have any effect on ability to perform staging.
The issue has been traced to an error in stage.fragment.

Modification:

A fix to environment variable handling in stage.fragment.

Result:

Stage protection gets enabled.

    Acked-by: Albert Rossi <arossi@fnalgov>
    RB: https://rb.dcache.org/r/9876/
    Target: master
    Request: 3.0
    Request: 2.16
    Request: 2.15
    Request: 2.14
    Request: 2.13
    Request: 2.10
(cherry picked from commit fa7b0fb8bdb481efd46d3946bfc753bb99099ff9)