### PR TITLE
srmmanager: use path to support srmSetPermission operations

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -1266,10 +1266,11 @@ public final class Storage
     }
 
     @Override
-    public void setFileMetaData(SRMUser abstractUser, FileMetaData fmd)
+    public void setFileMetaData(SRMUser abstractUser, URI surl, FileMetaData fmd)
         throws SRMException
     {
         DcacheUser user = asDcacheUser(abstractUser);
+        FsPath path = config.getPath(surl);
         PnfsHandler handler =
             new PnfsHandler(_pnfs, user.getSubject(), user.getRestriction());
 
@@ -1278,9 +1279,8 @@ public final class Storage
                 throw new SRMException("Storage.setFileMetaData: " +
                                        "metadata in not dCacheMetaData");
             }
-            PnfsId pnfsid = ((DcacheFileMetaData) fmd).getPnfsId();
             int mode = ((DcacheFileMetaData) fmd).permMode;
-            handler.setFileAttributes(pnfsid, FileAttributes.ofMode(mode));
+            handler.setFileAttributes(path, FileAttributes.ofMode(mode));
         } catch (TimeoutCacheException e) {
             throw new SRMInternalErrorException("PnfsManager is unavailable: "
                                                 + e.getMessage(), e);

--- a/modules/srm-server/src/main/java/org/dcache/srm/AbstractStorageElement.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/AbstractStorageElement.java
@@ -347,11 +347,14 @@ public interface AbstractStorageElement {
 
     /**
      * @param user User ID
-     * @param path
-     * @return
+     * @param surl The requested SURL to modify
+     * @param fmd The modified file attributes.
+     * @throws SRMInternalErrorException if PnfsManager is unavailable.
+     * @throws SRMInvalidPathException if SURL is unknown.
+     * @throws SRMAuthorizationException if user is not allowed to modify file.
+     * @throws SRMException for any other error.
      */
-
-    void setFileMetaData(SRMUser user, FileMetaData fmd) throws SRMException;
+    void setFileMetaData(SRMUser user, URI surl, FileMetaData fmd) throws SRMException;
 
     /** This method allows to unpin file in the Storage Element,
      * i.e. cancel the request to have the file in "fast access state"

--- a/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmSetPermission.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/handler/SrmSetPermission.java
@@ -117,7 +117,7 @@ public class SrmSetPermission
         }
 
         fmd.permMode = toNewPermissions(fmd.permMode, permissionType, ownerMode, groupMode, otherMode);
-        storage.setFileMetaData(user, fmd);
+        storage.setFileMetaData(user, surl, fmd);
 
         return new SrmSetPermissionResponse(new TReturnStatus(TStatusCode.SRM_SUCCESS, null));
     }


### PR DESCRIPTION
Motivation:

User Restriction are enforced on path-based operations.  To achieve
this, PnfsManager requests need to be supplied the path of the object
being operated upon.

Modification:

Update AbstractStorageElement abstraction to supply the SURL when
requesting a file's metadata be modified.

Update dCache implementation to use the file's path, as obtained from
the SURL.

Result:

Restrictions are enforced on srmSetPermission operations.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Albert Rossi
Patch: https://rb.dcache.org/r/10277/