### PR TITLE
config: use consistent terminology

### DIFF
--- a/skel/share/defaults/replica.properties
+++ b/skel/share/defaults/replica.properties
@@ -15,7 +15,7 @@
 #
 replica.cell.name=replicaManager
 
-#  ---- Named queues to subscribe to
+#  ---- Named queues to consume from
 #
 #   A service can consume messages from named queues. Other service can
 #   write messages to such queues. A named queue has an unqualified cell


### PR DESCRIPTION
Motivation:

Adopt a consistent terminology: cells consume from named queues and
subscribe to topics.

Modification:

Update replica manager configuration to use this terminology; other
services are updated by a pull-request from Chris Mitterer.

Result:

Potentially easier to understand configuration.

Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10318/
Acked-by: Tigran Mkrtchyan