### PR TITLE
pool: Delete files concurrently

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/cells/MessageReply.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/MessageReply.java
@@ -48,7 +48,7 @@ public class MessageReply<T extends Message>
         return (_envelope == null || delay <= _envelope.getTtl() - _envelope.getLocalAge());
     }
 
-    public void fail(T msg, Exception e)
+    public void fail(T msg, Throwable e)
     {
         if (e instanceof CacheException) {
             CacheException ce = (CacheException) e;

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -92,6 +92,7 @@
     <property name="ioQueueManager" ref="io-queue-manager" />
     <property name="poolMode" ref="pool-mode"/>
     <property name="billingStub" ref="billing-stub"/>
+    <property name="executor" ref="workerThreadPool"/>
   </bean>
 
   <bean id="pnfs" class="diskCacheV111.util.PnfsHandler">

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -97,7 +97,8 @@ pool.check-health-command=
 #
 (one-of?true|false)pool.enable.remove-precious-files-on-delete = true
 
-# Worker thread pool size. Used by migration module and for pool to pool transfers.
+# Worker thread pool size. Used by migration module, for pool to pool transfers,
+# and for processing requests from cleaner.
 pool.limits.worker-threads=5
 
 # Nearline storage thread pool size. Used for blocking nearline storage operations,


### PR DESCRIPTION
Motivation:

cleaner submits batches of files to delete to a pool, but a pool processed this
batch sequentially. On a pool with slow meta data operations (for whatever
reason), this can result if fairly low deletion rates and this can in turn slow
down deletion in the entire system.

Modification:

Submit delete to the pool's worker thread pool. Not only does this free one of
the message threads, it allows the delete tasks to be run concurrently. The
increase in concurrency can reduce the overhead of syncing the meta data to
disk after every deletion, thus increasing the deletion rate.

Result:

Improved the deletion rate of files being cleaned on a pool by running deletion
of multiple files on a pool concurrently from the pool's worker thread pool.

I am asking for backport as sites have complained about deletion throughput,
but will only ask for backport to 2.16 as it isn't really fixing a bug. Sites
should move ahead to 2.16 if they want to benefit from this improvement.

Target: master
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9924/

(cherry picked from commit ece9982a985d5b4eeb86cbea48896eb8ae45a157)