### PR TITLE
pool: log why a transfer was forcefully aborted

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -221,8 +221,11 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
                     LOGGER.error("Transfer failed: {}", e.getMessage());
                     setTransferStatus(e.getRc(), e.getMessage());
                 } catch (InterruptedIOException | InterruptedException e) {
-                    LOGGER.error("Transfer was forcefully killed");
-                    setTransferStatus(CacheException.DEFAULT_ERROR_CODE, "Transfer was forcefully killed");
+                    String message = e.getMessage() != null
+                            ? ("Transfer forcefully killed: " + e.getMessage())
+                            : "Transfer was forcefully killed";
+                    LOGGER.error(message);
+                    setTransferStatus(CacheException.DEFAULT_ERROR_CODE, message);
                 } catch (RuntimeException e) {
                     LOGGER.error("Transfer failed due to a bug", e);
                     setTransferStatus(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, "Bug detected (please report): " + e.getMessage());


### PR DESCRIPTION
Motivation:

A mover may be forcefully aborted for any number of reasons. Currently,
the pool's domain log shows only a place-holder text "Transfer was
forcefully killed", which is also sent to billing.

This is almost certainly insufficient information to deduce what went
wrong.  Although the door might (or might not) log more accurate
information, providing the explanation when logging will likely improve
the speed with which admin can diagnose problems.

Modification:

Log the reason why a transfer was aborted: both in the domain log file
and in billing.

Note that the door's report of the failed transfer may contain duplicate
information.

Result:

More accurate information is available when transfers fail.

Target: master
Request: 3.1
Request: 3.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10219/
Acked-by: Tigran Mkrtchyan