### PR TITLE
dcap: don't create stack-trace if tunnel fails due to bad client

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -849,7 +849,11 @@ public class LoginManager
                 if (cause instanceof Error) {
                     throw (Error) cause;
                 }
-                LOGGER.warn("Exception (ITE) in secure protocol : {}", cause);
+                if (cause instanceof RuntimeException) {
+                    LOGGER.warn("Bug detected in dCache; please report this to <support@dcache.org>", cause);
+                } else {
+                    LOGGER.warn("Exception (ITE) in secure protocol: {}", cause.getMessage());
+                }
                 try {
                     _socket.close();
                 } catch (IOException ee) {/* dead any way....*/}


### PR DESCRIPTION
Motivation:

Tunnel verification can fail; e.g., from a non-dcap client connecting to
the dcap port.  Such failures in creating the tunnel are always reported
with a stack-trace, which indicates a bug in dCache.

Modification:

Descriminate between causes that are RuntimeException (i.e., bugs) vs
other exceptions.  Log RuntimeException causes with a suitable error
message.  Log other exceptions with a simple message; i.e., without a
stack-trace.

Result:

No more stack-traces when a non-dcap client connects to dCache.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9845/
Acked-by: Tigran Mkrtchyan