### PR TITLE
srm: remove file-level timeout

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
@@ -296,9 +296,10 @@ public class SRM implements CellLifeCycleAware
          */
         for (JobStorage<?> jobStorage : databaseFactory.getJobStorages().values()) {
             tasks.add(executor.scheduleWithFixedDelay(() -> {
-                for (Job job : jobStorage.getActiveJobs()) {
-                    job.checkExpiration();
-                }
+                jobStorage.getActiveJobs().stream()
+                        .filter(Request.class::isInstance)
+                        .map(Request.class::cast)
+                        .forEach(Request::checkExpiration);
             }, expiryPeriod, expiryPeriod, TimeUnit.MILLISECONDS));
         }
     }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -676,25 +676,6 @@ public abstract class Job  {
         return getGenerator().nextLong();
     }
 
-    public void checkExpiration()
-    {
-        wlock();
-        try {
-            if (creationTime + lifetime < System.currentTimeMillis() && !state.isFinal()) {
-                logger.info("expiring job #{}", getId());
-                StringBuilder sb = new StringBuilder();
-                sb.append("Request lifetime (");
-                TimeUtils.appendDuration(sb, lifetime, MILLISECONDS, TimeUnitFormat.SHORT);
-                sb.append(") expired.");
-                setState(State.FAILED, sb.toString());
-            }
-        } catch (IllegalStateTransition e) {
-            logger.error("Illegal state transition while expiring job: {}", e.toString());
-        } finally {
-            wunlock();
-        }
-    }
-
     /**
      * Getter for property creationTime.
      * @return Value of property creationTime.


### PR DESCRIPTION
Motivation:

Some asynchronous requests have a finite lifetime, after which the
storage system is allowed to ABORT the request.  For bulk requests, this
timeout applies to the entire request, but dCache SRM (mistakenly) also
applies the timeout to individual files.

That the request and the files contained within both have timeouts
creates a race condition: sometimes the container will timeout and
sometimes the files within the container. If the files timeout first
then dCache returns an incorrect error code.

Once consequence of this race condition is that the S2 PutTimeout
usecase test fails randomly.

Modification:

Never timeout file requests.

Note that, although much more work is needed to remove broken behaviour
(which also extends into srmExtendFileLifeTime support), this patch is
deliberately left small to facilitate back-porting.

Result:

Requests that time out always return SRM_REQUEST_TIMED_OUT at request
level and SRM_FAILURE for the SURLs in that request.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Resolves #3033
Patch: https://rb.dcache.org/r/10177/
Acked-by: Tigran Mkrtchyan