### PR TITLE
srmclient: show SOAP response from server when debug enabled

### DIFF
--- a/modules/srm-common/src/main/java/org/dcache/srm/client/HttpClientSender.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/client/HttpClientSender.java
@@ -433,7 +433,7 @@ public class HttpClientSender extends BasicHandler
                 Message outMsg = extractResponse(msgContext, response);
                 msgContext.setResponseMessage(outMsg);
                 outMsg.getSOAPEnvelope();
-                if (LOGGER.isTraceEnabled()) {
+                if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug(outMsg.getSOAPPartAsString());
                 }
             }


### PR DESCRIPTION
Motivation:

The '-debug' srmfs option provides considerable information, including
the SOAP request sent to the server but not the response.  This makes it
harder to diagnose problems.

Modification:

Show the SOAP response from the server.

Result:

Some calls of problems becomes easier to diagnose.

Target: master
Request: 3.0
Requires-notes: no
Requires-book: no
Requires-srmclient-notes: yes
Patch: https://rb.dcache.org/r/9955/
Acked-by: Gerd Behrmann