### PR TITLE
srmclient: ensure a reasonable error message

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -1622,7 +1622,8 @@ public class SrmShell extends ShellApplication
                 public void onFailure(Throwable t)
                 {
                     synchronized (notifications) {
-                        notifications.add("[" + id + "] Transfer failed: " + t.toString());
+                        String msg = t.getMessage();
+                        notifications.add("[" + id + "] Transfer failed: " + msg == null ? t.toString() : msg);
                         FileTransfer failedTransfer = ongoingTransfers.remove(id);
                         completedTransfers.put(id, failedTransfer);
                     }

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/TStatusCodes.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/TStatusCodes.java
@@ -61,6 +61,9 @@ public class TStatusCodes
         if (asList(success).contains(statusCode)) {
             return;
         }
+        if (explanation == null) {
+            explanation = "Operation failed with " + returnStatus.getStatusCode();
+        }
         if (statusCode == TStatusCode.SRM_FAILURE) {
             throw new SRMException(explanation);
         } else if (statusCode == TStatusCode.SRM_PARTIAL_SUCCESS) {


### PR DESCRIPTION
Motivation:

The explanation field is optional in the SRM specification, which could
lead to "null" being logged.

Modification:

Add a default message if the server declined to add an explanation.

Result:

Users should always see a non-null error message.

Target: master
Request: 3.0
Requires-notes: no
Requires-book: no
Requires-srmclient-notes: yes
Patch: https://rb.dcache.org/r/9929/
Acked-by: Tigran Mkrtchyan