### PR TITLE
acl: refactoring slf4j logging messages

### DIFF
--- a/modules/acl/src/main/java/org/dcache/acl/mapper/AclMapper.java
+++ b/modules/acl/src/main/java/org/dcache/acl/mapper/AclMapper.java
@@ -31,10 +31,12 @@ public class AclMapper {
     }
 
     public static Permission getPermission(Subject subject, Origin origin, Owner owner, ACL acl) {
+        // if ( logger.isDebugEnabled() )
         // logger.debug("Subject: {}", subject);
         // logger.debug("Origin: {}", origin);
         // logger.debug("Owner: {}", owner);
         // logger.debug("ACL: {}", acl);
+        // }
 
         Permission permACL = new Permission();
         RsType rsType = null;
@@ -65,6 +67,7 @@ public class AclMapper {
                     }
                 }
 
+                // if ( logger.isDebugEnabled() )
                 // logger.debug("Step {}) {}", ace.getOrder(), (new Permission(def_msk,
                 // allow_msk).asString(rsType)));
             }
@@ -75,9 +78,10 @@ public class AclMapper {
         } catch (ACLException e) {
             logger.error(e.getMessage());
         } finally {
-
-            logger.debug("Getted Permission: {}", (rsType == null ? permACL
+            if ( logger.isDebugEnabled() ) {
+                logger.debug("Getted Permission: {}", (rsType == null ? permACL
                         .toString() : permACL.asString(rsType)));
+            }
         }
         return permACL;
     }
@@ -93,11 +97,13 @@ public class AclMapper {
     }
 
     private static Permission getPermission(Subject subject, Origin origin, Owner owner, ACE ace, RsType rsType) throws ACLException {
+        // if ( logger.isDebugEnabled() ) {
         // logger.debug("Subject: {}", subject);
         // logger.debug("Origin: {}", origin);
         // logger.debug("Owner: {}", owner);
         // logger.debug("ACE: {}", ace.toNFSv4String(rsType));
         // logger.debug("rsType: {}", rsType);
+        // }
 
         Permission perm = null;
         // match this ace only if either recourse is not a directory or an INHERIT_ONLY_ACE bit is not set in ace.flags

--- a/modules/acl/src/main/java/org/dcache/acl/mapper/AclMapper.java
+++ b/modules/acl/src/main/java/org/dcache/acl/mapper/AclMapper.java
@@ -31,12 +31,10 @@ public class AclMapper {
     }
 
     public static Permission getPermission(Subject subject, Origin origin, Owner owner, ACL acl) {
-        // if ( logger.isDebugEnabled() ) {
-        // logger.debug("Subject: " + subject);
-        // logger.debug("Origin: " + origin);
-        // logger.debug("Owner: " + owner);
-        // logger.debug("ACL: " + acl);
-        // }
+        // logger.debug("Subject: {}", subject);
+        // logger.debug("Origin: {}", origin);
+        // logger.debug("Owner: {}", owner);
+        // logger.debug("ACL: {}", acl);
 
         Permission permACL = new Permission();
         RsType rsType = null;
@@ -67,8 +65,7 @@ public class AclMapper {
                     }
                 }
 
-                // if ( logger.isDebugEnabled() )
-                // logger.debug("Step " + ace.getOrder() + ") " + (new Permission(def_msk,
+                // logger.debug("Step {}) {}", ace.getOrder(), (new Permission(def_msk,
                 // allow_msk).asString(rsType)));
             }
 
@@ -78,10 +75,9 @@ public class AclMapper {
         } catch (ACLException e) {
             logger.error(e.getMessage());
         } finally {
-            if ( logger.isDebugEnabled() ) {
-                logger.debug("Getted Permission: " + (rsType == null ? permACL
+
+            logger.debug("Getted Permission: {}", (rsType == null ? permACL
                         .toString() : permACL.asString(rsType)));
-            }
         }
         return permACL;
     }
@@ -97,13 +93,11 @@ public class AclMapper {
     }
 
     private static Permission getPermission(Subject subject, Origin origin, Owner owner, ACE ace, RsType rsType) throws ACLException {
-        // if ( logger.isDebugEnabled() ) {
-        // logger.debug("Subject: " + subject);
-        // logger.debug("Origin: " + origin);
-        // logger.debug("Owner: " + owner);
-        // logger.debug("ACE: " + ace.toNFSv4String(rsType));
-        // logger.debug("rsType: " + rsType);
-        // }
+        // logger.debug("Subject: {}", subject);
+        // logger.debug("Origin: {}", origin);
+        // logger.debug("Owner: {}", owner);
+        // logger.debug("ACE: {}", ace.toNFSv4String(rsType));
+        // logger.debug("rsType: {}", rsType);
 
         Permission perm = null;
         // match this ace only if either recourse is not a directory or an INHERIT_ONLY_ACE bit is not set in ace.flags

--- a/modules/acl/src/main/java/org/dcache/acl/mapper/AclUnixMapper.java
+++ b/modules/acl/src/main/java/org/dcache/acl/mapper/AclUnixMapper.java
@@ -88,7 +88,7 @@ public class AclUnixMapper {
                 break;
 
             default:
-                logger.info("Unsupported who: " + who);
+                logger.info("Unsupported who: {}", who);
             }
         }
 


### PR DESCRIPTION
Motivation: with normal string concatenations in log-messages strings are always build, regardless if log-level is activated or not. with parameterized log-messages the strings only become build, when the log-level is activated;

Modification: using placeholder with parameterized messages instead of string concatenations

Result: gained efficiency

Signed-off-by: Lotta Rüger <s0551814@htw-berlin.de>

Signed-off-by: marisanest <marisanest@mailbox.org>