### PR TITLE
nfs: discover open-stateid during layout return

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoClose.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoClose.java
@@ -40,7 +40,8 @@ public class ProxyIoClose extends AbstractNFSv4Operation {
 
         context.getDeviceManager().layoutReturn(context, _args.opclose.open_stateid);
 
-        client.releaseState(_args.opclose.open_stateid);
+        // REVISIT: as we pass open-state id as layout state id, we dont need to invalidate it
+        // client.releaseState(_args.opclose.open_stateid);
         client.updateLeaseTime();
 
         res.open_stateid = Stateids.invalidStateId();


### PR DESCRIPTION
Motivation:
Layoutreturn operation uses layout-stateid. Nevertheless, transfer objects
are mapped to open-stateid. Thus, layoutreturn does not finds the
transfer object to stop the mover.

Modification:
Discover open-stateid and invalidate layout-stateid on layout return.

Result:
better spec compliance.

Acked-by: Paul Millar
Target: master, 3.0
Require-book: no
Require-notes: no
(cherry picked from commit 0702d733bd534c529f203640169f29fe2e7b475b)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>