### PR TITLE
srm/srmmanager: update documentation about root path

### DIFF
--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -143,6 +143,15 @@ srm.service.gplazma.cache.timeout.unit = SECONDS
 srm.credential-service.topic = ${dcache.credential-service.topic}
 
 # ---- Login broker publishing
+#
+# Be aware that modifying 'srm.loginbroker.root' property does not
+# affect how corresponding srmmanager service(s) behave.  If
+# 'srm.loginbroker.root' is modified then it is the admin's
+# responsibility to ensure the 'srmmanager.root' property of
+# corresponding srmmanager services are updated accordingly.
+# Alternatively, simply configure the 'dcache.srm-root' property to
+# update both properties together.
+#
 srm.loginbroker.update-topic= ${dcache.loginbroker.update-topic}
 srm.loginbroker.request-topic= ${dcache.loginbroker.request-topic}
 srm.loginbroker.tags= ${dcache.loginbroker.tags}

--- a/skel/share/defaults/srmmanager.properties
+++ b/skel/share/defaults/srmmanager.properties
@@ -855,6 +855,13 @@ srmmanager.request.copy.lifetime = ${srmmanager.request.lifetime}
 srmmanager.request.copy.lifetime.unit=${srmmanager.request.lifetime.unit}
 
 # ---- File system root exported by the srm service
+#
+# Be aware that modifying the 'srmmanager.root' property does not
+# affect the root path advertised by corresponding 'srm' services (SRM
+# doors).  The 'srm.loginbroker.root' property for those SRM doors
+# must be updated accordingly.  Alternatively, simply configure the
+# 'dcache.srm-root' property to update both properties together.
+#
 srmmanager.root = ${dcache.srm-root}
 
 # Cell address of pnfsmanager service


### PR DESCRIPTION
Motivation:

The two properties 'srmmanager.root' and 'srm.loginbroker.root' are
related without this relationship being documented.  This could lead to
a misconfigured dCache.

Modification:

Add documentation to describe the relationship between the two
properties.

Result:

Hopefully fewer misconfigured dCache instances.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10321/
Acked-by: Tigran Mkrtchyan
Closes: #3302