### PR TITLE
srm-common: don't retry when JVM runs out of memory

### DIFF
--- a/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
@@ -398,7 +398,7 @@ public class SRMClientV2 implements ISRM {
                 if (e instanceof AxisFault && e.getCause() != null) {
                     e = e.getCause();
                 }
-                Throwables.propagateIfInstanceOf(e, ConnectException.class);
+                Throwables.propagateIfPossible(e, ConnectException.class);
                 if (e instanceof AxisFault) {
                     AxisFault af = (AxisFault) e;
                     if (af.getFaultCode().equals(AXIS_HTTP)) {


### PR DESCRIPTION
Motivation:

The generic SRMClient code invokes SRM stub methods using reflection.
This process will always retry the request if the exception isn't
ConnectionException.  This means that the client will retry an
operation, even if there is a critical Errors and or a bug
(RuntimeExceptions).

Modification:

Ensure bugs and JVM-critical errors do not trigger a retry of the
operation, but favour a fail-fast approach.

Result:

Slightly better user experience.

Target: master
Request: 3.0
Requires-notes: no
Requires-srmclient-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/9976/
Acked-by: Tigran Mkrtchyan