### PR TITLE
nfs: fix loosing movers due to short timeout

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -163,12 +163,11 @@ public class NFSv41Door extends AbstractCellComponent implements
     private final Map<stateid4, NfsTransfer> _ioMessages = new ConcurrentHashMap<>();
 
     /**
-     * The usual timeout for NFS operations is 30s. Nevertheless, as client
-     * will block, we try to block as short as we can. The rule for interactive users:
-     * never block longer than 10s.
+     * Maximal time the NFS request will blocked before we reply with
+     * NFSERR_DELAY. The usual timeout for NFS operations is 30s. Nevertheless,
+     * as client's other requests will blocked as well, we try to block as short
+     * as we can. The rule for interactive users: never block longer than 10s.
      */
-    private static final long NFS_REPLY_TIMEOUT = TimeUnit.SECONDS.toMillis(3);
-
     private static final long NFS_REQUEST_BLOCKING = TimeUnit.SECONDS.toMillis(3);
 
     /**
@@ -230,15 +229,9 @@ public class NFSv41Door extends AbstractCellComponent implements
     private ProxyIoFactory _proxyIoFactory;
 
     /**
-     * retry policy used for accessing online files.
+     * Retry policy used for accessing files.
      */
-    private static final TransferRetryPolicy RETRY_POLICY =
-        new TransferRetryPolicy(Integer.MAX_VALUE, NFS_RETRY_PERIOD, NFS_REPLY_TIMEOUT);
-
-    /**
-     * Retry policy used for accessing off-line files.
-     */
-    private static final TransferRetryPolicy RETRY_POLICY_WITH_STAGE =
+    private static final TransferRetryPolicy POOL_SELECTION_RETRY_POLICY =
         new TransferRetryPolicy(Integer.MAX_VALUE, NFS_RETRY_PERIOD, STAGE_REQUEST_TIMEOUT);
 
     private VfsCacheConfig _vfsCacheConfig;
@@ -940,7 +933,7 @@ public class NFSv41Door extends AbstractCellComponent implements
                  */
                 setOnlineFilesOnly(true);
                 _log.debug("looking for {} pool for {}", (isWrite() ? "write" : "read"), getPnfsId());
-                _redirectFuture = selectPoolAndStartMoverAsync(RETRY_POLICY);
+                _redirectFuture = selectPoolAndStartMoverAsync(POOL_SELECTION_RETRY_POLICY);
             }
 
             /*
@@ -977,7 +970,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
                 // kick stage/ p2p
                 setOnlineFilesOnly(false);
-                _redirectFuture = selectPoolAndStartMoverAsync(RETRY_POLICY_WITH_STAGE);
+                _redirectFuture = selectPoolAndStartMoverAsync(POOL_SELECTION_RETRY_POLICY);
                 throw new LayoutTryLaterException("File is not online: stage or p2p required");
             }
             _log.debug("mover ready: pool={} moverid={}", getPool(), getMoverId());


### PR DESCRIPTION
Motivation:
When selecting a pool and starting a mover, nfs door uses short timeout.
If selection process times out, then client will re-try the request. The
assumption in the door, that Transfer class eventually will have a mover.
However, if message live time is shorter than selection process took,
then reply from the poll manager or a pool will be ignored and Transfer
will never get mover id, even if mover started.

Modification:
Always use retry policy with big timeout, but query for result of selection
with a short timeout. The door still distinct between slow selection and
staging/p2p.

Result:
Even if selection process took longer than was expected, the door eventually
gets a mover.

Acked-by: Paul Millar
Target: master, 3.1, 3.0
Require-book: no
Require-notes: yes
(cherry picked from commit 0ebcceaff4ed4b4aa950aba775b45038fa333abc)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>