### PR TITLE
poolmanager: fix unit-test to avoid race-condition

### DIFF
--- a/modules/dcache/src/test/java/diskCacheV111/util/CheckStagePermissionTests.java
+++ b/modules/dcache/src/test/java/diskCacheV111/util/CheckStagePermissionTests.java
@@ -499,7 +499,11 @@ public class CheckStagePermissionTests
 
         public FileStateAssertion withDifferentMtime() throws InterruptedException
         {
-            _mtime = _file.lastModified();
+            // CheckStagePermission uses current time (rather than file's mtime)
+            // when checking if the file has been modified.  Not only is this
+            // wrong (racy), it also means the testing code must also use
+            // currentTimeMillis to avoid race-conditions when testing.
+            _mtime = System.currentTimeMillis();
             return this;
         }
 
@@ -512,7 +516,7 @@ public class CheckStagePermissionTests
                 _file.delete();
             } else {
                 updateContent();
-                while (_mtime != 0 && _mtime == _file.lastModified()) {
+                while (_mtime != 0 && _mtime >= _file.lastModified()) {
                     Thread.sleep(10);
                     updateContent();
                 }


### PR DESCRIPTION
Motivation:

CheckStagePermission stores the current time (rather than the file's
mtime) when determining whether a file has changed.  This needs some
adjustment to avoid race-conditions.

Modification:

Use System.currentTimeInMillis rather than file mtime to avoid
race-condition.

Result:

Hopefully more reliable unit-tests

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/10278/
Acked-by: Tigran Mkrtchyan