### PR TITLE
xrootd: better error responses to invalid open requests

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -251,9 +251,9 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                 FileDescriptor descriptor;
                 IoMode mode = file.getIoMode();
                 if (msg.isNew() && mode != IoMode.WRITE) {
-                    throw new XrootdException(kXR_ArgInvalid, "File exists.");
+                    throw new XrootdException(kXR_ArgInvalid, "Open without write mode but isNew.");
                 } else if (msg.isDelete() && mode != IoMode.WRITE) {
-                    throw new XrootdException(kXR_Unsupported, "File exists.");
+                    throw new XrootdException(kXR_ArgInvalid, "Open without write mode but isDelete.");
                 } else if ((msg.isNew() || msg.isReadWrite()) && mode == IoMode.WRITE) {
                     descriptor = new WriteDescriptor(file, (msg.getOptions() & kXR_posc) == kXR_posc ||
                             file.getProtocolInfo().getFlags().contains(XrootdProtocolInfo.Flags.POSC));


### PR DESCRIPTION
Motivation:
When opening file with no write flag but a delete or create operation, the response text was generic, while the response codes are different.
kXR_Unsuported does not fit, as it is not an operation that is expected to work on any server.

Change:
Respond to both with kXR_ArgInvalid with specific error text.

Result:
No change shoud be noticeable with any sane client, but debugging errors a bad xrootd client code should become easier.