### PR TITLE
httpd: Fix incomplete restore list in HA setup

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -516,7 +516,7 @@ public class CellNucleus implements ThreadFactory
                             long timeout)
         throws SerializationException
     {
-        checkState(_state.isSendWithCallbackAllowed);
+        checkState(_state.isSendWithCallbackAllowed, "Cannot send message with callback in state {}", _state);
         checkArgument(!msg.isFinalDestination(), "Message has no next destination: %s", msg.getDestinationPath());
 
         if (shouldAddSource) {

--- a/modules/cells/src/main/java/dmg/util/HttpResponseEngine.java
+++ b/modules/cells/src/main/java/dmg/util/HttpResponseEngine.java
@@ -11,18 +11,5 @@ package dmg.util ;
   *   - <init>()
   */
 public interface HttpResponseEngine {
-
-    void queryUrl(HttpRequest request)
-           throws HttpException ;
-
-    /**
-     * This method is called from the http thread when the engine
-     * should start activity.
-     */
-    void startup();
-
-    /**
-     * Method called to indicate that the http engine should shutdown
-     */
-    void shutdown();
+    void queryUrl(HttpRequest request) throws HttpException;
 }

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/InfoHttpEngine.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/InfoHttpEngine.java
@@ -261,16 +261,4 @@ public class InfoHttpEngine implements HttpResponseEngine, CellMessageSender
 
         return bestHandler;
     }
-
-    @Override
-    public void startup()
-    {
-        // This class has no background activity.
-    }
-
-    @Override
-    public void shutdown()
-    {
-        // No background activity to shutdown.
-    }
 }

--- a/modules/dcache-vehicles/src/main/java/org/dcache/poolmanager/PoolManagerGetRestoreHandlerInfo.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/poolmanager/PoolManagerGetRestoreHandlerInfo.java
@@ -1,0 +1,53 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.poolmanager;
+
+import java.util.List;
+
+import diskCacheV111.vehicles.PoolManagerMessage;
+import diskCacheV111.vehicles.RestoreHandlerInfo;
+
+/**
+ * Request information about current request container tasks.
+ */
+public class PoolManagerGetRestoreHandlerInfo extends PoolManagerMessage
+{
+    private static final long serialVersionUID = 765552672615264580L;
+
+    private List<RestoreHandlerInfo> result;
+
+    public PoolManagerGetRestoreHandlerInfo()
+    {
+    }
+
+    public PoolManagerGetRestoreHandlerInfo(List<RestoreHandlerInfo> result)
+    {
+        this.result = result;
+    }
+
+    public void setResult(List<RestoreHandlerInfo> result)
+    {
+        this.result = result;
+    }
+
+    public List<RestoreHandlerInfo> getResult()
+    {
+        return result;
+    }
+}

--- a/modules/dcache/src/main/java/diskCacheV111/cells/HttpBillingEngine.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/HttpBillingEngine.java
@@ -40,18 +40,6 @@ public class HttpBillingEngine
     }
 
     @Override
-    public void startup()
-    {
-        // No background activity to start
-    }
-
-    @Override
-    public void shutdown()
-    {
-        // No background activity to shutdown
-    }
-
-    @Override
     public void setCellEndpoint(CellEndpoint endpoint)
     {
         _billing = new CellStub(endpoint, new CellPath(_billingAddress), 5, SECONDS);

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HttpHsmFlushMgrEngineV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HttpHsmFlushMgrEngineV1.java
@@ -178,18 +178,6 @@ public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageS
        }
    }
 
-   @Override
-   public void startup()
-   {
-       // No background activity to start
-   }
-
-   @Override
-   public void shutdown()
-   {
-       // No background activity to shutdown
-   }
-
    private void printUpdateThis( PrintWriter pw , String thisManager ){
      pw.println("<center><a class=\"big-link\" href=\"");
      pw.println(thisManager);

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -67,11 +68,14 @@ import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.Partition;
 import org.dcache.poolmanager.PartitionManager;
 import org.dcache.poolmanager.PoolInfo;
+import org.dcache.poolmanager.PoolManagerGetRestoreHandlerInfo;
 import org.dcache.poolmanager.PoolSelector;
 import org.dcache.poolmanager.SelectedPool;
 import org.dcache.util.Args;
 import org.dcache.util.FireAndForgetTask;
 import org.dcache.vehicles.FileAttributes;
+
+import static java.util.stream.Collectors.toList;
 
 public class RequestContainerV5
     extends AbstractCellComponent
@@ -608,6 +612,18 @@ public class RequestContainerV5
         }
        return sb.toString();
     }
+
+    public PoolManagerGetRestoreHandlerInfo messageArrived(PoolManagerGetRestoreHandlerInfo msg) {
+        List<RestoreHandlerInfo> requests;
+        Map<String, PoolRequestHandler> handlerHash = _handlerHash;
+        synchronized (handlerHash) {
+            requests = handlerHash.values().stream().filter(Objects::nonNull).map(
+                    PoolRequestHandler::getRestoreHandlerInfo).collect(toList());
+        }
+        msg.setResult(requests);
+        return msg;
+    }
+
     public static final String hh_xrc_ls = " # lists pending requests (binary)" ;
     public Object ac_xrc_ls( Args args ){
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/web/ContextPictureEngine.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/web/ContextPictureEngine.java
@@ -41,18 +41,6 @@ public class ContextPictureEngine implements HttpResponseEngine, DomainContextAw
     public ContextPictureEngine(String [] args) {
     }
 
-   @Override
-   public void startup()
-   {
-       // No background activity to start
-   }
-
-   @Override
-   public void shutdown()
-   {
-       // No background activity to shutdown
-   }
-
     @Override
     public void setDomainContext(Map<String, Object> context)
     {

--- a/modules/dcache/src/main/java/diskCacheV111/services/web/PoolInfoObserverEngineV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/web/PoolInfoObserverEngineV2.java
@@ -53,18 +53,6 @@ public class PoolInfoObserverEngineV2 implements HttpResponseEngine, DomainConte
     }
 
     @Override
-    public void startup()
-    {
-          // No background activity to start
-    }
-
-    @Override
-    public void shutdown()
-    {
-        // No background activity to shutdown
-    }
-
-    @Override
     public void queryUrl(HttpRequest request)
         throws HttpException
     {

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/ResponseEngineHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/ResponseEngineHandler.java
@@ -47,18 +47,4 @@ public class ResponseEngineHandler extends AbstractHandler
                     e.getMessage());
         }
     }
-
-    @Override
-    protected void doStart() throws Exception
-    {
-        engine.startup();
-        super.doStart();
-    }
-
-    @Override
-    protected void doStop() throws Exception
-    {
-        super.doStop();
-        engine.shutdown();
-    }
 }

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/probe/ProbeResponseEngine.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/probe/ProbeResponseEngine.java
@@ -72,16 +72,4 @@ public class ProbeResponseEngine implements HttpResponseEngine, CellMessageSende
             throw new HttpException(503, "Received interrupt whilst processing data. Please try again later.");
         }
     }
-
-    @Override
-    public void startup()
-    {
-
-    }
-
-    @Override
-    public void shutdown()
-    {
-
-    }
 }


### PR DESCRIPTION
Motivation:

In an HA setup with multiple pool managers, the httpd (old) service failed to
fetch the list of restore requests from all instances. Instead the service
would query one of the instances, possibly alternating depending on the
grouping of services in domains.

Modification:

The gist of the fix is to let the responsible collector in the httpd service
use a PoolManagerHandler to query the list of restores and then extend the
implementations of PoolManagerHandler to recognize that query and fetch the
list from all PoolManager instances.

Since PoolManagerHandler is limited to PoolManagerMessage subclasses, a new
request object is introduced. To maintain backwards compatibility, the
PoolManagerHandler implementations translate this request to the classic `xrc
ls` command, but that translation can be reduced once backwards compatibility
is no longer required.

To handle the startup and shutdown of the PoolManagerHandlerSubscriber
correctly, the httpd engine interface had to be adjusted to remove the custom
startup and shutdown methods and instead rely on regular cell lifecycle
callbacks.

Target:

Fixed a problem in which the restore list in the old httpd interface did not
show all restored when used in an HA setup.

Target: trunk
Require-notes: yes
Require-book: no
Request: 3.1
Request: 3.0
Acked-by: Tigran Mkrtchya <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/10192/

(cherry picked from commit d7db2599227895891d61ba7044cb7e8298e4593d)