### PR TITLE
webdav: make Milton work-around more robust

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
@@ -88,8 +88,7 @@ public class DcacheDirectoryResource
     @Override
     public Resource createNew(String newName, InputStream inputStream,
                               Long length, String contentType)
-        throws IOException, ConflictException, NotAuthorizedException,
-               BadRequestException
+        throws ConflictException, BadRequestException
     {
         try {
             FsPath path = _path.child(newName);
@@ -98,12 +97,16 @@ public class DcacheDirectoryResource
             } else {
                 return _factory.createFile(path, inputStream, length);
             }
-        } catch (EofException e) {
+        } catch (IOException e) {
             // Milton reacts badly to receiving any IOException and wraps the
-            // IOException in a RuntimeException.  Here, we translate this to
-            // a bad request, as the Content-Length didn't match the
-            // transferred entity's size.
-            throw new BadRequestException(this, "Connection closed prematurely, entity smaller than expected.");
+            // IOException in a RuntimeException, which dCache logs as a bug.
+            // Here, we translate this to a 500 Internal Server Error response.
+            //
+            // Note that a 400 Bad Request response indicates that "The client
+            //     SHOULD NOT repeat the request without modifications." --
+            //     RFC 2616.
+            //
+            throw new WebDavException("Problem with transferred data: " + e.getMessage(), e, this);
         } catch (PermissionDeniedCacheException e) {
             throw WebDavExceptions.permissionDenied(this);
         } catch (FileExistsCacheException e) {


### PR DESCRIPTION
Motivation:

Commit 5abc0e1c introduced a work-around against Milton's bad behaviour
if there is an IOException during an upload.  Unfortunately, that
work-around wasn't broad enough to cover all failure modes.  The result
is that bad client behaviour can trigger a stack-trace in dCache.

Additionally, the work-around returned a 400 error code.  Conforming
clients will not retry if they see this error, which is undesireable
behaviour since an IOException may be a transitory problem.

Modification:

Update work-around to cover any IOException that is thrown.

Return 500 Internal Error instead of 400 Bad Request.

Result:

Bad client or network behaviour should no longer trigger a stack-trace.

Clients should be free to retry the failed upload.

Target: master
Patch: https://rb.dcache.org/r/10223
Acked-by: Tigran Mkrtchyan
Requires-notes: yes
Requires-book: no
Request: 3.1
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13