### PR TITLE
nfs: rework pool selection to get rid of too many retries

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -141,6 +141,12 @@ public class RequestContainerV5
     public static final EnumSet<RequestState> allStatesExceptStage =
         EnumSet.complementOf(EnumSet.of(RequestState.ST_STAGE));
 
+    /**
+     * RC state machine states sufficient to access online files.
+     */
+    public static final EnumSet<RequestState> ONLINE_FILES_ONLY
+            = EnumSet.of(RequestState.ST_INIT, RequestState.ST_DONE);
+
     public RequestContainerV5(long tickerInterval) {
         _ticketInterval = tickerInterval;
     }


### PR DESCRIPTION
Motivation:
To keep client's more responsive, NFS door uses very short timeouts (100ms)
when talks to PnfsManager. As a side effect of that, request, which may
take slightly loner fail with NFSERR_DELAY. This has big impact on the
client as it will re-try the request after some timeout, typically 15s.

A better strategy to handle requests is required, to keep requests to 'online'
files fast, but do not block clients, if file is on tape or p2p is required.

Modification:
Transfer class is updated to request online files only. Pool selection
process in the NFS door split into two phases:

  - restrict initial pool selection to online files only.
    The max timeout is 3s.

  - for offline files (or if p2p is required) a stage-enabled selection
    is performed. Max timeout 7 days to cover broken HSM.

While stage is not complete (possibly with an error), door will return
an appropriate error right away.

Result:
less spontaneous NFSERR_DELAY. Better client/server interaction when file
is off-line.

Acked-by: Albert Rossi
Target: master, 3.0?
Require-book: no
Require-notes: yes
(cherry picked from commit 9324747ef6017a91126fb365bb9cb7c969db2959)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>