### PR TITLE
pool: Delete files concurrently

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -5,6 +5,9 @@ package org.dcache.pool.classic;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.InetAddresses;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFutureTask;
 import com.google.common.util.concurrent.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,11 +28,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import diskCacheV111.pools.PoolCellInfo;
 import diskCacheV111.pools.PoolCostInfo;
@@ -89,6 +95,7 @@ import dmg.util.command.Command;
 import org.dcache.alarms.AlarmMarkerFactory;
 import org.dcache.alarms.PredefinedAlarm;
 import org.dcache.cells.CellStub;
+import org.dcache.cells.MessageReply;
 import org.dcache.pool.FaultEvent;
 import org.dcache.pool.FaultListener;
 import org.dcache.pool.assumption.Assumption;
@@ -200,6 +207,8 @@ public class PoolV4
 
     private final RateLimiter _pingLimiter = RateLimiter.create(100);
 
+    private Executor _executor;
+
     protected void assertNotRunning(String error)
     {
         checkState(!_running, error);
@@ -298,6 +307,12 @@ public class PoolV4
         } else {
             throw new IllegalArgumentException("Illegal 'dupRequest' value");
         }
+    }
+
+    @Required
+    public void setExecutor(Executor executor)
+    {
+        _executor = executor;
     }
 
     @Required
@@ -1170,47 +1185,58 @@ public class PoolV4
         return msg;
     }
 
-    public PoolRemoveFilesMessage messageArrived(PoolRemoveFilesMessage msg)
-        throws CacheException, InterruptedException
+    public Reply messageArrived(PoolRemoveFilesMessage msg)
+        throws CacheException
     {
         if (_poolMode.isDisabled(PoolV2Mode.DISABLED)) {
-            _log.warn("PoolRemoveFilesMessage request rejected due to "
-                      + _poolMode);
+            _log.warn("PoolRemoveFilesMessage request rejected due to {}", _poolMode);
             throw new CacheException(CacheException.POOL_DISABLED, "Pool is disabled");
         }
 
-        String[] fileList = msg.getFiles();
-        int counter = 0;
-        for (int i = 0; i < fileList.length; i++) {
-            try {
-                PnfsId pnfsId = new PnfsId(fileList[i]);
-                if (!_cleanPreciousFiles && _hasTapeBackend
-                    && (_repository.getState(pnfsId) == ReplicaState.PRECIOUS)) {
-                    counter++;
-                    _log.error("Replica " + fileList[i] + " kept (precious)");
-                } else {
-                    _repository.setState(pnfsId, ReplicaState.REMOVED);
-                    fileList[i] = null;
-                }
-            } catch (IllegalTransitionException e) {
-                _log.error("Replica " + fileList[i] + " not removed: "
-                           + e.getMessage());
-                counter++;
-            }
-        }
-        if (counter > 0) {
-            String[] replyList = new String[counter];
-            for (int i = 0, j = 0; i < fileList.length; i++) {
-                if (fileList[i] != null) {
-                    replyList[j++] = fileList[i];
-                }
-            }
-            msg.setFailed(1, replyList);
-        } else {
-            msg.setSucceeded();
-        }
+        List<ListenableFutureTask<String>> tasks = Stream.of(msg.getFiles())
+                .map(file -> ListenableFutureTask.create(() -> remove(file))).collect(toList());
+        tasks.forEach(_executor::execute);
+        MessageReply<PoolRemoveFilesMessage> reply = new MessageReply<>();
+        Futures.addCallback(Futures.allAsList(tasks),
+                            new FutureCallback<List<String>>()
+                            {
+                                @Override
+                                public void onSuccess(List<String> files)
+                                {
+                                    String[] replyList = files.stream().filter(Objects::nonNull).toArray(String[]::new);
+                                    if (replyList.length > 0) {
+                                        msg.setFailed(1, replyList);
+                                    } else {
+                                        msg.setSucceeded();
+                                    }
+                                    reply.reply(msg);
+                                }
 
-        return msg;
+                                @Override
+                                public void onFailure(Throwable t)
+                                {
+                                    reply.fail(msg, t);
+                                }
+                            });
+        return reply;
+    }
+
+    private String remove(String file) throws CacheException, InterruptedException
+    {
+        try {
+            PnfsId pnfsId = new PnfsId(file);
+            if (!_cleanPreciousFiles && _hasTapeBackend
+                && (_repository.getState(pnfsId) == ReplicaState.PRECIOUS)) {
+                _log.error("Replica {} kept (precious)", file);
+                return file;
+            } else {
+                _repository.setState(pnfsId, ReplicaState.REMOVED);
+                return null;
+            }
+        } catch (IllegalTransitionException e) {
+            _log.error("Replica {} not removed: {}", file, e.getMessage());
+            return file;
+        }
     }
 
     public PoolModifyPersistencyMessage

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -92,6 +92,7 @@
     <property name="ioQueueManager" ref="io-queue-manager" />
     <property name="poolMode" ref="pool-mode"/>
     <property name="billingStub" ref="billing-stub"/>
+    <property name="executor" ref="workerThreadPool"/>
   </bean>
 
   <bean id="pnfs" class="diskCacheV111.util.PnfsHandler">

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -100,7 +100,8 @@ pool.check-health-command=
 #
 (one-of?true|false)pool.enable.remove-precious-files-on-delete = true
 
-# Worker thread pool size. Used by migration module and for pool to pool transfers.
+# Worker thread pool size. Used by migration module, for pool to pool transfers,
+# and for processing requests from cleaner.
 pool.limits.worker-threads=5
 
 # Nearline storage thread pool size. Used for blocking nearline storage operations,


### PR DESCRIPTION
Motivation:

cleaner submits batches of files to delete to a pool, but a pool processed this
batch sequentially. On a pool with slow meta data operations (for whatever
reason), this can result if fairly low deletion rates and this can in turn slow
down deletion in the entire system.

Modification:

Submit delete to the pool's worker thread pool. Not only does this free one of
the message threads, it allows the delete tasks to be run concurrently. The
increase in concurrency can reduce the overhead of syncing the meta data to
disk after every deletion, thus increasing the deletion rate.

Result:

Improved the deletion rate of files being cleaned on a pool by running deletion
of multiple files on a pool concurrently from the pool's worker thread pool.

I am asking for backport as sites have complained about deletion throughput,
but will only ask for backport to 2.16 as it isn't really fixing a bug. Sites
should move ahead to 2.16 if they want to benefit from this improvement.

Target: master
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9924/

(cherry picked from commit ece9982a985d5b4eeb86cbea48896eb8ae45a157)