### PR TITLE
acl: refactoring slf4j logging messages

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/posix/UnixPermissionHandler.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/posix/UnixPermissionHandler.java
@@ -184,7 +184,7 @@ public class UnixPermissionHandler implements AclHandler {
 
         } // switch( userUid )
 
-        _log.debug("IsAllowed: " + isAllowed);
+        _log.debug("IsAllowed: {}", isAllowed);
         return isAllowed;
     }
 }


### PR DESCRIPTION
Motivation: 
With normal string concatenations in log-messages strings are always build, regardless if log-level is activated or not. with parameterized log-messages the strings only become build, when the log-level is activated;

Modification: 
Using placeholder with parameterized messages instead of string concatenations

Result: 
Gained efficiency

Signed-off-by: 
marisanest <marisanest@mailbox.org>