### PR TITLE
config: add obsolete|forbidden annotation for dropped properties

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1026,5 +1026,6 @@ dcache.description =
 (obsolete)dcache.service.copymanager =
 
 (obsolete)dcache.broker.host = See dcache.zookeeper.connection
+(obsolete)dcache.zookeeper.net.port = See dcache.zookeeper.connection
 (obsolete)dcache.broker.domain = See dcache.broker.scheme
 (obsolete)dcache.service.billing = See dcache.queue.billing and dcache.topic.billing

--- a/skel/share/defaults/resilience.properties
+++ b/skel/share/defaults/resilience.properties
@@ -302,3 +302,5 @@ resilience.service.pinmanager.timeout=1
 #
 resilience.service.pool.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)resilience.service.pool.timeout.unit=MINUTES
+
+(obsolete)resilience.cell.export = The resilience service is always exported

--- a/skel/share/defaults/zookeeper.properties
+++ b/skel/share/defaults/zookeeper.properties
@@ -94,3 +94,5 @@ zookeeper.max-client-connections = 1000
 
 #  Document which TCP ports are opened
 (immutable)zookeeper.net.ports.tcp=${zookeeper.net.port}
+
+(obsolete)zookeeper.cell.export = The zookeeper service is always exported


### PR DESCRIPTION
Motivation:

Providing dropped properties with an obsolete or forbidden annotation
allows the admin to discover changes that might affect their dCache
instance.  This is both through manual inspection and through the
'dcache check-config' command.

Modification:

Add annotations and, where appropriate, descriptions to support admins
as they upgrade.

Result:

Hopefully fewer support tickets.

Target: master
Request: 3.1
Request: 3.0
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10327/
Acked-by: Albert Rossi