### PR TITLE
ftp: prevent execution of most commands when unwrapped

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1071,6 +1071,11 @@ public abstract class AbstractFtpDoorV1
         }
     }
 
+    protected interface CommandMethodVisitor
+    {
+        void acceptCommand(Method method, String name);
+    }
+
     protected FtpTransfer _transfer;
 
     public AbstractFtpDoorV1(String ftpDoorName, String tlogName)
@@ -1078,15 +1083,24 @@ public abstract class AbstractFtpDoorV1
         _ftpDoorName = ftpDoorName;
         _tlogName = tlogName;
 
-        for (Method method : getClass().getMethods()) {
-            String name = method.getName();
-            if (name.startsWith("ftp_")) {
-                String command = name.substring(4);
+        visitFtpCommands(new CommandMethodVisitor() {
+            @Override
+            public void acceptCommand(Method method, String command) {
                 _methodDict.put(command, method);
                 Help help = method.getAnnotation(Help.class);
                 if (help != null) {
                     _helpDict.put(command, help);
                 }
+            }
+        });
+    }
+
+    final protected void visitFtpCommands(CommandMethodVisitor visitor)
+    {
+        for (Method method : getClass().getMethods()) {
+            String name = method.getName();
+            if (name.startsWith("ftp_")) {
+                visitor.acceptCommand(method, name.substring(4));
             }
         }
     }
@@ -1257,7 +1271,22 @@ public abstract class AbstractFtpDoorV1
         }
     }
 
-    public void ftpcommand(String cmdline)
+    protected boolean isCommandAllowed(String command, Object commandContext)
+    {
+        // If a transfer is in progress, only permit ABORT and a few
+        // other commands to be processed
+        if (getTransfer() != null && !(command.equals("abor") ||
+                command.equals("mic") || command.equals("conf") ||
+                command.equals("enc") || command.equals("quit") ||
+                command.equals("bye"))) {
+            reply("503 Transfer in progress", false);
+            return false;
+        }
+
+        return true;
+    }
+
+    public void ftpcommand(String cmdline, Object commandContext)
         throws CommandExitException
     {
         int l = 4;
@@ -1283,13 +1312,7 @@ public abstract class AbstractFtpDoorV1
             _lastCommand = cmdline;
         }
 
-        // If a transfer is in progress, only permit ABORT and a few
-        // other commands to be processed
-        if (getTransfer() != null &&
-                !(cmd.equals("abor") || cmd.equals("mic")
-                        || cmd.equals("conf") || cmd.equals("enc")
-                        || cmd.equals("quit") || cmd.equals("bye"))) {
-            reply("503 Transfer in progress", false);
+        if (!isCommandAllowed(cmd, commandContext)) {
             return;
         }
 
@@ -1382,7 +1405,7 @@ public abstract class AbstractFtpDoorV1
                 reply(err("",""));
             } else {
                 _commandCounter++;
-                ftpcommand(command);
+                ftpcommand(command, null);
             }
         } finally {
             _commandLine = null;
@@ -1764,7 +1787,6 @@ public abstract class AbstractFtpDoorV1
             throw new FTPCommandException(550,"Cannot delete file, reason:"+e);
         }
     }
-
 
     @Help("USER <SP> <name> - Authentication username.")
     public abstract void ftp_user(String arg);


### PR DESCRIPTION
Motivation:

Currently dCache FTP command dispatch does not distinguish between
commands executed directly and those executed via RFC 2228 security
extensions.

Modification:

Annotate those commands allowed to be executed plain-text within the GSS
abstraction that adds RFC 2228 support.  Enforce that only those
commands may be run directly; all others must be wrapped using ENC, CONF
or MIC commands.

Result:

Most commands are protected from being run directly (unencrypted).

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Require-notes: yes
Require-book: no

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GsiFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/KerberosFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/WeakFtpDoorV1.java

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java