### PR TITLE
resilience: make namespace provider properties immutable

### DIFF
--- a/modules/dcache-resilience/src/main/resources/org/dcache/resilience/resilience.xml
+++ b/modules/dcache-resilience/src/main/resources/org/dcache/resilience/resilience.xml
@@ -54,8 +54,10 @@
 
     <bean id="extractor" class="${resilience.plugins.storage-info-extractor}">
       <description>Storage info extractor</description>
-      <constructor-arg value="#{ T(diskCacheV111.util.AccessLatency).getAccessLatency('${resilience.default-access-latency}') }"/>
-      <constructor-arg value="#{ T(diskCacheV111.util.RetentionPolicy).getRetentionPolicy('${resilience.default-retention-policy}') }"/>
+      <!-- these are placeholder values which do not effect how resilience works,
+           so the dcache defaults are fine -->
+      <constructor-arg value="#{ T(diskCacheV111.util.AccessLatency).getAccessLatency('NEARLINE') }"/>
+      <constructor-arg value="#{ T(diskCacheV111.util.RetentionPolicy).getRetentionPolicy('CUSTODIAL') }"/>
     </bean>
 
     <bean id="liquibase" class="org.dcache.util.SpringLiquibase">
@@ -68,13 +70,15 @@
     <bean id="name-space-provider"
           class="org.dcache.chimera.namespace.ChimeraNameSpaceProvider">
       <description>Name space provider</description>
-      <property name="permissionHandler" ref="permission-handler"/>
-      <property name="inheritFileOwnership" value="${resilience.enable.inherit-file-ownership}"/>
-      <property name="verifyAllLookups" value="${resilience.enable.full-path-permission-check}"/>
       <property name="allowMoveToDirectoryWithDifferentStorageClass" value="${pnfsmanager.enable.move-to-directory-with-different-storageclass}"/>
       <property name="fileSystem" ref="file-system"/>
       <property name="extractor" ref="extractor"/>
-      <property name="aclEnabled" value="${resilience.enable.acl}"/>
+      <property name="permissionHandler" ref="permission-handler"/>
+      <!-- these are placeholder values which do not effect how resilience works,
+            so the dcache defaults are fine -->
+      <property name="inheritFileOwnership" value="false"/>
+      <property name="verifyAllLookups" value="true"/>
+      <property name="aclEnabled" value="false"/>
     </bean>
 
     <bean id="NamespaceAccess" class="org.dcache.resilience.db.LocalNamespaceAccess">

--- a/skel/share/defaults/resilience.properties
+++ b/skel/share/defaults/resilience.properties
@@ -100,15 +100,10 @@ resilience.db.connections.idle = 1
 #
 resilience.db.fetch-size=1000
 
-# ---- File-system-related properties.  These mirror the normal
-#      namespace service setup.
+#   -- replace with org.dcache.chimera.namespace.ChimeraEnstoreStorageInfoExtractor
+#      if you are running an enstore HSM backend.
 #
-resilience.plugins.storage-info-extractor=org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor
-(one-of?ONLINE|NEARLINE)resilience.default-access-latency=NEARLINE
-(one-of?CUSTODIAL|REPLICA|OUTPUT)resilience.default-retention-policy=CUSTODIAL
-resilience.enable.inherit-file-ownership = false
-resilience.enable.full-path-permission-check=true
-resilience.enable.acl = false
+resilience.plugins.storage-info-extractor=${dcache.plugins.storage-info-extractor}
 
 # ---- Base directory where any resilience metadata is stored.  This
 #      includes the checkpoint file, inaccessible file lists, and statistics
@@ -303,4 +298,11 @@ resilience.service.pinmanager.timeout=1
 resilience.service.pool.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)resilience.service.pool.timeout.unit=MINUTES
 
+# ---- Obsolete
+#
 (obsolete)resilience.cell.export = The resilience service is always exported
+(obsolete)resilience.default-access-latency = value was not significant
+(obsolete)resilience.default-retention-policy = value was not significant
+(obsolete)resilience.enable.inherit-file-ownership = value was not significant
+(obsolete)resilience.enable.full-path-permission-check = value was not significant
+(obsolete)resilience.enable.acl = value was not significant

--- a/skel/share/services/resilience.batch
+++ b/skel/share/services/resilience.batch
@@ -23,11 +23,6 @@ check -strong resilience.db.connections.max
 check -strong resilience.db.fetch-size
 
 check -strong resilience.plugins.storage-info-extractor
-check -strong resilience.default-access-latency
-check -strong resilience.default-retention-policy
-check -strong resilience.enable.inherit-file-ownership
-check -strong resilience.enable.full-path-permission-check
-check -strong resilience.enable.acl
 
 check -strong resilience.home
 check -strong resilience.enable.watchdog


### PR DESCRIPTION
See https://github.com/dCache/dcache/issues/3310

Motivation:

Resilience uses its own namespace provider, but its interactions
with it are read-only.  While the provider needs to be fully
configured, some properties need not be exposed to the user.

Modifiation:

Remove properties that do not need to be exposed.
Inject defaults directly.
Mark removed properties as obsolete.

Result:  properties not needing to be exposed to configuration
are not.

Target: master
Request: 3.2
Request: 3.1
Request: 2.16
Acked-by: Paul
Closes: #3310