### PR TITLE
ftpclient: fix compatibility with Globus FTP server

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/GridFTPTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/GridFTPTransferAgent.java
@@ -332,8 +332,8 @@ public class GridFTPTransferAgent extends AbstractFileTransferAgent implements C
         {
             GridFTPClient client = new GridFTPClient(_remote.getHost(), getPort());
             client.setUsageInformation("srmfs", "0.0.1");
-            client.setType(GridFTPSession.TYPE_IMAGE);
             client.authenticate(_dssContextFactory);
+            client.setType(GridFTPSession.TYPE_IMAGE);
 
             if (client.isFeatureSupported("DCAU")) {
                 client.setDataChannelAuthentication(DataChannelAuthentication.NONE);


### PR DESCRIPTION
Motivation:

Currently, the dCache GridFTP client does not work with Globus FTP server

Changes:

Send the command to specify the type of image after authenticated.

Result:

The client works with Globus FTP server.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Requires-notes: yes
Requires-book: no
Requires-srmnotes: yes
Patch: https://rb.dcache.org/r/9944
Acked-by: Gerd Behrmann