### PR TITLE
ftp: add support for paths relative to home directory

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -547,6 +547,7 @@ public abstract class AbstractFtpDoorV1
     protected Restriction _authz = Restrictions.denyAll();
     protected FsPath _userRootPath = FsPath.ROOT;
     protected FsPath _doorRootPath = FsPath.ROOT;
+    protected FsPath _userHomePath = FsPath.ROOT;
     protected String _cwd = "/";    // Relative to _doorRootPath
     protected FsPath _filepath; // Absolute filepath to the file to be renamed
     protected PnfsId _fileId; // Id of the file to be renamed
@@ -1226,6 +1227,7 @@ public abstract class AbstractFtpDoorV1
         _doorRootPath = doorRootPath;
         _userRootPath = userRootPath;
         _identityResolver = _identityResolverFactory.withSubject(mappedSubject);
+        _userHomePath = FsPath.create(userHomePath);
     }
 
     public static final String hh_get_door_info = "[-binary]";
@@ -1793,7 +1795,19 @@ public abstract class AbstractFtpDoorV1
 
     private FsPath absolutePath(String path) throws FTPCommandException
     {
-        return path.startsWith("/") ? _doorRootPath.chroot(path) : _doorRootPath.chroot(_cwd + "/" + path);
+        String absPath;
+
+        if (path.startsWith("/")) {
+            absPath = path;
+        } else if (path.equals("~")) {
+            absPath = _userHomePath.toString();
+        } else if (path.startsWith("~/")) {
+            absPath = _userHomePath + path.substring(1);
+        } else {
+            absPath = _cwd + "/" + path;
+        }
+
+        return _doorRootPath.chroot(absPath);
     }
 
 


### PR DESCRIPTION
Motivation:

Globus client makes requests using paths like '~/', with the tilde
symbol is a common place-holder for the users home directory.

Modification:

When resolving a client-supplied path, interpret paths that start '~/'
as the same path without this prefix and resolved relative to the users
home directory.  If the user has no home directory, this is resolved
relative to the root directory.

Note that '~NAME' is a common place-holder for the home directory of
user NAME.  Implementing support for this is deferred until a client
requires it.

Result:

Globus transfer service shows the user's home directory when first
logged it, rather than failing.

Target: master
Request: 3.0
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10064/
Acked-by: Dmitry Litvintsev