### PR TITLE
NFS: throw FileNotFoundHimeraFsException in case of fumbled ".(get)" …

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -871,8 +871,7 @@ public class JdbcFs implements FileSystemProvider {
                     case "checksums":
                         return new FsInode_PCRC(this, inode.ino());
                     default:
-                        throw new ChimeraFsException
-                            ("unsupported argument for .(get) " + cmd[2]);
+                        throw new FileNotFoundHimeraFsException(cmd[2]);
                 }
             }
 


### PR DESCRIPTION
…command

Motivation:

If user fumbles .(get) command s/he gets a Remote I/O error is generated
on the client side accompanied by stacktrace on server side

Modification:

Throw FileNotFoundHimeraFsException instead of generic ChimeraFsException

Result:

Client side sees No such file or directory error and no
stacktrace in log file.

Target: trunk
Request: 3.0
Request: 2.16
(cherry picked from commit c6c18c927f890d015ef8a8b55d5c0caf5a2fb616)