### PR TITLE
dcache: update dcache-view version to 1.0.4

### DIFF
--- a/packages/fhs/src/main/assembly/fhs.xml
+++ b/packages/fhs/src/main/assembly/fhs.xml
@@ -36,7 +36,7 @@
             <includes>
                 <include>org.dcache:dcache-view:jar:*</include>
             </includes>
-            <outputDirectory>usr/share/dcache</outputDirectory>
+            <outputDirectory>usr/share/dcache/dcache-view</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>
             <unpack>true</unpack>

--- a/packages/system-test/src/main/assembly/assembly.xml
+++ b/packages/system-test/src/main/assembly/assembly.xml
@@ -46,7 +46,7 @@
             <includes>
                 <include>org.dcache:dcache-view:jar:*</include>
             </includes>
-            <outputDirectory>share</outputDirectory>
+            <outputDirectory>share/dcache-view</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>
             <unpack>true</unpack>

--- a/packages/tar/src/main/assembly/tar.xml
+++ b/packages/tar/src/main/assembly/tar.xml
@@ -36,7 +36,7 @@
             <includes>
                 <include>org.dcache:dcache-view:jar:*</include>
             </includes>
-            <outputDirectory>share</outputDirectory>
+            <outputDirectory>share/dcache-view</outputDirectory>
             <fileMode>644</fileMode>
             <directoryMode>755</directoryMode>
             <unpack>true</unpack>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.3.0</version.wicket>
         <version.xrootd4j>3.1.1</version.xrootd4j>
         <version.jersey>2.22.2</version.jersey>
-        <version.dcache-view>1.0.3</version.dcache-view>
+        <version.dcache-view>1.0.4</version.dcache-view>
         <version.dcache>${project.version}</version.dcache>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
1. Changelog from v1.0.3 to v1.0.4

a16f1f91cf93372fd91f208d47d65eed1ffea7a7 [maven-release-plugin] prepare release v1.0.4
ec9a17c6dc468e0146b101448a63f520fc1cef78 Merge pull request #8 from femiadeyemi/github/1.0/rb10009/control/third-parties/dependencies
3e95d4c7560bff9d183b60b327d48119e929e9b8 dcache-view: control third party dependencies
26676d90133f8ba2d620f6d2e1e49afcf3b245bf Merge pull request #5 from femiadeyemi/github/1.0/rb10004/release/and/deployment
176863db0d972b8b18b2e9fe87f928b8a0830a5d dcache-view: make release more standardise
2cb4fb1bcf415b12b2ff92c499abcaf3d046a4b8 Merge branch '1.0' of https://github.com/dCache/dcache-view into 1.0
8f95856712af3e111183269a12dba12368080717 prepare release 1.0.4
d6df7389ca9038db94ce0b41e75484a075076027 prepare release 1.0.4

2. Since dcache-view release have been standardise (see https://rb.dcache.org/r/10004/ ),
the output of all the packages have been adjusted to reflect the new release.

Target: master
Request: 2.16, 3.0
Require-book: no
Require-notes: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10005/

(cherry picked from commit 0b6d777e45ede71e7d05424deeb462948e17bc85)