### PR TITLE
ftp: Add support for SITE WHOAMI command

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/PrincipalSetMaker.java
+++ b/modules/common/src/main/java/org/dcache/util/PrincipalSetMaker.java
@@ -1,4 +1,4 @@
-package org.dcache.gplazma.plugins;
+package org.dcache.util;
 
 import com.google.common.collect.Sets;
 import org.globus.gsi.gssapi.jaas.GlobusPrincipal;
@@ -8,7 +8,9 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.dcache.auth.FQANPrincipal;
+import org.dcache.auth.GidPrincipal;
 import org.dcache.auth.UidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
 
 /**
  * The PrincipalSetMaker is a class that allows code to easily build a
@@ -45,6 +47,36 @@ public class PrincipalSetMaker
     public PrincipalSetMaker withUid(int uid)
     {
         _principals.add(new UidPrincipal(uid));
+        return this;
+    }
+
+    /**
+     * Add a username Principal to the set.
+     * @param uid the id to add
+     */
+    public PrincipalSetMaker withUsername(String username)
+    {
+        _principals.add(new UserNamePrincipal(username));
+        return this;
+    }
+
+    /**
+     * Add a primary gid Principal to the set.
+     * @param gid the id to add
+     */
+    public PrincipalSetMaker withPrimaryGid(int gid)
+    {
+        _principals.add(new GidPrincipal(gid, true));
+        return this;
+    }
+
+    /**
+     * Add a non-primary gid Principal to the set.
+     * @param gid the id to add
+     */
+    public PrincipalSetMaker withGid(int gid)
+    {
+        _principals.add(new GidPrincipal(gid, false));
         return this;
     }
 

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -2496,7 +2496,8 @@ public abstract class AbstractFtpDoorV1
             "SITE <SP> CLIENTINFO <SP> <id> - Provide server with information about the client\r\n" +
             "SITE <SP> SYMLINKFROM <SP> <path> - Register symlink location; SYMLINKTO must follow\r\n" +
             "SITE <SP> SYMLINKTO <SP> <path> - Create symlink to <path>; SYMLINKFROM must be earlier command\r\n" +
-            "SITE <SP> TASKID <SP> <id> - Provide server with an identifier")
+            "SITE <SP> TASKID <SP> <id> - Provide server with an identifier\r\n" +
+            "SITE <SP> WHOAMI - Provides the username or uid of the user")
     public void ftp_site(String arg)
         throws FTPCommandException
     {
@@ -2568,6 +2569,12 @@ public abstract class AbstractFtpDoorV1
                 return;
             }
             doTaskid(arg.substring(6));
+        } else if (args[0].equalsIgnoreCase("WHOAMI")) {
+            if (args.length != 1) {
+                reply("501 Invalid command arguments.");
+                return;
+            }
+            doWhoami();
         } else {
             reply("500 Unknown SITE command");
         }
@@ -2871,6 +2878,15 @@ public abstract class AbstractFtpDoorV1
         //     discoverable, provided this file still exists.  In future, we
         //     may want to record client-supplied identifiers in billing.
         reply("250 OK");
+    }
+
+    public void doWhoami()
+    {
+        String name = Subjects.getUserName(_subject);
+        if (name == null) {
+            name = Long.toString(Subjects.getUid(_subject));
+        }
+        reply("200 " + name);
     }
 
     @Help("SBUF <SP> <size> - Set buffer size.")

--- a/modules/dcache-ftp/src/test/java/org/dcache/ftp/door/AbstractFtpDoorV1Test.java
+++ b/modules/dcache-ftp/src/test/java/org/dcache/ftp/door/AbstractFtpDoorV1Test.java
@@ -14,6 +14,8 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
 
+import javax.security.auth.Subject;
+
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
 import java.net.InterfaceAddress;
@@ -36,9 +38,12 @@ import org.dcache.auth.attributes.Restrictions;
 import org.dcache.namespace.FileType;
 import org.dcache.util.OptionParser;
 
+import static org.dcache.util.PrincipalSetMaker.aSetOfPrincipals;
 import static com.google.common.net.InetAddresses.forString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Matchers.matches;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")
@@ -57,6 +62,8 @@ public class AbstractFtpDoorV1Test {
     @Mock
     Logger logger;
 
+    Subject subject;
+
     @Before
     public void setUp()
     {
@@ -66,6 +73,8 @@ public class AbstractFtpDoorV1Test {
         door._doorRootPath = FsPath.create("/pathRoot");
         door._cwd = "/cwd";
         door._pnfs = pnfs;
+        subject = new Subject();
+        door._subject = subject;
         door._authz = Restrictions.none();
     }
 
@@ -555,5 +564,25 @@ public class AbstractFtpDoorV1Test {
                 EnumSet.of(FileType.DIR));
         thrown.expectCode(550);
         door.ftp_rmd(OLD_DIR);
+    }
+
+    @Test
+    public void whenSiteWhoamiShowUsername() throws Exception {
+        subject.getPrincipals().addAll(aSetOfPrincipals().withUid(1234).withUsername("test-user").build());
+        doCallRealMethod().when(door).doWhoami();
+
+        door.doWhoami();
+
+        verify(door).reply(matches("200 .*test-user"));
+    }
+
+    @Test
+    public void whenSiteWhoamiShowUid() throws Exception {
+        subject.getPrincipals().addAll(aSetOfPrincipals().withUid(1234).build());
+        doCallRealMethod().when(door).doWhoami();
+
+        door.doWhoami();
+
+        verify(door).reply(matches("200 .*1234"));
     }
 }

--- a/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/plugins/VoRoleMapPluginTest.java
+++ b/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/plugins/VoRoleMapPluginTest.java
@@ -17,8 +17,9 @@ import org.dcache.auth.UidPrincipal;
 import org.dcache.auth.UserNamePrincipal;
 import org.dcache.gplazma.AuthenticationException;
 import org.dcache.gplazma.util.NameRolePair;
+import org.dcache.util.PrincipalSetMaker;
 
-import static org.dcache.gplazma.plugins.PrincipalSetMaker.aSetOfPrincipals;
+import static org.dcache.util.PrincipalSetMaker.aSetOfPrincipals;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;


### PR DESCRIPTION
Motivation:

Globus transfer service issues the SITE WHOAMI, which currently fails.

Modification:

Add a new FTP command that returns the username, if known, or the
numerical uid if not.

Result:

Better interoperability with Globus transfer agents.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10059/
Acked-by: Dmitry Litvintsev