### PR TITLE
srmclient: consolidate credential expiry, don't use RuntimeException

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMAbortFilesClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMAbortFilesClientV2.java
@@ -24,6 +24,8 @@ import org.dcache.srm.v2_2.SrmAbortFilesResponse;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TSURLReturnStatus;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMAbortFilesClientV2 extends SRMClient {
     private ISRM isrm;
     private X509Credential credential;
@@ -49,9 +51,7 @@ public class SRMAbortFilesClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception{
-        if (credential.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(credential);
         StringBuilder sb = new StringBuilder();
         boolean failed=false;
         if (configuration.getArrayOfRequestTokens()!=null) {

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMAbortRequestClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMAbortRequestClientV2.java
@@ -22,6 +22,8 @@ import org.dcache.srm.v2_2.SrmAbortRequestRequest;
 import org.dcache.srm.v2_2.SrmAbortRequestResponse;
 import org.dcache.srm.v2_2.TReturnStatus;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 
 public class SRMAbortRequestClientV2 extends SRMClient {
     private ISRM isrm;
@@ -51,9 +53,7 @@ public class SRMAbortRequestClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception{
-        if (credential.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(credential);
         for (String requestToken : configuration.getArrayOfRequestTokens()) {
             try {
                 SrmAbortRequestRequest request = new SrmAbortRequestRequest();

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCheckPermissionClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCheckPermissionClientV2.java
@@ -88,6 +88,8 @@ import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TSURLPermissionReturn;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMCheckPermissionClientV2 extends SRMClient {
     private X509Credential cred;
     private java.net.URI[] surls;
@@ -125,9 +127,7 @@ public class SRMCheckPermissionClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         ArrayOfAnyURI surlarray=new ArrayOfAnyURI();
         URI[] uriarray=new URI[surl_string.length];
         URI uri;

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
@@ -136,6 +136,8 @@ import org.dcache.srm.v2_2.TRetentionPolicyInfo;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 
 public class SRMCopyClientV2 extends SRMClient implements Runnable {
     private java.net.URI from[];
@@ -184,9 +186,7 @@ public class SRMCopyClientV2 extends SRMClient implements Runnable {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         try {
             //
             // form the request

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMExtendFileLifeTimeClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMExtendFileLifeTimeClientV2.java
@@ -90,6 +90,8 @@ import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TSURLLifetimeReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMExtendFileLifeTimeClientV2 extends SRMClient {
     private X509Credential cred;
     private java.net.URI surls[];
@@ -130,9 +132,7 @@ public class SRMExtendFileLifeTimeClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         ArrayOfAnyURI surlarray=new ArrayOfAnyURI();
         URI uriarray[] = new URI[surls.length];
         URI uri;

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetPermissionClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetPermissionClientV2.java
@@ -100,6 +100,8 @@ import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 import org.dcache.srm.v2_2.TUserPermission;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMGetPermissionClientV2 extends SRMClient {
     private X509Credential cred;
     private java.net.URI[] surls;
@@ -135,9 +137,7 @@ public class SRMGetPermissionClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         ArrayOfAnyURI surlarray=new ArrayOfAnyURI();
         URI[] uriarray=new URI[surl_string.length];
         URI uri;

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetRequestSummaryClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetRequestSummaryClientV2.java
@@ -26,6 +26,8 @@ import org.dcache.srm.v2_2.TRequestSummary;
 import org.dcache.srm.v2_2.TRequestType;
 import org.dcache.srm.v2_2.TReturnStatus;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMGetRequestSummaryClientV2 extends SRMClient  {
 
     private java.net.URI srmURL;
@@ -61,9 +63,7 @@ public class SRMGetRequestSummaryClientV2 extends SRMClient  {
 
     @Override
     public void start() throws Exception {
-        if (credential.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(credential);
         try {
             String[] tokens = configuration.getArrayOfRequestTokens();
             SrmGetRequestSummaryRequest request = new SrmGetRequestSummaryRequest();

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetRequestTokensClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetRequestTokensClientV2.java
@@ -26,6 +26,8 @@ import org.dcache.srm.v2_2.SrmGetRequestTokensResponse;
 import org.dcache.srm.v2_2.TRequestTokenReturn;
 import org.dcache.srm.v2_2.TReturnStatus;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMGetRequestTokensClientV2 extends SRMClient  {
     private URI srmURL;
     private X509Credential credential;
@@ -59,9 +61,7 @@ public class SRMGetRequestTokensClientV2 extends SRMClient  {
 
     @Override
     public void start() throws Exception {
-        if (credential.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(credential);
         try {
             SrmGetRequestTokensRequest request = new SrmGetRequestTokensRequest();
             request.setUserRequestDescription(configuration.getUserRequestDescription());

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetSpaceMetaDataClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetSpaceMetaDataClientV2.java
@@ -98,6 +98,8 @@ import org.dcache.srm.v2_2.TRetentionPolicyInfo;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMGetSpaceMetaDataClientV2 extends SRMClient  {
     private java.net.URI srmURL;
     private X509Credential credential;
@@ -133,9 +135,7 @@ public class SRMGetSpaceMetaDataClientV2 extends SRMClient  {
 
     @Override
     public void start() throws Exception {
-        if (credential.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(credential);
         try {
             String[] tokens = configuration.getSpaceTokensList();
             SrmGetSpaceMetaDataRequest request = new SrmGetSpaceMetaDataRequest();

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetSpaceTokensClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetSpaceTokensClientV2.java
@@ -94,6 +94,8 @@ import org.dcache.srm.v2_2.SrmGetSpaceTokensRequest;
 import org.dcache.srm.v2_2.SrmGetSpaceTokensResponse;
 import org.dcache.srm.v2_2.TReturnStatus;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMGetSpaceTokensClientV2 extends SRMClient  {
     private java.net.URI srmURL;
     private X509Credential credential;
@@ -129,9 +131,7 @@ public class SRMGetSpaceTokensClientV2 extends SRMClient  {
 
     @Override
     public void start() throws Exception {
-        if (credential.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(credential);
         try {
             String tokenDescription = configuration.getSpaceTokenDescription();
             SrmGetSpaceTokensRequest request = new SrmGetSpaceTokensRequest();

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMLsClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMLsClientV2.java
@@ -104,6 +104,8 @@ import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 import org.dcache.srm.v2_2.TUserPermission;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 
 public class SRMLsClientV2 extends SRMClient implements Runnable {
     private X509Credential cred;
@@ -145,9 +147,7 @@ public class SRMLsClientV2 extends SRMClient implements Runnable {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         try {
             SrmLsRequest req = new SrmLsRequest();
             req.setAllLevelRecursive(Boolean.FALSE);

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMMkDirClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMMkDirClientV2.java
@@ -93,6 +93,8 @@ import org.dcache.srm.v2_2.SrmMkdirResponse;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMMkDirClientV2 extends SRMClient {
     private X509Credential cred;
     private java.net.URI surl;
@@ -129,9 +131,7 @@ public class SRMMkDirClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         SrmMkdirRequest req = new SrmMkdirRequest();
         req.setSURL(new URI(surl_string));
         SrmMkdirResponse resp = isrm.srmMkdir(req);

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMMvClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMMvClientV2.java
@@ -93,6 +93,8 @@ import org.dcache.srm.v2_2.SrmMvResponse;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMMvClientV2 extends SRMClient {
     private X509Credential cred;
     private java.net.URI[] surls;
@@ -129,9 +131,7 @@ public class SRMMvClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         SrmMvRequest req = new SrmMvRequest();
         req.setFromSURL(new URI(surl_strings[0]));
         req.setToSURL(new URI(surl_strings[1]));

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReleaseFilesClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReleaseFilesClientV2.java
@@ -24,6 +24,8 @@ import org.dcache.srm.v2_2.SrmReleaseFilesResponse;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TSURLReturnStatus;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMReleaseFilesClientV2 extends SRMClient {
     private ISRM isrm;
     private X509Credential credential;
@@ -49,9 +51,7 @@ public class SRMReleaseFilesClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception{
-        if (credential.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(credential);
         StringBuilder sb = new StringBuilder();
         boolean failed=false;
         if (configuration.getArrayOfRequestTokens()!=null) {

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReleaseSpaceClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReleaseSpaceClientV2.java
@@ -94,6 +94,8 @@ import org.dcache.srm.v2_2.SrmReleaseSpaceRequest;
 import org.dcache.srm.v2_2.SrmReleaseSpaceResponse;
 import org.dcache.srm.v2_2.TReturnStatus;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMReleaseSpaceClientV2 extends SRMClient  {
     private java.net.URI srmURL;
     SrmReleaseSpaceRequest request = new SrmReleaseSpaceRequest();
@@ -130,9 +132,7 @@ public class SRMReleaseSpaceClientV2 extends SRMClient  {
 
     @Override
     public void start() throws Exception {
-        if (credential.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(credential);
         try {
             request.setSpaceToken(configuration.getSpaceToken());
             request.setForceFileRelease(configuration.getForceFileRelease());

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReserveSpaceClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReserveSpaceClientV2.java
@@ -109,6 +109,8 @@ import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 import org.dcache.srm.v2_2.TTransferParameters;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 
 public class SRMReserveSpaceClientV2 extends SRMClient implements Runnable {
     private java.net.URI srmURL;
@@ -147,9 +149,7 @@ public class SRMReserveSpaceClientV2 extends SRMClient implements Runnable {
 
     @Override
     public void start() throws Exception {
-        if (credential.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(credential);
         try {
             TRetentionPolicy rp = configuration.getRetentionPolicy() != null ?
                 RetentionPolicy.fromString(configuration.getRetentionPolicy()).toTRetentionPolicy() : null;

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMRmClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMRmClientV2.java
@@ -95,6 +95,8 @@ import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TSURLReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMRmClientV2 extends SRMClient {
     private X509Credential cred;
     private java.net.URI surls[];
@@ -132,9 +134,7 @@ public class SRMRmClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         SrmRmRequest req = new SrmRmRequest();
         URI[] uris = new URI[surls.length];
         for(int i =0; i<surls.length; ++i) {

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMRmdirClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMRmdirClientV2.java
@@ -93,6 +93,8 @@ import org.dcache.srm.v2_2.SrmRmdirResponse;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMRmdirClientV2 extends SRMClient {
     private X509Credential cred;
     private java.net.URI surl;
@@ -129,9 +131,7 @@ public class SRMRmdirClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         SrmRmdirRequest req = new SrmRmdirRequest();
         if (configuration.isRecursive()) {
             req.setRecursive(Boolean.TRUE);

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMSetPermissionClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMSetPermissionClientV2.java
@@ -97,6 +97,8 @@ import org.dcache.srm.v2_2.TPermissionType;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
 
+import static org.dcache.srm.util.Credentials.checkValid;
+
 public class SRMSetPermissionClientV2 extends SRMClient {
     //
     // SRM v2.2 WSDL srmSetPermission requires non-nullable groupid string
@@ -141,9 +143,7 @@ public class SRMSetPermissionClientV2 extends SRMClient {
 
     @Override
     public void start() throws Exception {
-        if (cred.getCertificate().getNotAfter().before(new Date())) {
-            throw new RuntimeException("credentials have expired");
-        }
+        checkValid(cred);
         URI uri = new URI(surl_string);
         SrmSetPermissionRequest req = new SrmSetPermissionRequest();
         req.setSURL(uri);

--- a/modules/srm-common/src/main/java/org/dcache/srm/util/Credentials.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/util/Credentials.java
@@ -1,0 +1,34 @@
+package org.dcache.srm.util;
+
+import eu.emi.security.authn.x509.X509Credential;
+
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+/**
+ * Utility class with static methods to handle X.509 Credentials.
+ */
+public class Credentials
+{
+    private Credentials()
+    {
+        // prevent instantiation.
+    }
+
+    public static X509Credential checkValid(X509Credential credential) throws IOException
+    {
+        Date now = new Date();
+        X509Certificate certificate = credential.getCertificate();
+
+        if (certificate.getNotAfter().before(now)) {
+            throw new IOException("X.509 credentials have expired");
+        }
+
+        if (certificate.getNotBefore().after(now)) {
+            throw new IOException("X.509 credential not yet valid");
+        }
+
+        return credential;
+    }
+}


### PR DESCRIPTION
Motivation:

A RuntimeException indicates a bug, which isn't appropriate for a credential
expiring.

Modification:

Refactor credential checking to make code more DRY.  Use IOException
instead.

The SRMClientV1 SRM operation methods are somewhat restructured for
better error handling

Result:

More maintainable code, better support for reporting bugs.

Target: master
Request: 3.0
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/9977/
Acked-by: Tigran Mkrtchyan