### PR TITLE
xrootd: writing to an existing file is kXR_NotAuthorized, not kXR_Unsupported

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -201,7 +201,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
         } catch (FileNotFoundCacheException e) {
             return withError(req, kXR_NotFound, "No such file");
         } catch (FileExistsCacheException e) {
-            return withError(req, kXR_Unsupported, "File already exists");
+            return withError(req, kXR_NotAuthorized, "File already exists");
         } catch (TimeoutCacheException e) {
             return withError(req, kXR_ServerError, "Internal timeout");
         } catch (PermissionDeniedCacheException e) {


### PR DESCRIPTION
Motivation:
kXR_Unsupported is interpreted by xrootd as ENOSYS, which gets ignored by FUSE and leads to errors later that are hard to diagnose.
Attempting to copy a file to dcache mounted over xrootd leads to as segfault in xrootd filesystem code because the (second) open operation fails, but the error is ENOSYS so FUSE does not stop and tries to use the null file descriptor for writing. 

Modification:
Respond kXR_NotAuthorized instead

Result:
Attempting to copy a file to dcache mounted over xrootd by fuse leads to a "permission denied" error and a file in a 'new' state in dcache. This situation needs fixing, but it is better, as the exact point of failure is easier to locate.
`cp: cannot create regular file 'mnt/public/123': Permission denied`