### PR TITLE
movers: fix NPE caused on upload of a zero length file

### DIFF
--- a/modules/dcache-dcap/src/main/java/org/dcache/pool/movers/DCapProtocol_3_nio.java
+++ b/modules/dcache-dcap/src/main/java/org/dcache/pool/movers/DCapProtocol_3_nio.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -1150,6 +1152,7 @@ public class DCapProtocol_3_nio implements MoverProtocol, ChecksumMover, CellArg
         return  _clientChecksum ;
     }
 
+    @Nonnull
     @Override
     public Set<Checksum> getActualChecksums()
     {

--- a/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
@@ -5,6 +5,8 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.net.BindException;
 import java.net.ConnectException;
@@ -619,6 +621,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
     }
 
     /** Part of the ChecksumMover interface. */
+    @Nonnull
     @Override
     public Set<Checksum> getActualChecksums()
     {

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumModule.java
@@ -18,6 +18,8 @@
 
 package org.dcache.pool.classic;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Set;
@@ -81,6 +83,7 @@ public interface ChecksumModule
      * @throws NoSuchAlgorithmException If no suitable checksum algorithm is supported
      * @throws CacheException If the checksums of the file could not be retrieved
      */
+    @Nonnull
     Set<ChecksumFactory> getProvidedChecksumsFactories(ReplicaDescriptor handle)
             throws NoSuchAlgorithmException, CacheException;
 
@@ -98,7 +101,7 @@ public interface ChecksumModule
      * @throws InterruptedException If the thread is interrupted
      */
     void enforcePostTransferPolicy(
-            ReplicaDescriptor handle, Iterable<Checksum> actualChecksums)
+            ReplicaDescriptor handle, @Nonnull Iterable<Checksum> actualChecksums)
             throws CacheException, NoSuchAlgorithmException, IOException, InterruptedException;
 
     /**
@@ -142,6 +145,7 @@ public interface ChecksumModule
      * @throws InterruptedException If the thread is interrupted
      * @return Any checksum computed for the file
      */
+    @Nonnull
     Iterable<Checksum> verifyChecksum(ReplicaDescriptor handle)
             throws NoSuchAlgorithmException, IOException, InterruptedException, CacheException;
 
@@ -157,6 +161,7 @@ public interface ChecksumModule
      * @throws InterruptedException If the thread is interrupted
      * @return Any checksum computed for the file
      */
-    Iterable<Checksum> verifyChecksum(RepositoryChannel channel, Iterable<Checksum> checksums)
+    @Nonnull
+    Iterable<Checksum> verifyChecksum(RepositoryChannel channel, @Nonnull Iterable<Checksum> checksums)
             throws NoSuchAlgorithmException, IOException, InterruptedException, CacheException;
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumModuleV1.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumModuleV1.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.security.NoSuchAlgorithmException;
@@ -366,6 +368,7 @@ public class ChecksumModuleV1
         return _policy.contains(flag);
     }
 
+    @Nonnull
     @Override
     public Set<ChecksumFactory> getProvidedChecksumsFactories(ReplicaDescriptor handle)
             throws NoSuchAlgorithmException, CacheException
@@ -414,6 +417,7 @@ public class ChecksumModuleV1
         }
     }
 
+    @Nonnull
     @Override
     public Iterable<Checksum> verifyChecksum(ReplicaDescriptor handle)
             throws NoSuchAlgorithmException, IOException, InterruptedException, CacheException
@@ -423,6 +427,7 @@ public class ChecksumModuleV1
         }
     }
 
+    @Nonnull
     @Override
     public Iterable<Checksum> verifyChecksum(RepositoryChannel channel, Iterable<Checksum> expectedChecksums)
             throws NoSuchAlgorithmException, IOException, InterruptedException, CacheException

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.pool.classic;
 
+import com.google.common.base.Optional;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -27,6 +28,7 @@ import org.springframework.beans.factory.annotation.Required;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.nio.channels.CompletionHandler;
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -86,8 +88,11 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
             try {
                 try {
                     if (mover.getIoMode() == IoMode.WRITE) {
-                        handle.addChecksums(mover.getExpectedChecksums());
-                        _checksumModule.enforcePostTransferPolicy(handle, mover.getActualChecksums());
+                        handle.addChecksums(Optional.fromNullable(mover.getExpectedChecksums())
+                                                    .or(Collections.emptySet()));
+                        _checksumModule.enforcePostTransferPolicy(handle,
+                                                                  Optional.fromNullable(mover.getActualChecksums())
+                                                                          .or(Collections.emptySet()));
                     }
                     handle.commit();
                 } finally {

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -22,6 +22,7 @@ import com.google.common.reflect.TypeToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.security.auth.Subject;
 
 import java.io.IOException;
@@ -274,6 +275,7 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
         return channel;
     }
 
+    @Nonnull
     @Override
     public Set<Checksum> getActualChecksums() {
         return (_checksumChannel == null)
@@ -281,6 +283,7 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
                 : _checksumChannel.getChecksums();
     }
 
+    @Nonnull
     @Override
     public Set<Checksum> getExpectedChecksums() {
         return Collections.emptySet();

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
@@ -319,7 +319,7 @@ public class ChecksumChannel implements RepositoryChannel
                                                       .collect(Collectors.toSet());
                 } catch (IOException e) {
                     _log.info("Unable to generate checksum of sparse file: {}", e.toString());
-                    return null;
+                    return Collections.emptySet();
                 }
             }
         }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumMover.java
@@ -1,5 +1,7 @@
 package org.dcache.pool.movers;
 
+import javax.annotation.Nonnull;
+
 import java.security.NoSuchAlgorithmException;
 import java.util.Set;
 
@@ -27,6 +29,7 @@ public interface ChecksumMover
      *
      * @return a checksum value for the data or null if none is available.
      */
+    @Nonnull
     Set<Checksum> getActualChecksums();
 
     /**

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.pool.movers;
 
+import javax.annotation.Nonnull;
 import javax.security.auth.Subject;
 
 import java.nio.channels.CompletionHandler;
@@ -125,11 +126,13 @@ public interface Mover<T extends ProtocolInfo>
     /**
      * Returns any checksums computed during the transfer.
      */
+    @Nonnull
     Set<Checksum> getActualChecksums();
 
     /**
      * Returns any known-good checksums obtained from the client.
      */
+    @Nonnull
     Set<Checksum> getExpectedChecksums();
 
     /**

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
@@ -19,6 +19,8 @@ package org.dcache.pool.movers;
 
 import com.google.common.base.Optional;
 
+import javax.annotation.Nonnull;
+
 import java.util.Collections;
 import java.util.Set;
 
@@ -68,6 +70,7 @@ public class MoverProtocolMover extends AbstractMover<ProtocolInfo, MoverProtoco
         return _moverProtocol.getLastTransferred();
     }
 
+    @Nonnull
     @Override
     public Set<Checksum> getExpectedChecksums()
     {

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
@@ -71,6 +71,8 @@ package org.dcache.pool.movers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -79,6 +81,7 @@ import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Map;
@@ -327,12 +330,13 @@ public class RemoteGsiftpTransferProtocol
         return null;
     }
 
+    @Nonnull
     @Override
     public Set<Checksum> getActualChecksums()
     {
         try {
             if (_transferMessageDigests == null) {
-                return null;
+                return Collections.emptySet();
             }
 
             ByteBuffer buffer = ByteBuffer.allocate(KiB.toBytes(128));
@@ -349,7 +353,7 @@ public class RemoteGsiftpTransferProtocol
                                      .collect(Collectors.toSet());
         } catch (IOException e) {
             _log.error(e.toString());
-            return null;
+            return Collections.emptySet();
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -20,6 +20,8 @@ import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.net.URI;
 import java.nio.channels.Channels;
@@ -614,6 +616,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
         _onTransfer = ChecksumFactory.getFactory(suggestedAlgorithm);
     }
 
+    @Nonnull
     @Override
     public Set<Checksum> getActualChecksums()
     {


### PR DESCRIPTION
A NPE was generated in the following cases when <? extends
Mover>.getActualChecksums() is called. This was caused because,

1. Null value was returned from the ChecksumChannel#finalizeChecksums
method
2. Null value was returned by
RemoteGsiftpTransferProtocol#getActualChecksums method.

A NPE was caused when ChecksumModule#enforcePostTransferPolicy was
called with a NULL argument.

java.lang.NullPointerException: null
	at com.google.common.collect.Iterables.isEmpty(Iterables.java:963) ~[guava-20.0.jar:na]
	at org.dcache.pool.classic.ChecksumModuleV1.enforcePostTransferPolicy(ChecksumModuleV1.java:386) ~[dcache-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.dcache.pool.classic.DefaultPostTransferService.lambda$execute$0(DefaultPostTransferService.java:90) ~[dcache-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) ~[dcache-common-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149) ~[dcache-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_121]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_121]
	at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_121]

This commit returns an empty set instead of null.

Ticket:
Acked-by:
Target: master
Require-book: no
Require-notes: no
Patch: