### PR TITLE
dcache: release dcache-view 1.2.1 for dcache 3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.5.0</version.wicket>
         <version.xrootd4j>3.2.2</version.xrootd4j>
         <version.jersey>2.24</version.jersey>
-        <version.dcache-view>1.2.0</version.dcache-view>
+        <version.dcache-view>1.2.1</version.dcache-view>
         <version.netty>4.1.6.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
 


### PR DESCRIPTION
Changelog from v1.2.0 to v1.2.1 (for dcache 3.1)
    37c9c26 dcache-view: fix Uncaught TypeError in DirectoryLsError
    ccfa887 dcache-view: reset the multiselection after create and mv operations
    c8c8e1e dcache-view: update QosBackendInformation element usuage
    a81979f dcache-view: fix wrongly encoded credential
    8027a10 dcache-view: add Suppress-WWW-Authenticate header Motivation:
    f01a86c dcache-view: modify file quality of service
    8f2b4ff dcache-view: log errors during vulcanisation
    6d44599 dcache-view: add user home directory tab
    cccbd46 dcache-view: update in-house dependencies to the latest version
    6c41297 dcache-view: add checkbox when multiple selection is enable
    554f14d dcache-view: show the current qos of files
    ad257e5 dcache-view: provide more user information
    9685649 dcache-view: hide main menu button base on page width
    6a09ebb dcache-view: enable multiple selection for move op.

Request: 3.1
Require-book: no
Require-notes: yes
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10274/