### PR TITLE
srmclient: avoid NPE when stat directory with DPM

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -1147,7 +1147,9 @@ public class SrmShell extends ShellApplication
             if (arrayOfSpaceTokens != null) {
                 writer.append("    Spaces: ").println(asList(arrayOfSpaceTokens.getStringArray()));
             }
-            writer.append("  Locality: ").println(fileLocality.getValue().toLowerCase());
+            if (fileLocality != null) {
+                writer.append("  Locality: ").println(fileLocality.getValue().toLowerCase());
+            }
             if (fileStorageType != null) {
                 writer.append("Durability: ").append(fileStorageType.getValue().toLowerCase());
                 if (fileStorageType != TFileStorageType.PERMANENT) {


### PR DESCRIPTION
Motivation:

The result of srmLs against a directory in DPM does not contain a
Locality field.  Currently this triggers a NPE, which prevents
displaying any information.

Modification:

Make displaying Location information optional.

Result:

Correct information displayed about directories from DPM.

Target: master
Request: 3.0
Request: 2.16
Requires-notes: no
Requires-book: no
Requires-srmclient-notes: yes
Patch: https://rb.dcache.org/r/9915/
Acked-by: Tigran Mkrtchyan