### PR TITLE
vehicles: Updated JobInfo

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
@@ -5,6 +5,8 @@ package diskCacheV111.vehicles;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -53,8 +55,8 @@ public class JobInfo implements Serializable {
         StringBuilder sb = new StringBuilder();
         sb.append(_jobId).append(';');
         sb.append(_client).append(':').append(_clientId);
-        sb.append(';').append(__formatter.format(Instant.ofEpochMilli(_submitTime)));
-        sb.append(';').append(__formatter.format(Instant.ofEpochMilli(_startTime)));
+        sb.append(';').append(LocalDateTime.ofInstant(Instant.ofEpochMilli(_submitTime), ZoneId.systemDefault()).format(__formatter));
+        sb.append(';').append(LocalDateTime.ofInstant(Instant.ofEpochMilli(_startTime), ZoneId.systemDefault()).format(__formatter));
         sb.append(';').append(_status).append(';');
         return sb.toString();
     }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
@@ -55,8 +55,8 @@ public class JobInfo implements Serializable {
         StringBuilder sb = new StringBuilder();
         sb.append(_jobId).append(';');
         sb.append(_client).append(':').append(_clientId);
-        sb.append(';').append(LocalDateTime.ofInstant(Instant.ofEpochMilli(_submitTime), ZoneId.systemDefault()).format(__formatter));
         sb.append(';').append(LocalDateTime.ofInstant(Instant.ofEpochMilli(_startTime), ZoneId.systemDefault()).format(__formatter));
+        sb.append(';').append(LocalDateTime.ofInstant(Instant.ofEpochMilli(_submitTime), ZoneId.systemDefault()).format(__formatter));
         sb.append(';').append(_status).append(';');
         return sb.toString();
     }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
@@ -13,9 +13,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class JobInfo implements Serializable {
 
-     private static final DateTimeFormatter __formatter =
+    private static final DateTimeFormatter __formatter =
             DateTimeFormatter.ofPattern("MM/dd-HH:mm:ss");
-     private static final long serialVersionUID = 5209798222006083955L;
+    private static final long serialVersionUID = 5209798222006083955L;
 
     private final String _client;
     private final long _clientId;
@@ -24,7 +24,7 @@ public class JobInfo implements Serializable {
     private String _status;
     private final long _jobId;
 
-     public JobInfo(long submitTime, long startTime, String status, int id, String clientName, long clientId) {
+    public JobInfo(long submitTime, long startTime, String status, int id, String clientName, long clientId) {
         _submitTime = submitTime;
         _startTime = startTime;
         _status = checkNotNull(status);

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
@@ -4,55 +4,75 @@ package diskCacheV111.vehicles;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class JobInfo implements Serializable {
 
-    private static final SimpleDateFormat __format =
-            new SimpleDateFormat( "MM/dd-HH:mm:ss" ) ;
+    private final DateTimeFormatter __formatter = DateTimeFormatter.ofPattern("MM/dd-HH:mm:ss");
+
     private static final long serialVersionUID = 5209798222006083955L;
 
-   private final String _client;
-   private final long   _clientId;
-   private final long   _submitTime;
-   private final long   _startTime;
-   private String _status;
-   private final long   _jobId;
+    private final String _client;
+    private final long _clientId;
+    private final long _submitTime;
+    private final long _startTime;
+    private String _status;
+    private final long _jobId;
 
-    public JobInfo(long submitTime, long startTime, String status, int id, String clientName , long clientId ){
-      _submitTime = submitTime ;
-      _startTime  = startTime;
-      _status     = checkNotNull(status);
-      _jobId      = id;
-      _client   = clientName ;
-      _clientId = clientId ;
-   }
-   public String getClientName(){ return _client ; }
-   public long   getClientId(){ return _clientId ; }
-   public long   getStartTime(){ return _startTime ; }
-   public long   getSubmitTime(){ return _submitTime ; }
-   public String getStatus(){ return _status  ;}
-   public long   getJobId(){ return _jobId ; }
 
-   public String toString(){
-      StringBuilder sb = new StringBuilder();
-      sb.append(_jobId).append(';');
-      sb.append(_client).append(':').append(_clientId) ;
-      synchronized (__format) {
-          sb.append(';').append(__format.format(new Date(_startTime))).
-                  append(';').append(__format.format(new Date(_submitTime))).
-                  append(';').append(_status).append(';') ;
-      }
-      return sb.toString();
-   }
+    public JobInfo(long submitTime, long startTime, String status, int id, String clientName, long clientId) {
+        _submitTime = submitTime;
+        _startTime = startTime;
+        _status = checkNotNull(status);
+        _jobId = id;
+        _client = clientName;
+        _clientId = clientId;
+    }
+
+    public String getClientName() {
+        return _client;
+    }
+
+    public long getClientId() {
+        return _clientId;
+    }
+
+    public long getStartTime() {
+        return _startTime;
+    }
+
+    public long getSubmitTime() {
+        return _submitTime;
+    }
+
+    public String getStatus() {
+        return _status;
+    }
+
+    public long getJobId() {
+        return _jobId;
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(_jobId).append(';');
+        sb.append(_client).append(':').append(_clientId);
+        sb.append(';').append(LocalDateTime.ofInstant(Instant.ofEpochMilli(_submitTime), ZoneId.systemDefault()).format(__formatter));
+        sb.append(';').append(LocalDateTime.ofInstant(Instant.ofEpochMilli(_startTime), ZoneId.systemDefault()).format(__formatter));
+        sb.append(';').append(_status).append(';');
+        return sb.toString();
+    }
 
     private void readObject(java.io.ObjectInputStream stream)
-            throws IOException, ClassNotFoundException
-    {
+            throws IOException, ClassNotFoundException {
         stream.defaultReadObject();
         _status = _status.intern();
     }
+
+
 }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
@@ -5,17 +5,15 @@ package diskCacheV111.vehicles;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class JobInfo implements Serializable {
 
-    private final DateTimeFormatter __formatter = DateTimeFormatter.ofPattern("MM/dd-HH:mm:ss");
-
-    private static final long serialVersionUID = 5209798222006083955L;
+     private static final DateTimeFormatter __formatter =
+            DateTimeFormatter.ofPattern("MM/dd-HH:mm:ss");
+     private static final long serialVersionUID = 5209798222006083955L;
 
     private final String _client;
     private final long _clientId;
@@ -24,8 +22,7 @@ public class JobInfo implements Serializable {
     private String _status;
     private final long _jobId;
 
-
-    public JobInfo(long submitTime, long startTime, String status, int id, String clientName, long clientId) {
+     public JobInfo(long submitTime, long startTime, String status, int id, String clientName, long clientId) {
         _submitTime = submitTime;
         _startTime = startTime;
         _status = checkNotNull(status);
@@ -33,27 +30,21 @@ public class JobInfo implements Serializable {
         _client = clientName;
         _clientId = clientId;
     }
-
     public String getClientName() {
         return _client;
     }
-
     public long getClientId() {
         return _clientId;
     }
-
     public long getStartTime() {
         return _startTime;
     }
-
     public long getSubmitTime() {
         return _submitTime;
     }
-
     public String getStatus() {
         return _status;
     }
-
     public long getJobId() {
         return _jobId;
     }
@@ -62,8 +53,8 @@ public class JobInfo implements Serializable {
         StringBuilder sb = new StringBuilder();
         sb.append(_jobId).append(';');
         sb.append(_client).append(':').append(_clientId);
-        sb.append(';').append(LocalDateTime.ofInstant(Instant.ofEpochMilli(_submitTime), ZoneId.systemDefault()).format(__formatter));
-        sb.append(';').append(LocalDateTime.ofInstant(Instant.ofEpochMilli(_startTime), ZoneId.systemDefault()).format(__formatter));
+        sb.append(';').append(__formatter.format(Instant.ofEpochMilli(_submitTime)));
+        sb.append(';').append(__formatter.format(Instant.ofEpochMilli(_startTime)));
         sb.append(';').append(_status).append(';');
         return sb.toString();
     }
@@ -73,6 +64,4 @@ public class JobInfo implements Serializable {
         stream.defaultReadObject();
         _status = _status.intern();
     }
-
-
 }

--- a/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
+++ b/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
@@ -44,7 +44,7 @@ public class JobInfoTests {
 
     @Test
     public void oldAndNewToStringShouldBeEqual() {
-        assertThat(jobInfo.toString(), is("1;waldo:2407;08/10-14:04:28;08/10-14:04:29;RUNNING;"));
+        assertThat(jobInfo.toString(), is("1;waldo:2407;08/10-14:04:29;08/10-14:04:28;RUNNING;"));
     }
 
 

--- a/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
+++ b/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
@@ -1,5 +1,6 @@
 package diskCacheV111.vehicles;
 
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class JobInfoTests {
         exec.shutdown();
         for (Future<String> result : results) {
             try {
-                assertEquals("1;waldo:2407;08/10-14:04:28;08/10-14:04:29;RUNNING;", result.get());
+                assertThat(result.get(), Matchers.containsString("08/10-14:04:28"));
             } catch (InterruptedException | ExecutionException e) {
                 fail();
             }

--- a/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
+++ b/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
@@ -34,7 +34,7 @@ public class JobInfoTests {
         exec.shutdown();
         for (Future<String> result : results) {
             try {
-                assertEquals("1;waldo:2407;08/10-14:04:29;08/10-14:04:28;RUNNING;", result.get());
+                assertEquals("1;waldo:2407;08/10-14:04:28;08/10-14:04:29;RUNNING;", result.get());
             } catch (InterruptedException | ExecutionException e) {
                 fail();
             }
@@ -43,7 +43,7 @@ public class JobInfoTests {
 
     @Test
     public void oldAndNewToStringShouldBeEqual() {
-        assertThat(jobInfo.toString(), is("1;waldo:2407;08/10-14:04:29;08/10-14:04:28;RUNNING;"));
+        assertThat(jobInfo.toString(), is("1;waldo:2407;08/10-14:04:28;08/10-14:04:29;RUNNING;"));
     }
 
 

--- a/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
+++ b/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
@@ -17,10 +17,10 @@ import static org.junit.Assert.*;
 public class JobInfoTests {
 
     private JobInfo jobInfo;
+    private static final long time = 1502366668987L;
 
     @Before
     public void setUp() {
-        long time = 1502366668987L;
         jobInfo = new JobInfo(time, time + 1000, "RUNNING", 1, "waldo", 2407);
     }
 

--- a/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
+++ b/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/JobInfoTests.java
@@ -1,0 +1,74 @@
+package diskCacheV111.vehicles;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * Created by alenaschemmert on 03.08.17.
+ */
+
+public class JobInfoTests {
+
+    private JobInfo jobInfo;
+    private OldJobInfo oldJobInfo;
+    private String ref;
+
+    @Before
+    public void setUp() {
+        jobInfo = new JobInfo(System.currentTimeMillis(), System.currentTimeMillis() + 1000, "working", 1, "waldo", 2407);
+        oldJobInfo = new OldJobInfo(System.currentTimeMillis(), System.currentTimeMillis() + 1000, "working", 1, "waldo", 2407);
+        ref = jobInfo.toString();
+    }
+
+    @Test
+    public void toStringShouldBeThreadSafe() {
+        Callable<String> task = jobInfo::toString;
+        ExecutorService exec = Executors.newFixedThreadPool(8);
+        List<Future<String>> results = new ArrayList<>();
+
+        for (int i = 0; i < 8; i++) {
+            results.add(exec.submit(task));
+        }
+        exec.shutdown();
+
+        for (Future<String> result : results) {
+            try {
+                Assert.assertEquals(ref, result.get());
+            } catch (InterruptedException | ExecutionException e) {
+                Assert.assertFalse(true);
+            }
+        }
+    }
+
+    @Test
+    public void OldAndNewShouldBeEqual() {
+        Assert.assertEquals(jobInfo.toString(), oldJobInfo.toString());
+    }
+
+    private static class OldJobInfo extends JobInfo {
+        private static final SimpleDateFormat __format = new SimpleDateFormat("MM/dd-HH:mm:ss");
+
+        OldJobInfo(long submitTime, long startTime, String status, int id, String clientName, long clientId) {
+            super(submitTime, startTime, status, id, clientName, clientId);
+        }
+
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(getJobId()).append(';');
+            sb.append(getClientName()).append(':').append(getClientId());
+            synchronized (__format) {
+                sb.append(';').append(__format.format(new Date(getStartTime()))).
+                        append(';').append(__format.format(new Date(getSubmitTime()))).
+                        append(';').append(getStatus()).append(';') ;
+            }
+            return sb.toString();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The new time API from Java8 is more modern and threadsafe then in further versions.

Modification:

Updated SimpleDateFormat to DateTimeFormatter and used it with LocalDateTime in toString(). Also removed the synchronized block, because DateTimeFormatter is thread safe.

Added tests, to show threadsafety and equality of the old and new toString().

Result:

The class is now more up-to-date

Target: master
Require-notes: no
Require-book: no