### PR TITLE
movers: fix NPE caused by finalize Checksum for ChecksumChannel

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.pool.classic;
 
+import com.google.common.base.Optional;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -27,6 +28,7 @@ import org.springframework.beans.factory.annotation.Required;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.nio.channels.CompletionHandler;
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -86,8 +88,11 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
             try {
                 try {
                     if (mover.getIoMode() == IoMode.WRITE) {
-                        handle.addChecksums(mover.getExpectedChecksums());
-                        _checksumModule.enforcePostTransferPolicy(handle, mover.getActualChecksums());
+                        handle.addChecksums(Optional.fromNullable(mover.getExpectedChecksums())
+                                                    .or(Collections.emptySet()));
+                        _checksumModule.enforcePostTransferPolicy(handle,
+                                                                  Optional.fromNullable(mover.getActualChecksums())
+                                                                          .or(Collections.emptySet()));
                     }
                     handle.commit();
                 } finally {

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
@@ -319,7 +319,7 @@ public class ChecksumChannel implements RepositoryChannel
                                                       .collect(Collectors.toSet());
                 } catch (IOException e) {
                     _log.info("Unable to generate checksum of sparse file: {}", e.toString());
-                    return null;
+                    return Collections.emptySet();
                 }
             }
         }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
@@ -79,6 +79,7 @@ import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Map;
@@ -332,7 +333,7 @@ public class RemoteGsiftpTransferProtocol
     {
         try {
             if (_transferMessageDigests == null) {
-                return null;
+                return Collections.emptySet();
             }
 
             ByteBuffer buffer = ByteBuffer.allocate(KiB.toBytes(128));
@@ -349,7 +350,7 @@ public class RemoteGsiftpTransferProtocol
                                      .collect(Collectors.toSet());
         } catch (IOException e) {
             _log.error(e.toString());
-            return null;
+            return Collections.emptySet();
         }
     }
 


### PR DESCRIPTION
A NPE is generated when mover.getActualChecksums() is called. This was
caused because a null value was returned from the ChecksumChannel#finalizeChecksums
method

java.lang.NullPointerException: null
	at com.google.common.collect.Iterables.isEmpty(Iterables.java:963) ~[guava-20.0.jar:na]
	at org.dcache.pool.classic.ChecksumModuleV1.enforcePostTransferPolicy(ChecksumModuleV1.java:386) ~[dcache-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.dcache.pool.classic.DefaultPostTransferService.lambda$execute$0(DefaultPostTransferService.java:90) ~[dcache-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) ~[dcache-common-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149) ~[dcache-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_121]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_121]
	at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_121]

This commit returns an empty set instead of null.

Ticket:
Acked-by:
Target: master
Require-book: no
Require-notes: no
Patch: