### PR TITLE
frontend: fix "Attribute is not defined: SIZE" bug

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -190,7 +190,9 @@ public class FileResources {
                                          boolean isLocality) throws CacheException {
         fileAttributes.setMtime(namespaceAttrributes.getModificationTime());
         fileAttributes.setCreationTime(namespaceAttrributes.getCreationTime());
-        fileAttributes.setSize(namespaceAttrributes.getSize());
+        if (namespaceAttrributes.isDefined(FileAttribute.SIZE)) {
+            fileAttributes.setSize(namespaceAttrributes.getSize());
+        }
         fileAttributes.setFileType(namespaceAttrributes.getFileType());
 
         // when user set locality param. in the request, the locality should be returned only for directories


### PR DESCRIPTION
Motivation:

During a file upload, a file has undefined file size.  This allows
doors to relay this information in whichever way makes most sense; for
example, using a default value, omit the size value, flag the file as
currently being uploaded, or omit the file from a listing altogether.

Currently, the frontend does not cater for this possibility.  A file
being uploaded results in a stack-trace and reporting an internal
error.

Modification:

Make reporting a file's size optional.  It is not reported if the file
is being uploaded.

Result:

Directory listing in the frontend no longer fails in there is a file
currently being uploaded.

Target: master
Request: 3.1
Request: 3.0
Request: 2.6
Require-notes: yes
Require-book: no
Fixes: #3179
Patch: https://rb.dcache.org/r/10240/
Acked-by: Olufemi Adeyemi
Acked-by: Tigran Mkrtchyan