### PR TITLE
cells: fix 'This stopwatch is already stopped' error

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
@@ -564,8 +564,6 @@ public class LoginBrokerPublisher
 
     public static class AnyAddressSupplier implements Supplier<List<InetAddress>>
     {
-        private final Stopwatch _stopwatch = Stopwatch.createUnstarted();
-
         private List<InetAddress> _previous = Collections.emptyList();
 
         @Override
@@ -574,7 +572,7 @@ public class LoginBrokerPublisher
             NDC.push("NIC auto-discovery");
             try {
                 ArrayList<InetAddress> addresses = new ArrayList<>();
-                _stopwatch.reset().start();
+                Stopwatch stopwatch = Stopwatch.createStarted();
                 try {
                     Enumeration<NetworkInterface> interfaces =
                             NetworkInterface.getNetworkInterfaces();
@@ -593,11 +591,9 @@ public class LoginBrokerPublisher
                     }
                 } catch (SocketException e) {
                     _log.warn("Not publishing NICs: {}", e.getMessage());
-                } finally {
-                    _stopwatch.stop();
                 }
 
-                _log.debug("Scan took {}", _stopwatch);
+                _log.debug("Scan took {}", stopwatch);
                 logChanges(addresses);
                 return addresses;
             } finally {


### PR DESCRIPTION
Motivation:

On startup, doors can log a stack-trace like:

java.lang.IllegalStateException: This stopwatch is already stopped.
    at com.google.common.base.Preconditions.checkState(Preconditions.java:174) ~[guava-19.0.jar:na]
    at com.google.common.base.Stopwatch.stop(Stopwatch.java:167) ~[guava-19.0.jar:na]
    at dmg.cells.services.login.LoginBrokerPublisher$AnyAddressSupplier.get(LoginBrokerPublisher.java:597) ~[cells-3.0.2.jar:3.0.2]
    at dmg.cells.services.login.LoginBrokerPublisher$AnyAddressSupplier.get(LoginBrokerPublisher.java:565) ~[cells-3.0.2.jar:3.0.2]
    at dmg.cells.services.login.LoginBrokerPublisher.sendUpdate(LoginBrokerPublisher.java:235) ~[cells-3.0.2.jar:3.0.2]
    at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) ~[dcache-common-3.0.2.jar:3.0.2]
    at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149) [dcache-core-3.0.2.jar:3.0.2]
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_111]
    at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_111]
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_111]
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_111]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_111]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_111]
    at java.lang.Thread.run(Thread.java:745) [na:1.8.0_111]

This is because the door potentially receves multiple overlapping
LoginBrokerInfoMessage, which trigger re-scanning of the available
interfaces.  These processes share the Stopwatch instance resulting in
the above stack-trace.

Modification:

Create a stopwatch instance per invocation.

Result:

No more stack-traces

Target: master
Request: 3.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9967/
Acked-by: Albert Rossi