### PR TITLE
cells: Schedule watcher notifications on cell event thread

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/zookeeper/CellCuratorFramework.java
+++ b/modules/cells/src/main/java/dmg/cells/zookeeper/CellCuratorFramework.java
@@ -17,6 +17,9 @@
  */
 package dmg.cells.zookeeper;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import org.apache.curator.CuratorZookeeperClient;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.ACLBackgroundPathAndBytesable;
@@ -64,10 +67,13 @@ import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.listen.Listenable;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.EnsurePath;
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
@@ -86,8 +92,45 @@ import org.dcache.util.SequentialExecutor;
  */
 public class CellCuratorFramework implements CuratorFramework
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CellCuratorFramework.class);
+
     private final CuratorFramework inner;
     private final BoundedExecutor executor;
+
+    private final LoadingCache<Watcher, Watcher> watchers =
+            CacheBuilder.newBuilder().build(new CacheLoader<Watcher, Watcher>()
+            {
+                @Override
+                public Watcher load(Watcher watcher) throws Exception
+                {
+                    CDC cdc = new CDC();
+                    return event -> executor.execute(() -> {
+                        try (CDC ignore = cdc.restore()) {
+                            watcher.process(event);
+                        }
+                    });
+                }
+            });
+
+    private final LoadingCache<CuratorWatcher, CuratorWatcher> curatorWatchers =
+            CacheBuilder.newBuilder().build(new CacheLoader<CuratorWatcher, CuratorWatcher>()
+            {
+                @Override
+                public CuratorWatcher load(CuratorWatcher watcher) throws Exception
+                {
+                    CDC cdc = new CDC();
+                    return event -> executor.execute(() -> {
+                        try (CDC ignore = cdc.restore()) {
+                            try {
+                                watcher.process(event);
+                            } catch (Exception e) {
+                                ThreadUtils.checkInterrupted(e);
+                                LOGGER.error("Watcher exception", e);
+                            }
+                        }
+                    });
+                }
+            });
 
     public CellCuratorFramework(CuratorFramework inner, Executor executor)
     {
@@ -99,7 +142,7 @@ public class CellCuratorFramework implements CuratorFramework
                 try {
                     super.execute(task);
                 } catch (RejectedExecutionException e) {
-                    /* There is no way to unregister watchers from ZooKeeper. Thus
+                    /* There is no way to unregister curatorWatchers from ZooKeeper. Thus
                      * it is possible for ZooKeeper to try to call a watcher after a
                      * cell shut down, resulting in a RejectedExecutionException.
                      */
@@ -119,6 +162,16 @@ public class CellCuratorFramework implements CuratorFramework
                 callback.processResult(client, event);
             }
         };
+    }
+
+    protected Watcher wrap(Watcher watcher)
+    {
+        return watchers.getUnchecked(watcher);
+    }
+
+    protected CuratorWatcher wrap(CuratorWatcher watcher)
+    {
+        return curatorWatchers.getUnchecked(watcher);
     }
 
     @Override
@@ -272,7 +325,10 @@ public class CellCuratorFramework implements CuratorFramework
     @Override
     public void clearWatcherReferences(Watcher watcher)
     {
-        inner.clearWatcherReferences(watcher);
+        Watcher wrapped = watchers.getIfPresent(watcher);
+        if (wrapped != null) {
+            inner.clearWatcherReferences(wrapped);
+        }
     }
 
     @Override
@@ -548,13 +604,13 @@ public class CellCuratorFramework implements CuratorFramework
         @Override
         public BackgroundPathable<Stat> usingWatcher(Watcher watcher)
         {
-            return new BackgroundPathableDecorator<>(inner.usingWatcher(watcher));
+            return new BackgroundPathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
 
         @Override
         public BackgroundPathable<Stat> usingWatcher(CuratorWatcher watcher)
         {
-            return new BackgroundPathableDecorator<>(inner.usingWatcher(watcher));
+            return new BackgroundPathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
     }
 
@@ -644,13 +700,13 @@ public class CellCuratorFramework implements CuratorFramework
         @Override
         public BackgroundPathable<byte[]> usingWatcher(Watcher watcher)
         {
-            return new BackgroundPathableDecorator<>(inner.usingWatcher(watcher));
+            return new BackgroundPathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
 
         @Override
         public BackgroundPathable<byte[]> usingWatcher(CuratorWatcher watcher)
         {
-            return new BackgroundPathableDecorator<>(inner.usingWatcher(watcher));
+            return new BackgroundPathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
     }
 
@@ -790,13 +846,13 @@ public class CellCuratorFramework implements CuratorFramework
         @Override
         public BackgroundPathable<List<String>> usingWatcher(Watcher watcher)
         {
-            return new BackgroundPathableDecorator<>(inner.usingWatcher(watcher));
+            return new BackgroundPathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
 
         @Override
         public BackgroundPathable<List<String>> usingWatcher(CuratorWatcher watcher)
         {
-            return new BackgroundPathableDecorator<>(inner.usingWatcher(watcher));
+            return new BackgroundPathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
     }
 
@@ -1927,17 +1983,17 @@ public class CellCuratorFramework implements CuratorFramework
         @Override
         public BackgroundPathable<byte[]> usingWatcher(Watcher watcher)
         {
-            return new BackgroundPathableDecorator<>(inner.usingWatcher(watcher));
+            return new BackgroundPathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
 
         @Override
         public BackgroundPathable<byte[]> usingWatcher(CuratorWatcher watcher)
         {
-            return new BackgroundPathableDecorator<>(inner.usingWatcher(watcher));
+            return new BackgroundPathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
     }
 
-    private static class WatchPathableDecorator<T> implements WatchPathable<T>
+    private class WatchPathableDecorator<T> implements WatchPathable<T>
     {
         private final WatchPathable<T> inner;
 
@@ -1961,13 +2017,13 @@ public class CellCuratorFramework implements CuratorFramework
         @Override
         public Pathable<T> usingWatcher(Watcher watcher)
         {
-            return new PathableDecorator<>(inner.usingWatcher(watcher));
+            return new PathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
 
         @Override
         public Pathable<T> usingWatcher(CuratorWatcher watcher)
         {
-            return new PathableDecorator<>(inner.usingWatcher(watcher));
+            return new PathableDecorator<>(inner.usingWatcher(wrap(watcher)));
         }
     }
 


### PR DESCRIPTION
Motivation:

ZooKeeper through the Curator API supports two types of callbacks: Completion
callbacks for background operations and watchers. The former are wrapped and
scheduled on the cells event thread in our wrapper of the Curator API, however
the Watcher callbacks were called directly from the ZooKeeper event thread
(without being placed in the correct cells logging context and without being
synchronized with message delivery).

Thus there are cases - such as in location manager - in which what was supposed
to be a single threaded cell we have multiple concurrent threads. Also, threads
run outside the proper logging context, meaning log messages do not show up
in the proper pinboard.

Modification:

Wrap watchers and schedule the callbacks on the cell event executor. Since watchers
are identified by identity, we have to use a weakly referenced cache to reuse the
wrapper for each watcher.

Result:

Fixed a race condition and logging bug affecting cells relying on zookeeper. This
could affect location manager, space manager and pool manager.

Target: trunk
Request: 2.16
Request: 2.15
Require-notes: yes
Require-book: no
Acked-by: Tigran Mkrthchyan <tigran.mkrtchyan@desy.de>
Acked-by: Paul Millar <paul.millar@desy.de>
(cherry picked from commit 5165e846c8903bdb8f5c6f1a4b393a0e5bcc715a)