### PR TITLE
nfs: show transfer status when displayed

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -847,13 +847,20 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         @Override
         public String toString() {
-            return String.format("    %s : %s %s@%s, OS=%s,cl=[%s]",
+
+            String status = getStatus();
+            if (status == null) {
+                status = "idle";
+            }
+
+            return String.format("    %s : %s %s@%s, OS=%s, cl=[%s], status=[%s]",
                     getPnfsId(),
                     isWrite() ? "WRITE" : "READ",
                     getMoverId(),
                     getPool(),
                     ((NFS4ProtocolInfo)getProtocolInfoForPool()).stateId(),
-                    ((NFS4ProtocolInfo)getProtocolInfoForPool()).getSocketAddress().getAddress().getHostAddress());
+                    ((NFS4ProtocolInfo)getProtocolInfoForPool()).getSocketAddress().getAddress().getHostAddress(),
+                    status);
         }
 
         Inode getInode() {


### PR DESCRIPTION
Motivation:
During debugging of stuck transfers we can't say in which state they are
currently in:

 nfs> show transfers
    2017-05-05T16:11:43.596+02:00 : 0000ABFEB5292AC14853B15897255D0107E6 : READ null@null, OS=[590a037200000006000839b6, seq: 1], cl=[131.169.5.210]
    2017-05-05T16:11:43.406+02:00 : 00002CC82A5AE1F24ACF9E5B7C3DA4F63840 : READ null@null, OS=[590a037200000006000839b4, seq: 1], cl=[131.169.5.210]

Modification:

add status information to the output:

nfs> show transfers
    2017-05-07T18:01:29.057+02:00 : 00009A0D28D5535B47BD97E529769C51BF73 : READ null@dcache-cloud04-08, OS=[590f35340000000300008dc1, seq: 1], cl=[131.169.5.174], status=[Pool dcache-cloud04-08: Creating mover]
    2017-05-07T18:03:36.893+02:00 : 00006036270EEACD488EB1CCFDE508D9A235 : READ null@null, OS=[590f353500000005000031c4, seq: 1], cl=[131.169.5.236], status=[PnfsManager: Fetching storage info]

Result:
better debugging.

Acked-by: Paul Millar
Target: master, 3.1, 3.0, 2.16
Require-book: no
Require-notes: yes
(cherry picked from commit f77ebaa6c6350f7d6148191019991fb521703df0)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>