### PR TITLE
parent/dcache: add mail jar to deployment

### DIFF
--- a/modules/dcache/pom.xml
+++ b/modules/dcache/pom.xml
@@ -311,6 +311,12 @@
         <groupId>org.dcache</groupId>
         <artifactId>rados4j</artifactId>
     </dependency>
+
+    <!-- used by alarms, needs to be deployed -->
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>mail</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -832,6 +832,12 @@
                 <artifactId>ldap4testing</artifactId>
                 <version>1.0</version>
             </dependency>
+            <!-- used by alarms, needs to be deployed -->
+            <dependency>
+                <groupId>javax.mail</groupId>
+                <artifactId>mail</artifactId>
+                <version>1.4.7</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Motivation:

The alarms service needs a javax.mail implementation
jar to be present in order for it to send email alerts.

This jar was present in 2.13, but somehow disappeared
from the pom of 2.16+.

Modification:

Add the jar to the parent pom.xml and to the dcache pom.xml.

Result:

Alarms is happy when you configure it to send emails.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Bug: 3135
Acked-by: Tigran