### PR TITLE
pom: update jglobus2 to fix RFC proxy support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.jetty>9.2.14.v20151106</version.jetty>
         <version.wicket>6.19.0</version.wicket>
         <version.xrootd4j>2.1.5</version.xrootd4j>
-        <version.jglobus>2.0.6-rc9.d</version.jglobus>
+        <version.jglobus>2.0.6-rc10.d</version.jglobus>
 
         <!-- BouncyCastle seems to change the naming convention of
              their ArtifactId fairly often.  Here is a summary of


### PR DESCRIPTION
Motivation:
RFC proxy failures for some services and some CAs

$ gfal-copy
srm://srm.triumf.ca:8443/srm/managerv2\?SFN=/atlas/atlasscratchdisk/rucio/user/cheinz/6f/81/user.cheinz.00309039.calibration_ALFACalib2p5km_ELAST_v6b.log.9474898.002946.log.tgz
file://tmp/test.$$
gfal-copy error: 70 (Communication error on send) - Could not stat the
source: srm-ifce err: Communication error on send, err: [SE][Ls][]
httpg://srm.triumf.ca:8443/srm/managerv2: CGSI-gSOAP running on
lxplus111.cern.ch reports Error reading token data header: Connection closed

Modification:
Update to jglobus library with fixes recommended by WLCG security experts.

GGUS: https://ggus.eu/index.php?mode=ticket_info&ticket_id=124650
Ticket: #9117
Acked-by:
Target: master
Require-book: no
Require-notes: yes