### PR TITLE
chimera: use jsr-107 jcache interface for caching

### DIFF
--- a/modules/chimera/pom.xml
+++ b/modules/chimera/pom.xml
@@ -86,5 +86,10 @@
         <artifactId>h2</artifactId>
         <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>javax.cache</groupId>
+        <artifactId>cache-api</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -79,7 +79,9 @@
       <property name="shouldUpdate" value="${pnfsmanager.db.schema.auto}"/>
   </bean>
 
-  <bean id="file-system" class="org.dcache.chimera.JdbcFs" depends-on="liquibase">
+  <bean id="hazelcast" class="org.dcache.hazelcast.HazelcastService" init-method="start" destroy-method="shutdown"/>
+
+  <bean id="file-system" class="org.dcache.chimera.JdbcFs" depends-on="liquibase,hazelcast">
       <description>Chimera</description>
       <constructor-arg ref="data-source"/>
       <constructor-arg ref="tx-manager"/>

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -129,7 +129,10 @@ import org.dcache.xdr.gss.GssSessionManager;
 import static java.util.stream.Collectors.toList;
 
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.annotation.concurrent.GuardedBy;
+import javax.cache.Cache;
+import javax.cache.Caching;
 
 import org.dcache.auth.attributes.Restrictions;
 

--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -91,8 +91,10 @@
         <property name="shouldUpdate" value="${nfs.db.schema.auto}"/>
     </bean>
 
+    <bean id="hazelcast" class="org.dcache.hazelcast.HazelcastService" init-method="start" destroy-method="shutdown"/>
+
     <bean id="fileSystem" class="org.dcache.chimera.DCacheAwareJdbcFs"
-            depends-on="liquibase">
+            depends-on="liquibase,hazelcast">
         <description>Chimera Filesystem</description>
         <constructor-arg ref="dataSource" />
         <constructor-arg ref="tx-manager" />

--- a/modules/dcache/pom.xml
+++ b/modules/dcache/pom.xml
@@ -315,6 +315,18 @@
         <groupId>org.dcache</groupId>
         <artifactId>rados4j</artifactId>
     </dependency>
+    <dependency>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast-zookeeper</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast-client</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.curator</groupId>
+        <artifactId>curator-x-discovery</artifactId>
+    </dependency>
 
     <!-- used by alarms, needs to be deployed -->
     <dependency>

--- a/modules/dcache/src/main/java/org/dcache/hazelcast/HazelcastService.java
+++ b/modules/dcache/src/main/java/org/dcache/hazelcast/HazelcastService.java
@@ -1,0 +1,98 @@
+package org.dcache.hazelcast;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.zookeeper.ZookeeperDiscoveryProperties;
+import com.hazelcast.zookeeper.ZookeeperDiscoveryStrategyFactory;
+import org.apache.curator.framework.CuratorFramework;
+import org.dcache.cells.CuratorFrameworkAware;
+
+import dmg.cells.nucleus.CellAddressCore;
+import dmg.cells.nucleus.CellIdentityAware;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * Hazelcast cluster's member service.
+ */
+public class HazelcastService implements CuratorFrameworkAware, CellIdentityAware {
+
+    private CuratorFramework client;
+    private CellAddressCore address;
+
+    @Override
+    public void setCuratorFramework(CuratorFramework client) {
+        this.client = client;
+    }
+
+    @Override
+    public void setCellAddress(CellAddressCore address) {
+        this.address = address;
+    }
+
+    public void start() {
+        client.getZookeeperClient().getCurrentConnectionString();
+        String zookeeperURL = client.getZookeeperClient().getCurrentConnectionString();
+
+        DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(new ZookeeperDiscoveryStrategyFactory());
+        discoveryStrategyConfig.addProperty(ZookeeperDiscoveryProperties.ZOOKEEPER_URL.key(), zookeeperURL);
+        discoveryStrategyConfig.addProperty(ZookeeperDiscoveryProperties.ZOOKEEPER_PATH.key(), "/dcache/discovery/hazelcast");
+        discoveryStrategyConfig.addProperty(ZookeeperDiscoveryProperties.GROUP.key(), "dcache");
+
+
+        URL url = Config.class.getClassLoader().getResource("org/dcache/hazelcast/hazelcast.xml");
+        if (url == null) {
+            throw new RuntimeException("Can't find hazelcast configuration");
+        }
+
+        InputStream in = Config.class.getClassLoader().getResourceAsStream("org/dcache/hazelcast/hazelcast.xml");
+        if (in == null) {
+            throw new RuntimeException("Can't load hazelcast configuration");
+        }
+
+        /*
+         * Embedded Hazelcast cluster member initialization
+         */
+        // we initialize through XML config to pic-up cache configurations
+        Config config = new XmlConfigBuilder(in).build();
+        config.setConfigurationUrl(url); // required to keep hazelcast happy (NPE)
+        config.getNetworkConfig().getJoin().getDiscoveryConfig().addDiscoveryStrategyConfig(discoveryStrategyConfig);
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED, "true");
+        config.setProperty(GroupProperty.ENABLE_JMX, "true");
+        config.setProperty(GroupProperty.ENABLE_JMX_DETAILED, "true");
+        config.setProperty(GroupProperty.LOGGING_TYPE, "slf4j");
+        config.setLiteMember(false);
+
+        // use domain name only to enforce single cache server per JVM
+        config.setInstanceName(address.getCellDomainName());
+
+        // initialize server
+        Hazelcast.getOrCreateHazelcastInstance(config);
+
+        /*
+         * Embedded Hazelcast client initialization
+         */
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().getDiscoveryConfig().addDiscoveryStrategyConfig(discoveryStrategyConfig);
+        clientConfig.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED, "true");
+        clientConfig.setProperty(GroupProperty.ENABLE_JMX, "true");
+        clientConfig.setProperty(GroupProperty.ENABLE_JMX_DETAILED, "true");
+        clientConfig.setProperty(GroupProperty.LOGGING_TYPE, "slf4j");
+        clientConfig.setInstanceName(address.toString());
+
+        // initialize client
+        HazelcastClient.newHazelcastClient(clientConfig);
+    }
+
+    public void shutdown() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+}

--- a/modules/dcache/src/main/resources/org/dcache/hazelcast/hazelcast.xml
+++ b/modules/dcache/src/main/resources/org/dcache/hazelcast/hazelcast.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+                               http://www.hazelcast.com/schema/config/hazelcast-config-3.6.xsd"
+           xmlns="http://www.hazelcast.com/schema/config">
+
+
+    <import resource="classpath:org/dcache/hazelcast/ino-cache.xml" />
+
+
+</hazelcast>

--- a/modules/dcache/src/main/resources/org/dcache/hazelcast/ino-cache.xml
+++ b/modules/dcache/src/main/resources/org/dcache/hazelcast/ino-cache.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+                               http://www.hazelcast.com/schema/config/hazelcast-config-3.6.xsd"
+           xmlns="http://www.hazelcast.com/schema/config">
+
+    <cache name="inumber-pnfsid-mapping">
+        <key-type class-name="java.lang.Long"/>
+        <value-type class-name="java.lang.String"/>
+
+        <read-through>false</read-through>
+        <write-through>false</write-through>
+
+        <in-memory-format>OBJECT</in-memory-format>
+        <eviction size="100000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
+
+        <statistics-enabled>true</statistics-enabled>
+    </cache>
+
+
+    <cache name="pnfsid-inumber-mapping">
+        <key-type class-name="java.lang.String"/>
+        <value-type class-name="java.lang.Long"/>
+
+        <read-through>false</read-through>
+        <write-through>false</write-through>
+
+        <in-memory-format>OBJECT</in-memory-format>
+        <eviction size="100000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
+
+        <statistics-enabled>true</statistics-enabled>
+    </cache>
+
+</hazelcast>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,8 @@
         <version.dcache-view>1.3.1</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
+        <version.hazelcast>3.6.3</version.hazelcast>
+        <version.curator>2.11.1</version.curator>
 
         <!-- BouncyCastle seems to change the naming convention of
              their ArtifactId fairly often.  Here is a summary of
@@ -184,7 +186,7 @@
             <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
-                <version>2.11.1</version>
+                <version>${version.curator}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>
@@ -863,6 +865,31 @@
                 <groupId>org.dcache</groupId>
                 <artifactId>ldap4testing</artifactId>
                 <version>1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast</artifactId>
+                <version>${version.hazelcast}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast-client</artifactId>
+                <version>${version.hazelcast}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast-zookeeper</artifactId>
+                <version>${version.hazelcast}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-x-discovery</artifactId>
+                <version>${version.curator}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.cache</groupId>
+                <artifactId>cache-api</artifactId>
+                <version>1.0.0</version>
             </dependency>
             <!-- used by alarms, needs to be deployed -->
             <dependency>


### PR DESCRIPTION
TEST pull request


Motivation:
to reduce load on DB, chimera caches inumber <-> pnfsid mapping.
This there is an assumption that this mapping will never change.
As some functionality in dCache may break this rule, we need a
way to invalidate cached values.

In case of multiple direct chimera instances, like PnfsManager in
HA setup or nfs door, the cache invalidation must be propagated to
all instances.

JSR-107 defines interface only API for caching. Depending on
implementation, cache can be local or distributed.

Modification:
Use JCache based distributed cache to load data into Guava's cache. This
construct still uses local cache, but loads data from distributed cache
if available. additionally, cache invalidation events handled by all cache
clients.

The JdbcFs updated to join or create a distributed Hazelcast cache.
A zookeeper based autodiscovery is added to cluster members to discover
each other.

The Guava's cache size is reduced to ensure, that values are always in the
shared cache, when they are in the local caches.

Result:
No visible user changes. However all direct chimera clients build a distributed
cache with autodiscovery.

Acked-by:
Target: master
Require-book: no
Require-notes: yes