### PR TITLE
webdav: improve logging on transfer failures

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/Exceptions.java
+++ b/modules/common/src/main/java/org/dcache/util/Exceptions.java
@@ -1,0 +1,41 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+/**
+ * Utility class for handling exceptions.
+ */
+public class Exceptions
+{
+    private Exceptions()
+    {
+        // prevent instantiation.
+    }
+
+    /**
+     * Return an Exception's message, if it was constructed with one, otherwise
+     * return the Exception's class name.  This method is intended to handle
+     * describing problems (e.g., for logging) identified by an Exception that
+     * was created outside dCache's control.
+     */
+    public static String messageOrClassName(Exception e)
+    {
+        String message = e.getMessage();
+        return message == null ? e.getClass().getName() : message;
+    }
+}


### PR DESCRIPTION
Motivation:

There is a race-condition when the door proxies an upload that
subsequently fails: the door kills the mover, removes the namespace
entry and then notifies billing.  If the door receives the
DoorTransferFinishedMessage before the PnfsDeleteEntryMessage reply then
the pool's error message is sent to billing, rather than the intended
message.

Additionally, the pool is not given a reasonable explanation of why the
transfer was aborted.

Modification:

Remove race-condition by notifying billing before killing the mover.

Provide more accurate information to pool on why a transfer was aborted.

Result:

More accurate information is logged if there is any misbehaviour that
prevents a transfer from succeeding.

Target: master
Request: 3.1
Request: 3.0
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10221/
Acked-by: Tigran Mkrtchyan