### PR TITLE
ftp: prevent execution of most commands when unwrapped

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1059,6 +1059,11 @@ public abstract class AbstractFtpDoorV1
         }
     }
 
+    protected interface CommandMethodVisitor
+    {
+        void acceptCommand(Method method, String name);
+    }
+
     protected FtpTransfer _transfer;
 
     public AbstractFtpDoorV1(String ftpDoorName, String tlogName)
@@ -1066,15 +1071,24 @@ public abstract class AbstractFtpDoorV1
         _ftpDoorName = ftpDoorName;
         _tlogName = tlogName;
 
-        for (Method method : getClass().getMethods()) {
-            String name = method.getName();
-            if (name.startsWith("ftp_")) {
-                String command = name.substring(4);
+        visitFtpCommands(new CommandMethodVisitor() {
+            @Override
+            public void acceptCommand(Method method, String command) {
                 _methodDict.put(command, method);
                 Help help = method.getAnnotation(Help.class);
                 if (help != null) {
                     _helpDict.put(command, help);
                 }
+            }
+        });
+    }
+
+    final protected void visitFtpCommands(CommandMethodVisitor visitor)
+    {
+        for (Method method : getClass().getMethods()) {
+            String name = method.getName();
+            if (name.startsWith("ftp_")) {
+                visitor.acceptCommand(method, name.substring(4));
             }
         }
     }
@@ -1236,7 +1250,22 @@ public abstract class AbstractFtpDoorV1
         }
     }
 
-    public void ftpcommand(String cmdline)
+    protected boolean isCommandAllowed(String command, Object commandContext)
+    {
+        // If a transfer is in progress, only permit ABORT and a few
+        // other commands to be processed
+        if (getTransfer() != null && !(command.equals("abor") ||
+                command.equals("mic") || command.equals("conf") ||
+                command.equals("enc") || command.equals("quit") ||
+                command.equals("bye"))) {
+            reply("503 Transfer in progress", false);
+            return false;
+        }
+
+        return true;
+    }
+
+    public void ftpcommand(String cmdline, Object commandContext)
         throws CommandExitException
     {
         int l = 4;
@@ -1262,13 +1291,7 @@ public abstract class AbstractFtpDoorV1
             _lastCommand = cmdline;
         }
 
-        // If a transfer is in progress, only permit ABORT and a few
-        // other commands to be processed
-        if (getTransfer() != null &&
-                !(cmd.equals("abor") || cmd.equals("mic")
-                        || cmd.equals("conf") || cmd.equals("enc")
-                        || cmd.equals("quit") || cmd.equals("bye"))) {
-            reply("503 Transfer in progress", false);
+        if (!isCommandAllowed(cmd, commandContext)) {
             return;
         }
 
@@ -1361,7 +1384,7 @@ public abstract class AbstractFtpDoorV1
                 reply(err("",""));
             } else {
                 _commandCounter++;
-                ftpcommand(command);
+                ftpcommand(command, null);
             }
         } finally {
             _commandLine = null;
@@ -1720,7 +1743,6 @@ public abstract class AbstractFtpDoorV1
             throw new FTPCommandException(550,"Cannot delete file, reason:"+e);
         }
     }
-
 
     @Help("USER <SP> <name> - Authentication username.")
     public abstract void ftp_user(String arg);

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
@@ -1,6 +1,5 @@
 package org.dcache.ftp.door;
 
-import com.google.common.base.Throwables;
 import org.dcache.dss.DssContext;
 import org.dcache.dss.DssContextFactory;
 
@@ -10,9 +9,13 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.Subject;
 
 import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
 import java.nio.charset.Charset;
-import java.security.cert.CertPathValidatorException;
 import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PermissionDeniedCacheException;
@@ -21,13 +24,13 @@ import dmg.util.CommandExitException;
 
 import org.dcache.auth.LoginNamePrincipal;
 
-import static com.google.common.collect.Iterables.filter;
-import static com.google.common.collect.Iterables.getFirst;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(GssFtpDoorV1.class);
-
+    private static final GssCommandContext SECURE_COMMAND_CONTEXT = new GssCommandContext();
     public static final String GLOBUS_URL_COPY_DEFAULT_USER =
             ":globus-mapping:";
 
@@ -40,11 +43,41 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
     protected DssContext context;
     private DssContextFactory dssContextFactory;
 
+    private boolean _hasControlPortCleared;
+
+    private final Set<String> _plaintextCommands = new HashSet<>();
+
+    /**
+     * Commands that are annotated @Plaintext are allowed to be sent directly,
+     * as unencrypted commands.  All other commands must be sent indirectly via
+     * an MIC, ENC or CONF command.
+     */
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    @interface Plaintext
+    {
+    }
+
+    public static class GssCommandContext
+    {
+    }
+
     public GssFtpDoorV1(String ftpDoorName, String tlogName, String gssFlavor, DssContextFactory dssContextFactory)
     {
         super(ftpDoorName, tlogName);
+
         this.gssFlavor = gssFlavor;
         this.dssContextFactory = dssContextFactory;
+
+        visitFtpCommands(new CommandMethodVisitor() {
+            @Override
+            public void acceptCommand(Method method, String command) {
+                Plaintext plaintext = method.getAnnotation(Plaintext.class);
+                if (plaintext != null) {
+                    _plaintextCommands.add(command);
+                }
+            }
+        });
     }
 
     @Override
@@ -62,6 +95,7 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
     }
 
     @Help("AUTH <SP> <arg> - Initiate secure context negotiation.")
+    @Plaintext
     public void ftp_auth(String arg) throws FTPCommandException
     {
         LOGGER.info("GssFtpDoorV1::secure_reply: going to authorize using {}", gssFlavor);
@@ -103,6 +137,7 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
     }
 
     @Help("ADAT <SP> <arg> - Supply context negotation data.")
+    @Plaintext
     public void ftp_adat(String arg)
     {
         if (arg == null || arg.length() <= 0) {
@@ -153,6 +188,7 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
     }
 
     @Help("MIC <SP> <arg> - Integrity protected command.")
+    @Plaintext
     public void ftp_mic(String arg)
             throws CommandExitException
     {
@@ -160,6 +196,7 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
     }
 
     @Help("ENC <SP> <arg> - Privacy protected command.")
+    @Plaintext
     public void ftp_enc(String arg)
             throws CommandExitException
     {
@@ -167,6 +204,7 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
     }
 
     @Help("CONF <SP> <arg> - Confidentiality protection command.")
+    @Plaintext
     public void ftp_conf(String arg)
             throws CommandExitException
     {
@@ -215,12 +253,27 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
 
         if (msg.equalsIgnoreCase("CCC")) {
             _gReplyType = "clear";
+            _hasControlPortCleared = true;
             reply("200 OK");
         } else {
             _gReplyType = sectype;
-            ftpcommand(msg);
+            ftpcommand(msg, SECURE_COMMAND_CONTEXT);
         }
 
+    }
+
+    @Override
+    protected boolean isCommandAllowed(String command, Object commandContext)
+    {
+        boolean isSecureCommand = commandContext == SECURE_COMMAND_CONTEXT;
+
+        if (!_hasControlPortCleared && !isSecureCommand &&
+                !_plaintextCommands.contains(command)) {
+            reply("530 Command must be wrapped in MIC, ENC or CONF", false);
+            return false;
+        }
+
+        return super.isCommandAllowed(command, commandContext);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Currently dCache FTP command dispatch does not distinguish between
commands executed directly and those executed via RFC 2228 security
extensions.

Modification:

Annotate those commands allowed to be executed plain-text within the GSS
abstraction that adds RFC 2228 support.  Enforce that only those
commands may be run directly; all others must be wrapped using ENC, CONF
or MIC commands.

Result:

Most commands are protected from being run directly (unencrypted).

Target: master
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Require-notes: yes
Require-book: no

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GsiFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/KerberosFtpDoorV1.java
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/WeakFtpDoorV1.java

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java