### PR TITLE
info: avoid sending messages too early.

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/DataGatheringScheduler.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/DataGatheringScheduler.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import dmg.cells.nucleus.CellLifeCycleAware;
 import dmg.cells.nucleus.EnvironmentAware;
 import dmg.cells.nucleus.UOID;
 
@@ -30,7 +31,7 @@ import static com.google.common.base.Preconditions.checkState;
  * @author Paul Millar <paul.millar@desy.de>
  */
 
-public class DataGatheringScheduler implements Runnable, EnvironmentAware
+public class DataGatheringScheduler implements Runnable, EnvironmentAware, CellLifeCycleAware
 {
     private static final long FIVE_MINUTES = 5*60*1000;
     private static final Logger LOGGER_SCHED = LoggerFactory.getLogger(DataGatheringScheduler.class);
@@ -206,7 +207,8 @@ public class DataGatheringScheduler implements Runnable, EnvironmentAware
         }
     }
 
-    public synchronized void start()
+    @Override
+    public synchronized void afterStart()
     {
         checkState(_thread == null, "DataGatheringScheduler already started");
 
@@ -390,7 +392,8 @@ public class DataGatheringScheduler implements Runnable, EnvironmentAware
      * Request that this thread sends no more requests
      * for data.
      */
-    public void shutdown()
+    @Override
+    public void beforeStop()
     {
         LOGGER_SCHED.debug("Requesting DGA Scheduler to shutdown.");
         synchronized (_activity) {

--- a/modules/dcache-info/src/main/resources/org/dcache/services/info/info.xml
+++ b/modules/dcache-info/src/main/resources/org/dcache/services/info/info.xml
@@ -62,8 +62,7 @@
   </bean>
 
 
-  <bean id="data-gathering-scheduler" class="org.dcache.services.info.gathers.DataGatheringScheduler"
-        init-method="start" destroy-method="shutdown">
+  <bean id="data-gathering-scheduler" class="org.dcache.services.info.gathers.DataGatheringScheduler">
       <property name="stateUpdateManager" ref="state-update-manager"/>
       <property name="messageMetadataRepository" ref="message-handler-chain"/>
       <property name="messageSender" ref="message-handler-chain"/>


### PR DESCRIPTION
Motivation:

The info cell can send messages before the cell is properly registered.
Message sending is randomised, so this does not always happen, but when
it does, it can lead to errors like:

    java.lang.IllegalStateException: Cannot send message with callback in state \{\} \[PRE_STARTUP\]
    	at com.google.common.base.Preconditions.checkState(Preconditions.java:199) ~\[guava-19.0.jar:na\]
    	at dmg.cells.nucleus.CellNucleus.sendMessage(CellNucleus.java:519) ~\[cells-3.0.19-SNAPSHOT.jar:3.0.19-SNAPSHOT\]
    	at dmg.cells.nucleus.CellAdapter.sendMessage(CellAdapter.java:468) ~\[cells-3.0.19-SNAPSHOT.jar:3.0.19-SNAPSHOT\]
    	at org.dcache.services.info.gathers.MessageHandlerChain.sendMessage(MessageHandlerChain.java:129) ~\[dcache-info-3.0.19-SNAPSHOT.jar:3.0.19-SNAPSHOT\]
    	at org.dcache.services.info.gathers.MessageHandlerChain.sendMessage(MessageHandlerChain.java:99) ~\[dcache-info-3.0.19-SNAPSHOT.jar:3.0.19-SNAPSHOT\]
    	at org.dcache.services.info.gathers.SingleMessageDga.trigger(SingleMessageDga.java:83) ~\[dcache-info-3.0.19-SNAPSHOT.jar:3.0.19-SNAPSHOT\]
    	at org.dcache.services.info.gathers.DataGatheringScheduler$RegisteredActivity.checkAndTrigger(DataGatheringScheduler.java:131) ~\[dcache-info-3.0.19-SNAPSHOT.jar:3.0.19-SNAPSHOT\]
    	at org.dcache.services.info.gathers.DataGatheringScheduler.run(DataGatheringScheduler.java:281) ~\[dcache-info-3.0.19-SNAPSHOT.jar:3.0.19-SNAPSHOT\]
    	at java.lang.Thread.run(Thread.java:748) ~\[na:1.8.0_131\]

Modification:

Only start sending messages once the cell nucleus is in POST_STARTUP
phase.

Result:

No more IllegalStateException stack-traces about attempting to send
message with callback in state PRE_STARTUP.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10234/
Acked-by: Tigran Mkrtchyan
Fixes #3219