### PR TITLE
restful: support querying QoS through namespace

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/JsonFileAttributes.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/JsonFileAttributes.java
@@ -153,6 +153,12 @@ public class JsonFileAttributes {
 
     public FileLocality fileLocality;
 
+    /** Current QoS for this file. */
+    public String currentQos;
+
+    /** The target QoS if the file is changing QoS, or null otherwise. */
+    public String targetQos;
+
     public ACL getAcl() {
         return _acl;
     }
@@ -367,5 +373,21 @@ public class JsonFileAttributes {
 
     public List<JsonFileAttributes> getChildren() {
         return children;
+    }
+
+    public void setCurrentQos(String qos) {
+        this.currentQos = qos;
+    }
+
+    public String getCurrentQos() {
+        return currentQos;
+    }
+
+    public void setTargetQos(String qos) {
+        targetQos = qos;
+    }
+
+    public String getTargetQos() {
+        return targetQos;
     }
 }

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
@@ -38,6 +38,7 @@ public class QosManagement {
     public static final String DISK = "disk";
     public static final String TAPE = "tape";
     public static final String DISK_TAPE = "disk+tape";
+    public static final String UNAVAILABLE = "unavailable";
 
     public static List<String> cdmi_geographic_placement_provided = Arrays.asList("DE");
 

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java
@@ -74,6 +74,7 @@ public class QosManagementNamespace {
      * @return JSONObject current QoS status
      * @throws CacheException
      */
+    @Deprecated
     @GET
     @Path("{requestPath : .*}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -142,6 +143,7 @@ public class QosManagementNamespace {
      * @return JSONObject current QoS status
      * @throws CacheException
      */
+    @Deprecated
     @POST
     @Path("{requestPath : .*}")
     @Consumes({MediaType.APPLICATION_JSON})

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -23,31 +23,45 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileLocality;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
+import diskCacheV111.vehicles.HttpProtocolInfo;
+import diskCacheV111.vehicles.ProtocolInfo;
+
+import dmg.cells.nucleus.NoRouteToCellException;
 
 import org.dcache.auth.Subjects;
+import org.dcache.cells.CellStub;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.namespace.FileType;
+import org.dcache.pinmanager.PinManagerCountPinsMessage;
+import org.dcache.pinmanager.PinManagerPinMessage;
+import org.dcache.pinmanager.PinManagerUnpinMessage;
 import org.dcache.poolmanager.RemotePoolMonitor;
 import org.dcache.restful.providers.JsonFileAttributes;
+import org.dcache.restful.qos.QosManagement;
 import org.dcache.restful.util.ServletContextHandlerAttributes;
 import org.dcache.util.list.DirectoryEntry;
 import org.dcache.util.list.DirectoryStream;
 import org.dcache.util.list.ListDirectoryHandler;
 import org.dcache.vehicles.FileAttributes;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.dcache.restful.providers.SuccessfulResponse.successfulResponse;
+import static org.dcache.restful.util.Preconditions.checkRequest;
 
 /**
  * RestFul API to  provide files/folders manipulation operations
@@ -57,6 +71,7 @@ import static org.dcache.restful.providers.SuccessfulResponse.successfulResponse
 @Path("/namespace")
 public class FileResources {
 
+    private final String QOS_PIN_REQUEST_ID = "qos";
 
     @Context
     ServletContext ctx;
@@ -125,7 +140,10 @@ public class FileResources {
                                                 @DefaultValue("false")
                                                 @QueryParam("children") boolean isList,
                                                 @DefaultValue("false")
-                                                @QueryParam("locality") boolean isLocality) throws CacheException {
+                                                @QueryParam("locality") boolean isLocality,
+                                                @DefaultValue("false")
+                                                @QueryParam("qos") boolean isQos) throws CacheException
+    {
         JsonFileAttributes fileAttributes = new JsonFileAttributes();
         Set<FileAttribute> attributes = EnumSet.allOf(FileAttribute.class);
         PnfsHandler handler = ServletContextHandlerAttributes.getPnfsHandler(ctx);
@@ -142,6 +160,9 @@ public class FileResources {
 
             FileAttributes namespaceAttrributes = handler.getFileAttributes(path, attributes);
             chimeraToJsonAttributes(fileAttributes, namespaceAttrributes, isLocality);
+            if (isQos) {
+                addQoSAttributes(fileAttributes, namespaceAttrributes);
+            }
 
 
             // fill children list id it's a directory and listing is requested
@@ -166,6 +187,9 @@ public class FileResources {
 
                     chimeraToJsonAttributes(childrenAttributes, entry.getFileAttributes(), isLocality);
                     childrenAttributes.setFileName(fName);
+                    if (isQos) {
+                        addQoSAttributes(childrenAttributes, entry.getFileAttributes());
+                    }
                     children.add(childrenAttributes);
                 }
 
@@ -181,7 +205,7 @@ public class FileResources {
             } else {
                 throw new ForbiddenException(e);
             }
-        } catch (CacheException | InterruptedException ex) {
+        } catch (CacheException | InterruptedException | NoRouteToCellException ex) {
             throw new InternalServerErrorException(ex);
         }
         return fileAttributes;
@@ -193,15 +217,15 @@ public class FileResources {
     @Produces(MediaType.APPLICATION_JSON)
     public Response cmrResources (@PathParam("value") String path, String requestPayload)
     {
-        JSONObject reqPayload = new JSONObject(requestPayload);
-        String action = (String) reqPayload.get("action");
-        PnfsHandler handler = ServletContextHandlerAttributes.getPnfsHandler(ctx);
         try {
+            JSONObject reqPayload = new JSONObject(requestPayload);
+            String action = (String) reqPayload.get("action");
+            PnfsHandler handler = ServletContextHandlerAttributes.getPnfsHandler(ctx);
             switch (action) {
                 case "mkdir":
                     String folderName = (String) reqPayload.get("name");
-                    checkArgument(!folderName.contains("/"), "The folderName cannot contain forward slash.");
-                    checkArgument(!folderName.isEmpty(), "The folderName cannot be empty.");
+                    checkRequest(!folderName.contains("/"), "The folderName cannot contain forward slash.");
+                    checkRequest(!folderName.isEmpty(), "The folderName cannot be empty.");
 
                     String newPath;
                     if (path == null || path.isEmpty()) {
@@ -212,15 +236,80 @@ public class FileResources {
 
                     handler.createPnfsDirectory(newPath);
                     break;
+
                 case "mv":
                     String dest = (String) reqPayload.get("destination");
                     FsPath source = FsPath.ROOT.resolve(path);
                     FsPath target = source.parent().resolve(dest);
                     handler.renameEntry(source.toString(), target.toString(), true);
                     break;
+
+                case "qos":
+                    String targetQos = reqPayload.getString("target");
+
+                    // FIXME: which attributes do we actually need?
+                    FileAttributes attributes = handler.getFileAttributes(FsPath.ROOT.resolve(path), EnumSet.allOf(FileAttribute.class));
+                    RemotePoolMonitor monitor = ServletContextHandlerAttributes.getRemotePoolMonitor(ctx);
+                    FileLocality locality = monitor.getFileLocality(attributes, request.getRemoteHost());
+
+                    if (locality == FileLocality.NONE) {
+                        throw new BadRequestException("Transition for directories not supported");
+                    }
+
+                    CellStub pinmanager = ServletContextHandlerAttributes.getPinManager(ctx);
+                    switch (targetQos) {
+                    case QosManagement.DISK_TAPE:
+                        switch (locality) {
+                        case NEARLINE:
+                        case ONLINE_AND_NEARLINE:
+                            ProtocolInfo info = new HttpProtocolInfo("Http", 1, 1,
+                                            new InetSocketAddress(request.getRemoteHost(), 0),
+                                            null, null, null,
+                                            URI.create("http://"+request.getRemoteHost()+"/"));
+                            PinManagerPinMessage message =
+                                    new PinManagerPinMessage(attributes, info,
+                                            QOS_PIN_REQUEST_ID, -1);
+                            pinmanager.notify(message);
+                            break;
+
+                        default:
+                            throw new BadRequestException("Unsupported QoS transition");
+                        }
+                        break;
+
+                    case QosManagement.DISK:
+                        switch (locality) {
+                        case ONLINE:
+                            // do nothing
+                            break;
+
+                        default:
+                            throw new BadRequestException("Unsupported QoS transition");
+                        }
+
+                    case QosManagement.TAPE:
+                        switch (locality) {
+                        case ONLINE_AND_NEARLINE:
+                            PinManagerUnpinMessage message = new PinManagerUnpinMessage(attributes.getPnfsId());
+                            message.setRequestId(QOS_PIN_REQUEST_ID);
+                            pinmanager.notify(message);
+                            break;
+
+                        case NEARLINE:
+                            break; // Nothing to do.
+
+                        default:
+                            throw new BadRequestException("Unsupported QoS transition");
+                        }
+                        break;
+
+                    default:
+                        throw new BadRequestException("Unknown target QoS: " + targetQos);
+                    }
+                    break;
+
                 default:
-                    throw new IllegalArgumentException("The request body must contain the action to be perform. " +
-                            "See the documentation for details.");
+                    throw new BadRequestException("Unknown action: " + action);
             }
         } catch (FileNotFoundCacheException e) {
             throw new NotFoundException(e);
@@ -230,10 +319,8 @@ public class FileResources {
             } else {
                 throw new ForbiddenException(e);
             }
-        } catch (JSONException | IllegalArgumentException | CacheException e) {
-            throw new BadRequestException(e);
-        } catch (Exception e) {
-            throw new InternalServerErrorException(e);
+        } catch (JSONException | CacheException e) {
+            throw new BadRequestException(e.getMessage(), e);
         }
         return successfulResponse(Response.Status.CREATED);
     }
@@ -263,5 +350,47 @@ public class FileResources {
         }
     }
 
+    private void addQoSAttributes(JsonFileAttributes json, FileAttributes attributes)
+            throws CacheException, NoRouteToCellException, InterruptedException
+    {
+        if (Subjects.isNobody(ServletContextHandlerAttributes.getSubject())) {
+            throw new PermissionDeniedCacheException("Permission denied");
+        }
 
+        CellStub pinmanager = ServletContextHandlerAttributes.getPinManager(ctx);
+        boolean isPinned = pinmanager.sendAndWait(new PinManagerCountPinsMessage(attributes.getPnfsId())).getCount() != 0;
+
+        RemotePoolMonitor monitor = ServletContextHandlerAttributes.getRemotePoolMonitor(ctx);
+        FileLocality locality = monitor.getFileLocality(attributes, request.getRemoteHost());
+        switch (locality) {
+        case NEARLINE:
+            json.setCurrentQos(QosManagement.TAPE);
+            if (isPinned) {
+                json.setTargetQos(QosManagement.DISK_TAPE);
+            }
+            break;
+
+        case ONLINE:
+            json.setCurrentQos(QosManagement.DISK);
+            break;
+
+        case ONLINE_AND_NEARLINE:
+            json.setCurrentQos(isPinned ? QosManagement.DISK_TAPE : QosManagement.TAPE);
+            break;
+
+        case NONE: // NONE implies the target is a directory.
+            json.setCurrentQos(attributes.getAccessLatency() == AccessLatency.ONLINE ? QosManagement.DISK : QosManagement.TAPE);
+            break;
+
+        case UNAVAILABLE:
+            json.setCurrentQos(QosManagement.UNAVAILABLE);
+            break;
+
+        // LOST is currently not used by dCache
+        case LOST:
+        default:
+            // error cases
+            throw new InternalServerErrorException("Unexpected file locality: " + locality);
+        }
+    }
 }

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/Preconditions.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/Preconditions.java
@@ -1,0 +1,38 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.restful.util;
+
+import javax.ws.rs.BadRequestException;
+
+/**
+ * Utility methods for throwing JAX-WS exceptions
+ */
+public class Preconditions
+{
+    private Preconditions()
+    {
+        // It's a utility class!
+    }
+
+    public static void checkRequest(boolean isOk, String message) throws BadRequestException
+    {
+        if (!isOk) {
+            throw new BadRequestException(message);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Currently, the RESTful interface exposes some namespace-targeted
information through /api/v1/namespace, and QoS information through
/api/v1/qos-management/namespace.  This is undesirable as dCache exposes
namespace-targeted operations in two places.  It is also inconsistent
with how file-locality is exposed through /api/v1/namespace.

Modification:

Update QoS information so the client may obtain information by querying
/api/v1/namespace.  As with file-locality, QoS is not returned by
default but the client may request QoS information by adding 'qos=true'
query-parameter to a directory information.  A stat-like operation is
also supported by not including 'children=true' query-parameter.

The code is largely based on the existing code-base, but somewhat
restructured to make the behaviour clearer.

Support for QoS operations in the existing path
(/api/v1/qos-management/namespace) is kept for now and marked as
duplicated.  Support for this is to be removed once the clients have
been updated to use the new path.

Result:

More consistent interface where queries and operations on files or
directories happen in a common path.

Target: master
Request: 3.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10056/
Acked-by: Olufemi Adeyemi
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java