### PR TITLE
frontend: fix Restriction usage

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java
@@ -1,27 +1,23 @@
 package org.dcache.restful.qos;
 
-
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import javax.servlet.ServletContext;
-
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Path;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Produces;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Context;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
-import javax.ws.rs.ForbiddenException;
-import javax.ws.rs.BadRequestException;
-
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -29,26 +25,24 @@ import java.net.URISyntaxException;
 import java.util.EnumSet;
 import java.util.Set;
 
-import org.dcache.pinmanager.PinManagerPinMessage;
-import org.dcache.pinmanager.PinManagerUnpinMessage;
-import org.dcache.pinmanager.PinManagerCountPinsMessage;
-
-import org.dcache.auth.Subjects;
-import org.dcache.namespace.FileAttribute;
-import org.dcache.restful.util.ServletContextHandlerAttributes;
-import org.dcache.vehicles.FileAttributes;
-
-
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileLocality;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
-
-import org.dcache.cells.CellStub;
-import org.dcache.poolmanager.RemotePoolMonitor;
 import diskCacheV111.vehicles.HttpProtocolInfo;
+
+import org.dcache.auth.Subjects;
+import org.dcache.cells.CellStub;
+import org.dcache.namespace.FileAttribute;
+import org.dcache.pinmanager.PinManagerCountPinsMessage;
+import org.dcache.pinmanager.PinManagerPinMessage;
+import org.dcache.pinmanager.PinManagerUnpinMessage;
+import org.dcache.poolmanager.RemotePoolMonitor;
+import org.dcache.restful.util.HandlerBuilders;
+import org.dcache.restful.util.ServletContextHandlerAttributes;
+import org.dcache.vehicles.FileAttributes;
 
 /**
  * Query current QoS for a file or  change the current QoS
@@ -202,7 +196,7 @@ public class QosManagementNamespace {
 
     public FileAttributes getFileAttributes(String requestPath) throws CacheException {
 
-        PnfsHandler handler = ServletContextHandlerAttributes.getPnfsHandler(ctx);
+        PnfsHandler handler = HandlerBuilders.pnfsHandler(ctx, request);
         FsPath path;
         if (requestPath == null || requestPath.isEmpty()) {
             path = FsPath.ROOT;

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/identity/UserResource.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/identity/UserResource.java
@@ -34,6 +34,7 @@ import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.HomeDirectory;
 import org.dcache.auth.attributes.LoginAttribute;
 import org.dcache.restful.providers.UserAttributes;
+import org.dcache.restful.util.HttpServletRequests;
 import org.dcache.restful.util.ServletContextHandlerAttributes;
 
 /**
@@ -63,7 +64,7 @@ public class UserResource
                     .collect(Collectors.toList());
             user.setGids(gids);
 
-            for (LoginAttribute attribute : ServletContextHandlerAttributes.getLoginAttributes(request)) {
+            for (LoginAttribute attribute : HttpServletRequests.getLoginAttributes(request)) {
                 if (attribute instanceof HomeDirectory) {
                     user.setHomeDirectory(((HomeDirectory)attribute).getHome());
                 }

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.Response;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -53,13 +52,14 @@ import org.dcache.pinmanager.PinManagerUnpinMessage;
 import org.dcache.poolmanager.RemotePoolMonitor;
 import org.dcache.restful.providers.JsonFileAttributes;
 import org.dcache.restful.qos.QosManagement;
+import org.dcache.restful.util.HandlerBuilders;
+import org.dcache.restful.util.HttpServletRequests;
 import org.dcache.restful.util.ServletContextHandlerAttributes;
 import org.dcache.util.list.DirectoryEntry;
 import org.dcache.util.list.DirectoryStream;
 import org.dcache.util.list.ListDirectoryHandler;
 import org.dcache.vehicles.FileAttributes;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.dcache.restful.providers.SuccessfulResponse.successfulResponse;
 import static org.dcache.restful.util.Preconditions.checkRequest;
 
@@ -146,7 +146,7 @@ public class FileResources {
     {
         JsonFileAttributes fileAttributes = new JsonFileAttributes();
         Set<FileAttribute> attributes = EnumSet.allOf(FileAttribute.class);
-        PnfsHandler handler = ServletContextHandlerAttributes.getPnfsHandler(ctx);
+        PnfsHandler handler = HandlerBuilders.pnfsHandler(ctx, request);
 
         FsPath path;
         if (value == null || value.isEmpty()) {
@@ -174,7 +174,7 @@ public class FileResources {
 
                 DirectoryStream stream = listDirectoryHandler.list(
                         ServletContextHandlerAttributes.getSubject(),
-                        ServletContextHandlerAttributes.getRestriction(),
+                        HttpServletRequests.getRestriction(request),
                         path,
                         null,
                         Range.<Integer>all(),
@@ -220,7 +220,7 @@ public class FileResources {
         try {
             JSONObject reqPayload = new JSONObject(requestPayload);
             String action = (String) reqPayload.get("action");
-            PnfsHandler handler = ServletContextHandlerAttributes.getPnfsHandler(ctx);
+            PnfsHandler handler = HandlerBuilders.pnfsHandler(ctx, request);
             switch (action) {
                 case "mkdir":
                     String folderName = (String) reqPayload.get("name");

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/HandlerBuilders.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/HandlerBuilders.java
@@ -1,0 +1,41 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.restful.util;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+
+import diskCacheV111.util.PnfsHandler;
+
+import org.dcache.cells.CellStub;
+
+/**
+ * Utility class for building classes that facilitate interacting with dCache.
+ */
+public class HandlerBuilders
+{
+    public static PnfsHandler pnfsHandler(ServletContext ctx, HttpServletRequest request)
+    {
+        CellStub cellStub = ServletContextHandlerAttributes.getCellStub(ctx);
+        PnfsHandler handler = new PnfsHandler(cellStub);
+        handler.setSubject(ServletContextHandlerAttributes.getSubject());
+        handler.setRestriction(HttpServletRequests.getRestriction(request));
+        return handler;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/HttpServletRequests.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/HttpServletRequests.java
@@ -1,0 +1,50 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.restful.util;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.Set;
+
+import org.dcache.auth.attributes.LoginAttribute;
+import org.dcache.auth.attributes.Restriction;
+import org.dcache.http.AuthenticationHandler;
+
+import static org.dcache.http.AuthenticationHandler.DCACHE_LOGIN_ATTRIBUTES;
+
+/**
+ * Utility class for methods that operate on an HttpServletRequest object.
+ */
+public class HttpServletRequests
+{
+    private HttpServletRequests()
+    {
+        // Prevent instantiation.
+    }
+
+    public static Set<LoginAttribute> getLoginAttributes(HttpServletRequest request)
+    {
+        return (Set<LoginAttribute>) request.getAttribute(DCACHE_LOGIN_ATTRIBUTES);
+    }
+
+    public static Restriction getRestriction(HttpServletRequest request)
+    {
+        return (Restriction) request.getAttribute(AuthenticationHandler.DCACHE_RESTRICTION_ATTRIBUTE);
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/ServletContextHandlerAttributes.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/ServletContextHandlerAttributes.java
@@ -2,21 +2,13 @@ package org.dcache.restful.util;
 
 import javax.security.auth.Subject;
 import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
 
 import java.security.AccessController;
-import java.util.Set;
 
-import diskCacheV111.util.PnfsHandler;
-
-import org.dcache.auth.attributes.LoginAttribute;
-import org.dcache.auth.attributes.Restriction;
-import org.dcache.auth.attributes.Restrictions;
 import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.RemotePoolMonitor;
 import org.dcache.util.list.ListDirectoryHandler;
 
-import static org.dcache.http.AuthenticationHandler.DCACHE_LOGIN_ATTRIBUTES;
 
 public class ServletContextHandlerAttributes {
     public final static String DL = "org.dcache.restful";
@@ -29,28 +21,14 @@ public class ServletContextHandlerAttributes {
         return Subject.getSubject(AccessController.getContext());
     }
 
-    public static Set<LoginAttribute> getLoginAttributes(HttpServletRequest request)
-    {
-        return (Set<LoginAttribute>) request.getAttribute(DCACHE_LOGIN_ATTRIBUTES);
-    }
-
-    public static Restriction getRestriction()
-    {
-        return Restrictions.readOnly();
-    }
-
     public static ListDirectoryHandler getListDirectoryHandler(ServletContext ctx)
     {
         return (ListDirectoryHandler) (ctx.getAttribute(DL));
     }
 
-    public static PnfsHandler getPnfsHandler(ServletContext ctx)
+    public static CellStub getCellStub(ServletContext ctx)
     {
-        CellStub cellStub = (CellStub) (ctx.getAttribute(CS));
-        PnfsHandler handler = new PnfsHandler(cellStub);
-        handler.setSubject(getSubject());
-
-        return handler;
+        return (CellStub) (ctx.getAttribute(CS));
     }
 
     public static RemotePoolMonitor getRemotePoolMonitor(ServletContext ctx)


### PR DESCRIPTION
Motivation:

Currently, restful interface either ignores a user's restrictions or
uses a hard-coded read-only value.

Modification:

Take the restriction, as provided by AuthenticationHandler and use it
when creating PnfsHandler objects or elsewhere, where appropriate.

Result:

Frontend now honours restrictions placed on the user's activity.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10280/
Acked-by: Albert Rossi

Conflicts:
	modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
	modules/dcache-restful-api/src/main/java/org/dcache/restful/util/ServletContextHandlerAttributes.java

Conflicts:
	modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java
	modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/namespace/FileResources.java