### PR TITLE
core: Add Remote-Host-Restriction capability to Ssh2Admin PublicKeyAu…

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -364,7 +364,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
                 } catch (IllegalArgumentException e) {
                     String remoteName = ((InetSocketAddress) remote).getHostName();
                     if (Glob.isGlob(pattern)) {
-                        Pattern p = convertPatternToRegex(pattern);
+                        Pattern p = Glob.parseGlobToPattern(pattern);
                         Matcher addressMatcher = p.matcher(remoteAddress);
                         Matcher nameMatcher = p.matcher(remoteName);
                         patternMatches = (addressMatcher.matches() || nameMatcher.matches());
@@ -390,11 +390,6 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
                     return false;
                 }
             }
-
-        private Pattern convertPatternToRegex(String pattern) {
-            pattern = pattern.replace(".", "\\.");
-            return Glob.parseGlobToPattern(pattern);
-        }
 
         private String strip(String linePart) {
             return linePart.substring(6, linePart.length()-1);

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.UnknownHostException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
@@ -38,8 +37,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import diskCacheV111.util.AuthorizedKeyParser;


### PR DESCRIPTION
…thenticator

Motivation:
To increase security when authentication users to the AdminInterface,
one can now optionally specify restrictions on which remote hosts are
allowed to authenticate with a given public key in the authorized_key
file. This makes using stolen keys more difficult.

Modification:
Add RemoteHostValidator subclass to Ssh2Admins PublicKeyAuthenticator.
Update the authenticate method to evaluate restrictions from authorized_keys.

Result:
Public key authentication for the Admin-Interface will only succeed if
the remote host can satisfy all restrictions or no restrictions are set
for the associated key

Target: master
Require-notes: yes
Require-book: yes

Signed-off-by: Max Patzelt <max.patzelt@gmail.com>