### PR TITLE
pnfsmanager: remove obsolete comments from properties file

### DIFF
--- a/skel/share/defaults/pnfsmanager.properties
+++ b/skel/share/defaults/pnfsmanager.properties
@@ -237,22 +237,6 @@ pnfsmanager.upload-directory=${dcache.upload-directory}
 #
 #  The maximum number of concurrent database connections.
 #
-#  NOTE:  when running resilience embedded here, this number should
-#         be increased. The recommended minimum setting would be
-#
-#               pnfsmanager.resilience.submit-threads
-#             + pnfsmanager.resilience.pnfs-op-threads
-#             + pnfsmanager.resilience.db.connections.max
-#             + whatever maximum allowed for normal namespace settings
-#               (default = 30)
-#
-#       Submit and pnfs threads require 1 database connection, and scan
-#       threads need 2.
-#
-#       Be sure to adjust postgresql.conf max connections to allow
-#       for the larger value here, plus the added pool scan
-#       connections specified by pnfsmanager.resilience.db.connections.max.
-#
 pnfsmanager.db.connections.max = 30
 
 #


### PR DESCRIPTION
See https://github.com/dCache/dcache/issues/3310

Resilience in its released version cannot be run as part of pnfsmanager.  These comments no longer apply.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Acked-by: Paul