### PR TITLE
pool: fix error message on timeout

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -308,8 +308,10 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
     {
         try {
             return checksumModule.getPreferredChecksumFactory(handle);
-        } catch (NoSuchAlgorithmException | CacheException e) {
-            LOGGER.error("Failed to instantiate mover due to unsupported checksum type: " + e.getMessage(), e);
+        } catch (NoSuchAlgorithmException e) {
+            LOGGER.error("Failed to instantiate mover due to unsupported checksum type: " + e.getMessage());
+        } catch (CacheException e) {
+            LOGGER.error("Failed to instantiate mover: " + e.getMessage());
         }
         return null;
     }


### PR DESCRIPTION
Motivation:

Currently, the pool will log an error message like:

    Failed to instantiate mover due to unsupported checksum type: Request to [>PnfsManager@local] timed out.

Clearly, the fact that a request to PnfsManager timed out has nothing to
do with a checksum type not being supported.

Modification:

Catch CacheException separately and report a more generic preamble to
the CacheException's message.

Result:

Pool will log a more accurate error message, if communication with
PnfsManager after an upload times out.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Require-notes: yes
Require-book: no
Fixes: #2929
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java