### PR TITLE
httpd: Fix incomplete restore list in HA setup

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellNucleus.java
@@ -516,7 +516,7 @@ public class CellNucleus implements ThreadFactory
                             long timeout)
         throws SerializationException
     {
-        checkState(_state.isSendWithCallbackAllowed);
+        checkState(_state.isSendWithCallbackAllowed, "Cannot send message with callback in state {}", _state);
         checkArgument(!msg.isFinalDestination(), "Message has no next destination: %s", msg.getDestinationPath());
 
         if (shouldAddSource) {

--- a/modules/cells/src/main/java/dmg/util/HttpResponseEngine.java
+++ b/modules/cells/src/main/java/dmg/util/HttpResponseEngine.java
@@ -11,18 +11,5 @@ package dmg.util ;
   *   - <init>()
   */
 public interface HttpResponseEngine {
-
-    void queryUrl(HttpRequest request)
-           throws HttpException ;
-
-    /**
-     * This method is called from the http thread when the engine
-     * should start activity.
-     */
-    void startup();
-
-    /**
-     * Method called to indicate that the http engine should shutdown
-     */
-    void shutdown();
+    void queryUrl(HttpRequest request) throws HttpException;
 }

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/InfoHttpEngine.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/InfoHttpEngine.java
@@ -259,16 +259,4 @@ public class InfoHttpEngine implements HttpResponseEngine, CellMessageSender
 
         return bestHandler;
     }
-
-    @Override
-    public void startup()
-    {
-        // This class has no background activity.
-    }
-
-    @Override
-    public void shutdown()
-    {
-        // No background activity to shutdown.
-    }
 }

--- a/modules/dcache-vehicles/src/main/java/org/dcache/poolmanager/PoolManagerGetRestoreHandlerInfo.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/poolmanager/PoolManagerGetRestoreHandlerInfo.java
@@ -1,0 +1,53 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.poolmanager;
+
+import java.util.List;
+
+import diskCacheV111.vehicles.PoolManagerMessage;
+import diskCacheV111.vehicles.RestoreHandlerInfo;
+
+/**
+ * Request information about current request container tasks.
+ */
+public class PoolManagerGetRestoreHandlerInfo extends PoolManagerMessage
+{
+    private static final long serialVersionUID = 765552672615264580L;
+
+    private List<RestoreHandlerInfo> result;
+
+    public PoolManagerGetRestoreHandlerInfo()
+    {
+    }
+
+    public PoolManagerGetRestoreHandlerInfo(List<RestoreHandlerInfo> result)
+    {
+        this.result = result;
+    }
+
+    public void setResult(List<RestoreHandlerInfo> result)
+    {
+        this.result = result;
+    }
+
+    public List<RestoreHandlerInfo> getResult()
+    {
+        return result;
+    }
+}

--- a/modules/dcache/src/main/java/diskCacheV111/cells/HttpBillingEngine.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/HttpBillingEngine.java
@@ -39,18 +39,6 @@ public class HttpBillingEngine
     }
 
     @Override
-    public void startup()
-    {
-        // No background activity to start
-    }
-
-    @Override
-    public void shutdown()
-    {
-        // No background activity to shutdown
-    }
-
-    @Override
     public void setCellEndpoint(CellEndpoint endpoint)
     {
         _billing = new CellStub(endpoint, new CellPath(_billingAddress), 5, SECONDS);

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HttpHsmFlushMgrEngineV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HttpHsmFlushMgrEngineV1.java
@@ -177,18 +177,6 @@ public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageS
        }
    }
 
-   @Override
-   public void startup()
-   {
-       // No background activity to start
-   }
-
-   @Override
-   public void shutdown()
-   {
-       // No background activity to shutdown
-   }
-
    private void printUpdateThis( PrintWriter pw , String thisManager ){
      pw.println("<center><a class=\"big-link\" href=\"");
      pw.println(thisManager);

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/HttpPoolMgrEngineV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/HttpPoolMgrEngineV3.java
@@ -1,5 +1,6 @@
 package diskCacheV111.poolManager;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +30,7 @@ import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellInfo;
 import dmg.cells.nucleus.CellInfoProvider;
+import dmg.cells.nucleus.CellLifeCycleAware;
 import dmg.cells.nucleus.CellMessageSender;
 import dmg.cells.nucleus.CellPath;
 import dmg.cells.nucleus.DomainContextAware;
@@ -41,6 +43,8 @@ import dmg.util.HttpResponseEngine;
 import org.dcache.cells.CellStub;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.poolmanager.Partition;
+import org.dcache.poolmanager.PoolManagerGetRestoreHandlerInfo;
+import org.dcache.poolmanager.PoolManagerHandlerSubscriber;
 import org.dcache.util.Args;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.PnfsGetFileAttributes;
@@ -49,7 +53,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class HttpPoolMgrEngineV3 implements
         HttpResponseEngine, Runnable, CellInfoProvider, CellMessageSender, DomainContextAware,
-        CellCommandListener
+        CellCommandListener, CellLifeCycleAware
 {
     private static final String PARAMETER_DCACHE = "dcache";
     private static final String PARAMETER_GREP = "grep";
@@ -74,6 +78,8 @@ public class HttpPoolMgrEngineV3 implements
     private CellStub _pnfsManager;
     private CellStub _hsmController;
 
+    private PoolManagerHandlerSubscriber _pm;
+
     private final AgingHash   _pnfsPathMap     = new AgingHash(500);
     private final AgingHash _fileAttributesMap = new AgingHash(500);
     private final boolean     _takeAll         = true;
@@ -97,6 +103,8 @@ public class HttpPoolMgrEngineV3 implements
     private String[]    _siDetails;
     private String      _cssFile         = "/poolInfo/css/default.css";
     private Map<String, Object> _context;
+
+    private CellEndpoint _endpoint;
 
     public HttpPoolMgrEngineV3(String[] argsString)
     {
@@ -126,9 +134,12 @@ public class HttpPoolMgrEngineV3 implements
     @Override
     public void setCellEndpoint(CellEndpoint endpoint)
     {
+        _endpoint = endpoint;
         _poolManager = new CellStub(endpoint, new CellPath(_poolManagerAddress), TIMEOUT, SECONDS);
         _pnfsManager = new CellStub(endpoint, new CellPath(_pnfsManagerAddress), TIMEOUT, SECONDS);
         _hsmController = new CellStub(endpoint, new CellPath("HsmManager"), TIMEOUT, SECONDS);
+        _pm = new PoolManagerHandlerSubscriber();
+        _pm.setPoolManager(_poolManager);
     }
 
     @Override
@@ -138,13 +149,15 @@ public class HttpPoolMgrEngineV3 implements
     }
 
     @Override
-    public void startup()
+    public void afterStart()
     {
+        _pm.start();
+        _pm.afterStart();
         _restoreCollector.start();
     }
 
     @Override
-    public void shutdown()
+    public void beforeStop()
     {
         _restoreCollector.interrupt();
         try {
@@ -152,6 +165,7 @@ public class HttpPoolMgrEngineV3 implements
         } catch (InterruptedException e) {
             _log.warn("Interrupted while waiting for restore-collector to terminate");
         }
+        _pm.beforeStop();
     }
 
     private void decodeCss(String cssDetails)
@@ -226,9 +240,11 @@ public class HttpPoolMgrEngineV3 implements
     private void runRestoreCollector()
         throws NoRouteToCellException, InterruptedException
     {
-        RestoreHandlerInfo[] infos;
+        List<RestoreHandlerInfo> infos;
         try {
-            infos = _poolManager.sendAndWait("xrc ls", RestoreHandlerInfo[].class);
+            ListenableFuture<PoolManagerGetRestoreHandlerInfo> future =
+                    _pm.sendAsync(_endpoint, new PoolManagerGetRestoreHandlerInfo(), _poolManager.getTimeoutInMillis());
+            infos = CellStub.getMessage(future).getResult();
         } catch (CacheException e) {
             _log.warn("runRestoreCollector : failure reply from PoolManager : " + e.getMessage());
             return;

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -66,11 +67,14 @@ import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.Partition;
 import org.dcache.poolmanager.PartitionManager;
 import org.dcache.poolmanager.PoolInfo;
+import org.dcache.poolmanager.PoolManagerGetRestoreHandlerInfo;
 import org.dcache.poolmanager.PoolSelector;
 import org.dcache.poolmanager.SelectedPool;
 import org.dcache.util.Args;
 import org.dcache.util.FireAndForgetTask;
 import org.dcache.vehicles.FileAttributes;
+
+import static java.util.stream.Collectors.toList;
 
 public class RequestContainerV5
     extends AbstractCellComponent
@@ -607,6 +611,18 @@ public class RequestContainerV5
         }
        return sb.toString();
     }
+
+    public PoolManagerGetRestoreHandlerInfo messageArrived(PoolManagerGetRestoreHandlerInfo msg) {
+        List<RestoreHandlerInfo> requests;
+        Map<String, PoolRequestHandler> handlerHash = _handlerHash;
+        synchronized (handlerHash) {
+            requests = handlerHash.values().stream().filter(Objects::nonNull).map(
+                    PoolRequestHandler::getRestoreHandlerInfo).collect(toList());
+        }
+        msg.setResult(requests);
+        return msg;
+    }
+
     public static final String hh_xrc_ls = " # lists pending requests (binary)" ;
     public Object ac_xrc_ls( Args args ){
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/web/ContextPictureEngine.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/web/ContextPictureEngine.java
@@ -41,18 +41,6 @@ public class ContextPictureEngine implements HttpResponseEngine, DomainContextAw
     public ContextPictureEngine(String [] args) {
     }
 
-   @Override
-   public void startup()
-   {
-       // No background activity to start
-   }
-
-   @Override
-   public void shutdown()
-   {
-       // No background activity to shutdown
-   }
-
     @Override
     public void setDomainContext(Map<String, Object> context)
     {

--- a/modules/dcache/src/main/java/diskCacheV111/services/web/PoolInfoObserverEngineV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/web/PoolInfoObserverEngineV2.java
@@ -53,18 +53,6 @@ public class PoolInfoObserverEngineV2 implements HttpResponseEngine, DomainConte
     }
 
     @Override
-    public void startup()
-    {
-          // No background activity to start
-    }
-
-    @Override
-    public void shutdown()
-    {
-        // No background activity to shutdown
-    }
-
-    @Override
     public void queryUrl(HttpRequest request)
         throws HttpException
     {

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolManagerHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolManagerHandler.java
@@ -18,12 +18,17 @@
  */
 package org.dcache.poolmanager;
 
+import com.google.common.base.Function;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+
+import java.io.Serializable;
 
 import diskCacheV111.vehicles.Message;
 import diskCacheV111.vehicles.PoolIoFileMessage;
 import diskCacheV111.vehicles.PoolManagerMessage;
+import diskCacheV111.vehicles.RestoreHandlerInfo;
 
 import dmg.cells.nucleus.CellAddressCore;
 import dmg.cells.nucleus.CellEndpoint;
@@ -33,6 +38,7 @@ import dmg.cells.nucleus.CellPath;
 import org.dcache.cells.FutureCellMessageAnswerable;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -49,9 +55,14 @@ public class RemotePoolManagerHandler implements SerializablePoolManagerHandler
         this.destination = requireNonNull(destination);
     }
 
-    @Override
+    @Override @SuppressWarnings("unchecked")
     public <T extends PoolManagerMessage> ListenableFuture<T> sendAsync(CellEndpoint endpoint, T msg, long timeout)
     {
+        if (msg instanceof PoolManagerGetRestoreHandlerInfo) {
+            return (ListenableFuture<T>) Futures.transform(
+                    submit(endpoint, new CellPath(destination), "xrc ls", RestoreHandlerInfo[].class, timeout),
+                    (Function<? super RestoreHandlerInfo[], ? extends PoolManagerGetRestoreHandlerInfo>) a -> new PoolManagerGetRestoreHandlerInfo(asList(a)));
+        }
         return submit(endpoint, new CellPath(destination), msg, timeout);
     }
 
@@ -88,7 +99,12 @@ public class RemotePoolManagerHandler implements SerializablePoolManagerHandler
     @SuppressWarnings("unchecked")
     protected <T extends Message> ListenableFuture<T> submit(CellEndpoint endpoint, CellPath path, T msg, long timeout)
     {
-        FutureCellMessageAnswerable<T> callback = new FutureCellMessageAnswerable<>((Class<T>) msg.getClass());
+        return submit(endpoint, path, msg, (Class<T>) msg.getClass(), timeout);
+    }
+
+    protected <T extends Serializable> ListenableFuture<T> submit(CellEndpoint endpoint, CellPath path, Serializable msg, Class<T> reply, long timeout)
+    {
+        FutureCellMessageAnswerable<T> callback = new FutureCellMessageAnswerable<>(reply);
         endpoint.sendMessage(new CellMessage(path, msg), callback, MoreExecutors.directExecutor(), timeout);
         return callback;
     }

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/RendezvousPoolManagerHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/RendezvousPoolManagerHandler.java
@@ -19,19 +19,28 @@
 
 package org.dcache.poolmanager;
 
+import com.google.common.base.Function;
 import com.google.common.collect.Ordering;
 import com.google.common.hash.Hashing;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.gson.internal.Streams;
 
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.Message;
 import diskCacheV111.vehicles.PoolIoFileMessage;
 import diskCacheV111.vehicles.PoolManagerMessage;
 import diskCacheV111.vehicles.PoolMgrGetPoolMsg;
+import diskCacheV111.vehicles.RestoreHandlerInfo;
 
 import dmg.cells.nucleus.CellAddressCore;
 import dmg.cells.nucleus.CellEndpoint;
@@ -43,6 +52,7 @@ import org.dcache.cells.FutureCellMessageAnswerable;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 /**
  */
@@ -99,10 +109,27 @@ public class RendezvousPoolManagerHandler implements SerializablePoolManagerHand
                 .hash().asInt();
     }
 
-    @Override
+    @Override @SuppressWarnings("unchecked")
     public <T extends PoolManagerMessage> ListenableFuture<T> sendAsync(CellEndpoint endpoint, T msg, long timeout)
     {
-        return submit(endpoint, new CellPath(backendFor(msg)), msg, timeout);
+        if (msg instanceof PoolManagerGetRestoreHandlerInfo) {
+            return (ListenableFuture<T>)
+                    Futures.transform(
+                            allSuccessful(endpoint, "xrc ls", RestoreHandlerInfo[].class, timeout),
+                            (Function<List<RestoreHandlerInfo[]>, PoolManagerGetRestoreHandlerInfo>)
+                                    l -> new PoolManagerGetRestoreHandlerInfo(
+                                            l.stream()
+                                                    .filter(Objects::nonNull)
+                                                    .flatMap(Stream::of)
+                                                    .collect(toList())));
+        } else {
+            return submit(endpoint, new CellPath(backendFor(msg)), msg, timeout);
+        }
+    }
+
+    private <T extends Serializable> ListenableFuture<List<T>> allSuccessful(CellEndpoint endpoint, Serializable msg, Class<T> reply, long timeout) {
+        return Futures.successfulAsList(
+                backends.stream().map(b -> submit(endpoint, new CellPath(b), msg, reply, timeout)).collect(toList()));
     }
 
     @Override
@@ -138,7 +165,12 @@ public class RendezvousPoolManagerHandler implements SerializablePoolManagerHand
     @SuppressWarnings("unchecked")
     protected <T extends Message> ListenableFuture<T> submit(CellEndpoint endpoint, CellPath path, T msg, long timeout)
     {
-        FutureCellMessageAnswerable<T> callback = new FutureCellMessageAnswerable<>((Class<T>) msg.getClass());
+        return submit(endpoint, path, msg, (Class<T>) msg.getClass(), timeout);
+    }
+
+    protected <T extends Serializable> ListenableFuture<T> submit(CellEndpoint endpoint, CellPath path, Serializable msg, Class<T> reply, long timeout)
+    {
+        FutureCellMessageAnswerable<T> callback = new FutureCellMessageAnswerable<>(reply);
         endpoint.sendMessage(new CellMessage(path, msg), callback, MoreExecutors.directExecutor(), timeout);
         return callback;
     }

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/ResponseEngineHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/ResponseEngineHandler.java
@@ -47,18 +47,4 @@ public class ResponseEngineHandler extends AbstractHandler
                     e.getMessage());
         }
     }
-
-    @Override
-    protected void doStart() throws Exception
-    {
-        engine.startup();
-        super.doStart();
-    }
-
-    @Override
-    protected void doStop() throws Exception
-    {
-        super.doStop();
-        engine.shutdown();
-    }
 }

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/probe/ProbeResponseEngine.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/probe/ProbeResponseEngine.java
@@ -69,16 +69,4 @@ public class ProbeResponseEngine implements HttpResponseEngine, CellMessageSende
             throw new HttpException(503, "Received interrupt whilst processing data. Please try again later.");
         }
     }
-
-    @Override
-    public void startup()
-    {
-
-    }
-
-    @Override
-    public void shutdown()
-    {
-
-    }
 }


### PR DESCRIPTION
Motivation:

In an HA setup with multiple pool managers, the httpd (old) service failed to
fetch the list of restore requests from all instances. Instead the service
would query one of the instances, possibly alternating depending on the
grouping of services in domains.

Modification:

The gist of the fix is to let the responsible collector in the httpd service
use a PoolManagerHandler to query the list of restores and then extend the
implementations of PoolManagerHandler to recognize that query and fetch the
list from all PoolManager instances.

Since PoolManagerHandler is limited to PoolManagerMessage subclasses, a new
request object is introduced. To maintain backwards compatibility, the
PoolManagerHandler implementations translate this request to the classic `xrc
ls` command, but that translation can be reduced once backwards compatibility
is no longer required.

To handle the startup and shutdown of the PoolManagerHandlerSubscriber
correctly, the httpd engine interface had to be adjusted to remove the custom
startup and shutdown methods and instead rely on regular cell lifecycle
callbacks.

Target:

Fixed a problem in which the restore list in the old httpd interface did not
show all restored when used in an HA setup.

Target: trunk
Require-notes: yes
Require-book: no
Request: 3.1
Request: 3.0
Acked-by: Tigran Mkrtchya <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/10192/

(cherry picked from commit d7db2599227895891d61ba7044cb7e8298e4593d)