### PR TITLE
dcache-common: refactoring slf4j logging messages and logger variable name

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/OpenIdCredentialRefreshable.java
+++ b/modules/common/src/main/java/org/dcache/auth/OpenIdCredentialRefreshable.java
@@ -26,7 +26,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class OpenIdCredentialRefreshable extends WrappingOpenIdCredential
 {
-    private static final Logger LOG =
+    private static final Logger logger =
             LoggerFactory.getLogger(OpenIdCredentialRefreshable.class);
     private final HttpClient client;
 
@@ -42,7 +42,7 @@ public class OpenIdCredentialRefreshable extends WrappingOpenIdCredential
             try {
                 refreshOpenIdCredentials();
             } catch (IOException | AuthenticationException e) {
-                LOG.warn("Error Refreshing OpenId Bearer Token with {}: {}",
+                logger.warn("Error Refreshing OpenId Bearer Token with {}: {}",
                         credential.getOpenidProvider(), e.getMessage());
             }
         }

--- a/modules/common/src/main/java/org/dcache/auth/StaticOpenIdCredential.java
+++ b/modules/common/src/main/java/org/dcache/auth/StaticOpenIdCredential.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 public class StaticOpenIdCredential implements OpenIdCredential, Serializable
 {
     private static final long serialVersionUID = 1L;
-    private static final Logger LOG =
+    private static final Logger logger =
             LoggerFactory.getLogger(StaticOpenIdCredential.class);
 
     private final String accessToken;

--- a/modules/common/src/main/java/org/dcache/commons/stats/RequestExecutionTimeGaugeImpl.java
+++ b/modules/common/src/main/java/org/dcache/commons/stats/RequestExecutionTimeGaugeImpl.java
@@ -21,7 +21,7 @@ import org.dcache.util.TimeUtils;
  */
 public class RequestExecutionTimeGaugeImpl implements RequestExecutionTimeGaugeMXBean {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RequestExecutionTimeGaugeImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(RequestExecutionTimeGaugeImpl.class);
 
     private final String name;
 
@@ -48,11 +48,11 @@ public class RequestExecutionTimeGaugeImpl implements RequestExecutionTimeGaugeM
                 server.registerMBean(this, mxBeanName);
             }
         } catch (MalformedObjectNameException ex) {
-            LOG.warn("Failed to create a MXBean with name: {} : {}" , mxName, ex.toString());
+            logger.warn("Failed to create a MXBean with name: {} : {}" , mxName, ex.toString());
         } catch (InstanceAlreadyExistsException | MBeanRegistrationException ex) {
-            LOG.warn("Failed to register a MXBean: {}", ex.toString());
+            logger.warn("Failed to register a MXBean: {}", ex.toString());
         } catch (NotCompliantMBeanException ex) {
-            LOG.warn("Failed to create a MXBean: {}", ex.toString());
+            logger.warn("Failed to create a MXBean: {}", ex.toString());
         }
         startTime = System.currentTimeMillis();
     }
@@ -65,7 +65,7 @@ public class RequestExecutionTimeGaugeImpl implements RequestExecutionTimeGaugeM
     public synchronized void update(long nextExecTime) {
 
         if (nextExecTime < 0) {
-            LOG.info("possible backwards time shift detected; discarding invalid data ({})", nextExecTime);
+            logger.info("possible backwards time shift detected; discarding invalid data ({})", nextExecTime);
             return;
         }
 

--- a/modules/common/src/main/java/org/dcache/commons/stats/rrd/RRDRequestCounter.java
+++ b/modules/common/src/main/java/org/dcache/commons/stats/rrd/RRDRequestCounter.java
@@ -97,7 +97,7 @@ public class RRDRequestCounter {
             throw new IllegalArgumentException("updatePeriodSecs="+updatePeriodSecs+
                     ", should be greater than 0 and less than "+fivemin+" secs");
         }
-        logger.debug("RRDRequestCounter(" + rrdDirectory + ", " + counter + ',' + updatePeriodSecs + ')');
+        logger.debug("RRDRequestCounter({}, {}, {})",rrdDirectory , counter, updatePeriodSecs);
         File dir = new File(rrdDirectory);
         if(!dir.exists() || !dir.isDirectory() || !dir.canWrite() ) {
             throw new AccessControlException("directory "+
@@ -185,7 +185,7 @@ public class RRDRequestCounter {
      */
     public void update() throws IOException {
 
-        logger.debug("RRDRequestCounter.update() rrdFileName is "+rrdFileName);
+        logger.debug("RRDRequestCounter.update() rrdFileName is {}", rrdFileName);
         RrdDb rrdDb = new RrdDb(rrdFileName);
         Sample sample = rrdDb.createSample();
         long currentTimeSecs =   Util.getTime();
@@ -194,7 +194,7 @@ public class RRDRequestCounter {
         sb.append(counter.getTotalRequests()).append(':');
         sb.append(counter.getFailed());
         sample.setAndUpdate(sb.toString());
-        logger.debug("RRDRequestCounter.update() updated with : " + sb);
+        logger.debug("RRDRequestCounter.update() updated with : {}", sb);
         rrdDb.close();
         logger.debug("RRDRequestCounter.update() succeeded");
         logger.debug("RRDRequestCounter.update() let us try to fetch data");
@@ -204,7 +204,7 @@ public class RRDRequestCounter {
         }
         FetchRequest fetchRequest = rrdDb.createFetchRequest(ConsolFun.AVERAGE, dumpstart, currentTimeSecs+1);
         FetchData fetchData = fetchRequest.fetchData();
-        logger.debug("RRDRequestCounter.update() dump is: "+fetchData.dump());
+        logger.debug("RRDRequestCounter.update() dump is: {}", fetchData.dump());
         rrdDb.close();
     }
 
@@ -248,7 +248,7 @@ public class RRDRequestCounter {
         RrdGraph graph = new RrdGraph(graphDef);
         BufferedImage bi = new BufferedImage(imageWidth,imageHeight,BufferedImage.TYPE_INT_RGB);
         graph.render(bi.getGraphics());
-        logger.debug("RRDRequestCounter.graph() wrote "+rrdHourlyImage);
+        logger.debug("RRDRequestCounter.graph() wrote {}", rrdHourlyImage);
 
 
         graphDef.setTimeSpan(currentTime-hour, currentTime);
@@ -256,7 +256,7 @@ public class RRDRequestCounter {
         graph = new RrdGraph(graphDef);
         bi = new BufferedImage(imageWidth,imageHeight,BufferedImage.TYPE_INT_RGB);
         graph.render(bi.getGraphics());
-        logger.debug("RRDRequestCounter.graph() wrote "+rrdHourlyImage);
+        logger.debug("RRDRequestCounter.graph() wrote {}", rrdHourlyImage);
 
         //day
         //graphDef.setStartTime(-day);

--- a/modules/common/src/main/java/org/dcache/commons/stats/rrd/RRDRequestExecutionTimeGauge.java
+++ b/modules/common/src/main/java/org/dcache/commons/stats/rrd/RRDRequestExecutionTimeGauge.java
@@ -96,7 +96,7 @@ public class RRDRequestExecutionTimeGauge {
             throw new IllegalArgumentException("updatePeriodSecs="+updatePeriodSecs+
                     ", should be greater than 0 and less than "+FIVEMIN+" secs");
         }
-        logger.debug("RRDRequestExecutionTimeGauge(" + rrdDirectory + ", " + gauge + ',' + updatePeriodSecs + ')');
+        logger.debug("RRDRequestExecutionTimeGauge({}, {}, {})", rrdDirectory, gauge, updatePeriodSecs);
         if(!rrdDirectory.exists() || !rrdDirectory.isDirectory() || !rrdDirectory.canWrite() ) {
             throw new AccessControlException("directory "+
                     rrdDirectory + " does not exists or is not accessable");
@@ -181,7 +181,7 @@ public class RRDRequestExecutionTimeGauge {
      */
     public void update() throws IOException {
 
-        logger.debug("RRDRequestExecutionTimeGauge.update() rrdFileName is "+rrdFileName);
+        logger.debug("RRDRequestExecutionTimeGauge.update() rrdFileName is {}", rrdFileName);
         RrdDb rrdDb = new RrdDb(rrdFileName);
         try {
             Sample sample = rrdDb.createSample();
@@ -189,7 +189,7 @@ public class RRDRequestExecutionTimeGauge {
             String update = Long.toString(currentTimeSecs) +':'+
                             (long) gauge.resetAndGetAverageExecutionTime()+':';
             sample.setAndUpdate(update);
-            logger.debug("RRDRequestExecutionTimeGauge.update() updated with : "+update);
+            logger.debug("RRDRequestExecutionTimeGauge.update() updated with : {}", update);
 
         } finally {
             rrdDb.close();
@@ -206,7 +206,7 @@ public class RRDRequestExecutionTimeGauge {
         RrdGraph graph = new RrdGraph(graphDef);
         BufferedImage bi = new BufferedImage(imageWidth,imageHeight,BufferedImage.TYPE_INT_RGB);
         graph.render(bi.getGraphics());
-        logger.debug("RRDRequestExecutionTimeGauge.graph() wrote "+filename);
+        logger.debug("RRDRequestExecutionTimeGauge.graph() wrote {}", filename);
     }
 
     /**

--- a/modules/common/src/main/java/org/dcache/commons/stats/rrd/RrdRequestCounters.java
+++ b/modules/common/src/main/java/org/dcache/commons/stats/rrd/RrdRequestCounters.java
@@ -70,7 +70,7 @@ public class RrdRequestCounters<T> {
     public RrdRequestCounters(RequestCounters<T> requestCounters,
             String rrdDir,long updatePeriodSecs,
             long graphPeriodSecs) throws IOException {
-        logger.debug("RrdRequestCounters("+requestCounters+", "+rrdDir);
+        logger.debug("RrdRequestCounters({}, {}", requestCounters, rrdDir);
         this.requestCounters = requestCounters;
         this.rrdDir = rrdDir;
         File dir = new File(rrdDir);
@@ -116,13 +116,13 @@ public class RrdRequestCounters<T> {
 
     private void updateRrds() throws IOException {
         boolean countersAdded = false;
-        logger.debug("updateRrds() for "+requestCounters);
+        logger.debug("updateRrds() for {}", requestCounters);
         synchronized (requestCounters) {
             for(T key:requestCounters.keySet()) {
-                logger.debug("updatePrds(): key is "+key);
+                logger.debug("updatePrds(): key is {}", key);
                 if(!rrdcounters.containsKey(key)) {
                     RequestCounter requestCounter = requestCounters.getCounter(key);
-                    logger.debug("updatePrds(): creating RRDRequestCounter for "+requestCounter);
+                    logger.debug("updatePrds(): creating RRDRequestCounter for {}", requestCounter);
                     RRDRequestCounter rrdRequestCounter =
                             new RRDRequestCounter(rrdDir,requestCounter,updatePeriodSecs);
                     rrdcounters.put(key, rrdRequestCounter);

--- a/modules/common/src/main/java/org/dcache/commons/stats/rrd/RrdRequestExecutionTimeGauges.java
+++ b/modules/common/src/main/java/org/dcache/commons/stats/rrd/RrdRequestExecutionTimeGauges.java
@@ -67,7 +67,7 @@ public class RrdRequestExecutionTimeGauges<T> {
     public RrdRequestExecutionTimeGauges(RequestExecutionTimeGauges<T> requestGauges,
             File rrdDir,long updatePeriodSecs,
             long graphPeriodSecs) throws IOException {
-        logger.debug("RrdRequestGauges("+requestGauges+", "+rrdDir);
+        logger.debug("RrdRequestGauges({}, {}", requestGauges, rrdDir);
         this.gauges = requestGauges;
         this.rrdDir = rrdDir;
         if(!rrdDir.exists()) {
@@ -108,13 +108,13 @@ public class RrdRequestExecutionTimeGauges<T> {
 
     private void updateRrds() throws IOException {
         boolean gaugesAdded = false;
-        logger.debug("updateRrds() for "+gauges);
+        logger.debug("updateRrds() for {}", gauges);
         synchronized (gauges) {
             for(T key:gauges.keySet()) {
-                logger.debug("updatePrds(): key is "+key);
+                logger.debug("updatePrds(): key is {}", key);
                 if(!rrdgauges.containsKey(key)) {
                     RequestExecutionTimeGauge requestGauges = gauges.getGauge(key);
-                    logger.debug("updatePrds(): creating RRDRequestExecutionTimeGauge for "+requestGauges);
+                    logger.debug("updatePrds(): creating RRDRequestExecutionTimeGauge for {}", requestGauges);
                     RRDRequestExecutionTimeGauge rrdRequestGauges =
                             new RRDRequestExecutionTimeGauge(rrdDir,requestGauges,updatePeriodSecs);
                     rrdgauges.put(key, rrdRequestGauges);

--- a/modules/common/src/main/java/org/dcache/util/OptionParser.java
+++ b/modules/common/src/main/java/org/dcache/util/OptionParser.java
@@ -11,7 +11,7 @@ import java.math.BigInteger;
 
 public class OptionParser
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OptionParser.class);
+    private static final Logger logger = LoggerFactory.getLogger(OptionParser.class);
     private final Args args;
 
     public OptionParser(Args args)
@@ -270,9 +270,9 @@ public class OptionParser
                                 description = option.name();
                             }
                             if (!unit.isEmpty()) {
-                                LOGGER.info("{} set to {} {}", description, value, unit);
+                                logger.info("{} set to {} {}", description, value, unit);
                             } else {
-                                LOGGER.info("{} set to {}", description, value);
+                                logger.info("{} set to {}", description, value);
                             }
                         }
                     }

--- a/modules/common/src/main/java/org/dcache/util/SqlHelper.java
+++ b/modules/common/src/main/java/org/dcache/util/SqlHelper.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 public class SqlHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SqlHelper.class);
+    private static final Logger logger = LoggerFactory.getLogger(SqlHelper.class);
 
     private SqlHelper() {
         // no instance allowed
@@ -28,7 +28,7 @@ public class SqlHelper {
                 o.close();
             }
         } catch (SQLException e) {
-            LOGGER.error("failed to close prepared statement: {}", e.getMessage());
+            logger.error("failed to close prepared statement: {}", e.getMessage());
         }
     }
 
@@ -43,7 +43,7 @@ public class SqlHelper {
                 o.close();
             }
         } catch (SQLException e) {
-            LOGGER.error("failed to close result statement: {}", e.getMessage());
+            logger.error("failed to close result statement: {}", e.getMessage());
         }
     }
 
@@ -58,7 +58,7 @@ public class SqlHelper {
                 o.close();
             }
         } catch (SQLException e) {
-            LOGGER.error("failed to close result set: {}", e.getMessage());
+            logger.error("failed to close result set: {}", e.getMessage());
         }
     }
 
@@ -73,7 +73,7 @@ public class SqlHelper {
                 o.close();
             }
         } catch (SQLException e) {
-            LOGGER.error("failed to close connection: {}", e.getMessage());
+            logger.error("failed to close connection: {}", e.getMessage());
         }
     }
 
@@ -81,7 +81,7 @@ public class SqlHelper {
         try {
             o.rollback();
         } catch (SQLException e) {
-            LOGGER.error("failed to rollback transaction: {}", e.getMessage());
+            logger.error("failed to rollback transaction: {}", e.getMessage());
         }
     }
 }

--- a/modules/common/src/main/java/org/dcache/util/Strings.java
+++ b/modules/common/src/main/java/org/dcache/util/Strings.java
@@ -24,7 +24,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  */
 public final class Strings {
 
-    private static final Logger LOGGER =
+    private static final Logger logger =
         LoggerFactory.getLogger( Strings.class);
 
     private static final String ANSI_ESCAPE = "\u001b[";
@@ -48,7 +48,7 @@ public final class Strings {
      * zero length array of strings if the argument string is null
      */
     public static String[] splitArgumentString(String argumentString) {
-        LOGGER.debug("splitting argument string {}",argumentString);
+        logger.debug("splitting argument string {}",argumentString);
         if(argumentString == null) {
             return ZERO_LENGTH_STRING_ARRAY;
         }
@@ -67,17 +67,17 @@ public final class Strings {
          if (regexMatcher.group(1) != null) {
                 // Add double-quoted string without the quotes
                 String groupMatch=  regexMatcher.group(1);
-                LOGGER.debug("first group matched [{}]",groupMatch);
+                logger.debug("first group matched [{}]",groupMatch);
                 matchList.add(groupMatch);
             } else if (regexMatcher.group(2) != null) {
                 // Add single-quoted string without the quotes
                 String groupMatch=  regexMatcher.group(2);
-                LOGGER.debug("second group matched [{}]",groupMatch);
+                logger.debug("second group matched [{}]",groupMatch);
                 matchList.add(groupMatch);
             } else if (regexMatcher.group(3) != null) {
                 //everything else
                 String groupMatch=  regexMatcher.group(3);
-                LOGGER.debug("third group matched [{}]",groupMatch);
+                logger.debug("third group matched [{}]",groupMatch);
                 matchList.add(groupMatch);
             }
         }

--- a/modules/common/src/test/java/org/dcache/util/histograms/HistogramModelTest.java
+++ b/modules/common/src/test/java/org/dcache/util/histograms/HistogramModelTest.java
@@ -69,7 +69,7 @@ import java.util.Random;
 import static junit.framework.TestCase.assertNull;
 
 abstract class HistogramModelTest {
-    protected static final Logger LOGGER = LoggerFactory.getLogger(
+    protected static final Logger logger = LoggerFactory.getLogger(
                     HistogramModelTest.class);
     protected static final Random RANDOM = new Random(
                     System.currentTimeMillis());
@@ -82,10 +82,10 @@ abstract class HistogramModelTest {
     @After
     public void printDiagnostics() {
         if (model != null) {
-            LOGGER.info(new GsonBuilder().setPrettyPrinting()
+            logger.info(new GsonBuilder().setPrettyPrinting()
                                          .disableHtmlEscaping()
                                          .create().toJson(model));
-            LOGGER.info(new GsonBuilder().setPrettyPrinting()
+            logger.info(new GsonBuilder().setPrettyPrinting()
                                          .disableHtmlEscaping()
                                          .create().toJson(model.toHistogram()));
         }


### PR DESCRIPTION
Motivation: with normal string concatenations in log-messages strings are always build, regardless if log-level is activated or not. with parameterized log-messages the strings only become build, when the log-level is activated. With a consistent variable name for the logger the application gets more standardized.

Modification: using placeholder with parameterized messages instead of string concatenations. Naming all logger variables "logger".

Result: gained efficiency and standardization

Signed-off-by: marisanest <marisanest@mailbox.org>