### PR TITLE
dcache: correct the output directory

### DIFF
--- a/packages/fhs/src/main/assembly/fhs.xml
+++ b/packages/fhs/src/main/assembly/fhs.xml
@@ -36,7 +36,7 @@
             <includes>
                 <include>org.dcache:dcache-view:jar:*</include>
             </includes>
-            <outputDirectory>usr/share/dcache/dcache-view</outputDirectory>
+            <outputDirectory>usr/share/dcache</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>
             <unpack>true</unpack>

--- a/packages/system-test/src/main/assembly/assembly.xml
+++ b/packages/system-test/src/main/assembly/assembly.xml
@@ -46,7 +46,7 @@
             <includes>
                 <include>org.dcache:dcache-view:jar:*</include>
             </includes>
-            <outputDirectory>share/dcache-view</outputDirectory>
+            <outputDirectory>share</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>
             <unpack>true</unpack>

--- a/packages/tar/src/main/assembly/tar.xml
+++ b/packages/tar/src/main/assembly/tar.xml
@@ -36,7 +36,7 @@
             <includes>
                 <include>org.dcache:dcache-view:jar:*</include>
             </includes>
-            <outputDirectory>share/dcache-view</outputDirectory>
+            <outputDirectory>share</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>
             <unpack>true</unpack>


### PR DESCRIPTION
Target: trunk
Request: 2.16
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9995/

(cherry picked from commit ead5889a469b232a5f03bf0a075b3169f4350b9b)