### PR TITLE
system-test: explicit specify nfs domain

### DIFF
--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -224,6 +224,7 @@ webdav.root = /users-root/door-root
 nfs.version=3,4.1
 nfs.enable.portmap=false
 nfs.export.file=${system-test.home}/etc/exports
+nfs.domain=localhostdomain
 
 [dCacheDomain/resilience]
 


### PR DESCRIPTION
Motivation:
on some platforms (osx) the revers lookup of the IP may
produce results that will force dcache-startup to fail

Modification:
define nfs.domain property in system-test.layout

Result:
dcache start on osx with weird network config

Target: master
Require-book: no
Require-notes: no
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>