### PR TITLE
srmclient: percent-encode paths that require it

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/GridFTPTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/GridFTPTransferAgent.java
@@ -224,7 +224,7 @@ public class GridFTPTransferAgent extends AbstractFileTransferAgent implements C
         private final TransferMode transferMode = GridFTPTransferAgent.this._transferMode;
         private final ChecksumMode checksumHandling = GridFTPTransferAgent.this._checksumHandling;
 
-        private final URI _remote;
+        private final java.net.URI _remote;
         private final File _localFile;
 
         private long _bytesTransferred;
@@ -234,7 +234,7 @@ public class GridFTPTransferAgent extends AbstractFileTransferAgent implements C
 
         GridFTPTransfer(URI remote, File localFile)
         {
-            _remote = remote;
+            _remote = java.net.URI.create(remote.toString());
             _localFile = localFile;
 
             Futures.addCallback(this, new FutureCallback(){
@@ -280,11 +280,6 @@ public class GridFTPTransferAgent extends AbstractFileTransferAgent implements C
         protected long getBytesTransferred()
         {
             return _bytesTransferred;
-        }
-
-        protected URI getRemote()
-        {
-            return _remote;
         }
 
         protected ChecksumMode getChecksumHandling()

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -134,6 +134,7 @@ import static com.google.common.collect.Iterables.transform;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.dcache.commons.stats.MonitoringProxy.decorateWithMonitoringProxy;
+import static org.dcache.util.StringMarkup.percentEncode;
 import static org.dcache.util.TimeUtils.TimeUnitFormat.SHORT;
 import static org.dcache.util.TimeUtils.duration;
 
@@ -410,7 +411,7 @@ public class SrmShell extends ShellApplication
         if (path == null) {
             return pwd;
         } else {
-            return new URI(pwd, path.getPath());
+            return new URI(pwd, percentEncode(path.getPath()));
         }
     }
 
@@ -1704,11 +1705,10 @@ public class SrmShell extends ShellApplication
                 if (!plan.isEmpty()) {
                     ArrayList<URI> surlList = new ArrayList<>(plan.size());
                     for (Map.Entry<File,Collection<String>> dirFiles : plan.asMap().entrySet()) {
-                        String dir = dirFiles.getKey().toString();
                         for (String name : dirFiles.getValue()) {
-                            String path = new File(dir + "/" + name).toString();
+                            File path = new File(dirFiles.getKey() + "/" + name);
                             try {
-                                surlList.add(new URI(pwd, path));
+                                surlList.add(lookup(path));
                             } catch (URI.MalformedURIException ee) {
                                 consolePrintln("Failed to stat " + path + ": " + ee.getMessage());
                             }


### PR DESCRIPTION
Motivation:

srmfs does not work with paths that require percent encoding. This
includes any file containing a space or a hash symbol.

Modification:

The problem stems from Axis' URI class failing to do any escaping.
Therefore, this patch ensures paths are encoded before delivering them
to Axis.

A similar problem exists in the FTP transfer agent: the path was not
decoded, resulting in files being uploaded as their encoded filename
("test%20file" rather than "test file") subsequently failing the upload.

Use existing support in dCache for percent-encoding a path and switch
FTP handler to store the remote URI using Java's URI, which handles
encoding correctly.

Result:

Namespace operations and file transfers succeed with files containing
escapable characters.

Target: master
Request: 3.0
Requires-notes: no
Requires-book: no
Requires-srmclient-notes: yes
Patch: https://rb.dcache.org/r/9957/
Acked-by: Gerd Behrmann