### PR TITLE
chimera-enstore: specify fields order on insert

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.15.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.15.xml
@@ -1846,7 +1846,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet author="litvinse" id="24.1" dbms="postgresql">
+    <changeSet author="litvinse" id="24.2" dbms="postgresql">
       <comment>Fix trigger on insert or update on t_level_4</comment>
 
         <createProcedure>
@@ -1869,7 +1869,8 @@
                 CONTINUE;
               ELSE
                 BEGIN
-                  INSERT INTO t_locationinfo VALUES ( ichain.inumber, 0, ilocation, 10, NOW(), NOW(), 1);
+                  INSERT INTO t_locationinfo (inumber, itype, ilocation, ipriority, ictime, iatime, istate)
+                      VALUES (ichain.inumber, 0, ilocation, 10, NOW(), NOW(), 1);
                   EXCEPTION WHEN unique_violation THEN
                         -- do nothing
                     RAISE NOTICE 'Tape location for % aready exist.', ichain.inumber;
@@ -1906,12 +1907,14 @@
               IF location IS NULL THEN
                 -- encp only creates empty layer 4 file
                 -- so NEW.ifiledata is null
-                INSERT INTO t_locationinfo VALUES (NEW.inumber,0,'enstore:',10,NOW(),NOW(),1);
+                INSERT INTO t_locationinfo (inumber, itype, ilocation, ipriority, iatime, ictime, istate)
+                    VALUES (NEW.inumber,0,'enstore:',10,NOW(),NOW(),1);
                 INSERT INTO t_storageinfo
                VALUES (NEW.inumber,'enstore','enstore','enstore');
               ELSE
                     l_entries = string_to_array(encode(NEW.ifiledata,'escape'), E'\n');
-                INSERT INTO t_locationinfo VALUES (NEW.inumber,0,location,10,NOW(),NOW(),1);
+                INSERT INTO t_locationinfo (inumber, itype, ilocation, ipriority, iatime, ictime, istate)
+                    VALUES (NEW.inumber,0,location,10,NOW(),NOW(),1);
                 INSERT INTO t_storageinfo
                VALUES (NEW.inumber,'enstore','enstore',l_entries[4]);
                   END IF;


### PR DESCRIPTION
Motivation:
commit d7a890c have changed db scheme. During the migration in  t_locationinfo
table the order of the fields was changed. Nevertheless, the enstore functions
are not updated to the new order.

Modification:
add explicit order of the values in the insert statement.

Result:
the sql statements works as expected.

Ticket: #9102
Acked-by: Paul Millar
Tested-by: Igor Tkachenko
Target: master, 3.0, 2.16, 2.15
Require-book: no
Require-notes: yes
(cherry picked from commit 8d685bec4605dc728cd9c4b7aaaea5edf8aea58f)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>