### PR TITLE
zookeeper: work-around race-condition in zookeeper server shutdown

### DIFF
--- a/skel/etc/logback.xml
+++ b/skel/etc/logback.xml
@@ -185,6 +185,15 @@
         <level>error</level>
     </threshold>
     <threshold>
+        <!-- ZK currently contains a race-condition that triggers a
+             CancelledKeyException on shutdown; if triggered, a
+             stack-trace is logged at WARN level. See
+             https://issues.apache.org/jira/browse/ZOOKEEPER-2838
+             Adjusting log-level as a work-around. -->
+        <logger>org.apache.zookeeper.server.NIOServerCnxnFactory</logger>
+        <level>error</level>
+    </threshold>
+    <threshold>
       <logger>liquibase</logger>
       <level>warn</level>
     </threshold>


### PR DESCRIPTION
Motivation:

ZooKeeper contains a race-condition during shutdown, where the
ServerSocketChannel is closed while thread(s) are still active.  This is
problematic as closing the channel also closes any SelectionKey objects
that are registered, which can lead to CancelledKeyException that
ZooKeeper logs, with a stack-trace, at WARN level:

04 Jul 2017 15:54:15 (zookeeper) [] Ignoring unexpected runtime exception
java.nio.channels.CancelledKeyException: null
	at sun.nio.ch.SelectionKeyImpl.ensureValid(SelectionKeyImpl.java:73) ~[na:1.8.0_131]
	at sun.nio.ch.SelectionKeyImpl.readyOps(SelectionKeyImpl.java:87) ~[na:1.8.0_131]
	at org.apache.zookeeper.server.NIOServerCnxnFactory.run(NIOServerCnxnFactory.java:187) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_131]

This interfers with our test infrastructure, which detects and reports
any stack-traces.

Modification:

Unfortunately, there is no easy way to work-around the issue with ZK
v3.4.  (Although the problem is still present in ZK v3.5, it would be
possible to implement a work-around by subclassing.)  Therefore, the
only option is to increase the log-level threshold for this class.

Note that the suppressed class is only used by ZooKeeper server (i.e.,
not the client).  Therefore, only the 'zookeeper' service is affected.

Result:

One less cause of stack-traces from the 'zookeeper' service.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/10306/
Acked-by: Tigran Mkrtchyan