### PR TITLE
dcache: release dcache-view 1.2.2 for dcache 3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.5.0</version.wicket>
         <version.xrootd4j>3.2.2</version.xrootd4j>
         <version.jersey>2.24</version.jersey>
-        <version.dcache-view>1.2.1</version.dcache-view>
+        <version.dcache-view>1.2.2</version.dcache-view>
         <version.netty>4.1.6.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
 


### PR DESCRIPTION
Changelog from v1.2.1 to v1.2.2 (for dcache 3.1)
    62ca10b dcache-view: change configuration state names

Request: 3.1
Require-book: no
Require-notes: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10334/