### PR TITLE
ftp: add support in OPTS RETR for specifying performance marker frequ…

### DIFF
--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -157,8 +157,15 @@ ftp.net.internal =
 
 #  Period between successive GridFTP performance markers
 #
-#  This variable controls how often performance markers are written.
-#  A value of '0' will disable performance markers.
+#  This variable controls how often performance markers are written by
+#  default.  Specifying a value of '0' will disable performance
+#  markers by default.
+#
+#  Note that an FTP client may request that dCache sends performance
+#  markers at a specific rate.  Such requests are always honoured,
+#  provided the period is at least 2 seconds and not more than 5
+#  minutes.
+#
 ftp.performance-marker-period = 70
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)ftp.performance-marker-period.unit = SECONDS
 


### PR DESCRIPTION
…ency

Motivation:

Satisfy Globus client's desire to have performance markers at specific
intervals.

Modification:

Add support for the OPTS RETR command with arguments like "markers=10;".

Result:

Globus client is happier.

Target: master
Request: 3.0
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10061/
Acked-by: Dmitry Litvintsev