### PR TITLE
dcache: release dcache-view 1.0.7 for dcache 2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.3.0</version.wicket>
         <version.xrootd4j>3.1.1</version.xrootd4j>
         <version.jersey>2.22.2</version.jersey>
-        <version.dcache-view>1.0.6</version.dcache-view>
+        <version.dcache-view>1.0.7</version.dcache-view>
         <version.dcache>${project.version}</version.dcache>
 
         <!-- BouncyCastle seems to change the naming convention of


### PR DESCRIPTION
Changelog from v1.0.6 to v1.0.7 (for dcache 2.16)
    06683c5 dcache-view: change configuration state names

Request: 2.16
Require-book: no
Require-notes: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10331/