### PR TITLE
ceph: map RadosException to corresponding IOException

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ceph/CephFileStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ceph/CephFileStore.java
@@ -32,6 +32,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.Set;
 import java.util.stream.Collectors;
+import jnr.constants.platform.Errno;
 
 import org.dcache.pool.movers.IoMode;
 import org.dcache.pool.repository.FileStore;
@@ -197,11 +198,7 @@ public class CephFileStore implements FileStore {
                 }
             };
         } catch (RadosException e) {
-            // try to map CEPH errors to dCache/java.io alternatives
-            // the errcodes are negative numbers :)
-            if ( Math.abs(e.getErrorCode()) == jnr.constants.platform.Errno.ENOENT.intValue()) {
-                throw new NoSuchFileException(imageName);
-            }
+            throwIfMappable(e, "Failed to get file's attribute: " + imageName);
             throw e;
         }
     }
@@ -209,41 +206,73 @@ public class CephFileStore implements FileStore {
     @Override
     public URI create(PnfsId id) throws IOException {
         String imageName = toImageName(id);
-        rbd.create(imageName, 0);
-        ctx.setXattr(toObjName(imageName),
-                CREATION_TIME_ATTR,
-                Longs.toByteArray(System.currentTimeMillis()));
+        try {
+            rbd.create(imageName, 0);
+            ctx.setXattr(toObjName(imageName),
+                    CREATION_TIME_ATTR,
+                    Longs.toByteArray(System.currentTimeMillis()));
+        } catch (RadosException e) {
+            throwIfMappable(e, "Failed to create file: " + imageName);
+            throw e;
+        }
         return toUri(imageName);
     }
 
     @Override
     public void remove(PnfsId id) throws IOException {
-        rbd.remove(toImageName(id));
+        String imageName = toImageName(id);
+        try {
+            rbd.remove(imageName);
+        } catch (RadosException e) {
+            throwIfMappable(e, "Failed to remove file: " + imageName);
+            throw e;
+        }
     }
 
     @Override
     public RepositoryChannel openDataChannel(PnfsId id, IoMode ioMode) throws IOException {
-        return new CephRepositoryChannel(rbd, toImageName(id), ioMode.toOpenString());
+        String imageName = toImageName(id);
+        try {
+            return new CephRepositoryChannel(rbd, imageName, ioMode.toOpenString());
+        } catch (RadosException e) {
+            throwIfMappable(e, "Failed to open file: " + imageName);
+            throw e;
+        }
     }
 
     @Override
     public Set<PnfsId> index() throws IOException {
-        return rbd.list()
-                .stream()
-                .map(this::toPnfsId)
-                .collect(Collectors.toSet());
+        try {
+            return rbd.list()
+                    .stream()
+                    .map(this::toPnfsId)
+                    .collect(Collectors.toSet());
+        } catch (RadosException e) {
+            throwIfMappable(e, "Failed to get list of images");
+            throw e;
+        }
     }
 
     @Override
     public long getFreeSpace() throws IOException {
-        RadosClusterInfo clusterInfo = rados.statCluster();
-        return clusterInfo.kb_avail.get() * 1024;
+        try {
+            RadosClusterInfo clusterInfo = rados.statCluster();
+            return clusterInfo.kb_avail.get() * 1024;
+        } catch (RadosException e) {
+            throwIfMappable(e, "Failed to get cluster info");
+            throw e;
+        }
     }
 
     @Override
     public long getTotalSpace() throws IOException {
-        RadosClusterInfo clusterInfo = rados.statCluster();
-        return clusterInfo.kb.get()*1024;
+        try {
+            RadosClusterInfo clusterInfo = rados.statCluster();
+            return clusterInfo.kb.get()*1024;
+        } catch (RadosException e) {
+            throwIfMappable(e, "Failed to get cluster info");
+            throw e;
+        }
     }
 
     @Override
@@ -287,6 +316,18 @@ public class CephFileStore implements FileStore {
             ctx.destroy();
         } finally {
             rados.shutdown();
+        }
+    }
+
+    private void throwIfMappable(RadosException e, String msg) throws IOException {
+        // try to map CEPH errors to dCache/java.io alternatives
+        // the errcodes are negative numbers :)
+
+        Errno err = Errno.valueOf(Math.abs(e.getErrorCode()));
+
+        switch(err) {
+            case ENOENT:
+                throw new NoSuchFileException(msg + " : " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Motivation:
In many cases dCache knows how to handle various IOExceptions. By converting
RadosExceptions into corresponding IOException, we give dCache's pool
a better changes to take the correct actions.

Modification:
Introduce throwMappedException method to map RadosExceptions to IOException.
For now, only NoSuchFileException is processed. If mapping is not supported,
then RadosException is re-thrown.

Result:
better error handling with CEPH

Acked-by: Paul Millar
Target: master, 3.1, 3.0
Require-book: no
Require-notes: yes
(cherry picked from commit 04f929cf1c27f0c65fd889f848a6e5905503a11a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>