### PR TITLE
gplazma-ldap: fix default properties for root and home

### DIFF
--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -297,8 +297,8 @@ gplazma.ldap.userfilter = (uid=%s)
 # In both variables %homeDirectory% will be replaced by the user's home
 # directory as it is stored on the LDAP server.
 #
-gplazma.ldap.home-dir = "%homeDirectory%"
-gplazma.ldap.root-dir = "/"
+gplazma.ldap.home-dir = %homeDirectory%
+gplazma.ldap.root-dir = /
 
 
 # ---- BanFile plugin


### PR DESCRIPTION
Motivation:

25 Jan 2017 18:39:13 (gPlazma) [WebDAV-dcache-door-atlas19-ops Login]
Login operation failed
java.lang.IllegalArgumentException: null
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:108) ~[guava-19.0.jar:na]
        at diskCacheV111.util.FsPath.create(FsPath.java:45) ~[dcache-common-3.0.4.jar:3.0.4]
        at org.dcache.auth.Gplazma2LoginStrategy.lambda$convertLoginReply$2(Gplazma2LoginStrategy.java:134) ~[dcache-gplazma-3.0.4.jar:3.0.4]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[na:1.8.0_121]
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175) ~[na:1.8.0_121]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[na:1.8.0_121]
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175) ~[na:1.8.0_121]
        ...

Modification:
fix root and home properties.

Result:
fixes exception

Acked-by: Paul Millar
Target: master, 3.0, 2.16
Require-book: no
Require-notes: yes
(cherry picked from commit de3802e90718fcf27cc57383c05bb9ae315e2340)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>