### PR TITLE
postgresql driver: update version to 9.4.1212

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
                 <!-- 1204 appears to contain a bug in handling timestamp types (pinmanager fails) -->
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>9.4-1203-jdbc42</version>
+                <version>9.4.1212</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Motivation:

liquibase fails to apply changesets when running on postgresql 9.6 with the following error

ERROR: column am.amcanorder does not exist

Issue is documented in https://liquibase.jira.com/browse/CORE-2939

Recommendation is to upgrade jdbc driver to version 9.4.1212

Modification:

update postgresql driver to version 9.4.1212

Result:

no error "ERROR: column am.amcanorder does not exist" is seen

Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
Target: 3.0
Request: 2.16
Request: 2.13
Request: 2.15
Requets: 2.14
Patch: https://rb.dcache.org/r/10179/

Require-book: no
Require-notes: yes