### PR TITLE
alarms: guard against NPEs on LogEntry getters

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/dao/LogEntry.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/dao/LogEntry.java
@@ -116,11 +116,11 @@ public class LogEntry implements Comparable<LogEntry>, IRegexFilterable {
     }
 
     public Date getDateOfFirstArrival() {
-        return new Date(firstArrived);
+        return firstArrived == null ? null : new Date(firstArrived);
     }
 
     public Date getDateOfLastUpdate() {
-        return new Date(lastUpdate);
+        return lastUpdate == null ? null : new Date(lastUpdate);
     }
 
     public String getDomain() {
@@ -132,11 +132,13 @@ public class LogEntry implements Comparable<LogEntry>, IRegexFilterable {
     }
 
     public String getFormattedDateOfFirstArrival() {
-        return getFormattedDate(getDateOfFirstArrival());
+        return firstArrived == null ? "" :
+                        getFormattedDate(getDateOfFirstArrival());
     }
 
     public String getFormattedDateOfLastUpdate() {
-        return getFormattedDate(getDateOfLastUpdate());
+        return lastUpdate == null ? "" :
+                        getFormattedDate(getDateOfLastUpdate());
     }
 
     public String getHost() {


### PR DESCRIPTION
Motivation:

Use of LogEntry as JSON has uncovered potential NPEs in
four getter methods.

Modification:

Do a null check.

Result:

No NPEs.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Acked-by: Paul