### PR TITLE
dcache: update dcache-view version

### DIFF
--- a/packages/fhs/src/main/assembly/fhs.xml
+++ b/packages/fhs/src/main/assembly/fhs.xml
@@ -36,7 +36,7 @@
             <includes>
                 <include>org.dcache:dcache-view:jar:*</include>
             </includes>
-            <outputDirectory>usr/share/dcache</outputDirectory>
+            <outputDirectory>usr/share/dcache/dcache-view</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>
             <unpack>true</unpack>

--- a/packages/system-test/src/main/assembly/assembly.xml
+++ b/packages/system-test/src/main/assembly/assembly.xml
@@ -46,7 +46,7 @@
             <includes>
                 <include>org.dcache:dcache-view:jar:*</include>
             </includes>
-            <outputDirectory>share</outputDirectory>
+            <outputDirectory>share/dcache-view</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>
             <unpack>true</unpack>

--- a/packages/tar/src/main/assembly/tar.xml
+++ b/packages/tar/src/main/assembly/tar.xml
@@ -36,7 +36,7 @@
             <includes>
                 <include>org.dcache:dcache-view:jar:*</include>
             </includes>
-            <outputDirectory>share</outputDirectory>
+            <outputDirectory>share/dcache-view</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>
             <unpack>true</unpack>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.3.0</version.wicket>
         <version.xrootd4j>3.1.1</version.xrootd4j>
         <version.jersey>2.22.2</version.jersey>
-        <version.dcache-view>1.0.2</version.dcache-view>
+        <version.dcache-view>1.0.3</version.dcache-view>
         <version.dcache>${project.version}</version.dcache>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
1. dcache 2.16 -> dcache-view version 1.0.3

Changelog from v1.0.2 to v1.0.3
[0c176e7] dcache-view: hide table header
[ad7a515] dcache-view: fix file download
[61fcc14] dcache-view: automate deployment and release

2. dcache 3.0 -> dcache-view version 1.1.0

Changelog from v1.0.3 to v1.1.0
[9aab19c] dcache-view: add delete button for a file
[1341b24] dcache-view: create admin page with the route mechanism
[892221b] dcache-view: add create new directory feature
[0e721a1] dcache-view: hide table header
[e40705a] dcache-view: add files upload functionality and feature
[fcd8d05] dcache-view: fix file download
[df99597] dcache-view: automate deployment and release

Target: trunk
Request: 2.16
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9991/

(cherry picked from commit 9e08ca3a663d05ca6594226cb1f307fe9b7c67d5)