### PR TITLE
pool: add a possibility to control nfs movers threading policy

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -49,6 +49,7 @@ import org.dcache.pool.repository.ReplicaDescriptor;
 import org.dcache.util.Bytes;
 import org.dcache.util.NetworkUtils;
 import org.dcache.util.PortRange;
+import org.dcache.xdr.IoStrategy;
 import org.dcache.xdr.OncRpcException;
 
 /**
@@ -72,6 +73,7 @@ public class NfsTransferService
     private ChecksumModule _checksumModule;
     private int _minTcpPort;
     private int _maxTcpPort;
+    private IoStrategy _ioStrategy;
 
     /**
      * file to store TCP port number used by pool.
@@ -116,7 +118,7 @@ public class NfsTransferService
             retry--;
             portRange = new PortRange(minTcpPort, maxTcpPort);
             try {
-                _nfsIO = new NFSv4MoverHandler(portRange, _withGss, _cellAddress.getCellName(), _door, _bootVerifier);
+                _nfsIO = new NFSv4MoverHandler(portRange, _ioStrategy, _withGss, _cellAddress.getCellName(), _door, _bootVerifier);
                 bound = true;
             } catch (BindException e) {
                 bindException = e;
@@ -177,6 +179,15 @@ public class NfsTransferService
     @Required
     public void setMaxTcpPort(int maxPort) {
         _maxTcpPort = maxPort;
+    }
+
+    @Required
+    public void setIoStrategy(IoStrategy ioStrategy) {
+        _ioStrategy = ioStrategy;
+    }
+
+    public IoStrategy getIoStrategy() {
+        return _ioStrategy;
     }
 
     public void setTcpPortFile(File path) {

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -327,6 +327,7 @@
       <property name="minTcpPort" value="${pool.mover.nfs.port.min}"/>
       <property name="maxTcpPort" value="${pool.mover.nfs.port.max}"/>
       <property name="tcpPortFile" value="${pool.path}/mover-tcp-port.nfs"/>
+      <property name="ioStrategy" value="${pool.mover.nfs.thread-policy}" />
   </bean>
 
   <bean id="xrootd-transfer-service" class="org.dcache.xrootd.pool.XrootdTransferService"

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -200,6 +200,17 @@ pool.plugins.meta.db!je.lock.timeout = 60 s
 pool.mover.nfs.port.min = ${dcache.net.lan.port.min}
 pool.mover.nfs.port.max = ${dcache.net.lan.port.max}
 
+#  ---- NFS mover's request processing policy ----
+#
+# When a NFS request received over the network there are two
+# possible ways to process it - to use the same thread, which received the
+# request, called SAME_THREAD, or to use a pool of worker threads,
+# called WORKER_THREAD. WORKER_THREAD typically gives better throughput with
+# the risk that more aggressive clients can degrade the performance of less
+# aggressive clients.  SAME_THREAD limits the impact of aggressive clients on
+# less aggressive clients but also reduces the maximum throughput of any one client.
+(one-of?SAME_THREAD|WORKER_THREAD)pool.mover.nfs.thread-policy = SAME_THREAD
+
 #  ---- Port used for passive DCAP movers
 #
 #   When zero then a random port from the LAN port range is used.


### PR DESCRIPTION
Motivation:
currently nfs mover uses same-thread-policy, e.q a thread, which have
received request over the network will process the request. The alternative
is to use a dedicated worker thread pool. The second option gives a better
overall throughput, but allows a single client to consume all threads.

To avoid en extra switch we have tried both options (see commit d8b899d).
Unfortunately non of the strategies fulfill all use cases and we have to
push the burden of choosing the right strategy to admins, until a better
thread sharing mechanism, like an user-aware capacity-thread-pool is not
available.

Modification:
Introduce a new pool.mover.nfs.thread-policy property which defaults to
same-thread strategy.

Result:
more burden for sysadmins, with a potential to get more optimal configuration.

Acked-by: Paul Millar
Target: master, 3.0
Require-book: no
Require-notes: yes
(cherry picked from commit 5c8fc8085e18452c8fd4e6f5ba44bd9493c03943)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>