### PR TITLE
ftp: modify facts describing namespace ownership

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LegacyLoginCellProvider.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LegacyLoginCellProvider.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Modifier;
 
 import dmg.cells.nucleus.Cell;
 import dmg.cells.nucleus.CellAdapter;
+import dmg.cells.nucleus.CellEndpoint;
 import dmg.util.StreamEngine;
 
 import org.dcache.util.Args;
@@ -41,7 +42,7 @@ public class LegacyLoginCellProvider implements LoginCellProvider
     }
 
     @Override
-    public LoginCellFactory createFactory(String name, Args args, String parentCellName)
+    public LoginCellFactory createFactory(String name, Args args, CellEndpoint parentEndpoint, String parentCellName)
     {
         try {
             Class<? extends CellAdapter> loginClass = Class.forName(name).asSubclass(CellAdapter.class);

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginCellFactoryBuilder.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginCellFactoryBuilder.java
@@ -5,6 +5,8 @@ import com.google.common.collect.Ordering;
 
 import java.util.ServiceLoader;
 
+import dmg.cells.nucleus.CellEndpoint;
+
 import org.dcache.util.Args;
 
 public class LoginCellFactoryBuilder
@@ -15,6 +17,7 @@ public class LoginCellFactoryBuilder
     private String name;
     private Args args;
     private String loginManagerName;
+    private CellEndpoint endpoint;
 
     public LoginCellFactoryBuilder setName(String name)
     {
@@ -34,6 +37,12 @@ public class LoginCellFactoryBuilder
         return this;
     }
 
+    public LoginCellFactoryBuilder setCellEndpoint(CellEndpoint endpoint)
+    {
+        this.endpoint = endpoint;
+        return this;
+    }
+
     public LoginCellFactory build()
     {
         LoginCellProvider bestProvider =
@@ -41,7 +50,7 @@ public class LoginCellFactoryBuilder
         if (bestProvider.getPriority(name) == Integer.MIN_VALUE) {
             throw new IllegalArgumentException("No login cell provider found for " + name);
         }
-        return bestProvider.createFactory(name, args, loginManagerName);
+        return bestProvider.createFactory(name, args, endpoint, loginManagerName);
     }
 
 }

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginCellProvider.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginCellProvider.java
@@ -1,5 +1,7 @@
 package dmg.cells.services.login;
 
+import dmg.cells.nucleus.CellEndpoint;
+
 import org.dcache.util.Args;
 
 /**
@@ -25,10 +27,12 @@ public interface LoginCellProvider
      *
      * @param name Identifier for a type of login cell
      * @param args Arguments for the login cell
+     * @param parentEndpoint CellEndpoint of the parent cell
      * @param parentCellName Name of the parent login manager
      * @return A new LoginCellFactory
      * @see LoginCellFactory#stop
      */
-    LoginCellFactory createFactory(String name, Args args, String parentCellName)
+    LoginCellFactory createFactory(String name, Args args,
+        CellEndpoint parentEndpoint, String parentCellName)
         throws IllegalArgumentException;
 }

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -192,6 +192,7 @@ public class LoginManager
                 .setName(loginCell)
                 .setLoginManagerName(getCellName())
                 .setArgs(childArgs)
+                .setCellEndpoint(this)
                 .build();
         _version = new CellVersion(Version.of(_loginCellFactory));
 

--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoor.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoor.java
@@ -20,6 +20,7 @@ import dmg.util.CommandExitException;
 import dmg.util.StreamEngine;
 
 import org.dcache.cells.AbstractCell;
+import org.dcache.services.login.IdentityResolverFactory;
 import org.dcache.util.Args;
 import org.dcache.util.CDCExecutorServiceDecorator;
 import org.dcache.util.SequentialExecutor;
@@ -47,6 +48,7 @@ public class LineBasedDoor
     private final StreamEngine engine;
 
     private final LineBasedInterpreterFactory factory;
+    private final IdentityResolverFactory identityFactory;
 
     private final CountDownLatch shutdownGate = new CountDownLatch(1);
 
@@ -59,13 +61,15 @@ public class LineBasedDoor
     private volatile boolean isStartupCompleted;
 
     public LineBasedDoor(String cellName, Args args, LineBasedInterpreterFactory factory,
-                         StreamEngine engine, ExecutorService executor)
+                         StreamEngine engine, ExecutorService executor,
+                         IdentityResolverFactory identityFactory)
     {
         super(cellName, args, executor);
 
         this.factory = factory;
         this.engine = engine;
         this.executor = new CDCExecutorServiceDecorator<>(executor);
+        this.identityFactory = identityFactory;
     }
 
     @Override
@@ -77,7 +81,7 @@ public class LineBasedDoor
 
         LOGGER.debug("Client host: {}", engine.getInetAddress().getHostAddress());
 
-        interpreter = factory.create(this, engine, executor);
+        interpreter = factory.create(this, engine, executor, identityFactory);
         if (interpreter instanceof CellCommandListener) {
             addCommandListener(interpreter);
         }

--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoorFactory.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoorFactory.java
@@ -9,23 +9,42 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import dmg.cells.nucleus.Cell;
+import dmg.cells.nucleus.CellEndpoint;
+import dmg.cells.nucleus.CellPath;
 import dmg.cells.services.login.LoginCellFactory;
 import dmg.util.StreamEngine;
 
+import org.dcache.auth.LoginStrategy;
+import org.dcache.cells.CellStub;
+import org.dcache.services.login.IdentityResolverFactory;
+import org.dcache.services.login.RemoteLoginStrategy;
 import org.dcache.util.Args;
+import org.dcache.util.Option;
+import org.dcache.util.OptionParser;
 
 public class LineBasedDoorFactory extends AbstractService implements LoginCellFactory
 {
     private final String parentCellName;
     private final Args args;
     private final LineBasedInterpreterFactory factory;
+    private final IdentityResolverFactory idResolverFactory;
     private ExecutorService executor;
 
-    public LineBasedDoorFactory(LineBasedInterpreterFactory factory, Args args, String parentCellName)
+    @Option(name = "gplazma",
+            description = "Cell path to gPlazma",
+            defaultValue = "gPlazma")
+    protected CellPath gPlazma;
+
+    public LineBasedDoorFactory(LineBasedInterpreterFactory factory, Args args, CellEndpoint parentEndpoint, String parentCellName)
     {
         this.factory = factory;
         this.parentCellName = parentCellName;
         this.args = args;
+
+        new OptionParser(args).inject(this);
+
+        LoginStrategy loginStrategy = new RemoteLoginStrategy(new CellStub(parentEndpoint, gPlazma, 30000));
+        idResolverFactory = new IdentityResolverFactory(loginStrategy);
     }
 
     @Override
@@ -37,7 +56,8 @@ public class LineBasedDoorFactory extends AbstractService implements LoginCellFa
     @Override
     public Cell newCell(StreamEngine engine, String userName) throws InvocationTargetException
     {
-        LineBasedDoor door = new LineBasedDoor(parentCellName + "*", args, factory, engine, executor);
+        LineBasedDoor door = new LineBasedDoor(parentCellName + "*", args, factory,
+                engine, executor, idResolverFactory);
         try {
             door.start();
         } catch (ExecutionException | InterruptedException e) {

--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoorProvider.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoorProvider.java
@@ -2,6 +2,7 @@ package diskCacheV111.doors;
 
 import diskCacheV111.util.ConfigurationException;
 
+import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.services.login.LoginCellFactory;
 import dmg.cells.services.login.LoginCellProvider;
 
@@ -22,14 +23,15 @@ public class LineBasedDoorProvider implements LoginCellProvider
     }
 
     @Override
-    public LoginCellFactory createFactory(String name, Args args, String parentCellName) throws IllegalArgumentException
+    public LoginCellFactory createFactory(String name, Args args,
+            CellEndpoint parentEndpoint, String parentCellName) throws IllegalArgumentException
     {
         try {
             Class<?> interpreter = Class.forName(name);
             if (LineBasedInterpreterFactory.class.isAssignableFrom(interpreter)) {
                 LineBasedInterpreterFactory factory = interpreter.asSubclass(LineBasedInterpreterFactory.class).newInstance();
                 factory.configure(args);
-                return new LineBasedDoorFactory(factory, args, parentCellName);
+                return new LineBasedDoorFactory(factory, args, parentEndpoint, parentCellName);
             }
             throw new IllegalArgumentException("Not a LineBasedInterpreterFactory: " + interpreter);
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | ConfigurationException e) {

--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedInterpreterFactory.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedInterpreterFactory.java
@@ -24,10 +24,12 @@ import diskCacheV111.util.ConfigurationException;
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.util.StreamEngine;
 
+import org.dcache.services.login.IdentityResolverFactory;
 import org.dcache.util.Args;
 
 public interface LineBasedInterpreterFactory
 {
     void configure(Args args) throws ConfigurationException;
-    LineBasedInterpreter create(CellEndpoint endpoint, StreamEngine engine, Executor executor) throws Exception;
+    LineBasedInterpreter create(CellEndpoint endpoint, StreamEngine engine,
+            Executor executor, IdentityResolverFactory idResolverFactory) throws Exception;
 }

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -188,6 +188,8 @@ import org.dcache.namespace.FileAttribute;
 import org.dcache.namespace.FileType;
 import org.dcache.namespace.PermissionHandler;
 import org.dcache.namespace.PosixPermissionHandler;
+import org.dcache.services.login.IdentityResolverFactory;
+import org.dcache.services.login.IdentityResolverFactory.IdentityResolver;
 import org.dcache.services.login.RemoteLoginStrategy;
 import org.dcache.util.Args;
 import org.dcache.util.AsynchronousRedirectedTransfer;
@@ -296,6 +298,9 @@ public abstract class AbstractFtpDoorV1
     protected CellAddressCore _cellAddress;
     protected CellEndpoint _cellEndpoint;
     protected Executor _executor;
+    private IdentityResolverFactory _identityResolverFactory;
+    private IdentityResolver _identityResolver;
+
 
     /**
      * Enumeration type for representing the connection mode.
@@ -341,6 +346,8 @@ public abstract class AbstractFtpDoorV1
         PERM("Perm"),
         OWNER("UNIX.owner"),
         GROUP("UNIX.group"),
+        UID("UNIX.uid"),
+        GID("UNIX.gid"),
         MODE("UNIX.mode"),
         // See http://www.iana.org/assignments/os-specific-parameters
         CHANGE("UNIX.ctime"),
@@ -606,7 +613,7 @@ public abstract class AbstractFtpDoorV1
     /** List of selected RFC 3659 facts. */
     protected Set<Fact> _currentFacts = Sets.newHashSet(
             Fact.SIZE, Fact.MODIFY, Fact.TYPE, Fact.UNIQUE, Fact.PERM,
-            Fact.OWNER, Fact.GROUP, Fact.MODE );
+            Fact.OWNER, Fact.GROUP, Fact.UID, Fact.GID, Fact.MODE );
 
     /**
      * Encapsulation of an FTP transfer.
@@ -1120,6 +1127,12 @@ public abstract class AbstractFtpDoorV1
         _executor = executor;
     }
 
+    public void setIdentityResolverFactory(IdentityResolverFactory factory)
+    {
+        _identityResolverFactory = factory;
+        _identityResolver = factory.withoutSubject();
+    }
+
     @Override
     public void init() throws Exception
     {
@@ -1208,6 +1221,7 @@ public abstract class AbstractFtpDoorV1
         _cwd = cwd;
         _doorRootPath = doorRootPath;
         _userRootPath = userRootPath;
+        _identityResolver = _identityResolverFactory.withSubject(mappedSubject);
     }
 
     public static final String hh_get_door_info = "[-binary]";
@@ -4315,10 +4329,12 @@ public abstract class AbstractFtpDoorV1
                 case UNIQUE:
                     attributes.add(PNFSID);
                     break;
+                case UID:
                 case OWNER:
                     attributes.add(OWNER);
                     attributes.addAll(_pdp.getRequiredAttributes());
                     break;
+                case GID:
                 case GROUP:
                     attributes.add(OWNER_GROUP);
                     attributes.addAll(_pdp.getRequiredAttributes());
@@ -4417,6 +4433,22 @@ public abstract class AbstractFtpDoorV1
                             }
                         }
                         break;
+                    case UID:
+                        if (attr.isDefined(OWNER)) {
+                            access = _pdp.canGetAttributes(_subject, attr, EnumSet.of(OWNER));
+                            if (access == AccessType.ACCESS_ALLOWED) {
+                                printUidFact(attr);
+                            }
+                        }
+                        break;
+                    case GID:
+                        if (attr.isDefined(OWNER_GROUP)) {
+                            access = _pdp.canGetAttributes(_subject, attr, EnumSet.of(OWNER_GROUP));
+                            if (access == AccessType.ACCESS_ALLOWED) {
+                                printGidFact(attr);
+                            }
+                        }
+                        break;
                     case MODE:
                         if (attr.isDefined(MODE)) {
                             access = _pdp.canGetAttributes(_subject, attr, EnumSet.of(MODE));
@@ -4479,13 +4511,27 @@ public abstract class AbstractFtpDoorV1
         /** Writes a RFC 3659 UNIX.Owner fact to a writer. */
         private void printOwnerFact(FileAttributes attr)
         {
-            printFact(Fact.OWNER, attr.getOwner());
+            long uid = attr.getOwner();
+            printFact(Fact.OWNER, _identityResolver.uidToName(uid).orElseGet(() -> Long.toString(uid)));
         }
 
         /** Writes a RFC 3659 UNIX.group fact to a writer. */
         private void printGroupFact(FileAttributes attr)
         {
-            printFact(Fact.GROUP, attr.getGroup());
+            long gid = attr.getGroup();
+            printFact(Fact.GROUP,  _identityResolver.gidToName(gid).orElseGet(() -> Long.toString(gid)));
+        }
+
+        /** Writes a numerical uid fact to a writer. */
+        private void printUidFact(FileAttributes attr)
+        {
+            printFact(Fact.UID, attr.getOwner());
+        }
+
+        /** Writes a numerical gid fact to a writer. */
+        private void printGidFact(FileAttributes attr)
+        {
+            printFact(Fact.GID, attr.getGroup());
         }
 
         /** Writes a RFC 3659 UNIX.mode fact to a writer. */

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpInterpreterFactory.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpInterpreterFactory.java
@@ -27,6 +27,7 @@ import diskCacheV111.util.ConfigurationException;
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.util.StreamEngine;
 
+import org.dcache.services.login.IdentityResolverFactory;
 import org.dcache.util.Args;
 import org.dcache.util.OptionParser;
 
@@ -45,7 +46,8 @@ public abstract class FtpInterpreterFactory implements LineBasedInterpreterFacto
     }
 
     @Override
-    public LineBasedInterpreter create(CellEndpoint endpoint, StreamEngine engine, Executor executor) throws Exception
+    public LineBasedInterpreter create(CellEndpoint endpoint, StreamEngine engine,
+            Executor executor, IdentityResolverFactory idResolverFactory) throws Exception
     {
         AbstractFtpDoorV1 interpreter = createInterpreter();
         interpreter.setSettings(settings);
@@ -54,6 +56,7 @@ public abstract class FtpInterpreterFactory implements LineBasedInterpreterFacto
         interpreter.setLocalSocketAddress((InetSocketAddress) engine.getSocket().getLocalSocketAddress());
         interpreter.setExecutor(executor);
         interpreter.setCellEndpoint(endpoint);
+        interpreter.setIdentityResolverFactory(idResolverFactory);
         interpreter.init();
         return interpreter;
     }

--- a/modules/dcache/src/main/java/org/dcache/services/login/IdentityResolverFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/login/IdentityResolverFactory.java
@@ -1,0 +1,249 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.services.login;
+
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+
+import java.security.Principal;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import diskCacheV111.util.CacheException;
+
+import org.dcache.auth.GidPrincipal;
+import org.dcache.auth.GroupNamePrincipal;
+import org.dcache.auth.LoginStrategy;
+import org.dcache.auth.UidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Maps numerical uid or gid values to username or groupname, respectively.
+ * A small cache is used to improve response time and to avoid clients
+ * overloading the LoginStrategy. In effect, this class acts as a helper class
+ * for LoginStrategy to simplify interactions.
+ * <p>
+ * There are two forms of IdentityResolver: with-Subject and without-Subject.
+ * The without-Subject will use the cached results and the LoginStrategy to
+ * resolve an identity.
+ */
+public class IdentityResolverFactory
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdentityResolverFactory.class);
+    private static final Long INVALID_ID = -1L;
+
+    private final LoginStrategy loginStrategy;
+
+    private final LoadingCache<Long, Optional<String>> uidToName = CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(1, TimeUnit.MINUTES)
+                .build(new CacheLoader<Long, Optional<String>>()
+                    {
+                        @Override
+                        public Optional<String> load(Long uid) throws CacheException
+                        {
+                            for (Principal p : loginStrategy.reverseMap(new UidPrincipal(uid))) {
+                                if (p instanceof UserNamePrincipal) {
+                                    return Optional.of(p.getName());
+                                }
+                            }
+                            return Optional.empty();
+                        }
+                    });
+
+    private final LoadingCache<Long, Optional<String>> gidToName = CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(1, TimeUnit.MINUTES)
+                .build(new CacheLoader<Long, Optional<String>>()
+                    {
+                        @Override
+                        public Optional<String> load(Long gid) throws CacheException
+                        {
+                            for (Principal p : loginStrategy.reverseMap(new GidPrincipal(gid, false))) {
+                                if (p instanceof GroupNamePrincipal) {
+                                    return Optional.of(p.getName());
+                                }
+                            }
+
+                            return Optional.empty();
+                        }
+                    });
+
+
+    public IdentityResolverFactory(LoginStrategy loginStrategy)
+    {
+        this.loginStrategy = loginStrategy;
+    }
+
+    /**
+     * Provide additional information for identity resolving.
+     */
+    public IdentityResolver withSubject(Subject subject)
+    {
+        return new IdentityResolver(subject);
+    }
+
+    public IdentityResolver withoutSubject()
+    {
+        return new IdentityResolver(null);
+    }
+
+    /**
+     * Try to discover a UserName that matches the uid based on information
+     * taken from the Subject.
+     */
+    private static Optional<String> userNameFromSubject(Subject subject, long uid)
+    {
+        String name = null;
+
+        if (subject != null) {
+            long subjectUid = INVALID_ID;
+            String subjectName = null;
+
+            for (Principal principal : subject.getPrincipals()) {
+                if (principal instanceof UidPrincipal) {
+                    checkArgument(subjectUid == INVALID_ID, "subject has multiple UidPrincipal");
+                    subjectUid = ((UidPrincipal) principal).getUid();
+                }
+                if (principal instanceof UserNamePrincipal) {
+                    checkArgument(subjectName == null, "subject has multiple UserNamePrincipal");
+                    subjectName = principal.getName();
+                }
+            }
+
+            if (subjectUid != INVALID_ID && subjectName != null
+                    && subjectUid == uid) {
+                name = subjectName;
+            }
+        }
+
+        return Optional.ofNullable(name);
+    }
+
+    /**
+     * Try to discover a GroupName that matches the gid from the Subject.
+     */
+    private static Optional<String> groupNameFromSubject(Subject subject, long gid)
+    {
+        String name = null;
+
+        if (subject != null) {
+            String primaryName = null;
+            String nonPrimaryName = null;
+            long primaryGid = INVALID_ID;
+            long nonPrimaryGid = INVALID_ID;
+
+            int gidCount = 0;
+            int nameCount = 0;
+            for (Principal principal : subject.getPrincipals()) {
+                if (principal instanceof GidPrincipal) {
+                    gidCount++;
+                    GidPrincipal p = (GidPrincipal) principal;
+                    if (p.isPrimaryGroup()) {
+                        checkArgument(primaryGid == INVALID_ID, "Subject has multiple primary GidPrincipal");
+                        primaryGid = p.getGid();
+                    } else {
+                        nonPrimaryGid = p.getGid();
+                    }
+                } else if (principal instanceof GroupNamePrincipal) {
+                    nameCount++;
+                    GroupNamePrincipal p = (GroupNamePrincipal) principal;
+                    if (p.isPrimaryGroup()) {
+                        checkArgument(primaryName == null, "Subject has multiple primary GroupNamePrincipal");
+                        primaryName = p.getName();
+                    } else {
+                        nonPrimaryName = p.getName();
+                    }
+                }
+            }
+
+            if (primaryGid != INVALID_ID && primaryName != null) {
+                if (primaryGid == gid) {
+                    name = primaryName;
+                } else if (gidCount == 2 && nameCount == 2 && nonPrimaryGid == gid) {
+                    name = nonPrimaryName;
+                }
+            }
+        }
+
+        return Optional.ofNullable(name);
+    }
+
+    public class IdentityResolver
+    {
+        private final Subject subject;
+
+        private IdentityResolver(Subject subject)
+        {
+            this.subject = subject;
+        }
+
+        public Optional<String> uidToName(long uid)
+        {
+            Optional<String> name = userNameFromSubject(subject, uid);
+
+            if (!name.isPresent()) {
+                try {
+                    name = uidToName.get(uid);
+                } catch (ExecutionException e) {
+                    Throwable t = e.getCause();
+                    Throwables.propagateIfPossible(t);
+                    LOGGER.warn("Failed to obtain username for uid {}: {}", uid,
+                            e.getMessage());
+                } catch (UncheckedExecutionException e) {
+                    Throwables.propagateIfPossible(e.getCause());
+                    throw e;
+                }
+            }
+
+            return name;
+        }
+
+        public Optional<String> gidToName(long gid)
+        {
+            Optional<String> name = groupNameFromSubject(subject, gid);
+
+            if (!name.isPresent()) {
+                try {
+                    name = gidToName.get(gid);
+                } catch (ExecutionException e) {
+                    Throwable t = e.getCause();
+                    Throwables.propagateIfPossible(t);
+                    LOGGER.warn("Failed to obtain groupname for gid {}: {}", gid,
+                            e.getMessage());
+                } catch (UncheckedExecutionException e) {
+                    Throwables.propagateIfPossible(e.getCause());
+                    throw e;
+                }
+            }
+
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Better compatibility with how Globus server describes namespace
ownership.

Modification:

The UNIX.owner and UNIX.group facts are not actually defined anywhere.
Some servers (e.g., dCache currently, ProFTPd) supply numerical values
while others (e.g., Globus, ncftp) supply names.  In contrast, some
servers also publish UNIX.uid and UNIX.gid facts, which are always
numerical values.

This patch updates UNIX.owner and UNIX.group so they provide the owner
name and owner-group name (respectively), if these values are known.

There are different possible strategies for when the door is unable to
discover the name correpsonding to the owner or group-owner of a file,
when publishing UNIX.owner or UNIX.group; for example, it could publish
the numerical value instead, substitute a place-holder name, or refrain
from publishing the fact.

Currently, the door publishes numerical values as a fall-back for
UNIX.owner or UNIX.group.  This is similar to dCache's current
behaviour.  This decision may be revisited once a clearer picture
emerges of what different clients expect.

In addition to querying gPlazma, the logged-in user's identity is also
used to discover suitable names.  This means UNIX.owner will be the
logged-in user's name (and not a numerical value) for all files owned by
that user.  Similarly, UNIX.group will be the logged-in user's primary
group name for all files with that group-owner.

This patch also adds IdentityResolver and IdentityResolverFactory
classes, which act as helper classes when mapping uid/gid to
corresponding username or groupname values.  It holds the logic
associated with this process and provides a small cache to prevent the
door from placing too much load on gPlazma.

A single IdentityResolverFactory instance is shared between all login
session; therefore, all GridFTP sessions share the same cache.  This is
necessary as Globus transfer agents typically have many short-lived
sessions.  Without the shared cache, the benefits from caching results
would be lost.

Result:

Better compatibility with Globus server responses.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10057/
Acked-by: Dmitry Litvintsev
Requires-notes: yes
Requires-book: no

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpInterpreterFactory.java
	modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
	modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoorFactory.java
	modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedInterpreterFactory.java

Conflicts:
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoor.java
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedInterpreterFactory.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpInterpreterFactory.java