### PR TITLE
ftp: do not fail proxy transfer if read returns zero bytes

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/EDataBlockNio.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/EDataBlockNio.java
@@ -160,7 +160,7 @@ public class EDataBlockNio {
                 break;
             }
 
-            if (n <= 0) {
+            if (n == -1) {
                 break;
             }
             len += n;
@@ -190,7 +190,7 @@ public class EDataBlockNio {
             } catch (Exception e) {
                 break;
             }
-            if (nr <= 0) {
+            if (nr == -1) {
                 break;
             }
             n += nr;


### PR DESCRIPTION
Motivation:

The Socket#read method may return zero to indicate that no bytes were
read.  Although this is not an error, such occurances will result
in a transfer failing.

Modification:

Continue reading from a socket if a read operation does not read any
bytes.

Result:

FTP proxied transfers are more reliable.

Target: master
Requires-notes: yes
Requires-book: no
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10098/
Acked-by: Dmitry Litvintsev