### PR TITLE
xrootd: allow xrootd to overwrite new empty files.

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/StorageInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/StorageInfo.java
@@ -110,8 +110,7 @@ public interface StorageInfo
     void setHsm(String newHsm);
     /**
       * Determines whether the file exists somewhere (cache or HSM)
-      * or not. Currently isCreatedOnly returns true is the
-      * size of the level-0 file is not zero.
+      * or not. Basically getIsNew()
       */
     boolean isCreatedOnly() ;
     void setIsNew(boolean isNew);

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -177,7 +177,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
             XrootdTransfer transfer;
             if (neededPerm == FilePerm.WRITE) {
                 boolean createDir = req.isMkPath();
-                boolean overwrite = req.isDelete();
+                boolean overwrite = req.isDelete() && !req.isNew();
 
                 transfer =
                     _door.write(remoteAddress, createFullPath(req.getPath()), ioQueue,


### PR DESCRIPTION
Motivation:
Xrootdfs FUSE driver immediately closes a file on creation, then reopens it to write.
The file cannot be opened as it already exists. This patch allows the dcache xrootd door to tolerate this behavior.

Modification:
If a file is newly created, allow overwriting it even if the request flags don't ask for it.

Specifically, unless XrdCl::OpenFlags::Delete is set overwriting is disallowed.
But XrootdDoor now checks if the file is new by querying transfer.isCreatedOnly(), and in that case overwrites the file anyway.

Result:
xrootdfs FUSE driver can be used to copy a file onto a mounted dCache filesystem.
This process is inefficient, because the file is created twice, but getting rid of the double open requires changes in the xrootd driver.