### PR TITLE
doors: add diagnostic information for NIC auto-discovery

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
@@ -1,6 +1,7 @@
 package dmg.cells.services.login;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.net.InetAddresses;
 import org.slf4j.Logger;
@@ -27,6 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import dmg.cells.nucleus.AbstractCellComponent;
 import dmg.cells.nucleus.CellAddressCore;
@@ -44,6 +46,7 @@ import dmg.util.command.Command;
 import dmg.util.command.Option;
 
 import org.dcache.util.FireAndForgetTask;
+import org.dcache.util.NDC;
 import org.dcache.util.NetworkUtils;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -51,6 +54,8 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Utility class to periodically publish login broker information.
@@ -559,30 +564,84 @@ public class LoginBrokerPublisher
 
     public static class AnyAddressSupplier implements Supplier<List<InetAddress>>
     {
+        private final Stopwatch _stopwatch = Stopwatch.createUnstarted();
+
+        private List<InetAddress> _previous = Collections.emptyList();
+
         @Override
         public List<InetAddress> get()
         {
-            ArrayList<InetAddress> addresses = new ArrayList<>();
+            NDC.push("NIC auto-discovery");
             try {
-                Enumeration<NetworkInterface> interfaces =
-                        NetworkInterface.getNetworkInterfaces();
-                while (interfaces.hasMoreElements()) {
-                    NetworkInterface i = interfaces.nextElement();
-                    try {
-                        if (i.isUp() && !i.isLoopback()) {
-                            Enumeration<InetAddress> e = i.getInetAddresses();
-                            while (e.hasMoreElements()) {
-                                addresses.add(NetworkUtils.withCanonicalAddress(e.nextElement()));
+                ArrayList<InetAddress> addresses = new ArrayList<>();
+                _stopwatch.reset().start();
+                try {
+                    Enumeration<NetworkInterface> interfaces =
+                            NetworkInterface.getNetworkInterfaces();
+                    while (interfaces.hasMoreElements()) {
+                        NetworkInterface i = interfaces.nextElement();
+                        try {
+                            if (i.isUp() && !i.isLoopback()) {
+                                Enumeration<InetAddress> e = i.getInetAddresses();
+                                while (e.hasMoreElements()) {
+                                    addresses.add(NetworkUtils.withCanonicalAddress(e.nextElement()));
+                                }
                             }
+                        } catch (SocketException e) {
+                            _log.warn("Not publishing NIC {}: {}", i.getName(), e.getMessage());
                         }
-                    } catch (SocketException e) {
-                        _log.warn("Not publishing NIC {}: {}", i.getName(), e.getMessage());
                     }
+                } catch (SocketException e) {
+                    _log.warn("Not publishing NICs: {}", e.getMessage());
+                } finally {
+                    _stopwatch.stop();
                 }
-            } catch (SocketException e) {
-                _log.warn("Not publishing NICs: {}", e.getMessage());
+
+                _log.debug("Scan took {}", _stopwatch);
+                logChanges(addresses);
+                return addresses;
+            } finally {
+                NDC.pop();
             }
-            return addresses;
+        }
+
+        private synchronized void logChanges(List<InetAddress> addresses)
+        {
+            if (!_previous.equals(addresses)) {
+                List<InetAddress> added = addresses.stream().filter(a -> !_previous.contains(a)).collect(toList());
+                List<InetAddress> removed = _previous.stream().filter(a -> !addresses.contains(a)).collect(toList());
+
+                boolean adding = !added.isEmpty();
+                boolean removing = !removed.isEmpty();
+
+                if (removing || adding) {
+                    StringBuilder sb = new StringBuilder();
+                    if (removing) {
+                        sb.append("Removing ").append(describeList(removed));
+                    }
+
+                    if (adding) {
+                        if (removing) {
+                            sb.append(", adding ");
+                        } else {
+                            sb.append("Adding ");
+                        }
+                        sb.append(describeList(added));
+                    }
+                    _log.warn(sb.toString());
+                }
+
+                _previous = new ArrayList<>(addresses);
+            }
+        }
+
+        private static String describeList(List<InetAddress> addresses)
+        {
+            if (addresses.size() == 1) {
+                return addresses.get(0).toString();
+            } else {
+                return addresses.stream().map(NetworkUtils::toString).collect(joining(", ", "[", "]"));
+            }
         }
     }
 }

--- a/modules/common/src/main/java/org/dcache/util/NetworkUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/NetworkUtils.java
@@ -257,6 +257,17 @@ public abstract class NetworkUtils {
         throw new IllegalArgumentException("Unknown protocol family: " + address);
     }
 
+    public static String toString(InetAddress a)
+    {
+        String name = a.getHostName();
+        if (InetAddresses.isInetAddress(name)) {
+            return InetAddresses.toAddrString(a);
+        } else {
+            return name + "/" + InetAddresses.toUriString(a);
+        }
+    }
+
+
     private static String getPreferredHostName() {
         List<InetAddress> addresses =
                 Ordering.natural().onResultOf(InetAddressScope.OF).reverse().sortedCopy(getLocalAddresses());


### PR DESCRIPTION
Motivation:

The auto-discovery mechanism provides feedback only when some problem
prevents enumeration of interfaces or addresses.  Events, such as
including or removing an interface are potentially significant, as is
the time taken to acquire the information.

Modification:

Log (at warning level, so they go to the log file) if an interface is
added or removed.  Log (at debug level) the time taken to build the list
of interfaces.

Information is pushed onto the NDC to indicate that logged messages
relate to the NIC auto-discovery process.

Result:

Log when the list of auto-discovered NIC interfaces changes.  Support
logging the time taken to acquire NIC information.  Update logged
messages to indicate the context.

Target: master
Patch: https://rb.dcache.org/r/9872/
Acked-by: Gerd Behrmann
Request: 3.0
Requires-notes: yes
Requires-book: yes