### PR TITLE
nfs: change proxy-io client initialization to limit number of threads

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIo.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/NfsProxyIo.java
@@ -30,9 +30,11 @@ import org.dcache.nfs.v4.xdr.stateid4;
 import org.dcache.nfs.v4.xdr.state_protect_how4;
 import org.dcache.nfs.vfs.Inode;
 import org.dcache.nfs.vfs.VirtualFileSystem;
+import org.dcache.xdr.IoStrategy;
 import org.dcache.xdr.IpProtocolType;
 import org.dcache.xdr.OncRpcException;
-import org.dcache.xdr.OncRpcClient;
+import org.dcache.xdr.OncRpcSvc;
+import org.dcache.xdr.OncRpcSvcBuilder;
 import org.dcache.xdr.RpcAuth;
 import org.dcache.xdr.RpcAuthTypeUnix;
 import org.dcache.xdr.RpcCall;
@@ -75,17 +77,26 @@ public class NfsProxyIo implements ProxyIoAdapter {
 
     private final InetSocketAddress remoteClient;
     private final RpcCall client;
-    private final OncRpcClient rpcClient;
+    private final OncRpcSvc rpcsvc;
     private final XdrTransport transport;
     private final ScheduledExecutorService sessionThread;
 
     public NfsProxyIo(InetSocketAddress poolAddress,  InetSocketAddress remoteClient, Inode inode, stateid4 stateid, long timeout, TimeUnit timeUnit) throws IOException {
         this.remoteClient = remoteClient;
-        rpcClient = new OncRpcClient(poolAddress, IpProtocolType.TCP);
+        rpcsvc = new OncRpcSvcBuilder()
+                .withClientMode()
+                .withPort(0)
+                .withIpProtocolType(IpProtocolType.TCP)
+                .withIoStrategy(IoStrategy.SAME_THREAD)
+                .withServiceName("proxy-io-rpc-selector-" + poolAddress.getAddress().getHostAddress())
+                .withSelectorThreadPoolSize(1)
+                .build();
+
         try {
-            transport = rpcClient.connect(timeout, timeUnit);
+            rpcsvc.start();
+            transport = rpcsvc.connect(poolAddress, timeout, timeUnit);
         } catch (IOException | Error | RuntimeException e) {
-            rpcClient.close();
+            rpcsvc.stop();
             throw e;
         }
 
@@ -158,7 +169,7 @@ public class NfsProxyIo implements ProxyIoAdapter {
         try {
             destroy_session();
         } finally {
-            rpcClient.close();
+            rpcsvc.stop();
         }
     }
     /**


### PR DESCRIPTION
Motivation:
by default, rpc client starts 2x#Cores threads for request processing.
When client is used to implement NFS door's proxy-io functionality
we don't need such a high number of threads. Worse, in case of flood
of proxy-io request, NFS door easily can run out of open file
descriptors.

Modification:
Manually initialize rpc client to fine-tune number of threads.

Result:
Reduced likelihood of NFS door hitting the limmit of open file
descriptors.

Acked-by:
Target: 2.16
Require-book: no
Require-notes: yes