### PR TITLE
dcache,movers: Storing multiple checksums for a file when the client …

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
@@ -319,7 +319,7 @@ public class ChecksumChannel implements RepositoryChannel
                                                       .collect(Collectors.toSet());
                 } catch (IOException e) {
                     _log.info("Unable to generate checksum of sparse file: {}", e.toString());
-                    return null;
+                    return Collections.emptySet();
                 }
             }
         }


### PR DESCRIPTION
…provided checksum is of different type than that of the pool setup.

Motivation:
In the current behaviour, dcache computes a checksum for an uploaded
file if the client doesn't provide a checksum along with the request. The
checksum type chosen by dcache depends on the pool setup. If the default
checksum type in the pool setup is ADLER32, then ADLER32 is chosen for
the file.

In case the client provides a checksum for the file, the checksum
provided by the client is chosen. This behaviour is insufficient and
does not satisfy the checksum setup as configured by the admin for the pool.

Modification:
When the client does not provide a checksum, dcache computes and stores
the checksum as configured in the pool. And when the client provides a
checksum, dcache verifies and stores the provided checksums as well as
computes and stores the checksum of type configured by the admin in the
pool setup.

Ticket:
Acked-by:
Target: trunk
Require-book: no
Require-notes: no
Patch: