### PR TITLE
cells: better handling of rogue domains with badly formatted dCache v…

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/network/LocationMgrTunnel.java
+++ b/modules/cells/src/main/java/dmg/cells/network/LocationMgrTunnel.java
@@ -49,6 +49,7 @@ import dmg.cells.nucleus.MessageEvent;
 import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.cells.nucleus.RoutedMessageEvent;
 import dmg.util.Releases;
+import dmg.util.Releases.BadVersionException;
 import dmg.util.StreamEngine;
 
 import org.dcache.util.Args;
@@ -191,6 +192,8 @@ public class LocationMgrTunnel
             _allowForwardingOfRemoteMessages = (_remoteDomainInfo.getRole() != CellDomainRole.CORE);
 
             _log.info("Established connection with {}", _remoteDomainInfo);
+        } catch (BadVersionException e) {
+            throw new IOException("Invalid information presented during handshake: " + e.getMessage(), e);
         } catch (ClassNotFoundException e) {
             throw new IOException("Cannot deserialize object. This is most likely due to a version mismatch.", e);
         }

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellDomainInfo.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellDomainInfo.java
@@ -20,6 +20,7 @@ package dmg.cells.nucleus;
 import java.io.Serializable;
 
 import dmg.util.Releases;
+import dmg.util.Releases.BadVersionException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -42,7 +43,7 @@ public class CellDomainInfo implements Serializable
         return _version;
     }
 
-    public short getRelease()
+    public short getRelease() throws BadVersionException
     {
         return _version == null ? Releases.PRE_2_6 : Releases.getRelease(_version);
     }

--- a/modules/cells/src/main/java/dmg/util/Releases.java
+++ b/modules/cells/src/main/java/dmg/util/Releases.java
@@ -31,15 +31,28 @@ public abstract class Releases
     public static final short RELEASE_2_16 = 0x0210;
     public static final short RELEASE_3_0  = 0x0300;
 
-    public static short getRelease(String version)
+    public static short getRelease(String version) throws BadVersionException
     {
         int i = version.indexOf('.');
         if (i < 0) {
-            throw new NumberFormatException("Invalid dCache version: " + version);
+            throw new BadVersionException("Invalid dCache version '" + version + "'");
         }
         int j = version.indexOf('.', i + 1);
-        return j < 0
-               ? (short) (Short.parseShort(version.substring(0, i)) << 8)
-               : (short) ((Short.parseShort( version.substring(0, i)) << 8) | Short.parseShort(version.substring(i + 1, j)));
+        try {
+            return j < 0
+                   ? (short) (Short.parseShort(version.substring(0, i)) << 8)
+                   : (short) ((Short.parseShort( version.substring(0, i)) << 8) | Short.parseShort(version.substring(i + 1, j)));
+        } catch (NumberFormatException e) {
+            throw new BadVersionException("Invalid dCache version '" + version
+                    + "': " + e.getMessage());
+        }
+    }
+
+    public static class BadVersionException extends Exception
+    {
+        public BadVersionException(String message)
+        {
+            super(message);
+        }
     }
 }


### PR DESCRIPTION
…ersions

Motivation:

Reports of stack-trace like:

    25 Jul 2017 15:08:13 (l-AAVVKQzyFMg) [130.199.148.177:45808] Bug detected in dCache; please report this to <support@dcache.org>
    java.lang.NumberFormatException: Invalid dCache version: undefined
            at dmg.util.Releases.getRelease(Releases.java:38) ~[cells-3.0.11.jar:3.0.11]
            at dmg.cells.nucleus.CellDomainInfo.getRelease(CellDomainInfo.java:47) ~[cells-3.0.11.jar:3.0.11]
            at dmg.cells.network.LocationMgrTunnel.handshake(LocationMgrTunnel.java:172) ~[cells-3.0.11.jar:3.0.11]
            at dmg.cells.network.LocationMgrTunnel.starting(LocationMgrTunnel.java:109) ~[cells-3.0.11.jar:3.0.11]
            at dmg.cells.nucleus.CellAdapter.prepareStartup(CellAdapter.java:722) ~[cells-3.0.11.jar:3.0.11]
            at dmg.cells.nucleus.CellNucleus.doStart(CellNucleus.java:918) [cells-3.0.11.jar:3.0.11]
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$5(CellNucleus.java:751) [cells-3.0.11.jar:3.0.11]
            at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:108) ~[guava-19.0.jar:na]
            at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:41) ~[guava-19.0.jar:na]
            at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:77) ~[guava-19.0.jar:na]
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) ~[dcache-common-3.0.11.jar:3.0.11]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_121]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_121]
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$4(CellNucleus.java:742) [cells-3.0.11.jar:3.0.11]
            at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_121]

Modification:

Since the problem is due (in part) to forgetting about an unchecked
exception, this patch switches NumberFormatException to a checked
exception as quickly as possible.

It also adds explicit handling of this checked exception that should
prevent dCache logging a stack-trace in this case.

Result:

One less stack-trace.

Target: master
Require-notes: yes
Require-book: no
Target: master
Request: 3.1
Request: 3.0
Request: 2.16