### PR TITLE
ftp: add support for paths relative to home directory

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -533,6 +533,7 @@ public abstract class AbstractFtpDoorV1
     protected boolean _isUserReadOnly;
     protected FsPath _userRootPath = new FsPath();
     protected FsPath _doorRootPath = new FsPath();
+    protected FsPath _userHomePath = new FsPath();
     protected String _cwd = "/";    // Relative to _doorRootPath
     protected FsPath _filepath; // Absolute filepath to the file to be renamed
     protected PnfsId _fileId; // Id of the file to be renamed
@@ -1201,16 +1202,14 @@ public abstract class AbstractFtpDoorV1
             }
         }
         FsPath doorRootPath;
-        String cwd;
         if (_settings.getRoot() == null) {
             doorRootPath = userRootPath;
-            cwd = userHomePath.toString();
         } else {
             doorRootPath = new FsPath(_settings.getRoot());
             if (userRootPath.startsWith(doorRootPath)) {
-                cwd = doorRootPath.relativize(new FsPath(userRootPath, userHomePath)).toString();
+                userHomePath = doorRootPath.relativize(new FsPath(userRootPath, userHomePath));
             } else if (_absoluteUploadPath != null && _absoluteUploadPath.startsWith(doorRootPath)) {
-                cwd = doorRootPath.relativize(_absoluteUploadPath).toString();
+                userHomePath = doorRootPath.relativize(_absoluteUploadPath);
             } else {
                 throw new PermissionDeniedCacheException("User's files are not visible through this FTP service.");
             }
@@ -1221,11 +1220,12 @@ public abstract class AbstractFtpDoorV1
         _listSource = new ListDirectoryHandler(_pnfs);
 
         _subject = mappedSubject;
-        _cwd = cwd;
+        _cwd = userHomePath.toString();
         _doorRootPath = doorRootPath;
         _userRootPath = userRootPath;
         _isUserReadOnly = isUserReadOnly;
         _identityResolver = _identityResolverFactory.withSubject(mappedSubject);
+        _userHomePath = userHomePath;
     }
 
     public static final String hh_get_door_info = "[-binary]";
@@ -1803,6 +1803,11 @@ public abstract class AbstractFtpDoorV1
 
     private FsPath absolutePath(String path) throws FTPCommandException
     {
+        if (path.equals("~")) {
+            path = _userHomePath.toString();
+        } else if (path.startsWith("~/")) {
+            path = _userHomePath + path.substring(1);
+        }
         FsPath relativePath = new FsPath(_cwd);
         relativePath.add(path);
         FsPath absolutePath = new FsPath(_doorRootPath, relativePath);


### PR DESCRIPTION
Motivation:

Globus client makes requests using paths like '~/', with the tilde
symbol is a common place-holder for the users home directory.

Modification:

When resolving a client-supplied path, interpret paths that start '~/'
as the same path without this prefix and resolved relative to the users
home directory.  If the user has no home directory, this is resolved
relative to the root directory.

Note that '~NAME' is a common place-holder for the home directory of
user NAME.  Implementing support for this is deferred until a client
requires it.

Result:

Globus transfer service shows the user's home directory when first
logged it, rather than failing.

Target: master
Request: 3.0
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10064/
Acked-by: Dmitry Litvintsev

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java