### PR TITLE
frontend,webdav: add supress-wwwauthenticate to allow headers

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/filters/ResponseHeaderFilter.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/filters/ResponseHeaderFilter.java
@@ -18,6 +18,6 @@ public class ResponseHeaderFilter implements ContainerResponseFilter
 
         headers.add("Access-Control-Allow-Origin", "*");
         headers.add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
-        headers.add("Access-Control-Allow-Headers", "Content-Type, Authorization");
+        headers.add("Access-Control-Allow-Headers", "Content-Type, Authorization, Suppress-WWW-Authenticate");
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
@@ -95,7 +95,7 @@ public class MiltonHandler
         String clientOrigin = request.getHeader("origin");
         if (Objects.equals(request.getMethod(), "OPTIONS")) {
             response.setHeader("Access-Control-Allow-Methods", "PUT");
-            response.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+            response.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, Suppress-WWW-Authenticate");
             response.setHeader("Access-Control-Allow-Credentials", "true");
             response.setHeader("Access-Control-Allow-Origin", clientOrigin);
             if (_allowedClientOrigins.size() > 1) {


### PR DESCRIPTION
Most (if not all) browsers do a prefligt request and if one of the setted
headers is not found in the  Access-Control-Allow-Headers response header;
the main request response will not be pass down.

Hence, this patch add Suppress-WWW-Authenticate to the list of allowed headers.

This suppose to be part of https://rb.dcache.org/r/10227/ but I forgot to
include it :(.

Target: trunk
Request: 3.0
Request: 3.1
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10233/

(cherry picked from commit 4ac977ab439b6dea3caa891c8da969a1fc2e4f2c)