### PR TITLE
resilience: fix fairness algorithm bugs in file operation map

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
@@ -90,7 +90,10 @@ import org.dcache.resilience.util.CheckpointUtils;
 import org.dcache.resilience.util.Operation;
 import org.dcache.resilience.util.OperationHistory;
 import org.dcache.resilience.util.OperationStatistics;
+import org.dcache.resilience.util.ForegroundBackgroundAllocator;
+import org.dcache.resilience.util.ForegroundBackgroundAllocator.ForegroundBackgroundAllocation;
 import org.dcache.resilience.util.ResilientFileTask;
+import org.dcache.resilience.util.StandardForegroundBackgroundAllocator;
 import org.dcache.util.RunnableModule;
 import org.dcache.vehicles.FileAttributes;
 
@@ -458,6 +461,14 @@ public class FileOperationMap extends RunnableModule {
      *    task execution.</p>
      */
     class WaitingOperationProcessor {
+        /*
+         *  The algorithm type is hard-coded for now.  We may eventually
+         *  wish to inject this, if there arises a need for custom
+         *  algorithms.
+         */
+        final ForegroundBackgroundAllocator allocator
+                        = new StandardForegroundBackgroundAllocator();
+
         long fgAvailable;
         long bgAvailable;
 
@@ -474,54 +485,14 @@ public class FileOperationMap extends RunnableModule {
             reset();
         }
 
-        /**
-         * <p>The number of waiting operations which can be promoted
-         *    to running is based on the available slots (maximum minus
-         *    the number of operations still running).</p>
-         *
-         * <p>The proportion allotted to foreground vs background is based
-         *    on the proportion of operations in the queues.</p>
-         *
-         * <p>The maximum allocation percentage places both lower and upper
-         *    bounds on the apportioned number of operations per queue.</p>
-         *
-         * <p>If after application of the bound, the proportion rounds to 0,
-         *    but the relevant queue is not empty, one of its waiting tasks
-         *    will be guaranteed to run.</p>
-         */
         private void computeAvailable() {
-            long available = copyThreads - running.size();
-
-            if (available == 0) {
-                fgAvailable = 0;
-                bgAvailable = 0;
-                return;
-            }
-
-            double fgsize = foreground.size();
-            double bgsize = background.size();
-
-            double size = fgsize+bgsize;
-
-            if (size == 0.0) {
-                fgAvailable = 0;
-                bgAvailable = 0;
-                return;
-            }
-
-            double fgweight = Math.min(Math.max(fgsize/size, 100-maxAllocation),
-                                       maxAllocation);
-
-            fgAvailable = Math.round(available * fgweight);
-            bgAvailable = available - fgAvailable;
-
-            if (fgAvailable == 0 && fgsize > 0) {
-                fgAvailable = 1;
-                --bgAvailable;
-            } else if (bgAvailable == 0 && bgsize > 0) {
-                bgAvailable = 1;
-                --fgAvailable;
-            }
+            ForegroundBackgroundAllocation available = allocator.allocate(copyThreads,
+                                                                          running.size(),
+                                                                          foreground.size(),
+                                                                          background.size(),
+                                                                          maxAllocation);
+            fgAvailable = available.getForeground();
+            bgAvailable = available.getBackground();
         }
 
         /**

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/ForegroundBackgroundAllocator.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/ForegroundBackgroundAllocator.java
@@ -1,0 +1,103 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.resilience.util;
+
+/**
+ * <p>Determines the proportions of free slots to allocate to foreground
+ *    and background, respectively.</p>
+ */
+public abstract class ForegroundBackgroundAllocator {
+
+    /**
+     * Simple struct for returning results.
+     */
+    public class ForegroundBackgroundAllocation {
+        private final long foreground;
+        private final long background;
+
+        public ForegroundBackgroundAllocation(long foreground, long background) {
+            this.foreground = foreground;
+            this.background = background;
+        }
+
+        public long getBackground() {
+            return background;
+        }
+
+        public long getForeground() {
+            return foreground;
+        }
+    }
+
+    /**
+     * @param slots  total number of possible queue slots.
+     * @param occupied number of slots currently taken.
+     * @param foreground number of waiting requests on foreground queue.
+     * @param background number of waiting requests on background queue.
+     * @param maxAllocation maximum percentage given to a queue (heuristic).
+     *
+     * @return the actual number of slots given to the two queues.
+     */
+    public abstract ForegroundBackgroundAllocation allocate(long slots,
+                                                            long occupied,
+                                                            long foreground,
+                                                            long background,
+                                                            double maxAllocation);
+}

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/StandardForegroundBackgroundAllocator.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/StandardForegroundBackgroundAllocator.java
@@ -1,0 +1,166 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.resilience.util;
+
+/**
+ * <p>The proportion allotted to foreground vs background is based
+ *    on the proportion of operations in the queues.</p>
+ *
+ * <p>The maximum allocation percentage places both lower and upper
+ *    bounds on the apportioned number of slots per queue.</p>
+ *
+ * <p>Weighting is done following these rules:
+ *    <ol>
+ *        <li>Compute the foreground proportion, and take the minimum
+ *            between that and the maximum allowed.</li>
+ *        <li>Round the value of the weighted available slots, and
+ *            take the minimum between that and the actual foreground
+ *            queue size.</li>
+ *        <li>Give the minimum between the remaining slots and the
+ *            size of the background queue to background.</li>
+ *        <li>If there are still slots available after this, give
+ *            them to the foreground.</li>
+ *        <li>If either background or foreground proportions compute
+ *            to 0 using this method, elect one of the waiting tasks
+ *            to run from the other quota.  This may still result
+ *            in 0 tasks being given to background, if there is only
+ *            1 slot available.</li>
+ *    </ol>
+ * </p>
+ */
+public class StandardForegroundBackgroundAllocator extends
+                ForegroundBackgroundAllocator {
+
+    @Override
+    public ForegroundBackgroundAllocation allocate(long slots,
+                                                   long occupied,
+                                                   long foreground,
+                                                   long background,
+                                                   double maxAllocation) {
+        long available = slots - occupied;
+
+        /*
+         * No open slots.
+         */
+        if (available == 0) {
+            return new ForegroundBackgroundAllocation(0L, 0L);
+        }
+
+        /*
+         * In the case of a single slot available, give it to the foreground.
+         */
+        if (available == 1) {
+            return new ForegroundBackgroundAllocation(1L, 0L);
+        }
+
+        /*
+         * One of the queues is empty; allocate all slots to the other.
+         */
+        if (foreground == 0) {
+            return new ForegroundBackgroundAllocation(0L, Math.min(available, background));
+        } else if (background == 0) {
+            return new ForegroundBackgroundAllocation(Math.min(available, foreground), 0L);
+        }
+
+        double fgsize = foreground;
+        double bgsize = background;
+
+        /*
+         *  Either the proportion of foreground requests to total queued,
+         *  or the max allocation weight, whichever is less.  The proportion
+         *  is given a lower bound equal to the complement of the maximum.
+         */
+        double fgweight  = Math.min(Math.max(fgsize/(fgsize+bgsize),
+                                             1.0-maxAllocation),
+                                    maxAllocation);
+
+        /*
+         *  The weighted quota, or the size of the foreground queue, if the
+         *  latter is less than the allocated size.
+         */
+        long fgAvailable = Math.min(Math.round(available * fgweight), foreground);
+
+        /*
+         *  The remainder of the available slots, or the size of the background
+         *  queue, if the latter is less than the allocated size.
+         */
+        long bgAvailable = Math.min(available - fgAvailable, background);
+
+        /*
+         *  In case of under-allocation (fewer background requests than
+         *  its allocation), make sure foreground queue gets the remainder.
+         */
+        fgAvailable = Math.min(available - bgAvailable, foreground);
+
+        /*
+         * If the rounding produced a 0 value for available here, the queues
+         * are nevertheless > 0, so allocate at least one request to that queue.
+         */
+        if (fgAvailable == 0) {
+            fgAvailable = 1;
+            --bgAvailable;
+        } else if (bgAvailable == 0) {
+            bgAvailable = 1;
+            --fgAvailable;
+        }
+
+        return new ForegroundBackgroundAllocation(fgAvailable, bgAvailable);
+    }
+}

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/util/QueueAllocatorTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/util/QueueAllocatorTest.java
@@ -1,0 +1,168 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.resilience.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import diskCacheV111.util.CacheException;
+import org.dcache.resilience.util.ForegroundBackgroundAllocator.ForegroundBackgroundAllocation;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueueAllocatorTest {
+    private static final String FORMAT =
+                    "total threads %s, running %s, foreground queue %s, "
+                                    + "background queue %s, max %s: incorrect %s result";
+
+    private static final long[][] EDGE_CASES = {
+                    { 200, 200000, 200000, 0, 0 },
+                    { 0, 0, 0, 0, 0 },
+                    { 0, 200000, 0, 200, 0 },
+                    { 0, 0, 200000, 0, 200 },
+                    { 0, 200000, 1, 199, 1 },
+                    { 0, 1, 200000, 1, 199 },
+                    { 199, 200000, 1, 1, 0 },
+                    { 199, 1, 200000, 1, 0 },
+                    { 198, 1, 200000, 1, 1 },
+                    { 198, 200000, 1, 1, 1 },
+                    { 100, 200000, 1, 99, 1 },
+                    { 100, 1, 200000, 1, 99 },
+                    { 2, 200000, 1, 197, 1 },
+                    { 2, 1, 200000, 1, 197 },
+                    { 1, 200000, 1, 198, 1 },
+                    { 1, 1, 200000, 1, 198 },
+                    { 0, 200000, 200000, 100, 100 },
+                    { 199, 200000, 200000, 1, 0 },
+                    { 198, 200000, 200000, 1, 1 },
+                    { 100, 200000, 200000, 50, 50 },
+                    { 2, 200000, 200000, 99, 99 },
+                    { 1, 200000, 200000, 100, 99 },
+                    };
+
+    private static final long NUM_THREADS = 200L;
+
+    ForegroundBackgroundAllocator allocator;
+
+    @Before
+    public void setUp() throws CacheException {
+        allocator = new StandardForegroundBackgroundAllocator();
+    }
+
+    @Test
+    public void testEdgeCasesWithMax50Percent() {
+        testEdgeCases(0.5);
+    }
+
+    @Test
+    public void testEdgeCasesWithMax80Percent() {
+        testEdgeCases(0.8);
+    }
+
+    @Test
+    public void testProportionGreaterThanMaxForBg() {
+        testCase(100, 100, 500, 0.8, 20, 80);
+    }
+
+    @Test
+    public void testProportionGreaterThanMaxForFg() {
+        testCase(100, 500, 100, 0.8, 80, 20);
+    }
+
+    @Test
+    public void testProportionLessThanMaxForBg() {
+        testCase(100, 100, 500, 0.9, 17, 83);
+    }
+
+    @Test
+    public void testProportionLessThanMaxForFg() {
+        testCase(100, 500, 100, 0.9, 83, 17);
+    }
+
+    private void testCase(long running,
+                          long foreground,
+                          long background,
+                          double maxAllocation,
+                          long correctFgResult,
+                          long correctBgResult) {
+        ForegroundBackgroundAllocation allocation = allocator.allocate(
+                        NUM_THREADS, running, foreground, background,
+                        maxAllocation);
+
+        assertEquals(String.format(FORMAT, NUM_THREADS, running, foreground,
+                                   background, maxAllocation, "foreground"),
+                     correctFgResult, allocation.getForeground());
+
+        assertEquals(String.format(FORMAT, NUM_THREADS, running, foreground,
+                                   background, maxAllocation, "background"),
+                     correctBgResult, allocation.getBackground());
+    }
+
+    private void testEdgeCases(double maxAllocation) {
+        for (int i = 0; i < EDGE_CASES.length; ++i) {
+            testCase(EDGE_CASES[i][0],
+                     EDGE_CASES[i][1],
+                     EDGE_CASES[i][2],
+                     maxAllocation,
+                     EDGE_CASES[i][3],
+                     EDGE_CASES[i][4]);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

In order to provide some fairness in handling requests for file copy
or removal, the resilience file operation map uses an algorithm which
allocates free slots to queued requests on the basis of three factors:

    whether foreground vs background (i.e., new files vs files from a location scan);
    what the total proportion of those two types to the total waiting requests is;
    what the maximum allocation percentage is (this is configurable).

The algorithm attempts to promote requests to running on the basis of
the backlog (more requests for the queue with the greater backlog),
up to a maximum (so that starvation is avoided).

There are several bugs in the current code, however.  Aside from
a (silly) arithmetic error (interpreting max allocation weight on
a scale of 0 < p < 100 instead of 0 < p < 1), a number of different
edge cases were not being handled properly.

Modification:

Add the necessary adjustments and restructure somewhat the main method.
I decided to factor out this code into a separate class, though I
did not expose its selection through Spring injection.  The refactoring
is only in case we should discover the need to allow for customizing
the algorithm in the future.  The code changes should remain
invisible to the user.

The allocation algorithm was in need of a minimal unit test, which
has been provided.

Result:

Correct algorithm behavior.

Target: master
Request: 3.0
Request: 2.16
Acked-by: Tigran