### PR TITLE
ftp: Add support for SITE WHOAMI command

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/PrincipalSetMaker.java
+++ b/modules/common/src/main/java/org/dcache/util/PrincipalSetMaker.java
@@ -1,4 +1,4 @@
-package org.dcache.gplazma.plugins;
+package org.dcache.util;
 
 import com.google.common.collect.Sets;
 import org.globus.gsi.gssapi.jaas.GlobusPrincipal;
@@ -8,7 +8,9 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.dcache.auth.FQANPrincipal;
+import org.dcache.auth.GidPrincipal;
 import org.dcache.auth.UidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
 
 /**
  * The PrincipalSetMaker is a class that allows code to easily build a
@@ -45,6 +47,36 @@ public class PrincipalSetMaker
     public PrincipalSetMaker withUid(int uid)
     {
         _principals.add(new UidPrincipal(uid));
+        return this;
+    }
+
+    /**
+     * Add a username Principal to the set.
+     * @param uid the id to add
+     */
+    public PrincipalSetMaker withUsername(String username)
+    {
+        _principals.add(new UserNamePrincipal(username));
+        return this;
+    }
+
+    /**
+     * Add a primary gid Principal to the set.
+     * @param gid the id to add
+     */
+    public PrincipalSetMaker withPrimaryGid(int gid)
+    {
+        _principals.add(new GidPrincipal(gid, true));
+        return this;
+    }
+
+    /**
+     * Add a non-primary gid Principal to the set.
+     * @param gid the id to add
+     */
+    public PrincipalSetMaker withGid(int gid)
+    {
+        _principals.add(new GidPrincipal(gid, false));
         return this;
     }
 

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -2753,7 +2753,8 @@ public abstract class AbstractFtpDoorV1
             "SITE <SP> CHKSUM <SP> <value> - Fail upload if ADLER32 checksum isn't <value>\r\n" +
             "SITE <SP> CHMOD <SP> <perm> <SP> <path> - Change permission of <path> to octal value <perm>\r\n" +
             "SITE <SP> CLIENTINFO <SP> <id> - Provide server with information about the client\r\n" +
-            "SITE <SP> TASKID <SP> <id> - Provide server with an identifier")
+            "SITE <SP> TASKID <SP> <id> - Provide server with an identifier\r\n" +
+            "SITE <SP> WHOAMI - Provides the username or uid of the user")
     public void ftp_site(String arg)
         throws FTPCommandException
     {
@@ -2807,6 +2808,12 @@ public abstract class AbstractFtpDoorV1
                 return;
             }
             doTaskid(arg.substring(6));
+        } else if (args[0].equalsIgnoreCase("WHOAMI")) {
+            if (args.length != 1) {
+                reply("501 Invalid command arguments.");
+                return;
+            }
+            doWhoami();
         } else {
             reply("500 Unknown SITE command");
         }
@@ -3005,6 +3012,15 @@ public abstract class AbstractFtpDoorV1
         //     discoverable, provided this file still exists.  In future, we
         //     may want to record client-supplied identifiers in billing.
         reply("250 OK");
+    }
+
+    public void doWhoami()
+    {
+        String name = Subjects.getUserName(_subject);
+        if (name == null) {
+            name = Long.toString(Subjects.getUid(_subject));
+        }
+        reply("200 " + name);
     }
 
     @Help("SBUF <SP> <size> - Set buffer size.")

--- a/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/plugins/VoRoleMapPluginTest.java
+++ b/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/plugins/VoRoleMapPluginTest.java
@@ -17,8 +17,9 @@ import org.dcache.auth.UidPrincipal;
 import org.dcache.auth.UserNamePrincipal;
 import org.dcache.gplazma.AuthenticationException;
 import org.dcache.gplazma.util.NameRolePair;
+import org.dcache.util.PrincipalSetMaker;
 
-import static org.dcache.gplazma.plugins.PrincipalSetMaker.aSetOfPrincipals;
+import static org.dcache.util.PrincipalSetMaker.aSetOfPrincipals;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;


### PR DESCRIPTION
Motivation:

Globus transfer service issues the SITE WHOAMI, which currently fails.

Modification:

Add a new FTP command that returns the username, if known, or the
numerical uid if not.

Result:

Better interoperability with Globus transfer agents.

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10059/
Acked-by: Dmitry Litvintsev

Conflicts:
	modules/dcache-ftp/src/test/java/org/dcache/ftp/door/AbstractFtpDoorV1Test.java

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java