### PR TITLE
FTPServerFacade: refactoring slf4j logging messages

### DIFF
--- a/modules/ftp-client/readme.md
+++ b/modules/ftp-client/readme.md
@@ -1,0 +1,3 @@
+Modul ftp-client
+
+author: Lotta Rüger

--- a/modules/ftp-client/readme.md
+++ b/modules/ftp-client/readme.md
@@ -1,3 +1,3 @@
-Modul ftp-client
+Module: ftp-client
 
 author: Lotta Rüger

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/FTPServerFacade.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/FTPServerFacade.java
@@ -214,7 +214,7 @@ public class FTPServerFacade
                     new HostPort(address, localPort);
         }
 
-        logger.debug("started passive server at port " +
+        logger.debug("started passive server at port {}",
                      session.serverAddress.getPort());
         return session.serverAddress;
 
@@ -232,7 +232,7 @@ public class FTPServerFacade
             IOException
     {
         if (logger.isDebugEnabled()) {
-            logger.debug("hostport: " + hp.getHost() + " " + hp.getPort());
+            logger.debug("hostport: {} {}", hp.getHost(), hp.getPort());
         }
         session.serverMode = Session.SERVER_ACTIVE;
         this.remoteServerAddress = hp;
@@ -272,7 +272,6 @@ public class FTPServerFacade
                                                e.toString() + "\n" +
                                                stack);
         control.write(reply);
-
     }
 
     /**
@@ -536,7 +535,7 @@ public class FTPServerFacade
                 if (aborted.flag) {
                     throw new InterruptedException();
                 }
-                logger.debug("slept " + i);
+                logger.debug("slept {}", i);
                 Thread.sleep(ioDelay);
                 i += ioDelay;
                 if (maxWait != WAIT_FOREVER


### PR DESCRIPTION
Motivation: with normal string concatenations in log-messages strings are always build, regardless if log-level is activated or not. with parameterized log-messages the strings only become build, when the log-level is activated;

Modification: using placeholder with parameterized messages instead of string concatenations

Result: gained efficiency

Signed-off-by: Lotta Rüger <s0551814@htw-berlin.de>