### PR TITLE
nfs: recall file layout on pool disable

### DIFF
--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -15,7 +15,8 @@ nfs.cell.name=NFS-${host.name}
 #   consume from.
 #
 nfs.cell.consume = ${nfs.cell.name}
-nfs.cell.subscribe=${nfs.loginbroker.request-topic}
+nfs.cell.subscribe=${nfs.loginbroker.request-topic},PoolStatusTopic
+
 
 #
 # NFS versions to support.

--- a/skel/share/services/nfs.batch
+++ b/skel/share/services/nfs.batch
@@ -53,6 +53,7 @@ check nfs.mover.queue
 create org.dcache.cells.UniversalSpringCell ${nfs.cell.name} \
         "classpath:org/dcache/chimera/nfsv41/door/nfsv41-common.xml \
             -consume=${nfs.cell.consume} \
+            -subscribe=${nfs.cell.subscribe} \
             -cell.max-message-threads=${nfs.cell.max-message-threads} -cell.max-messages-queued=${nfs.cell.max-messages-queued} \
             -profiles=portmap-${nfs.enable.portmap}"
 


### PR DESCRIPTION
Motivation:
nfs door keeps a mapping between file's open state, unique id associated
with an open, and a transfer, associated with the mover on pool. Every time
when a client requests a mover for a given open-stateid, the same transfer
will be used.

Nevertheless, if pool gets disabled, restarted or unavailable, the mover
associated with the transfer is not valid any more. To create a new mover
on the same on a different pool, door have to 'forget' existing transfer
and notify nfs client that data server does not exists any more.

Modification:
NFS door reacts on pool-disable message and recall layouts. The read
transfers will become new movers. Writes are poisoned with IO error.

Result:
pool restart on read will resume the transfer when pool is back.
As a side effect, pool disable till redirect transfer to an other
pool, if replica exists. Pool disable in pool manager will trigger
p2p and transfer will continue.

All writed will fail with IO error.

Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit ee816235190616bf157f7a9359b3bd4233c22518)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>