### PR TITLE
srmclient: support srmfs with command on command-line

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/Configuration.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/Configuration.java
@@ -103,7 +103,7 @@ import org.dcache.util.Args;
  *
  * @author  timur
  */
-public class Configuration {
+public class Configuration extends ConnectionConfiguration {
 
     public static final String SRMCPCONFIGNAMESPACE="srmcp.srm.fnal.gov";
     private static final String webservice_pathv1 = "srm/managerv1";
@@ -255,10 +255,6 @@ public class Configuration {
         return ws_path;
     }
 
-    public String getRawWebservice_path() {
-        return webservice_path;
-    }
-
     public void setWebservice_path(String webservice_path) {
         this.webservice_path = webservice_path;
     }
@@ -365,26 +361,6 @@ public class Configuration {
 
     public void setGlobus_tcp_port_range(String globus_tcp_port_range) {
         this.globus_tcp_port_range = globus_tcp_port_range;
-    }
-
-    @Option(
-            name = "gss_expected_name",
-            description = "gss expected name",
-            required=false,
-            log=true,
-            save=true
-    )
-    private String gss_expected_name;
-
-    public String getGss_expected_name() {
-        if (gss_expected_name == null){
-            gss_expected_name = "host";
-        }
-        return gss_expected_name;
-    }
-
-    public void setGss_expected_name(String gss_expected_name) {
-        this.gss_expected_name = gss_expected_name;
     }
 
     @Option(
@@ -1305,44 +1281,6 @@ public class Configuration {
     }
 
     @Option(
-            name = "retry_timeout",
-            description =  "number of miliseconds to sleep after a failure",
-            defaultValue = "10000",
-            unit="milliseconds",
-            required=false,
-            log=true,
-            save=true
-    )
-    private long retry_timeout;
-
-    public long getRetry_timeout() {
-        return retry_timeout;
-    }
-    public void setRetry_timeout(long retry_timeout) {
-        this.retry_timeout = retry_timeout;
-    }
-
-
-    @Option(
-            name = "retry_num",
-            description =  "number of retries before client gives up",
-            defaultValue = "20",
-            required=false,
-            log=true,
-            save=true
-    )
-    private int retry_num;
-
-    public int getRetry_num() {
-        return retry_num;
-    }
-
-    public void setRetry_num(int retry_num) {
-        this.retry_num = retry_num;
-    }
-
-
-    @Option(
             name = "connect_to_wsdl",
             description =  "connect to WSDL instead of connecting to the server directly",
             defaultValue = "false",
@@ -1374,42 +1312,6 @@ public class Configuration {
 
     public void setTransport(String transport) {
         this.transport = Transport.transportFor(transport).name();
-    }
-
-    @Option(
-            name = "delegate",
-            description =  "enables delegation of user credenital to the server",
-            defaultValue = "false",
-            required=false,
-            log=true,
-            save=true
-    )
-    private boolean delegate;
-
-    public boolean isDelegate() {
-        return delegate;
-    }
-
-    public void setDelegate(boolean delegate) {
-        this.delegate = delegate;
-    }
-
-    @Option(
-            name = "full_delegation",
-            description =  	"specifies type (full or limited) of delegation",
-            defaultValue = "true",
-            required=false,
-            log=true,
-            save=true
-    )
-    private boolean full_delegation;
-
-    public boolean isFull_delegation() {
-        return full_delegation;
-    }
-
-    public void setFull_delegation(boolean full_delegation) {
-        this.full_delegation = full_delegation;
     }
 
     @Option(
@@ -2467,13 +2369,13 @@ public class Configuration {
             help=true;
         }
 
-        if (retry_timeout <= 0) {
+        if (getRetry_timeout() <= 0) {
             throw new IllegalArgumentException("illegal retry timeout : "+
-                    retry_timeout);
+                    getRetry_timeout());
         }
-        if(retry_num < 0) {
+        if(getRetry_num() < 0) {
             throw new IllegalArgumentException("illegal number of retries : "+
-                    retry_num);
+                    getRetry_num());
         }
         if (isSrmv1&&isSrmv2) {
             throw new IllegalArgumentException(

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/ConnectionConfiguration.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/ConnectionConfiguration.java
@@ -1,0 +1,150 @@
+package gov.fnal.srm.util;
+
+/**
+ *  Configuration specifically about the connection with the server.
+ */
+public class ConnectionConfiguration
+{
+    @Option(name="use_proxy", description = "use user proxy(true) or use certificates directly(false)",
+            defaultValue="true", required=false, log=true, save=true)
+    private boolean useproxy;
+
+    public boolean isUseproxy()
+    {
+        return useproxy;
+    }
+
+    public void setUseproxy(boolean useproxy)
+    {
+        this.useproxy = useproxy;
+    }
+
+    @Option(name="x509_user_proxy", description="absolute path to user proxy",
+            required=false, log=true, save=true)
+    private String x509_user_proxy;
+
+    public String getX509_user_proxy()
+    {
+        return x509_user_proxy;
+    }
+
+    public void setX509_user_proxy(String x509_user_proxy)
+    {
+        this.x509_user_proxy = x509_user_proxy;
+    }
+
+    @Option(name="x509_user_cert", description="absolute path to user (or host) certificate",
+            required=false, log=true, save=true)
+    private String x509_user_cert;
+
+    public String getX509_user_cert()
+    {
+        return x509_user_cert;
+    }
+
+    public void setX509_user_cert(String x509_user_cert)
+    {
+        this.x509_user_cert = x509_user_cert;
+    }
+
+    @Option(name="x509_user_key", description="absolute path to user (or host) private key",
+            required=false, log=true, save=true)
+    private String x509_user_key;
+
+    public String getX509_user_key()
+    {
+        return x509_user_key;
+    }
+
+    public void setX509_user_key(String x509_user_key)
+    {
+        this.x509_user_key = x509_user_key;
+    }
+
+    @Option(name="x509_user_trusted_certificates", description="absolute path to the trusted certificates directory",
+            defaultValue="/etc/grid-security/certificates", required=false,
+            log=true, save=true)
+    private String x509_user_trusted_certificates;
+
+    public String getX509_user_trusted_certificates()
+    {
+        return x509_user_trusted_certificates;
+    }
+
+    public void setX509_user_trusted_certificates(String x509_user_trusted_certificates)
+    {
+        this.x509_user_trusted_certificates = x509_user_trusted_certificates;
+    }
+
+    @Option(name="gss_expected_name", description="gss expected name",
+            required=false, log=true, save=true)
+    private String gss_expected_name;
+
+    public String getGss_expected_name() {
+        if (gss_expected_name == null){
+            gss_expected_name = "host";
+        }
+        return gss_expected_name;
+    }
+
+    public void setGss_expected_name(String gss_expected_name) {
+        this.gss_expected_name = gss_expected_name;
+    }
+
+    @Option(name = "retry_timeout", description="number of miliseconds to sleep after a failure",
+            defaultValue="10000", unit="milliseconds", required=false, log=true,
+            save=true)
+    private long retry_timeout;
+
+    public long getRetry_timeout()
+    {
+        return retry_timeout;
+    }
+
+    public void setRetry_timeout(long retry_timeout)
+    {
+        this.retry_timeout = retry_timeout;
+    }
+
+    @Option(name="retry_num", description="number of retries before client gives up",
+            defaultValue="20", required=false, log=true, save=true)
+    private int retry_num;
+
+    public int getRetry_num()
+    {
+        return retry_num;
+    }
+
+    public void setRetry_num(int retry_num)
+    {
+        this.retry_num = retry_num;
+    }
+
+    @Option(name="delegate", description="enables delegation of user credenital to the server",
+            defaultValue="false", required=false, log=true, save=true)
+    private boolean delegate;
+
+    public boolean isDelegate()
+    {
+        return delegate;
+    }
+
+    public void setDelegate(boolean delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Option(name="full_delegation", description="specifies type (full or limited) of delegation",
+            defaultValue="true", required=false, log=true, save=true)
+    private boolean full_delegation;
+
+    public boolean isFull_delegation()
+    {
+        return full_delegation;
+    }
+
+    public void setFull_delegation(boolean full_delegation)
+    {
+        this.full_delegation = full_delegation;
+    }
+}

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/OptionParser.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/OptionParser.java
@@ -12,7 +12,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.dcache.util.Args;
@@ -254,11 +256,12 @@ public class OptionParser {
 
      /**
       * Sets class fields to the option values specified in args
-      * or default values
+      * or default values.
+      * @return Copy of supplied Args without any option that was used.
       */
-     public static <T>  void parseOptions(T t,
+     public static <T>  Args parseOptions(T t,
                                           Args args) {
-         checkOptions(t,args);
+         List<String> consumedOptions = new ArrayList<>();
          Class<?> c = t.getClass();
          while(c!=null) {
              for (Field field : c.getDeclaredFields()) {
@@ -281,6 +284,10 @@ public class OptionParser {
                                      s + "' to " + field.getType(), e);
                          }
                      }
+
+                     if (args.getOption(option.name()) != null) {
+                         consumedOptions.add(option.name());
+                     }
                  }
                  catch (SecurityException | IllegalAccessException e) {
                      throw new RuntimeException("Bug detected while processing option "+
@@ -289,6 +296,7 @@ public class OptionParser {
              }
              c = c.getSuperclass();
          }
+         return args.removeOptions(consumedOptions.toArray(new String[consumedOptions.size()]));
      }
 
 


### PR DESCRIPTION
Motivation:

Fix support for specifying a single command as a command-line argument
to srmfs.  For example:

    srmfs srm://srm.example.org/path ls

Modification:

Fix SRM argument parsing to provide an Args object without options that
have been used.  This prevents the SrmShell command from seeing generic
arguments.

Exiting will block if there are ongoing transfers.  Notifications are
printed, which should provide feedback on activity.

The user can force an exit by using Ctrl+C, which will still result in a
clean exit.

Result:

Command-line arguments with srmfs are supported, including transfers.

Target: master
Request: 3.0
Requires-notes: no
Requires-book: no
Requires-srmclient-notes: yes
Patch: https://rb.dcache.org/r/9928/
Acked-by: Tigran Mkrtchyan