### PR TITLE
billing: use cellName.cell instead of cellName

### DIFF
--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -298,19 +298,19 @@ billing.text.format.mover-info-message = $date$ [$cellType$:$cellName.cell$:$typ
 #
 #    Submitted by PnfsManager on file removal.
 #
-billing.text.format.remove-file-info-message = $date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ {$rc$:"$message$"}
+billing.text.format.remove-file-info-message = $date$ [$cellType$:$cellName.cell$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ {$rc$:"$message$"}
 
 #  ---- DoorRequestInfoMessage
 #
 #    Submitted by doors for each file transfer.
 #
-billing.text.format.door-request-info-message = $date$ [$cellType$:$cellName$:$type$] ["$owner$":$uid$:$gid$:$clientChain$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transactionTime$ $queuingTime$ {$rc$:"$message$"}
+billing.text.format.door-request-info-message = $date$ [$cellType$:$cellName.cell$:$type$] ["$owner$":$uid$:$gid$:$clientChain$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transactionTime$ $queuingTime$ {$rc$:"$message$"}
 
 #  ---- StorageInfoMessage
 #
 #    Submitted by pools for each flush to and fetch from tape.
 #
-billing.text.format.storage-info-message = $date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transferTime$ $queuingTime$ {$rc$:"$message$"}
+billing.text.format.storage-info-message = $date$ [$cellType$:$cellName.cell$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transferTime$ $queuingTime$ {$rc$:"$message$"}
 
 #  ---- PoolHitInfoMessage
 #
@@ -322,7 +322,7 @@ billing.text.format.pool-hit-info-message = $date$ [$cellType$:$cellName.cell$:$
 #
 #    Submitted by pool manager on various failures
 #
-billing.text.format.warning-pnfs-file-info-message = $date$ [$cellType$:$cellName$:$type$] {$rc$:"$message$"}
+billing.text.format.warning-pnfs-file-info-message = $date$ [$cellType$:$cellName.cell$:$type$] {$rc$:"$message$"}
 
 #  -----------------------------------------------------------------------
 #     Store billing data in database
@@ -458,11 +458,11 @@ billing.service.poolmanager=${dcache.service.poolmanager}
 # properties define default formats to use when a suitable formatting header is lacking.
 (prefix)billing.parser.format = Default formatting strings
 billing.parser.format!mover-info-message = $date$ [$cellType$:$cellName.cell$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transferred$ $connectionTime$ $created$ {$protocol$} [$initiator$] {$rc$:"$message$"}
-billing.parser.format!remove-file-info-message = $date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ {$rc$:"$message$"}
-billing.parser.format!door-request-info-message = $date$ [$cellType$:$cellName$:$type$] ["$owner$":$uid$:$gid$:$clientChain$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transactionTime$ $queuingTime$ {$rc$:"$message$"}
-billing.parser.format!storage-info-message = $date$ [$cellType$:$cellName$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transferTime$ $queuingTime$ {$rc$:"$message$"}
+billing.parser.format!remove-file-info-message = $date$ [$cellType$:$cellName.cell$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ {$rc$:"$message$"}
+billing.parser.format!door-request-info-message = $date$ [$cellType$:$cellName.cell$:$type$] ["$owner$":$uid$:$gid$:$clientChain$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transactionTime$ $queuingTime$ {$rc$:"$message$"}
+billing.parser.format!storage-info-message = $date$ [$cellType$:$cellName.cell$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $transferTime$ $queuingTime$ {$rc$:"$message$"}
 billing.parser.format!pool-hit-info-message = $date$ [$cellType$:$cellName.cell$:$type$] [$pnfsid$,$filesize$] [$path$] $if(storage)$$$$storage.storageClass$@$storage.hsm$$$$else$<Unknown>$endif$ $cached$ {$protocol$} {$rc$:"$message$"}
-billing.parser.format!warning-pnfs-file-info-message = $date$ [$cellType$:$cellName$:$type$] {$rc$:"$message$"}
+billing.parser.format!warning-pnfs-file-info-message = $date$ [$cellType$:$cellName.cell$:$type$] {$rc$:"$message$"}
 
 ##  Old properties that are no longer supported
 (obsolete)billing.db.inserts.max-before-commit =


### PR DESCRIPTION
Motivation:
In 2.16 the field “cellName” for billing format strings got extended by
sub-fields, amongst others “cell”.
The actual output of “cellName.cell” seems to be identical to just specifying
“cellName” and in some but not all of the default billing format strings this
has been adapted already.

Modification:

Consistently use “cellName.cell” instead of just “cellName” in all billing
format strings.

Result:

Should have no effect on acutal output, but result in a more consistent
configuration.

Target: master
Require-notes: no
Require-book: no

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>