### PR TITLE
configuration: update zookeeper configuration with hints

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -375,6 +375,20 @@ dcache.broker.scheme = satellite
 #   ZooKeeper instance, either a standalone single node instance or a
 #   redundant multi-node instance (three or five nodes are recommended for
 #   such a setup).
+#
+#   dCache does not use ZooKeeper internal permission handling / ACLs.
+#   Therefore, sites that have a dedicated ZooKeeper instance for
+#   dCache may disable ACL support (the 'skipACL' option), which the
+#   ZooKeeper documentation claims will yield some performance
+#   benefits.
+#
+#   Each dCache domain will connect to the ZooKeeper cluster; in
+#   particular, the same dCache node can run multiple domains, each of
+#   which will connect to the ZooKeeper cluster.  ZooKeeper limits the
+#   number of concurrent connections from the same IP address (see
+#   'maxClientCnxns' configuration parameter).  Sites should review
+#   this limit to ensure there is no problem.
+#
 #  -----------------------------------------------------------------------
 
 #  --- ZooKeeper connection string


### PR DESCRIPTION
configuration: update zookeeper configuration with hints

Motivation:

There are configuration options in zookeeper that may affect how well
the zookeeper cluster will work with dCache.  The lack of documentation
of how dCache uses zookeeper prevents admins from tuning their zookeeper
instance.  This could lead to sub-optimal performance or potentially
connection problems.

Modification:

Add some comments describing some aspects of how dCache uses zookeeper,
along with the corresponding zookeeper configuration properties.

Result:

Sites have more opportunity to tune their zookeeper instance to work
optimally for dCache.

Target: master
 Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Closes: 3365
Patch: https://rb.dcache.org/r/10401/
Acked-by: Tigran Mkrtchyan