### PR TITLE
ssh: add logging to domain access log file

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -4,7 +4,10 @@ import org.apache.sshd.common.Factory;
 import org.apache.sshd.common.FactoryManager;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.PropertyResolverUtils;
+import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.keyprovider.AbstractFileKeyPairProvider;
+import org.apache.sshd.common.session.Session;
+import org.apache.sshd.common.session.SessionListener;
 import org.apache.sshd.common.util.SecurityUtils;
 import org.apache.sshd.server.Command;
 import org.apache.sshd.server.SshServer;
@@ -43,6 +46,7 @@ import org.dcache.auth.Origin;
 import org.dcache.auth.PasswordCredential;
 import org.dcache.auth.Subjects;
 import org.dcache.util.Files;
+import org.dcache.util.NetLoggerBuilder;
 
 import static java.util.stream.Collectors.toList;
 
@@ -57,6 +61,8 @@ import static java.util.stream.Collectors.toList;
 public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
 {
     private static final Logger _log = LoggerFactory.getLogger(Ssh2Admin.class);
+    private static final Logger _accessLog =
+            LoggerFactory.getLogger("org.dcache.access.ssh2");
     private final SshServer _server;
     // UniversalSpringCell injected parameters
     private List<File> _hostKeys;
@@ -184,6 +190,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
 
         _server.setPort(_port);
         _server.setHost(_host);
+        _server.addSessionListener(new AdminConnectionLogger());
 
         try {
             _server.start();
@@ -201,11 +208,42 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
         }
     }
 
+    private void logLoginTry(String username, ServerSession session,
+                             String method, boolean successful, String reason)
+    {
+        NetLoggerBuilder.Level logLevel = NetLoggerBuilder.Level.INFO;
+        if(!successful) {
+            logLevel = NetLoggerBuilder.Level.WARN;
+        }
+
+        new NetLoggerBuilder(logLevel, "org.dcache.services.ssh2.login")
+                .omitNullValues()
+                .add("username", username)
+                .add("remote.socket", session.getClientAddress())
+                .add("method", method)
+                .add("successful", successful)
+                .add("reason", reason)
+                .toLogger(_accessLog);
+
+        // set session parameter
+        if(successful) {
+            try {
+                session.setAuthenticated();
+                session.setUsername(username);
+            } catch (IOException e) {
+                _log.error("Failed to set Authenticated: {}",
+                        e.getMessage());
+            }
+        }
+    }
+
     private class AdminPasswordAuthenticator implements PasswordAuthenticator {
 
         @Override
         public boolean authenticate(String userName, String password,
                 ServerSession session) {
+            boolean successful = false;
+            String reason = null;
             Subject subject = new Subject();
             addOrigin(session, subject);
             subject.getPrivateCredentials().add(new PasswordCredential(userName,
@@ -216,16 +254,20 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
 
                 Subject authenticatedSubject = reply.getSubject();
                 if (!Subjects.hasGid(authenticatedSubject, _adminGroupId)) {
-                    throw new PermissionDeniedCacheException("not member of admin gid");
+                    reason = "not member of admin gid";
+                    throw new PermissionDeniedCacheException(reason);
                 }
 
-                return true;
+                successful = true;
             } catch (PermissionDeniedCacheException e) {
                 _log.warn("Login for {} denied: {}", userName, e.getMessage());
             } catch (CacheException e) {
+                reason = e.toString();
                 _log.warn("Login for {} failed: {}", userName, e.toString());
             }
-            return false;
+
+            logLoginTry(userName, session, "Password", successful, reason);
+            return successful;
         }
     }
 
@@ -244,11 +286,13 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
         @Override
         public boolean authenticate(String userName, PublicKey key,
                 ServerSession session) {
+            boolean successful = false;
             _log.debug("Authentication username set to: {} publicKey: {}",
                     userName, key);
             try {
                 try(Stream<String> fileStream = java.nio.file.Files.lines(_authorizedKeyList.toPath())) {
-                    return fileStream
+                    successful =
+                        fileStream
                         .filter(l -> !l.isEmpty() && !l.matches(" *#.*"))
                         .map(this::toPublicKey)
                         .filter(k -> k != null)
@@ -262,7 +306,38 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
                 _log.error("Failed to read {}: {}", _authorizedKeyList,
                         e.getMessage());
             }
-            return false;
+
+            // the method gets called twice while pubkey authentication,
+            // to avoid duplicate logging, check if already authenticated
+            if(!session.isAuthenticated()) {
+                String method = "PublicKey (" + key.getAlgorithm() + " "
+                        + KeyUtils.getFingerPrint(key) + ")";
+                logLoginTry(userName, session, method, successful, null);
+            }
+            return successful;
         }
     }
+
+    private class AdminConnectionLogger implements SessionListener {
+
+        @Override
+        public void sessionCreated(Session session) {
+            logEvent("org.dcache.services.ssh2.connect", session);
+        }
+
+        @Override
+        public void sessionClosed(Session session) {
+            logEvent("org.dcache.services.ssh2.disconnect", session);
+        }
+
+        private void logEvent(String name, Session session) {
+            new NetLoggerBuilder(NetLoggerBuilder.Level.INFO, name)
+                    .omitNullValues()
+                    .add("username", session.getUsername())
+                    .add("remote.socket", session.getIoSession()
+                            .getRemoteAddress())
+                    .toLogger(_accessLog);
+        }
+    }
+
 }

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -212,7 +212,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
                              String method, boolean successful, String reason)
     {
         NetLoggerBuilder.Level logLevel = NetLoggerBuilder.Level.INFO;
-        if(!successful) {
+        if (!successful) {
             logLevel = NetLoggerBuilder.Level.WARN;
         }
 
@@ -226,7 +226,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
                 .toLogger(_accessLog);
 
         // set session parameter
-        if(successful) {
+        if (successful) {
             try {
                 session.setAuthenticated();
                 session.setUsername(username);
@@ -309,7 +309,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
 
             // the method gets called twice while pubkey authentication,
             // to avoid duplicate logging, check if already authenticated
-            if(!session.isAuthenticated()) {
+            if (!session.isAuthenticated()) {
                 String method = "PublicKey (" + key.getAlgorithm() + " "
                         + KeyUtils.getFingerPrint(key) + ")";
                 logLoginTry(userName, session, method, successful, null);


### PR DESCRIPTION
Motivation:

In scope of a semester project at HTW Berlin, the task was to log
ssh connection events to the domain access log file.

Modification:

Changed Ssh2Admin, added logging to AdminPasswordAuthenticator and
AdminPublickeyAuthenticator using NetLogger in scope org.dcache.access.ssh2.
Additionally set username (for display in disconnect log) and
authentication status (to avoid duplicate log events for PublicKey),
after successful authentication to session parameter.
Created the listener AdminConnectionLogger to log connect/disconnect.

Result:

Log events in <domainname>.access file:
Connect:
  level=INFO ts=2017-08-07T21:02:32.676+0200 event=org.dcache.services.ssh2.connect
  remote.socket=/127.0.0.1:46076

Password Auth:
  level=INFO ts=2017-08-07T21:02:36.711+0200 event=org.dcache.services.ssh2.login
  username=admin remote.socket=/127.0.0.1:46076 method=Password successful=true

Public Key Auth:
  level=INFO ts=2017-08-07T21:03:37.429+0200 event=org.dcache.services.ssh2.login
  username=local remote.socket=/127.0.0.1:46080
  method="PublicKey (RSA SHA256:ZWZyJkH57W176Tja84pZYGU8y1T/01WtBB7YfbcayDk)"
  successful=true

Auth failed:
  level=WARN ts=2017-08-07T21:07:27.952+0200 event=org.dcache.services.ssh2.login
  username=local remote.socket=/127.0.0.1:46082 method=Password successful=false
  reason="not member of admin gid"

Disconnect:
  level=INFO ts=2017-08-07T21:02:39.964+0200 event=org.dcache.services.ssh2.disconnect
  username=admin remote.socket=/127.0.0.1:46076

Target: master
Require-notes: yes
Require-book: yes

Signed-off-by: Stefan Moll <stefan@stefaus.de>