### PR TITLE
srmclient: fix Java 7 compatibility for srmfs

### DIFF
--- a/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
+++ b/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
@@ -84,7 +84,7 @@ public class AnnotatedCommandExecutor implements CommandExecutor
         _constructor = constructor;
         Class<? extends Callable<? extends Serializable>> commandClass = _constructor.getDeclaringClass();
         _handlers = createFieldHandlers(command, commandClass);
-        _isDeprecated = commandClass.getDeclaredAnnotation(Deprecated.class) != null;
+        _isDeprecated = commandClass.getAnnotation(Deprecated.class) != null;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

srmfs does not work with Java 7.

Modification:

Update CLI framework so it does not use Java 8 specific API.  This
results in different semantics to the @Deprecated annotation in CLI: the
@Deprecated annotation on a class that contains @Command annotated
subclasses will force all those @Command subclasses to be considered
deprecated, too.

There are no such @Deprecated annotated containing classes in the
current code-base, so this patch has no effect.

Result:

srmfs works with Java 7

Target: master
Request: 3.0
Requires-notes: no
Requires-srmclient-notes: yes
Requires-book: no
Acked-by: Gerd Behrmann
Patch: https://rb.dcache.org/r/9961/