### PR TITLE
Task8

### DIFF
--- a/modules/chimera/README
+++ b/modules/chimera/README
@@ -1,0 +1,3 @@
+Name : Vuong
+Modul : Chimera
+

--- a/modules/chimera/README
+++ b/modules/chimera/README
@@ -1,3 +1,4 @@
 Name : Vuong
 Modul : Chimera
+LOL
 


### PR DESCRIPTION
Motivation: Prior to Java 1.5 enums did not exist, thus integer constants were used. These constants can now be replaced by enums.
    
Modification: diskCacheV111/poolManager/RequestContainerV5  return code constants were replaced by an enum called RequestStatusCode
for instance :    RT_OK  to  RequestStatusCode.OK
    
Result: slightly higher memory consumption for the benefits of type safety and more maintainable code
    
Signed-off-by: Vuong Luu Minh s0548844@htw-berlin.de
