### PR TITLE
logback: make socket appender construction depend on log level

### DIFF
--- a/modules/dcache/pom.xml
+++ b/modules/dcache/pom.xml
@@ -39,6 +39,10 @@
         <artifactId>logback-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
                 <version>1.0.12</version>
             </dependency>
             <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.0.6</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
                 <version>2.11.0</version>

--- a/skel/etc/logback.xml
+++ b/skel/etc/logback.xml
@@ -106,23 +106,33 @@
     </encoder>
   </appender>
 
-  <appender name="socket" class="ch.qos.logback.classic.net.SocketAppender">
-      <!-- Regardless of the level to which the remote appender is set,
-           only messages marked as ALARM are allowed through -->
-      <filter class="org.dcache.alarms.logback.AlarmFilter"/>
-      <remoteHost>${dcache.log.server.host}</remoteHost>
-      <port>${dcache.log.server.port}</port>
-      <reconnectionDelay>10000</reconnectionDelay>
-  </appender>
-
-  <appender name="remote" class="ch.qos.logback.classic.AsyncAppender">
-      <appender-ref ref="socket" />
-  </appender>
+  <!-- The conditional is to avoid an infinite retry of a non-existent connection
+       by the socket appender if an alarms service is not running, which,
+       for example, is the case when remote logging is left off system-wide. -->
+  <if condition='!"${dcache.log.level.remote}".equals("off")'>
+    <then>
+      <appender name="socket" class="ch.qos.logback.classic.net.SocketAppender">
+        <!-- Regardless of the level to which the remote appender is set,
+             only messages marked as ALARM are allowed through -->
+        <filter class="org.dcache.alarms.logback.AlarmFilter"/>
+        <remoteHost>${dcache.log.server.host}</remoteHost>
+        <port>${dcache.log.server.port}</port>
+        <reconnectionDelay>10000</reconnectionDelay>
+      </appender>
+      <appender name="remote" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="socket" />
+      </appender>
+    </then>
+  </if>
 
   <root>
     <appender-ref ref="stdout"/>
     <appender-ref ref="pinboard"/>
-    <appender-ref ref="remote"/>
+    <if condition='!"${dcache.log.level.remote}".equals("off")'>
+      <then>
+        <appender-ref ref="remote"/>
+      </then>
+    </if>
   </root>
 
   <logger name="org.dcache.events" additivity="false">
@@ -141,7 +151,11 @@
     <appender-ref ref="pinboard"/>
     <appender-ref ref="events"/>
     <appender-ref ref="access"/>
-    <appender-ref ref="remote"/>
+    <if condition='!"${dcache.log.level.remote}".equals("off")'>
+      <then>
+        <appender-ref ref="remote"/>
+      </then>
+    </if>
   </logger>
 
   <turboFilter class="dmg.util.logback.CellThresholdFilter">
@@ -206,11 +220,15 @@
       <level>${dcache.log.level.file}</level>
     </threshold>
 
-    <threshold>
-      <appender>remote</appender>
-      <logger>root</logger>
-      <level>${dcache.log.level.remote}</level>
-    </threshold>
+    <if condition='!"${dcache.log.level.remote}".equals("off")'>
+      <then>
+        <threshold>
+          <appender>remote</appender>
+          <logger>root</logger>
+          <level>${dcache.log.level.remote}</level>
+        </threshold>
+      </then>
+    </if>
 
     <threshold>
       <appender>pinboard</appender>


### PR DESCRIPTION
see https://github.com/dCache/dcache/issues/3115

Motivation:

The default host for the remote logging server used by
the alarms service is localhost.  However, even when
the remote logging level is set to 'off', the socket
appender is created by the logback.xml file.  If
it does not find a valid endpoint at the address used
to configure it, it will keep retrying.  This is
visible only if <configuration debug="true">.
If the remote host is left blank, the socket appender
will not try to connect.

Modification:

Use logback conditional configuration to create
remote appender using socket and async appenders
only if dcache.log.level.remote is not set to 'off'.

This requires the addition of the janino library to
the pom.

Result:

While generally benign, the sub-optimal reconnect
behavior has been eliminated.

An added advantage is that even if a remote server
is defined and running, if logging is turned off
for a domain, the appender will not attempt to
connect.

Target: master
Request: 3.1
Request: 3.0
Request. 2.16
Closes: #3115
Acked-by: Dmitry
Acked-by: Paul