### PR TITLE
dcache: release dcache-view 1.0.6 for dcache 2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.3.0</version.wicket>
         <version.xrootd4j>3.1.1</version.xrootd4j>
         <version.jersey>2.22.2</version.jersey>
-        <version.dcache-view>1.0.5</version.dcache-view>
+        <version.dcache-view>1.0.6</version.dcache-view>
         <version.dcache>${project.version}</version.dcache>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
Changelog from v1.0.5 to v1.0.6 (for dcache 2.16)
    38304f8 dcache-view: log errors during vulcanisation
    2a2589f dcache-view: provide more user information
    73cb03b dcache-view: hide main menu button base on page width

Request: 2.16
Require-book: no
Require-notes: yes
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10276/