### PR TITLE
srm: include remaining request lifetime in various responses

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
@@ -82,6 +82,7 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.dcache.srm.SRMFileRequestNotFoundException;
@@ -292,6 +293,7 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
             counter = _stateChangeCounter.get();
             response = getSrmBringOnlineResponse();
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -306,6 +308,7 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
             new ArrayOfTBringOnlineRequestFileStatus();
         arrayOfTBringOnlineRequestFileStatus.setStatusArray(getArrayOfTBringOnlineRequestFileStatus());
         response.setArrayOfFileStatuses(arrayOfTBringOnlineRequestFileStatus);
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -334,6 +337,7 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
             }
             logger.debug(s.toString());
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
@@ -87,6 +87,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.dcache.srm.SRM;
 import org.dcache.srm.SRMException;
@@ -779,6 +780,7 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
         response.setReturnStatus(getTReturnStatus());
         response.setRequestToken(getTRequestToken());
         response.setArrayOfFileStatuses(new ArrayOfTCopyRequestFileStatus(getArrayOfTCopyRequestFileStatuses()));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -833,6 +835,7 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
         response.setReturnStatus(getTReturnStatus());
         TCopyRequestFileStatus[] fileStatuses = getArrayOfTCopyRequestFileStatuses(fromurls, tourls);
         response.setArrayOfFileStatuses(new ArrayOfTCopyRequestFileStatus(fileStatuses));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
@@ -83,6 +83,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.dcache.srm.SRMFileRequestNotFoundException;
@@ -286,6 +287,7 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
             tryToReady();
             response = getSrmPrepareToGetResponse();
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
 
         return response;
     }
@@ -297,6 +299,7 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
         response.setReturnStatus(getTReturnStatus());
         response.setRequestToken(getTRequestToken());
         response.setArrayOfFileStatuses(new ArrayOfTGetRequestFileStatus(getArrayOfTGetRequestFileStatus()));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -323,6 +326,7 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
             }
             logger.debug(s.toString());
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -78,6 +78,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.dcache.srm.SRMAbortedException;
@@ -726,6 +727,10 @@ public abstract class Job  {
         } finally {
             runlock();
         }
+    }
+
+    public int getRemainingLifetimeIn(TimeUnit unit) {
+        return (int) Math.min(unit.convert(getRemainingLifetime(), TimeUnit.MILLISECONDS), Integer.MAX_VALUE);
     }
 
     public long getLastStateTransitionTime(){

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/PutRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/PutRequest.java
@@ -83,6 +83,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.dcache.srm.SRMException;
 import org.dcache.srm.SRMFileRequestNotFoundException;
@@ -360,6 +361,7 @@ public final class PutRequest extends ContainerRequest<PutFileRequest> {
             tryToReady();
             response = getSrmPrepareToPutResponse();
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
 
         return response;
     }
@@ -371,6 +373,7 @@ public final class PutRequest extends ContainerRequest<PutFileRequest> {
         response.setReturnStatus(getTReturnStatus());
         response.setRequestToken(getTRequestToken());
         response.setArrayOfFileStatuses(new ArrayOfTPutRequestFileStatus(getArrayOfTPutRequestFileStatus()));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -398,6 +401,7 @@ public final class PutRequest extends ContainerRequest<PutFileRequest> {
         }
 
         response.setArrayOfFileStatuses(new ArrayOfTPutRequestFileStatus(statusArray));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 


### PR DESCRIPTION
Motivation:

During an ATLAS stress-test of tape recalls, it was discovered that
various sites had relatively short request lifetimes.  However, the SRM
spec provides the opportunity for the server to inform the client (FTS,
in this case) of what lifetime a request actually has.

This gives the client an opportunity to discover a discrepency between
desired lifetime and the lifetime of the job.

Modification:

Include the requests remaining lifetime in the response from the server.

Target: master
Requires-notes: yes
Requires-book: no
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10077/
Acked-by: Tigran Mkrtchyan