### PR TITLE
webdav: Fix restriction check when downloading a file

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -2309,6 +2309,8 @@ public class PnfsManagerV3
             if (path != null) {
                 checkRestriction(message.getRestriction(), message.getAccessMask(),
                         activity, path);
+            } else {
+                _log.warn("Restriction check by-passed due to missing path; please report this to <support@dCache.org>");
             }
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -137,6 +137,7 @@ public class Transfer implements Comparable<Transfer>
      *
      * @param pnfs             PnfsHandler used for pnfs communication
      * @param namespaceSubject The subject performing the namespace operations
+     * @param namespaceRestriction Any additional restrictions from this users session
      * @param ioSubject        The subject performing the transfer
      * @param path             The path of the file to transfer
      */
@@ -157,6 +158,7 @@ public class Transfer implements Comparable<Transfer>
      *
      * @param pnfs    PnfsHandler used for pnfs communication
      * @param subject The subject performing the transfer and namespace operations
+     * @param restriction Any additional restrictions from this users session
      * @param path    The path of the file to transfer
      */
     public Transfer(PnfsHandler pnfs, Subject subject, Restriction restriction, FsPath path)
@@ -749,6 +751,10 @@ public class Transfer implements Comparable<Transfer>
         PnfsGetFileAttributes request;
         if (pnfsId != null) {
             request = new PnfsGetFileAttributes(pnfsId, attr);
+            if (_path != null) {
+                // Needed for restriction check.
+                request.setPnfsPath(_path.toString());
+            }
         } else {
             request = new PnfsGetFileAttributes(_path.toString(), attr);
         }


### PR DESCRIPTION
Motivation:

The Restriction allows for namespace limitations on what a user can do.
By omitting to send the file's path to PnfsManager, the WebDAV door
effectively by-passed the restrictions check when downloading a file.

Modification:

Fix Transfer class to include the path when querying file attributes,
even if the PnfsId is already known.

Update PnfsManager to log if a door has supplied insufficient
information for the Restriction check.  This should hopefully make it
easier to find any similar bugs.

Result:

Restrictions are enforced when downloading files using the WebDAV door.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10211/
Acked-by: Tigran Mkrtchyan