### PR TITLE
chimerashell: use chimera.db.* options as defaults

### DIFF
--- a/skel/share/defaults/chimerashell.properties
+++ b/skel/share/defaults/chimerashell.properties
@@ -6,27 +6,27 @@
 
 #  ---- Chimera database name
 #
-chimerashell.db.name = chimera
+chimerashell.db.name = ${chimera.db.name}
 
 #  ---- Chimera database host name
 #
 # See dcache.db.host for details.
 #
-chimerashell.db.host = ${dcache.db.host}
+chimerashell.db.host = ${chimera.db.host}
 
 #  ---- URL of db connection
 chimerashell.db.url = jdbc:postgresql://${chimerashell.db.host}/${chimerashell.db.name}?prepareThreshold=3&targetServerType=master
 #  ---- Database user name
 #
-chimerashell.db.user = ${dcache.db.user}
+chimerashell.db.user = ${chimera.db.user}
 
 #  ---- Database user password
 #
-chimerashell.db.password = ${dcache.db.password}
+chimerashell.db.password = ${chimera.db.password}
 
 # ---- Database password file
 #
-chimerashell.db.password.file = ${dcache.db.password.file}
+chimerashell.db.password.file = ${chimera.db.password.file}
 
 chimerashell.db.schema.changelog = org/dcache/chimera/changelog/changelog-master.xml
 


### PR DESCRIPTION
Motivation:

chimerashell accesses the Chimera DB.
With respect to the DB config settings, there are basically two scenarios:
The Chimera DB is on the DB server as specified by the global defaults
(dcache.db.*) or on another one and then the chimera “service” specific options
(chimera.db.*) are set accordingly.

Currently, in the later case, chimerashell will not find the right DB server, as
the dcache.db.* options are used (which may still point to the DB server, where
all non-Chimera-DBs run).

Modification:

For the chimerashell.db.* options, use their respective chimera.db.*
counterparts and no longer a static name for chimerashell.db.name.

Result:

In any case, the chimerashell should now get the right connection settings.

Target: master
Request: 3.1
Require-notes: yes

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>