### PR TITLE
pool: Fix csm check command in the pressence of broken files

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -1435,8 +1435,7 @@ public class ChimeraNameSpaceProvider
                 long expectedSize = Long.parseLong(size.get(0));
                 long actualSize = inodeOfFile.statCache().getSize();
                 if (expectedSize != actualSize) {
-                    throw new FileCorruptedCacheException("File has unexpected size (expected=" + expectedSize +
-                                                          ";actual=" + actualSize + ").");
+                    throw new FileCorruptedCacheException(expectedSize, actualSize);
                 }
             }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
@@ -133,8 +133,13 @@ public class ChecksumScanner
                         /* It was removed before we could get it. No problem.
                          */
                     } catch (FileCorruptedCacheException e) {
-                        _bad.put(id, e.getActualChecksums().get());
-                        _badCount++;
+                        if (e.getActualChecksums().isPresent()) {
+                            _bad.put(id, e.getActualChecksums().get());
+                            _badCount++;
+                        } else {
+                            _log.warn("csm scan command unable to verify {}: {}", id, e.getMessage());
+                            _unableCount++;
+                        }
                     } catch (CacheException e) {
                         _log.warn("csm scan command unable to verify {}: {}", id, e.getMessage());
                         _unableCount++;


### PR DESCRIPTION
Motivation:

FullScan Idle java.lang.IllegalStateException: Optional.get() cannot be called on an absent value  0 files: 0 corrupt, 0 unable to check
SingleScan Idle

There are several causes of FileCorruptedCacheException and not all of them
are a result of a checksum verification failure.

Modification:

Check if a checksum is pressent before assuming the failure is caused
by a checksum validation failure.

Also fixed the use of the wrong constructor of this exception.

Result:

Fixed a problem in the pool that caused the csm check command to fail
on pools containing broken files.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9945/

(cherry picked from commit 81af267c13e9682faf041ffd0e5fec0b2fbf9692)