### PR TITLE
ftp: add support in OPTS RETR for specifying performance marker frequ…

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -124,6 +124,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -300,6 +301,9 @@ public abstract class AbstractFtpDoorV1
         implements LineBasedInterpreter, CellMessageReceiver, CellCommandListener,
         CellInfoProvider, CellMessageSender, CellIdentityAware
 {
+    private static final long MINIMUM_PERFORMANCE_MARKER_PERIOD = 2;
+    private static final long MAXIMUM_PERFORMANCE_MARKER_PERIOD = TimeUnit.MINUTES.toSeconds(5);
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFtpDoorV1.class);
     private static final Timer TIMER = new Timer("Performance marker timer", true);
     private static final Logger ACCESS_LOGGER = LoggerFactory.getLogger("org.dcache.access.ftp");
@@ -609,6 +613,7 @@ public abstract class AbstractFtpDoorV1
     //when doing mode e transfers
     protected int _parallel;
     protected int _bufSize;
+    private long _performanceMarkerPeriod = 0;
 
     private final String _ftpDoorName;
     private final String _tlogName;
@@ -930,13 +935,10 @@ public abstract class AbstractFtpDoorV1
 
             reply(_commandLine, "150 Opening BINARY data connection for " + _path, false);
 
-            if (isWrite() && _xferMode.equals("E") && _settings.getPerformanceMarkerPeriod() > 0) {
-                long period = _settings.getPerformanceMarkerPeriodUnit().toMillis(
-                        _settings.getPerformanceMarkerPeriod());
-                long timeout = period / 2;
-                _perfMarkerTask =
-                    new PerfMarkerTask(_commandLine, getPoolAddress(), getMoverId(), timeout);
-                TIMER.schedule(_perfMarkerTask, period, period);
+            if (isWrite() && _xferMode.equals("E") && _performanceMarkerPeriod > 0) {
+                _perfMarkerTask = new PerfMarkerTask(_commandLine, getPoolAddress(),
+                        getMoverId(), _performanceMarkerPeriod / 2);
+                TIMER.schedule(_perfMarkerTask, _performanceMarkerPeriod, _performanceMarkerPeriod);
             }
         }
 
@@ -1160,6 +1162,10 @@ public abstract class AbstractFtpDoorV1
 
     public void init() throws Exception
     {
+        if (_settings.getPerformanceMarkerPeriod() > 0) {
+            _performanceMarkerPeriod = _settings.getPerformanceMarkerPeriodUnit().toMillis(_settings.getPerformanceMarkerPeriod());
+        }
+
         _clientDataAddress =
             new InetSocketAddress(_remoteSocketAddress.getAddress(), DEFAULT_DATA_PORT);
 
@@ -1610,23 +1616,40 @@ public abstract class AbstractFtpDoorV1
         reply(builder.toString());
     }
 
-    public void opts_retr(String opt)
+    public void opts_retr(String opt) throws FTPCommandException
     {
         String[] st = opt.split("=");
-        String real_opt = st[0];
-        String real_value= st[1];
-        if (!real_opt.equalsIgnoreCase("Parallelism")) {
-            reply("501 Unrecognized option: " + real_opt + " (" + real_value + ")");
-            return;
+        if (st.length != 2) {
+            throw new FTPCommandException(500, "OPTS failed.");
         }
 
-        st = real_value.split(",|;");
-        _parallel = Integer.parseInt(st[0]);
-        if (_settings.getMaxStreamsPerClient() > 0) {
-            _parallel = Math.min(_parallel, _settings.getMaxStreamsPerClient());
-        }
+        String key = st[0];
+        String value = st[1].split(",|;") [0];
+        switch (key.toLowerCase()) {
+        case "parallelism":
+            _parallel = Integer.parseInt(value);
+            if (_settings.getMaxStreamsPerClient() > 0) {
+                _parallel = Math.min(_parallel, _settings.getMaxStreamsPerClient());
+            }
+            reply("200 Parallel streams set (" + opt + ")");
+            break;
 
-        reply("200 Parallel streams set (" + opt + ")");
+        case "markers":
+            try {
+                long period = Integer.parseInt(value);
+                if (period < MINIMUM_PERFORMANCE_MARKER_PERIOD || period > MAXIMUM_PERFORMANCE_MARKER_PERIOD) {
+                    throw new FTPCommandException(500, "Value \"" + value + "\" not acceptable");
+                }
+                _performanceMarkerPeriod = TimeUnit.SECONDS.toMillis(period);
+                reply("200 OPTS Command Successful.");
+            } catch (NumberFormatException e) {
+                throw new FTPCommandException(500, "Value \"" + value + "\" not an integer");
+            }
+            break;
+
+        default:
+            throw new FTPCommandException(501, "Unrecognized RETR option: " + key);
+        }
     }
 
     public void opts_stor(String opt, String val)
@@ -1706,7 +1729,7 @@ public abstract class AbstractFtpDoorV1
     }
 
     @Help("OPTS <SP> <feat> [<SP> <arg>] - Select desired behaviour for a feature.")
-    public void ftp_opts(String arg)
+    public void ftp_opts(String arg) throws FTPCommandException
     {
         String[] st = arg.split("\\s+");
         if (st.length == 2 && st[0].equalsIgnoreCase("RETR")) {

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -145,8 +145,15 @@ ftp.net.internal =
 
 #  Period between successive GridFTP performance markers
 #
-#  This variable controls how often performance markers are written.
-#  A value of '0' will disable performance markers.
+#  This variable controls how often performance markers are written by
+#  default.  Specifying a value of '0' will disable performance
+#  markers by default.
+#
+#  Note that an FTP client may request that dCache sends performance
+#  markers at a specific rate.  Such requests are always honoured,
+#  provided the period is at least 2 seconds and not more than 5
+#  minutes.
+#
 ftp.performance-marker-period = 70
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)ftp.performance-marker-period.unit = SECONDS
 


### PR DESCRIPTION
…ency

Motivation:

Satisfy Globus client's desire to have performance markers at specific
intervals.

Modification:

Add support for the OPTS RETR command with arguments like "markers=10;".

Result:

Globus client is happier.

Target: master
Request: 3.0
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10061/
Acked-by: Dmitry Litvintsev