### PR TITLE
restful: improve error handling

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/DcacheRestApplication.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/DcacheRestApplication.java
@@ -8,6 +8,7 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.filter.EncodingFilter;
 
 import org.dcache.restful.filters.ResponseHeaderFilter;
+import org.dcache.restful.providers.ErrorResponseProvider;
 import org.dcache.restful.providers.ObjectMapperProvider;
 import org.dcache.restful.qos.QosManagement;
 import org.dcache.restful.resources.namespace.FileResources;
@@ -36,6 +37,7 @@ public class DcacheRestApplication extends ResourceConfig
         register(JacksonJsonProvider.class);
         register(JacksonJaxbJsonProvider.class);
         register(EntityFilteringFeature.class);
+        register(ErrorResponseProvider.class);
 
         /**
          * Jersey framework has a built-in functionality to easily enable content encoding.

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/errorHandling/RestAPIExceptionHandler.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/errorHandling/RestAPIExceptionHandler.java
@@ -1,6 +1,5 @@
 package org.dcache.restful.errorHandling;
 
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 
@@ -18,23 +17,13 @@ public class RestAPIExceptionHandler extends ErrorHandler
     public void handle(String target, Request baseRequest, HttpServletRequest request,
                        HttpServletResponse response) throws IOException
     {
-        int code = response.getStatus();
-        String message = HttpStatus.getMessage(code);
-
         response.setHeader("Access-Control-Allow-Origin", "*");
         response.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
         response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
         response.setHeader("content-type", "application/json");
 
-        if (code == 401) {
+        if (response.getStatus() == 401) {
             response.setHeader("WWW-Authenticate", "");
         }
-
-        response.getWriter()
-                .append("{\"errors\": [{\"status\" : ")
-                .append(String.valueOf(code))
-                .append(", \"message\": \"")
-                .append(message)
-                .append("\"}]}");
     }
 }

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/ErrorResponseProvider.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/ErrorResponseProvider.java
@@ -1,0 +1,74 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.restful.providers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.json.JSONObject;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response.Status;
+
+import java.util.Collections;
+
+/**
+ * Map errors to the appropriate JSON response object.  It is the
+ * responsibility of the resource to map any non-JAX-WS (e.g., dCache-specific)
+ * exception to a generic exception.  Any non-JAX-WS exception is treated as a bug.
+ */
+public class ErrorResponseProvider implements ExceptionMapper<Exception>
+{
+    @Override
+    public Response toResponse(Exception e)
+    {
+        if (e instanceof BadRequestException) {
+            return buildResponse(Response.Status.BAD_REQUEST,
+                    e.getMessage() == null ? "Bad request" : e.getMessage());
+        } else if (e instanceof InternalServerErrorException) {
+            return buildResponse(Response.Status.INTERNAL_SERVER_ERROR,
+                    e.getMessage() == null ? "Internal error" : e.getMessage());
+        } else if (e instanceof WebApplicationException) {
+            Response r = ((WebApplicationException)e).getResponse();
+            return buildResponse(r.getStatus(), r.getStatusInfo().getReasonPhrase());
+        } else {
+            // All other Exceptions are bug -- log them.
+            Thread t = Thread.currentThread();
+            t.getUncaughtExceptionHandler().uncaughtException(t, e);
+            return buildResponse(Response.Status.INTERNAL_SERVER_ERROR,
+                    "Internal error: " + e);
+        }
+    }
+
+    private Response buildResponse(Status status, String jsonMessage)
+    {
+        return buildResponse(status.getStatusCode(), jsonMessage);
+    }
+
+    private Response buildResponse(int status, String jsonMessage)
+    {
+        JSONObject error = new JSONObject();
+        error.put("status", String.valueOf(status));
+        error.put("message", jsonMessage);
+        JSONObject json = new JSONObject();
+        json.put("errors", Collections.singletonList(error));
+        return Response.status(status).entity(json.toString()).build();
+    }
+}


### PR DESCRIPTION
Motivation:

When there is some kind of failure, the response is a JSON object
contains a list of error objects.  Each error object contains a status
code and a message.  However, the message is predetermined and contains
no contextual information about what went wrong.  This makes it hard for
someone using the dCache REST API to discover what went wrong when the
request is a 400 or 500 response.

If the Resource handling the request contains a bug, nothing is logged.
This is against dCache behaviour elsewhere where all bugs trigger a
stack-trace.

Modification:

Add a ExceptionMapper to control how exceptions are mapped to Response
objects.  Any non JAX-WS exception is treated as a bug: the Resource is
responsible for mapping all other exceptions (e.g., CacheException) to a
corresponding JAX-WS exception.

Result:

The error JSON object contains potentially useful information in the
message, as supplied by the exception.  Any bugs are logged with
stack-trace to facilitate debugging.

Target: master
Patch: https://rb.dcache.org/r/10054/
Acked-by: Olufemi Adeyemi
Requires-notes: yes
Requires-book: no
Request: 3.0