### PR TITLE
fix minor tyo

### DIFF
--- a/skel/share/defaults/pnfsmanager.properties
+++ b/skel/share/defaults/pnfsmanager.properties
@@ -166,7 +166,7 @@ pnfsmanager.limits.queue-length = 0
 #
 (one-of?true|false)pnfsmanager.enable.full-path-permission-check = true
 
-#  ---- Whether to allow move to directory with different storage class and cache clss
+#  ---- Whether to allow move to directory with different storage class and cache class
 #
 #   Pool selection may be based on directory tags. A move in the chimera namespace
 #   is purely a rename operation. Therefore, a possibility of conflict exists


### PR DESCRIPTION
Fixed a minor typo in pnfsmanager.properties.

Target: master
Require-notes: no
Require-book: no

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>