### PR TITLE
webdav: avoid stack-trace on bad user requests

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
@@ -66,6 +66,9 @@ public class DcacheStandardFilter implements Filter
             }
         } catch (BadRequestException e) {
             responseHandler.respondBadRequest(e.getResource(), response, request);
+        } catch (UncheckedBadRequestException e) {
+            log.debug("Client supplied bad request parameters: {}", e.getMessage());
+            responseHandler.respondBadRequest(e.getResource(), response, request);
         } catch (ConflictException e) {
             responseHandler.respondConflict(e.getResource(), response, request, e.getMessage());
         } catch (NotAuthorizedException e) {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
@@ -1,9 +1,12 @@
 package org.dcache.webdav;
 
 import io.milton.http.Auth;
+import io.milton.http.FileItem;
 import io.milton.http.HttpManager;
+import io.milton.http.RequestParseException;
 import io.milton.servlet.ServletRequest;
 import io.milton.servlet.ServletResponse;
+import org.apache.commons.fileupload.FileUploadException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -17,6 +20,12 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.AccessController;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import dmg.cells.nucleus.CDC;
 import dmg.cells.nucleus.CellAddressCore;
@@ -85,6 +94,34 @@ public class MiltonHandler
         public DcacheServletRequest(HttpServletRequest request,
                                     ServletContext context) {
             super(request, context);
+        }
+
+        @Override
+        public void parseRequestParameters(Map<String, String> params, Map<String, FileItem> files)
+                throws RequestParseException
+        {
+            /*
+             * io.milton.http.ResourceHandlerHelper#process calls
+             * Request#parseRequestParameters and catches any
+             * RequestParseException thrown.  Unfortunately, it logs this
+             * with a stack-trace, but otherwise ignores such failures.
+             *
+             * See  https://github.com/miltonio/milton2/issues/93 for details.
+             *
+             * As a work-around, such exceptions are caught here and
+             * converted into an unchecked exception that results in
+             * the server responding with a 400 Bad Request.
+             */
+            try {
+                super.parseRequestParameters(params, files);
+            } catch (RequestParseException e) {
+                // Inexplicably, Milton wraps any FileUploadException with a
+                // RequestParseException containing a meaningless message.
+                String message = e.getCause() instanceof FileUploadException
+                    ? e.getCause().getMessage()
+                    : e.getMessage();
+                throw new UncheckedBadRequestException(message, e, null);
+            }
         }
 
         @Override

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/UncheckedBadRequestException.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/UncheckedBadRequestException.java
@@ -1,0 +1,43 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.webdav;
+
+import io.milton.resource.Resource;
+
+/**
+ * An exception thrown to indicate the server should return a 400 Bad Request
+ * response to the client, but in a place where milton did not anticipate this
+ * possibility.
+ */
+public class UncheckedBadRequestException extends WebDavException
+{
+    public UncheckedBadRequestException(Resource resource)
+    {
+        super(resource);
+    }
+
+    public UncheckedBadRequestException(String message, Resource resource)
+    {
+        super(message, resource);
+    }
+
+    public UncheckedBadRequestException(String message, Throwable cause, Resource resource)
+    {
+        super(message, cause, resource);
+    }
+}


### PR DESCRIPTION
Motivation:

Vulnerability testing often involves sending odd sequences to the server.  One such sequence resulted in the following stack-trace:

    18 Jul 2017 13:28:24 (webdav-insecure) [door:webdav-insecure@dCacheDomain:AAVUldBCQug] exception parsing request. probably interrupted upload
    io.milton.http.RequestParseException: FileUploadException
            at io.milton.servlet.ServletRequest.parseRequestParameters(ServletRequest.java:230) ~[milton-server-ce-2.7.2.0.jar:na]
            at io.milton.http.ResourceHandlerHelper.process(ResourceHandlerHelper.java:75) ~[milton-server-ce-2.7.2.0.jar:na]
            at org.dcache.webdav.DcacheResourceHandlerHelper.process(DcacheResourceHandlerHelper.java:45) [dcache-webdav-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
            at io.milton.http.http11.GetHandler.process(GetHandler.java:60) [milton-server-ce-2.7.2.0.jar:na]
            at org.dcache.webdav.DcacheStandardFilter.process(DcacheStandardFilter.java:48) [dcache-webdav-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
            at io.milton.http.FilterChain.process(FilterChain.java:40) [milton-server-ce-2.7.2.0.jar:na]
            at org.dcache.webdav.transfer.CopyFilter.process(CopyFilter.java:266) [dcache-webdav-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
            at io.milton.http.FilterChain.process(FilterChain.java:40) [milton-server-ce-2.7.2.0.jar:na]
            at io.milton.http.HttpManager.process(HttpManager.java:158) [milton-server-ce-2.7.2.0.jar:na]
            at org.dcache.webdav.MiltonHandler.handle(MiltonHandler.java:154) [dcache-webdav-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
            at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:61) [jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132) [jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.dcache.http.AuthenticationHandler.access$101(AuthenticationHandler.java:62) [dcache-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
            at org.dcache.http.AuthenticationHandler.lambda$handle$0(AuthenticationHandler.java:113) [dcache-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
            at java.security.AccessController.doPrivileged(Native Method) ~[na:1.8.0_131]
            at javax.security.auth.Subject.doAs(Subject.java:360) ~[na:1.8.0_131]
            at org.dcache.http.AuthenticationHandler.handle(AuthenticationHandler.java:111) [dcache-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
            at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:61) [jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132) [jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.dcache.webdav.LoggingHandler.handle(LoggingHandler.java:38) ~[dcache-webdav-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
            at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:61) [jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132) [jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.rewrite.handler.RewriteHandler.handle(RewriteHandler.java:335) ~[jetty-rewrite-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132) [jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.server.Server.handle(Server.java:564) ~[jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:317) ~[jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:251) ~[jetty-server-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:279) ~[jetty-io-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:110) ~[jetty-io-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:124) ~[jetty-io-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:673) ~[jetty-util-9.4.6.v20170531.jar:9.4.6.v20170531]
            at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:591) ~[jetty-util-9.4.6.v20170531.jar:9.4.6.v20170531]
            at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_131]
    Caused by: org.apache.commons.fileupload.FileUploadBase$InvalidContentTypeException: the request doesn't contain a multipart/form-data or multipart/mixed stream, content type header is %{(#nike='multipart/form-data').(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS).(#_memberAccess?(#_memberAccess=#dm):((#container=#context['com.opensymphony.xwork2.ActionContext.container']).(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class)).(#ognlUtil.getExcludedPackageNames().clear()).(#ognlUtil.getExcludedClasses().clear()).(#context.setMemberAccess(#dm)))).(#cmd='echo "Struts2045"').(#iswin=(@java.lang.System@getProperty('os.name').toLowerCase().contains('win'))).(#cmds=(#iswin?{'cmd.exe','/c',#cmd}:{'/bin/bash','-c',#cmd})).(#p=new java.lang.ProcessBuilder(#cmds)).(#p.redirectErrorStream(true)).(#process=#p.start()).(#ros=(@org.apache.struts2.ServletActionContext@getResponse().getOutputStream())).(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros)).(#ros.flush())}
            at org.apache.commons.fileupload.FileUploadBase$FileItemIteratorImpl.<init>(FileUploadBase.java:948) ~[commons-fileupload-1.3.2.jar:1.3.2]
            at org.apache.commons.fileupload.FileUploadBase.getItemIterator(FileUploadBase.java:310) ~[commons-fileupload-1.3.2.jar:1.3.2]
            at org.apache.commons.fileupload.FileUploadBase.parseRequest(FileUploadBase.java:334) ~[commons-fileupload-1.3.2.jar:1.3.2]
            at org.apache.commons.fileupload.servlet.ServletFileUpload.parseRequest(ServletFileUpload.java:115) ~[commons-fileupload-1.3.2.jar:1.3.2]
            at io.milton.servlet.ServletRequest.parseRequestParameters(ServletRequest.java:190) ~[milton-server-ce-2.7.2.0.jar:na]
            ... 32 common frames omitted

Stack-traces are considered bugs; therefore, this behaviour is undesired.

Modification:

This stack-trace logging is hard-coded in
io.milton.http.ResourceHandlerHelper#process, therefore this patch adds
a work-around by wrapping
io.milton.servlet.ServletRequest#parseRequestParameters.  Any thrown
RequestParseException is converted to a new unchecked webdav exception,
which indicates the server should respond with a 400 Bad Request.

Result:

No more stack-traces on bad client input.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10359/
Acked-by: Gerd Behrmann

Conflicts:
	modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java