### PR TITLE
srm: update srm request.*.lifetime configuration properties documenta…

### DIFF
--- a/skel/share/defaults/srmmanager.properties
+++ b/skel/share/defaults/srmmanager.properties
@@ -787,8 +787,29 @@ srmmanager.limits.ls.entries = 10000
 #
 srmmanager.limits.ls.levels = infinity
 
-# --- Request lifetimes
-
+# --- Maximum lifetime of an SRM request
+#
+#  Each scheduled kind SRM operation (GET, PUT, BRING-ONLINE, COPY)
+#  has a finite lifetime.  If the operation does not complete within
+#  that lifetime then the operation is automatically failed.
+#
+#  In the request that initiated the operation (srmPrepareToGet, etc),
+#  the client may specify a desired lifetime of the operation.  The
+#  client may also choose not to specify the timeout, in which case
+#  the server is free to choose the lifetime.
+#
+#  If the client requests a lifetime in excess of the configured value
+#  then dCache will accept the request but ignore the client's desired
+#  lifetime, using the configured maximum value instead.
+#
+#  If the SRM request does not specify a desired timeout (or the value
+#  is zero) then dCache will use the maximum value as the default
+#  value.
+#
+#  Note that, although the maximum lifetime for each kind of SRM
+#  request may be configured independently, by default they share a
+#  common value.
+#
 srmmanager.request.lifetime=14400000
 (one-of?MILLISECONDS|\
 	SECONDS|\


### PR DESCRIPTION
…tion

Motivation:

Reports from Tier-1 centres indicated that the existing document does
not make it clear with which semantics dCache uses the
request.*.lifetime configuration properties.  This confusion led to a
delay in fixing undesirable configuration.

Modification:

Add a description for these properties.

Result:

Admins have a better understanding how to configure dCache correctly.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10076/
Acked-by: Tigran Mkrtchyan