### PR TITLE
transfermanager: tidy up output from 'info' 'queue' and the two 'ls' …

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -525,7 +525,7 @@ public class RemoteTransferHandler implements CellMessageReceiver
             _out.println("    Timestamp: " +
                     MILLISECONDS.toSeconds(System.currentTimeMillis()));
             _out.println("    State: " + state);
-            _out.println("    State description: " + descriptionForState(state));
+            _out.println("    State description: " + TransferManagerHandler.describeState(state));
             _out.println("    Stripe Index: 0");
             if (info != null) {
                 _out.println("    Stripe Start Time: " +
@@ -541,50 +541,6 @@ public class RemoteTransferHandler implements CellMessageReceiver
             _out.println("    Total Stripe Count: 1");
             _out.println("End");
             _out.flush();
-        }
-
-        private String descriptionForState(int state)
-        {
-            switch (state) {
-            case TransferManagerHandler.INITIAL_STATE:
-                return "initialising";
-            case TransferManagerHandler.WAITING_FOR_PNFS_INFO_STATE:
-                return "querying file metadata";
-            case TransferManagerHandler.RECEIVED_PNFS_INFO_STATE:
-                return "recieved file metadata";
-            case TransferManagerHandler.WAITING_FOR_PNFS_ENTRY_CREATION_INFO_STATE:
-                return "creating namespace entry";
-            case TransferManagerHandler.RECEIVED_PNFS_ENTRY_CREATION_INFO_STATE:
-                return "namespace entry created";
-            case TransferManagerHandler.WAITING_FOR_POOL_INFO_STATE:
-                return "selecting pool";
-            case TransferManagerHandler.RECEIVED_POOL_INFO_STATE:
-                return "pool selected";
-            case TransferManagerHandler.WAITING_FIRST_POOL_REPLY_STATE:
-                return "waiting for transfer to start";
-            case TransferManagerHandler.RECEIVED_FIRST_POOL_REPLY_STATE:
-                return "transfer has started";
-            case TransferManagerHandler.WAITING_FOR_SPACE_INFO_STATE:
-                return "reserving space";
-            case TransferManagerHandler.RECEIVED_SPACE_INFO_STATE:
-                return "space reserved";
-            case TransferManagerHandler.WAITING_FOR_PNFS_ENTRY_DELETE:
-                return "requesting file deletion";
-            case TransferManagerHandler.RECEIVED_PNFS_ENTRY_DELETE:
-                return "notified of file deletion";
-            case TransferManagerHandler.WAITING_FOR_PNFS_CHECK_BEFORE_DELETE_STATE:
-                return "checking before file deletion";
-            case TransferManagerHandler.RECEIVED_PNFS_CHECK_BEFORE_DELETE_STATE:
-                return "confirmed file deletion OK";
-            case TransferManagerHandler.SENT_ERROR_REPLY_STATE:
-                return "transfer failed";
-            case TransferManagerHandler.SENT_SUCCESS_REPLY_STATE:
-                return "transfer succeeded";
-            case TransferManagerHandler.UNKNOWN_ID:
-                return "unknown transfer";
-            default:
-                return "unknown state: " + state;
-            }
         }
     }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -44,6 +44,8 @@ import org.dcache.poolmanager.PoolManagerStub;
 import org.dcache.util.Args;
 import org.dcache.util.CDCExecutorServiceDecorator;
 
+import static java.util.stream.Collectors.joining;
+
 
 /**
  * Base class for services that transfer files on behalf of SRM. Used to
@@ -88,25 +90,14 @@ public abstract class TransferManager extends AbstractCellComponent
     @Override
     public void getInfo(PrintWriter pw)
     {
-        pw.printf("    %s\n", getClass().getName());
-        pw.println("---------------------------------");
-        pw.printf("Name   : %s\n", getCellName());
-        if (doDbLogging()) {
-            pw.println("dblogging=true");
-        } else {
-            pw.println("dblogging=false");
-        }
-        if (idGenerator != null) {
-            pw.println("TransferID is generated using Data Base");
-        } else {
-            pw.println("TransferID is generated w/o DB access");
-        }
-        pw.printf("number of active transfers : %d\n", _numTransfers);
-        pw.printf("max number of active transfers  : %d\n", getMaxTransfers());
-        pw.printf("PoolManager  : %s\n", _poolManager);
-        pw.printf("next id  : %d seconds\n", nextMessageID);
-        pw.printf("io-queue  : %s\n", _ioQueueName);
-        pw.printf("maxNumberofDeleteRetries  : %d\n", _maxNumberOfDeleteRetries);
+        pw.printf("DB logging            : %b\n", doDbLogging());
+        pw.printf("Transfer ID generated : %s\n", idGenerator == null ? "locally" : "from DB");
+        pw.printf("Next Transfer ID      : %d\n", nextMessageID);
+        pw.printf("Active transfers      : %d\n", _numTransfers);
+        pw.printf("Max active transfers  : %d\n", getMaxTransfers());
+        pw.printf("Pool manager          : %s\n", _poolManager);
+        pw.printf("io-queue              : %s\n", _ioQueueName);
+        pw.printf("Max delete retries    : %d\n", _maxNumberOfDeleteRetries);
     }
 
     public String ac_set_maxNumberOfDeleteRetries_$_1(Args args)
@@ -150,18 +141,14 @@ public abstract class TransferManager extends AbstractCellComponent
             if (handler == null) {
                 return "ID not found : " + id;
             }
-            return " transfer id=" + id + " : " + handler.toString(long_format);
+            return handler.toString(long_format);
         }
-        StringBuilder sb = new StringBuilder();
         if (_activeTransfers.isEmpty()) {
-            return "No Active Transfers";
+            return "No active transfers.";
         }
-        sb.append("  Active Transfers ");
-        for (Map.Entry<Long, TransferManagerHandler> e : _activeTransfers.entrySet()) {
-            sb.append("\n#").append(e.getKey());
-            sb.append(" ").append(e.getValue().toString(long_format));
-        }
-        return sb.toString();
+        return _activeTransfers.values().stream()
+                .map(h -> h.toString(long_format))
+                .collect(joining("\n", "", "\n"));
     }
 
     public static final String hh_kill = " id";


### PR DESCRIPTION
…commands

Motivation:

The output from 'info', 'queue', 'ls internal' and 'ls external' are
badly laid out and poorly describes the information presented.

Modification:

Fix layout and description of the information.

Result:

The output of 'info', 'queue', 'ls internal' and 'ls external' admin
commands in RemoteTransferManager is now easier to read.

Target: master
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/9973/
Acked-by: Tigran Mkrtchyan