### PR TITLE
pool: Fix transactional behaviour with Berkeley DB

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/AbstractBerkeleyDBReplicaStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/AbstractBerkeleyDBReplicaStore.java
@@ -19,6 +19,7 @@
 package org.dcache.pool.repository.meta.db;
 
 import com.sleepycat.collections.StoredMap;
+import com.sleepycat.collections.TransactionWorker;
 import com.sleepycat.je.DatabaseException;
 import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.EnvironmentFailureException;
@@ -176,9 +177,9 @@ public abstract class AbstractBerkeleyDBReplicaStore implements ReplicaStore, En
         return database.getEnvironment().getConfig();
     }
 
-    public Transaction beginTransaction()
+    public void run(TransactionWorker worker) throws Exception
     {
-        return database.getEnvironment().beginTransaction(null, null);
+        database.run(worker);
     }
 
     public abstract void setLastModifiedTime(PnfsId pnfsId, long time) throws IOException;

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/ReplicaStoreDatabase.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/ReplicaStoreDatabase.java
@@ -1,6 +1,8 @@
 package org.dcache.pool.repository.meta.db;
 
 import com.sleepycat.bind.serial.StoredClassCatalog;
+import com.sleepycat.collections.TransactionRunner;
+import com.sleepycat.collections.TransactionWorker;
 import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseConfig;
 import com.sleepycat.je.DatabaseException;
@@ -33,6 +35,8 @@ public class ReplicaStoreDatabase
     private final StoredClassCatalog javaCatalog;
     private final Database storageInfoDatabase;
     private final Database stateDatabase;
+    private final TransactionRunner transactionRunner;
+
     private boolean _failed;
     private boolean _closed;
 
@@ -65,6 +69,8 @@ public class ReplicaStoreDatabase
         storageInfoDatabase =
             env.openDatabase(null, STORAGE_INFO_STORE, dbConfig);
         stateDatabase = env.openDatabase(null, STATE_STORE, dbConfig);
+
+        transactionRunner = new TransactionRunner(env);
     }
 
     private synchronized void setFailed()
@@ -92,6 +98,11 @@ public class ReplicaStoreDatabase
     public final Environment getEnvironment()
     {
         return env;
+    }
+
+    public void run(TransactionWorker worker) throws Exception
+    {
+        transactionRunner.run(worker);
     }
 
     public final StoredClassCatalog getClassCatalog()


### PR DESCRIPTION
Motivation:

In version 3.0 we enabled transactional updates of the Berkeley DB meta data
database used in pools, however the code was flawed: The low level transactions
exposed by Berkeley DB are not bound to threads and a simple beginTransaction
call is not enough to make subsequent operations by this part of that transaction.

Modification:

Use the TransactionRunner helper class to encapsulate the update in a transaction.
This helper class associates the transaction with the calling thread.

Result:

Fixed a flaw in the pool in which transactional updates were not transactional.

Target: trunk
Request: 3.0
Require-notes: yes
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>
Patch: https://rb.dcache.org/r/10028/
(cherry picked from commit 2469be06e6a2795a7c7a8ad64bfc52026c946094)