### PR TITLE
rest-api: include username to the user attributes

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/UserAttributes.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/UserAttributes.java
@@ -47,6 +47,8 @@ public class UserAttributes
 
     private String home;
 
+    private String username;
+
     public AuthenticationStatus getStatus()
     {
         return status;
@@ -85,5 +87,15 @@ public class UserAttributes
     public void setHomeDirectory(String dir)
     {
         home = dir;
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public void setUsername(String name)
+    {
+        username = name;
     }
 }

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/identity/UserResource.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/identity/UserResource.java
@@ -57,6 +57,7 @@ public class UserResource
         } else {
             user.setStatus(UserAttributes.AuthenticationStatus.AUTHENTICATED);
             user.setUid(Subjects.getUid(subject));
+            user.setUsername(Subjects.getUserName(subject));
             List<Long> gids = Arrays.stream(Subjects.getGids(subject))
                     .boxed()
                     .collect(Collectors.toList());


### PR DESCRIPTION
Motivation:

A client like dcache-view needs the recognise username in dcache.

When authenticating through openID connect (that is, by sending the
access token obtained to dcache); username from the openID connect
provider might not be the same as the one in dcache.

Modification:

Add username field to UserAttributes class and if the user is known,
the username will be set.

Result:

Request to /api/v1/user will now include the username of the user.

Target: trunk
Request: 3.1
Request: 3.0
Require-note: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10196/

(cherry picked from commit 83ba36f475cb4aeadf982b7ca6f2080c7f298f01)