### PR TITLE
resilience: restore extractor class value for extractor property

### DIFF
--- a/skel/share/defaults/resilience.properties
+++ b/skel/share/defaults/resilience.properties
@@ -115,7 +115,7 @@ resilience.db.fetch-size=1000
 #   -- replace with org.dcache.chimera.namespace.ChimeraEnstoreStorageInfoExtractor
 #      if you are running an enstore HSM backend.
 #
-resilience.plugins.storage-info-extractor=${dcache.plugins.storage-info-extractor}
+resilience.plugins.storage-info-extractor=org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor
 
 # ---- Base directory where any resilience metadata is stored.  This
 #      includes the checkpoint file, inaccessible file lists, and statistics


### PR DESCRIPTION
Motivation:

dcache.plugins.storage-info-extractor

was introduced in 3.1.  Patch #10325
made the resilience property reference it.

The pull requests for 2.16 and 3.0 erroneously backported
the change.

Modification:

Restore the original concrete default value.

Result:

No config errors.

Target: 3.0
Request: 2.16
Closes: #3377
Acked-by: Paul