### PR TITLE
dependencies: remove log4j jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
                 <version>2.10.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>jline</groupId>
@@ -220,6 +226,12 @@
                 <groupId>org.glite.authz</groupId>
                 <artifactId>pep-java</artifactId>
                 <version>2.3.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Motivation:

We currently ship dCache with two jars that implement the log4j API:
log4j itself and log4j-over-slf4j.  The latter is intended and is there
to bridge library that use the log4j API into our logging
infrastructure.  The former is not intended.

The library load order is non-deterministic.  If the admin is unlucky
then the log4j jar is loaded ahead of log4j-over-slf4j and some
libraries will not log correctly.  This may even lead to error messages
like:

    log4j:WARN No appenders could be found for logger (DataNucleus.General).
    log4j:WARN Please initialize the log4j system properly.

Modification:

Add exclusions to remove 3rd-party library dependencies on log4j.

Result:

dCache no longer ships with log4j jar file.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/10246/
Acked-by: Tigran Mkrtchyan

Conflicts:
	pom.xml

Conflicts:
	pom.xml