### PR TITLE
systemtest: allow anonymous dcap activity

### DIFF
--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -125,6 +125,7 @@ spacemanager.perished-space-purge-delay.unit = MINUTES
 
 [dCacheDomain/dcap]
 dcap.authn.protocol=plain
+dcap.authz.anonymous-operations = FULL
 
 [dCacheDomain/dcap]
 dcap.authn.protocol=auth


### PR DESCRIPTION
Motivation:

The system-test 'test' script attempts to upload a file into dCache
using plain (unauthenticated) dcap.  While this is supported by dCache,
such operations are denied by default and must be explicitly enabled.
This results in that particular test always failing.

Modification:

Update the system-test configuration so that the plain dcap door allows
anonymous users full read-write access to dCache.

Result:

System-test 'test' script passes all tests with the dcap door.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10021/
Acked-by: Tigran Mkrtchyan
Requires-notes: no
Requires-book: no