### PR TITLE
srmclient: by default show only CN of owner in 'ls -l' output

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.srm.shell;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
@@ -70,7 +71,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import dmg.util.command.Argument;
@@ -132,6 +133,9 @@ import static org.dcache.util.TimeUtils.duration;
 
 public class SrmShell extends ShellApplication
 {
+    @VisibleForTesting
+    static final Pattern DN_WITH_CAPTURED_CN = Pattern.compile("^(?:/.+?=.+?)+?/CN=(?<cn>[^/=]+)(?:/.+?=[^/]*)*$");
+
     private final FileSystem lfs = FileSystems.getDefault();
     private final SrmFileSystem fs;
     private final URI home;
@@ -1018,6 +1022,12 @@ public class SrmShell extends ShellApplication
                 usage = "Use abbreviated file sizes.")
         boolean abbrev;
 
+        @Option(name = "full-dn",
+                usage = "If server identifies owner with a Distinguished Name, " +
+                        "show complete value with long format.  By default, " +
+                        "only the first common name (CN) element is shown.")
+        boolean fullDn;
+
         @Argument(required = false)
         File path;
 
@@ -1034,9 +1044,11 @@ public class SrmShell extends ShellApplication
                         .space().date("time")
                         .space().left("name");
                 for (TMetaDataPathDetail entry : fs.list(lookup(path), verbose)) {
+                    String userId = entry.getOwnerPermission().getUserID();
+
                     writer.row()
                             .value("mode", permissionsFor(entry))
-                            .value("owner", entry.getOwnerPermission().getUserID())
+                            .value("owner", fullDn ? userId : simplifyUserId(userId))
                             .value("group", entry.getGroupPermission().getGroupID())
                             .value("size", (entry.getType() == TFileType.FILE) ? entry.getSize().longValue() : null)
                             .value("time", getTime(entry).getTime())
@@ -1051,6 +1063,12 @@ public class SrmShell extends ShellApplication
                 console.printColumns(names);
             }
             return null;
+        }
+
+        private String simplifyUserId(String id)
+        {
+            Matcher m = DN_WITH_CAPTURED_CN.matcher(id);
+            return m.matches() ? m.group("cn") : id;
         }
 
         private Calendar getTime(TMetaDataPathDetail entry)

--- a/modules/srm-client/src/test/java/org/dcache/srm/shell/SrmShellTest.java
+++ b/modules/srm-client/src/test/java/org/dcache/srm/shell/SrmShellTest.java
@@ -1,0 +1,47 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.srm.shell;
+
+import org.junit.Test;
+
+import java.util.regex.Matcher;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class SrmShellTest
+{
+    @Test
+    public void shouldMatchSimpleDN()
+    {
+        Matcher m = SrmShell.DN_WITH_CAPTURED_CN.matcher("/C=UK/O=eScience/OU=Glasgow/L=Compserv/CN=graeme stewart");
+
+        assertThat(m.matches(), is(equalTo(true)));
+        assertThat(m.group("cn"), is(equalTo("graeme stewart")));
+    }
+
+    @Test
+    public void shouldMatchMoreAwkwardDN()
+    {
+        Matcher m = SrmShell.DN_WITH_CAPTURED_CN.matcher("/C=IT/O=INFN/OU=Personal Certificate/L=Pisa/CN=Flavia Donno/Email=flavia.donno@pi.infn.it");
+
+        assertThat(m.matches(), is(equalTo(true)));
+        assertThat(m.group("cn"), is(equalTo("Flavia Donno")));
+    }
+}


### PR DESCRIPTION
Motivation:

Some SRM storage systems provide a Distinguished Name (DN) in OpenSSL
format (e.g., "/C=DE/O=GermanGrid/OU=...").  This is cumbersome since in
the vast majority of cases, only the person's name is of interest which
(with high likelihood) identifies the person.  This is encoded in the
Common Name (CN) RDN, with the remaining text both taking up horizontal
space and being largely irrelevant.

Modification:

Add support for detecting file owners that are expressed as an
OpenSSL-formatted DN string.  By default, such strings are parsed and
only the CN value is printed.  Strings that do not match as an
OpenSSL-formatted DN string with a CN RDN are shown as-is.  An option is
provided to bypass this behaviour, always showing the owner as returned
by the server.

Result:

Output from 'ls -l' is more likely to fit within a typical terminal
dimensions.

Target: master
Request: 3.0
Requires-notes: no
Requires-srmclient-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9902/
Acked-by: Albert Rossi

Conflicts:
	modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java