### PR TITLE
PoolManager : stage protection add protocol to the list of discrimina…

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -2121,7 +2121,9 @@ public class DCapDoorInterpreterV3 implements KeepAliveListener,
                EnumSet<RequestContainerV5.RequestState> allowedStates;
                try {
                    allowedStates =
-                       _checkStagePermission.canPerformStaging(_subject, _fileAttributes)
+                       _checkStagePermission.canPerformStaging(_subject,
+                                                               _fileAttributes,
+                                                               _protocolInfo)
                        ? RequestContainerV5.allStates
                        : RequestContainerV5.allStatesExceptStage;
                } catch (IOException e) {

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -1155,7 +1155,9 @@ public class RequestContainerV5
                 try {
                     PoolMgrSelectReadPoolMsg msg =
                         (PoolMgrSelectReadPoolMsg) envelope.getMessageObject();
-                    if (_stagePolicyDecisionPoint.canPerformStaging(msg.getSubject(), msg.getFileAttributes())) {
+                    if (_stagePolicyDecisionPoint.canPerformStaging(msg.getSubject(),
+                                                                    msg.getFileAttributes(),
+                                                                    msg.getProtocolInfo())) {
                         return true;
                     }
                 } catch (IOException | PatternSyntaxException e) {

--- a/modules/dcache/src/main/java/diskCacheV111/util/CheckStagePermission.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/CheckStagePermission.java
@@ -18,11 +18,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import diskCacheV111.vehicles.ProtocolInfo;
+
 import org.dcache.auth.FQAN;
 import org.dcache.auth.Subjects;
 import org.dcache.vehicles.FileAttributes;
 
 public class CheckStagePermission {
+    private static final Pattern LINE_PATTERN = Pattern.compile("\"(?<dn>[^\"]*)\"([ \t]+\"(?<fqan>[^\"]*)\"([ \t]+\"(?<su>[^\"]*)\"([ \t]+\"(?<protocol>[^\"]*)\")?)?)?");
     private File _stageConfigFile;
     private long _lastTimeReadingStageConfigFile;
     private List<Pattern[]> _regexList;
@@ -33,7 +36,7 @@ public class CheckStagePermission {
     private final Lock _fileWriteLock = _fileReadWriteLock.writeLock();
 
     public CheckStagePermission(String stageConfigurationFilePath) {
-        if ( stageConfigurationFilePath == null || stageConfigurationFilePath.length() == 0 ) {
+        if ( stageConfigurationFilePath == null || stageConfigurationFilePath.isEmpty()) {
             _isEnabled = false;
             return;
         }
@@ -50,7 +53,9 @@ public class CheckStagePermission {
      * @return true if and only if the subject is allowed to perform
      * staging
      */
-    public boolean canPerformStaging(Subject subject, FileAttributes fileAttributes)
+    public boolean canPerformStaging(Subject subject,
+                                     FileAttributes fileAttributes,
+                                     ProtocolInfo protocolInfo)
         throws PatternSyntaxException, IOException
     {
         if (!_isEnabled || Subjects.isRoot(subject)) {
@@ -73,11 +78,13 @@ public class CheckStagePermission {
                 dn = "";
             }
 
+            String protocol = protocolInfo.getProtocol()+"/"+protocolInfo.getMajorVersion();
+
             if (fqans.isEmpty()) {
-                return canPerformStaging(dn, null, storeUnit);
+                return canPerformStaging(dn, null, storeUnit, protocol);
             } else {
                 for (FQAN fqan: fqans) {
-                    if (canPerformStaging(dn, fqan, storeUnit)) {
+                    if (canPerformStaging(dn, fqan, storeUnit, protocol)) {
                         return true;
                     }
                 }
@@ -99,145 +106,149 @@ public class CheckStagePermission {
      * @throws PatternSyntaxException
      * @throws IOException
      */
-     public boolean canPerformStaging(String dn, FQAN fqan, String storeUnit) throws PatternSyntaxException, IOException {
 
-         if ( !_isEnabled ) {
-             return true;
-         }
+    public boolean canPerformStaging(String dn,
+                                     FQAN fqan,
+                                     String storeUnit,
+                                     String protocol) throws PatternSyntaxException, IOException {
 
-         if ( !_stageConfigFile.exists() ) {
-             //if file does not exist, staging is denied for all users
-             return false;
-         }
-
-         if ( fileNeedsRereading() ) {
-             rereadConfig();
-         }
-
-         return userMatchesPredicates(dn, Objects.toString(fqan, ""), storeUnit);
-     }
-
-     /**
-      * Reread the contents of the configuration file.
-      * @throws IOException
-      * @throws PatternSyntaxException
-      */
-      void rereadConfig() throws PatternSyntaxException, IOException {
-          try {
-              _fileWriteLock.lock();
-              if ( fileNeedsRereading() ) {
-                  try (BufferedReader reader = new BufferedReader(new FileReader(_stageConfigFile))) {
-                      _regexList = readStageConfigFile(reader);
-                      _lastTimeReadingStageConfigFile = System
-                              .currentTimeMillis();
-                  }
-
-              }
-          } finally {
-              _fileWriteLock.unlock();
-          }
-      }
-
-      /**
-       * Check whether the stageConfigFile needs rereading.
-       *
-       * @return true if the file should be reread.
-       */
-       boolean fileNeedsRereading() {
-           long modificationTimeStageConfigFile;
-           modificationTimeStageConfigFile = _stageConfigFile.lastModified();
-
-           return modificationTimeStageConfigFile > _lastTimeReadingStageConfigFile;
-       }
-
-      /**
-       * Check whether the user matches predicates, that is, whether the user is in the
-       * list of authorized users that are allowed to perform staging of the object in the
-       * given storage group.
-       *
-       * @param dn user's Distinguished Name
-       * @param fqanStr user's FQAN as a String
-       * @param storeUnit object's storage unit
-       * @return true if the user and object match predicates
-       */
-       boolean userMatchesPredicates(String dn, String fqanStr, String storeUnit) {
-           try {
-               _fileReadLock.lock();
-               for (Pattern[] regexLine : _regexList) {
-                   if ( regexLine[0].matcher(dn).matches() ) {
-
-                       if ( regexLine[1] == null ) {
-                           return true; // line contains only DN; DN match -> STAGE allowed
-                       } else if ( regexLine[1].matcher(fqanStr).matches() && (regexLine[2] == null || regexLine[2].matcher(storeUnit).matches()) ) {
-                           return true;
-                           //two cases covered here:
-                           //line contains DN and FQAN; DN and FQAN match -> STAGE allowed
-                           //line contains DN, FQAN, storeUnit; DN, FQAN, storeUnit match -> STAGE allowed
-                       }
-                   }
-               }
-           } finally {
-               _fileReadLock.unlock();
-           }
-           return false;
-       }
-
-       /**
-        * Read configuration file and create list of compiled patterns, containing DNs and FQANs(optionally)
-        * of the users that are allowed to perform staging,
-        * as well as storage group of the object to be staged (optionally).
-        *
-        * @param  reader
-        * @return list of compiled patterns
-        * @throws IOException
-        * @throws PatternSyntaxException
-        */
-        List<Pattern[]> readStageConfigFile(BufferedReader reader) throws IOException, PatternSyntaxException {
-
-            String line;
-            Pattern linePattern = Pattern.compile("\"([^\"]*)\"([ \t]+\"([^\"]*)\"([ \t]+\"([^\"]*)\")?)?");
-            Matcher matcherLine;
-
-            List<Pattern[]> regexList = new ArrayList<>();
-
-            while ((line = reader.readLine()) != null) {
-
-                line = line.trim();
-                matcherLine = linePattern.matcher(line);
-                if ( line.startsWith("#") || line.isEmpty() ) { //commented or empty line
-                    continue;
-                }
-
-                if ( !matcherLine.matches() ) {
-                    continue;
-                }
-
-                Pattern[] arrayPattern = new Pattern[3];
-
-                String matchDN = matcherLine.group(1);
-                String matchFQAN = matcherLine.group(3);
-                String matchStoreUnit = matcherLine.group(5);
-
-                if ( matchFQAN != null ) {
-                    if (matchStoreUnit != null) { //line: DN, FQAN, StoreUnit
-                        arrayPattern[0] = Pattern.compile(matchDN);
-                        arrayPattern[1] = Pattern.compile(matchFQAN);
-                        arrayPattern[2] = Pattern.compile(matchStoreUnit);
-                        regexList.add(arrayPattern);
-                    } else { //line: DN, FQAN
-                        arrayPattern[0] = Pattern.compile(matchDN);
-                        arrayPattern[1] = Pattern.compile(matchFQAN);
-                        arrayPattern[2] = null;
-                        regexList.add(arrayPattern);
-                    }
-                } else { //line: DN
-                    arrayPattern[0] = Pattern.compile(matchDN);
-                    arrayPattern[1] = null;
-                    arrayPattern[2] = null;
-                    regexList.add(arrayPattern);
-                }
-            }
-            return regexList;
+        if ( !_isEnabled ) {
+            return true;
         }
 
+        if ( !_stageConfigFile.exists() ) {
+            //if file does not exist, staging is denied for all users
+            return false;
+        }
+
+        if ( fileNeedsRereading() ) {
+            rereadConfig();
+        }
+
+        return userMatchesPredicates(dn,
+                                     Objects.toString(fqan, ""),
+                                     storeUnit,
+                                     protocol);
+    }
+
+    /**
+     * Reread the contents of the configuration file.
+     * @throws IOException
+     * @throws PatternSyntaxException
+     */
+    public void rereadConfig() throws PatternSyntaxException, IOException {
+        _fileWriteLock.lock();
+        try {
+            if ( fileNeedsRereading() ) {
+                try (BufferedReader reader = new BufferedReader(new FileReader(_stageConfigFile))) {
+                        _regexList = readStageConfigFile(reader);
+                        _lastTimeReadingStageConfigFile = System
+                            .currentTimeMillis();
+                    }
+
+            }
+        } finally {
+            _fileWriteLock.unlock();
+        }
+    }
+
+    /**
+     * Check whether the stageConfigFile needs rereading.
+     *
+     * @return true if the file should be reread.
+     */
+    public boolean fileNeedsRereading() {
+        long modificationTimeStageConfigFile;
+        modificationTimeStageConfigFile = _stageConfigFile.lastModified();
+
+        return modificationTimeStageConfigFile > _lastTimeReadingStageConfigFile;
+    }
+
+    /**
+     * Check whether the user matches predicates, that is, whether the user is in the
+     * list of authorized users that are allowed to perform staging of the object in the
+     * given storage group.
+     *
+     * @param dn user's Distinguished Name
+     * @param fqanStr user's FQAN as a String
+     * @param storeUnit object's storage unit
+     * @return true if the user and object match predicates
+     */
+    private boolean userMatchesPredicates(String dn,
+                                          String fqanStr,
+                                          String storeUnit,
+                                          String protocol) {
+        try {
+            _fileReadLock.lock();
+            for (Pattern[] regexLine : _regexList) {
+                if ( regexLine[0].matcher(dn).matches() ) {
+
+                    if ( regexLine[1] == null ) {
+                        return true; // line contains only DN; DN match -> STAGE allowed
+                    } else if ( regexLine[1].matcher(fqanStr).matches() &&
+                                (regexLine[2] == null || regexLine[2].matcher(storeUnit).matches()) &&
+                                (regexLine[3] == null || regexLine[3].matcher(protocol).matches())) {
+                        //three cases covered here:
+                        //line contains DN and FQAN; DN and FQAN match -> STAGE allowed
+                        //line contains DN, FQAN, storeUnit; DN, FQAN, storeUnit match -> STAGE allowed
+                        //line contains DN, FQAN, storeUnit, protocol; all match -> STAGE allowed
+                        return true;
+                    }
+                }
+            }
+        } finally {
+            _fileReadLock.unlock();
+        }
+        return false;
+    }
+
+    /**
+     * Read configuration file and create list of compiled patterns, containing DNs and FQANs(optionally)
+     * of the users that are allowed to perform staging,
+     * as well as storage group of the object to be staged (optionally).
+     *
+     * @param  reader
+     * @return list of compiled patterns
+     * @throws IOException
+     * @throws PatternSyntaxException
+     */
+    List<Pattern[]> readStageConfigFile(BufferedReader reader) throws IOException, PatternSyntaxException {
+
+        String line;
+        Matcher matcherLine;
+
+        List<Pattern[]> regexList = new ArrayList<>();
+
+        while ((line = reader.readLine()) != null) {
+
+            line = line.trim();
+            if ( line.startsWith("#") || line.isEmpty() ) { //commented or empty line
+                continue;
+            }
+
+            matcherLine = LINE_PATTERN.matcher(line);
+            if ( !matcherLine.matches() ) {
+                continue;
+            }
+
+            Pattern[] arrayPattern = new Pattern[4];
+
+            int i = 0;
+            for (String match : new String[] { matcherLine.group("dn"),
+                                               matcherLine.group("fqan"),
+                                               matcherLine.group("su"),
+                                               matcherLine.group("protocol")} ) {
+                if ( match != null ) {
+                    if ( match.startsWith("!") ) {
+                        arrayPattern[i] = Pattern.compile("(?!"+match.substring(1)+").*");
+                    } else {
+                        arrayPattern[i] = Pattern.compile(match);
+                    }
+                }
+                ++i;
+            }
+            regexList.add(arrayPattern);
+        }
+        return regexList;
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
@@ -213,7 +213,9 @@ public class PinRequestProcessor
     {
         try {
             Subject subject = task.getSubject();
-            return _checkStagePermission.canPerformStaging(subject, task.getFileAttributes()) ?
+            return _checkStagePermission.canPerformStaging(subject,
+                                                           task.getFileAttributes(),
+                                                           task.getProtocolInfo()) ?
                 RequestContainerV5.allStates :
                 RequestContainerV5.allStatesExceptStage;
         } catch (PatternSyntaxException | IOException ex) {

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -954,7 +954,9 @@ public class Transfer implements Comparable<Transfer>
         } else {
             EnumSet<RequestContainerV5.RequestState> allowedStates;
             try {
-                allowedStates = _checkStagePermission.canPerformStaging(_subject, fileAttributes)
+                allowedStates = _checkStagePermission.canPerformStaging(_subject,
+                                                                        fileAttributes,
+                                                                        protocolInfo)
                                 ? RequestContainerV5.allStates
                                 : RequestContainerV5.allStatesExceptStage;
             } catch (IOException e) {

--- a/modules/dcache/src/test/java/diskCacheV111/util/CheckStagePermissionTests.java
+++ b/modules/dcache/src/test/java/diskCacheV111/util/CheckStagePermissionTests.java
@@ -10,6 +10,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.regex.PatternSyntaxException;
 
+import diskCacheV111.vehicles.ProtocolInfo;
+
 import org.dcache.auth.FQAN;
 
 import static org.junit.Assert.assertFalse;
@@ -34,6 +36,40 @@ public class CheckStagePermissionTests {
 
     public static final String VALID_STOREUNIT = "sql:chimera@osm";
 
+    /*
+     * definition is taken verbatim from NFS4ProtocolInfo
+     * (NFS4) and major=4 seem to be redundant
+     */
+
+    public static final String TEST_PROTOCOL = ".*";
+
+    public static final ProtocolInfo PROTOCOL_INFO = new ProtocolInfo () {
+            private static final String _protocolName = "NFS4";
+            private static final int _minor = 1;
+            private static final int _major = 4;
+
+            @Override
+            public String getProtocol() {
+                return _protocolName;
+            }
+
+            @Override
+            public int getMinorVersion() {
+                return _minor;
+            }
+
+            @Override
+            public int getMajorVersion() {
+                return _major;
+            }
+
+            @Override
+            public String getVersionString() {
+                return _protocolName + "-" + _major + "." + _minor;
+            }
+        };
+
+
     File _testConfigFile;
     CheckStagePermission _check;
 
@@ -50,20 +86,31 @@ public class CheckStagePermissionTests {
     }
 
     // those 2 tests below were adopted for testing the method canPerformStaging(String dn, String fqan, String StoreUnit)
+
     @Test
     public void testEmptyFilepath() throws PatternSyntaxException, IOException {
         CheckStagePermission check = new CheckStagePermission( "");
         assertTrue( "Empty filepath to config file allows user with DN and FQAN", check.canPerformStaging( VALID_DN,
-                                                                                                           VALID_FQAN, VALID_STOREUNIT));
-        assertTrue( "Empty filepath to config file allows user with DN", check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT));
+                                                                                                           VALID_FQAN,
+                                                                                                           VALID_STOREUNIT,
+                                                                                                           PROTOCOL_INFO.getVersionString()));
+        assertTrue( "Empty filepath to config file allows user with DN", check.canPerformStaging( VALID_DN,
+                                                                                                  null,
+                                                                                                  VALID_STOREUNIT,
+                                                                                                  PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testNullFilepath() throws PatternSyntaxException, IOException {
         CheckStagePermission check = new CheckStagePermission( null);
         assertTrue( "Null filepath to config file allows user with DN and FQAN", check.canPerformStaging( VALID_DN,
-                                                                                                          VALID_FQAN, VALID_STOREUNIT));
-        assertTrue( "Null filepath to config file allows user with DN", check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT));
+                                                                                                          VALID_FQAN,
+                                                                                                          VALID_STOREUNIT,
+                                                                                                          PROTOCOL_INFO.getVersionString()));
+        assertTrue( "Null filepath to config file allows user with DN", check.canPerformStaging( VALID_DN,
+                                                                                                 null,
+                                                                                                 VALID_STOREUNIT,
+                                                                                                 PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
@@ -90,88 +137,125 @@ public class CheckStagePermissionTests {
     @Test
     public void testZeroLengthDNEmptyFile() throws PatternSyntaxException, IOException {
         assertFalse( "user with ZeroLength DN and FQAN can not stage with empty file", _check.canPerformStaging("",
-                                                                                                                VALID_FQAN, VALID_STOREUNIT));
+                                                                                                                VALID_FQAN,
+                                                                                                                VALID_STOREUNIT,
+                                                                                                                PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testZeroLengthDN() throws PatternSyntaxException, IOException {
         authoriseDn( VALID_DN );
-        assertFalse( "user with ZeroLengthDN and FQAN can not stage", _check.canPerformStaging("", VALID_FQAN, VALID_STOREUNIT));
+        assertFalse( "user with ZeroLengthDN and FQAN can not stage", _check.canPerformStaging("",
+                                                                                               VALID_FQAN,
+                                                                                               VALID_STOREUNIT,
+                                                                                               PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testZeroLengthDNAndFqan() throws PatternSyntaxException, IOException {
         authoriseDnFqan( VALID_DN, VALID_FQAN);
-        assertFalse( "user with ZeroLengthDN and FQAN can not stage", _check.canPerformStaging("", VALID_FQAN, VALID_STOREUNIT));
+        assertFalse( "user with ZeroLengthDN and FQAN can not stage", _check.canPerformStaging("",
+                                                                                               VALID_FQAN,
+                                                                                               VALID_STOREUNIT,
+                                                                                               PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testNullFqan() throws PatternSyntaxException, IOException {
         authoriseDn( VALID_DN );
-        assertTrue( "user with DN and FQAN=null staging when DN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT));
+        assertTrue( "user with DN and FQAN=null staging when DN is in file", _check.canPerformStaging(VALID_DN,
+                                                                                                      null,
+                                                                                                      VALID_STOREUNIT,
+                                                                                                      PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testNullFqan2() throws PatternSyntaxException, IOException {
         authoriseDnFqan( VALID_DN, VALID_FQAN);
-        assertFalse( "user with DN and FQAN=null cannot stage when DN and FQAN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT));
+        assertFalse( "user with DN and FQAN=null cannot stage when DN and FQAN is in file", _check.canPerformStaging(VALID_DN,
+                                                                                                                     null,
+                                                                                                                     VALID_STOREUNIT,
+                                                                                                                     PROTOCOL_INFO.getVersionString()));
     }
 
     @Test()
     public void testCanStageWithEmptyFile() throws PatternSyntaxException, IOException {
-        assertFalse( "Empty file allowed user to stage", _check.canPerformStaging( VALID_DN, VALID_FQAN, VALID_STOREUNIT));
+        assertFalse( "Empty file allowed user to stage", _check.canPerformStaging(VALID_DN,
+                                                                                  VALID_FQAN,
+                                                                                  VALID_STOREUNIT,
+                                                                                  PROTOCOL_INFO.getVersionString()));
     }
 
     @Test()
     public void testCanStageWithMissingFile() throws PatternSyntaxException, IOException {
         _testConfigFile.delete();
-        assertFalse( "Missing file allowed user to stage", _check.canPerformStaging( VALID_DN, VALID_FQAN, VALID_STOREUNIT));
+        assertFalse( "Missing file allowed user to stage", _check.canPerformStaging(VALID_DN,
+                                                                                    VALID_FQAN,
+                                                                                    VALID_STOREUNIT,
+                                                                                    PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testUserWithDnAuthorisedWithDnCanStage() throws IOException {
         authoriseDn( VALID_DN );
-        assertTrue( "user with DN staging when DN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT));
+        assertTrue( "user with DN staging when DN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                         null,
+                                                                                         VALID_STOREUNIT,
+                                                                                         PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testUserWithDnFqanAuthorisedWithDnCanStage() throws IOException {
         authoriseDn( VALID_DN );
-        assertTrue( "user with DN and FQAN staging when DN is in file", _check.canPerformStaging( VALID_DN, VALID_FQAN, VALID_STOREUNIT));
+        assertTrue( "user with DN and FQAN staging when DN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                                  VALID_FQAN,
+                                                                                                  VALID_STOREUNIT,
+                                                                                                  PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testUserWithDnAuthorisedWithDnAndFqanCanStage() throws IOException {
         authoriseDnFqan( VALID_DN, VALID_FQAN);
-        assertFalse( "user with DN staging when DN and FQAN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT));
+        assertFalse( "user with DN staging when DN and FQAN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                                   null,
+                                                                                                   VALID_STOREUNIT,
+                                                                                                   PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testUserWithDnAndDifferentFqanAuthorisedWithDnAndFqanCanStage() throws IOException {
         authoriseDnFqan( VALID_DN, VALID_FQAN);
         assertFalse( "user with DN and different FQAN staging when DN and FQAN is in file", _check.canPerformStaging( VALID_DN,
-                                                                                                                      OTHER_VALID_FQAN, VALID_STOREUNIT));
+                                                                                                                      OTHER_VALID_FQAN,
+                                                                                                                      VALID_STOREUNIT,
+                                                                                                                      PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testUserWithDnAndSameFqanAuthorisedWithDnAndFqanCanStage() throws IOException {
         authoriseDnFqan( VALID_DN, VALID_FQAN);
         assertTrue( "user with DN and same FQAN staging when DN and FQAN is in file", _check.canPerformStaging( VALID_DN,
-                                                                                                                VALID_FQAN, VALID_STOREUNIT));
+                                                                                                                VALID_FQAN,
+                                                                                                                VALID_STOREUNIT,
+                                                                                                                PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testWildcardsMatchingDNandFQAN() throws PatternSyntaxException, IOException {
         authoriseDnFqan( TEST_DN, TEST_FQAN);
         assertTrue( "check pattern .* : user with DN and FQAN can stage when DN and FQAN are in file", _check.canPerformStaging( USER_TEST1_DN,
-                                                                                                                                 USER_TEST1_FQAN, VALID_STOREUNIT));
+                                                                                                                                 USER_TEST1_FQAN,
+                                                                                                                                 VALID_STOREUNIT,
+                                                                                                                                 PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testWildecardsNotMatchingDN() throws PatternSyntaxException, IOException {
         authoriseDnFqan( TEST_DN, TEST_FQAN);
         assertFalse( "check pattern .* : user's DN does not match, staging not allowed", _check.canPerformStaging( USER_TEST2_DN,
-                                                                                                                   USER_TEST1_FQAN, VALID_STOREUNIT));
+                                                                                                                   USER_TEST1_FQAN,
+                                                                                                                   VALID_STOREUNIT,
+                                                                                                                   PROTOCOL_INFO.getVersionString()));
     }
 
     // below there are 7 tests for canPerformStaging(String dn, String fqan, String storeUnit),
@@ -180,59 +264,82 @@ public class CheckStagePermissionTests {
     @Test
     public void testStringUserWithDnAuthorisedWithDnCanStage() throws IOException {
         authoriseDn( VALID_DN );
-        assertTrue( "user with DN staging when DN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT ));
+        assertTrue( "user with DN staging when DN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                         null,
+                                                                                         VALID_STOREUNIT,
+                                                                                         PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testStringUserWithDnFqanAuthorisedWithDnCanStage() throws IOException {
         authoriseDn( VALID_DN );
-        assertTrue( "user with DN and FQAN staging when DN is in file", _check.canPerformStaging( VALID_DN, VALID_FQAN, VALID_STOREUNIT));
+        assertTrue( "user with DN and FQAN staging when DN is in file", _check.canPerformStaging(VALID_DN,
+                                                                                                 VALID_FQAN,
+                                                                                                 VALID_STOREUNIT,
+                                                                                                 PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testStringUserWithDnAuthorisedWithDnAndFqanCanStage() throws IOException {
         authoriseDnFqan( VALID_DN, VALID_FQAN);
-        assertFalse( "user with DN staging when DN and FQAN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT));
+        assertFalse( "user with DN staging when DN and FQAN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                                   null,
+                                                                                                   VALID_STOREUNIT,
+                                                                                                   PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testStringUserWithDnAndDifferentFqanAuthorisedWithDnAndFqanCanStage() throws IOException {
         authoriseDnFqan( VALID_DN, VALID_FQAN);
         assertFalse( "user with DN and different FQAN staging when DN and FQAN is in file", _check.canPerformStaging( VALID_DN,
-                                                                                                                      OTHER_VALID_FQAN, VALID_STOREUNIT));
+                                                                                                                      OTHER_VALID_FQAN,
+                                                                                                                      VALID_STOREUNIT,
+                                                                                                                      PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testStringUserWithDnAndSameFqanAuthorisedWithDnAndFqanCanStage() throws IOException {
         authoriseDnFqan( VALID_DN, VALID_FQAN);
         assertTrue( "user with DN and same FQAN staging when DN and FQAN is in file", _check.canPerformStaging( VALID_DN,
-                                                                                                                VALID_FQAN, VALID_STOREUNIT));
+                                                                                                                VALID_FQAN,
+                                                                                                                VALID_STOREUNIT,
+                                                                                                                PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testStringWildcardsMatchingDNandFQAN() throws PatternSyntaxException, IOException {
         authoriseDnFqan( TEST_DN, TEST_FQAN);
         assertTrue( "check pattern .* : user with DN and FQAN can stage when DN and FQAN are in file", _check.canPerformStaging( USER_TEST1_DN,
-                                                                                                                                 USER_TEST1_FQAN, VALID_STOREUNIT));
+                                                                                                                                 USER_TEST1_FQAN,
+                                                                                                                                 VALID_STOREUNIT,
+                                                                                                                                 PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testStringWildecardsNotMatchingDN() throws PatternSyntaxException, IOException {
         authoriseDnFqan( TEST_DN, TEST_FQAN);
         assertFalse( "check pattern .* : user's DN does not match, staging not allowed", _check.canPerformStaging( USER_TEST2_DN,
-                                                                                                                   USER_TEST1_FQAN, VALID_STOREUNIT));
+                                                                                                                   USER_TEST1_FQAN,
+                                                                                                                   VALID_STOREUNIT,
+                                                                                                                   PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testStringNullFqan() throws PatternSyntaxException, IOException {
         authoriseDn( VALID_DN );
-        assertTrue( "user with DN and FQAN=null staging when DN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT ));
+        assertTrue( "user with DN and FQAN=null staging when DN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                                       null,
+                                                                                                       VALID_STOREUNIT,
+                                                                                                       PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testStringNullFqan2() throws PatternSyntaxException, IOException {
         authoriseDnFqan( VALID_DN, VALID_FQAN);
-        assertFalse( "user with DN and FQAN=null cannot stage when DN and FQAN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT ));
+        assertFalse( "user with DN and FQAN=null cannot stage when DN and FQAN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                                                      null,
+                                                                                                                      VALID_STOREUNIT,
+                                                                                                                      PROTOCOL_INFO.getVersionString()));
     }
 
     //new tests for the method canPerformStaging(String dn, String fqan, String storeUnit)
@@ -240,47 +347,73 @@ public class CheckStagePermissionTests {
     @Test
     public void testNullFqanCanStage() throws PatternSyntaxException, IOException {
         authoriseDnFqanStoreunit( VALID_DN, (String) null, null); //config line: "/DC=org/DC=example/CN=test user"
-        assertTrue( "user with DN staging when DN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT ));
+        assertTrue( "user with DN staging when DN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                         null,
+                                                                                         VALID_STOREUNIT,
+                                                                                         PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testDnFqanCanStageWhenDnInConfigfile() throws IOException {
         authoriseDnFqanStoreunit( VALID_DN, (String) null, null); //config line: "/DC=org/DC=example/CN=test user"
-        assertTrue( "user with DN and FQAN staging when DN is in file", _check.canPerformStaging( VALID_DN, VALID_FQAN, VALID_STOREUNIT));
+        assertTrue( "user with DN and FQAN staging when DN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                                  VALID_FQAN,
+                                                                                                  VALID_STOREUNIT,
+                                                                                                  PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testNullFqanCannotStage() throws PatternSyntaxException, IOException {
         authoriseDnFqanStoreunit( VALID_DN, VALID_FQAN, null); //config line: "/DC=org/DC=example/CN=test user" "/atlas/Role=production"
-        assertFalse( "user with DN and FQAN=null cannot stage when DN and FQAN is in file", _check.canPerformStaging( VALID_DN, null, VALID_STOREUNIT));
+        assertFalse( "user with DN and FQAN=null cannot stage when DN and FQAN is in file", _check.canPerformStaging( VALID_DN,
+                                                                                                                      null,
+                                                                                                                      VALID_STOREUNIT,
+                                                                                                                      PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testDnFqanCanStageWhenDnFqanInConfigfile() throws IOException {
         authoriseDnFqanStoreunit( VALID_DN, VALID_FQAN, null); //config line: "/DC=org/DC=example/CN=test user" "/atlas/Role=production"
         assertTrue( "user with DN and FQAN staging when DN and FQAN are in file", _check.canPerformStaging( VALID_DN,
-                                                                                                            VALID_FQAN, VALID_STOREUNIT));
+                                                                                                            VALID_FQAN,
+                                                                                                            VALID_STOREUNIT,
+                                                                                                            PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testDnFqanStoreunitCanStageWhenDnFqanStoreunitInConfigfile() throws IOException {
         authoriseDnFqanStoreunit( VALID_DN, VALID_FQAN, VALID_STOREUNIT); //config line: "/DC=org/DC=example/CN=test user" "/atlas/Role=production" "sql:chimera@osm"
         assertTrue( "user with DN and FQAN staging when DN and FQAN are in file; also storage unit is in file ", _check.canPerformStaging( VALID_DN,
-                                                                                                                                           VALID_FQAN, VALID_STOREUNIT));
+                                                                                                                                           VALID_FQAN,
+                                                                                                                                           VALID_STOREUNIT,
+                                                                                                                                           PROTOCOL_INFO.getVersionString()));
+    }
+
+    @Test
+    public void testDnFqanStoreunitCanStageWhenDnFqanStoreunitAndProtocolInConfigfile() throws IOException {
+        authoriseDnFqanStoreUnitProtocol( VALID_DN, VALID_FQAN, VALID_STOREUNIT, TEST_PROTOCOL);
+        assertTrue( "user with DN and FQAN staging when DN and FQAN are in file; also storage unit and protocol is in file ", _check.canPerformStaging( VALID_DN,
+                                                                                                                                                        VALID_FQAN,
+                                                                                                                                                        VALID_STOREUNIT,
+                                                                                                                                                        PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testDnAndDifferentFqanAuthorisedWithDnAndFqanCanStage() throws IOException {
         authoriseDnFqanStoreunit( VALID_DN, VALID_FQAN, null); //config line: "/DC=org/DC=example/CN=test user" "/atlas/Role=production"
         assertFalse( "user with DN and wrong FQAN cannot stage when DN and FQAN is in file", _check.canPerformStaging( VALID_DN,
-                                                                                                                       OTHER_VALID_FQAN,  VALID_STOREUNIT));
+                                                                                                                       OTHER_VALID_FQAN,
+                                                                                                                       VALID_STOREUNIT,
+                                                                                                                       PROTOCOL_INFO.getVersionString()));
     }
 
     @Test
     public void testDnAndSameFqanAuthorisedWithDnAndFqanCanStage() throws IOException {
         authoriseDnFqanStoreunit( ".*", ".*", ".*"); //config line:  ".*" ".*" ".*"
         assertTrue( "user with DN, FQAN, and StorageGroup specified can stage in case ALL *s in ConfigFile", _check.canPerformStaging( VALID_DN,
-                                                                                                                                       VALID_FQAN, VALID_STOREUNIT ));
+                                                                                                                                       VALID_FQAN,
+                                                                                                                                       VALID_STOREUNIT,
+                                                                                                                                       PROTOCOL_INFO.getVersionString()));
     }
 
     /////////////////////
@@ -305,7 +438,7 @@ public class CheckStagePermissionTests {
 
         if( fqan != null) {
             sb.append("  \"");
-            sb.append( fqan);
+            sb.append( fqan );
             sb.append("\"");
         }
 
@@ -316,6 +449,34 @@ public class CheckStagePermissionTests {
         }
         sb.append("\n");
 
+        saveContents( sb.toString());
+    }
+
+    private void authoriseDnFqanStoreUnitProtocol( String dn, FQAN fqan, String storeUnit, String protocol) throws IOException {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("\"");
+        sb.append(dn);
+        sb.append("\"");
+
+        if( fqan != null) {
+            sb.append("  \"");
+            sb.append( fqan);
+            sb.append("\"");
+        }
+
+        if( storeUnit != null) {
+            sb.append("  \"");
+            sb.append( storeUnit);
+            sb.append("\"");
+        }
+
+        if ( protocol != null ) {
+            sb.append("  \"");
+            sb.append(protocol);
+            sb.append("\"");
+        }
+        sb.append("\n");
         saveContents( sb.toString());
     }
 


### PR DESCRIPTION
…tors

Motivation:

Ability to restrict staging to specific protocol was missing in
stage protection specification. Additionally it was not possible to
specify DN, FQAN, storage group and protocol that are not allowed
to stage.

Modification:

Added protocol to the list of discriminators in stage protection
configuration. Added ability to negate match on DN, FQAN, storage group
or protocol effectively implementing blacklisting.

Result:

Stage protection configuration can be used as a blacklist. Protocol is
added to the list of discriminators.

Target: master
Request: 3.x
Request: 2.16
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/9966/
Acked-by: Paul Millar

Conflicts:
	modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
	modules/dcache/src/main/java/diskCacheV111/util/CheckStagePermission.java
	modules/dcache/src/test/java/diskCacheV111/util/CheckStagePermissionTests.java