### PR TITLE
resilience: remove check on CUSTODIAL for inaccessible files

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -430,9 +430,7 @@ public class FileOperationHandler {
         LOGGER.trace("handleVerification, {}, readable locations {}", pnfsId,
                         readableLocations);
 
-        if (readableLocations.size() == 0
-                        && operation.getRetentionPolicy()
-                        != FileOperation.CUSTODIAL) {
+        if (readableLocations.size() == 0) {
             Integer pindex = operation.getParent();
             if (pindex == null) {
                 pindex = operation.getSource();


### PR DESCRIPTION
Motivation:

When a file has no readable replicas, the default behavior of resilience
is to raise an alarm.

Currently, files marked CUSTODIAL are excluded from this.  While from
a certain standpoint, this makes sense, it nevertheless is incorrect
behavior if there is no automatic mechanism to restore the file from
tape (which is missing from the default implementation).

Modification:

Remove the check which excludes CUSTODIAL files.

Result:

An alarm is raised for all files without readable disk copies, whether
the file is CUSTODIAL or not.

(This bug was already fixed on master in patch 10048)

Target: 3.0
Request: 2.16
Acked-by:  DmitryLitvintsev (litvinse@fnal.gov)