### PR TITLE
srmmanager: Adjust semantics of concurrent upload detection

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
@@ -663,19 +663,19 @@ public class SRM implements CellLifeCycleAware
     }
 
     /**
-     * Returns true if an upload on the given SURL exists or within the directory tree of the SURL.
+     * Returns true if an upload on the given SURL exists.
      */
     public boolean isFileBusy(URI surl) throws SRMException
     {
-        return getActivePutFileRequests(surl).findAny().isPresent();
+        return getActivePutFileRequests(surl).anyMatch(m -> m.getSurl().equals(surl));
     }
 
     /**
-     * Returns true if multiple uploads on the given SURL exist or within the directory tree of the SURL.
+     * Returns true if multiple uploads on the given SURL exist.
      */
     public boolean hasMultipleUploads(URI surl) throws SRMException
     {
-        return getActivePutFileRequests(surl).limit(2).count() > 1;
+        return getActivePutFileRequests(surl).filter(m -> m.getSurl().equals(surl)).limit(2).count() > 1;
     }
 
     /**


### PR DESCRIPTION
Motivation:

A previous patch modified the semantics of how we detect concurrent
uploads to also consider uploads within the same directory tree as
the SURL being queried. This simplified the code in an earlier version,
but is no longer necessary. Furthermore, there is an S2 test insisting
on the old behaviour (even though the SRM spec doesn't specify whether
an upload blocks a move on a parent directory).

Modification:

Change the checks back such that only uploads on the exact SURL are
considered.

Result:

Fixes an unreleased regression in srmmanager.

Target: master
Request: 3.0
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9904/

(cherry picked from commit 2db55843f4b13c43144e7174f552f9c625cfdff3)