### PR TITLE
httpd: Fixed table headers in usageInfo

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/cells/WebCollectorV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/WebCollectorV3.java
@@ -788,6 +788,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
                         "precious", "Precious Space/MiB",
                         "layout",   "<span>Layout   " +
                           "(<span class=\"layout_precious\">precious/</span>" +
+                          "<span class=\"layout_rest\">rest/</span>" +
                           "<span class=\"layout_used\">used/</span>" +
                           "<span class=\"layout_free\">free</span>)</span>");
 


### PR DESCRIPTION
Motivation:

There is a missing description in the usageInfo page and summary table
showing which color is used for all the rest category, i.e.
data that isn’t precious, cached and free.

Modification:

The 'other' category has been introduced in the headers of the
table with the rest layout.

Result:

The other category appears now in the summary table.

Target: master
Require-notes: yes
Require-book: no
Request: 3.1
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10263