### PR TITLE
spacemanager: Fix shutdown bug causing a file to leak from a reservation

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -529,8 +529,7 @@ public final class SpaceManagerService
                         // in case of a redundant space manager deployment, the resubmission may go to one of
                         // the other instances.
                         message.setFailed(CacheException.OUT_OF_DATE, "Space manager is shutting down.");
-                    } else if (message instanceof DoorTransferFinishedMessage ||
-                               message instanceof PoolAcceptFileMessage) {
+                    } else if (isEnRouteToDoor) {
                         // Pass it on as is since space manager will recover from the lost notification eventually
                     } else {
                         envelope.setMessageObject(new NoRouteToCellException(envelope, "Space manager is shutting down."));


### PR DESCRIPTION
Motivation:

Upon shutdown, space manager iterates over queued requests to notify various
services of the event. It passes on DoorTransferFinished and PoolAcceptFile
messages as is as space manager has other mechanisms to recover from lost
notifications. However PoolAcceptFile is intercepted both in the direction
to the pool and back from the pool and the described behaviour is only
correct for the reply from the pool.

Modification:

Only pass on the message unmodified when in route to the door.

Result:

Fixes an issue in which shutting down space manager could cause a file being
uploaded to leak from its space reservation.

Target: master
Request: 3.0
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9898/

(cherry picked from commit 45a584b583ba145571159f5700927ff75a1da5e2)