### PR TITLE
Add cascadeConstraints="true" to liquibase dropTable action on pinsv3…

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pinmanager/model/db.changelog-2.16.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pinmanager/model/db.changelog-2.16.xml
@@ -23,11 +23,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet author="behrmann" id="1">
+    <changeSet author="behrmann" id="1.1">
         <preConditions onFail="MARK_RAN">
             <tableExists tableName="pinsv3"/>
         </preConditions>
-        <dropTable tableName="pinsv3"/>
+        <dropTable cascadeConstraints="true" tableName="pinsv3"/>
         <rollback/>
     </changeSet>
 


### PR DESCRIPTION
… table

Motivation:

Upgrade from 2.13 fails on liquibase changeset execution due to failure to drop pinsv3 table referenced by FK in other table.

Modification:

Add cascadeConstraints="true" to dropTable section of the same changeSet

Result:

PinManager starts w/o issues.

Target: master
Request: 2.16, 3.0, 3.1
Patch: https://rb.dcache.org/r/10201
Bug: http://rt.dcache.org/Ticket/Display.html?id=9165
Require-book : no
Require-notes: yes
(cherry picked from commit db29ebc60c07398f4488b5a68bcf7e0b63f2897b)