### PR TITLE
configuration: update description for replicable

### DIFF
--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -28,6 +28,16 @@ gplazma.cell.name = ${dcache.queue.gplazma}
 #
 #   This property indicates if this service is replicable.
 #
+#   Note: it is the administrator's responsibility to ensure that all
+#   gplazma service instances have:
+#
+#       o  consistent dCache 'gplazma.' configuration,
+#
+#       o  the same gPlazma configuration (see
+#          gplazma.configuration.file),
+#
+#       o  the same configuration for each configured gPlazma plugin.
+#
 (immutable)gplazma.cell.replicable = true
 
 

--- a/skel/share/defaults/pinmanager.properties
+++ b/skel/share/defaults/pinmanager.properties
@@ -27,7 +27,12 @@ pinmanager.cell.name = ${dcache.queue.pinmanager}
 #
 #   This property indicates if this service is replicable.
 #
-#   Multiple instances must share the same databases.
+#   Note: it is the administrator's responsibility to ensure that all
+#   pinmanager service instances:
+#
+#       o  have consistent dCache 'pinmanager.' configuration,
+#
+#       o  share the same database.
 #
 (immutable)pinmanager.cell.replicable = true
 

--- a/skel/share/defaults/pnfsmanager.properties
+++ b/skel/share/defaults/pnfsmanager.properties
@@ -26,7 +26,12 @@ pnfsmanager.cell.name = ${dcache.queue.pnfsmanager}
 #
 #   This property indicates if this service is replicable.
 #
-#   Multiple instances must share the same databases.
+#   Note: it is the administrator's responsibility to ensure that all
+#   pnfsmanager service instances:
+#
+#       o  have consistent dCache 'pnfsmanager.' configuration,
+#
+#       o  share the same database.
 #
 (immutable)pnfsmanager.cell.replicable = true
 

--- a/skel/share/defaults/spacemanager.properties
+++ b/skel/share/defaults/spacemanager.properties
@@ -29,7 +29,12 @@ spacemanager.cell.name = ${dcache.queue.spacemanager}
 #
 #   This property indicates if this service is replicable.
 #
-#   Multiple instances must share the same databases.
+#   Note: it is the administrator's responsibility to ensure that all
+#   spacemanager service instances:
+#
+#       o  have consistent dCache 'spacemanager.' configuration,
+#
+#       o  share the same database.
 #
 (immutable)spacemanager.cell.replicable = true
 

--- a/skel/share/defaults/srmmanager.properties
+++ b/skel/share/defaults/srmmanager.properties
@@ -46,7 +46,12 @@ srmmanager.cell.name = ${dcache.queue.srmmanager}
 #
 #   This property indicates if this service is replicable.
 #
-#   Multiple instances should have separate SRM databases.
+#   Note: it is the administrator's responsibility to ensure that all
+#   srmmanager service instances:
+#
+#       o  have consistent dCache 'srmmanager.' configuration,
+#
+#       o  have *distinct* databases.
 #
 (immutable)srmmanager.cell.replicable = true
 

--- a/skel/share/defaults/topo.properties
+++ b/skel/share/defaults/topo.properties
@@ -26,6 +26,9 @@ topo.cell.name = ${dcache.queue.topo}
 #
 #   This property indicates if this service is replicable.
 #
+#   Note: it is the administrator's responsibility to ensure that all
+#   topo service instances have consistent 'topo.' configuration.
+#
 (immutable)topo.cell.replicable = true
 
 #  ---- Whether to export the topo cell as a well known cell


### PR DESCRIPTION
Motivation:

For some services it is unclear what are the admin's responsibilities in
terms of consistent configuration.

Modification:

Update documentation describing what is needed to deploy redundant
services.

Result:

A clearer picture of what is required to run multiple instances of
services that support this.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: no
Require-book: no
Closes: #3299
Patch: https://rb.dcache.org/r/10357/
Acked-by: Gerd Behrmann

Conflicts:
	skel/share/defaults/billing.properties
	skel/share/defaults/poolmanager.properties