### PR TITLE
pool: fix URISyntaxException in ceph backend

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ceph/CephFileStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ceph/CephFileStore.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2016 - 2017 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -261,7 +261,7 @@ public class CephFileStore implements FileStore {
 
     private URI toUri(String imageName) {
         try {
-            return new URI("rbd", poolName, imageName, null, null);
+            return new URI("rbd", poolName, "/" + imageName, null, null);
         } catch (URISyntaxException e) {
             // we sholud neve get here
             throw new RuntimeException("Faled to build URI", e);


### PR DESCRIPTION
Motivation:
ceph backend produces URI which required to have absolute paths

Modification:
add leading slash to produce uri like:

 rbd://dcache-pool-B/00007BB47C23484443DE8A6AC13FDD53D035

Result:
fixed URISyntaxException

Ticket: #9123
Acked-by: Paul Millar
Target: master, 3.0
Require-book: no
Require-notes: yes
(cherry picked from commit 4d4b45d1425e8e2091350b9a2347d6ed0be353a5)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>