### PR TITLE
dcache: update dcache-view version to 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.3.0</version.wicket>
         <version.xrootd4j>3.1.1</version.xrootd4j>
         <version.jersey>2.22.2</version.jersey>
-        <version.dcache-view>1.0.4</version.dcache-view>
+        <version.dcache-view>1.0.5</version.dcache-view>
         <version.dcache>${project.version}</version.dcache>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
Changelog from v1.0.4 to v1.0.5

fc8ce22b1285a640171a80de1c54a0ce3602f065 [maven-release-plugin] prepare release v1.0.5
c8ccba1a9045622c842ee51fd0453b9876217467 Merge pull request #20 from femiadeyemi/github/1.0/rb10043/fix/indentation
fe1969277d7d04e9c0a703ab4175e3b53c23ecc0 dcache-view: convert taps indentation to spaces
21fe2f57621cbb527dcfda210a2477e240f3752e Merge pull request #18 from femiadeyemi/github/1.0/rb10039/adjust/third/party/dependencies/injection
95dd395d54525762dcf6bb3001d804aa4d99ff50 dcache-view: control version of third party dependencies
c78eec68cdf34445a583c61d60da871a7699944e Merge pull request #10 from femiadeyemi/github/1.0/rb10034/fix/view-file/element/issue/with_latest_iron-list
81d3a204a59699c441164f7841a32173721e3917 dcache-view: fix styling problem in view-file
85bda539637e319fb09639bd878992f91a1b24c9 [gulp and package] prepare for next development iteration
0b3a534c66fc20518266de0b85271d20c93083d7 [maven-release-plugin] prepare for next development iteration

Target: master
Request: 2.16, 3.0
Require-book: no
Require-notes: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10049/

(cherry picked from commit cb40a599b2f79b6777de5b8057338e88e8be8b40)