### PR TITLE
chimera : handle empty paths elements in path2inode stored procedure

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.14.xml
@@ -405,6 +405,53 @@
         </rollback>
     </changeSet>
 
+    <changeSet author="behrmann" id="5.1" dbms="postgresql">
+        <comment>use encode on bytea field</comment>
+        <createProcedure>
+            CREATE OR REPLACE FUNCTION path2inode(root varchar, path varchar) RETURNS varchar AS $$
+            DECLARE
+                id varchar := root;
+                elements varchar[] := string_to_array(path, '/');
+                child varchar;
+                itype INT;
+                link varchar;
+            BEGIN
+                FOR i IN 1..array_upper(elements,1) LOOP
+                    CASE
+                    WHEN elements[i] = '' THEN
+                        RETURN id;
+                    WHEN elements[i] = '.' THEN
+                        child := id;
+                    WHEN elements[i] = '..' THEN
+                        IF id = '000000000000000000000000000000000000' THEN
+                            child := id;
+                        ELSE
+                            SELECT iparent INTO child FROM t_dirs WHERE ipnfsid=id;
+                        END IF;
+                    ELSE
+                        SELECT dir.ipnfsid, inode.itype INTO child, itype FROM t_dirs dir, t_inodes inode WHERE dir.ipnfsid = inode.ipnfsid AND dir.iparent=id AND dir.iname=elements[i];
+                        IF itype=40960 THEN
+                            SELECT encode(ifiledata,'escape') INTO link FROM t_inodes_data WHERE ipnfsid=child;
+                            IF link LIKE '/%' THEN
+                                child := path2inode('000000000000000000000000000000000000', substring(link from 2));
+                            ELSE
+                                child := path2inode(id, link);
+                            END IF;
+                        END IF;
+                    END CASE;
+                    IF child IS NULL THEN
+                        RETURN NULL;
+                    END IF;
+                    id := child;
+                END LOOP;
+                RETURN id;
+            END;
+            $$ LANGUAGE plpgsql;
+        </createProcedure>
+        <rollback>
+        </rollback>
+    </changeSet>
+
     <changeSet author="behrmann" id="6.1" dbms="postgresql">
         <createProcedure>
             CREATE OR REPLACE FUNCTION


### PR DESCRIPTION
Motivation:

User reported issue with a symbolic link to a directory where destination
where destination contained trailing slash.

Modification:

handle empty paths elements path2inumber storage procedure

Result:

path2inode works on a symbolic link that links to a directory including a slash at the end

RB: https://rb.dcache.org/r/10115/
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no