### PR TITLE
common-security: refactoring slf4j logging messages and logger variable name

### DIFF
--- a/modules/common-security/src/main/java/javatunnel/DssSocket.java
+++ b/modules/common-security/src/main/java/javatunnel/DssSocket.java
@@ -44,7 +44,7 @@ import java.net.UnknownHostException;
 
 public class DssSocket extends Socket implements TunnelSocket
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DssSocket.class);
+    private static final Logger logger = LoggerFactory.getLogger(DssSocket.class);
 
     private DssContext context;
     private final DssContextFactory factory;
@@ -209,7 +209,7 @@ public class DssSocket extends Socket implements TunnelSocket
             acceptSecurityContext();
             return true;
         } catch (IOException e) {
-            LOGGER.error("Failed to verify: {}", e.toString());
+            logger.error("Failed to verify: {}", e.toString());
             return false;
         }
     }

--- a/modules/common-security/src/main/java/org/dcache/gsi/KeyPairCache.java
+++ b/modules/common-security/src/main/java/org/dcache/gsi/KeyPairCache.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class KeyPairCache
 {
-    private static final Logger LOG = LoggerFactory.getLogger(KeyPairCache.class);
+    private static final Logger logger = LoggerFactory.getLogger(KeyPairCache.class);
 
     private static final String DEFAULT_ALGORITHM = "RSA";
     private static final String DEFAULT_PROVIDER = "BC";
@@ -137,7 +137,7 @@ public class KeyPairCache
     private KeyPair generate(int bits) throws NoSuchAlgorithmException,
             NoSuchProviderException
     {
-        LOG.debug("Generating KeyPair for {} bits", bits);
+        logger.debug("Generating KeyPair for {} bits", bits);
 
         KeyPairGenerator generator =
             KeyPairGenerator.getInstance(this.algorithm, this.provider);

--- a/modules/common-security/src/main/java/org/dcache/gsi/ServerGsiEngine.java
+++ b/modules/common-security/src/main/java/org/dcache/gsi/ServerGsiEngine.java
@@ -54,7 +54,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  */
 public class ServerGsiEngine extends InterceptingSSLEngine
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ServerGsiEngine.class);
+    private static final Logger logger = LoggerFactory.getLogger(ServerGsiEngine.class);
 
     public static final String X509_CREDENTIAL = "org.dcache.credential";
 
@@ -180,7 +180,7 @@ public class ServerGsiEngine extends InterceptingSSLEngine
         try (InputStream in = source.openStream()) {
             certificate = (X509Certificate) cf.generateCertificate(in);
         }
-        LOGGER.trace("Received delegated cert: {}", certificate);
+        logger.trace("Received delegated cert: {}", certificate);
 
         /* Verify that it matches our certificate request.
          */

--- a/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
@@ -64,7 +64,7 @@ import static org.dcache.util.Callables.memoizeWithExpiration;
  */
 public class CanlContextFactory implements SslContextFactory
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CanlContextFactory.class);
+    private static final Logger logger = LoggerFactory.getLogger(CanlContextFactory.class);
 
     private static final EnumSet<ValidationErrorCategory> VALIDATION_ERRORS_TO_LOG =
             EnumSet.of(NAMESPACE, X509_BASIC, X509_CHAIN, NAME_CONSTRAINT, CRL, OCSP);
@@ -241,20 +241,20 @@ public class CanlContextFactory implements SslContextFactory
                         switch (level) {
                         case ERROR:
                             if (cause != null) {
-                                LOGGER.error("Error loading {} from {}: {}", type, location, cause.getMessage());
+                                logger.error("Error loading {} from {}: {}", type, location, cause.getMessage());
                             } else {
-                                LOGGER.error("Error loading {} from {}.", type, location);
+                                logger.error("Error loading {} from {}.", type, location);
                             }
                             break;
                         case WARNING:
                             if (cause != null) {
-                                LOGGER.warn("Problem loading {} from {}: {}", type, location, cause.getMessage());
+                                logger.warn("Problem loading {} from {}: {}", type, location, cause.getMessage());
                             } else {
-                                LOGGER.warn("Problem loading {} from {}.", type, location);
+                                logger.warn("Problem loading {} from {}.", type, location);
                             }
                             break;
                         case NOTIFICATION:
-                            LOGGER.debug("Reloaded {} from {}.", type, location);
+                            logger.debug("Reloaded {} from {}.", type, location);
                             break;
                         }
                     } catch (Exception e) {
@@ -270,7 +270,7 @@ public class CanlContextFactory implements SslContextFactory
                     if (VALIDATION_ERRORS_TO_LOG.contains(error.getErrorCategory())) {
                         X509Certificate[] chain = error.getChain();
                         String subject = (chain != null && chain.length > 0) ? chain[0].getSubjectX500Principal().getName() : "";
-                        LOGGER.warn("The peer's certificate with DN {} was rejected: {}", subject, error);
+                        logger.warn("The peer's certificate with DN {} was rejected: {}", subject, error);
                     }
                     return false;
                 }

--- a/modules/common-security/src/main/java/org/dcache/ssl/CanlSslServerSocketCreator.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/CanlSslServerSocketCreator.java
@@ -31,7 +31,7 @@ import static java.util.Arrays.asList;
 
 public class CanlSslServerSocketCreator extends ServerSocketFactory
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CanlSslServerSocketCreator.class);
+    private static final Logger logger = LoggerFactory.getLogger(CanlSslServerSocketCreator.class);
 
     private static final String SERVICE_KEY = "service_key";
     private static final String SERVICE_CERT = "service_cert";
@@ -67,9 +67,9 @@ public class CanlSslServerSocketCreator extends ServerSocketFactory
                                       OCSPCheckingMode ocspMode) throws IOException
     {
         try {
-            LOGGER.info("service_key {}", keyPath);
-            LOGGER.info("service_certs {}", certPath);
-            LOGGER.info("service_trusted_certs {}", caPath);
+            logger.info("service_key {}", keyPath);
+            logger.info("service_certs {}", certPath);
+            logger.info("service_trusted_certs {}", caPath);
 
             this.bannedCiphers = ImmutableSet.copyOf(bannedCiphers);
 

--- a/modules/common-security/src/main/java/org/dcache/ssl/CanlSslSocketCreator.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/CanlSslSocketCreator.java
@@ -30,7 +30,7 @@ import static com.google.common.collect.Iterables.toArray;
 import static java.util.Arrays.asList;
 
 public class CanlSslSocketCreator extends SocketFactory {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CanlSslSocketCreator.class);
+    private static final Logger logger = LoggerFactory.getLogger(CanlSslSocketCreator.class);
 
     private static final String SERVICE_KEY = "service_key";
     private static final String SERVICE_CERT = "service_cert";
@@ -66,9 +66,9 @@ public class CanlSslSocketCreator extends SocketFactory {
                                 OCSPCheckingMode ocspMode) throws IOException
     {
         try {
-            LOGGER.info("service_key {}", keyPath);
-            LOGGER.info("service_certs {}", certPath);
-            LOGGER.info("service_trusted_certs {}", caPath);
+            logger.info("service_key {}", keyPath);
+            logger.info("service_certs {}", certPath);
+            logger.info("service_trusted_certs {}", caPath);
 
             this.bannedCiphers = ImmutableSet.copyOf(bannedCiphers);
 


### PR DESCRIPTION
Motivation: with normal string concatenations in log-messages strings are always build, regardless if log-level is activated or not. with parameterized log-messages the strings only become build, when the log-level is activated. With a consistent variable name for the logger the application gets more standardized.

Modification: using placeholder with parameterized messages instead of string concatenations. Naming all logger variables "logger".

Result: gained efficiency and standardization

Signed-off-by: marisanest <marisanest@mailbox.org>