### PR TITLE
Chimera: fix OOM Exception when too many messages are queued

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
@@ -76,7 +76,7 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
         LoggerFactory.getLogger(ChimeraCleaner.class);
 
     // ToDo: Spring Implementation for queryLimit ( used in runNotification() )
-    private final int queryLimit = 5000;
+    private final static int QUERYLIMIT = 5000;
 
     @Option(
         name="refresh",
@@ -470,9 +470,9 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
 
         List<String> queryList = new ArrayList<String>();
         do {
-            queryList = _db.queryForList(QUERY, String.class, queryLimit);
+            queryList = _db.queryForList(QUERY, String.class, QUERYLIMIT);
 
-            if(queryList.size() == 0) {
+            if( queryList.isEmpty()) {
                 break;
             }
 
@@ -484,7 +484,7 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
                     _log.warn(e.getCause().getMessage());
                 }
             }
-        } while (queryList.size() >= queryLimit);
+        } while (queryList.size() >= QUERYLIMIT);
     }
 
     private ListenableFuture<List<PnfsDeleteEntryNotificationMessage>> sendDeleteNotifications(PnfsId pnfsId)

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
@@ -470,7 +470,6 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
 
         List<String> queryFail = new ArrayList<String>();
         do {
-            }
             List<String> queryList = _db.queryForList(QUERY, String.class, QUERYLIMIT);
 
             for (String id : queryList) {

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCleaner.java
@@ -477,9 +477,7 @@ public class ChimeraCleaner extends AbstractCell implements Runnable
                     sendDeleteNotifications(new PnfsId(id)).get();
                     _db.update("DELETE FROM t_locationinfo_trash WHERE ipnfsid=? AND itype=2", id);
                 } catch (ExecutionException e) {
-                    if(!queryFail.contains(id)) {
                         queryFail.add(id);
-                    }
                     _log.warn(e.getCause().getMessage());
                 }
             }


### PR DESCRIPTION
Motivation:
To prevent future Out of Memory Exceptions in Chimera Cleaner when
processing too many messages

Modification:
Set a LIMIT in the SQL Query and loop until all messages are processed.

Result:
Messages are processed in chunks and prevent the method from crashing.

Ticket: #2529

Target: master

Signed-off-by: Robin Wenzel <info@robin-wenzel.de>