### PR TITLE
dcache: release dcache-view 1.1.5 for dcache 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.4.0</version.wicket>
         <version.xrootd4j>3.2.2</version.xrootd4j>
         <version.jersey>2.22.2</version.jersey>
-        <version.dcache-view>1.1.4</version.dcache-view>
+        <version.dcache-view>1.1.5</version.dcache-view>
         <version.netty>4.1.5.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
 


### PR DESCRIPTION
Changelog from v1.1.4 to v1.1.5 (for dcache 3.0)
    a65876a dcache-view: change configuration state names

Request: 3.0
Require-book: no
Require-notes: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10332/