### PR TITLE
pool: Reduce lock contention in migration module

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -1,6 +1,7 @@
 package org.dcache.pool.migration;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import org.parboiled.Parboiled;
 import org.parboiled.parserunners.ReportingParseRunner;
@@ -191,6 +192,11 @@ public class MigrationModule
     {
         _isStarted = true;
         _jobs.values().stream().filter(j -> j.getState() == Job.State.NEW).forEach(Job::start);
+    }
+
+    private synchronized Collection<Job> getJobs()
+    {
+        return ImmutableList.copyOf(_jobs.values());
     }
 
     /** Returns the job with the given id. */
@@ -1099,14 +1105,13 @@ public class MigrationModule
         }
     }
 
-    public synchronized
-        void messageArrived(PoolMigrationCopyFinishedMessage message)
+    public void messageArrived(PoolMigrationCopyFinishedMessage message)
     {
         if (!message.getPool().equals(_context.getPoolName())) {
             return;
         }
 
-        for (Job job: _jobs.values()) {
+        for (Job job: getJobs()) {
             job.messageArrived(message);
         }
     }


### PR DESCRIPTION
Motivation:

There is no need for MigrationModule to hold a lock on the entire subsytem
when delivering a message to individual jobs.

Modification:

Iterate over a copy of the job instead.

Result:

Reduced lock contention allowing multiple migration jobs to run concurrently
when before certain operations would be serialized.

Target: trunk
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/9905/

(cherry picked from commit dbe2429b061699d54253ab0550d560c5f96a9683)