### PR TITLE
libs: update to bug fix release nfs4j-0.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -782,7 +782,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.14.1</version>
+            <version>0.14.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
bugfix update with following highlights:

  - fix interoperability with RHEL7-based clients
    clients
  - fixes in locking code for stability and POSIX compatibility

Changelog for nfs4j-0.14.1..nfs4j-0.14.2
    * [571fade] [maven-release-plugin] prepare for next development iteration
    * [a1be931] nfs4: fix usage of stateid's with zero sequence ids
    * [43b73a6] nfs41: fix state owner
    * [e346a44] nlm: fix positive long overflow when calculating lock ranges
    * [879bd1f] nfs4: do not fail unlock of not locked regions
    * [c46256a] nfs41: include port number into server owner
    * [af54f64] [maven-release-plugin] prepare release nfs4j-0.14.2
    * [901a421] [maven-release-plugin] prepare for next development iteration

Acked-by: Paul Millar
Target: master, 3.1, 3.0
Require-book: no
Require-notes: yes
(cherry picked from commit de31f6141730fbe86c5e486e29bff23430d7bb82)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>