### PR TITLE
cleaner: show delete notification targets

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
@@ -564,6 +564,7 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
             } else {
                 sb.append("\n HSM Cleaner disabled.");
             }
+            sb.append("\nDelete notification targets: ").append(Arrays.toString(_deleteNotificationTargets));
             return sb.toString();
         }
     }


### PR DESCRIPTION
Motivation:

The admin may configure the delete notification targets that cleaner
will inform when a file's content has been cleaned; however, there is
currently no way to discover the current configuration.

Modification:

Add the delete notification targets as additional information in the
'show info' command.

Result:

Admins can discover and verify the targets.

Target: master
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10040/
Acked-by: Olufemi Adeyemi