### PR TITLE
nfs: bind vfs cache invalidation with file's layout

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -379,7 +379,6 @@ public class NFSv41Door extends AbstractCellComponent implements
         if(transfer != null) {
                 transfer.finished(transferFinishedMessage);
                 transfer.notifyBilling(transferFinishedMessage.getReturnCode(), "");
-                _vfs.invalidateStatCache(transfer.getInode());
         }
     }
 
@@ -590,6 +589,14 @@ public class NFSv41Door extends AbstractCellComponent implements
                         }
                     }
             );
+
+            if (ioMode == layoutiomode4.LAYOUTIOMODE4_RW) {
+                // in case of WRITE, invalidate vfs cache on close
+                nfsState.addDisposeListener(state -> {
+                    _vfs.invalidateStatCache(nfsInode);
+                });
+            }
+
             layoutStateId.bumpSeqid();
             return new Layout(true, layoutStateId.stateid(), new layout4[]{layout});
 


### PR DESCRIPTION
Motivation:
On write we have to invalidate vfs cache, as file's attributes are
changed. For now, we do this only for files that had a transfer. However
this have to be done for IO on dot files as well.

Modification:
Bind vfs cache invalidation with layout state id disposal. This will
happen on close for regular and dot files.

Result:
no stale information for dot files after update.

Acked-by: Paul Millar
Target: master, 3.1
Require-book: no
Require-notes: no
(cherry picked from commit 3961e557c61347f7d3d31b54521200b7322dc433)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>