### PR TITLE
srm: fix recovery procedure in internal copy if source is deleted

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java
@@ -383,6 +383,7 @@ public class CopyManager extends AbstractCellComponent
             // _target.setBillingStub();
 
             boolean success = false;
+            boolean targetCreated = false;
             _activeTransfers.put(_target.getId(), this);
             _activeTransfers.put(_source.getId(), this);
 
@@ -390,6 +391,7 @@ public class CopyManager extends AbstractCellComponent
             try {
                 _source.readNameSpaceEntry(false);
                 _target.createNameSpaceEntry();
+                targetCreated = true;
 
                 _target.setProtocolInfo(createTargetProtocolInfo(_target));
                 _target.setLength(_source.getLength());
@@ -419,8 +421,11 @@ public class CopyManager extends AbstractCellComponent
                 if (!success) {
                     String status = _source.getStatus();
                     _source.killMover(0);
-                    _target.killMover(1000);
-                    _target.deleteNameSpaceEntry();
+                    if (targetCreated) {
+                        _target.killMover(1000);
+                        // It is only valid to delete after createNameSpaceEntry returned successfully.
+                        _target.deleteNameSpaceEntry();
+                    }
                     _source.setStatus(status);
                 } else {
                     _source.setStatus("Success");


### PR DESCRIPTION
Motivation:

The code intended to recover from the source file being removed before
the an internal copy starts is buggy.  Under such circumstances, a
stack-trace is logged.

Modification:

Only attempt to remove the target file if it was created.

Result:

Such activity no longer triggers a stack-trace.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Closes #3012
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10022
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java