### PR TITLE
transfermanager: tidy up output from 'info' 'queue' and the two 'ls' …

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -524,7 +524,7 @@ public class RemoteTransferHandler implements CellMessageReceiver
             _out.println("    Timestamp: " +
                     MILLISECONDS.toSeconds(System.currentTimeMillis()));
             _out.println("    State: " + state);
-            _out.println("    State description: " + descriptionForState(state));
+            _out.println("    State description: " + TransferManagerHandler.describeState(state));
             _out.println("    Stripe Index: 0");
             if (info != null) {
                 _out.println("    Stripe Start Time: " +
@@ -540,50 +540,6 @@ public class RemoteTransferHandler implements CellMessageReceiver
             _out.println("    Total Stripe Count: 1");
             _out.println("End");
             _out.flush();
-        }
-
-        private String descriptionForState(int state)
-        {
-            switch (state) {
-            case TransferManagerHandler.INITIAL_STATE:
-                return "initialising";
-            case TransferManagerHandler.WAITING_FOR_PNFS_INFO_STATE:
-                return "querying file metadata";
-            case TransferManagerHandler.RECEIVED_PNFS_INFO_STATE:
-                return "recieved file metadata";
-            case TransferManagerHandler.WAITING_FOR_PNFS_ENTRY_CREATION_INFO_STATE:
-                return "creating namespace entry";
-            case TransferManagerHandler.RECEIVED_PNFS_ENTRY_CREATION_INFO_STATE:
-                return "namespace entry created";
-            case TransferManagerHandler.WAITING_FOR_POOL_INFO_STATE:
-                return "selecting pool";
-            case TransferManagerHandler.RECEIVED_POOL_INFO_STATE:
-                return "pool selected";
-            case TransferManagerHandler.WAITING_FIRST_POOL_REPLY_STATE:
-                return "waiting for transfer to start";
-            case TransferManagerHandler.RECEIVED_FIRST_POOL_REPLY_STATE:
-                return "transfer has started";
-            case TransferManagerHandler.WAITING_FOR_SPACE_INFO_STATE:
-                return "reserving space";
-            case TransferManagerHandler.RECEIVED_SPACE_INFO_STATE:
-                return "space reserved";
-            case TransferManagerHandler.WAITING_FOR_PNFS_ENTRY_DELETE:
-                return "requesting file deletion";
-            case TransferManagerHandler.RECEIVED_PNFS_ENTRY_DELETE:
-                return "notified of file deletion";
-            case TransferManagerHandler.WAITING_FOR_PNFS_CHECK_BEFORE_DELETE_STATE:
-                return "checking before file deletion";
-            case TransferManagerHandler.RECEIVED_PNFS_CHECK_BEFORE_DELETE_STATE:
-                return "confirmed file deletion OK";
-            case TransferManagerHandler.SENT_ERROR_REPLY_STATE:
-                return "transfer failed";
-            case TransferManagerHandler.SENT_SUCCESS_REPLY_STATE:
-                return "transfer succeeded";
-            case TransferManagerHandler.UNKNOWN_ID:
-                return "unknown transfer";
-            default:
-                return "unknown state: " + state;
-            }
         }
     }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsHandler;
+import diskCacheV111.util.PnfsId;
 import diskCacheV111.util.TimeoutCacheException;
 import diskCacheV111.vehicles.CopyManagerMessage;
 import diskCacheV111.vehicles.DCapClientPortAvailableMessage;
@@ -30,12 +31,15 @@ import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellMessage;
 import dmg.cells.nucleus.CellMessageReceiver;
 
+import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.cells.CellStub;
 import org.dcache.util.Args;
 import org.dcache.util.RedirectedTransfer;
 import org.dcache.util.Transfer;
 import org.dcache.util.TransferRetryPolicy;
+
+import static java.util.stream.Collectors.joining;
 
 public class CopyManager extends AbstractCellComponent
     implements CellMessageReceiver, CellCommandListener
@@ -82,48 +86,51 @@ public class CopyManager extends AbstractCellComponent
         boolean long_format = args.hasOption("l");
         if (args.argc() > 0) {
             long id = Long.parseLong(args.argv(0));
-            CopyHandler transferHandler = _activeTransfers.get(id);
-            if (transferHandler == null) {
-                return "ID not found : "+ id;
-            }
-            return " transfer id=" + id+" : " +
-                transferHandler.toString(long_format);
+            CopyHandler handler = _activeTransfers.get(id);
+            return id + ": " + (handler == null ? "no such ID" : handler.toString(long_format));
         }
-        StringBuilder sb =  new StringBuilder();
         if (_activeTransfers.isEmpty()) {
-            return "No Active Transfers";
+            return "No active transfers.";
         }
-        sb.append("  Active Transfers ");
-        for (Map.Entry<Long,CopyHandler> entry: _activeTransfers.entrySet()) {
-            sb.append("\n#").append(entry.getKey());
-            sb.append(" ").append(entry.getValue().toString(long_format));
-        }
-        return sb.toString();
+        return _activeTransfers.entrySet().stream()
+                .map(e -> e.getKey() + ": "  + e.getValue().toString(long_format))
+                .collect(joining("\n", "", "\n"));
+    }
+
+    private static void appendPaths(StringBuilder sb, CopyManagerMessage message)
+    {
+        sb.append(' ').append(message.getSrcPnfsPath()).append(" --> ").append(message.getDstPnfsPath());
+    }
+
+    private static StringBuilder appendExtendedInfo(StringBuilder sb, CopyManagerMessage message)
+    {
+        sb.append("    Attempt: ").append(1+message.getNumberOfPerformedRetries())
+                .append(" of ").append(message.getNumberOfRetries()).append('\n');
+        sb.append("    User: ").append(Subjects.getDisplayName(message.getSubject())).append('\n');
+        sb.append("    Restriction: ").append(message.getRestriction());
+        return sb;
     }
 
     public static final String hh_queue = "[-l]";
     public synchronized String ac_queue_$_0(Args args)
     {
-        boolean long_format = args.hasOption("l");
-        StringBuilder sb = new StringBuilder();
+        boolean longFormat = args.hasOption("l");
         if (_queue.isEmpty()) {
             return "Queue is empty";
         }
 
-        int i = 0;
+        StringBuilder sb = new StringBuilder();
+        int i = 1;
         for (CellMessage envelope: _queue) {
-            sb.append("\n#").append(i++);
-            CopyManagerMessage request =
-                (CopyManagerMessage) envelope.getMessageObject();
-            sb.append(" store src=");
-            sb.append(request.getSrcPnfsPath());
-            sb.append(" dest=");
-            sb.append(request.getDstPnfsPath());
+            sb.append("#").append(i++);
 
-            if (!long_format) {
-                continue;
+            CopyManagerMessage message = (CopyManagerMessage) envelope.getMessageObject();
+            appendPaths(sb, message);
+
+            if (longFormat) {
+                sb.append('\n');
+                appendExtendedInfo(sb, message).append('\n');
             }
-            sb.append("\n try#").append(request.getNumberOfPerformedRetries());
         }
         return sb.toString();
     }
@@ -131,23 +138,16 @@ public class CopyManager extends AbstractCellComponent
     @Override
     public synchronized void getInfo(PrintWriter pw)
     {
-        pw.println("    CopyManager");
-        pw.println("---------------------------------");
-        pw.printf("Name   : %s\n", getCellName());
-        pw.printf("number of active transfers : %d\n",
-                  _numTransfers);
-        pw.printf("number of queuedrequests : %d\n",
-                  _queue.size());
-        pw.printf("max number of active transfers  : %d\n",
-                  getMaxTransfers());
-        pw.printf("PoolManager  : %s\n",
-                  _poolManager.getDestinationPath());
-        pw.printf("PoolManager timeout : %d %s\n",
-                  _poolManager.getTimeout(), _poolManager.getTimeoutUnit());
-        pw.printf("Pool timeout  : %d %s\n",
-                  _poolStub.getTimeout(), _poolStub.getTimeoutUnit());
-        pw.printf("Mover timeout  : %d seconds",
-                  _moverTimeoutUnit.toSeconds(_moverTimeout));
+        pw.printf("Active transfers      : %d\n", _numTransfers);
+        pw.printf("Queued requests       : %d\n", _queue.size());
+        pw.printf("Max active transfers  : %d\n", getMaxTransfers());
+        pw.printf("Pool manager          : %s\n", _poolManager.getDestinationPath());
+        pw.printf("Pool manager timeout  : %d %s\n", _poolManager.getTimeout(),
+                _poolManager.getTimeoutUnit());
+        pw.printf("Pool timeout          : %d %s\n", _poolStub.getTimeout(),
+                _poolStub.getTimeoutUnit());
+        pw.printf("Mover timeout         : %d seconds",
+                _moverTimeoutUnit.toSeconds(_moverTimeout));
     }
 
     public void messageArrived(DoorTransferFinishedMessage message)
@@ -214,52 +214,67 @@ public class CopyManager extends AbstractCellComponent
             _envelope = envelope;
         }
 
-        public synchronized String toString(boolean long_format)
+        private void appendTransfer(StringBuilder sb, Transfer transfer)
         {
-            if (_envelope == null) {
-                return getState();
+            PnfsId id = transfer.getPnfsId();
+            String pool = transfer.getPool();
+            Integer mover = transfer.getMoverId();
+            sb.append("        PNFS-ID: ").append(id == null ? "Not yet known" : id).append('\n');
+            sb.append("        Pool: ").append(pool == null ? "Not yet selected" : pool);
+            if (mover != null) {
+                sb.append('\n');
+                sb.append("        Mover: ").append(mover);
+            }
+        }
+
+        public synchronized String toString(boolean isLongFormat)
+        {
+            CopyManagerMessage message = _envelope == null ? null :
+                    (CopyManagerMessage) _envelope.getMessageObject();
+
+            StringBuilder sb = new StringBuilder(getTransferState());
+
+            if (message != null) {
+                appendPaths(sb, message);
             }
 
-            CopyManagerMessage message =
-                (CopyManagerMessage) _envelope.getMessageObject();
+            if (isLongFormat) {
+                if (message != null) {
+                    sb.append('\n');
+                    appendExtendedInfo(sb, message);
+                }
 
-            StringBuilder sb = new StringBuilder();
-            sb.append("store src=");
-            sb.append(message.getSrcPnfsPath());
-            sb.append(" dest=");
-            sb.append(message.getDstPnfsPath());
-            if (!long_format) {
-                return sb.toString();
-            }
-            sb.append("\n   ").append(getState());
-            sb.append("\n try#").append(message.getNumberOfPerformedRetries());
+                if (_source != null) {
+                    sb.append('\n');
+                    sb.append("    SOURCE\n");
+                    appendTransfer(sb, _source);
+                }
 
-            if (_source != null && _source.getPnfsId() != null) {
-                sb.append("\n   srcPnfsId=").append(_source.getPnfsId());
-            }
-            if (_target != null && _target.getPnfsId() != null) {
-                sb.append("\n   dstPnfsId=").append(_target.getPnfsId());
-            }
-            if (_source != null && _source.getPool() != null) {
-                sb.append("\n   srcPool=").append(_source.getPool());
-            }
-            if (_target != null && _target.getPool() != null) {
-                sb.append("\n   dstPool=").append(_target.getPool());
+                if (_target != null) {
+                    sb.append('\n');
+                    sb.append("    TARGET\n");
+                    appendTransfer(sb, _target);
+                }
             }
             return sb.toString();
         }
 
-        public synchronized String getState()
+        private String statusOf(Transfer t)
         {
-            String source = (_source != null) ? _source.getStatus() : null;
-            if (source != null) {
-                return source;
+            if (t == null) {
+                return "no transfer";
+            } else {
+                String status = t.getStatus();
+                return status == null ? "idle" : status;
             }
-            String target = (_target != null) ? _target.getStatus() : null;
-            if (target != null) {
-                return target;
-            }
-            return "Pending";
+        }
+
+        private synchronized String getTransferState()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.append("source [").append(statusOf(_source)).append("] ");
+            sb.append("target [").append(statusOf(_target)).append("]");
+            return sb.toString();
         }
 
         @Override

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -42,7 +42,7 @@ import org.dcache.util.Args;
 import org.dcache.util.CDCExecutorServiceDecorator;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.joining;
 
 
 /**
@@ -89,30 +89,18 @@ public abstract class TransferManager extends AbstractCellComponent
     @Override
     public void getInfo(PrintWriter pw)
     {
-        pw.printf("    %s\n", getClass().getName());
-        pw.println("---------------------------------");
-        pw.printf("Name   : %s\n", getCellName());
-        if (doDbLogging()) {
-            pw.println("dblogging=true");
-        } else {
-            pw.println("dblogging=false");
-        }
-        if (idGenerator != null) {
-            pw.println("TransferID is generated using Data Base");
-        } else {
-            pw.println("TransferID is generated w/o DB access");
-        }
-        pw.printf("number of active transfers : %d\n", _numTransfers);
-        pw.printf("max number of active transfers  : %d\n", getMaxTransfers());
-        pw.printf("PoolManager  : %s\n", _poolManager);
-        pw.printf("PoolManager timeout : %d seconds\n", MILLISECONDS.toSeconds(_poolManager.getTimeoutInMillis()));
-        pw.printf("PnfsManager timeout : %d seconds\n", MILLISECONDS.toSeconds(_pnfsManager.getTimeoutInMillis()));
-        pw.printf("Pool timeout  : %d seconds\n", MILLISECONDS.toSeconds(_poolStub.getTimeoutInMillis()));
-        pw.printf("next id  : %d seconds\n", nextMessageID);
-        pw.printf("io-queue  : %s\n", _ioQueueName);
-        pw.printf("maxNumberofDeleteRetries  : %d\n", _maxNumberOfDeleteRetries);
-        pw.printf("Pool Proxy : %s\n",
-                (_poolProxy == null ? "not set" : ("set to " + _poolProxy)));
+        pw.printf("DB logging            : %b\n", doDbLogging());
+        pw.printf("Transfer ID generated : %s\n", idGenerator == null ? "locally" : "from DB");
+        pw.printf("Next Transfer ID      : %d\n", nextMessageID);
+        pw.printf("Active transfers      : %d\n", _numTransfers);
+        pw.printf("Max active transfers  : %d\n", getMaxTransfers());
+        pw.printf("PoolManager           : %s\n", _poolManager);
+        pw.printf("PoolManager timeout   : %d seconds\n", MILLISECONDS.toSeconds(_poolManager.getTimeoutInMillis()));
+        pw.printf("PnfsManager timeout   : %d seconds\n", MILLISECONDS.toSeconds(_pnfsManager.getTimeoutInMillis()));
+        pw.printf("pool proxy            : %s\n", _poolProxy == null ? "not set" : ("set to " + _poolProxy));
+        pw.printf("pool timeout          : %d seconds\n", MILLISECONDS.toSeconds(_poolStub.getTimeoutInMillis()));
+        pw.printf("io-queue              : %s\n", _ioQueueName);
+        pw.printf("Max delete retries    : %d\n", _maxNumberOfDeleteRetries);
     }
 
     public String ac_set_maxNumberOfDeleteRetries_$_1(Args args)
@@ -156,18 +144,14 @@ public abstract class TransferManager extends AbstractCellComponent
             if (handler == null) {
                 return "ID not found : " + id;
             }
-            return " transfer id=" + id + " : " + handler.toString(long_format);
+            return handler.toString(long_format);
         }
-        StringBuilder sb = new StringBuilder();
         if (_activeTransfers.isEmpty()) {
-            return "No Active Transfers";
+            return "No active transfers.";
         }
-        sb.append("  Active Transfers ");
-        for (Map.Entry<Long, TransferManagerHandler> e : _activeTransfers.entrySet()) {
-            sb.append("\n#").append(e.getKey());
-            sb.append(" ").append(e.getValue().toString(long_format));
-        }
-        return sb.toString();
+        return _activeTransfers.values().stream()
+                .map(h -> h.toString(long_format))
+                .collect(joining("\n", "", "\n"));
     }
 
     public static final String hh_kill = " id";

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import jersey.repackaged.com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +15,8 @@ import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.URI;
 import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 
 import diskCacheV111.doors.FTPTransactionLog;
@@ -56,7 +59,7 @@ import org.dcache.namespace.PosixPermissionHandler;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.PnfsGetFileAttributes;
 
-import static org.dcache.namespace.FileAttribute.STORAGEINFO;
+import static org.dcache.namespace.FileAttribute.*;
 
 public class TransferManagerHandler extends AbstractMessageCallback<Message>
 {
@@ -95,6 +98,28 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
     public static final int SENT_ERROR_REPLY_STATE = -1;
     public static final int SENT_SUCCESS_REPLY_STATE = -2;
     public static final int UNKNOWN_ID = -3;
+
+    public static final Map<Integer,String> STATE_DESCRIPTION =
+            ImmutableMap.<Integer,String>builder()
+            .put(INITIAL_STATE, "initialising")
+            .put(WAITING_FOR_PNFS_INFO_STATE, "querying file metadata")
+            .put(RECEIVED_PNFS_INFO_STATE, "recieved file metadata")
+            .put(WAITING_FOR_PNFS_ENTRY_CREATION_INFO_STATE, "creating namespace entry")
+            .put(RECEIVED_PNFS_ENTRY_CREATION_INFO_STATE, "namespace entry created")
+            .put(WAITING_FOR_POOL_INFO_STATE, "selecting pool")
+            .put(RECEIVED_POOL_INFO_STATE, "pool selected")
+            .put(WAITING_FIRST_POOL_REPLY_STATE, "waiting for transfer to start")
+            .put(RECEIVED_FIRST_POOL_REPLY_STATE, "transfer has started")
+            .put(WAITING_FOR_SPACE_INFO_STATE, "reserving space")
+            .put(RECEIVED_SPACE_INFO_STATE, "space reserved")
+            .put(WAITING_FOR_PNFS_ENTRY_DELETE, "requesting file deletion")
+            .put(RECEIVED_PNFS_ENTRY_DELETE, "notified of file deletion")
+            .put(WAITING_FOR_PNFS_CHECK_BEFORE_DELETE_STATE, "checking before file deletion")
+            .put(RECEIVED_PNFS_CHECK_BEFORE_DELETE_STATE, "confirmed file deletion OK")
+            .put(SENT_ERROR_REPLY_STATE, "transfer failed")
+            .put(SENT_SUCCESS_REPLY_STATE, "transfer succeeded")
+            .put(UNKNOWN_ID, "unknown transfer")
+            .build();
     public int state = INITIAL_STATE;
     private long id;
     private Integer moverId;
@@ -163,6 +188,12 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                 new ChainedPermissionHandler(
                 new ACLPermissionHandler(),
                 new PosixPermissionHandler());
+    }
+
+    public static String describeState(int state)
+    {
+        String description = STATE_DESCRIPTION.get(state);
+        return description != null ? description : ("Unknown state: " + state);
     }
 
     public void handle()
@@ -669,39 +700,54 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         sendErrorReply(24, new IOException("transfer cancelled: " + explanation));
     }
 
-    public synchronized String toString(boolean long_format)
+    public synchronized String toString(boolean isLongFormat)
     {
-        StringBuilder sb = new StringBuilder("id=");
-        sb.append(id);
-        if (!long_format) {
-            if (store) {
-                sb.append(" store src=");
-                sb.append(transferRequest.getRemoteURL());
-                sb.append(" dest=");
-                sb.append(transferRequest.getPnfsPath());
-            } else {
-                sb.append(" restore src=");
-                sb.append(transferRequest.getPnfsPath());
-                sb.append(" dest=");
-                sb.append(transferRequest.getRemoteURL());
+        String src = store ? transferRequest.getRemoteURL() : transferRequest.getPnfsPath();
+        String dest = store ? transferRequest.getPnfsPath() : transferRequest.getRemoteURL();
+        String siPath = fileAttributes == null ? null : fileAttributes.getStorageInfo().getKey("path");
+
+        StringBuilder sb = new StringBuilder("id: ").append(id);
+
+        if (isLongFormat) {
+            sb.append('\n');
+            sb.append("    Source: ").append(src).append('\n');
+            sb.append("    Destination: ").append(dest).append('\n');
+            if (store && siPath != null && !siPath.equals(dest)) {
+                sb.append("    Final destination: ").append(siPath).append('\n');
             }
-            return sb.toString();
-        }
-        sb.append("\n  state=").append(state);
-        sb.append("\n  user=").append(transferRequest.getSubject());
-        sb.append("\n  restriction=").append(transferRequest.getRestriction());
-        if (pnfsId != null) {
-            sb.append("\n   pnfsId=").append(pnfsId);
-        }
-        if (fileAttributes != null) {
-            sb.append("\n   fileAttributes=").append(fileAttributes);
-        }
-        if (pool != null) {
-            sb.append("\n   pool=").append(pool);
+            sb.append("    State: ").append(describeState(state)).append('\n');
+            sb.append("    User: ").append(Subjects.getDisplayName(transferRequest.getSubject())).append('\n');
+            sb.append("    Restriction: ").append(transferRequest.getRestriction()).append('\n');
+            if (pnfsId != null) {
+                sb.append("    PNFS-ID: ").append(pnfsId).append('\n');
+            }
+            if (fileAttributes != null) {
+                if (fileAttributes.isDefined(ACCESS_LATENCY)) {
+                    sb.append("    Access latency: ").append(fileAttributes.getAccessLatency()).append('\n');
+                }
+                if (fileAttributes.isDefined(RETENTION_POLICY)) {
+                    sb.append("    Retention policy: ").append(fileAttributes.getRetentionPolicy()).append('\n');
+                }
+                if (fileAttributes.isDefined(STORAGECLASS)) {
+                    sb.append("    Storage class: ").append(fileAttributes.getStorageClass()).append('\n');
+                }
+                if (fileAttributes.isDefined(SIZE)) {
+                    sb.append("    Size: ").append(fileAttributes.getSize()).append('\n');
+                }
+            }
+            sb.append("    Pool: ").append(pool == null ? "not yet selected" : pool);
             if (moverId != null) {
-                sb.append("\n   moverId=").append(moverId);
+                sb.append('\n');
+                sb.append("    Mover: ").append(moverId);
+            }
+        } else {
+            sb.append(' ').append(src).append(" --> ").append(dest);
+
+            if (store && siPath != null && !siPath.equals(dest)) {
+                sb.append(" [").append(siPath).append("]");
             }
         }
+
         return sb.toString();
     }
 


### PR DESCRIPTION
…commands

Motivation:

The output from 'info', 'queue', 'ls internal' and 'ls external' are
badly laid out and poorly describes the information presented.

Modification:

Fix layout and description of the information.

Result:

The output of 'info', 'queue', 'ls internal' and 'ls external' admin
commands in RemoteTransferManager is now easier to read.

Target: master
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/9973/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java
	modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java