### PR TITLE
frontend: expose open-id connect to dcache-view

### DIFF
--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -344,3 +344,34 @@ frontend.dcache-view.endpoints.webdav=
 #  ---- Name placed at the top of the dCacheView application
 #
 frontend.dcache-view.org-name=${dcache.description}
+
+#  ---- Enable OpenID Connect for dcache-view
+#
+#   After setting up openID connect in the webdav;
+#   dcache-view needs to be configured. This will enable
+#   user to be able to authenticate with an OpenID connect
+#   account.
+#
+#   These 3 properties below must be set.
+#   If you have more than one OpenID connect providers,
+#   each properties takes in space separated value, that is,
+#   one for each providers. Therefore, the set values of each
+#   properties MUST be in the same order, since these will be
+#   mapped together.
+#
+#   Example: Say you have enable two OpenID connect providers;
+#   namely: openid1 and openid2. The 3 properties will be setup
+#   as follow:
+#
+#   frontend.dcache-view.oidc-provider-name-list= openid1 openid2
+#   frontend.dcache-view.oidc-client-id-list= clientID1 clientID2
+#   frontend.dcache-view.oidc-authz-endpoint-list= https://server.openID1.com/authorize https://server.openID2.com/authorize
+#
+frontend.dcache-view.oidc-provider-name-list=
+frontend.dcache-view.oidc-client-id-list=
+frontend.dcache-view.oidc-authz-endpoint-list=
+
+#  ---- Root path
+# Default directory to be exported by doors
+#
+frontend.root = ${dcache.root}

--- a/skel/share/services/frontend.batch
+++ b/skel/share/services/frontend.batch
@@ -45,6 +45,9 @@ check -strong frontend.limits.graceful-shutdown.unit
 check -strong frontend.dcache-view.endpoints.webapi
 check frontend.dcache-view.endpoints.webdav
 check frontend.dcache-view.org-name
+check frontend.dcache-view.oidc-provider-name-list
+check frontend.dcache-view.oidc-client-id-list
+check frontend.dcache-view.oidc-authz-endpoint-list
 check -strong frontend.dcache-view.dir
 
 check frontend.authn.ciphers
@@ -76,7 +79,10 @@ var CONFIG =
 {
     "webapiEndpoint": "${frontend.dcache-view.endpoints.webapi}",
     "webdavEndpoint": "${frontend.dcache-view.endpoints.webdav}",
-    "orgName": "${frontend.dcache-view.org-name}"
+    "orgName": "${frontend.dcache-view.org-name}",
+    "oidcProviderName": "${frontend.dcache-view.oidc-provider-name-list}",
+    "oidcClientId": "${frontend.dcache-view.oidc-client-id-list}",
+    "oidcAuthorizationEndpoint": "${frontend.dcache-view.oidc-authz-endpoint-list}"
 };
 enddefine
 


### PR DESCRIPTION
Motivation:

To obtain an access token from an OpenID connect provider, the client
like dcache-view must send a request to the provider's authorization
endpoint with the client id.

Modification:

Add three properties to the frontend and expose these to dcache-view
config.js file.

Result:

OpenID connect can be enable in dcache-view.

Target: trunk
Request: 3.1
Request: 3.0
Require-note: yes
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/10200/

(cherry picked from commit cec2f1fd4b7668453d60bd9b9e9555049395892a)