### PR TITLE
webdav: fix more regressions with CredentialSource.NONE

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
@@ -351,7 +351,7 @@ public class CopyFilter implements Filter
 
         CredentialSource source = getCredentialSource(request, type);
         Object credential = fetchCredential(source);
-        if (credential == null) {
+        if (source != CredentialSource.NONE && credential == null) {
             if (source == CredentialSource.GRIDSITE) {
                 redirectWithDelegation(response);
             } else {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -225,8 +225,10 @@ public class RemoteTransferHandler implements CellMessageReceiver
             Object credential, Direction direction)
             throws ErrorResponseException, InterruptedException
     {
-        checkArgument(credential instanceof X509Credential || credential instanceof OpenIdCredential,
-                                            "Credential not supported for Third-Party Transfer");
+        checkArgument(credential == null
+                || credential instanceof X509Credential
+                || credential instanceof OpenIdCredential,
+                "Credential not supported for Third-Party Transfer");
         EnumSet<TransferFlag> flags = EnumSet.noneOf(TransferFlag.class);
         flags = addVerificationFlag(flags, requestHeaders);
         ImmutableMap<String,String> transferHeaders = buildTransferHeaders(requestHeaders);


### PR DESCRIPTION
Motivation:

A previous patch (committed as 7e5e81e1) attempted to fix the regression
introduced by commit d132d860 where the webdav service no longer
accepted the "Credential: none" header for HTTPS-based third-party
transfers.  Unfortunately that fix was incomplete and additional changes
proved necessary, which this patch provides.

Modification:

Relax conditions that prevented HTTPS-based third-party transfers
without delegation.

Result:

A regression is fixed that prevented third-party transfers without a
delegated credential (e.g., using HTTP basic authentication or a bearer
token like macaroons).

Target: master
Request: 3.1
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10386/
Acked-by: Tigran Mkrtchyan