### PR TITLE
Resilience: Support matching the universal and class default storage …

### DIFF
--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestBase.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestBase.java
@@ -404,6 +404,10 @@ public abstract class TestBase implements Cancellable {
         testNamespaceAccess.loadNewResilientOnHostTagDefined();
     }
 
+    protected void loadNewFilesWithUnmappedStorageUnit() {
+        testNamespaceAccess.loadNewResilientWithUnmappedStorageUnit();
+    }
+
     protected void loadNewFilesOnPoolsWithNoTags() {
         testNamespaceAccess.loadNewResilient();
     }

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestData.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestData.java
@@ -163,7 +163,8 @@ final class TestData {
                     "resilient-2.dcache-devel-test",
                     "resilient-3.dcache-devel-test",
                     "resilient-4.dcache-devel-test",
-                    "standard.dcache-devel-test"
+                    "standard.dcache-devel-test",
+                    "*@*"
     };
 
     static final String[] STORAGE_UNITS = {
@@ -172,7 +173,8 @@ final class TestData {
                     getStorageUnitName(STORAGE_CLASSES[2]),
                     getStorageUnitName(STORAGE_CLASSES[3]),
                     getStorageUnitName(STORAGE_CLASSES[4]),
-                    getStorageUnitName(STORAGE_CLASSES[5])
+                    getStorageUnitName(STORAGE_CLASSES[5]),
+                    STORAGE_CLASSES[6]
     };
 
     static final String[][] STORAGE_UNITS_SET = {
@@ -181,7 +183,8 @@ final class TestData {
                     {"2", "rack"},
                     {"2", "hostname,rack"},
                     {"3", ""},
-                    null
+                    null,
+                    {"2", ""}
     };
 
     static final String[][] POOL_GROUPS = {
@@ -206,6 +209,7 @@ final class TestData {
                     {UNIT_GROUPS[3], STORAGE_UNITS[2], "false"},
                     {UNIT_GROUPS[3], STORAGE_UNITS[3], "false"},
                     {UNIT_GROUPS[3], STORAGE_UNITS[4], "false"},
+                    {UNIT_GROUPS[3], STORAGE_UNITS[6], "false"}
     };
 
     static final String[][] LINKS = {

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestNamespaceAccess.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestNamespaceAccess.java
@@ -206,6 +206,15 @@ public final class TestNamespaceAccess extends LocalNamespaceAccess {
         }
     }
 
+    void loadNewResilientWithUnmappedStorageUnit() {
+        for (int i = 0; i < TestData.REPLICA_ONLINE.length; ++i) {
+            loadRequired(TestData.REPLICA_ONLINE[i], AccessLatency.ONLINE,
+                         RetentionPolicy.REPLICA, TestData.HSM,
+                         "unmapped-storage",
+                         TestData.NEW_RESILIENT_LOCATIONS_H[i]);
+        }
+    }
+
     void loadNewResilientOnHostTagDefined() {
         for (int i = 0; i < TestData.REPLICA_ONLINE.length; ++i) {
             loadRequired(TestData.REPLICA_ONLINE[i], AccessLatency.ONLINE,

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/FileOperationMapTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/FileOperationMapTest.java
@@ -101,6 +101,15 @@ public final class FileOperationMapTest extends TestBase {
     }
 
     @Test
+    public void shouldMakeDefaultNumberOfCopiesForFileWithUnmappedStorageUnit()
+                    throws CacheException, IOException {
+        givenANewPnfsIdWithUnmappedStorageUnit();
+        afterOperationAdded(1);
+        whenScanIsRun();
+        assertNotNull(fileOperationMap.getOperation(operation.getPnfsId()));
+    }
+
+    @Test
     public void shouldBehaveLikeCancelAllWhenOperationIsVoided()
                     throws CacheException, IOException {
         givenANewPnfsId();
@@ -323,10 +332,9 @@ public final class FileOperationMapTest extends TestBase {
     private void afterOperationAdded(int count) throws CacheException {
         PnfsId pnfsId = attributes.getPnfsId();
         String pool = attributes.getLocations().iterator().next();
-        String unit = attributes.getStorageClass() + "@" + attributes.getHsm();
         Integer pindex = poolInfoMap.getPoolIndex(pool);
         Integer gindex = poolInfoMap.getResilientPoolGroup(pindex);
-        Integer sindex = poolInfoMap.getGroupIndex(unit);
+        Integer sindex = poolInfoMap.getStorageUnitIndex(attributes);
         FileUpdate update = new FileUpdate(pnfsId, pool,
                                            MessageType.ADD_CACHE_LOCATION, pindex, gindex, sindex,
                                            attributes);
@@ -352,6 +360,11 @@ public final class FileOperationMapTest extends TestBase {
 
     private void givenANewPnfsId() throws CacheException {
         loadNewFilesOnPoolsWithNoTags();
+        attributes = aReplicaOnlineFileWithNoTags();
+    }
+
+    private void givenANewPnfsIdWithUnmappedStorageUnit() throws CacheException {
+        loadNewFilesWithUnmappedStorageUnit();
         attributes = aReplicaOnlineFileWithNoTags();
     }
 

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolInfoMapTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolInfoMapTest.java
@@ -127,9 +127,9 @@ public final class PoolInfoMapTest extends TestBase {
     }
 
     @Test
-    public void shouldReturnFiveStorageClassesForResilientPoolGroup() {
+    public void shouldReturnSixStorageClassesForResilientPoolGroup() {
         whenStorageGroupsAreRequestedFor("resilient-group");
-        assertEquals(5, collection.size());
+        assertEquals(6, collection.size());
     }
 
     @Test

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/util/PoolManagerInfoExtractorTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/util/PoolManagerInfoExtractorTest.java
@@ -103,8 +103,8 @@ public final class PoolManagerInfoExtractorTest extends TestBase {
     }
 
     @Test
-    public void shouldReturnFiveStorageUnitsForResilientPoolGroup() {
-        assertEquals(5, StorageUnitInfoExtractor.getStorageUnitsInGroup(
+    public void shouldReturnSixStorageUnitsForResilientPoolGroup() {
+        assertEquals(6, StorageUnitInfoExtractor.getStorageUnitsInGroup(
                         "resilient-group", testSelectionUnit).size());
     }
 


### PR DESCRIPTION
…unit expressions

Motivation:

PoolManager allows a configuration to set a globbed expression asterisk@class
and also automatically adds asterisk@asterisk to the set of storage units
against which to match in the PoolSelectionUnit.  The current implementation
of Resilience neglected to support these.

This actually breaks a basic compatibility with the pool manager definitions,
but also removes the possibility of conveniently providing default
behavior for unmapped storage classes (i.e., if a system wished to make
all files or any in directories without a storage class tag have a
common resilience setting).

Modification:

The method which resolves the storage unit from the FileAttributes in
resilience's PoolInfoMap now calls out to an alternative method if
it cannot find the mapping for the derived storage unit name.

A unit test and supporting data has been added to test the case the
basic case described above.  (The size of the patch is owed to these
additions; the actual change is confined to one class.)

Result:

Resilience is now compatible with PoolSelectionUnit.   Note:
resilience does not yet support regular expression matching on
the storage class names.  A separate patch (for master only,
until someone actually complains that a stable branch does
not support this) will follow.

Target: master
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Tigran