### PR TITLE
rest: add home directory to user info

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/UserAttributes.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/UserAttributes.java
@@ -45,6 +45,8 @@ public class UserAttributes
 
     private List<Long> gids;
 
+    private String home;
+
     public AuthenticationStatus getStatus()
     {
         return status;
@@ -73,5 +75,15 @@ public class UserAttributes
     public void setGids(List<Long> gids)
     {
         this.gids = gids;
+    }
+
+    public String getHomeDirectory()
+    {
+        return home;
+    }
+
+    public void setHomeDirectory(String dir)
+    {
+        home = dir;
     }
 }

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/identity/UserResource.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/identity/UserResource.java
@@ -18,20 +18,21 @@
  */
 package org.dcache.restful.resources.identity;
 
-import jersey.repackaged.com.google.common.collect.Lists;
-
 import javax.security.auth.Subject;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.dcache.auth.Subjects;
+import org.dcache.auth.attributes.HomeDirectory;
+import org.dcache.auth.attributes.LoginAttribute;
 import org.dcache.restful.providers.UserAttributes;
 import org.dcache.restful.util.ServletContextHandlerAttributes;
 
@@ -44,7 +45,7 @@ public class UserResource
 {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public UserAttributes getUserAttributes()
+    public UserAttributes getUserAttributes(@Context HttpServletRequest request)
     {
         UserAttributes user = new UserAttributes();
 
@@ -60,6 +61,12 @@ public class UserResource
                     .boxed()
                     .collect(Collectors.toList());
             user.setGids(gids);
+
+            for (LoginAttribute attribute : ServletContextHandlerAttributes.getLoginAttributes(request)) {
+                if (attribute instanceof HomeDirectory) {
+                    user.setHomeDirectory(((HomeDirectory)attribute).getHome());
+                }
+            }
         }
 
         return user;

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/ServletContextHandlerAttributes.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/ServletContextHandlerAttributes.java
@@ -2,16 +2,21 @@ package org.dcache.restful.util;
 
 import javax.security.auth.Subject;
 import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
 
 import java.security.AccessController;
+import java.util.Set;
 
 import diskCacheV111.util.PnfsHandler;
 
+import org.dcache.auth.attributes.LoginAttribute;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.auth.attributes.Restrictions;
 import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.RemotePoolMonitor;
 import org.dcache.util.list.ListDirectoryHandler;
+
+import static org.dcache.http.AuthenticationHandler.DCACHE_LOGIN_ATTRIBUTES;
 
 public class ServletContextHandlerAttributes {
     public final static String DL = "org.dcache.restful";
@@ -22,6 +27,11 @@ public class ServletContextHandlerAttributes {
     public static Subject getSubject()
     {
         return Subject.getSubject(AccessController.getContext());
+    }
+
+    public static Set<LoginAttribute> getLoginAttributes(HttpServletRequest request)
+    {
+        return (Set<LoginAttribute>) request.getAttribute(DCACHE_LOGIN_ATTRIBUTES);
     }
 
     public static Restriction getRestriction()

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -86,6 +86,7 @@ import org.dcache.auth.SubjectWrapper;
 import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.cells.CellStub;
+import org.dcache.http.AuthenticationHandler;
 import org.dcache.missingfiles.AlwaysFailMissingFileStrategy;
 import org.dcache.missingfiles.MissingFileStrategy;
 import org.dcache.namespace.FileAttribute;

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
@@ -44,7 +44,7 @@ import org.dcache.util.Slf4jSTErrorListener;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.milton.http.Response.Status.*;
-import static org.dcache.webdav.AuthenticationHandler.DCACHE_LOGIN_ATTRIBUTES;
+import static org.dcache.http.AuthenticationHandler.DCACHE_LOGIN_ATTRIBUTES;
 
 /**
  * This class controls how Milton responds under different circumstances by

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/LoggingHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/LoggingHandler.java
@@ -19,8 +19,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.cert.X509Certificate;
 
+import static org.dcache.http.AuthenticationHandler.DCACHE_SUBJECT_ATTRIBUTE;
 import static org.dcache.webdav.DcacheResourceFactory.TRANSACTION_ATTRIBUTE;
-import static org.dcache.webdav.AuthenticationHandler.DCACHE_SUBJECT_ATTRIBUTE;
 
 
 public class LoggingHandler extends HandlerWrapper {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
@@ -54,12 +54,12 @@ import org.dcache.acl.enums.AccessMask;
 import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.cells.CellStub;
+import org.dcache.http.AuthenticationHandler;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.namespace.FileType;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.webdav.PathMapper;
 import org.dcache.webdav.transfer.RemoteTransferHandler.Direction;
-import org.dcache.webdav.AuthenticationHandler;
 import org.dcache.webdav.transfer.RemoteTransferHandler.TransferType;
 
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -132,7 +132,7 @@
                         </bean>
                     </property>
                 </bean>
-                <bean class="org.dcache.webdav.AuthenticationHandler">
+                <bean class="org.dcache.http.AuthenticationHandler">
                     <property name="handler">
                         <bean class="org.eclipse.jetty.server.handler.HandlerList">
                             <property name="handlers">

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -319,7 +319,7 @@
         </property>
     </bean>
 
-    <bean id="authhandler" class="org.dcache.webdav.AuthenticationHandler">
+    <bean id="authhandler" class="org.dcache.http.AuthenticationHandler">
         <property name="handler">
             <bean class="org.eclipse.jetty.server.handler.HandlerList">
                 <property name="handlers">

--- a/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
@@ -1,4 +1,4 @@
-package org.dcache.webdav;
+package org.dcache.http;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;


### PR DESCRIPTION
Motivation:

dCache has the concept of a home directory: each user may have a
directory that is somehow "theirs".  This information is currently not
available to clients accessing dCache via the REST interface.

Modification:

Add the user's home directory as part of the JSON response.  To avoid
circular dependencies, the AuthenticationHandler is moved from webdav
into dcache-core.  This makes sense since both REST and WebDAV make use
of it.

Result:

Querying /api/v1/user provides the user's home directory in addition to
other user-centric information.

Target: master
Request: 3.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10066/
Acked-by: Olufemi Adeyemi

Conflicts:
	modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java