### PR TITLE
pool: fix regression in HTTP third-party transfer with redirection

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -331,7 +331,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
         URI location = info.getUri();
 
         for (int attempt = 0; attempt < MAX_REDIRECTIONS; attempt++) {
-            HttpPut put = buildPutRequest(info, length);
+            HttpPut put = buildPutRequest(info, location, length);
 
             try (CloseableHttpResponse response = _client.execute(put)) {
                 StatusLine status = response.getStatusLine();
@@ -381,9 +381,10 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                 "number of redirections; last location was " + location);
     }
 
-    private HttpPut buildPutRequest(RemoteHttpDataTransferProtocolInfo info, long length)
+    private HttpPut buildPutRequest(RemoteHttpDataTransferProtocolInfo info,
+            URI location, long length)
     {
-        HttpPut put = new HttpPut(info.getUri());
+        HttpPut put = new HttpPut(location);
         put.setConfig(RequestConfig.custom()
                                   .setConnectTimeout(CONNECTION_TIMEOUT)
                                   .setExpectContinueEnabled(true)


### PR DESCRIPTION
Motivation:

Unlike GET, the Apache HTTP client library does not follow redirection
on PUT; this logic is present within the pool.

Unfortunately, commit d132d860 introduced a regression where, after
receiving a redirection response, the pool will retry with the same URL
(i.e., does not follow the redirection).  This is repeated until the
loop-detection prevents any further attempts and fails the transfer.

Modification:

Use the updated location when the upload is redirected.

Result:

Third-party transfers work again when uploading to services that
redirect-on-PUT (such as dCache, if so configured).

Target: master
Request: 3.1
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10387/
Acked-by: Tigran Mkrtchyan