### PR TITLE
webdav: fix regression in third-party copy with no delegation

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -129,7 +129,7 @@ public class RemoteTransferHandler implements CellMessageReceiver
     public enum TransferType {
         GSIFTP("gsiftp", GRIDSITE, EnumSet.noneOf(CredentialSource.class)),
         HTTP(  "http",   NONE,     EnumSet.noneOf(CredentialSource.class)),
-        HTTPS( "https",  GRIDSITE, EnumSet.of(OIDC));
+        HTTPS( "https",  GRIDSITE, EnumSet.of(OIDC, NONE));
 
         private static final ImmutableMap<String,TransferType> BY_SCHEME =
             ImmutableMap.of("gsiftp", GSIFTP, "http", HTTP, "https", HTTPS);


### PR DESCRIPTION
Motivation:

In dCache prior to v3.1, it was possible to request a third-party
transfer using HTTPS but without any delegating: it is assumed that the
request is authorised through some other mechanism (e.g., by specifying
the 'TransferHeaderAuthorization' header).

Unfortunately, the patch adding OIDC delegation (commit d132d860)
inadvertently removed this possibility.

Modification:

Register NONE as a valid Credential header value for https transfers.

Result:

HTTP-initiated third party transfers that do not use delegation works
again.

Target: master
Request: 3.1
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10382/
Acked-by: Tigran Mkrtchyan