### PR TITLE
resilience: remove reference to pnfsmanager property

### DIFF
--- a/modules/dcache-resilience/src/main/resources/org/dcache/resilience/resilience.xml
+++ b/modules/dcache-resilience/src/main/resources/org/dcache/resilience/resilience.xml
@@ -70,7 +70,6 @@
     <bean id="name-space-provider"
           class="org.dcache.chimera.namespace.ChimeraNameSpaceProvider">
       <description>Name space provider</description>
-      <property name="allowMoveToDirectoryWithDifferentStorageClass" value="${pnfsmanager.enable.move-to-directory-with-different-storageclass}"/>
       <property name="fileSystem" ref="file-system"/>
       <property name="extractor" ref="extractor"/>
       <property name="permissionHandler" ref="permission-handler"/>
@@ -79,6 +78,7 @@
       <property name="inheritFileOwnership" value="false"/>
       <property name="verifyAllLookups" value="true"/>
       <property name="aclEnabled" value="false"/>
+      <property name="allowMoveToDirectoryWithDifferentStorageClass" value="true"/>
     </bean>
 
     <bean id="NamespaceAccess" class="org.dcache.resilience.db.LocalNamespaceAccess">


### PR DESCRIPTION
Motivation:

Commit 09abff118fa2a255d77568e213ddf558584f7432 introduced into
version 3.0 a new pnfsmanager property concerning moving files to another
directory (see RB #9494):

pnfsmanager.enable.move-to-directory-with-different-storageclass

This property must also be set by resilience, since it has its own
copy of the namespace provider.  The original patch, however, has
resilience reference the property directly.

On the principle that services should not directly reference
each other's properties, this needs to be handled differently.

Modification:

Since some value for this property must be given, but it
has to do with operations that are irrelevant to resilience,
the default value can simply be hard-coded.

Result:

The agreed-upon namespace conventions and constraints are not violated.

Target:  master
Request: 3.1
Request: 3.0
Acked-by: Dmitry
Acked-by: Paul
Patch: #10340
Committed: 3e596ed3baae4a64c77f8f36787a3f0e15f5764c