### PR TITLE
chimera: refactoring slf4j logging messages and logger variable name

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/DB2FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/DB2FsSqlDriver.java
@@ -32,7 +32,7 @@ import org.dcache.acl.enums.RsType;
  */
 class DB2FsSqlDriver extends FsSqlDriver {
 
-    private static final Logger _log = LoggerFactory.getLogger(DB2FsSqlDriver.class);
+    private static final Logger logger = LoggerFactory.getLogger(DB2FsSqlDriver.class);
 
     /**
      *  this is a utility class which issues SQL queries on database
@@ -41,7 +41,7 @@ class DB2FsSqlDriver extends FsSqlDriver {
     protected DB2FsSqlDriver(DataSource dataSource) throws ChimeraFsException
     {
         super(dataSource);
-        _log.info("Running DB2 specific Driver");
+        logger.info("Running DB2 specific Driver");
     }
 
     @Override

--- a/modules/chimera/src/main/java/org/dcache/chimera/DirectoryStreamHelper.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/DirectoryStreamHelper.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class DirectoryStreamHelper {
 
-    private static final Logger _log = LoggerFactory.getLogger(DirectoryStreamHelper.class);
+    private static final Logger logger = LoggerFactory.getLogger(DirectoryStreamHelper.class);
 
     /**
      * Convert directory stream into a {@link List}.

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -82,7 +82,7 @@ public class FsSqlDriver {
     /**
      * logger
      */
-    private static final Logger _log = LoggerFactory.getLogger(FsSqlDriver.class);
+    private static final Logger logger = LoggerFactory.getLogger(FsSqlDriver.class);
 
     private static final ServiceLoader<DBDriverProvider> ALL_PROVIDERS
             = ServiceLoader.load(DBDriverProvider.class);
@@ -246,7 +246,7 @@ public class FsSqlDriver {
                             inode.setParent(dir);
                             return new HimeraDirectoryEntry(rs.getString("iname"), inode, stat);
                         } catch (SQLException e) {
-                            _log.error("failed to fetch next entry: {}", e.getMessage());
+                            logger.error("failed to fetch next entry: {}", e.getMessage());
                             return null;
                         }
                     }
@@ -1674,12 +1674,12 @@ public class FsSqlDriver {
         for (DBDriverProvider driverProvider: ALL_PROVIDERS) {
             if (driverProvider.isSupportDB(dataSource)) {
                 FsSqlDriver driver = driverProvider.getDriver(dataSource);
-                _log.info("Using DBDriverProvider: {}", driver.getClass().getName());
+                logger.info("Using DBDriverProvider: {}", driver.getClass().getName());
                 return driver;
             }
         }
         // fall back to generic implementation
-        _log.warn("No sutable DBDriverProvider found. Falling back to generic.");
+        logger.warn("No sutable DBDriverProvider found. Falling back to generic.");
         return new FsSqlDriver(dataSource);
     }
 

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -84,7 +84,7 @@ public class JdbcFs implements FileSystemProvider {
     /**
      * logger
      */
-    private static final Logger _log = LoggerFactory.getLogger(JdbcFs.class);
+    private static final Logger logger = LoggerFactory.getLogger(JdbcFs.class);
     /**
      * the number of pnfs levels. Level zero associated with file real
      * content, which is not our regular case.
@@ -217,18 +217,18 @@ public class JdbcFs implements FileSystemProvider {
      * @throws TransactionException in case of a rollback error
      */
     private void rollbackOnException(TransactionStatus status, Throwable ex) throws TransactionException {
-        _log.debug("Initiating transaction rollback on application exception", ex);
+        logger.debug("Initiating transaction rollback on application exception", ex);
         try {
             _tx.rollback(status);
         } catch (TransactionSystemException e) {
-            _log.error("Application exception overridden by rollback exception", ex);
+            logger.error("Application exception overridden by rollback exception", ex);
             e.initApplicationException(ex);
             throw e;
         } catch (RuntimeException e) {
-            _log.error("Application exception overridden by rollback exception", ex);
+            logger.error("Application exception overridden by rollback exception", ex);
             throw e;
         } catch (Error err) {
-            _log.error("Application exception overridden by rollback error", ex);
+            logger.error("Application exception overridden by rollback error", ex);
             throw err;
         }
     }
@@ -1022,7 +1022,7 @@ public class JdbcFs implements FileSystemProvider {
         return inTransaction(status -> {
             try {
                 if (level == 0 && !inode.isIoEnabled()) {
-                    _log.debug("{}: IO (write) not allowed", inode);
+                    logger.debug("{}: IO (write) not allowed", inode);
                     return -1;
                 }
                 return _sqlDriver.write(inode, level, beginIndex, data, offset, len);
@@ -1039,7 +1039,7 @@ public class JdbcFs implements FileSystemProvider {
     @Override
     public int read(FsInode inode, int level, long beginIndex, byte[] data, int offset, int len) throws ChimeraFsException {
         if (level == 0 && !inode.isIoEnabled()) {
-            _log.debug("{}: IO(read) not allowed", inode);
+            logger.debug("{}: IO(read) not allowed", inode);
             return -1;
         }
         return _sqlDriver.read(inode, level, beginIndex, data, offset, len);

--- a/modules/chimera/src/main/java/org/dcache/chimera/OracleFsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/OracleFsSqlDriver.java
@@ -33,7 +33,7 @@ import org.dcache.acl.enums.RsType;
  */
 class OracleFsSqlDriver extends FsSqlDriver {
 
-    private static final Logger _log = LoggerFactory.getLogger(OracleFsSqlDriver.class);
+    private static final Logger logger = LoggerFactory.getLogger(OracleFsSqlDriver.class);
 
     /**
      *  this is a utility class which is issues SQL queries on database
@@ -42,7 +42,7 @@ class OracleFsSqlDriver extends FsSqlDriver {
     protected OracleFsSqlDriver(DataSource dataSource) throws ChimeraFsException
     {
         super(dataSource);
-        _log.info("Running Oracle specific Driver");
+        logger.info("Running Oracle specific Driver");
     }
 
     /**

--- a/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
@@ -36,7 +36,7 @@ public class PgSQL95FsSqlDriver extends PgSQLFsSqlDriver {
     /**
      * logger
      */
-    private static final Logger _log = LoggerFactory.getLogger(PgSQL95FsSqlDriver.class);
+    private static final Logger logger = LoggerFactory.getLogger(PgSQL95FsSqlDriver.class);
 
     /**
      *  this is a utility class which is issues SQL queries on database
@@ -45,7 +45,7 @@ public class PgSQL95FsSqlDriver extends PgSQLFsSqlDriver {
     public PgSQL95FsSqlDriver(DataSource dataSource) throws ChimeraFsException
     {
         super(dataSource);
-        _log.info("Running PostgreSQL >= 9.5 specific Driver");
+        logger.info("Running PostgreSQL >= 9.5 specific Driver");
     }
 
 

--- a/modules/chimera/src/main/java/org/dcache/chimera/PgSQLFsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PgSQLFsSqlDriver.java
@@ -45,7 +45,7 @@ public class PgSQLFsSqlDriver extends FsSqlDriver {
     /**
      * logger
      */
-    private static final Logger _log = LoggerFactory.getLogger(PgSQLFsSqlDriver.class);
+    private static final Logger logger = LoggerFactory.getLogger(PgSQLFsSqlDriver.class);
 
     /**
      *  this is a utility class which is issues SQL queries on database
@@ -54,7 +54,7 @@ public class PgSQLFsSqlDriver extends FsSqlDriver {
     public PgSQLFsSqlDriver(DataSource dataSource) throws ChimeraFsException
     {
         super(dataSource);
-        _log.info("Running PostgreSQL specific Driver");
+        logger.info("Running PostgreSQL specific Driver");
     }
 
     @Override

--- a/modules/chimera/src/main/java/org/dcache/chimera/posix/UnixPermissionHandler.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/posix/UnixPermissionHandler.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 public class UnixPermissionHandler implements AclHandler {
 
-    private static final Logger _log = LoggerFactory.getLogger(UnixPermissionHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(UnixPermissionHandler.class);
     private static final UnixPermissionHandler HANDLER = new UnixPermissionHandler();
 
     private UnixPermissionHandler() {
@@ -68,7 +68,7 @@ public class UnixPermissionHandler implements AclHandler {
 
 
 
-        if (_log.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             StringBuilder sb = new StringBuilder("ACL request : ");
             sb.append("user=").append(((UnixUser) user).getUID()).append(':').append(((UnixUser) user).getGID());
             sb.append(' ');
@@ -106,7 +106,7 @@ public class UnixPermissionHandler implements AclHandler {
 
             } // switch( requsetedAcl )
 
-            _log.debug(sb.toString());
+            logger.debug(sb.toString());
         }
 
         switch (userUid) {
@@ -184,7 +184,7 @@ public class UnixPermissionHandler implements AclHandler {
 
         } // switch( userUid )
 
-        _log.debug("IsAllowed: " + isAllowed);
+        logger.debug("IsAllowed: {}", isAllowed);
         return isAllowed;
     }
 }

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.*;
 
 public class BasicTest extends ChimeraTestCaseHelper {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BasicTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(BasicTest.class);
 
     @Test
     public void testLevelRemoveOnDelete() throws Exception {
@@ -328,10 +328,10 @@ public class BasicTest extends ChimeraTestCaseHelper {
                 f.get();
                 nlink++;
             } catch (ExecutionException e) {
-                LOG.warn("ExecutionException, triggered by {}", String.valueOf(e.getCause()));
+                logger.warn("ExecutionException, triggered by {}", String.valueOf(e.getCause()));
                 exceptions++;
             } catch (InterruptedException e) {
-                LOG.warn("Interrupted.");
+                logger.warn("Interrupted.");
             }
         }
 


### PR DESCRIPTION
Motivation: with normal string concatenations in log-messages strings are always build, regardless if log-level is activated or not. with parameterized log-messages the strings only become build, when the log-level is activated. With a consistent variable name for the logger the application gets more standardized.

Modification: using placeholder with parameterized messages instead of string concatenations. Naming all logger variables "logger".

Result: gained efficiency and standardization

Signed-off-by: marisanest <marisanest@mailbox.org>