### PR TITLE
srmclient: use streaming deserialisation, allow more memory.

### DIFF
--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/AxisSrmFileSystem.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/AxisSrmFileSystem.java
@@ -95,6 +95,7 @@ import static org.dcache.srm.shell.TStatusCodes.checkSuccess;
 public class AxisSrmFileSystem implements SrmFileSystem
 {
     private final int MAX_BULK_STAT = 1_000;
+    private final int MAX_LS_RESPONSE = 2_000;
 
     private final ISRM srm;
     private final SrmTransferAgent srmAgent = new SrmTransferAgent();
@@ -298,7 +299,7 @@ public class AxisSrmFileSystem implements SrmFileSystem
     public TMetaDataPathDetail[] list(URI surl, boolean verbose) throws RemoteException, SRMException, InterruptedException
     {
         int offset = 0;
-        int count = 1000;
+        int count = MAX_LS_RESPONSE;
         TMetaDataPathDetail[] list = {};
         do {
             TMetaDataPathDetail detail = list(surl, verbose, offset, count);

--- a/modules/srm-client/src/main/lib/srm
+++ b/modules/srm-client/src/main/lib/srm
@@ -61,7 +61,7 @@ fi
 SRM_CP="${SRM_PATH}/lib/*"
 
 if [ -z "${SRM_JAVA_OPTIONS}" ]; then
-    SRM_JAVA_OPTIONS="-Xms64m -Xmx64m -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    SRM_JAVA_OPTIONS="-Xms64m -Xmx178m -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
 fi
 
 OPTIONS=" ${SRM_JAVA_OPTIONS} -Djava.protocol.handler.pkgs=org.globus.net.protocol"

--- a/modules/srm-common/src/main/java/org/dcache/srm/client/HttpClientSender.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/client/HttpClientSender.java
@@ -430,6 +430,7 @@ public class HttpClientSender extends BasicHandler
 
             HttpUriRequest request = createHttpRequest(msgContext, uri);
             try (CloseableHttpResponse response = httpClient.execute(request, context)) {
+                msgContext.setPastPivot(true);
                 Message outMsg = extractResponse(msgContext, response);
                 msgContext.setResponseMessage(outMsg);
                 outMsg.getSOAPEnvelope();

--- a/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
@@ -327,6 +327,7 @@ public class SRMClientV2 implements ISRM {
                 stub._setProperty(HttpClientTransport.TRANSPORT_HTTP_CREDENTIALS, user_cred);
                 stub._setProperty(HttpClientTransport.TRANSPORT_HTTP_DELEGATION, delegation);
                 stub._setProperty(Call.SESSION_MAINTAIN_PROPERTY, true);
+                stub._setProperty(Call.STREAMING_PROPERTY, true);
             }
 
             return stub;


### PR DESCRIPTION
Motivation:

srmls -l runs out of memory.

Modification:

In general, we cannot prevent srmls running out of memory without
rewriting it to use pagination: if the server responds with sufficiently
large directory then the srmls client (as is currently) will run out of
memory.

That said, servers usually implementation a limit on their response
size, returning SRM_TOO_MANY_RESULTS if the requested listing is too
large.  Unfortunately, the client cannot easily discover what is this
limit to tune its requests.

The srmls in srmfs uses paging with a conservative limit to avoid these
issues.

This patch makes two adjustments to make srmls work more reliably: it
considerably reduces the memory used per directory item and it allows
the JVM to expand its memory usage somewhat.

Axis supports two modes of deserialisation: so called high-fidelity (the
default) and streaming. The high-fidelity creates a list of SAX2 events
from the HTTP response with which it then generates the response object;
this means the response content is more-or-less duplicated: as SAX2
events and as the deserialised object.  With streaming, the response
object is generated on-the-fly, which (roughly) halves the required
memory.

Tests to find the minimum JVM -Xmx value for srmls that is successful
against directories with various number of children (9926, 8179, 6023,
4000 and 2000) yielded the following linear regressions:

    High fidelity: (0.02851 ± 0.001212) * n + 9.631 ± 8.073

    Streaming: (0.01556 ± 0.0003952) * n + 10.45 ± 2.631

Therefore, switching to streaming changes the memory overhead per item from
29 ± 1 kiB  to 16 ± 0.4 kiB.

DPM seems to limit the number of responses to ~5000, so requiring ~96
MiB. dCache (by default) limits response to 10000, so requiring ~178
MiB.  Therefore the maximum JVM memory usage for srmls is increased.

Since the memory overhead has been halved, the limit in srmfs is doubled
to 2,000 items.

Result:

srmls -l should no longer runs out of memory showing particular
directory; however, it may now show SRM_TOO_MANY_RESULTS.

Target: master
Request: 3.0
Requires-notes: no
Requires-srmclient-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9971/
Acked-by: Tigran Mkrtchyan