### PR TITLE
dcache: release dcache-view 1.1.4 for dcache 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.4.0</version.wicket>
         <version.xrootd4j>3.2.2</version.xrootd4j>
         <version.jersey>2.22.2</version.jersey>
-        <version.dcache-view>1.0.5</version.dcache-view>
+        <version.dcache-view>1.1.4</version.dcache-view>
         <version.netty>4.1.5.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
 


### PR DESCRIPTION
3. Changelog from v1.1.3 to v1.1.4 (for dcache 3.0)
    3cd0789 dcache-view: fix Uncaught TypeError in DirectoryLsError
    d020a46 dcache-view: adjust mkdir to the latest dcache-namespace
    650367c dcache-view: add Suppress-WWW-Authenticate header
    c7b392c dcache-view: log errors during vulcanisation
    5ea6686 dcache-view: provide more user information
    44bebe2 dcache-view: hide main menu button base on page width

Request: 3.0
Require-book: no
Require-notes: yes
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10275/