### PR TITLE
zookeeper: work-around racy startup

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/zookeeper/service/ZooKeeperCell.java
+++ b/modules/dcache/src/main/java/org/dcache/zookeeper/service/ZooKeeperCell.java
@@ -22,6 +22,7 @@ import org.apache.zookeeper.server.DatadirCleanupManager;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.SessionTrackerImpl;
+import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.ZooTrace;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
@@ -131,6 +132,9 @@ public class ZooKeeperCell extends AbstractCell
         zkServer.setTickTime((int) tickTimeUnit.toMillis(tickTime));
         zkServer.setMinSessionTimeout(minSessionTimeout == -1 ? -1 : (int) minSessionTimeoutUnit.toMillis(minSessionTimeout));
         zkServer.setMaxSessionTimeout(maxSessionTimeout == -1 ? -1 : (int) maxSessionTimeoutUnit.toMillis(maxSessionTimeout));
+
+        zkServer.setZKDatabase(new ZKDatabase(txnLog)); // Work-around https://issues.apache.org/jira/browse/ZOOKEEPER-2810
+
         ServerCnxnFactory cnxnFactory;
         cnxnFactory = new NIOServerCnxnFactory() {
             @Override


### PR DESCRIPTION
Motivation:

Sometimes we see zookeeper log a stack-trace on startup.

Modification:

Add work-around for race-condition in zookeeper.

Result:

Hopefully no more stack-traces

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Fixes: #3240
Patch: https://rb.dcache.org/r/10253/
Acked-by: Dmitry Litvintsev