### PR TITLE
ftp: convert timestamps to GMT (to follow RFC 3659)

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -122,7 +122,8 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -1105,6 +1106,10 @@ public abstract class AbstractFtpDoorV1
     {
         _ftpDoorName = ftpDoorName;
         _tlogName = tlogName;
+        /**
+         * RFC 3659 requires GMT
+         */
+        TIMESTAMP_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
 
         visitFtpCommands(new CommandMethodVisitor() {
             @Override


### PR DESCRIPTION
Motivation:

It has been discovered that timestamp facts reported by dCache
GFTP server are expressed in local (to server) time. FTP RFC
3659 requires all timestamps to be in UTC/GMT.

Modification:

Report timestamps in GMT.

Result:

Timestamp facts are reported in GMT. Clients like globus-url-copty -sync
work properly, ubefrtp -ls returns correct timestamp.

Patch: https://rb.dcache.org/r/10342/
Target: trunk
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Acked-by: Albert Rossi <arossi@fnal.gov>
Acked-by: Paul Millar <paul.millar@desy.de>
(cherry picked from commit af7136e45d4a7491143f75bdd1c8d79848d6f640)