### PR TITLE
pool: 'hsm ls' must show all configured hsm if no argument is provided

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
@@ -396,14 +396,14 @@ public class HsmSet
             description = "Lists all nearline storages defined on this pool.")
     public class LsCommand implements Callable<String>
     {
-        @Argument(usage = "Limit output to these instances.")
+        @Argument(usage = "Limit output to these instances.", required = false)
         String[] instances;
 
         @Override
         public String call() throws Exception
         {
             StringBuilder sb = new StringBuilder();
-            if (instances.length > 0) {
+            if (instances != null && instances.length > 0) {
                 for (String instance : instances) {
                     printInfos(sb, instance);
                 }


### PR DESCRIPTION
Motivation:
'hsm ls' must list all configured HSMs if no argument is provided.
(well, it's quite confusing to ask for a hsm instance if you can't see
which instances are configured)

Modification:
make hsm instance argument optional

Result:
can list configured HSMs without knowing what is configured

Acked-by: Paul Millar
Target: master, 3.0
Require-book: no
Require-notes: no
(cherry picked from commit 1aa72c0d6c9fbb32713bc9dd4adf4f7039d0c838)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>