### PR TITLE
spacemanager: dont try to release expired spaces

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -613,9 +613,11 @@ public final class SpaceManagerService
         }
 
         Space space = db.selectSpaceForUpdate(spaceToken);
-        if (space.getState() == SpaceState.RELEASED) {
+        SpaceState state = space.getState();
+        if (state.isFinal()) {
             /* Stupid way to signal that it isn't found, but there is no other way at the moment. */
-            throw new EmptyResultDataAccessException("Space reservation " + spaceToken + " was already released.", 1);
+            throw new EmptyResultDataAccessException("Space reservation " + spaceToken
+                    + " is " + state.toString().toLowerCase() + ".", 1);
         }
         Subject subject = release.getSubject();
         authorizationPolicy.checkReleasePermission(subject, space);


### PR DESCRIPTION
Motivation:

If the timing is unfortunate, a user can request dCache releases a space
reservation after it has expired but before it has been garbage
collected.  This leads to a stack-trace like:

    java.lang.IllegalStateException: Change from EXPIRED to RELEASED is not allowed.
    	at diskCacheV111.services.space.Space.setState(Space.java:102) ~[dcache-vehicles-3.1.5-SNAPSHOT.jar:3.1.5-SNAPSHOT]
    	at diskCacheV111.services.space.SpaceManagerService.releaseSpace(SpaceManagerService.java:699) [dcache-spacemanager-3.1.5-SNAPSHOT.jar:3.1.5-SNAPSHOT]
    [...]
    	at diskCacheV111.services.space.SpaceManagerService.processMessageTransactionally_aroundBody0(SpaceManagerService.java:639) [dcache-spacemanager-3.1.5-SNAPSHOT.jar:3.1.5-SNAPSHOT]
    	at diskCacheV111.services.space.SpaceManagerService$AjcClosure1.run(SpaceManagerService.java:1) ~[dcache-spacemanager-3.1.5-SNAPSHOT.jar:3.1.5-SNAPSHOT]
    	at diskCacheV111.services.space.SpaceManagerService.processMessageTransactionally(SpaceManagerService.java:619) [dcache-spacemanager-3.1.5-SNAPSHOT.jar:3.1.5-SNAPSHOT]
    	at diskCacheV111.services.space.SpaceManagerService.processMessage(SpaceManagerService.java:568) [dcache-spacemanager-3.1.5-SNAPSHOT.jar:3.1.5-SNAPSHOT]
    	at diskCacheV111.services.space.SpaceManagerService.access$200(SpaceManagerService.java:128) [dcache-spacemanager-3.1.5-SNAPSHOT.jar:3.1.5-SNAPSHOT]
    	at diskCacheV111.services.space.SpaceManagerService$1.process(SpaceManagerService.java:481) [dcache-spacemanager-3.1.5-SNAPSHOT.jar:3.1.5-SNAPSHOT]
    	at diskCacheV111.services.space.SpaceManagerService$FibonacciBackoffMessageProcessor.run(SpaceManagerService.java:1284) [dcache-spacemanager-3.1.5-SNAPSHOT.jar:3.1.5-SNAPSHOT]
    [...]

Modification:

Modify the check to be more general: if the space state is in a final
state then fail the users release request.

Result:

No more stack-trace.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Fixes: #3197
Patch: https://rb.dcache.org/r/10238/
Acked-by: Albert Rossi
Acked-by: Dmitry Litvintsev