### PR TITLE
srmclient: fix deploying srm-client in path with spaces

### DIFF
--- a/modules/srm-client/src/main/assembly/filter.properties
+++ b/modules/srm-client/src/main/assembly/filter.properties
@@ -5,16 +5,16 @@ printCanonicalPath() # in $1 = path                                             
     local ret                                                                          \n\
     link="$1"                                                                          \n\
     if readlink -f / > /dev/null 2>&1; then                                            \n\
-        readlink -f $link                                                              \n\
+        readlink -f "$link"                                                            \n\
     else                                                                               \n\
-        ret="$(cd $(dirname $link); pwd -P)/$(basename $link)"                         \n\
+        ret="$(cd $(dirname "$link"); pwd -P)/$(basename "$link")"                     \n\
         while [ -h "$ret" ]; do                                                        \n\
             link="$(readlink "$ret")"                                                  \n\
             if [ -z "${link##/*}" ]; then                                              \n\
                 ret="${link}"                                                          \n\
             else                                                                       \n\
-                link=$(dirname $ret)/${link}                                           \n\
-                ret="$(cd $(dirname $link); pwd -P)/$(basename $link)"                 \n\
+                link="$(dirname $ret)/${link}"                                         \n\
+                ret="$(cd $(dirname "$link"); pwd -P)/$(basename "$link")"             \n\
             fi                                                                         \n\
         done                                                                           \n\
         echo "$ret"                                                                    \n\

--- a/modules/srm-client/src/main/bin/srmfs
+++ b/modules/srm-client/src/main/bin/srmfs
@@ -5,10 +5,10 @@
 conf_dir=$SRM_PATH/conf
 
 if [ "$1" = "-debug" ]; then
-    logbackDefn=-Dlogback.configurationFile=$conf_dir/logback-all.xml
+    logbackDefn="-Dlogback.configurationFile=$conf_dir/logback-all.xml"
     shift
 else
-    logbackDefn=-Dlogback.configurationFile=$conf_dir/logback.xml
+    logbackDefn="-Dlogback.configurationFile=$conf_dir/logback.xml"
 fi
 
 if [ -n "$X509_USER_PROXY" ]; then
@@ -36,7 +36,7 @@ CLASSPATH="$SRM_PATH/lib/*" exec java -Dlog=${DELEGATION_LOG:-warn} \
     -client \
     -Djava.awt.headless=true \
     -DwantLog4jSetup=n \
-    $logbackDefn \
+    "$logbackDefn" \
     -XX:+TieredCompilation \
     -XX:TieredStopAtLevel=1 \
     org.dcache.srm.shell.SrmShell -x509_user_proxy="$x509_user_proxy" -x509_user_trusted_certificates="$x509_user_trusted_certs" "$@"

--- a/modules/srm-client/src/main/lib/srm
+++ b/modules/srm-client/src/main/lib/srm
@@ -68,12 +68,12 @@ OPTIONS=" ${SRM_JAVA_OPTIONS} -Djava.protocol.handler.pkgs=org.globus.net.protoc
 
 SRMCP_OPTIONS=""
 if [ "$DEBUG" = "true" ]; then
-    OPTIONS=" ${OPTIONS} -Dlogback.configurationFile=${SRM_PATH}/conf/logback-axis.xml"
+    OPTIONS=" ${OPTIONS} \"-Dlogback.configurationFile=${SRM_PATH}/conf/logback-axis.xml\""
     OPTIONS=" ${OPTIONS} -Delectric.logging=SOAP,HTTP"
 elif [ "$SECURITY_DEBUG" = "true" ]; then
-    OPTIONS=" ${OPTIONS} -Dlogback.configurationFile=${SRM_PATH}/conf/logback-security.xml"
+    OPTIONS=" ${OPTIONS} \"-Dlogback.configurationFile=${SRM_PATH}/conf/logback-security.xml\""
 else
-    OPTIONS=" ${OPTIONS} -Dlogback.configurationFile=${SRM_PATH}/conf/logback.xml"
+    OPTIONS=" ${OPTIONS} \"-Dlogback.configurationFile=${SRM_PATH}/conf/logback.xml\""
 fi
 
 if [ -n "$SRM_CONFIG" -a  "$SRM_CONFIG" != "NONE" -a  ! -f "$SRM_CONFIG" ]; then
@@ -115,13 +115,13 @@ if [ -n "$SRM_CONFIG" -a "$SRM_CONFIG" != "NONE" ]; then
       url_copy="$SRM_PATH/sbin/url-copy.sh"
 
       cmd="$java_location -cp $SRM_CP $OPTIONS gov.fnal.srm.util.SRMDispatcher \
-        -urlcopy=$url_copy \
+        \"-urlcopy=$url_copy\" \
         -x509_user_proxy=$x509_user_proxy \
         -x509_user_key=$HOME/.globus/userkey.pem \
         -x509_user_cert=$HOME/.globus/usercert.pem \
         -x509_user_trusted_certificates=$x509_user_trusted_certs \
         -use_proxy=$use_proxy \
-        -srmcphome=$SRM_PATH \
+        \"-srmcphome=$SRM_PATH\" \
         -save_conf=$SRM_CONFIG \
         $args"
 
@@ -155,7 +155,7 @@ cmd="$java_location $OPTIONS gov.fnal.srm.util.SRMDispatcher $SRMCP_OPTIONS $arg
 if [ "$DEBUG" = "true" ]; then
     echo "CLASSPATH: $SRM_CP"
     echo
-    echo $cmd
+    echo "$cmd"
 fi
-CLASSPATH="$SRM_CP" exec $cmd
+CLASSPATH="$SRM_CP" sh -c "$cmd"
 


### PR DESCRIPTION
Motivation:

All srm-client commands are useless if their path contains a space.

Modification:

Ensure path is properly quoted.

The 'eval' in the 'srm' script was modified to invoke an external shell
('sh') to force re-evaluation of quoted arguments.

Result:

The srm-client commands work when deployed in a directory containing
spaces.

Target: master
Request: 3.0
Requires-notes: no
Requires-srmclient-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9958/
Acked-by: Gerd Behrmann