### PR TITLE
ONLY FOR TESTING srmmanager: fix NPE when querying spaces

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -305,14 +305,12 @@ public final class Storage
      * however a failure path that would exist in any case, as the reservation may expire
      * after handing out the TURL.
      */
-    private final LoadingCache<String,Optional<Space>> spaces =
-            ReservationCaches.buildSpaceLookupCache(_spaceManagerStub, _executor);
+    private LoadingCache<String,Optional<Space>> spaces;
 
     /**
      * A loading cache for looking up space tokens by owner and description.
      */
-    private final LoadingCache<GetSpaceTokensKey, long[]> spaceTokens =
-            ReservationCaches.buildOwnerDescriptionLookupCache(_spaceManagerStub, _executor);
+    private LoadingCache<GetSpaceTokensKey, long[]> spaceTokens;
 
     public Storage()
     {
@@ -324,6 +322,18 @@ public final class Storage
     public void setExecutor(Executor executor)
     {
         _executor = executor;
+    }
+
+    @Required
+    public void setSpaceLookupCache(LoadingCache<String,Optional<Space>> cache)
+    {
+        spaces = cache;
+    }
+
+    @Required
+    public void setOwnerDescriptionLookupCache(LoadingCache<GetSpaceTokensKey, long[]> cache)
+    {
+        spaceTokens = cache;
     }
 
     @Required

--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srmmanager.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srmmanager.xml
@@ -189,17 +189,17 @@
          =====================================================================================
       -->
 
+    <bean id="storage-executor" class="org.dcache.util.CDCExecutorServiceDecorator"
+          destroy-method="shutdown">
+        <constructor-arg>
+            <bean class="java.util.concurrent.Executors"
+                  factory-method="newCachedThreadPool"/>
+        </constructor-arg>
+    </bean>
+
     <bean id="storage" class="diskCacheV111.srm.dcache.Storage">
         <description>dCache plugin for SRM</description>
-        <property name="executor">
-            <bean class="org.dcache.util.CDCExecutorServiceDecorator"
-                  destroy-method="shutdown">
-                <constructor-arg>
-                    <bean class="java.util.concurrent.Executors"
-                          factory-method="newCachedThreadPool"/>
-                </constructor-arg>
-            </bean>
-        </property>
+        <property name="executor" ref="storage-executor"/>
         <property name="directoryListSource" ref="list-handler"/>
         <property name="loginBrokerSource" ref="login-broker-source"/>
         <property name="pnfsStub" ref="pnfs-stub"/>
@@ -222,6 +222,18 @@
         <property name="srmGetNotSupportedProtocols" value="${srmmanager.protocols.disallowed.get}"/>
         <property name="srmPreferredProtocols" value="${srmmanager.protocols.preferred}"/>
         <property name="verificationRequired" value="${srmmanager.enable.third-party.requiring-verification-by-default}"/>
+        <property name="spaceLookupCache">
+            <bean class="org.dcache.space.ReservationCaches" factory-method="buildSpaceLookupCache">
+                <constructor-arg index="0" ref="space-manager-stub"/>
+                <constructor-arg index="1" ref="storage-executor"/>
+            </bean>
+        </property>
+        <property name="ownerDescriptionLookupCache">
+            <bean class="org.dcache.space.ReservationCaches" factory-method="buildOwnerDescriptionLookupCache">
+                <constructor-arg index="0" ref="space-manager-stub"/>
+                <constructor-arg index="1" ref="storage-executor"/>
+            </bean>
+        </property>
     </bean>
 
     <bean id="config" class="diskCacheV111.srm.dcache.Configuration" depends-on="liquibase">


### PR DESCRIPTION
Motivation:

Commit 45a40c3e broke srmmanager by instantiating the SpaceManager
caches before the CellStub for space-manager was injected.  This results
in a NullPointerException being thrown under certain circumstances.

Modification:

Move the instantiation of the caches into Spring and inject the
completed caches.

Result:

Fix unreleased regression, resulting in NPE.

Target: master
Require-notes: no
Require-book: no