### PR TITLE
chimera: do not update inode generation on atime only update

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -1698,7 +1698,7 @@ public class FsSqlDriver {
              * ATIME only update. The CTIME must stay unchanged.
              */
             PreparedStatement preparedStatement = dbConnection.prepareStatement(
-                    "UPDATE t_inodes SET iatime=?,igeneration=igeneration+1 WHERE inumber=?");
+                    "UPDATE t_inodes SET iatime=? WHERE inumber=?");
             preparedStatement.setTimestamp(1, new Timestamp(stat.getATime()));
             preparedStatement.setLong(2, inode.ino());
             return preparedStatement;


### PR DESCRIPTION
Motivation:
generation used for cache consistency by NFS clients. If dCache configure
to update atime, then it will invalidate clients cache and force extra
read requests to re-read unchanged data.

Modification:
do not update inode generation on atime only update

Result:
no re-reads of the cached content. Better IO performance.

Acked-by: Paul Millar
Target: master, 3.1, 3.0, 2.16
Require-book: no
Require-notes: yes
(cherry picked from commit 19ec5b3078c2c391d391a7be718cfa11b4411d79)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>