### PR TITLE
systemd: start service after ZooKeeper

### DIFF
--- a/skel/lib/systemd/system-generators/dcache-generator
+++ b/skel/lib/systemd/system-generators/dcache-generator
@@ -15,7 +15,7 @@ for domain in $(getProperty dcache.domains); do
     cat <<-EOF > "$1/dcache@$domain.service"
 	[Unit]
 	Description=dCache $domain domain
-	After=network.target
+	After=network.target zookeeper.service
 
 	[Service]
 	Type=simple


### PR DESCRIPTION
Motivation:

Every dCache domain connects to ZooKeeper.
If a ZooKeeper service is running on a host where dCache domains are running, it
should in practise be pretty likely that this is a ZooKeeper server from the
ensmble used by dCache.
To prevent log messages it would be beneficial if dCache starts after a local
ZooKeeper service (if any).

Modification:

Added zookeeper.service to systemd’s “After” option.

Result:

dCache domains will start after a local ZooKeeper service (if any).

Target: master
Require-notes: no
Require-book: no

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>