### PR TITLE
chimera: fixed database query for storing multiple checksums for a file.

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -2227,7 +2227,9 @@ class FsSqlDriver {
 
         return path;
     }
-    private static final String sqlSetInodeChecksum = "INSERT INTO t_inodes_checksum VALUES(?,?,?)";
+    private static final String sqlSetInodeChecksum =
+                                "INSERT INTO t_inodes_checksum (SELECT * FROM (VALUES (?,?,?)) v WHERE NOT EXISTS " +
+                                "(SELECT 1 FROM t_inodes_checksum WHERE ipnfsid=? AND itype=?))";
 
     /**
      * add a checksum value of <i>type</i> to an inode
@@ -2248,6 +2250,8 @@ class FsSqlDriver {
             stSetInodeChecksum.setString(1, inode.toString());
             stSetInodeChecksum.setInt(2, type);
             stSetInodeChecksum.setString(3, value);
+            stSetInodeChecksum.setString(4, inode.toString());
+            stSetInodeChecksum.setInt(5, type);
 
             stSetInodeChecksum.executeUpdate();
 


### PR DESCRIPTION
The db query for setInodeChecksum would only store one checksum per
file. This caused a problem if the ChecksumChannel created and
sent multiple checksums for a file to the PnfsManager. The PnfsManager
would store only one of the checksums. The other checksums were ignored
and never stored.

Ticket:
Acked-by: Paul Millar <paul.millar@desy.de>
Target: master
Require-book:
Require-notes:
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10124/