### PR TITLE
ftp: add support for SITE TASKID command

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -2451,7 +2451,8 @@ public abstract class AbstractFtpDoorV1
             "SITE <SP> CHGRP <SP> <group> <SP> <path> - Change group-owner of <path> to group <group>\r\n" +
             "SITE <SP> CHMOD <SP> <perm> <SP> <path> - Change permission of <path> to octal value <perm>\r\n" +
             "SITE <SP> SYMLINKFROM <SP> <path> - Register symlink location; SYMLINKTO must follow\r\n" +
-            "SITE <SP> SYMLINKTO <SP> <path> - Create symlink to <path>; SYMLINKFROM must be earlier command.")
+            "SITE <SP> SYMLINKTO <SP> <path> - Create symlink to <path>; SYMLINKFROM must be earlier command\r\n" +
+            "SITE <SP> TASKID <SP> <id> - Provide server with an identifier")
     public void ftp_site(String arg)
         throws FTPCommandException
     {
@@ -2517,6 +2518,12 @@ public abstract class AbstractFtpDoorV1
                 return;
             }
             doSymlinkTo(args[1]);
+        } else if (args[0].equalsIgnoreCase("TASKID")) {
+            if (args.length == 1) {
+                reply("501 Syntax error in parameters or arguments.");
+                return;
+            }
+            doTaskid(arg.substring(6));
         } else {
             reply("500 Unknown SITE command");
         }
@@ -2790,6 +2797,14 @@ public abstract class AbstractFtpDoorV1
             }
         }
 
+        reply("250 OK");
+    }
+
+    public void doTaskid(String arg)
+    {
+        // REVISIT: the task id is recorded in the access log, so may be
+        //     discoverable, provided this file still exists.  In future, we
+        //     may want to record client-supplied identifiers in billing.
         reply("250 OK");
     }
 


### PR DESCRIPTION
Motivation:

The Globus transfer agents issue the SITE TASKID command with the UUID
associated with a transfer.  This command currently fails.

Modification:

Add a trivial SITE TASKID command.  Currently, the ID is discarded as
the access log file contains the ID.

Result:

Fewer commands failing for the Globus transfer agents.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10063/
Acked-by: Dmitry Litvintsev
Requires-notes: yes
Requires-book: no