### PR TITLE
billing: update documentation to describe CellAddress

### DIFF
--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -263,6 +263,16 @@ billing.text.dir = ${dcache.paths.billing}
 # Type: CellAddress
 # ------------
 #
+#   The address of a cell within dCache, which may be qualified.
+#
+#   If a CellAddress 'addr' is qualified then $addr.isQualified$
+#   expands to true, $addr.domain$ provides the domain name of this
+#   cell, and $addr$ expands to $addr.cell$@$addr.domain$.
+#
+#   If a CellAddress 'addr' is not qualified then $addr.isQualified$
+#   expands to false, $addr.domain$ expands to 'local' and $addr$
+#   expands to $addr.cell$.
+#
 #   Field          Type         Description
 #   -----          ----         -----------
 #   cell           String       Name of the dCache cell


### PR DESCRIPTION
Motivation:

The expansion of a CellAddress value and its fields are not well
documented.

Modification:

Add documentation that describes how a CellAddress and its fields
expand.

Result:

Less confusion.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Closes: #3301
Patch: https://rb.dcache.org/r/10320/
Acked-by: Tigran Mkrtchyan