### PR TITLE
zookeeper: silence ZK server errors

### DIFF
--- a/skel/etc/logback.xml
+++ b/skel/etc/logback.xml
@@ -178,7 +178,14 @@
         <logger>io.netty.handler.logging.LoggingHandler</logger>
         <level>off</level>
     </threshold>
-
+    <threshold>
+        <!-- With v3.4, ZK logs a stacktrace when the client
+             disconnects unexpectedly.  This is fixed with v3.5 and
+             later.  See
+             https://issues.apache.org/jira/browse/ZOOKEEPER-2809 -->
+        <logger>org.apache.zookeeper.server.NIOServerCnxn</logger>
+        <level>error</level>
+    </threshold>
     <threshold>
       <logger>liquibase</logger>
       <level>warn</level>


### PR DESCRIPTION
Motivation:

ZK logs a stack-trace if the client disconnects unexpectedly, which is
overkill, simply logging that this happened is sufficient, which is what
later major versions of ZK do.

Modification:

Set the threshold for logging of server connections to avoid the
stack-trace.

Result:

No more stack-traces

Target: master
Request: 3.1
Request: 3.0
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/10252/
Acked-by: Tigran Mkrtchyan