### PR TITLE
srm,srmmanager: add configuration property to allow easy modification…

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -248,6 +248,11 @@ dcache.domain.service.uri = ${dcache.domain.service}.batch
 # Default directory to be exported by doors
 dcache.root = /
 
+# The 'srm' service(s) and the 'srmmanager' service(s) cooperate to
+# provide support for the SRM protocol.  These services need a
+# consistent configuration of their root directory.
+dcache.srm-root = ${dcache.root}
+
 # Reporting from pools concerning broken files
 dcache.corrupt-file.topic=CorruptFileTopic
 

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -152,7 +152,7 @@ srm.loginbroker.update-period.unit = ${dcache.loginbroker.update-period.unit}
 srm.loginbroker.update-threshold = ${dcache.loginbroker.update-threshold}
 srm.loginbroker.version = 1.1.1
 srm.loginbroker.family = srm
-srm.loginbroker.root = ${dcache.root}
+srm.loginbroker.root = ${dcache.srm-root}
 srm.loginbroker.address = ${srm.net.listen}
 srm.loginbroker.port = ${srm.net.port}
 

--- a/skel/share/defaults/srmmanager.properties
+++ b/skel/share/defaults/srmmanager.properties
@@ -855,7 +855,7 @@ srmmanager.request.copy.lifetime = ${srmmanager.request.lifetime}
 srmmanager.request.copy.lifetime.unit=${srmmanager.request.lifetime.unit}
 
 # ---- File system root exported by the srm service
-srmmanager.root = ${dcache.root}
+srmmanager.root = ${dcache.srm-root}
 
 # Cell address of pnfsmanager service
 srmmanager.service.pnfsmanager=${dcache.service.pnfsmanager}


### PR DESCRIPTION
… of srm root

Motivation:

srm service(s) and srmmanager service(s) should have consistent
configuration.

Modification:

Add an extra layer of default value for the loginbroker root published
by 'srm' service and the root enforced by 'srmmanager' service.

Result:

Easier to configure a consistent non-default root for SRM protocol support.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Closes: #3302
Patch: https://rb.dcache.org/r/10322/
Acked-by: Tigran Mkrtchyan