### PR TITLE
srm/srmmanager: fix srmPing confusion

### DIFF
--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srmmanager.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srmmanager.xml
@@ -420,11 +420,6 @@
                   value="${srmmanager.persistence.reserve-space.enable.clean-pending-on-restart}"/>
         <property name="databaseParametersForReserve.storeCompletedRequestsOnly"
                   value="#{ '${srmmanager.persistence.reserve-space.enable.store-transient-state}'.equals('false') ? true : false }"/>
-        <property name="pingExtraInfo">
-            <bean class="org.dcache.util.ConfigurationMapFactoryBean">
-                <property name="prefix" value="srm.ping-extra-info"/>
-            </bean>
-        </property>
         <property name="maximumClientAssumedBandwidth" value="${srmmanager.request.maximum-client-assumed-bandwidth}"/>
     </bean>
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/util/Configuration.java
@@ -194,8 +194,6 @@ public class Configuration {
         new HashMap<>();
     private String caCertificatePath;
 
-    private ImmutableMap<String,String> pingExtraInfo = ImmutableMap.of();
-
     /** Creates a new instance of Configuration */
     public Configuration() {
         databaseParameters.put(PUT_PARAMETERS, new DatabaseParameters("Put"));
@@ -204,16 +202,6 @@ public class Configuration {
         databaseParameters.put(COPY_PARAMETERS, new DatabaseParameters("Copy"));
         databaseParameters.put(BRINGONLINE_PARAMETERS, new DatabaseParameters("Bring Online"));
         databaseParameters.put(RESERVE_PARAMETERS, new DatabaseParameters("Reserve Space"));
-    }
-
-    public ImmutableMap<String,String> getPingExtraInfo()
-    {
-        return pingExtraInfo;
-    }
-
-    public void setPingExtraInfo(Map<String,String> additionalInfo)
-    {
-        pingExtraInfo = ImmutableMap.copyOf(additionalInfo);
     }
 
     /** Getter for property urlcopy.

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -238,7 +238,7 @@ srm.authn.ciphers = ${dcache.authn.ciphers}
 #  is the property name without this prefix and the ExtraInfo value is
 #  the property's value.
 #
-(prefix)srmmanager.ping-extra-info = The ExtraInfo items in an srmPing response.
+(prefix)srm.ping-extra-info = The ExtraInfo items in an srmPing response.
 srm.ping-extra-info!backend_type = dCache
 srm.ping-extra-info!backend_version = ${dcache.version}
 
@@ -463,5 +463,4 @@ srm.ping-extra-info!backend_version = ${dcache.version}
 (obsolete)srm.authn.vomsdir =
 (obsolete)srm.net.host =
 (obsolete)srm.net.local-hosts =
-(obsolete)srm.ping-extra-info =
 (obsolete)srm.root =


### PR DESCRIPTION
Motivation:

dCache allows for custom SRM ping responses.  It is currently unclear
where this should be configured due to inconsistent naming.

Modification:

Fix default configuration for srm service; remove redundant setting of
srmPing in srmmanager.

Result:

Less confusion over how to configure custom srmPing responses.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Closes: #3303
Patch: https://rb.dcache.org/r/10345/
Acked-by: Tigran Mkrtchyan