### PR TITLE
ftp: show SIZE facts for directories

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -4290,7 +4290,6 @@ public abstract class AbstractFtpDoorV1
             for (Fact fact: _currentFacts) {
                 switch (fact) {
                 case SIZE:
-                    attributes.add(SIMPLE_TYPE);
                     attributes.add(SIZE);
                     attributes.addAll(_pdp.getRequiredAttributes());
                     break;
@@ -4348,7 +4347,7 @@ public abstract class AbstractFtpDoorV1
                 for (Fact fact: _currentFacts) {
                     switch (fact) {
                     case SIZE:
-                        if (attr.isDefined(SIZE) && attr.getFileType() != FileType.DIR) {
+                        if (attr.isDefined(SIZE)) {
                             access =
                                 _pdp.canGetAttributes(_subject, attr,
                                                       EnumSet.of(SIZE));


### PR DESCRIPTION
Motivation:

The Globus server supplies the SIZE fact for directories.

Although supplying this information is not required by any specification
or agreement, its omission may be causing problems with clients that are
unable to parse MLSD output.  Since we have this information anyway,
supplying it poses no additional overhead.

Modification:

Show size fact for directory items.

Result:

Potentially better compatibility with Globus clients.

Target: master
Request: 3.0
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10062/
Acked-by: Dmitry Litvintsev

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java