### PR TITLE
script-nearline-spi: fix space leak when polling script is used

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -974,6 +974,7 @@ public class NearlineStorageHandler
     {
         private final StorageInfoMessage infoMsg;
         private final ReplicaDescriptor descriptor;
+        private ListenableFuture<Void> allocationFuture;
 
         public StageRequestImpl(NearlineStorage storage, FileAttributes fileAttributes) throws CacheException
         {
@@ -993,15 +994,18 @@ public class NearlineStorageHandler
         }
 
         @Override
-        public ListenableFuture<Void> allocate()
+        public synchronized ListenableFuture<Void> allocate()
         {
             LOGGER.debug("Allocating space for stage of {}.", getFileAttributes().getPnfsId());
-            return register(executor.submit(
-                    () -> {
-                        descriptor.allocate(descriptor.getFileAttributes().getSize());
-                        return null;
-                    }
-            ));
+            if (allocationFuture == null) {
+                allocationFuture = register(executor.submit(
+                        () -> {
+                            descriptor.allocate(descriptor.getFileAttributes().getSize());
+                            return null;
+                        }
+                ));
+            }
+            return allocationFuture;
         }
 
         @Override


### PR DESCRIPTION
Motivation:
Before a stage request is performed, nearline storage provider allocates
a space for incoming data. However, if stage request instructed to re-try,
then allocation will be re-initialize as well.

Modification:
Update StageRequest implementation to allocate only once.

Result:
no space leak

Ticket: #9199
Acked-by: Albert Rossi
Acked-by: Paul Millar
Target: master, 3.1, 3.0
Require-book: no
Require-notes: yes
(cherry picked from commit 773bc0df99fa99a2ecc1ae8f743fa4b9a71ba691)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>