### PR TITLE
system-test: add series of functional test for frontend service

### DIFF
--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -160,8 +160,24 @@ xrootd.plugins=gplazma:gsi,access-log
 xrootd.authz.write-paths=/
 
 [dCacheDomain/frontend]
+frontend.cell.name=Frontend-${host.name}
 frontend.authz.anonymous-operations=READONLY
+frontend.net.port = 3880
+frontend.authn.basic = true
+frontend.authn.protocol = http
+
+[dCacheDomain/frontend]
+frontend.cell.name = Frontend-S-${host.name}
+frontend.authz.anonymous-operations=READONLY
+frontend.authn.protocol = https
+frontend.net.port = 3881
+
+[dCacheDomain/frontend]
+frontend.cell.name=Frontend-NA-${host.name}
+frontend.net.port=3882
 frontend.authn.basic=true
+frontend.authn.protocol=https
+frontend.net.internal=127.0.0.1
 
 [dCacheDomain/webdav]
 webdav.cell.name=WebDAV-${host.name}

--- a/packages/system-test/src/main/skel/share/robot/doc/frontend-test.md
+++ b/packages/system-test/src/main/skel/share/robot/doc/frontend-test.md
@@ -1,0 +1,188 @@
+Series of dCache Frontend Service Tests
+=======================================
+
+dCache Frontend Service is a Restful API for dCache. These series of tests can
+be only run after the system-test module have been successfully build and
+started.
+
+This document contain instructions on the recommended installation procedure for
+software behind the test system and how to run the test(s).
+
+
+### Table of Contents
+**[Robot Framework Installation Procedure](#Robot-Framework-Installation-Procedure)**<br>
+**[How to Run the test(s)](#How-to-Run-the-test)**<br>
+
+
+<a name="Robot-Framework-Installation-Procedure"/>
+
+## Robot Framework Installation Procedure
+
+We are using [Robot Framework](http://robotframework.org/) for our test system.
+Robot Framework utilizes the keyword-driven testing automation approach. How to
+install Robot Framework is well documented
+[here](https://github.com/robotframework/robotframework/blob/master/INSTALL.rst).
+
+However, below is the installation procedure I will recommend:
+
+#### Pre-installation
+
+Before installing robot framework, these following must be
+installed first:
+
+1. Make sure you have python installed on your system. The latest release of Robot
+Framework, that is, version 3.0 will required at lease Python 2.7 and it also support
+Python >= 3.0.  Before installing python, please check if it is alread pre-installed
+on your system. To check, typed this in your `terminal`:
+
+>     python -V
+
+If you have it installed, you see something like:
+
+```
+Python 2.7.10
+```
+
+So, if you don't have python on your system, go to https://www.python.org/ to
+download the right package and follow the installation instruction for your OS.
+
+2. Next thing to do is to install `pip` (if you don't have it already).
+Installation instruction can be found
+[here](https://pip.pypa.io/en/stable/installing/). _pip is a package management
+system used to install and manage software packages written in Python._
+
+First check if pip is installed on system
+
+>     pip -V
+
+or
+
+>     pip --version
+
+If it is not install, on Linux or macOS run the following command
+
+>     sudo easy_install pip
+
+On Linux or macOS to update
+
+>     pip install -U pip
+
+
+#### Installation
+
+To install Robot Framework using pip, execute the following command
+
+>     pip install robotframework
+
+Upgrading to the latest version is even very easy
+
+>     pip install --upgrade robotframework
+
+Uninstall
+
+>     pip uninstall robotframework
+
+
+Check if everything is fine before proceeding
+
+>     robot --version
+
+If robot is install, you should see something like:
+
+```
+Robot Framework 3.0 (Python 2.7.10 on linux2)
+```
+
+#### Post - Robot Framework Installation
+
+The system-test test for the frontend is using an external library called
+`robotframework-requests`.  Hence one needs to install the library dependency
+before install the library itself.
+
+Via `pip`, execute the following command one after the other
+
+>     pip install -U requests
+>     pip install -U robotframework-requests
+
+
+<a name="How-to-Run-the-test"/>
+
+## How to Run the test(s)
+
+Once all the necessary dependencies had been installed, now you can run the
+test.  In your terminal, change directory to where dcache project source files
+is located.
+
+The robot test files for the frontend service can be found in a directory named
+`frontend` which is located in:
+
+```
+packages/system-test/target/dcache/share/robot
+```
+
+or
+
+```
+packages/system-test/src/main/skel/share/robot
+```
+
+Hence, change directory into either of these two.
+
+
+###### For the whole frontend tests:
+
+>     robot frontend
+
+
+###### For a particular test suite:
+
+Specify the path to the file (that is, the test-suite file):
+
+>     robot  [path_to_the_test_suite_file]
+
+Example
+-------
+
+Say the test-suite file path is
+`frontend/authentication-test/invalid_login_attempt.robot`;
+
+hence simply run the command below to test it:
+
+>     robot frontend/authentication-test/Suppress_WWW_Authenticate.robot
+
+
+###### To test a particular test case in a test suite,
+
+>     robot --test [name_of_the_test_case] [path_to_the_test_suite_where_the_test_case_is]
+
+or
+
+>     robot -t [name_of_the_test_case] [path_to_the_test_suite_where_the_test_case_is]
+
+Example:
+---------
+
+To test a test case with
+
+`name`: _Response Header Include WWW-Authenticate_
+
+and the test suite file path
+
+`path`: _frontend/authentication-test/Suppress_WWW_Authenticate_ ;
+
+your robot command test will look like this:
+
+```
+    robot --test 'Response Header Include WWW-Authenticate' frontend/authentication-test/Suppress_WWW_Authenticate.robot
+```
+
+
+###### For a particular tag:
+
+>     robot --include [space_seperated_tag_name/s]  [path_to_the_test]
+
+By default, the system-test uses default credentials, that is, username and
+password. This might not work if it not setup properly. Therefore, to use a
+specific username and password, simply do this:
+
+>     robot --variable username:[enter_username_here] --variable password:[enter_password_here] frontend

--- a/packages/system-test/src/main/skel/share/robot/frontend/authentication-test/Basic_Authentication_Login_Tests.robot
+++ b/packages/system-test/src/main/skel/share/robot/frontend/authentication-test/Basic_Authentication_Login_Tests.robot
@@ -1,0 +1,75 @@
+*** Settings ***
+Resource          ../resources.robot
+Suite Setup       Run Keywords
+...               Get Username    AND
+...               Get Password    AND
+...               Get Basic Authentication Credential
+Default Tags      Basic-Authentication    Authentication
+
+*** Test Cases ***
+Wrong Username And Password
+    ${wrong_auth}=      Create List             nousername          nopassword
+    ${Site1}=           Set Up A Site Entry     ${HTTP}             /private?children=true    ${wrong_auth}         401
+    ${Site2}=           Set Up A Site Entry     ${HTTPS}            /private?children=true    ${wrong_auth}         401
+    ${Site3}=           Set Up A Site Entry     ${HTTPS_NA}         /                         ${wrong_auth}         401
+    @{List Of Sites}=   Create List             ${Site1}            ${Site2}                  ${Site3}
+    Send Request to All Listed Sites            @{List Of Sites}
+
+*** Test Cases ***
+No Username And Password
+    ${Site1}=           Set Up A Site Entry     ${HTTP}             /private?children=true    ${EMPTY}              401
+    ${Site2}=           Set Up A Site Entry     ${HTTPS}            /private?children=true    ${EMPTY}              401
+    ${Site3}=           Set Up A Site Entry     ${HTTPS_NA}         /                         ${EMPTY}              401
+    @{List Of Sites}=   Create List             ${Site1}            ${Site2}                  ${Site3}
+    Send Request to All Listed Sites            @{List Of Sites}
+
+*** Test Cases ***
+Empty Password
+    ${empty_pw_auth}=   Create List             nousername          ${EMPTY}
+    ${Site1}=           Set Up A Site Entry     ${HTTP}             /private?children=true    ${empty_pw_auth}      401
+    ${Site2}=           Set Up A Site Entry     ${HTTPS}            /private?children=true    ${empty_pw_auth}      401
+    ${Site3}=           Set Up A Site Entry     ${HTTPS_NA}         /                         ${empty_pw_auth}      401
+    @{List Of Sites}=   Create List             ${Site1}            ${Site2}                  ${Site3}
+    Send Request to All Listed Sites            @{List Of Sites}
+
+
+*** Test Cases ***
+Empty Username
+    ${empty_un_auth}=   Create List             ${EMPTY}            nopassword
+    ${Site1}=           Set Up A Site Entry     ${HTTP}             /private?children=true    ${empty_un_auth}      401
+    ${Site2}=           Set Up A Site Entry     ${HTTPS}            /private?children=true    ${empty_un_auth}      401
+    ${Site3}=           Set Up A Site Entry     ${HTTPS_NA}         /                         ${empty_un_auth}      401
+    @{List Of Sites}=   Create List             ${Site1}            ${Site2}                  ${Site3}
+    Send Request to All Listed Sites            @{List Of Sites}
+
+*** Test Cases ***
+Valid Username and Password
+    ${Site1}=           Set Up A Site Entry     ${HTTP}             /private?children=true    ${auth}               200
+    ${Site2}=           Set Up A Site Entry     ${HTTPS}            /private?children=true    ${auth}               200
+    ${Site3}=           Set Up A Site Entry     ${HTTPS_NA}         /                         ${auth}               200
+    @{List Of Sites}=   Create List             ${Site1}            ${Site2}                  ${Site3}
+    Send Request to All Listed Sites            @{List Of Sites}
+
+
+*** Keywords ***
+Get Basic Authentication Credential
+    ${auth}=                                    Create List         ${username}               ${password}
+    Set Suite Variable                          ${auth}
+
+
+Send Request to All Listed Sites
+    [Arguments]         @{SiteInformation}
+    :FOR                ${entry}                IN                   @{SiteInformation}
+    \                   ${SiteName}=            Get From Dictionary  ${entry}                SiteName
+    \                   ${Path}=                Get From Dictionary  ${entry}                Path
+    \                   ${AuthValue}=           Get From Dictionary  ${entry}                AuthValue
+    \                   ${ExceptedStatusCode}=  Get From Dictionary  ${entry}                ExceptedStatusCode
+    \                   Create Session          rest                 ${SiteName}             auth=${AuthValue}
+    \                   ${resp}=                Get Request          rest                    ${Path}
+    \                   Should Be Equal As Strings                   ${resp.status_code}     ${ExceptedStatusCode}
+
+Set Up A Site Entry
+    [Arguments]         ${SiteName}             ${Path}              ${AuthValue}            ${Code}
+    ${site}=            Create Dictionary       Path=${Path}         AuthValue=${AuthValue}  SiteName=${SiteName}
+    ...                 ExceptedStatusCode=${Code}
+    [return]            ${site}

--- a/packages/system-test/src/main/skel/share/robot/frontend/authentication-test/Suppress_WWW-Authenticate_tests.robot
+++ b/packages/system-test/src/main/skel/share/robot/frontend/authentication-test/Suppress_WWW-Authenticate_tests.robot
@@ -1,0 +1,60 @@
+*** Settings ***
+Resource          ../resources.robot
+Default Tags      Suppress WWW-Authenticate    Authentication
+
+*** Variables ***
+${StatusCode}         401
+
+
+*** Test Cases ***
+Response Header Include WWW-Authenticate
+    ${RequestHeaders}=                   Create Dictionary             Accept=application\/json
+    &{ExpectedResponseHeader}=           Create Dictionary             include=WWW-Authenticate
+    ...                                  exclude=Suppress-WWW-Authenticate
+    ${Site1}=                            Set Up A Site Entry           ${HTTP}
+    ...                                  /private?children=true        ${ExpectedResponseHeader}     ${RequestHeaders}
+    ${Site2}=                            Set Up A Site Entry           ${HTTPS}
+    ...                                  /private?children=true        ${ExpectedResponseHeader}     ${RequestHeaders}
+    ${Site3}=                            Set Up A Site Entry           ${HTTPS_NA}                   /
+    ...                                  ${ExpectedResponseHeader}     ${RequestHeaders}
+    @{List Of Sites}=   Create List      ${Site1}                      ${Site2}                      ${Site3}
+    Send Request to All Listed Sites     @{List Of Sites}
+
+*** Test Cases ***
+Response Header Include Suppress-WWW-Authenticate but No WWW-Authenticate
+    ${RequestHeaders}=                   Create Dictionary             Accept=application\/json
+    ...                                  Suppress-WWW-Authenticate=Suppress
+    &{ExpectedResponseHeader}=           Create Dictionary             include=Suppress-WWW-Authenticate
+    ...                                  exclude=WWW-Authenticate
+    ${Site1}=                            Set Up A Site Entry           ${HTTP}
+    ...                                  /private?children=true        ${ExpectedResponseHeader}     ${RequestHeaders}
+    ${Site2}=                            Set Up A Site Entry           ${HTTPS}
+    ...                                  /private?children=true        ${ExpectedResponseHeader}     ${RequestHeaders}
+    ${Site3}=                            Set Up A Site Entry           ${HTTPS_NA}                   /
+    ...                                  ${ExpectedResponseHeader}     ${RequestHeaders}
+    @{List Of Sites}=   Create List      ${Site1}                      ${Site2}                      ${Site3}
+    Send Request to All Listed Sites     @{List Of Sites}
+
+*** Keywords ***
+Send Request to All Listed Sites
+    [Arguments]    @{SiteInformation}
+    :FOR           ${entry}                      IN                     @{SiteInformation}
+    \              ${SiteName}=                  Get From Dictionary    ${entry}                SiteName
+    \              ${Path}=                      Get From Dictionary    ${entry}                Path
+    \              ${ExpectedResponseHeader}=    Get From Dictionary    ${entry}                ExpectedResponseHeader
+    \              ${RequestHeaders}=            Get From Dictionary    ${entry}                RequestHeaders
+    \              Create Session                rest                   ${SiteName}
+    \              ${resp}=                      Get Request            rest                    ${Path}
+    ...            headers=${RequestHeaders}
+    \              Should Be Equal As Strings    ${resp.status_code}    ${StatusCode}
+    \              Should Not Contain            ${resp.headers}        ${ExpectedResponseHeader.exclude}
+    ...            case_insensitive=False
+    \              Should Contain                ${resp.headers}        ${ExpectedResponseHeader.include}
+    ...            case_insensitive=False
+
+Set Up A Site Entry
+    [Arguments]    ${SiteName}                   ${Path}                ${ExpectedResponseHeader}
+    ...            ${RequestHeaders}
+    ${site}=       Create Dictionary             SiteName=${SiteName}   Path=${Path}
+    ...            RequestHeaders=${RequestHeaders}                     ExpectedResponseHeader=${ExpectedResponseHeader}
+    [return]       ${site}

--- a/packages/system-test/src/main/skel/share/robot/frontend/resources.robot
+++ b/packages/system-test/src/main/skel/share/robot/frontend/resources.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Library           Collections
+Library           RequestsLibrary
+Library           Process
+
+*** Variables ***
+${SERVER}         localhost
+${ENDPOINT}       api/v1/namespace
+${HTTP}           http://${SERVER}:3880/${ENDPOINT}
+${HTTPS}          https://${SERVER}:3881/${ENDPOINT}
+${HTTPS_NA}       https://${SERVER}:3882/${ENDPOINT}
+
+*** Keywords ***
+Run WhoAmI Command
+    ${whoamI}=                Run Process                   whoami           shell=true
+    [return]                  ${whoamI.stdout}
+
+Get Username
+    ${whoamI} =               Run WhoAmI Command
+    ${username} =             Get Variable Value            ${username}      ${whoamI}
+    Set Suite Variable        ${username}
+
+Get Password
+    ${password} =             Get Variable Value            ${password}      password
+    Set Suite Variable        ${password}


### PR DESCRIPTION
Motivation:

Frontend service is currently the only service in dcache that
has neither a unit test or functional test. The absence of test
is causing some fixed problem to be unknowing reintroduce back
into the service by another patch.

Modification:

1. Add some more frontend services to the system test domain.
2. Introduce set of tests for authentication using Robot Framework
3. Add a frontend-test.md README file which contain instruction on
how to install Robot framework and how to run the tests.

Result:

A more reliable system

Target: trunk
Request: 3.0
Request: 3.1
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10290/

(cherry picked from commit 4f8b39f7e42077dd2690f51e370dcfe00766144f)