### PR TITLE
ssh: fix handling of ssh idle timeout

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -1,7 +1,9 @@
 package org.dcache.services.ssh2;
 
 import org.apache.sshd.common.Factory;
+import org.apache.sshd.common.FactoryManager;
 import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.PropertyResolverUtils;
 import org.apache.sshd.common.keyprovider.AbstractFileKeyPairProvider;
 import org.apache.sshd.common.util.SecurityUtils;
 import org.apache.sshd.server.Command;
@@ -175,11 +177,11 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
     }
 
     private void startServer() {
-        // MINA SSH uses int to store timeout. Strip the long valued to max int if required.
-        int effectiveTimeout = (int)Math.min((long)Integer.MAX_VALUE,
-                _idleTimeoutUnit.toMillis(_idleTimeout > 0? _idleTimeout : Long.MAX_VALUE));
+        long effectiveTimeout = _idleTimeoutUnit.toMillis(_idleTimeout);
+        PropertyResolverUtils.updateProperty(_server, FactoryManager.IDLE_TIMEOUT, effectiveTimeout);
+        // esure, that read timeout is longer than idle timeout
+        PropertyResolverUtils.updateProperty(_server, FactoryManager.NIO2_READ_TIMEOUT, effectiveTimeout*2);
 
-        _server.getProperties().put(SshServer.IDLE_TIMEOUT, Integer.toString(effectiveTimeout));
         _server.setPort(_port);
         _server.setHost(_host);
 


### PR DESCRIPTION
Motivation:
To preserve idle ssh connection one have to adjust IDLE_TIMEOUT, however
sshd has yet an other timeout - READ timeout, which tells ssh session how
long server waits for ssh message to be read. This timeout is calculated
relative to DEFAULT_IDLE_TIMEOUT if not explicitly set.

Modification:
Explicitly set read timeout to prevent it to fire before idle timeout.

Result:
idle ssh session is not closed

Ticket: #9175
Acked-by: Paul Millar
Target: master, 3.1, 3.0, 2.16
Require-book: no
Require-notes: no