### PR TITLE
ftp: update parsing of CLIENTINFO command

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -2456,6 +2456,7 @@ public abstract class AbstractFtpDoorV1
             "SITE <SP> CHKSUM <SP> <value> - Fail upload if ADLER32 checksum isn't <value>\r\n" +
             "SITE <SP> CHGRP <SP> <group> <SP> <path> - Change group-owner of <path> to group <group>\r\n" +
             "SITE <SP> CHMOD <SP> <perm> <SP> <path> - Change permission of <path> to octal value <perm>\r\n" +
+            "SITE <SP> CLIENTINFO <SP> <id> - Provide server with information about the client\r\n" +
             "SITE <SP> SYMLINKFROM <SP> <path> - Register symlink location; SYMLINKTO must follow\r\n" +
             "SITE <SP> SYMLINKTO <SP> <path> - Create symlink to <path>; SYMLINKFROM must be earlier command\r\n" +
             "SITE <SP> TASKID <SP> <id> - Provide server with an identifier")
@@ -2778,12 +2779,33 @@ public abstract class AbstractFtpDoorV1
         }
     }
 
+    /**
+     * Create a map from a semi-colon list of chunks, with each chunk
+     * having the form "key=value", "key=\"value\"", or "value".  For the
+     * last type, we assume the key should be "appname".
+     */
+    private static Map<String,String> splitToMap(String info)
+    {
+        Map<String,String> items = new HashMap<>();
+        for (String chunk : Splitter.on(';').omitEmptyStrings().split(info)) {
+            int index = chunk.indexOf('=');
+            if (index == -1) {
+                items.put("appname", chunk.trim());
+            } else {
+                String value = chunk.substring(index+1).trim();
+                if (value.charAt(0) == '\"' && value.charAt(value.length()-1) == '\"') {
+                    value = value.substring(1, value.length()-1);
+                }
+                items.put(chunk.substring(0, index).trim(), value);
+            }
+        }
+        return items;
+    }
+
     public void doClientinfo(String description)
     {
         LOGGER.debug("client-info: {}", description);
-        Map<String,String> items = Splitter.on(';').omitEmptyStrings().
-                withKeyValueSeparator(Splitter.on('=').trimResults(CharMatcher.is('\"'))).
-                split(description);
+        Map<String,String> items = splitToMap(description);
         String appname = items.get("appname");
         if (appname != null && appname.equals("globusonline-fxp")) {
             /* GlobusOnline transfer client expects an upload to have a


### PR DESCRIPTION
Motivation:

One of Globus (transfer service) agents invokes the CLIENTINFO command
like:

    SITE CLIENTINFO gshtest

This does not follow the key-value pattern of other agents, which causes
this command to fail.

Modification:

Relax parsing to cope with a simple text.

Result:

Globus transfer agent can invoke the CLIENTINFO command without
receiving an error response.

Target: master
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no