### PR TITLE
libs: update to nfs4j-0.12.4

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -84,7 +84,6 @@ import org.dcache.nfs.v4.NFS4State;
 import org.dcache.nfs.v4.NFSServerV41;
 import org.dcache.nfs.v4.NFSv41DeviceManager;
 import org.dcache.nfs.v4.NFSv4Defaults;
-import org.dcache.nfs.v4.RoundRobinStripingPattern;
 import org.dcache.nfs.v4.StateDisposeListener;
 import org.dcache.nfs.v4.StripingPattern;
 import org.dcache.nfs.v4.xdr.device_addr4;
@@ -98,6 +97,10 @@ import org.dcache.nfs.v4.xdr.nfs4_prot;
 import org.dcache.nfs.v4.xdr.nfsv4_1_file_layout_ds_addr4;
 import org.dcache.nfs.v4.xdr.nfs_fh4;
 import org.dcache.nfs.v4.xdr.stateid4;
+import org.dcache.nfs.v4.LayoutDriver;
+import org.dcache.nfs.v4.NfsV41FileLayoutDriver;
+import org.dcache.nfs.v4.xdr.length4;
+import org.dcache.nfs.v4.xdr.offset4;
 import org.dcache.nfs.vfs.Inode;
 import org.dcache.nfs.vfs.VfsCache;
 import org.dcache.nfs.vfs.VfsCacheConfig;
@@ -128,15 +131,20 @@ public class NFSv41Door extends AbstractCellComponent implements
     private static final Logger _log = LoggerFactory.getLogger(NFSv41Door.class);
 
     /**
+     * Layout type specific driver.
+     */
+    private final LayoutDriver _layoutDriver = new NfsV41FileLayoutDriver();
+
+    /**
      * Array if layout types supported by the door. For now, dCache supports only
      * NFS4.1 file layout type.
      */
-    private static final int[] SUPPORTED_LAYOUT_TYPES = new int[]{layouttype4.LAYOUT4_NFSV4_1_FILES};
+    private final int[] SUPPORTED_LAYOUT_TYPES = new int[]{_layoutDriver.getLayoutType()};
 
     /**
      * A mapping between pool name, nfs device id and pool's ip addresses.
      */
-    private final PoolDeviceMap _poolDeviceMap = new PoolDeviceMap(new RoundRobinStripingPattern<>());
+    private final PoolDeviceMap _poolDeviceMap = new PoolDeviceMap(_layoutDriver);
 
     /*
      * reserved device for IO through MDS (for pnfs dot files)
@@ -271,26 +279,25 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         _isWellKnown = getArgs().getBooleanOption("export");
 
+        _vfs = new VfsCache(new ChimeraVfs(_fileFileSystemProvider, _idMapper), _vfsCacheConfig);
+        MountServer ms = new MountServer(_exportFile, _vfs);
+
         OncRpcSvcBuilder oncRpcSvcBuilder = new OncRpcSvcBuilder()
                 .withPort(_port)
                 .withTCP()
                 .withAutoPublish()
-                .withWorkerThreadIoStrategy();
+                .withWorkerThreadIoStrategy()
+                .withRpcService(new OncRpcProgram(mount_prot.MOUNT_PROGRAM, mount_prot.MOUNT_V3), ms);
+
         if (_enableRpcsecGss) {
             oncRpcSvcBuilder.withGssSessionManager(new GssSessionManager(_idMapper));
         }
-        _rpcService = oncRpcSvcBuilder.build();
-
-        _vfs = new VfsCache(new ChimeraVfs(_fileFileSystemProvider, _idMapper), _vfsCacheConfig);
-
-        MountServer ms = new MountServer(_exportFile, _vfs);
-        _rpcService.register(new OncRpcProgram(mount_prot.MOUNT_PROGRAM, mount_prot.MOUNT_V3), ms);
 
         for (String version : _versions) {
             switch (version) {
                 case V3:
                     NfsServerV3 nfs3 = new NfsServerV3(_exportFile, _vfs);
-                    _rpcService.register(new OncRpcProgram(nfs3_prot.NFS_PROGRAM, nfs3_prot.NFS_V3), nfs3);
+                    oncRpcSvcBuilder.withRpcService(new OncRpcProgram(nfs3_prot.NFS_PROGRAM, nfs3_prot.NFS_V3), nfs3);
                     _loginBrokerPublisher.setTags(Collections.emptyList());
                     break;
                 case V41:
@@ -298,7 +305,7 @@ public class NFSv41Door extends AbstractCellComponent implements
                     _proxyIoFactory = new NfsProxyIoFactory(_dm);
                     _nfs4 = new NFSServerV41(new ProxyIoMdsOpFactory(_proxyIoFactory, new MDSOperationFactory()),
                             _dm, _vfs, _exportFile);
-                    _rpcService.register(new OncRpcProgram(nfs4_prot.NFS4_PROGRAM, nfs4_prot.NFS_V4), _nfs4);
+                    oncRpcSvcBuilder.withRpcService(new OncRpcProgram(nfs4_prot.NFS4_PROGRAM, nfs4_prot.NFS_V4), _nfs4);
                     updateLbPaths();
                     break;
                 default:
@@ -306,6 +313,7 @@ public class NFSv41Door extends AbstractCellComponent implements
             }
         }
 
+        _rpcService = oncRpcSvcBuilder.build();
         _rpcService.start();
 
     }
@@ -397,11 +405,10 @@ public class NFSv41Door extends AbstractCellComponent implements
      */
 
     @Override
-    public device_addr4 getDeviceInfo(CompoundContext context, deviceid4 deviceId) {
+    public device_addr4 getDeviceInfo(CompoundContext context, deviceid4 deviceId, int layoutType) throws ChimeraNFSException {
         /* in case of MDS access we return the same interface which client already connected to */
         if (deviceId.equals(MDS_ID)) {
-            return deviceAddrOf( new RoundRobinStripingPattern<>(),
-                    new InetSocketAddress[] { context.getRpcCall().getTransport().getLocalSocketAddress() } );
+            return _layoutDriver.getDeviceAddress(context.getRpcCall().getTransport().getLocalSocketAddress());
         }
 
         PoolDS ds = _poolDeviceMap.getByDeviceId(deviceId);
@@ -431,8 +438,8 @@ public class NFSv41Door extends AbstractCellComponent implements
         NDC.push(context.getRpcCall().getTransport().getRemoteSocketAddress().toString());
         try {
 
-            if (layoutType != layouttype4.LAYOUT4_NFSV4_1_FILES) {
-                _log.warn("unsupported layout type ({}) requests from");
+            if (layoutType != _layoutDriver.getLayoutType()) {
+                _log.warn("unsupported layout type ({}) request", layoutType);
                 throw new LayoutUnavailableException("Unsuported layout type: " + layoutType);
             }
 
@@ -525,8 +532,11 @@ public class NFSv41Door extends AbstractCellComponent implements
             nfs_fh4 fh = new nfs_fh4(nfsInode.toNfsHandle());
 
             //  -1 is special value, which means entire file
-            layout4 layout = Layout.getLayoutSegment(deviceid, NFSv4Defaults.NFS4_STRIPE_SIZE, fh, ioMode,
-                    0, nfs4_prot.NFS4_UINT64_MAX);
+            layout4 layout = new layout4();
+            layout.lo_iomode = ioMode;
+            layout.lo_offset = new offset4(0);
+            layout.lo_length = new length4(nfs4_prot.NFS4_UINT64_MAX);
+            layout.lo_content = _layoutDriver.getLayoutContent(deviceid, stateid, NFSv4Defaults.NFS4_STRIPE_SIZE, fh);
 
             /*
              * on on error client will issue layout return.
@@ -817,20 +827,15 @@ public class NFSv41Door extends AbstractCellComponent implements
         private final device_addr4 _deviceAddr;
         private final long _verifier;
 
-        public PoolDS(deviceid4 deviceId, StripingPattern<InetSocketAddress[]> stripingPattern,
-                InetSocketAddress[] ip, long verifier) {
+        public PoolDS(deviceid4 deviceId, device_addr4 deviceAddr, InetSocketAddress[] ip, long verifier) {
             _deviceId = deviceId;
             _socketAddress = ip;
-            _deviceAddr = deviceAddrOf(stripingPattern, ip);
+            _deviceAddr = deviceAddr;
             _verifier = verifier;
         }
 
         public deviceid4 getDeviceId() {
             return _deviceId;
-        }
-
-        public InetSocketAddress[] getInetSocketAddress() {
-            return _socketAddress;
         }
 
         public device_addr4 getDeviceAddr() {
@@ -946,61 +951,6 @@ public class NFSv41Door extends AbstractCellComponent implements
             doorInfo.setIoDoorEntries(entries.toArray(new IoDoorEntry[0]));
             return isBinary ? doorInfo : doorInfo.toString();
         }
-    }
-
-    /**
-     * Create a multipath based NFSv4.1 file layout address.
-     *
-     * @param stripingPattern of the device
-     * @param deviceAddress
-     * @return device address
-     */
-    public static device_addr4 deviceAddrOf(StripingPattern<InetSocketAddress[]> stripingPattern,
-            InetSocketAddress[]... deviceAddress) {
-
-        nfsv4_1_file_layout_ds_addr4 file_type = new nfsv4_1_file_layout_ds_addr4();
-
-        file_type.nflda_multipath_ds_list = new multipath_list4[deviceAddress.length];
-
-        for (int i = 0; i < deviceAddress.length; i++) {
-            file_type.nflda_multipath_ds_list[i] = toMultipath(deviceAddress[i]);
-        }
-
-        file_type.nflda_stripe_indices = stripingPattern.getPattern(deviceAddress);
-
-        XdrBuffer xdr = new XdrBuffer(128);
-        try {
-            xdr.beginEncoding();
-            file_type.xdrEncode(xdr);
-            xdr.endEncoding();
-        } catch (OncRpcException e) {
-            /* forced by interface, should never happen. */
-            throw new RuntimeException("Unexpected OncRpcException:", e);
-        } catch (IOException e) {
-            /* forced by interface, should never happen. */
-            throw new RuntimeException("Unexpected IOException:", e);
-        }
-
-        Buffer body = xdr.asBuffer();
-        byte[] retBytes = new byte[body.remaining()];
-        body.get(retBytes);
-
-        device_addr4 addr = new device_addr4();
-        addr.da_layout_type = layouttype4.LAYOUT4_NFSV4_1_FILES;
-        addr.da_addr_body = retBytes;
-
-        return addr;
-
-    }
-
-    private static multipath_list4 toMultipath(InetSocketAddress[] addresses)
-    {
-        multipath_list4 multipath = new multipath_list4();
-        multipath.value = new netaddr4[addresses.length];
-        for(int i = 0; i < addresses.length; i++) {
-            multipath.value[i] = new netaddr4(addresses[i]);
-        }
-        return multipath;
     }
 
     @Command(name="stats", hint = "Show nfs requests statstics.")

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/StrategyIdMapper.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/StrategyIdMapper.java
@@ -10,15 +10,20 @@ import java.security.Principal;
 import java.util.Set;
 
 import diskCacheV111.util.CacheException;
+import javax.security.auth.kerberos.KerberosPrincipal;
 
 import org.dcache.auth.GidPrincipal;
 import org.dcache.auth.GroupNamePrincipal;
 import org.dcache.auth.LoginStrategy;
+import org.dcache.auth.Origin;
 import org.dcache.auth.Subjects;
 import org.dcache.auth.UidPrincipal;
 import org.dcache.auth.UserNamePrincipal;
 import org.dcache.nfs.v4.NfsIdMapping;
 import org.dcache.xdr.RpcLoginService;
+import org.dcache.xdr.XdrTransport;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSException;
 
 public class StrategyIdMapper implements NfsIdMapping, RpcLoginService {
 
@@ -141,15 +146,19 @@ public class StrategyIdMapper implements NfsIdMapping, RpcLoginService {
     }
 
     @Override
-    public Subject login(Principal principal) {
-        Subject in = new Subject();
-        in.getPrincipals().add(principal);
-        in.setReadOnly();
+    public Subject login(XdrTransport xt, GSSContext gssc) {
 
         try {
+
+            KerberosPrincipal principal = new KerberosPrincipal(gssc.getSrcName().toString());
+            Subject in = new Subject();
+            in.getPrincipals().add(principal);
+            in.getPrincipals().add(new Origin(xt.getRemoteSocketAddress().getAddress()));
+            in.setReadOnly();
+
             return _remoteLoginStrategy.login(in).getSubject();
-        }catch(CacheException e) {
-            _log.debug("Failed to login for : {} : {}", principal.getName(), e.toString());
+        }catch(GSSException | CacheException e) {
+            _log.debug("Failed to login for : {} : {}", gssc, e.toString());
         }
         return Subjects.NOBODY;
     }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIo.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIo.java
@@ -58,7 +58,8 @@ public class NfsProxyIo implements ProxyIoAdapter {
      * How long we wait for an IO request. The typical NFS client will wait
      * 30 sec. We will use a shorter timeout to avoid retry.
      */
-    private static final int IO_TIMEOUT = (int)TimeUnit.SECONDS.toMillis(15);
+    private static final int IO_TIMEOUT = 15;
+    private static final TimeUnit IO_TIMEOUT_UNIT = TimeUnit.SECONDS;
 
     /**
      * Most up-to-date seqid for a given stateid as defined by rfc5661.
@@ -174,7 +175,7 @@ public class NfsProxyIo implements ProxyIoAdapter {
         COMPOUND4res result = new COMPOUND4res();
 
         try {
-            client.call(nfs4_prot.NFSPROC4_COMPOUND_4, arg, result, IO_TIMEOUT);
+            client.call(nfs4_prot.NFSPROC4_COMPOUND_4, arg, result, IO_TIMEOUT, IO_TIMEOUT_UNIT);
         } catch (TimeoutException e) {
             throw new DelayException(e.getMessage(), e);
         }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIoFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIoFactory.java
@@ -114,7 +114,7 @@ public class NfsProxyIoFactory implements ProxyIoFactory {
         // we assume only one segment as dcache doesn't support striping
         nfsv4_1_file_layout4 fileLayoutSegment = LayoutgetStub.decodeLayoutId(layout.getLayoutSegments()[0].lo_content.loc_body);
         deviceid4 dsId = fileLayoutSegment.nfl_deviceid;
-        device_addr4 deviceAddr = deviceManager.getDeviceInfo(context, dsId);
+        device_addr4 deviceAddr = deviceManager.getDeviceInfo(context, dsId, layouttype4.LAYOUT4_NFSV4_1_FILES);
         nfsv4_1_file_layout_ds_addr4 nfs4DeviceAddr = GetDeviceListStub.decodeFileDevice(deviceAddr.da_addr_body);
 
         Stopwatch connectStopwatch = Stopwatch.createStarted();

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NFSv4MoverHandler.java
@@ -9,8 +9,6 @@ import javax.security.auth.Subject;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.security.Principal;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -60,7 +58,6 @@ import org.dcache.xdr.IpProtocolType;
 import org.dcache.xdr.OncRpcProgram;
 import org.dcache.xdr.OncRpcSvc;
 import org.dcache.xdr.OncRpcSvcBuilder;
-import org.dcache.xdr.RpcDispatchable;
 import org.dcache.xdr.RpcLoginService;
 import org.dcache.xdr.gss.GssSessionManager;
 import org.dcache.xdr.OncRpcException;
@@ -230,24 +227,16 @@ public class NFSv4MoverHandler {
                 .withMaxPort(portRange.getUpper())
                 .withTCP()
                 .withoutAutoPublish()
+                .withRpcService(new OncRpcProgram(nfs4_prot.NFS4_PROGRAM, nfs4_prot.NFS_V4), _embededDS)
                 .withSameThreadIoStrategy();
 
         if (withGss) {
-            RpcLoginService rpcLoginService = new RpcLoginService() {
-
-                @Override
-                public Subject login(Principal principal) {
-                    return Subjects.NOBODY;
-                }
-            };
+            RpcLoginService rpcLoginService = (t, gss) -> Subjects.NOBODY;
             GssSessionManager gss = new GssSessionManager(rpcLoginService);
             oncRpcSvcBuilder.withGssSessionManager(gss);
         }
 
-        final Map<OncRpcProgram, RpcDispatchable> programs = new HashMap<>();
-        programs.put(new OncRpcProgram(nfs4_prot.NFS4_PROGRAM, nfs4_prot.NFS_V4), _embededDS);
         _rpcService = oncRpcSvcBuilder.build();
-        _rpcService.setPrograms(programs);
         _rpcService.start();
         _door = door;
         _bootVerifier = bootVerifier;

--- a/modules/dcache-nfs/src/test/java/org/dcache/chimera/nfsv41/door/PoolDeviceMapTest.java
+++ b/modules/dcache-nfs/src/test/java/org/dcache/chimera/nfsv41/door/PoolDeviceMapTest.java
@@ -2,8 +2,7 @@ package org.dcache.chimera.nfsv41.door;
 
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import org.dcache.nfs.v4.RoundRobinStripingPattern;
-import org.dcache.nfs.v4.StripingPattern;
+import org.dcache.nfs.v4.NfsV41FileLayoutDriver;
 import org.dcache.nfs.v4.xdr.deviceid4;
 import org.junit.Assert;
 import org.junit.Before;
@@ -12,20 +11,13 @@ import org.junit.Test;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
 
-/**
- *
- * @author tigran
- */
 public class PoolDeviceMapTest {
-
-    private final StripingPattern<InetSocketAddress[]> _stripingPattern
-            = new RoundRobinStripingPattern<>();
 
     private PoolDeviceMap _poolDeviceMap;
 
     @Before
     public void setUp() {
-        _poolDeviceMap = new PoolDeviceMap(_stripingPattern);
+        _poolDeviceMap = new PoolDeviceMap(new NfsV41FileLayoutDriver());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.11.2</version>
+            <version>0.12.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.12.1</version>
+            <version>0.12.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
update nfs4j used in 2.16 for better NFS support

Changelog for nfs4j-0.11.0..nfs4j-0.12.1
    * [3d83f56] preparing for next major release: updated version in master
    * [9fda609] src: use Objects#hash() to generate hashCode()
    * [2eb2ae0] nfs4: trim result of OperationGETATTR#attrMask2String()
    * [8e651b5] nfs41: add xdr for flex-file layout
    * [71c10d8] nfs: introduce layouttype4#LAYOUT4_TYPE_MAX
    * [024487b] nfs: fix bad cookie
    * [a66937d] nfs41: introduce layout driver
    * [e0d5e8b] libs: update oncrpc4j-2.4.2
    * [a08c10e] nfs4: add missing values in nfs_opnum4#toString
    * [3eeebae] nfs41: return NOENT error on GETDEVICEINFO
    * [30e92fa] nfs41: add flexfile layout driver
    * [b19589d] nfs4: do not indicate device notification if client don't expect them
    * [990aa58] nfs4: initialize notification bitmap
    * [3cf66e0] nfs4: fix fattr4_maxfilesize constructor
    * [493a556] nfs4: simplify lock_owner4 and open_owner4
    * [0d77931] readme: add howto contribute
    * [2bb63fd] nfs: reduce loglevel on all_root access
    * [c6169cf] nfs: add ISO formated nfstime4#toString()
    * [4184959] libs: switch to oncrpc4j-2.5.0
    * [1976cbd] libs: update to oncrpc4j-2.5.2
    * [99d3a70] respect the gid and uid sent in creation attributes
    * [b2f29f1] nfs41: remove unused constructor in SessionSlot
    * [8c168e6] utils: use java.time.Clock as a time source for Cache
    * [cb0900e] nfs4: simplify seqid4 type
    * [00fd96d] flexfiles: specify nfs version and minorversion numbers to layout driver
    * [7a315c0] flexfiles: sync with draft7
    * [a1f3b00] pseudo-fs: enforce source inode permission check on create hardlink
    * [b6de32a] pom: use ssh url for developerConnection
    * [d64755f] flexfiles: do not hard code user and group principal used by DS
    * [8ea77d6] nfs4: change NFSv41DeviceManager#getDeviceInfo to accept layout type
    * [c621b0e] lins: update to oncrpc4j-2.5.3
    * [50b574f] [maven-release-plugin] prepare branch 0.12
    * [f8c22e2] [maven-release-plugin] prepare release nfs4j-0.12.0
    * [aee1c04] [maven-release-plugin] prepare for next development iteration
    * [d0c504c] nfs4: fix multipath list generation
    * [b6d1806] [maven-release-plugin] prepare release nfs4j-0.12.1

Modification:
updated dcache code to new API changes

Result:
allows dcache to provide flexfile layout.

acked-by: Paul Millar
Target: 2.15
Require-notes: yes
Require-book: no
(cherry picked from commit d1aaf742afb1f044e83d5c36f6afefce5f467b29)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>