### PR TITLE
xrootd  : use lower case for checksum algorithm names when replying

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -409,7 +409,12 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                     s.append(0);
                     break;
                 case "csname":
-                    s.append("1:ADLER32,2:MD5");
+                    /**
+                     * xrdcp expects lower case names for checksum algorithms
+                     * https://github.com/xrootd/xrootd/issues/459
+                     * TODO: revert to upper case then above issue is addressed
+                     */
+                    s.append("1:adler32,2:md5");
                     break;
                 default:
                     s.append(_queryConfig.getOrDefault(name, name));
@@ -424,7 +429,13 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                 Set<Checksum> checksums = _door.getChecksums(createFullPath(msg.getArgs()), msg.getSubject());
                 if (!checksums.isEmpty()) {
                     Checksum checksum = Checksums.preferrredOrder().min(checksums);
-                    return new QueryResponse(msg, checksum.getType().getName() + " " + checksum.getValue());
+                    /**
+                     * xrdcp expects lower case names for checksum algorithms
+                     * https://github.com/xrootd/xrootd/issues/459
+                     * TODO: remove toLowerCase() call when above issue is addressed
+                     */
+                    return new QueryResponse(msg,
+                                             checksum.getType().getName().toLowerCase() + " " + checksum.getValue());
                 }
             } catch (FileNotFoundCacheException e) {
                 throw new XrootdException(kXR_NotFound, e.getMessage());

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -623,7 +623,12 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                 throw new XrootdException(kXR_Unsupported, "No checksum available for this file.");
             }
             Checksum checksum = Checksums.preferrredOrder().min(attributes.getChecksums());
-            return new QueryResponse(msg, checksum.getType().getName() + " " + checksum.getValue());
+            /**
+             * xrdcp expects lower case names for checksum algorithms
+             * https://github.com/xrootd/xrootd/issues/459
+             * TODO: remove toLowerCase() call when above issue is addressed
+             */
+            return new QueryResponse(msg, checksum.getType().getName().toLowerCase() + " " + checksum.getValue());
 
         default:
             return unsupported(ctx, msg);


### PR DESCRIPTION
          to checksum queries.

Motivation:

     xrdcp --cksum adler:value ...
and
     xrdcp --cksum adler:print ...

does not work because dCache replies with ADLER32 which xrdcp
fails to match to adler32.

Issie : https://github.com/xrootd/xrootd/issues/459

Modification:

Return lower case "adler32" in xrootd door.

Result:
     xrdcp --cksum adler:value ...
and
     xrdcp --cksum adler:print ...
work.

xrdfs .... query checksum /path
returns lower case "adler32" (or "md5")

    RB: https://rb.dcache.org/r/10051/
    Ack-ed: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
    Require-notes: yes
    Require-book: no
    Target: trunk
    Request: 2.13
    Request: 2.16
    Request: 3.0
(cherry picked from commit 3d91506a31b8a68551005a18d47bdd16849347a5)