### PR TITLE
frontend: refactor static (configuration) data

### DIFF
--- a/modules/dcache-restful-api/pom.xml
+++ b/modules/dcache-restful-api/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>jersey-media-json-jackson</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
             <version>1.0.4</version>

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/StaticDataHandler.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/StaticDataHandler.java
@@ -1,0 +1,143 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.restful.util;
+
+import com.google.common.base.Splitter;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import com.google.gson.GsonBuilder;
+import org.eclipse.jetty.http.HttpStatus.Code;
+import org.springframework.beans.factory.annotation.Required;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.jetty.http.HttpStatus.Code.METHOD_NOT_ALLOWED;
+
+
+/**
+ * A class that accepts client GET requests and replies with
+ * static information.  The data is static, but the representation is
+ * negotiable, based on the client-supplied preferences.  If the client
+ * expresses no preference then the filename determines the format.
+ */
+public class StaticDataHandler extends AbstractHandler
+{
+    private static enum Media
+    {
+        JSON("application/json", "", "\n"),
+        JAVASCRIPT("application/javascript", "var CONFIG = ", ";\n");
+
+        private final String pre;
+        private final String post;
+        private final String mime;
+
+        Media(String mime, String pre, String post)
+        {
+            this.mime = mime;
+            this.pre = pre;
+            this.post = post;
+        }
+    }
+
+    private List<String> paths;
+    private String json;
+
+    @Required
+    public void setPath(String path)
+    {
+        paths = Splitter.on(':').splitToList(path);
+    }
+
+    @Required
+    public void setData(Map<String,String> data)
+    {
+        json = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(data);
+    }
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    {
+        if (isStarted() && !baseRequest.isHandled() && paths.contains(target)) {
+            if (request.getMethod().equals("GET")) {
+                handleRequest(target, baseRequest, response);
+                baseRequest.setHandled(true);
+            } else {
+                Code error = METHOD_NOT_ALLOWED;
+                response.sendError(error.getCode(), error.getMessage());
+            }
+        }
+    }
+
+    private Media decideMedia(String target, Request request)
+    {
+        MetaData.Request metadata = request.getMetaData();
+        List<String> types = metadata == null
+                ? Collections.emptyList()
+                : metadata.getFields().getQualityCSV(HttpHeader.ACCEPT);
+
+        for (String type : types) {
+            switch (type) {
+            case "application/json":
+            case "text/json":
+                return Media.JSON;
+            case "application/javascript":
+            case "text/javascript":
+                return Media.JAVASCRIPT;
+            }
+        }
+
+        int dot = target.lastIndexOf('.');
+        if (dot != -1) {
+            String extension = target.substring(dot+1);
+            switch (extension) {
+            case "js":
+                return Media.JAVASCRIPT;
+            case "json":
+                return Media.JSON;
+            }
+        }
+
+        return Media.JAVASCRIPT;
+    }
+
+    private void handleRequest(String target, Request request, HttpServletResponse response) throws IOException
+    {
+        Media media = decideMedia(target, request);
+
+        response.setContentType(media.mime);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentLength(media.pre.length() + json.length() + media.post.length());
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        PrintWriter writer = response.getWriter();
+        writer.print(media.pre);
+        writer.print(json);
+        writer.print(media.post);
+        writer.flush();
+    }
+}

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -129,12 +129,11 @@
                     <property name="directoriesListed" value="true"/>
                     <property name="resourceBase" value="${frontend.dcache-view.dir}"/>
                 </bean>
-                <bean class="org.eclipse.jetty.server.handler.ContextHandler">
-                    <property name="contextPath" value="/scripts/config.js"/>
-                    <property name="allowNullPathInfo" value="true"/>
-                    <property name="handler">
-                        <bean class="org.dcache.services.httpd.handlers.ContextHandler">
-                            <constructor-arg value="config-${frontend.cell.name}.js"/>
+                <bean class="org.dcache.restful.util.StaticDataHandler">
+                    <property name="path" value="${frontend.static.path}" />
+                    <property name="data">
+                        <bean class="org.dcache.util.ConfigurationMapFactoryBean">
+                            <property name="prefix" value="frontend.static"/>
                         </bean>
                     </property>
                 </bean>

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -314,6 +314,7 @@ frontend.service.gplazma.cache.timeout = 10
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
 frontend.service.gplazma.cache.timeout.unit = MINUTES
 
+
 #  ---- Directory with default static content
 #
 #   The directory in the local file system containing the dcache-view
@@ -321,57 +322,110 @@ frontend.service.gplazma.cache.timeout.unit = MINUTES
 #
 frontend.dcache-view.dir = ${dcache.paths.share}/dcache-view
 
-#  ---- HTTP endpoint of dCache's webapi
-#
-#   The webapi is offered by this frontend service, so the default
-#   value is a relative path pointing back to this server.
-#
-#   MUST end with a slash.
-#
-frontend.dcache-view.endpoints.webapi=/api/v1/
 
-#  ---- HTTP endpoint of dCache webdav service
+#  ---- Static values for frontend
 #
-#   dCacheView uses the webapi for meta data access, but actual
-#   file transfers are served from the regular webdav door.
+#   The frontend can provide arbitrary information to clients based on
+#   dCache configuration.  This is likely most useful for providing
+#   static information (such as configuration) to clients that use
+#   frontend.
 #
-#   If left empty, is is assumed the webdav service runs on the same
-#   host as the frontend door on port 2880. One could set this
-#   to something like https://example.org:443/.
+#   The data is organised as key-value pairs.  These key-value pairs
+#   are serialised into a JSON object.  This JSON object is available
+#   to clients making GET requests in two forms: as the simple JSON
+#   object itself and in the form of a simple JavaScript fragment that
+#   defines the 'CONFIG' variable, depending on which MIME type the
+#   client requests.
 #
-#   MUST end with a slash if non-empty.
+#   A colon-separated list of paths on which the client may request
+#   the values.
 #
-frontend.dcache-view.endpoints.webdav=
+frontend.static.path = /scripts/config.js
 
-#  ---- Name placed at the top of the dCacheView application
+#   The information conveyed as a JSON object.  It is recommended that
+#   all values intended for the same client have a common prefix.
 #
-frontend.dcache-view.org-name=${dcache.description}
+#   The following keys are understood by dCache View:
+#
+#       dcache-view.endpoints.webapi
+#
+#           The webapi is offered by this frontend service, so the
+#           default value is a relative path pointing back to this
+#           server.
+#
+#           MUST end with a slash.
+#
+#       dcache-view.endpoints.webdav
+#
+#           dCacheView uses the webapi for meta data access, but
+#           actual file transfers are served from the regular webdav
+#           door.
+#
+#           If left empty, is is assumed the webdav service runs on
+#           the same host as the frontend door on port 2880. One could
+#           set this to something like https://example.org:443/.
+#
+#           MUST end with a slash if non-empty.
+#
+#       dcache-view.org-name
+#
+#           Name placed at the top of the dCacheView application.
+#
+#       dcache-view.oidc-provider-name-list
+#       dcache-view.oidc-client-id-list
+#       dcache-view.oidc-authz-endpoint-list
+#
+#           Support for OpenID Connect in dCacheView
+#
+#           After setting up openID connect in the webdav; dcache-view
+#           needs to be configured. This will enable user to be able
+#           to authenticate with an OpenID connect account.
+#
+#           These 3 properties below must be set.
+#
+#           If you have more than one OpenID connect provider, each
+#           property takes a space separated value; that is, one for
+#           each providers. Therefore, the set values of each
+#           properties MUST be in the same order, since these will be
+#           mapped together.
+#
+#           Example: Say you have enable two OpenID connect providers;
+#           namely: openid1 and openid2. The 3 properties will be
+#           setup as follow:
+#
+#           frontend.static!dcache-view.oidc-provider-name-list = openid1 openid2
+#           frontend.static!dcache-view.oidc-client-id-list = clientID1 clientID2
+#           frontend.static!dcache-view.oidc-authz-endpoint-list = \
+#               https://oidc.example.com/authz \
+#               https://auth.example.org/authorize
+#
+(prefix)frontend.static = A set of values exposed as a JSON response
+frontend.static!dcache-view.endpoints.webapi = ${frontend.dcache-view.endpoints.webapi}
+frontend.static!dcache-view.endpoints.webdav = ${frontend.dcache-view.endpoints.webdav}
+frontend.static!dcache-view.org-name = ${frontend.dcache-view.org-name}
+frontend.static!dcache-view.oidc-provider-name-list = ${frontend.dcache-view.oidc-provider-name-list}
+frontend.static!dcache-view.oidc-client-id-list = ${frontend.dcache-view.oidc-client-id-list}
+frontend.static!dcache-view.oidc-authz-endpoint-list = ${frontend.dcache-view.oidc-authz-endpoint-list}
+##
+##  The following six properties are to publish information in a
+##  backwards-compatible fashion.  Do not use these values!
+##
+(immutable)frontend.static!webapiEndpoint = ${frontend.static!dcache-view.endpoints.webapi}
+(immutable)frontend.static!webdavEndpoint = ${frontend.static!dcache-view.endpoints.webdav}
+(immutable)frontend.static!orgName = ${frontend.static!dcache-view.org-name}
+(immutable)frontend.static!oidcProviderName = ${frontend.static!dcache-view.oidc-provider-name-list}
+(immutable)frontend.static!oidcClientId = ${frontend.static!dcache-view.oidc-client-id-list}
+(immutable)frontend.static!oidcAuthorizationEndpoint = ${frontend.static!dcache-view.oidc-authz-endpoint-list}
+##
+##  Provide backwards compatbility with existing configuration
+##
+(deprecated)frontend.dcache-view.endpoints.webapi = /api/v1/
+(deprecated)frontend.dcache-view.endpoints.webdav =
+(deprecated)frontend.dcache-view.org-name = ${dcache.description}
+(deprecated)frontend.dcache-view.oidc-provider-name-list =
+(deprecated)frontend.dcache-view.oidc-client-id-list =
+(deprecated)frontend.dcache-view.oidc-authz-endpoint-list =
 
-#  ---- Enable OpenID Connect for dcache-view
-#
-#   After setting up openID connect in the webdav;
-#   dcache-view needs to be configured. This will enable
-#   user to be able to authenticate with an OpenID connect
-#   account.
-#
-#   These 3 properties below must be set.
-#   If you have more than one OpenID connect providers,
-#   each properties takes in space separated value, that is,
-#   one for each providers. Therefore, the set values of each
-#   properties MUST be in the same order, since these will be
-#   mapped together.
-#
-#   Example: Say you have enable two OpenID connect providers;
-#   namely: openid1 and openid2. The 3 properties will be setup
-#   as follow:
-#
-#   frontend.dcache-view.oidc-provider-name-list= openid1 openid2
-#   frontend.dcache-view.oidc-client-id-list= clientID1 clientID2
-#   frontend.dcache-view.oidc-authz-endpoint-list= https://server.openID1.com/authorize https://server.openID2.com/authorize
-#
-frontend.dcache-view.oidc-provider-name-list=
-frontend.dcache-view.oidc-client-id-list=
-frontend.dcache-view.oidc-authz-endpoint-list=
 
 #  ---- Root path
 # Default directory to be exported by doors

--- a/skel/share/services/frontend.batch
+++ b/skel/share/services/frontend.batch
@@ -41,14 +41,21 @@ check -strong frontend.limits.threads.idle-time.unit
 check -strong frontend.limits.queue-length
 check -strong frontend.limits.graceful-shutdown
 check -strong frontend.limits.graceful-shutdown.unit
-
-check -strong frontend.dcache-view.endpoints.webapi
-check frontend.dcache-view.endpoints.webdav
-check frontend.dcache-view.org-name
-check frontend.dcache-view.oidc-provider-name-list
-check frontend.dcache-view.oidc-client-id-list
-check frontend.dcache-view.oidc-authz-endpoint-list
 check -strong frontend.dcache-view.dir
+
+check -strong frontend.static!webapiEndpoint
+check frontend.static!webdavEndpoint
+check frontend.static!orgName
+check frontend.static!oidcProviderName
+check frontend.static!oidcClientId
+check frontend.static!oidcAuthorizationEndpoint
+
+check -strong frontend.static!dcache-view.endpoints.webapi
+check frontend.static!dcache-view.endpoints.webdav
+check frontend.static!dcache-view.org-name
+check frontend.static!dcache-view.oidc-provider-name-list
+check frontend.static!dcache-view.oidc-client-id-list
+check frontend.static!dcache-view.oidc-authz-endpoint-list
 
 check frontend.authn.ciphers
 
@@ -73,18 +80,6 @@ define env verify-TLS.exe enddefine
 enddefine
 
 exec env verify-${frontend.authn.connector}.exe
-
-define context config-${frontend.cell.name}.js enddefine
-var CONFIG =
-{
-    "webapiEndpoint": "${frontend.dcache-view.endpoints.webapi}",
-    "webdavEndpoint": "${frontend.dcache-view.endpoints.webdav}",
-    "orgName": "${frontend.dcache-view.org-name}",
-    "oidcProviderName": "${frontend.dcache-view.oidc-provider-name-list}",
-    "oidcClientId": "${frontend.dcache-view.oidc-client-id-list}",
-    "oidcAuthorizationEndpoint": "${frontend.dcache-view.oidc-authz-endpoint-list}"
-};
-enddefine
 
 onerror shutdown
 create org.dcache.cells.UniversalSpringCell ${frontend.cell.name} \


### PR DESCRIPTION
Motivation:

Frontend exposes some static information, mainly to supply dCache-View
with configuration information.  It does this by building (during dCache
start-up) a small JavaScript script that declares the CONFIG variable as
a simple JSON object.  The frontend then replies with this content when
a client makes a GET request to some hard-coded path.

This is problematic because a) which information is exposed is not
obvious, b) it is hard for admins to add additional information, c) it
is possible for an admin to configure dCache so that dCache emits
malformed JSON.

Modification:

Use a configuration prefix to identify properties that should be exposed
via JSON object.

Add a Handler to write out this data as either a JSON object or as an
equivalent JavaScript script, based on HTTP content negotiation,
otherwise from the "filename" extension (.js or .json), otherwise
default to JavaScript.

The JSON object keys have been rationalised, so that those key-value
pairs intended for dCache-View are clearly indicated as such.  The
existing documentation has been collated.  The existing keys are also
publish for backwards compatibility.

This version of the patch retains support for existing config options,
but marks them as deprecated.

Result:

Easily configurable JSON is available via frontend.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: yes
Fixes: #3231
Patch: https://rb.dcache.org/r/10282/
Acked-by: Albert Rossi

Conflicts:
	skel/share/services/frontend.batch