### PR TITLE
srmclient: fix handling of checksum options

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/Configuration.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/Configuration.java
@@ -98,6 +98,9 @@ import java.util.Set;
 import org.dcache.srm.Logger;
 import org.dcache.srm.client.Transport;
 import org.dcache.util.Args;
+import org.dcache.util.Checksum;
+import org.dcache.util.ChecksumType;
+
 
 /**
  *
@@ -2584,8 +2587,26 @@ public class Configuration extends ConnectionConfiguration {
 
     private void readCksmOptions()
     {
-        if ( this.cksm_type == null && this.cksm_value != null ) {
-            this.cksm_type = "adler32";
+        if ( cksm_type == null ) {
+            if ( cksm_value == null ) {
+                return;
+            }
+            cksm_type = "adler32";
+        }
+
+        if ( cksm_type.equals("negotiate") ) {
+            if ( cksm_value != null ) {
+                throw new IllegalArgumentException("-cksm_type=negotiate and -cksm_value=<value> are mutually exclusive");
+            }
+        }
+        else {
+            /**
+             *  The following just checks checksum validity:
+             */
+            ChecksumType checksumType = ChecksumType.getChecksumType(cksm_type);
+            if ( cksm_value != null ) {
+                Checksum checksum = new Checksum(checksumType,cksm_value);
+            }
         }
     }
 

--- a/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
@@ -575,8 +575,7 @@ public class GridftpClient
             return supportedByClientAndServer.get(0);
         }
 
-        if( algorithms.contains(_cksmType)) {
-            // checksum type is specified, but is not supported by the server
+        if( algorithms.contains(_cksmType.toUpperCase())) {
             return _cksmType;
         }
 


### PR DESCRIPTION
Motivation:

It has been observed that checksum options of srmcp are messed up. E.g. lower case "md5" would be actually assumed ot be "ADLER32"

Modification:

Fix handling of checksum options. Additionally verify values.

Result:

Works as was originally expected.

Acked-by: Albert Rossi <arossi@fnal.gov>
Target: trunk
Request: 3.1
Request: 3.0
Require-book: no
Require-notes: yes
RB: https://rb.dcache.org/r/10097/
(cherry picked from commit dd2b4bf1eacd13105eb43fc84a19bb95c78e0a52)