### PR TITLE
srmclient: probe for SRM endpoint parameters that the user doesn't sp…

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/Configuration.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/Configuration.java
@@ -255,6 +255,10 @@ public class Configuration {
         return ws_path;
     }
 
+    public String getRawWebservice_path() {
+        return webservice_path;
+    }
+
     public void setWebservice_path(String webservice_path) {
         this.webservice_path = webservice_path;
     }

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -215,14 +215,14 @@ public class SrmShell extends ShellApplication
             credential = new PEMCredential(configuration.getX509_user_key(), configuration.getX509_user_cert(), null);
         }
         fs = new AxisSrmFileSystem(
-                new SRMClientV2(SrmUrl.withDefaultPort(configuration.getSrmUrl()),
+                new SRMClientV2(configuration.getSrmUrl(),
                                 credential,
                                 configuration.getRetry_timeout(),
                                 configuration.getRetry_num(),
                                 configuration.isDelegate(),
                                 configuration.isFull_delegation(),
                                 configuration.getGss_expected_name(),
-                                configuration.getWebservice_path(),
+                                configuration.getRawWebservice_path(),
                                 configuration.getX509_user_trusted_certificates(),
                                 Transport.GSI));
 

--- a/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
@@ -15,23 +15,31 @@
 
 package org.dcache.srm.client;
 
+import com.google.common.base.Throwables;
+import com.google.common.primitives.Ints;
 import eu.emi.security.authn.x509.X509Credential;
+import org.apache.axis.AxisFault;
 import org.apache.axis.SimpleTargetedChain;
 import org.apache.axis.client.Call;
-import org.apache.axis.client.Stub;
 import org.apache.axis.configuration.SimpleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+import javax.xml.namespace.QName;
 import javax.xml.rpc.ServiceException;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.ConnectException;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.rmi.RemoteException;
+import java.util.ArrayList;
 import java.util.Date;
 
 import org.dcache.srm.v2_2.ISRM;
@@ -94,6 +102,7 @@ import org.dcache.srm.v2_2.SrmRmdirRequest;
 import org.dcache.srm.v2_2.SrmRmdirResponse;
 import org.dcache.srm.v2_2.SrmSetPermissionRequest;
 import org.dcache.srm.v2_2.SrmSetPermissionResponse;
+import org.dcache.srm.v2_2.SrmSoapBindingStub;
 import org.dcache.srm.v2_2.SrmStatusOfBringOnlineRequestRequest;
 import org.dcache.srm.v2_2.SrmStatusOfBringOnlineRequestResponse;
 import org.dcache.srm.v2_2.SrmStatusOfChangeSpaceForFilesRequestRequest;
@@ -117,6 +126,8 @@ import org.dcache.srm.v2_2.SrmUpdateSpaceResponse;
 import org.dcache.ssl.CanlContextFactory;
 
 import static com.google.common.net.InetAddresses.isInetAddress;
+import static javax.xml.rpc.Stub.ENDPOINT_ADDRESS_PROPERTY;
+import static org.apache.axis.Constants.NS_URI_AXIS;
 /**
  *
  * @author  timur
@@ -127,13 +138,49 @@ public class SRMClientV2 implements ISRM {
     private static final String SFN_STRING="?SFN=";
     private static final String WEB_SERVICE_PATH="srm/managerv2";
     private static final String GSS_EXPECTED_NAME="host";
-    private int retries;
-    private long retrytimeout;
+    private static final QName AXIS_HTTP = new QName(NS_URI_AXIS, "HTTP");
 
-    private ISRM axis_isrm;
-    private X509Credential user_cred;
-    private String service_url;
-    private String host;
+    private static final URI[] PROBE_URLS = {
+            URI.create("httpg://dCache-and-CASTOR.invalid:8443/srm/managerv2"),
+            URI.create("httpg://dpm.invalid:8446/srm/managerv2"),
+            URI.create("httpg://StoRM.invalid:8444/srm/managerv2"),
+            URI.create("httpg://bestman.invalid:8443/srm/v2/server")
+        };
+    private static final int[] PROBE_PORTS =  uniquePorts(PROBE_URLS);
+    private static final String[] PROBE_PATHS = uniquePaths(PROBE_URLS);
+
+    private final long retrytimeout;
+    private final int retries;
+    private final X509Credential user_cred;
+    private final SRMServiceLocator sl;
+    private final HttpClientTransport.Delegation delegation;
+    private final URL serviceUrl;
+
+    private SrmSoapBindingStub axis_isrm;
+    private boolean haveSuccessfulCall;
+    private int nextProbe;
+
+    private static int[] uniquePorts(URI[] uris)
+    {
+        ArrayList<Integer> ports = new ArrayList<>(uris.length);
+        for (URI uri : uris) {
+            if (!ports.contains(uri.getPort())) {
+                ports.add(uri.getPort());
+            }
+        }
+        return Ints.toArray(ports);
+    }
+
+    private static String[] uniquePaths(URI[] uris)
+    {
+        ArrayList<String> paths = new ArrayList<>(uris.length);
+        for (URI uri : uris) {
+            if (!paths.contains(uri.getPath())) {
+                paths.add(uri.getPath());
+            }
+        }
+        return paths.toArray(new String[paths.size()]);
+    }
 
     static {
         Call.setTransportForProtocol("http", HttpClientTransport.class);
@@ -161,23 +208,43 @@ public class SRMClientV2 implements ISRM {
              transport);
     }
 
-    public SRMClientV2(URI srmurl,
-                       X509Credential user_cred,
-                       long retrytimeout,
-                       int numberofretries,
-                       boolean do_delegation,
-                       boolean full_delegation,
-                       String gss_expected_name,
-                       String webservice_path,
-                       String caPath, Transport transport)
-    throws IOException,InterruptedException,ServiceException {
+    public SRMClientV2(URI srmurl, X509Credential user_cred, long retrytimeout,
+            int numberofretries, boolean do_delegation, boolean full_delegation,
+            String gss_expected_name, String webservice_path, String caPath,
+            Transport transport) throws IOException,InterruptedException
+    {
         this.retrytimeout = retrytimeout;
         this.retries = numberofretries;
         this.user_cred = user_cred;
+        this.delegation = TransportUtil.delegationModeFor(transport, do_delegation, full_delegation);
         if (user_cred.getCertificate().getNotAfter().before(new Date())) {
             throw new IOException("X.509 credentials have expired");
         }
-        host = srmurl.getHost();
+
+        sl = buildServiceLocator(caPath);
+        serviceUrl = buildServiceURL(srmurl, transport, webservice_path);
+        axis_isrm = buildStub(nextServiceURL());
+    }
+
+    private static SRMServiceLocator buildServiceLocator(String caPath)
+    {
+        SimpleProvider provider = new SimpleProvider();
+        GsiHttpClientSender sender = new GsiHttpClientSender();
+        sender.setSslContextFactory(CanlContextFactory.custom().withCertificateAuthorityPath(caPath).build());
+        sender.init();
+        provider.deployTransport(HttpClientTransport.DEFAULT_TRANSPORT_NAME, new SimpleTargetedChain(sender));
+        return new SRMServiceLocator(provider);
+    }
+
+    /**
+     * Build a URL describing the user-supplied information about the
+     * endpoint.  Both the port and path may be -1 or null (respectively) if
+     * that information was not supplied by the user.
+     */
+    private static URL buildServiceURL(URI srmurl, Transport transport,
+            String webservice_path) throws UnknownHostException, MalformedURLException
+    {
+        String host = srmurl.getHost();
         host = InetAddress.getByName(host).getCanonicalHostName();
         if (isInetAddress(host) && host.indexOf(':') != -1) {
             // IPv6 without DNS record
@@ -185,55 +252,135 @@ public class SRMClientV2 implements ISRM {
         }
         int port = srmurl.getPort();
 
-        if( port == 80) {
+        if (port == 80) {
             /* FIXME: assigning the transport based on the port number is
              * broken.  This code is here to preserve existing behaviour.
              * However, it should be removed when we can confirm no one
              * is relying on this behaviour. */
             transport = Transport.TCP;
         }
-        String path = srmurl.getPath();
-        if(path==null) {
-            path="/";
-        }
-        service_url = TransportUtil.uriSchemaFor(transport) +"://"+host+":"+port;
-        int indx=path.indexOf(SFN_STRING);
-        if(indx >0) {
-            String service_postfix = path.substring(0,indx);
-            if(!service_postfix.startsWith("/")){
-                service_url += "/";
+
+        String path = null;
+        String servicePath = srmurl.getPath();
+        if (servicePath != null) {
+            int i = servicePath.indexOf(SFN_STRING);
+            if (i > 0) {
+                path = servicePath.substring(0, i);
             }
-            service_url += service_postfix;
         }
-        else {
-            service_url += "/"+webservice_path;
+        if (path == null) {
+            path = webservice_path;
         }
-        SimpleProvider provider = new SimpleProvider();
-        GsiHttpClientSender sender = new GsiHttpClientSender();
-        sender.setSslContextFactory(CanlContextFactory.custom().withCertificateAuthorityPath(caPath).build());
-        sender.init();
-        provider.deployTransport(HttpClientTransport.DEFAULT_TRANSPORT_NAME, new SimpleTargetedChain(sender));
-        SRMServiceLocator sl = new SRMServiceLocator(provider);
-        URL url = new URL(service_url);
-        logger.debug("connecting to srm at {}",service_url);
-        axis_isrm = sl.getsrm(url);
-        if(axis_isrm instanceof Stub) {
-            Stub axis_isrm_as_stub = (Stub)axis_isrm;
-            axis_isrm_as_stub._setProperty(HttpClientTransport.TRANSPORT_HTTP_CREDENTIALS, user_cred);
-            axis_isrm_as_stub._setProperty(HttpClientTransport.TRANSPORT_HTTP_DELEGATION,
-                                           TransportUtil.delegationModeFor(transport, do_delegation, full_delegation));
-            axis_isrm_as_stub._setProperty(Call.SESSION_MAINTAIN_PROPERTY, true);
+        if (path != null && !path.startsWith("/")) {
+            path = "/" + path;
         }
-        else {
-            throw new IOException("can't set properties to the axis_isrm");
+
+        return new URL(TransportUtil.uriSchemaFor(transport), host, port,
+                path == null ? "/" : path);
+    }
+
+    /**
+     * Obtain a service URL.  If the service URL is fully specified then the
+     * returned URL is always the same value.  If some information was omitted
+     * then the returned value is the next possible service URL, or null if
+     * there are no further URLs to try.
+     */
+    @Nullable
+    private URL nextServiceURL()
+    {
+        boolean wildPort = serviceUrl.getPort() == -1;
+        boolean wildPath = serviceUrl.getPath().equals("/");
+
+        try {
+            if (wildPort && wildPath) {
+                if (nextProbe < PROBE_URLS.length) {
+                    URI probe = PROBE_URLS [nextProbe++];
+                    return new URL(serviceUrl.getProtocol(), serviceUrl.getHost(), probe.getPort(), probe.getPath());
+                }
+            } else if (wildPort) {
+                if (nextProbe < PROBE_PORTS.length) {
+                    int probe = PROBE_PORTS [nextProbe++];
+                    return new URL(serviceUrl.getProtocol(), serviceUrl.getHost(), probe, serviceUrl.getPath());
+                }
+            } else if (wildPath) {
+                if (nextProbe < PROBE_PATHS.length) {
+                    String probe = PROBE_PATHS [nextProbe++];
+                    return new URL(serviceUrl.getProtocol(), serviceUrl.getHost(), serviceUrl.getPort(), probe);
+                }
+            } else {
+                return serviceUrl;
+            }
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Failed to generate probe URL: " + e.toString(), e);
+        }
+
+        return null;
+    }
+
+    private SrmSoapBindingStub buildStub(URL url)
+    {
+        try {
+            logger.debug("connecting to srm at {}", url);
+            SrmSoapBindingStub stub = (SrmSoapBindingStub) sl.getsrm(url);
+
+            if (stub != null) {
+                stub._setProperty(HttpClientTransport.TRANSPORT_HTTP_CREDENTIALS, user_cred);
+                stub._setProperty(HttpClientTransport.TRANSPORT_HTTP_DELEGATION, delegation);
+                stub._setProperty(Call.SESSION_MAINTAIN_PROPERTY, true);
+            }
+
+            return stub;
+        } catch (ServiceException e) {
+            throw Throwables.propagate(e);
         }
     }
 
-
+    private boolean isWildServiceURL()
+    {
+        return serviceUrl.getPort() == -1 || serviceUrl.getPath().equals("/");
+    }
 
     public Object handleClientCall(String name, Object argument, boolean retry)
-    throws RemoteException {
-        logger.debug(" {} , contacting service {}",name,service_url);
+            throws RemoteException
+    {
+        while (true) {
+            try {
+                Object result = handleClientCallWithRetry(name, argument, retry);
+                haveSuccessfulCall = true;
+                return result;
+            } catch (ConnectException | AxisFault e) {
+                if (haveSuccessfulCall || !isWildServiceURL()) {
+                    throw new RemoteException("Failed to connect to server: " + e.toString(), e);
+                }
+
+                logger.debug("SRM operation failed for {}: {}",
+                        axis_isrm._getProperty(ENDPOINT_ADDRESS_PROPERTY), e.toString());
+
+                URL newServiceUrl = nextServiceURL();
+                if (newServiceUrl == null) {
+                    StringBuilder message = new StringBuilder("No SRM endpoint found");
+                    message.append(" at ").append(serviceUrl.getHost());
+                    if (serviceUrl.getPort() != -1) {
+                        message.append(':').append(serviceUrl.getPort());
+                    }
+                    if (!serviceUrl.getPath().equals("/")) {
+                        message.append(" with path ").append(serviceUrl.getPath());
+                    }
+                    message.append('.');
+                    throw new RemoteException(message.toString());
+                }
+                axis_isrm = buildStub(newServiceUrl);
+            }
+        }
+    }
+
+    public Object handleClientCallWithRetry(String name, Object argument, boolean retry)
+            throws RemoteException, ConnectException
+    {
+        if (logger.isDebugEnabled()) {
+            logger.debug(" {} , contacting service {}", name,
+                    axis_isrm._getProperty(ENDPOINT_ADDRESS_PROPERTY));
+        }
         int i = 0;
         while(true) {
             if (user_cred.getCertificate().getNotAfter().before(new Date())) {
@@ -247,7 +394,18 @@ public class SRMClientV2 implements ISRM {
             catch(NoSuchMethodException | IllegalAccessException nsme){
                 throw new RemoteException("incorrect usage of the handleClientCall", nsme);
             } catch(InvocationTargetException ite) {
-                Throwable e= ite.getCause();
+                Throwable e = ite.getCause();
+                if (e instanceof AxisFault && e.getCause() != null) {
+                    e = e.getCause();
+                }
+                Throwables.propagateIfInstanceOf(e, ConnectException.class);
+                if (e instanceof AxisFault) {
+                    AxisFault af = (AxisFault) e;
+                    if (af.getFaultCode().equals(AXIS_HTTP)) {
+                        throw af;
+                    }
+                }
+
                 logger.error("{} : try # {} failed with error {}", name, i, e != null ? e.getMessage() : "");
                 if(retry) {
                     if(i <retries) {


### PR DESCRIPTION
…ecify

Motivation:

The TCP port and path of the HTTP SOAP requests ("webservice path") was
never standardised; therefore, almost implementations have different
default values.  Only dCache and CASTOR have defaults that share these
values.

Currently the SRM client falls back to dCache default values if the port
or path are not specified.  This is (at best) annoying since it forces
the user to know and specify such values.  If only the SURL is supplied
then the webservice path is not known.

Modification:

Update SRMClientV2 to support the omission of a port or path.  If either
or both are omitted then it will use the first SRM operation to probe
which of the implementation defaults results in a TCP connection (i.e.,
correct port) and no HTTP-level failure (i.e., correct path).

The default endpoint parameters for the SRM implementations are used to
try likely values.  If the first operation fails with a TCP connection
problem or an HTTP problem then the next value is tried.

To support this, the retry logic is updated so it no longer retries on
TCP connection failure or if there is an HTTP-level failure.

SrmShell ('srmfs' command) has been updated to take advantage of this
auto-detect beahviour.  The other SRM client code has not been updated;
therefore, they retain their existing behaviour, apart from not retrying
on TCP- and HTTP-level problems.

Result:

All clients will not retry if there is a TCP or HTTP problem.

The srmfs client will auto-detect SRM port and path, allowing users to
specify SURLs without port number or path.

Target: master
Request: 3.0
Request: 2.16
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/9854/
Acked-by: Tigran Mkrtchyan