### PR TITLE
cleaner: Send notification more often

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
@@ -283,23 +283,19 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
         try {
             _log.info("*********NEW_RUN*************");
 
-            if (_log.isDebugEnabled()){
-                _log.debug("INFO: Refresh Interval : " + _refreshInterval + " " + _refreshIntervalUnit);
-                _log.debug("INFO: Number of files processed at once: " + _processAtOnce);
-            }
+            _log.debug("INFO: Refresh Interval : {} {}", _refreshInterval, _refreshIntervalUnit);
+            _log.debug("INFO: Number of files processed at once: {}", _processAtOnce);
 
             // get list of pool names from the trash_table
             List<String> poolList = getPoolList();
 
-            if (_log.isDebugEnabled()){
-                _log.debug("List of Pools from the trash-table : "+ poolList);
-            }
+            _log.debug("List of Pools from the trash-table : {}", poolList);
 
             // if there are some pools in the blackPoolList (i.e.,
             //pools that are down/do not exist), extract them from the
             //poolList
             if (!_poolsBlackList.isEmpty()) {
-                _log.debug("htBlackPools.size()="+ _poolsBlackList.size());
+                _log.debug("{} pools are currently blacklisted.", _poolsBlackList.size());
 
                 for (Map.Entry<String, Long> blackListEntry : _poolsBlackList.entrySet()) {
                     String poolName = blackListEntry.getKey();
@@ -310,28 +306,22 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
                         && (_recoverTimer > 0)
                         && ((System.currentTimeMillis() - valueTime) > _recoverTimerUnit.toMillis(_recoverTimer))) {
                         _poolsBlackList.remove(poolName);
-                        if (_log.isDebugEnabled()) {
-                            _log.debug("Remove the following pool from the Black List : "+ poolName);
-                        }
-                    }
+                        _log.debug("Removed the following pool from the black list: {}", poolName);}
                 }
 
                 poolList.removeAll(_poolsBlackList.keySet());
             }
 
             if (!poolList.isEmpty()) {
-                _log.debug("The following pools are sent to runDelete(..): {}",
-                           poolList);
+                _log.debug("The following pools are cleaned: {}", poolList);
                 runDelete(poolList);
             }
 
             //HSM part
             if (_hsmCleanerEnabled){
                 runDeleteHSM();
+                runNotification();
             }
-
-            // Notify other components that we are done deleting
-            runNotification();
         } catch (DataAccessException e) {
             _log.error("Database failure: " + e.getMessage());
         } catch (InterruptedException e) {
@@ -396,13 +386,21 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
                 throw new InterruptedException("Cleaner interrupted");
             }
 
-            _log.info("runDelete(): Now processing pool {}", pool);
-            if (!_poolsBlackList.containsKey(pool)) {
-                try {
-                    cleanPoolComplete(pool);
-                } catch (CacheException e) {
-                    _log.warn("Failed to remove files from {}: {}", pool, e.getMessage());
-                }
+            runDelete(pool);
+
+            // Notify other components that we are done deleting
+            runNotification();
+        }
+    }
+
+    private void runDelete(String pool) throws InterruptedException
+    {
+        _log.info("runDelete(): Now processing pool {}", pool);
+        if (!_poolsBlackList.containsKey(pool)) {
+            try {
+                cleanPoolComplete(pool);
+            } catch (CacheException e) {
+                _log.warn("Failed to remove files from {}: {}", pool, e.getMessage());
             }
         }
     }


### PR DESCRIPTION
Motivation:

In 2.13 we changed how we notify space manager and other components about
deleted files. Before we did so as soon as the replica on the pool had been
removed, but this process was lossy since if the receiving of the notification
was down, there was no way to ensure that the notification got resubmitted. In
2.13 this was changed such that upon deleting a file, an extra entry in the
chimera trash table is generated. This entry is not deleted until the file is
cleaned from all pools and all notification targets have been notified. The
notification on the other hand is not generated until the file has been cleaned
from all pools. This ensures that the notification will be retried until it
is successfully delivered.

The problem is now that we only send the notifications at the end of every
cleaner run. If a large number of files are queued in chimera, and pools delete
files slowly, it may take a long time before ANY space is marked free in space
manager, despite many files having been removed from the pools a long time ago.

Modification:

This patch moves the notification to run after every pool has been cleaned, as
well as after HSM locations have been cleaned. Thus one will observe space
being freed more incrementally in space manager.

The patch is deliberately kept simple to allow it to be backported. One could
certainly consider moving the notification part to a separate thread or to run
it asycnhronously while cleaning the next pool, but that is left for another
patch.

Result:

More incremental freeing of space in space reservations. Asking for back port
all the way to 2.13 as it fixes a regression.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9923/

(cherry picked from commit c993db8124f5c32e616246205df3a1a673d5e636)
(cherry picked from commit 8d77acc785997229b7dfb98daeaf81bf0ed72ddf)