### PR TITLE
srm-client: use default GridFTP port if not specified

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/Copier.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/Copier.java
@@ -580,8 +580,9 @@ public class Copier implements Runnable {
             }
             boolean emode = (numberOfStreams!=1);
             if(! dryRun ) {
+                int port = src_url.getPort();
                 GridftpClient client = new GridftpClient(src_url.getHost(),
-                                                         src_url.getPort(),
+                                                         port == -1 ? 8211 : port,
                                                          configuration.getBuffer_size(),
                                                          configuration.getGlobus_tcp_port_range() != null
                                                          ? PortRange.valueOf(configuration.getGlobus_tcp_port_range())
@@ -639,8 +640,9 @@ public class Copier implements Runnable {
             }
             boolean emode = (numberOfStreams!=1);
             if(! dryRun ) {
+                int port = dst_url.getPort();
                 GridftpClient client = new GridftpClient(dst_url.getHost(),
-                                                         dst_url.getPort(),
+                                                         port == -1 ? 2811 : port,
                                                          configuration.getBuffer_size(),
                                                          configuration.getGlobus_tcp_port_range() != null
                                                          ? PortRange.valueOf(configuration.getGlobus_tcp_port_range())

--- a/modules/srm-client/src/main/java/org/dcache/srm/util/GridftpList.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/util/GridftpList.java
@@ -58,8 +58,9 @@ public class GridftpList {
                     return;
         }
 
+        int port = directory_url.getPort();
         GridftpClient client = new GridftpClient(directory_url.getHost(),
-            directory_url.getPort(), PortRange.getGlobusTcpPortRange(), null, new String[0],
+            port == -1 ? 2811 : port, PortRange.getGlobusTcpPortRange(), null, new String[0],
                                                  "/etc/grid-security/certificates",
                                                  CrlCheckingMode.IF_VALID, NamespaceCheckingMode.EUGRIDPMA_GLOBUS,
                                                  OCSPCheckingMode.IF_AVAILABLE);

--- a/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
@@ -760,7 +760,8 @@ public class GridftpClient
             dst_url.getScheme().equals("file")) {
             GridftpClient client;
 
-            client = new GridftpClient(src_url.getHost(), src_url.getPort(), bs,
+            int port = src_url.getPort();
+            client = new GridftpClient(src_url.getHost(), port == -1 ? 2811 : port, bs,
                                        PortRange.getGlobusTcpPortRange(), x509Credential, new String[0],
                                        "/etc/grid-security/certificates", CrlCheckingMode.IF_VALID,
                                        NamespaceCheckingMode.EUGRIDPMA_GLOBUS, OCSPCheckingMode.IF_AVAILABLE);
@@ -781,7 +782,8 @@ public class GridftpClient
                dst_url.getScheme().equals("gridftp") )
              ) {
             GridftpClient client;
-            client = new GridftpClient(dst_url.getHost(), dst_url.getPort(), bs,
+            int port = dst_url.getPort();
+            client = new GridftpClient(dst_url.getHost(), port == -1 ? 2811 : port, bs,
                                        PortRange.getGlobusTcpPortRange(), x509Credential, new String[0],
                                        "/etc/grid-security/certificates", CrlCheckingMode.IF_VALID,
                                        NamespaceCheckingMode.EUGRIDPMA_GLOBUS, OCSPCheckingMode.IF_AVAILABLE);


### PR DESCRIPTION
Motivation:

srmcp fails when transferring files into or out of DPM.  This is a
regression introduced with commit 501ed18.

Modification:

As DPM returns TURLs that do not contain a port number, the code must
ensure the default port number is inserted whenever creating a
GridFTPClient object.

Result:

srmcp works with DPM again.

Target: master
Request: 3.0
Requires-notes: no
Requires-srmclient-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10083/
Acked-by: Gerd Behrmann
Acked-by: Marina Sahakyan