### PR TITLE
libs: update to bug fix release nfs4j-0.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -777,7 +777,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.13.0</version>
+            <version>0.13.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
bugfix update with following highlights:

  - fix interoperability with RHEL7-based clients
    clients
  - fix handling of invalid principals on SETATTR sent
    by OSX client

Changelog for nfs4j-0.13.0..nfs4j-0.13.1
    * [aaae2e7] [maven-release-plugin] prepare for next development iteration
    * [dd685c5] nfs41: do not sent NFSERR_IO on layout get
    * [b05ccc9] nfs4: fix invalid offset+len check on write
    * [0dfbaae] idmap: handle bad principals
    * [4382db9] nfs41: include port number into server owner
    * [0078c10] [maven-release-plugin] prepare release nfs4j-0.13.1

Target: 3.0
Require-book: no
Require-notes: yes