### PR TITLE
chimera : handle empty paths elements in path2inode stored procedure

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.9.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.9.xml
@@ -162,6 +162,9 @@
             END;
             $$ LANGUAGE plpgsql;
        </createProcedure>
+       <rollback/>
+    </changeSet>
+
 
     <changeSet author="tigran" id="19.1">
         <preConditions onFail="MARK_RAN" onFailMessage="Not adding igeneration column as it already exists (this is not an error)">

--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.9.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.9.xml
@@ -125,6 +125,44 @@
        <rollback/>
     </changeSet>
 
+    <changeSet author="litvinse" id="18.2" dbms="postgresql">
+       <comment>handle empty path element</comment>
+       <createProcedure>
+	    CREATE OR REPLACE FUNCTION
+	    path2inode(root varchar, path varchar)
+	    RETURNS varchar AS $$
+            DECLARE
+                id varchar := root;
+                elements varchar[] := string_to_array(path, '/');
+                child varchar;
+                itype INT;
+                link varchar;
+            BEGIN
+                FOR i IN 1..array_upper(elements,1) LOOP
+
+                    IF elements[i] = '' THEN
+                        RETURN id;
+                    END IF;
+                    SELECT dir.ipnfsid, inode.itype INTO child, itype FROM t_dirs dir, t_inodes inode WHERE dir.ipnfsid = inode.ipnfsid AND dir.iparent=id AND dir.iname=elements[i];
+                    IF itype=40960 THEN
+                       SELECT encode(ifiledata,'escape') INTO link FROM t_inodes_data WHERE ipnfsid=child;
+                       IF link LIKE '/%' THEN
+                          child := path2inode('000000000000000000000000000000000000',
+                                               substring(link from 2));
+                       ELSE
+                          child := path2inode(id, link);
+                       END IF;
+                    END IF;
+                    IF child IS NULL THEN
+                       RETURN NULL;
+                    END IF;
+                    id := child;
+                END LOOP;
+                RETURN id;
+            END;
+            $$ LANGUAGE plpgsql;
+       </createProcedure>
+
     <changeSet author="tigran" id="19.1">
         <preConditions onFail="MARK_RAN" onFailMessage="Not adding igeneration column as it already exists (this is not an error)">
             <not>


### PR DESCRIPTION
Motivation:

User reported issue with a symbolic link to a directory where destination
where destination contained trailing slash.

Modification:

handle empty paths elements path2inumber storage procedure

Result:

path2inode works on a symbolic link that links to a directory including a slash at the end

RB: https://rb.dcache.org/r/10115/
Acked-by: Paul Millar <paul.millar@desy.de>
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Requires-notes: yes
Requires-book: no