### PR TITLE
nfs: do not add Origin to read-only subject

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoMdsOpFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoMdsOpFactory.java
@@ -46,7 +46,10 @@ public class ProxyIoMdsOpFactory implements NFSv4OperationFactory {
             public void process(CompoundContext context, nfs_resop4 result) throws ChimeraNFSException, IOException, OncRpcException {
                 Optional<IOException> optionalException = Subject.doAs(context.getSubject(), (PrivilegedAction<Optional<IOException>>) () -> {
                     try {
-                        context.getSubject().getPrincipals().add( new Origin(context.getRemoteSocketAddress().getAddress()));
+                        Subject subject = context.getSubject();
+                        if (!subject.isReadOnly()) {
+                            context.getSubject().getPrincipals().add(new Origin(context.getRemoteSocketAddress().getAddress()));
+                        }
                         operation.process(context, result);
                     } catch (IOException e) {
                         return Optional.of(e);


### PR DESCRIPTION
Motivation:
nfs door modifies original subject by adding Origin
principal. This fails if subject is set to be immutable.

Modification:
do not add Origin if subject is read-only

Result:
fixed exception:

19 Apr 2017 15:27:24 (NFS-09f320f281b6) [] Access denied: (no export) fs root for client /172.18.0.1
19 Apr 2017 15:27:24 (NFS-09f320f281b6) [] Unhandled exception:
java.lang.IllegalStateException: Subject is read-only
      at javax.security.auth.Subject$SecureSet.add(Subject.java:1103) ~[na:1.8.0_111-internal]
      at java.util.Collections$SynchronizedCollection.add(Collections.java:2035) ~[na:1.8.0_111-internal]
      at org.dcache.chimera.nfsv41.door.proxy.ProxyIoMdsOpFactory$1.lambda$process$0(ProxyIoMdsOpFactory.java:49) ~[dcache-nfs-3.1.0.jar:3.1.0]
      at java.security.AccessController.doPrivileged(Native Method) ~[na:1.8.0_111-internal]
      at javax.security.auth.Subject.doAs(Subject.java:360) ~[na:1.8.0_111-internal]
      at org.dcache.chimera.nfsv41.door.proxy.ProxyIoMdsOpFactory$1.process(ProxyIoMdsOpFactory.java:47) ~[dcache-nfs-3.1.0.jar:3.1.0]
      at org.dcache.nfs.v4.NFSServerV41.NFSPROC4_COMPOUND_4(NFSServerV41.java:166) ~[nfs4j-core-0.14.2.jar:0.14.2]
      at org.dcache.nfs.v4.xdr.nfs4_prot_NFS4_PROGRAM_ServerStub.dispatchOncRpcCall(nfs4_prot_NFS4_PROGRAM_ServerStub.java:48) [nfs4j-core-0.14.2.jar:0.14.2]
      at org.dcache.xdr.RpcDispatcher$1.run(RpcDispatcher.java:110) [oncrpc4j-core-2.7.0.jar:na]
      at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:591) [grizzly-framework-2.3.24.jar:2.3.24]
      at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:571) [grizzly-framework-2.3.24.jar:2.3.24]

Acked-by: Albert Rossi
Target: master, 3.1, 3.0, 2.16
Require-book: no
Require-notes: no
(cherry picked from commit 7dbbe2b0a21862f56071e6235c26045ea54da8d5)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>