### PR TITLE
libs: use nfs4j-0.12.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -766,7 +766,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.12.2</version>
+            <version>0.12.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
bugfix update with better compatibility with REHL7 clients

Changelog for nfs4j-0.12.2..nfs4j-0.12.4
    * [53e7681] [maven-release-plugin] prepare for next development iteration
    * [4caf90e] pseudofs: fix NoSuchElementException with user mapped to subject NOBODY
    * [2141f5e] Fix leaked state resources on shutdown
    * [852ba20] Fix leaked state resources on lease timeout
    * [11de456] Make state disposal more robust against bugs
    * [2e937c5] [maven-release-plugin] prepare release nfs4j-0.12.3
    * [c58bc68] [maven-release-plugin] prepare for next development iteration
    * [a28e4ca] nfs41: include port number into server owner
    * [faccb05] libs: use oncrpc4j-2.6.0
    * [99f57bb] [maven-release-plugin] prepare release nfs4j-0.12.4

Acked-by:
Target: 2.16
Require-book: no
Require-notes: yes