### PR TITLE
srm: include remaining request lifetime in various responses

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineRequest.java
@@ -82,6 +82,7 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.dcache.srm.SRMFileRequestNotFoundException;
@@ -311,6 +312,7 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
             counter = _stateChangeCounter.get();
             response = getSrmBringOnlineResponse();
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -329,6 +331,7 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
             new ArrayOfTBringOnlineRequestFileStatus();
         arrayOfTBringOnlineRequestFileStatus.setStatusArray(getArrayOfTBringOnlineRequestFileStatus());
         response.setArrayOfFileStatuses(arrayOfTBringOnlineRequestFileStatus);
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -361,6 +364,7 @@ public final class BringOnlineRequest extends ContainerRequest<BringOnlineFileRe
             }
             logger.debug(s.toString());
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
@@ -86,6 +86,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.dcache.srm.SRM;
 import org.dcache.srm.SRMException;
@@ -931,6 +932,7 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
         response.setReturnStatus(getTReturnStatus());
         response.setRequestToken(getTRequestToken());
         response.setArrayOfFileStatuses(new ArrayOfTCopyRequestFileStatus(getArrayOfTCopyRequestFileStatuses()));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -985,6 +987,7 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
         response.setReturnStatus(getTReturnStatus());
         TCopyRequestFileStatus[] fileStatuses = getArrayOfTCopyRequestFileStatuses(fromurls, tourls);
         response.setArrayOfFileStatuses(new ArrayOfTCopyRequestFileStatus(fileStatuses));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetRequest.java
@@ -83,6 +83,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.dcache.srm.SRMFileRequestNotFoundException;
@@ -303,6 +304,7 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
             counter = _stateChangeCounter.get();
             response = getSrmPrepareToGetResponse();
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
 
         return response;
     }
@@ -318,6 +320,7 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
         response.setReturnStatus(getTReturnStatus());
         response.setRequestToken(getTRequestToken());
         response.setArrayOfFileStatuses(new ArrayOfTGetRequestFileStatus(getArrayOfTGetRequestFileStatus()));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -348,6 +351,7 @@ public final class GetRequest extends ContainerRequest<GetFileRequest> {
             }
             logger.debug(s.toString());
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -79,6 +79,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.dcache.srm.SRMAbortedException;
@@ -776,6 +777,10 @@ public abstract class Job  {
         } finally {
             runlock();
         }
+    }
+
+    public int getRemainingLifetimeIn(TimeUnit unit) {
+        return (int) Math.min(unit.convert(getRemainingLifetime(), TimeUnit.MILLISECONDS), Integer.MAX_VALUE);
     }
 
     public long getLastStateTransitionTime(){

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/PutRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/PutRequest.java
@@ -83,6 +83,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.dcache.srm.SRMException;
 import org.dcache.srm.SRMFileRequestNotFoundException;
@@ -380,6 +381,7 @@ public final class PutRequest extends ContainerRequest<PutFileRequest> {
             counter = _stateChangeCounter.get();
             response = getSrmPrepareToPutResponse();
         }
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
 
         return response;
     }
@@ -395,6 +397,7 @@ public final class PutRequest extends ContainerRequest<PutFileRequest> {
         response.setReturnStatus(getTReturnStatus());
         response.setRequestToken(getTRequestToken());
         response.setArrayOfFileStatuses(new ArrayOfTPutRequestFileStatus(getArrayOfTPutRequestFileStatus()));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 
@@ -427,6 +430,7 @@ public final class PutRequest extends ContainerRequest<PutFileRequest> {
         }
 
         response.setArrayOfFileStatuses(new ArrayOfTPutRequestFileStatus(statusArray));
+        response.setRemainingTotalRequestTime(getRemainingLifetimeIn(TimeUnit.SECONDS));
         return response;
     }
 


### PR DESCRIPTION
Motivation:

During an ATLAS stress-test of tape recalls, it was discovered that
various sites had relatively short request lifetimes.  However, the SRM
spec provides the opportunity for the server to inform the client (FTS,
in this case) of what lifetime a request actually has.

This gives the client an opportunity to discover a discrepency between
desired lifetime and the lifetime of the job.

Modification:

Include the requests remaining lifetime in the response from the server.

Target: master
Requires-notes: yes
Requires-book: no
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10077/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
	modules/srm-server/src/main/java/org/dcache/srm/request/Job.java