### PR TITLE
ftp: modify facts describing namespace ownership

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LegacyLoginCellProvider.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LegacyLoginCellProvider.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
 import dmg.cells.nucleus.Cell;
+import dmg.cells.nucleus.CellEndpoint;
 import dmg.util.StreamEngine;
 
 import org.dcache.util.Args;
@@ -40,7 +41,7 @@ public class LegacyLoginCellProvider implements LoginCellProvider
     }
 
     @Override
-    public LoginCellFactory createFactory(String name, Args args, String parentCellName)
+    public LoginCellFactory createFactory(String name, Args args, CellEndpoint parentEndpoint, String parentCellName)
     {
         try {
             Class<? extends Cell> loginClass = Class.forName(name).asSubclass(Cell.class);

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginCellFactoryBuilder.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginCellFactoryBuilder.java
@@ -5,6 +5,8 @@ import com.google.common.collect.Ordering;
 
 import java.util.ServiceLoader;
 
+import dmg.cells.nucleus.CellEndpoint;
+
 import org.dcache.util.Args;
 
 public class LoginCellFactoryBuilder
@@ -15,6 +17,7 @@ public class LoginCellFactoryBuilder
     private String name;
     private Args args;
     private String loginManagerName;
+    private CellEndpoint endpoint;
 
     public LoginCellFactoryBuilder setName(String name)
     {
@@ -34,6 +37,12 @@ public class LoginCellFactoryBuilder
         return this;
     }
 
+    public LoginCellFactoryBuilder setCellEndpoint(CellEndpoint endpoint)
+    {
+        this.endpoint = endpoint;
+        return this;
+    }
+
     public LoginCellFactory build()
     {
         LoginCellProvider bestProvider =
@@ -41,7 +50,7 @@ public class LoginCellFactoryBuilder
         if (bestProvider.getPriority(name) == Integer.MIN_VALUE) {
             throw new IllegalArgumentException("No login cell provider found for " + name);
         }
-        return bestProvider.createFactory(name, args, loginManagerName);
+        return bestProvider.createFactory(name, args, endpoint, loginManagerName);
     }
 
     private static Function<LoginCellProvider, Integer> priorityFor(final String name)

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginCellProvider.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginCellProvider.java
@@ -1,5 +1,7 @@
 package dmg.cells.services.login;
 
+import dmg.cells.nucleus.CellEndpoint;
+
 import org.dcache.util.Args;
 
 /**
@@ -25,10 +27,12 @@ public interface LoginCellProvider
      *
      * @param name Identifier for a type of login cell
      * @param args Arguments for the login cell
+     * @param parentEndpoint CellEndpoint of the parent cell
      * @param parentCellName Name of the parent login manager
      * @return A new LoginCellFactory
      * @see LoginCellFactory#stop
      */
-    LoginCellFactory createFactory(String name, Args args, String parentCellName)
+    LoginCellFactory createFactory(String name, Args args,
+        CellEndpoint parentEndpoint, String parentCellName)
         throws IllegalArgumentException;
 }

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -186,6 +186,7 @@ public class LoginManager
                     .setName(loginCell)
                     .setLoginManagerName(getCellName())
                     .setArgs(childArgs)
+                    .setCellEndpoint(this)
                     .build();
             _version = new CellVersion(Version.of(_loginCellFactory));
 

--- a/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoorProvider.java
+++ b/modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoorProvider.java
@@ -2,6 +2,7 @@ package diskCacheV111.doors;
 
 import diskCacheV111.doors.LineBasedDoor.LineBasedInterpreter;
 
+import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.services.login.LoginCellFactory;
 import dmg.cells.services.login.LoginCellProvider;
 
@@ -22,12 +23,13 @@ public class LineBasedDoorProvider implements LoginCellProvider
     }
 
     @Override
-    public LoginCellFactory createFactory(String name, Args args, String parentCellName) throws IllegalArgumentException
+    public LoginCellFactory createFactory(String name, Args args,
+            CellEndpoint parentEndpoint, String parentCellName) throws IllegalArgumentException
     {
         try {
             Class<?> interpreter = Class.forName(name);
             if (LineBasedInterpreter.class.isAssignableFrom(interpreter)) {
-                return new LineBasedDoorFactory(interpreter.asSubclass(LineBasedInterpreter.class), args, parentCellName);
+                return new LineBasedDoorFactory(interpreter.asSubclass(LineBasedInterpreter.class), args, parentEndpoint, parentCellName);
             }
         } catch (ClassNotFoundException ignored) {
         }

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -184,6 +184,8 @@ import org.dcache.namespace.FileAttribute;
 import org.dcache.namespace.FileType;
 import org.dcache.namespace.PermissionHandler;
 import org.dcache.namespace.PosixPermissionHandler;
+import org.dcache.services.login.IdentityResolverFactory;
+import org.dcache.services.login.IdentityResolverFactory.IdentityResolver;
 import org.dcache.services.login.RemoteLoginStrategy;
 import org.dcache.util.Args;
 import org.dcache.util.AsynchronousRedirectedTransfer;
@@ -284,6 +286,9 @@ public abstract class AbstractFtpDoorV1
     protected CellAddressCore _cellAddress;
     protected CellEndpoint _cellEndpoint;
     protected Executor _executor;
+    private IdentityResolverFactory _identityResolverFactory;
+    private IdentityResolver _identityResolver;
+
 
     /**
      * Enumeration type for representing the connection mode.
@@ -329,6 +334,8 @@ public abstract class AbstractFtpDoorV1
         PERM("Perm"),
         OWNER("UNIX.owner"),
         GROUP("UNIX.group"),
+        UID("UNIX.uid"),
+        GID("UNIX.gid"),
         MODE("UNIX.mode"),
         // See http://www.iana.org/assignments/os-specific-parameters
         CHANGE("UNIX.ctime"),
@@ -811,7 +818,7 @@ public abstract class AbstractFtpDoorV1
     /** List of selected RFC 3659 facts. */
     protected Set<Fact> _currentFacts = Sets.newHashSet(
             Fact.SIZE, Fact.MODIFY, Fact.TYPE, Fact.UNIQUE, Fact.PERM,
-            Fact.OWNER, Fact.GROUP, Fact.MODE );
+            Fact.OWNER, Fact.GROUP, Fact.UID, Fact.GID, Fact.MODE );
 
     /**
      * Encapsulation of an FTP transfer.
@@ -1315,6 +1322,12 @@ public abstract class AbstractFtpDoorV1
         _executor = executor;
     }
 
+    public void setIdentityResolverFactory(IdentityResolverFactory factory)
+    {
+        _identityResolverFactory = factory;
+        _identityResolver = factory.withoutSubject();
+    }
+
     @Override
     public void init() throws UnknownHostException
     {
@@ -1429,6 +1442,7 @@ public abstract class AbstractFtpDoorV1
         _doorRootPath = doorRootPath;
         _userRootPath = userRootPath;
         _isUserReadOnly = isUserReadOnly;
+        _identityResolver = _identityResolverFactory.withSubject(mappedSubject);
     }
 
     public static final String hh_get_door_info = "[-binary]";
@@ -4433,10 +4447,12 @@ public abstract class AbstractFtpDoorV1
                 case UNIQUE:
                     attributes.add(PNFSID);
                     break;
+                case UID:
                 case OWNER:
                     attributes.add(OWNER);
                     attributes.addAll(_pdp.getRequiredAttributes());
                     break;
+                case GID:
                 case GROUP:
                     attributes.add(OWNER_GROUP);
                     attributes.addAll(_pdp.getRequiredAttributes());
@@ -4550,6 +4566,22 @@ public abstract class AbstractFtpDoorV1
                             }
                         }
                         break;
+                    case UID:
+                        if (attr.isDefined(OWNER)) {
+                            access = _pdp.canGetAttributes(_subject, attr, EnumSet.of(OWNER));
+                            if (access == AccessType.ACCESS_ALLOWED) {
+                                printUidFact(attr);
+                            }
+                        }
+                        break;
+                    case GID:
+                        if (attr.isDefined(OWNER_GROUP)) {
+                            access = _pdp.canGetAttributes(_subject, attr, EnumSet.of(OWNER_GROUP));
+                            if (access == AccessType.ACCESS_ALLOWED) {
+                                printGidFact(attr);
+                            }
+                        }
+                        break;
                     case MODE:
                         if (attr.isDefined(MODE)) {
                             access =
@@ -4614,13 +4646,27 @@ public abstract class AbstractFtpDoorV1
         /** Writes a RFC 3659 UNIX.Owner fact to a writer. */
         private void printOwnerFact(FileAttributes attr)
         {
-            printFact(Fact.OWNER, attr.getOwner());
+            long uid = attr.getOwner();
+            printFact(Fact.OWNER, _identityResolver.uidToName(uid).orElseGet(() -> Long.toString(uid)));
         }
 
         /** Writes a RFC 3659 UNIX.group fact to a writer. */
         private void printGroupFact(FileAttributes attr)
         {
-            printFact(Fact.GROUP, attr.getGroup());
+            long gid = attr.getGroup();
+            printFact(Fact.GROUP,  _identityResolver.gidToName(gid).orElseGet(() -> Long.toString(gid)));
+        }
+
+        /** Writes a numerical uid fact to a writer. */
+        private void printUidFact(FileAttributes attr)
+        {
+            printFact(Fact.UID, attr.getOwner());
+        }
+
+        /** Writes a numerical gid fact to a writer. */
+        private void printGidFact(FileAttributes attr)
+        {
+            printFact(Fact.GID, attr.getGroup());
         }
 
         /** Writes a RFC 3659 UNIX.mode fact to a writer. */

--- a/modules/dcache/src/main/java/org/dcache/services/login/IdentityResolverFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/login/IdentityResolverFactory.java
@@ -1,0 +1,249 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.services.login;
+
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+
+import java.security.Principal;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import diskCacheV111.util.CacheException;
+
+import org.dcache.auth.GidPrincipal;
+import org.dcache.auth.GroupNamePrincipal;
+import org.dcache.auth.LoginStrategy;
+import org.dcache.auth.UidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Maps numerical uid or gid values to username or groupname, respectively.
+ * A small cache is used to improve response time and to avoid clients
+ * overloading the LoginStrategy. In effect, this class acts as a helper class
+ * for LoginStrategy to simplify interactions.
+ * <p>
+ * There are two forms of IdentityResolver: with-Subject and without-Subject.
+ * The without-Subject will use the cached results and the LoginStrategy to
+ * resolve an identity.
+ */
+public class IdentityResolverFactory
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdentityResolverFactory.class);
+    private static final Long INVALID_ID = -1L;
+
+    private final LoginStrategy loginStrategy;
+
+    private final LoadingCache<Long, Optional<String>> uidToName = CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(1, TimeUnit.MINUTES)
+                .build(new CacheLoader<Long, Optional<String>>()
+                    {
+                        @Override
+                        public Optional<String> load(Long uid) throws CacheException
+                        {
+                            for (Principal p : loginStrategy.reverseMap(new UidPrincipal(uid))) {
+                                if (p instanceof UserNamePrincipal) {
+                                    return Optional.of(p.getName());
+                                }
+                            }
+                            return Optional.empty();
+                        }
+                    });
+
+    private final LoadingCache<Long, Optional<String>> gidToName = CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(1, TimeUnit.MINUTES)
+                .build(new CacheLoader<Long, Optional<String>>()
+                    {
+                        @Override
+                        public Optional<String> load(Long gid) throws CacheException
+                        {
+                            for (Principal p : loginStrategy.reverseMap(new GidPrincipal(gid, false))) {
+                                if (p instanceof GroupNamePrincipal) {
+                                    return Optional.of(p.getName());
+                                }
+                            }
+
+                            return Optional.empty();
+                        }
+                    });
+
+
+    public IdentityResolverFactory(LoginStrategy loginStrategy)
+    {
+        this.loginStrategy = loginStrategy;
+    }
+
+    /**
+     * Provide additional information for identity resolving.
+     */
+    public IdentityResolver withSubject(Subject subject)
+    {
+        return new IdentityResolver(subject);
+    }
+
+    public IdentityResolver withoutSubject()
+    {
+        return new IdentityResolver(null);
+    }
+
+    /**
+     * Try to discover a UserName that matches the uid based on information
+     * taken from the Subject.
+     */
+    private static Optional<String> userNameFromSubject(Subject subject, long uid)
+    {
+        String name = null;
+
+        if (subject != null) {
+            long subjectUid = INVALID_ID;
+            String subjectName = null;
+
+            for (Principal principal : subject.getPrincipals()) {
+                if (principal instanceof UidPrincipal) {
+                    checkArgument(subjectUid == INVALID_ID, "subject has multiple UidPrincipal");
+                    subjectUid = ((UidPrincipal) principal).getUid();
+                }
+                if (principal instanceof UserNamePrincipal) {
+                    checkArgument(subjectName == null, "subject has multiple UserNamePrincipal");
+                    subjectName = principal.getName();
+                }
+            }
+
+            if (subjectUid != INVALID_ID && subjectName != null
+                    && subjectUid == uid) {
+                name = subjectName;
+            }
+        }
+
+        return Optional.ofNullable(name);
+    }
+
+    /**
+     * Try to discover a GroupName that matches the gid from the Subject.
+     */
+    private static Optional<String> groupNameFromSubject(Subject subject, long gid)
+    {
+        String name = null;
+
+        if (subject != null) {
+            String primaryName = null;
+            String nonPrimaryName = null;
+            long primaryGid = INVALID_ID;
+            long nonPrimaryGid = INVALID_ID;
+
+            int gidCount = 0;
+            int nameCount = 0;
+            for (Principal principal : subject.getPrincipals()) {
+                if (principal instanceof GidPrincipal) {
+                    gidCount++;
+                    GidPrincipal p = (GidPrincipal) principal;
+                    if (p.isPrimaryGroup()) {
+                        checkArgument(primaryGid == INVALID_ID, "Subject has multiple primary GidPrincipal");
+                        primaryGid = p.getGid();
+                    } else {
+                        nonPrimaryGid = p.getGid();
+                    }
+                } else if (principal instanceof GroupNamePrincipal) {
+                    nameCount++;
+                    GroupNamePrincipal p = (GroupNamePrincipal) principal;
+                    if (p.isPrimaryGroup()) {
+                        checkArgument(primaryName == null, "Subject has multiple primary GroupNamePrincipal");
+                        primaryName = p.getName();
+                    } else {
+                        nonPrimaryName = p.getName();
+                    }
+                }
+            }
+
+            if (primaryGid != INVALID_ID && primaryName != null) {
+                if (primaryGid == gid) {
+                    name = primaryName;
+                } else if (gidCount == 2 && nameCount == 2 && nonPrimaryGid == gid) {
+                    name = nonPrimaryName;
+                }
+            }
+        }
+
+        return Optional.ofNullable(name);
+    }
+
+    public class IdentityResolver
+    {
+        private final Subject subject;
+
+        private IdentityResolver(Subject subject)
+        {
+            this.subject = subject;
+        }
+
+        public Optional<String> uidToName(long uid)
+        {
+            Optional<String> name = userNameFromSubject(subject, uid);
+
+            if (!name.isPresent()) {
+                try {
+                    name = uidToName.get(uid);
+                } catch (ExecutionException e) {
+                    Throwable t = e.getCause();
+                    Throwables.propagateIfPossible(t);
+                    LOGGER.warn("Failed to obtain username for uid {}: {}", uid,
+                            e.getMessage());
+                } catch (UncheckedExecutionException e) {
+                    Throwables.propagateIfPossible(e.getCause());
+                    throw e;
+                }
+            }
+
+            return name;
+        }
+
+        public Optional<String> gidToName(long gid)
+        {
+            Optional<String> name = groupNameFromSubject(subject, gid);
+
+            if (!name.isPresent()) {
+                try {
+                    name = gidToName.get(gid);
+                } catch (ExecutionException e) {
+                    Throwable t = e.getCause();
+                    Throwables.propagateIfPossible(t);
+                    LOGGER.warn("Failed to obtain groupname for gid {}: {}", gid,
+                            e.getMessage());
+                } catch (UncheckedExecutionException e) {
+                    Throwables.propagateIfPossible(e.getCause());
+                    throw e;
+                }
+            }
+
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Better compatibility with how Globus server describes namespace
ownership.

Modification:

The UNIX.owner and UNIX.group facts are not actually defined anywhere.
Some servers (e.g., dCache currently, ProFTPd) supply numerical values
while others (e.g., Globus, ncftp) supply names.  In contrast, some
servers also publish UNIX.uid and UNIX.gid facts, which are always
numerical values.

This patch updates UNIX.owner and UNIX.group so they provide the owner
name and owner-group name (respectively), if these values are known.

There are different possible strategies for when the door is unable to
discover the name correpsonding to the owner or group-owner of a file,
when publishing UNIX.owner or UNIX.group; for example, it could publish
the numerical value instead, substitute a place-holder name, or refrain
from publishing the fact.

Currently, the door publishes numerical values as a fall-back for
UNIX.owner or UNIX.group.  This is similar to dCache's current
behaviour.  This decision may be revisited once a clearer picture
emerges of what different clients expect.

In addition to querying gPlazma, the logged-in user's identity is also
used to discover suitable names.  This means UNIX.owner will be the
logged-in user's name (and not a numerical value) for all files owned by
that user.  Similarly, UNIX.group will be the logged-in user's primary
group name for all files with that group-owner.

This patch also adds IdentityResolver and IdentityResolverFactory
classes, which act as helper classes when mapping uid/gid to
corresponding username or groupname values.  It holds the logic
associated with this process and provides a small cache to prevent the
door from placing too much load on gPlazma.

A single IdentityResolverFactory instance is shared between all login
session; therefore, all GridFTP sessions share the same cache.  This is
necessary as Globus transfer agents typically have many short-lived
sessions.  Without the shared cache, the benefits from caching results
would be lost.

Result:

Better compatibility with Globus server responses.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10057/
Acked-by: Dmitry Litvintsev
Requires-notes: yes
Requires-book: no

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpInterpreterFactory.java
	modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
	modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoorFactory.java
	modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedInterpreterFactory.java

Conflicts:
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoor.java
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedInterpreterFactory.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpInterpreterFactory.java

Conflicts:
	modules/cells/src/main/java/dmg/cells/services/login/LegacyLoginCellProvider.java
	modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoor.java
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoorFactory.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java

Conflicts:
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoor.java
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoorFactory.java
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedDoorProvider.java
	modules/dcache-ftp/src/main/java/diskCacheV111/doors/LineBasedInterpreterFactory.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpInterpreterFactory.java