### PR TITLE
pool: fix loading 'setup' that requires queues created by 'pool.queues'

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/IoQueueManager.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/IoQueueManager.java
@@ -83,10 +83,24 @@ public class IoQueueManager
      */
     private final MoverRequestScheduler p2pQueue;
 
+    /**
+     * Queues, as supplied by the 'pool.queues' configuration property.
+     */
+    private String[] propertyQueues = new String[0];
+
+
     public IoQueueManager()
     {
         defaultQueue = createQueue(DEFAULT_QUEUE, Order.LIFO);
         p2pQueue = createQueue(P2P_QUEUE_NAME, Order.LIFO);
+    }
+
+    @Override
+    public CellSetupProvider mock()
+    {
+        IoQueueManager mock = new IoQueueManager();
+        mock.setQueues(propertyQueues);
+        return mock;
     }
 
     public void addFaultListener(FaultListener listener)
@@ -107,6 +121,7 @@ public class IoQueueManager
 
     public void setQueues(String[] queues)
     {
+        propertyQueues = queues.clone();
         for (String queue : queues) {
             queue = queue.trim();
             if (queue.startsWith("-")) {


### PR DESCRIPTION
Motivation:

Pre-3.0, the 'pool.queues' configuration property defines which queues
are created for this pool.  dCache v3.0 introduced a new admin command
'mover queue create' that will replace this option.  To allow for an
orderly transition, both 'pool.queues' configuration property and the
'mover queue create' command are supported.

A pre-3.0 setup file will not contain any 'mover queue create' commands,
so it relies on the 'pool.queues' configuration property to work
correctly.

When loading configuration, dCache v3.0 and later will check whether the
set of commands will succeed before enacting them.  This currently fails
as the mocked version of IoQueueManager does not include any queues
created with the 'pool.queues' configuration property.

Therefore, sites attempting to upgrade pools to 3.0 that have custom
queues will fail.

Modification:

Inject existing queues into the mock object.

Result:

Upgrading pools now succeeds.

Target: master
Request: 3.1
Request: 3.0
Require-notes: yes
Require-book: no
Closes: 3389
Acked-by: Albert Rossi
Patch: https://rb.dcache.org/r/10406/