### PR TITLE
frontend: avoid error No Server set for [..].RestAPIExceptionHandler@…

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -268,7 +268,9 @@
                               '${frontend.limits.low-resource-idle-time.unit}')}" />
                     <property name="maxLowResourcesTime" value="180000"/>
                 </bean>
-                <bean class="org.dcache.restful.errorHandling.RestAPIExceptionHandler"/>
+                <bean class="org.dcache.restful.errorHandling.RestAPIExceptionHandler">
+                    <property name="server" ref="jetty"/>
+                </bean>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
…[..]

Motivation:

dCache logs an error message on startup.  Although this message is
harmless, it distracts admins who believe it is the cause of their
problem.

Modification:

Properly inject the required argument

Result:

Error messages like:

    No Server set for org.dcache.restful.errorHandling.RestAPIExceptionHandler@11d421ad

are no longer logged on dCache startup.

Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10242/
Acked-by: Olufemi Adeyemi
Fixes: #3225