### PR TITLE
spacemanager: Fixes a message bounce bug

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -480,6 +480,7 @@ public final class SpaceManagerService
                     if (!isStopped || isImportantMessage(message)) {
                         processMessage(message);
                         if (message.getReplyRequired()) {
+                            message.setReply();
                             returnMessage();
                         }
                     } else {

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerHandlerPublisher.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerHandlerPublisher.java
@@ -224,6 +224,7 @@ public class PoolManagerHandlerPublisher
             return null;
         }
         message.setHandler(handler);
+        message.setSucceeded();
         return message;
     }
 
@@ -268,6 +269,7 @@ public class PoolManagerHandlerPublisher
         public void send(SerializablePoolManagerHandler handler)
         {
             message.setHandler(handler);
+            message.setSucceeded();
             reply(message);
         }
 

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
@@ -740,6 +740,7 @@ public class PoolManagerV5
         messageArrived(PoolManagerGetPoolMonitor msg)
     {
         msg.setPoolMonitor(_poolMonitor);
+        msg.setSucceeded();
         return msg;
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/HsmFlushController.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/HsmFlushController.java
@@ -175,6 +175,7 @@ public class HsmFlushController
             gain.setCellInfo(getCellInfo());
             gain.setFlushInfos(_storageQueue.getFlushInfos());
         }
+        gain.setSucceeded();
         return gain;
     }
 
@@ -231,6 +232,7 @@ public class HsmFlushController
                     long flushId = info.flush((max == 0) ? Integer.MAX_VALUE : max, this, _flushExecutor);
                     _flush.setFlushId(flushId);
                 }
+                _flush.setSucceeded();
             } catch (RuntimeException e) {
                 LOGGER.error("Private flush failed for " + composed + ". Please report to support@dcache.org", e);
                 _flush.setFailed(576, e);

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -1116,6 +1116,7 @@ public class PoolV4
         {
             if (succeeded.size() + failed.size() >= msg.getFiles().size()) {
                 msg.setResult(succeeded, failed);
+                msg.setSucceeded();
                 reply(msg);
             }
         }


### PR DESCRIPTION
Motivation:

Commit 20fdc8130b4666f18aed9d5788d051ac2f675020 attempted to fix a bug
in which PoolMgrGetUpdatedHandler messages would bounce between space
manager and pool manager, however the fix was incomplete: The original
fix added code to recognize reply messages, however the message handlers
fail to properly mark the messages as replies.

Modification:

Mark messages as reply when replying to them. I went through various other
components and fixed a few more places that also failed to mark the reply
as a reply.

Result:

Fixes an unreleased regression in which messages would bounce between
space manager and pool manager and cause high CPU consumption.

Target: master
Request: 3.0
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9899/

(cherry picked from commit af7c8dce40b86adb562f42a6914a9fbd1e0cd9cb)