### PR TITLE
ftp: add initial support for checksum performance markers

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1612,6 +1612,12 @@ public abstract class AbstractFtpDoorV1
             return;
         }
 
+        if (algo.startsWith("markers=")) {
+            // REVISIT when support added for dynamic checksum calculation.
+            reply("200 OK");
+            return;
+        }
+
         try {
             if (!algo.equalsIgnoreCase("NONE")) {
                 _optCheckSumFactory =


### PR DESCRIPTION
Motivation:

Keep globus client happy

Modification:

Accept (and ignore) client requested checksum performance marker refresh
period.

Result:

Fewer commands failing.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10060/
Acked-by: Dmitry Litvintsev