### PR TITLE
dcache-core: refactoring slf4j logging messages

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/LegacyAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/LegacyAdminShell.java
@@ -600,7 +600,7 @@ public class LegacyAdminShell
         try {
             spreader.waitForReplies();
         } catch (InterruptedException ex) {
-            _log.info("InterruptedException while waiting for a reply from pools " + ex);
+            _log.info("InterruptedException while waiting for a reply from pools {}", ex.toString());
         }
 
         return spreader.getReplies();
@@ -1372,14 +1372,14 @@ public class LegacyAdminShell
             }
             return _completer.complete(buffer, cursor, candidates);
         } catch (Exception e) {
-            _log.info("Completion failed: " + e.toString());
+            _log.info("Completion failed: {}", e.toString());
             return -1;
         }
     }
 
     public Object executeCommand(String str) throws CommandException, InterruptedException, NoRouteToCellException
     {
-        _log.info("String command (super) " + str);
+        _log.info("String command (super) {}", str);
 
         if (str.trim().isEmpty()) {
             return "";

--- a/modules/dcache/src/main/java/diskCacheV111/admin/PAMAuthentificator.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/PAMAuthentificator.java
@@ -99,7 +99,7 @@ public class PAMAuthentificator  extends CellAdapter {
         _service = _args.getOpt("service");
         if (_service == null) {
             _service = "dcache";
-            _log.info("'service' not defined. Using '" + _service + "' as default service");
+            _log.info("'service' not defined. Using '{}' as default service", _service);
         }
 
 
@@ -137,7 +137,7 @@ public class PAMAuthentificator  extends CellAdapter {
                 try {
                     _userServiceNIS = new InitialDirContext(env);
                 } catch (NamingException ne) {
-                    _log.warn("Can't InitialDirContext(env) " + ne);
+                    _log.warn("Can't InitialDirContext(env) {}", ne.toString());
                     throw ne;
                 }
                 _userServiceType = USER_SERVICE_NIS;
@@ -217,14 +217,14 @@ public class PAMAuthentificator  extends CellAdapter {
             _sysPassword.update();
         }
      }catch(Exception ee ){
-        _log.warn( "Updating failed : "+_sysPassword ) ;
+        _log.warn( "Updating failed : {}", _sysPassword ) ;
      }
      try{
         if( _egPassword != null ) {
             _egPassword.update();
         }
      }catch(Exception ee ){
-        _log.warn( "Updating failed : "+_egPassword ) ;
+        _log.warn( "Updating failed : {}", _egPassword ) ;
      }
    }
    private boolean matchPassword( String userName , String password ){
@@ -261,7 +261,7 @@ public class PAMAuthentificator  extends CellAdapter {
 
          }
       }catch( Throwable t ){
-         _log.warn( "Found : "+t ) ;
+         _log.warn( "Found : {}", t.toString()) ;
       }
       return false ;
    }
@@ -289,14 +289,14 @@ public class PAMAuthentificator  extends CellAdapter {
       try{
          pamOk = authenticate( principal , password )  ;
       }catch(Exception ee ){
-         _log.warn( "_pam.authorize : "+ee ) ;
+         _log.warn( "_pam.authorize : {}", ee.toString() ) ;
       }
       if( ! pamOk ){
-         _log.info("pam _log.infos no to <"+principal+"> (switching to local)");
+         _log.info("pam _log.infos no to <{}> (switching to local)", principal);
          try{
             return matchPassword( principal , password ) ;
          }catch(Exception ee ){
-            _log.warn( "matchPassword : "+ee ) ;
+            _log.warn( "matchPassword : {}", ee.toString() ) ;
          }
       }
       return pamOk ;
@@ -307,7 +307,7 @@ public class PAMAuthentificator  extends CellAdapter {
       Serializable answer;
 
       try{
-         _log.info( "Message type : "+obj.getClass() ) ;
+         _log.info( "Message type : {}", obj.getClass() ) ;
          if( ( obj instanceof Object []              )  &&
              (  ((Object[])obj).length >= 3          )  &&
              (  ((Object[])obj)[0].equals("request") ) ){
@@ -317,7 +317,7 @@ public class PAMAuthentificator  extends CellAdapter {
                                    "unknown" : (String)request[1] ;
             String command       = (String)request[2] ;
 
-            _log.info( ">"+command+"< request from "+user ) ;
+            _log.info( ">{}< request from {}", command, user ) ;
             try{
                 switch (command) {
                 case "check-password":

--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -1107,7 +1107,7 @@ public class UserAdminShell
 
     public Object executeCommand(String str) throws CommandException, InterruptedException, NoRouteToCellException, AclException
     {
-        _log.info("String command (super) " + str);
+        _log.info("String command (super) {}", str);
 
         if (str.trim().isEmpty()) {
             return "";

--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserMetaDataProviderFnal.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserMetaDataProviderFnal.java
@@ -131,22 +131,22 @@ public class UserMetaDataProviderFnal implements UserMetaDataProvider {
             authf = new KAuthFile(_kpwdFilePath);
         }
         catch ( Exception e ) {
-            _log.warn("User authentication file not found: " + e);
+            _log.warn("User authentication file not found: {}", e.toString());
             return answer;
         }
         if (userRole.startsWith("UNSPECIFIED")) {
 
             userRole = authf.getIdMapping(userPrincipal);
-            _log.warn("userRole="+userRole);
+            _log.warn("userRole={}", userRole);
 
             if(userRole == null) {
-                _log.warn("User " + userPrincipal + " not found.");
+                _log.warn("User {} not found.", userPrincipal);
                 return answer;
             }
         }
         pwdRecord = authf.getUserRecord(userRole);
         if( pwdRecord == null ) {
-            _log.warn("User " + userRole + " not found.");
+            _log.warn("User {} not found.", userRole);
             return answer;
         }
 
@@ -162,7 +162,7 @@ public class UserMetaDataProviderFnal implements UserMetaDataProvider {
         answer.put("gid", String.valueOf(gid));
         answer.put("home", home);
 
-        _log.info("User "+userRole+" logged in");
+        _log.info("User {} logged in", userRole);
         return answer;
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -299,7 +299,7 @@ public class TransferObserverV1
                 _update = Long.parseLong(updateString) * 1000L;
             }
         } catch (NumberFormatException e) {
-            _log.warn("Illegal value for -update: " + updateString);
+            _log.warn("Illegal value for -update: {}", updateString);
         }
 
         useInterpreter(true);

--- a/modules/dcache/src/main/java/diskCacheV111/cells/WebCollectorV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/WebCollectorV3.java
@@ -75,8 +75,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
         {
             long start = System.currentTimeMillis();
             wait(_mode ? _shortPeriod / 2 : _regularPeriod / 2);
-            _log.debug("Woke up after " + (System.currentTimeMillis() - start)
-                       + " millis");
+            _log.debug("Woke up after {} millis", (System.currentTimeMillis() - start));
         }
 
         private synchronized void setShortPeriod(long shortPeriod)
@@ -93,7 +92,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
 
         private synchronized void topologyChanged(boolean modified)
         {
-            // _log.info("Topology changed : "+modified);
+            // _log.info("Topology changed : {}", modified);
             if (!_enabled) {
                 return;
             }
@@ -850,7 +849,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
         // get the translated list
         _log.debug("Preparing pool cost table");
         List<PoolCostEntry> list = preparePoolCostTable();
-        _log.debug("Preparing pool cost table done " + list.size());
+        _log.debug("Preparing pool cost table done {}", list.size());
         // calculate the totals ...
         TreeMap<String, int[]> moverMap = new TreeMap<>();
         int[][] total = new int[5][3];

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/HsmControlOsm.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/HsmControlOsm.java
@@ -86,7 +86,7 @@ public class HsmControlOsm extends CellAdapter implements Runnable {
        try{
           sendMessage( msg ) ;
        }catch(RuntimeException ee ){
-          _log.warn("Problem replying : "+ee ) ;
+          _log.warn("Problem replying : {}", ee.toString() ) ;
        }
     }
     @Override
@@ -114,7 +114,7 @@ public class HsmControlOsm extends CellAdapter implements Runnable {
                    try{
                       sendMessage( msg ) ;
                    }catch(RuntimeException ee ){
-                      _log.warn("Problem replying : "+ee ) ;
+                      _log.warn("Problem replying : {}", ee.toString() ) ;
                    }
                 }catch(Exception eee ){
                    _failed ++ ;
@@ -124,12 +124,12 @@ public class HsmControlOsm extends CellAdapter implements Runnable {
                    try{
                       sendMessage( msg ) ;
                    }catch(RuntimeException ee ){
-                      _log.warn("Problem replying : "+ee ) ;
+                      _log.warn("Problem replying : {}", ee.toString() ) ;
                    }
                 }
             }
         }catch(Exception ee ){
-            _log.warn("Got exception from run while : "+ee);
+            _log.warn("Got exception from run while : {}", ee.toString());
         }finally{
             _log.info("Working thread finished");
         }
@@ -201,7 +201,7 @@ public class HsmControlOsm extends CellAdapter implements Runnable {
         }
 
         HsmControllable hc = (HsmControllable)values[1] ;
-        _log.info("Controller found for "+hsm+" -> "+values[0]);
+        _log.info("Controller found for {}  -> {}", hsm, values[0]);
         hc.getBfDetails( storageInfo );
 
     }

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/HsmDriverOSM.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/HsmDriverOSM.java
@@ -47,7 +47,7 @@ import org.dcache.util.Args;
             try{
                 setVolumeDetails( storageInfo );
             }catch(Exception ee){
-                LOGGER.error("Can't get volume details " + ee);
+                LOGGER.error("Can't get volume details {}", ee.toString());
             }
 
         }
@@ -87,7 +87,7 @@ import org.dcache.util.Args;
                          error);
              }
 
-             LOGGER.info("Output : " + output);
+             LOGGER.info("Output : {}", output);
 
              String volNbf;
              String volStat;
@@ -147,7 +147,7 @@ import org.dcache.util.Args;
                          error);
              }
 
-             LOGGER.info("Output : " + output);
+             LOGGER.info("Output : {}", output);
 
              String tape;
              String status;

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HsmFlushControlManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HsmFlushControlManager.java
@@ -234,7 +234,7 @@ public class HsmFlushControlManager  extends CellAdapter {
                                _control ? gainControlInterval : 0L);
 
                if (LOG_ENABLED) {
-                   _log.info("sendFlushControlMessage : sending PoolFlushGainControlMessage to " + poolName);
+                   _log.info("sendFlushControlMessage : sending PoolFlushGainControlMessage to {}", poolName);
                }
                sendMessage(new CellMessage(new CellPath(poolName), msg));
            }
@@ -403,7 +403,7 @@ public class HsmFlushControlManager  extends CellAdapter {
            sendMessage( new CellMessage( new CellAddressCore("PoolManager") , msg ) ) ;
 
        }catch(RuntimeException ee ){
-           _log.warn("setPoolReadOnly : couldn't sent message to PoolManager"+ee);
+           _log.warn("setPoolReadOnly : couldn't sent message to PoolManager{}", ee.toString());
        }
     }
     private void queryPoolMode( String poolName ){
@@ -417,7 +417,7 @@ public class HsmFlushControlManager  extends CellAdapter {
            sendMessage( new CellMessage( new CellAddressCore("PoolManager") , msg ) ) ;
 
        }catch(RuntimeException ee ){
-           _log.warn("queryPoolMode : couldn't sent message to PoolManager"+ee);
+           _log.warn("queryPoolMode : couldn't sent message to PoolManager{}", ee.toString());
        }
     }
     private class PoolCollector implements FutureCallback<Object[]>
@@ -474,7 +474,7 @@ public class HsmFlushControlManager  extends CellAdapter {
            for (Object o : list) {
                String command = "psux ls pgroup " + o;
                if (LOG_ENABLED) {
-                   _log.info("runCollector sending : " + command + " to " + path);
+                   _log.info("runCollector sending : {} to {}", command, path);
                }
                Futures.addCallback(_poolManager.send(command, Object[].class), this);
                _waitingFor++;
@@ -484,7 +484,7 @@ public class HsmFlushControlManager  extends CellAdapter {
           _waitingFor-- ;
           if( _waitingFor == 0 ){
              if(LOG_ENABLED) {
-                 _log.info("PoolCollector : we are done : " + _poolGroupHash);
+                 _log.info("PoolCollector : we are done : {}", _poolGroupHash);
              }
              _active = false ;
              HashMap<String, HFCPool> map = new HashMap<>() ;
@@ -496,7 +496,7 @@ public class HsmFlushControlManager  extends CellAdapter {
                   for (Object aC : c) {
                       String pool = (String) aC;
                       if (LOG_ENABLED) {
-                          _log.info("Adding pool : " + pool);
+                          _log.info("Adding pool : {}", pool);
                       }
                       HFCPool p = _configuredPoolList.get(pool);
                       map.put(pool, p == null ? new HFCPool(pool) : p);
@@ -542,7 +542,7 @@ public class HsmFlushControlManager  extends CellAdapter {
                 String poolGroupName = (String) reply[0] ;
                 _poolGroupHash.put( poolGroupName , (Object[]) reply[1]);
                 if(LOG_ENABLED) {
-                    _log.info("PoolCollector : " + ((Object[]) reply[1]).length + " pools arrived for " + poolGroupName);
+                    _log.info("PoolCollector : {} pools arrived for {}", ((Object[]) reply[1]).length, poolGroupName);
                 }
             }else{
                 _log.warn("PoolCollector : invalid reply arrived");
@@ -860,7 +860,7 @@ public class HsmFlushControlManager  extends CellAdapter {
         synchronized( _propertyLock ){
             info.setDriverProperties( System.currentTimeMillis() - _propertiesUpdated , _properties ) ;
         }
-        //_log.info("DRIVER PROPERTIES : "+info ) ;
+        //_log.info("DRIVER PROPERTIES : {}", info ) ;
         return info ;
     }
     private class EventDispatcher implements HsmFlushControlCore, Runnable  {
@@ -1219,19 +1219,19 @@ public class HsmFlushControlManager  extends CellAdapter {
     //
     private void poolFlushDoFlushMessageArrived( PoolFlushDoFlushMessage msg ){
         if(LOG_ENABLED) {
-            _log.info("poolFlushDoFlushMessageArrived : " + msg);
+            _log.info("poolFlushDoFlushMessageArrived : {}", msg);
         }
         String poolName  = msg.getPoolName() ;
         synchronized( _poolCollector ){
             HFCPool pool = _poolCollector.getPoolByName( poolName) ;
             if( pool == null ){
-               _log.warn("poolFlushDoFlushMessageArrived : message arrived for non configured pool : "+poolName);
+               _log.warn("poolFlushDoFlushMessageArrived : message arrived for non configured pool : {}", poolName);
                return ;
             }
             String storageClass = msg.getStorageClassName()+"@"+msg.getHsmName() ;
             HFCFlushInfo info = pool.flushInfos.get( storageClass );
             if( info == null ){
-               _log.warn("poolFlushDoFlushMessageArrived : message arrived for non existing storage class : "+storageClass);
+               _log.warn("poolFlushDoFlushMessageArrived : message arrived for non existing storage class : {}", storageClass);
                //
                // the real one doesn't exists anymore, so we simulate one.
                //
@@ -1239,8 +1239,8 @@ public class HsmFlushControlManager  extends CellAdapter {
             }
             if( msg.getReturnCode() != 0 ){
                if(LOG_ENABLED) {
-                   _log.info("Flush failed (msg=" + (msg
-                           .isFinished() ? "Finished" : "Ack") + ") : " + msg);
+                   _log.info("Flush failed (msg={}) : {}", (msg
+                           .isFinished() ? "Finished" : "Ack"), msg);
                }
 
                info.setFlushingFailed(msg.getReturnCode(),msg.getErrorObject());
@@ -1251,7 +1251,7 @@ public class HsmFlushControlManager  extends CellAdapter {
             }
             if( msg.isFinished() ){
                 if(LOG_ENABLED) {
-                    _log.info("Flush finished : " + msg);
+                    _log.info("Flush finished : {}", msg);
                 }
 
                 updateFlushCellAndFlushInfos( msg , pool ) ;
@@ -1264,12 +1264,12 @@ public class HsmFlushControlManager  extends CellAdapter {
     }
     private void poolFlushGainControlMessageDidntArrive( String poolName ){
         if(LOG_ENABLED) {
-            _log.info("poolFlushGainControlMessageDidntArrive : " + poolName);
+            _log.info("poolFlushGainControlMessageDidntArrive : {}", poolName);
         }
         synchronized( _poolCollector ){
             HFCPool pool = _poolCollector.getPoolByName( poolName) ;
             if( pool == null ){
-               _log.warn("PoolFlushGainControlMessage : message arrived for non configured pool : "+poolName);
+               _log.warn("PoolFlushGainControlMessage : message arrived for non configured pool : {}", poolName);
                return ;
             }
             pool.isActive    = false ;
@@ -1308,13 +1308,13 @@ public class HsmFlushControlManager  extends CellAdapter {
     }
     private void poolFlushGainControlMessageArrived( PoolFlushGainControlMessage msg ){
         if(LOG_ENABLED) {
-            _log.info("PoolFlushGainControlMessage : " + msg);
+            _log.info("PoolFlushGainControlMessage : {}", msg);
         }
         String poolName  = msg.getPoolName() ;
         synchronized( _poolCollector ){
             HFCPool pool = _poolCollector.getPoolByName( poolName) ;
             if( pool == null ){
-               _log.warn("PoolFlushGainControlMessage : message arrived for non configured pool : "+poolName);
+               _log.warn("PoolFlushGainControlMessage : message arrived for non configured pool : {}", poolName);
                return ;
             }
 
@@ -1325,14 +1325,14 @@ public class HsmFlushControlManager  extends CellAdapter {
     }
     private void poolModeInfoArrived( PoolManagerPoolModeMessage msg ){
         if(LOG_ENABLED) {
-            _log.info("PoolManagerPoolModeMessage : " + msg);
+            _log.info("PoolManagerPoolModeMessage : {}", msg);
         }
         String poolName  = msg.getPoolName() ;
         synchronized( _poolCollector ){
 
             HFCPool pool = _poolCollector.getPoolByName( poolName) ;
             if( pool == null ){
-               _log.warn("poolModeInfoArrived : message arrived for non configured pool : "+poolName);
+               _log.warn("poolModeInfoArrived : message arrived for non configured pool : {}", poolName);
                return ;
             }
             pool.mode = msg.getPoolMode() ;
@@ -1369,13 +1369,12 @@ public class HsmFlushControlManager  extends CellAdapter {
           CellPath        path = nrtc.getDestinationPath() ;
           CellAddressCore core = path.getDestinationAddress() ;
           String          cellName = core.getCellName() ;
-          _log.warn( "NoRouteToCell : "+ cellName + " ("+path+")");
+          _log.warn( "NoRouteToCell : {} ({})", cellName, path);
 
           poolFlushGainControlMessageDidntArrive( cellName ) ;
 
        }else{
-          _log.warn("Unknown message arrived ("+msg.getSourcePath()+") : "+
-               msg.getMessageObject() ) ;
+          _log.warn("Unknown message arrived ({}) : {}", msg.getSourcePath(), msg.getMessageObject() ) ;
          _failed ++ ;
        }
     }

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HttpHsmFlushMgrEngineV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HttpHsmFlushMgrEngineV1.java
@@ -50,7 +50,7 @@ public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageS
    public HttpHsmFlushMgrEngineV1(String [] argsString ){
 
        for( int i = 0 ; i < argsString.length ; i++ ){
-          _log.info("HttpPoolMgrEngineV3 : argument : "+i+" : "+argsString[i]);
+          _log.info("HttpPoolMgrEngineV3 : argument : {} : {}", i, argsString[i]);
           if( argsString[i].startsWith("css=") ){
               decodeCss( argsString[i].substring(4) ) ;
           }else if( argsString[i].startsWith("mgr=") ){
@@ -67,8 +67,8 @@ public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageS
           _managerList.add("FlushManager");
       }
 
-      _log.info("Using Manager  : "+_managerList ) ;
-      _log.info("Using CSS file : "+_cssFile ) ;
+      _log.info("Using Manager  : {}", _managerList ) ;
+      _log.info("Using CSS file : {}", _cssFile ) ;
 
    }
 
@@ -134,7 +134,7 @@ public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageS
 
              CellStub flushManager = new CellStub(_endpoint, new CellPath(flushManagerName), 20, SECONDS);
 
-             _log.info("MAP -> "+optionsMap);
+             _log.info("MAP -> {}", optionsMap);
 
              printFlushHeader( pw ,  "Flush Info");
              printDirectory( pw ) ;

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/AlternateFlush.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/AlternateFlush.java
@@ -130,13 +130,13 @@ import org.dcache.util.Args;
          // printout what we got from our master
          //
          for( int i = 0 ; i < args.argc() ; i++ ){
-             _log.info("    args "+i+" : "+args.argv(i)) ;
+             _log.info("    args {} : {}", i, args.argv(i)) ;
          }
          for( int i = 0 ; i < args.optc() ; i++ ){
-             _log.info("    opts "+args.optv(i)+"="+args.getOpt(args.optv(i))) ;
+             _log.info("    opts {}={}", args.optv(i), args.getOpt(args.optv(i))) ;
          }
          for (Object pool : _core.getConfiguredPools()) {
-             _log.info("    configured pool : " + pool.toString());
+             _log.info("    configured pool : {}", pool.toString());
          }
          //
          //  reset the pool modes of all pools we are responsible for.
@@ -146,7 +146,7 @@ import org.dcache.util.Args;
              HsmFlushControlCore.Pool pool = (HsmFlushControlCore.Pool) o;
              pool.setDriverHandle(new Pool(pool.getName(), pool));
              pool.setReadOnly(false);
-             _log.info("init : setting readonly=false : " + pool.getName());
+             _log.info("init : setting readonly=false : {}", pool.getName());
          }
 
      }
@@ -154,7 +154,7 @@ import org.dcache.util.Args;
      public void propertiesUpdated( Map<String,Object> properties ){
 
         if(_evt) {
-            _log.info("EVENT : propertiesUpdated : " + properties);
+            _log.info("EVENT : propertiesUpdated : {}", properties);
         }
 
         Set<String> keys = new HashSet<>( properties.keySet() ) ;
@@ -194,7 +194,7 @@ import org.dcache.util.Args;
                          }
                          _countToFlush = count;
                      } catch (Exception ee) {
-                         _log.warn("Exception while seting " + key + " " + ee);
+                         _log.warn("Exception while seting {} {}", key, ee.toString());
                      }
                  }
                  break;
@@ -210,7 +210,7 @@ import org.dcache.util.Args;
                          }
                          _flushAtOnce = count;
                      } catch (Exception ee) {
-                         _log.warn("Exception while seting " + key + " " + ee);
+                         _log.warn("Exception while seting {} {}", key, ee.toString());
                      }
                  }
                  break;
@@ -227,7 +227,7 @@ import org.dcache.util.Args;
 
                          _percentageToFlush = percent;
                      } catch (Exception ee) {
-                         _log.warn("Exception while seting " + key + " " + ee);
+                         _log.warn("Exception while seting {} {}", key, ee.toString());
                      }
                  }
                  break;
@@ -254,7 +254,7 @@ import org.dcache.util.Args;
      public void poolIoModeUpdated( String poolName ,  HsmFlushControlCore.Pool pool ){
 
          if(_evt) {
-             _log.info("EVENT : poolIoModeUpdated : " + pool);
+             _log.info("EVENT : poolIoModeUpdated : {}", pool);
          }
 
          Pool ip = getInternalPool( pool ) ;
@@ -266,12 +266,12 @@ import org.dcache.util.Args;
      public void flushingDone( String poolName , String storageClassName , HsmFlushControlCore.FlushInfo flushInfo  ){
 
          if(_evt) {
-             _log.info("EVENT : flushingDone : pool =" + poolName + ";class=" + storageClassName /* + "flushInfo="+flushInfo */);
+             _log.info("EVENT : flushingDone : pool ={};class={}", poolName, storageClassName /* + "flushInfo="+flushInfo */);
          }
 
          HsmFlushControlCore.Pool pool = _core.getPoolByName( poolName ) ;
          if( pool == null ){
-            _log.warn("flushingDone for a non configured pool : "+poolName);
+            _log.warn("flushingDone for a non configured pool : {}", poolName);
             return ;
          }
 
@@ -282,12 +282,12 @@ import org.dcache.util.Args;
 
          if( ip.flushCounter <= 0 ){
              ip.flushCounter = 0 ;
-             _log.info("flushingDone : pool finished all flushing : "+poolName+" ; setting back to readWrite mode");
+             _log.info("flushingDone : pool finished all flushing : {} ; setting back to readWrite mode", poolName);
              pool.setReadOnly(false);
          }
      /*
         if( ! ip.isFlushing() ){
-             _log.info("flushingDone : pool finished all flushing : "+poolName+" ; setting back to readWrite mode");
+             _log.info("flushingDone : pool finished all flushing : {}  ; setting back to readWrite mode", poolName);
              pool.setReadOnly(false);
         }
       */
@@ -318,7 +318,7 @@ import org.dcache.util.Args;
             }
             set.add( poolName ) ;
 
-            _log.info("timer : Good candidate to flush : "+poolName);
+            _log.info("timer : Good candidate to flush : {}", poolName);
 
             Pool ip = getInternalPool( pool ) ;
             if( ! ip.modeReady ) {
@@ -335,10 +335,10 @@ import org.dcache.util.Args;
      public void poolFlushInfoUpdated( String poolName , HsmFlushControlCore.Pool pool ){
 
          if(_evt) {
-             _log.info("EVENT : poolFlushInfoUpdated : " + pool.getName());
+             _log.info("EVENT : poolFlushInfoUpdated : {}", pool.getName());
          }
          if( ! pool.isActive() ){
-             _log.info( "poolFlushInfoUpdated : Pool : "+poolName+" inactive");
+             _log.info( "poolFlushInfoUpdated : Pool : {} inactive", poolName);
              return ;
          }
          //
@@ -353,7 +353,7 @@ import org.dcache.util.Args;
      @Override
      public void command( Args args  ){
          if(_evt) {
-             _log.info("EVENT : command : " + args);
+             _log.info("EVENT : command : {}", args);
          }
          if (args.argc() == 0) {
              return;
@@ -364,9 +364,9 @@ import org.dcache.util.Args;
                  throw new
                          Exception("Null pointer from command call");
              }
-             _log.info("Command returns : "+reply.toString() );
+             _log.info("Command returns : {}", reply.toString() );
          }catch(Exception ee ){
-             _log.warn("Command returns an exception ("+ee.getClass().getName()+") : " + ee.toString());
+             _log.warn("Command returns an exception ({}) : {}", ee.getClass().getName(), ee.toString());
          }
      }
      @Override
@@ -379,12 +379,12 @@ import org.dcache.util.Args;
      public void configuredPoolAdded( String poolName ){
 
          if(_evt) {
-             _log.info("EVENT : Configured pool added : " + poolName);
+             _log.info("EVENT : Configured pool added : {}", poolName);
          }
 
          HsmFlushControlCore.Pool pool = _core.getPoolByName( poolName ) ;
          if( pool == null ){
-            _log.warn("Pool not found in _core database : "+poolName);
+            _log.warn("Pool not found in _core database : {}", poolName);
             return ;
          }
 
@@ -402,7 +402,7 @@ import org.dcache.util.Args;
      @Override
      public void configuredPoolRemoved( String poolName ){
          if(_evt) {
-             _log.info("EVENT : Configured pool removed : " + poolName + "  (ignoring)");
+             _log.info("EVENT : Configured pool removed : {}  (ignoring)", poolName);
          }
      }
      //-------------------------------------------------------------------------------------------
@@ -424,7 +424,7 @@ import org.dcache.util.Args;
 
             Pool ip = (Pool)pool.getDriverHandle() ;
             if( ip == null ){
-               _log.warn("getInternalPool : Unconfigured pool arrived "+pool.getName()+"; configuring");
+               _log.warn("getInternalPool : Unconfigured pool arrived {}; configuring", pool.getName());
                pool.setDriverHandle( ip = new Pool( pool.getName() , pool ) ) ;
             }
             return ip ;
@@ -445,22 +445,18 @@ import org.dcache.util.Args;
 
              long size = flush.getTotalPendingFileSize();
 
-             _log.info("flushPool : class = " + info
-                     .getName() + " size = " + size + " flushing = " + info
-                     .isFlushing());
+             _log.info("flushPool : class = {} size = {} flushing = {}", info.getName(), size, info.isFlushing());
              //
              // is precious size > 0 and are we not yet flushing ?
              //
              try {
                  if ((size > 0L) && !info.isFlushing()) {
-                     _log.info("flushPool : !!! flushing " + pool
-                             .getName() + " " + info.getName());
+                     _log.info("flushPool : !!! flushing {} {}", pool.getName(), info.getName());
                      info.flush(_flushAtOnce);
                      flushing++;
                  }
              } catch (Exception ee) {
-                 _log.warn("flushPool : Problem flushing " + pool
-                         .getName() + " " + info.getName() + " " + ee);
+                 _log.warn("flushPool : Problem flushing {} {} {}", pool.getName(), info.getName(), ee.toString());
              }
 
          }
@@ -516,7 +512,7 @@ import org.dcache.util.Args;
 
          for (HsmFlushControlCore.Pool pool : pools) {
              if (_ntf) {
-                 _log.info("nextToFlush : checking pool " + pool);
+                 _log.info("nextToFlush : checking pool {}", pool);
              }
 
              if (!pool.isActive()) {
@@ -527,8 +523,7 @@ import org.dcache.util.Args;
 
              if (ip.isFlushing()) {
                  if (_ntf) {
-                     _log.info("nextToFlush : is already flushing " + pool
-                             .getName());
+                     _log.info("nextToFlush : is already flushing {}", pool.getName());
                  }
              } else {
                  list.add(ip);
@@ -539,13 +534,12 @@ import org.dcache.util.Args;
          //
          if( list.size() < 2 ){
              if(_ntf) {
-                 _log.info("nextToFlush : currently not enough pools to write on (" + list
-                         .size() + ")");
+                 _log.info("nextToFlush : currently not enough pools to write on ({})", list.size());
              }
              return null ;
          }
          if(_ntf) {
-             _log.info("nextToFlush : possible candidates : " + list);
+             _log.info("nextToFlush : possible candidates : {}", list);
          }
          /**
            *  Get pool with highest pending file count and pool with highest
@@ -567,12 +561,12 @@ import org.dcache.util.Args;
              }
          }
          if(_ntf) {
-             _log.info("nextToFlush : highest percentage found for : " + poolWithHighestPercentage
-                     .pool.getName() + " (" + highestPercentage + ")");
+             _log.info("nextToFlush : highest percentage found for : {} ({})", poolWithHighestPercentage
+                     .pool.getName(), highestPercentage );
          }
          if(_ntf) {
-             _log.info("nextToFlush : highest counter    found for : " + poolWithHighestCounter
-                     .pool.getName() + " (" + highestCounter + ")");
+             _log.info("nextToFlush : highest counter    found for : {} ({})", poolWithHighestCounter
+                     .pool.getName(), highestCounter );
          }
          if( highestPercentage > _percentageToFlush  ) {
              return poolWithHighestPercentage.pool;

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/AlternatingFlushSchedulerV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/AlternatingFlushSchedulerV1.java
@@ -226,21 +226,22 @@ import static org.dcache.util.ByteUnit.MiB;
          public void poolIoModeUpdated( Pool ip , boolean newIsReadOnly ){
 
             if(_parameter._p_poolset) {
-                _log.info("PROGRESS-H(" + _name + "/" + ip._name + ") new pool i/o mode " + newIsReadOnly);
+                _log.info("PROGRESS-H({}/{}) new pool i/o mode {}", _name, ip._name, newIsReadOnly);
             }
             //
             // new pool mode arrived, in wrong state
             //
             if( _progressState != PS_WAITING_FOR_STATE_CHANGE ){
-              _log.warn("PROGRESS-H("+_name+"/"+ip._name+
-                   ") Warning : new pool i/o mode arrived unexpectedly in state "+_progressState);
+              _log.warn("PROGRESS-H({}/{}) Warning : new pool i/o mode arrived unexpectedly in state {}", _name,
+                      ip._name, _progressState);
               return ;
             }
             //
             // wrong pool mode arrived
             //
             if( ip._expectedReadOnly != newIsReadOnly ){
-              _log.warn("PROGRESS-H("+_name+"/"+ip._name+") Warning : got I/O mode rdonly="+newIsReadOnly+" expected rdOnly="+_expectedReadOnly);
+              _log.warn("PROGRESS-H({}/{}) Warning : got I/O mode rdonly={} expected rdOnly={}", _name,
+                      ip._name, newIsReadOnly, _expectedReadOnly);
               return ;
             }
             //
@@ -259,7 +260,7 @@ import static org.dcache.util.ByteUnit.MiB;
                  }
              }
             if(_parameter._p_poolset) {
-                _log.info("PROGRESS-H(" + _name + "/" + ip._name + ") new pool i/o mode total=" + total + ";rdOnly=" + modeOk);
+                _log.info("PROGRESS-H({}/{}) new pool i/o mode total={};rdOnly={}", _name, ip._name, total, modeOk);
             }
             //
             // not yet
@@ -274,7 +275,7 @@ import static org.dcache.util.ByteUnit.MiB;
                // all pools are readyOnly; flush them all.
                //
                if(_parameter._p_poolset) {
-                   _log.info("PROGRESS-H(" + _name + "/" + ip._name + ") new pool i/o mode done; Flushing all");
+                   _log.info("PROGRESS-H({}/{}) new pool i/o mode done; Flushing all", _name, ip._name);
                }
                int flushed = 0 ;
                 for (Object o : _poolMap.values()) {
@@ -292,13 +293,14 @@ import static org.dcache.util.ByteUnit.MiB;
                   newState( PS_WAITING_FOR_FLUSH_DONE ) ;
                }else{
                   if(_parameter._p_poolset) {
-                      _log.info("PROGRESS-H(" + _name + "/" + ip._name + ") new pool i/o mode done; nothing to flush; switching back to read/write");
+                      _log.info("PROGRESS-H({}/{}) new pool i/o mode done; nothing to flush; " +
+                              "switching back to read/write", _name, ip._name );
                   }
                   switchToNewPoolMode(false);
                }
             }else{
                if(_parameter._p_poolset) {
-                   _log.info("PROGRESS-H(" + _name + "/" + ip._name + ") new pool i/o mode done; Switching back to IDLE");
+                   _log.info("PROGRESS-H({}/{}) new pool i/o mode done; Switching back to IDLE", _name, ip._name );
                }
 
                newState( PS_IDLE ) ;
@@ -307,7 +309,7 @@ import static org.dcache.util.ByteUnit.MiB;
          public boolean inProgress(){ return _progressState != 0 ; }
          public void flushingDone( Pool ip  , String storageClassName , HsmFlushControlCore.FlushInfo flushInfo  ){
             if(_parameter._p_poolset) {
-                _log.info("PROGRESS-H(" + _name + "/" + ip._name + ") flushingDone");
+                _log.info("PROGRESS-H({}/{}) flushingDone", _name, ip._name );
             }
             //
             // check if all are done
@@ -334,7 +336,7 @@ import static org.dcache.util.ByteUnit.MiB;
          }
          private void flushAll(){
             if(_parameter._p_poolset) {
-                _log.info("PROGRESS-H(" + _name + ") flush all; switching to readOnly");
+                _log.info("PROGRESS-H({}) flush all; switching to readOnly", _name );
             }
             switchToNewPoolMode(true);
          }
@@ -374,7 +376,7 @@ import static org.dcache.util.ByteUnit.MiB;
 
          Pool ip = (Pool)pool.getDriverHandle() ;
          if( ip == null ){
-            _log.warn("getInternalPool : Yet unconfigured pool arrived "+pool.getName()+"; configuring");
+            _log.warn("getInternalPool : Yet unconfigured pool arrived {}; configuring", pool.getName());
             pool.setDriverHandle( ip = new Pool( pool.getName() , pool ) ) ;
          }
          return ip ;
@@ -402,13 +404,13 @@ import static org.dcache.util.ByteUnit.MiB;
          // printout what we got from our master
          //
          for( int i = 0 ; i < args.argc() ; i++ ){
-             _log.info("    args "+i+" : "+args.argv(i)) ;
+             _log.info("    args {} : ", i, args.argv(i)) ;
          }
          for( int i = 0 ; i < args.optc() ; i++ ){
-             _log.info("    opts "+args.optv(i)+"="+args.getOpt(args.optv(i))) ;
+             _log.info("    opts {}={}", args.optv(i), args.getOpt(args.optv(i))) ;
          }
          for (Object o : _core.getConfiguredPools()) {
-             _log.info("    configured pool : " + (o).toString());
+             _log.info("    configured pool : {}", (o).toString());
          }
          //
          //  Walk through the already known pools, create our internal presentation
@@ -418,7 +420,7 @@ import static org.dcache.util.ByteUnit.MiB;
 
              HsmFlushControlCore.Pool pool = (HsmFlushControlCore.Pool) o;
              Pool ip = getInternalPool(pool);
-             _log.info("init : " + pool.getName() + " " + ip);
+             _log.info("init : {} {}", pool.getName(), ip);
          }
          String tmp = args.getOpt("driver-config-file") ;
          if( tmp != null ) {
@@ -433,7 +435,7 @@ import static org.dcache.util.ByteUnit.MiB;
      @Override
      public void propertiesUpdated( Map<String,Object> properties ){
          if(_parameter._p_events) {
-             _log.info("EVENT : propertiesUpdated : " + properties);
+             _log.info("EVENT : propertiesUpdated : {}", properties);
          }
         _parameter.propertiesUpdated( properties ) ;
      }
@@ -445,11 +447,11 @@ import static org.dcache.util.ByteUnit.MiB;
      public void poolIoModeUpdated( String poolName ,  HsmFlushControlCore.Pool pool ){
 
          if(_parameter._p_events) {
-             _log.info("EVENT : poolIoModeUpdated : " + pool);
+             _log.info("EVENT : poolIoModeUpdated : {}", pool);
          }
 
          if( ! pool.isActive() ){
-            _log.warn("poolIoModeUpdated : Pool "+poolName+" not yet active (ignoring)");
+            _log.warn("poolIoModeUpdated : Pool {} not yet active (ignoring)", poolName);
             return ;
          }
 
@@ -466,16 +468,16 @@ import static org.dcache.util.ByteUnit.MiB;
      public void flushingDone( String poolName , String storageClassName , HsmFlushControlCore.FlushInfo flushInfo  ){
 
          if(_parameter._p_events) {
-             _log.info("EVENT : flushingDone : pool =" + poolName + ";class=" + storageClassName /* + "flushInfo="+flushInfo */);
+             _log.info("EVENT : flushingDone : pool ={};class={}", poolName, storageClassName /* + "flushInfo="+flushInfo */);
          }
 
          HsmFlushControlCore.Pool pool = _core.getPoolByName( poolName ) ;
          if( pool == null ){
-            _log.warn("flushingDone : for a non configured pool : "+poolName);
+            _log.warn("flushingDone : for a non configured pool : {}", poolName);
             return ;
          }
          if( ! pool.isActive() ){
-            _log.warn("flushingDone : Pool "+poolName+" not yet active (ignoring)");
+            _log.warn("flushingDone : Pool {} not yet active (ignoring)", poolName);
             return ;
          }
 
@@ -493,11 +495,11 @@ import static org.dcache.util.ByteUnit.MiB;
      public void poolFlushInfoUpdated( String poolName , HsmFlushControlCore.Pool pool ){
 
          if(_parameter._p_events) {
-             _log.info("EVENT : poolFlushInfoUpdated : " + pool.getName());
+             _log.info("EVENT : poolFlushInfoUpdated : {}", pool.getName());
          }
          //
          if( ! pool.isActive() ){
-            _log.warn("poolFlushInfoUpdated : Pool "+poolName+" not yet active (ignoring)");
+            _log.warn("poolFlushInfoUpdated : Pool {} not yet active (ignoring)", poolName);
             return ;
          }
          Pool ip = getInternalPool( pool ) ;
@@ -543,7 +545,7 @@ import static org.dcache.util.ByteUnit.MiB;
      @Override
      public void command( Args args  ){
          if(_parameter._p_events) {
-             _log.info("EVENT : command : " + args);
+             _log.info("EVENT : command : {}", args);
          }
          if (args.argc() == 0) {
              return;
@@ -554,9 +556,9 @@ import static org.dcache.util.ByteUnit.MiB;
                  throw new
                          Exception("Null pointer from command call");
              }
-             _log.info("Command returns : "+reply.toString() );
+             _log.info("Command returns : {}", reply.toString() );
          }catch(Exception ee ){
-             _log.warn("Command returns an exception ("+ee.getClass().getName()+") : " + ee.toString());
+             _log.warn("Command returns an exception ({}) : {}", ee.getClass().getName(), ee.toString());
          }
      }
      @Override
@@ -569,16 +571,16 @@ import static org.dcache.util.ByteUnit.MiB;
      public void configuredPoolAdded( String poolName ){
 
          if(_parameter._p_events) {
-             _log.info("EVENT : Configured pool added : " + poolName);
+             _log.info("EVENT : Configured pool added : {}", poolName);
          }
 
          HsmFlushControlCore.Pool pool = _core.getPoolByName( poolName ) ;
          if( pool == null ){
-            _log.warn("Pool not found in _core database : "+poolName);
+            _log.warn("Pool not found in _core database : {}", poolName);
             return ;
          }
          if( ! pool.isActive() ){
-            _log.warn("Pool "+poolName+" not yet active (ignoring)");
+            _log.warn("Pool {} not yet active (ignoring)", poolName);
             return ;
          }
          Pool ip = getInternalPool( pool ) ;
@@ -593,7 +595,7 @@ import static org.dcache.util.ByteUnit.MiB;
      @Override
      public void configuredPoolRemoved( String poolName ){
          if(_parameter._p_events) {
-             _log.info("EVENT : Configured pool removed : " + poolName + "  (ignoring)");
+             _log.info("EVENT : Configured pool removed : {}  (ignoring)", poolName );
          }
      }
      //-----------------------------------------------------------------------------------------
@@ -647,12 +649,8 @@ import static org.dcache.util.ByteUnit.MiB;
 
          }
          if(_parameter._p_rules) {
-             _log.info("RULES : statistics : " +
-                     "total=" + totalAvailable +
-                     ";readOnly=" + totalReadOnly +
-                     ";flushing=" + totalFlushing +
-                     ";progress=" + inProgress +
-                     ";candidates=" + candidates.size());
+             _log.info("RULES : statistics : total={};readOnly={};flushing={};progress={};candidates={}",
+                     totalAvailable, totalReadOnly, totalFlushing, inProgress, candidates.size());
          }
 
          if(candidates.isEmpty()){
@@ -662,14 +660,14 @@ import static org.dcache.util.ByteUnit.MiB;
             return ;
          }
          //if( totalReadOnly > (int)( (double)totalAvailable * _parameter._percentageToFlush ) ){
-         //   if(_parameter._p_rules)_log.info("RULES : too many pools ReadOnly ("+totalReadOnly+" out of "+totalAvailable+")") ;
+         //   if(_parameter._p_rules)_log.info("RULES : too many pools ReadOnly ({} out of {})", totalReadOnly, totalAvailable) ;
          //   return ;
          //}
          // DEBUG
          if(_parameter._p_rules){
              for (Object candidate : candidates) {
                  Pool pp = (Pool) candidate;
-                 _log.info("RULES : weight of " + pp._name + " " + getPoolMetric(pp));
+                 _log.info("RULES : weight of {} {}", pp._name, getPoolMetric(pp));
              }
          }
          Collections.sort( candidates , _poolComparator );
@@ -689,7 +687,7 @@ import static org.dcache.util.ByteUnit.MiB;
              PoolSet ps = pp.getParentPoolSet();
 
              if (_parameter._p_rules) {
-                 _log.info("RULES : checking " + pp._name + "/" + ps._name + " " + getPoolMetric(pp));
+                 _log.info("RULES : checking {}/ {} {}", pp._name, ps._name, getPoolMetric(pp));
              }
 
              Collection<String> potentialRdOnlyPools = new HashSet<>(rdOnlyHash);
@@ -697,13 +695,14 @@ import static org.dcache.util.ByteUnit.MiB;
                  potentialRdOnlyPools.add(o.toString());
              }
              if (_parameter._p_rules) {
-                 _log.info("RULES : potential rdOnlyPools : " + potentialRdOnlyPools);
+                 _log.info("RULES : potential rdOnlyPools : {}", potentialRdOnlyPools);
              }
              int total = potentialRdOnlyPools.size();
 
              if (total > (int) ((double) totalAvailable * _parameter._percentageToFlush)) {
                  if (_parameter._p_rules) {
-                     _log.info("RULES : " + ps._name + " would be too many pools ReadOnly (" + total + " out of " + totalAvailable + ")");
+                     _log.info("RULES : {} would be too many pools ReadOnly ({} out of {})",
+                             ps._name, total, totalAvailable );
                  }
                  continue;
              }
@@ -719,8 +718,7 @@ import static org.dcache.util.ByteUnit.MiB;
          }
 
          if(_parameter._p_rules) {
-             _log.info("RULES : flushing poolset : " + best._name + " with pools " + best
-                     .keySet());
+             _log.info("RULES : flushing poolset : {} with pools {}", best._name, best.keySet());
          }
 
          best.flushAll() ;
@@ -779,10 +777,10 @@ import static org.dcache.util.ByteUnit.MiB;
            for (Map.Entry<String, PoolSet> hostEntry : _hostMap.entrySet()) {
                String hostName = hostEntry.getKey();
                PoolSet hostMap = hostEntry.getValue();
-               _log.info(" >>" + hostName + "<<");
+               _log.info(" >>{}<<", hostName);
                for (Map.Entry<String, Pool> e : hostMap.entrySet()) {
                    String name = e.getKey();
-                   _log.info("     " + name + (extended ? e.getValue()
+                   _log.info("     {}{}", name, (extended ? e.getValue()
                            .toString() : ""));
                }
            }
@@ -833,22 +831,19 @@ import static org.dcache.util.ByteUnit.MiB;
 
              long size = flush.getTotalPendingFileSize();
 
-             _log.info("flushPool : class = " + info
-                     .getName() + " size = " + size + " flushing = " + info
-                     .isFlushing());
+             _log.info("flushPool : class = {} size = {} flushing = {}", info.getName(), size, info.isFlushing());
              //
              // is precious size > 0 and are we not yet flushing ?
              //
              try {
                  if ((size > 0L) && !info.isFlushing()) {
-                     _log.info("flushPool : !!! flushing " + _parameter._flushAtOnce + " of " + pool
-                             .getName() + " " + info.getName());
+                     _log.info("flushPool : !!! flushing {} of {} {}", _parameter._flushAtOnce, pool.
+                             getName(), info.getName());
                      info.flush(_parameter._flushAtOnce);
                      flushing++;
                  }
              } catch (Exception ee) {
-                 _log.warn("flushPool : Problem flushing " + pool
-                         .getName() + " " + info.getName() + " " + ee);
+                 _log.warn("flushPool : Problem flushing {} {} {}", pool.getName(), info.getName(), ee.toString());
              }
 
          }
@@ -1000,7 +995,7 @@ import static org.dcache.util.ByteUnit.MiB;
                         properties.remove(key);
                     }
                 } catch (Exception ee) {
-                    _log.warn("Exception while seting " + key + " " + ee);
+                    _log.warn("Exception while seting {} {}", key, ee.toString());
                 }
             }
            //

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/HandlerExample.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/HandlerExample.java
@@ -57,18 +57,17 @@ public class HandlerExample implements HsmFlushSchedulable {
          _log.info("init called");
          Args args = _core.getDriverArgs() ;
          for( int i = 0 ; i < args.argc() ; i++ ){
-             _log.info("    args "+i+" : "+args.argv(i)) ;
+             _log.info("    args {} : ", i, args.argv(i)) ;
          }
          for( int i = 0 ; i < args.optc() ; i++ ){
-             _log.info("    opts "+args.optv(i)+"="+args.getOpt(args.optv(i))) ;
+             _log.info("    opts {}={}", args.optv(i), args.getOpt(args.optv(i))) ;
          }
          _doNothing = args.hasOption("do-nothing") ;
          _properties.put( "mode" , _doNothing ? "manual" : "auto" ) ;
 
          for (Object o : _core.getConfiguredPoolNames()) {
              String poolName = o.toString();
-             _log.info("    configured pool : " + poolName + _core
-                     .getPoolByName(poolName).toString());
+             _log.info("    configured pool : {}{}", poolName, _core.getPoolByName(poolName).toString());
              _poolHash.put(poolName, new Pool(poolName));
          }
      }
@@ -78,23 +77,23 @@ public class HandlerExample implements HsmFlushSchedulable {
      }
      @Override
      public void configuredPoolAdded( String poolName ){
-         _log.info("configured pool added : "+poolName);
+         _log.info("configured pool added : {}", poolName);
 
      }
      @Override
      public void configuredPoolRemoved( String poolName ){
-         _log.info("configured pool removed : "+poolName);
+         _log.info("configured pool removed : {}", poolName);
          _poolHash.remove( poolName ) ;
      }
      @Override
      public void flushingDone( String poolName , String storageClassName , HsmFlushControlCore.FlushInfo flushInfo  ){
 
-         _log.info("flushingDone : pool ="+poolName+";class="+storageClassName /* + "flushInfo="+flushInfo */ );
+         _log.info("flushingDone : pool ={};class={}", poolName, storageClassName /* + "flushInfo="+flushInfo */ );
 
      }
      @Override
      public void command( Args args  ){
-         _log.info("command : "+args);
+         _log.info("command : {}", args);
          if (args.argc() == 0) {
              return;
          }
@@ -106,10 +105,10 @@ public class HandlerExample implements HsmFlushSchedulable {
                          Exception("Null pointer from command call");
              }
 
-             _log.info("Command returns : "+reply.toString() );
+             _log.info("Command returns : {}", reply.toString() );
 
          }catch(Exception ee ){
-             _log.warn("Command returns an exception ("+ee.getClass().getName()+") : " + ee.toString());
+             _log.warn("Command returns an exception ({}) : {}", ee.getClass().getName(), ee.toString());
          }
      }
      public String ac_set_mode_$_1( Args args ){
@@ -136,7 +135,7 @@ public class HandlerExample implements HsmFlushSchedulable {
      }
      @Override
      public void poolIoModeUpdated( String poolName ,  HsmFlushControlCore.Pool pool ){
-         _log.info("pool io mode updated : "+pool);
+         _log.info("pool io mode updated : {}", pool);
      }
      @Override
      public void reset(){
@@ -144,7 +143,7 @@ public class HandlerExample implements HsmFlushSchedulable {
      }
      @Override
      public void timer(){
-         _log.info( "Timer at : "+System.currentTimeMillis());
+         _log.info( "Timer at : {}", System.currentTimeMillis());
      }
      @Override
      public void propertiesUpdated( Map<String,Object> properties )
@@ -202,7 +201,7 @@ public class HandlerExample implements HsmFlushSchedulable {
          }
 
          if( ! pool.isActive() ){
-             _log.info( "poolFlushInfoUpdated : Pool : "+poolName+" inactive");
+             _log.info( "poolFlushInfoUpdated : Pool : {} inactive", poolName);
              return ;
          }
          PoolCellInfo cellInfo = pool.getCellInfo() ;
@@ -213,7 +212,7 @@ public class HandlerExample implements HsmFlushSchedulable {
          long total    = spaceInfo.getTotalSpace() ;
          long precious = spaceInfo.getPreciousSpace() ;
 
-         _log.info( "poolFlushInfoUpdated : Pool : "+poolName+";total="+total+";precious="+precious);
+         _log.info( "poolFlushInfoUpdated : Pool : {};total={};precious={}", poolName, total, precious);
          //
          // loop over all storage classes of this pool and flush
          // those with have some files pending and which are not yet
@@ -229,18 +228,18 @@ public class HandlerExample implements HsmFlushSchedulable {
 
              long size = flush.getTotalPendingFileSize();
 
-             _log.info("poolFlushInfoUpdated :       class = " + storageClass + " size = " + size + " flushing = " + info
-                     .isFlushing());
+             _log.info("poolFlushInfoUpdated :       class = {} size = {} flushing = {}", storageClass, size,
+                     info.isFlushing());
              //
              // is precious size > 0 and are we not yet flushing ?
              //
              try {
                  if ((size > 0L) && !info.isFlushing()) {
-                     _log.info("poolFlushInfoUpdated :       flushing " + poolName + " " + storageClass);
+                     _log.info("poolFlushInfoUpdated :       flushing {} {}", poolName, storageClass);
                      info.flush(0);
                  }
              } catch (Exception ee) {
-                 _log.warn("poolFlushInfoUpdated : Problem flushing " + poolName + " " + storageClass + " " + ee);
+                 _log.warn("poolFlushInfoUpdated : Problem flushing {} {} {}", poolName, storageClass, ee.toString());
              }
 
          }

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -1013,7 +1013,7 @@ public class PnfsManagerV3
         BlockingQueue<CellMessage> fifo = _fifos[queueId];
         Object[] fifoContent = fifo.toArray();
 
-        _log.warn("PnfsManager thread #" + queueId + " queue dump (" +fifoContent.length+ "):");
+        _log.warn("PnfsManager thread #{} queue dump ({}):", queueId, fifoContent.length);
 
         StringBuilder sb = new StringBuilder();
 
@@ -1134,7 +1134,7 @@ public class PnfsManagerV3
     }
 
     public void addCacheLocation(PnfsAddCacheLocationMessage pnfsMessage){
-        _log.info("addCacheLocation : "+pnfsMessage.getPoolName()+" for "+pnfsMessage.getPnfsId());
+        _log.info("addCacheLocation : {} for {}", pnfsMessage.getPoolName(), pnfsMessage.getPnfsId());
         try {
             /* At this point, the file is no longer new and should
              * really have level 2 set. Otherwise we would not be able
@@ -1164,7 +1164,7 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException fnf ) {
             pnfsMessage.setFailed(CacheException.FILE_NOT_FOUND, fnf.getMessage() );
         } catch (CacheException e){
-            _log.warn("Exception in addCacheLocation: " + e);
+            _log.warn("Exception in addCacheLocation: {}", e.toString());
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e){
             _log.error("Exception in addCacheLocation", e);
@@ -1176,7 +1176,7 @@ public class PnfsManagerV3
 
     public void clearCacheLocation(PnfsClearCacheLocationMessage pnfsMessage){
         PnfsId pnfsId = pnfsMessage.getPnfsId();
-        _log.info("clearCacheLocation : "+pnfsMessage.getPoolName()+" for "+pnfsId);
+        _log.info("clearCacheLocation : {} for {}", pnfsMessage.getPoolName(), pnfsId);
         try {
             checkMask(pnfsMessage);
             checkRestriction(pnfsMessage, UPDATE_METADATA);
@@ -1187,7 +1187,7 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException fnf ) {
             pnfsMessage.setFailed(CacheException.FILE_NOT_FOUND, fnf.getMessage() );
         } catch (CacheException e){
-            _log.warn("Exception in clearCacheLocation for "+pnfsId+": "+e);
+            _log.warn("Exception in clearCacheLocation for {}: {}", pnfsId, e.toString());
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e){
             _log.error("Exception in clearCacheLocation for "+pnfsId, e);
@@ -1201,7 +1201,7 @@ public class PnfsManagerV3
         Subject subject = pnfsMessage.getSubject();
         try {
             PnfsId pnfsId = populatePnfsId(pnfsMessage);
-            _log.info("get cache locations for " + pnfsId);
+            _log.info("get cache locations for {}", pnfsId);
 
             checkMask(pnfsMessage);
             checkRestriction(pnfsMessage, READ_METADATA);
@@ -1210,7 +1210,7 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException fnf ) {
             pnfsMessage.setFailed(CacheException.FILE_NOT_FOUND, fnf.getMessage() );
         } catch (CacheException e){
-            _log.warn("Exception in getCacheLocations: " + e);
+            _log.warn("Exception in getCacheLocations: {}", e.toString());
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e){
             _log.error("Exception in getCacheLocations", e);
@@ -1262,7 +1262,7 @@ public class PnfsManagerV3
                      */
                     attrs = _nameSpaceProvider.getFileAttributes(ROOT, pnfsId, requested);
                 } catch (CacheException e) {
-                    _log.warn("Can't determine storageInfo: " + e);
+                    _log.warn("Can't determine storageInfo: {}", e.toString());
                 }
                 break;
 
@@ -1430,7 +1430,7 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException e) {
             pnfsMessage.setFailed(CacheException.FILE_NOT_FOUND, e.getMessage());
         } catch (CacheException e) {
-            _log.warn("Failed to delete entry: " + e.getMessage());
+            _log.warn("Failed to delete entry: {}", e.getMessage());
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
             _log.error("Failed to delete entry", e);
@@ -1486,12 +1486,12 @@ public class PnfsManagerV3
 
         try {
             if (globalPath == null) {
-                _log.info("map:  id2path for " + pnfsId);
+                _log.info("map:  id2path for {}", pnfsId);
                 String path = pathfinder(subject, pnfsId);
                 checkRestriction(pnfsMessage, READ_METADATA, FsPath.create(path));
                 pnfsMessage.setGlobalPath(path);
             } else {
-                _log.info("map:  path2id for " + globalPath);
+                _log.info("map:  path2id for {}", globalPath);
                 checkRestriction(pnfsMessage, READ_METADATA, FsPath.create(globalPath));
                 pnfsMessage.setPnfsId(pathToPnfsid(subject, globalPath, shouldResolve));
             }
@@ -1500,7 +1500,7 @@ public class PnfsManagerV3
             pnfsMessage.setFailed( CacheException.FILE_NOT_FOUND , fnf.getMessage() ) ;
         }catch (CacheException ce) {
             pnfsMessage.setFailed(ce.getRc(), ce.getMessage());
-            _log.warn("mapPath: " + ce.getMessage());
+            _log.warn("mapPath: {}", ce.getMessage());
         } catch (RuntimeException e) {
             _log.error("Exception in mapPath (pathfinder) " + e, e);
             pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
@@ -2050,7 +2050,7 @@ public class PnfsManagerV3
             return db % _threadGroups;
         }
 
-        _log.info("Path cache miss for " + path);
+        _log.info("Path cache miss for {}", path);
 
         return MathUtils.absModulo(path.hashCode(), _threadGroups);
     }
@@ -2138,7 +2138,7 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException e){
             message.setFailed(e.getRc(), e);
         } catch (CacheException e) {
-            _log.warn("Error while retrieving file attributes: " + e.getMessage());
+            _log.warn("Error while retrieving file attributes: {}", e.getMessage());
             message.setFailed(e.getRc(), e);
         } catch (RuntimeException e) {
             _log.error("Error while retrieving file attributes: " + e.getMessage(), e);

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/HttpPoolMgrEngineV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/HttpPoolMgrEngineV3.java
@@ -113,7 +113,7 @@ public class HttpPoolMgrEngineV3 implements
         _pnfsManagerAddress = arguments.getOption("pnfsmanager");
 
         for (int i = 0; i < argsString.length; i++) {
-            _log.info("HttpPoolMgrEngineV3 : argument : "+i+" : "+argsString[i]);
+            _log.info("HttpPoolMgrEngineV3 : argument : {} : {}", i, argsString[i]);
             if (argsString[i].equals("addStorageInfo")) {
                 _addStorageInfo = true;
                 _log.info("Option accepted : addStorageInfo");
@@ -121,14 +121,14 @@ public class HttpPoolMgrEngineV3 implements
                 _addHsmInfo = true;
                 _log.info("Option accepted : addHsmInfo");
             } else if (argsString[i].startsWith("details=")) {
-                _log.info("Details for lazy restore : "+argsString[i]);
+                _log.info("Details for lazy restore : {}", argsString[i]);
                 decodeDetails(argsString[i]);
             } else if (argsString[i].startsWith("css=")) {
                 decodeCss(argsString[i].substring(4));
             }
         }
         _restoreCollector = new Thread(this, "restore-collector");
-        _log.info("Using CSS file : "+_cssFile);
+        _log.info("Using CSS file : {}", _cssFile);
     }
 
     @Override
@@ -246,7 +246,7 @@ public class HttpPoolMgrEngineV3 implements
                     _pm.sendAsync(_endpoint, new PoolManagerGetRestoreHandlerInfo(), _poolManager.getTimeoutInMillis());
             infos = CellStub.getMessage(future).getResult();
         } catch (CacheException | NoRouteToCellException e) {
-            _log.warn("runRestoreCollector : failure reply from PoolManager : " + e.getMessage());
+            _log.warn("runRestoreCollector : failure reply from PoolManager : {}", e.getMessage());
             return;
         }
 

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
@@ -291,7 +291,7 @@ public class PoolManagerV5
                 }
 
             } catch (Exception ee) {
-                _log.warn("WatchdogThread : illegal arguments [" + parameter + "] (using defaults) " + ee.getMessage());
+                _log.warn("WatchdogThread : illegal arguments [{}] (using defaults) {}", parameter, ee.getMessage());
             }
         }
 
@@ -749,7 +749,7 @@ public class PoolManagerV5
             QuotaMgrCheckQuotaMessage quotas = new QuotaMgrCheckQuotaMessage(storageClass);
            return _quotaManager.sendAndWait(quotas).isHardQuotaExceeded();
         } catch (Exception e) {
-            _log.warn("quotasExceeded of " + storageClass + " : Exception : {}", e.toString());
+            _log.warn("quotasExceeded of {} : Exception : {}", storageClass, e.toString());
             return false;
         }
     }

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -270,7 +270,7 @@ public class RequestContainerV5
     }
 
     public void poolStatusChanged(String poolName, int poolStatus) {
-        _log.info("Restore Manager : got 'poolRestarted' for " + poolName);
+        _log.info("Restore Manager : got 'poolRestarted' for {}", poolName);
         try {
             List<PoolRequestHandler> list;
             synchronized (_handlerHash) {
@@ -293,7 +293,7 @@ public class RequestContainerV5
                          * in this construction we will fall down to next case
                          */
                         if (rph.getPoolCandidate().equals(POOL_UNKNOWN_STRING) ) {
-                            _log.info("Restore Manager : retrying : " + rph);
+                            _log.info("Restore Manager : retrying : {}", rph);
                             rph.retry();
                         }
                     case PoolStatusChangedMessage.DOWN:
@@ -302,7 +302,7 @@ public class RequestContainerV5
                          * pool
                          */
                         if (rph.getPoolCandidate().equals(poolName) ) {
-                            _log.info("Restore Manager : retrying : " + rph);
+                            _log.info("Restore Manager : retrying : {}", rph);
                             rph.retry();
                         }
                 }
@@ -679,7 +679,7 @@ public class RequestContainerV5
         //
         //
         PoolRequestHandler handler;
-        _log.info( "Adding request for : "+canonicalName ) ;
+        _log.info( "Adding request for : {}", canonicalName ) ;
         synchronized( _handlerHash ){
            handler = _handlerHash.computeIfAbsent(canonicalName, n -> new PoolRequestHandler(pnfsId, n, allowedStates));
            handler.addRequest(envelope) ;
@@ -1016,7 +1016,7 @@ public class RequestContainerV5
             Pool2PoolTransferMsg pool2pool =
                     new Pool2PoolTransferMsg(sourcePool.name(), destPool.name(), _fileAttributes);
             pool2pool.setDestinationFileStatus(_destinationFileStatus);
-            _log.info("[p2p] Sending transfer request: " + pool2pool);
+            _log.info("[p2p] Sending transfer request: {}", pool2pool);
             CellMessage cellMessage =
                     new CellMessage(new CellPath(destPool.address()), pool2pool);
 
@@ -1051,9 +1051,7 @@ public class RequestContainerV5
                     CellMessage message = i.next();
                     long ttl = message.getTtl();
                     if (message.getLocalAge() >= ttl) {
-                        _log.info("Discarding request from "
-                                  + message.getSourcePath().getCellName()
-                                  + " because its time to live has been exceeded.");
+                        _log.info("Discarding request from {} because its time to live has been exceeded.", message.getSourcePath().getCellName());
                         i.remove();
                     } else if (ttl < Long.MAX_VALUE) {
                         _nextTtlTimeout = Math.min(_nextTtlTimeout, now + ttl);
@@ -1130,7 +1128,7 @@ public class RequestContainerV5
         }
         private void add( Object obj ){
            synchronized( _fifo ){
-               _log.info( "Adding Object : "+obj ) ;
+               _log.info( "Adding Object : {}", obj ) ;
                _fifo.addFirst(obj) ;
                if( _stateEngineActive ) {
                    return;
@@ -1148,7 +1146,7 @@ public class RequestContainerV5
         private void stateLoop(){
 
            Object inputObject ;
-           _log.info( "ACTIVATING STATE ENGINE "+_pnfsId+" "+(System.currentTimeMillis()-_started)) ;
+           _log.info( "ACTIVATING STATE ENGINE {} {}", _pnfsId, (System.currentTimeMillis()-_started)) ;
 
            while( ! Thread.interrupted() ){
 
@@ -1166,16 +1164,16 @@ public class RequestContainerV5
               }
               _forceContinue = false ;
               try{
-                 _log.info("StageEngine called in mode " +
-                           _state + " with object " +
-                        (  inputObject == null ?
-                             "(NULL)":
-                            (  inputObject instanceof Object [] ?
-                                 ((Object[])inputObject)[0].toString() :
-                                 inputObject.getClass().getName()
-                            )
-                        )
-                    );
+                 _log.info("StageEngine called in mode {}  with object {}", _state,
+                         (
+                         inputObject == null ? "(NULL)":
+                                 (
+                                         inputObject instanceof Object [] ?
+                                                 ((Object[])inputObject)[0].toString()
+                                                 : inputObject.getClass().getName()
+                                 )
+                         )
+                 );
 
                  stateEngine( inputObject ) ;
 
@@ -1209,7 +1207,7 @@ public class RequestContainerV5
                         return true;
                     }
                 } catch (IOException | PatternSyntaxException e) {
-                    _log.error("Failed to verify stage permissions: " + e.getMessage());
+                    _log.error("Failed to verify stage permissions: {}", e.getMessage());
                 }
             }
 
@@ -1501,7 +1499,7 @@ public class RequestContainerV5
                             }
                         }else{
                             _poolCandidate = _bestPool;
-                            _log.info("ST_POOL_2_POOL : Choosing high cost pool "+_poolCandidate.info());
+                            _log.info("ST_POOL_2_POOL : Choosing high cost pool {}", _poolCandidate.info());
 
                           setError(0,"");
                           nextStep(RequestState.ST_DONE , CONTINUE ) ;
@@ -1524,7 +1522,7 @@ public class RequestContainerV5
                           if( _bestPool != null ){
 
                               _poolCandidate = _bestPool;
-                              _log.info("ST_POOL_2_POOL : Choosing high cost pool "+_poolCandidate.info());
+                              _log.info("ST_POOL_2_POOL : Choosing high cost pool {}", _poolCandidate.info());
 
                              setError(0,"");
                              nextStep(RequestState.ST_DONE , CONTINUE ) ;
@@ -1834,7 +1832,7 @@ public class RequestContainerV5
 
               if( messageArrived instanceof Pool2PoolTransferMsg ){
                  Pool2PoolTransferMsg reply = (Pool2PoolTransferMsg)messageArrived ;
-                 _log.info("Pool2PoolTransferMsg replied with : "+reply);
+                 _log.info("Pool2PoolTransferMsg replied with : {}", reply);
                  if( ( _currentRc = reply.getReturnCode() ) == 0 ){
                      _poolCandidate = _p2pDestinationPool;
                     return RequestStatusCode.OK ;

--- a/modules/dcache/src/main/java/diskCacheV111/services/FileHoppingManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/FileHoppingManager.java
@@ -105,13 +105,13 @@ public class FileHoppingManager extends CellAdapter {
                 continue;
             }
             try{
-               _log.info( "Executing : "+line ) ;
+               _log.info( "Executing : {}", line ) ;
                String answer = command( line ) ;
                if(!answer.isEmpty()) {
-                   _log.info("Answer    : " + answer);
+                   _log.info("Answer    : {}", answer);
                }
             }catch( Exception ee ){
-               _log.warn("Exception : "+ee.toString() ) ;
+               _log.warn("Exception : {}", ee.toString() ) ;
             }
          }
       }finally{
@@ -389,18 +389,18 @@ public class FileHoppingManager extends CellAdapter {
    }
     @Override
     public void messageToForward(  CellMessage cellMessage ){
-        _log.info("Message to forward : "+cellMessage.getMessageObject().getClass().getName());
+        _log.info("Message to forward : {}", cellMessage.getMessageObject().getClass().getName());
         // super.messageToForward(cellMessage);
     }
    public void replicateReplyArrived( CellMessage message , PoolMgrReplicateFileMsg replicate ){
-      _log.info("replicateReplyArrived : "+message);
+      _log.info("replicateReplyArrived : {}", message);
    }
    @Override
    public void messageArrived( CellMessage message ){
 
       Object   request     = message.getMessageObject() ;
 
-      _log.info("messageArrived : "+request+" : "+message);
+      _log.info("messageArrived : {} : {}", request, message);
       if( request instanceof PoolMgrReplicateFileMsg ){
 
          PoolMgrReplicateFileMsg replicate = (PoolMgrReplicateFileMsg)request ;
@@ -438,7 +438,7 @@ public class FileHoppingManager extends CellAdapter {
 
                  matchCount++;
 
-                 _log.info("Entry found for : SC=<" + storageClass + "> source=" + replicationSource + " : " + entry);
+                 _log.info("Entry found for : SC=<{}> source={} : {}", storageClass, replicationSource, entry);
                  entry._hit++;
 
                  CellPath path = entry._path == null ? _defaultDestinationPath : entry._path;
@@ -451,7 +451,7 @@ public class FileHoppingManager extends CellAdapter {
                  try {
                      sendMessage(new CellMessage(path.clone(), replicate));
                  } catch (RuntimeException ee) {
-                     _log.warn("Problem : couldn't forward message to : " + entry._path + " : " + ee);
+                     _log.warn("Problem : couldn't forward message to : {} : {}", entry._path, ee.toString());
                  }
 
                  if (!entry._continue) {
@@ -459,7 +459,7 @@ public class FileHoppingManager extends CellAdapter {
                  }
              }
          }
-         _log.info("Total match count for <"+storageClass+"> was "+matchCount ) ;
+         _log.info("Total match count for <{}> was {}", storageClass, matchCount ) ;
 
       }
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -448,29 +448,29 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
             }
 
             try {
-                _log.info("Starting hourly run for : "+path);
+                _log.info("Starting hourly run for : {}", path);
 
                 createHourlyRawFile(path, _calendar);
 
-                _log.info("Hourly run finished for : "+path);
+                _log.info("Hourly run finished for : {}", path);
 
                 File today = getTodayPath(_calendar);
-                _log.info("Creating daily file : "+today);
+                _log.info("Creating daily file : {}", today);
 
                 //noinspection ResultOfMethodCallIgnored
                 today.delete();
                 copyFile(path, today);
 
-                _log.info("Daily file done : "+today);
+                _log.info("Daily file done : {}", today);
 
                 File yesterday = getYesterdayPath(_calendar);
                 if (yesterday.exists()) {
                     File diffFile  = getTodayDiffPath(_calendar);
-                    _log.info("Starting diff run for : "+yesterday);
+                    _log.info("Starting diff run for : {}", yesterday);
 
                     createDiffFile(today, yesterday, diffFile);
 
-                    _log.info("Finishing diff run for : "+diffFile);
+                    _log.info("Finishing diff run for : {}", diffFile);
                 }
                 if (_calendar.get(Calendar.HOUR_OF_DAY) == 23) {
                     resetBillingStatistics();
@@ -501,7 +501,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
     @Override
     public void run(CellCron.TimerTask task) {
         if (task == _hourly) {
-            _log.info("Hourly ticker : "+ new Date());
+            _log.info("Hourly ticker : {}", new Date());
             Calendar calendar = (Calendar)task.getCalendar().clone();
             new HourlyRunner(calendar);
             task.repeatNextHour();
@@ -774,7 +774,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
                                 synchronized(this) { _recentPoolStatistics = map; }
                                 _log.info("Finishing internal Manual run");
                             } catch(Exception e) {
-                                _log.info("Aborting internal Manual run "+e);
+                                _log.info("Aborting internal Manual run {}", e.toString());
                             }
                         }
                     },
@@ -785,11 +785,11 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
             final File file = new File(args.argv(0));
             _nucleus.newThread(() -> {
                 try {
-                    _log.info("Starting Manual run for file : "+file);
+                    _log.info("Starting Manual run for file : {}", file);
                     createHourlyRawFile(file, new GregorianCalendar());
-                    _log.info("Finishing Manual run for file : "+file);
+                    _log.info("Finishing Manual run for file : {}", file);
                 } catch(Exception e) {
-                    _log.info("Aborting Manual run for file : "+file+" "+e);
+                    _log.info("Aborting Manual run for file : {} {}", file, e.toString());
                 }
             }, file.toString()).start();
 
@@ -1034,7 +1034,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
         File diffFile  = getTodayDiffPath(calendar);
         if (! diffFile.exists()) {
-            _log.warn("prepareDailyHtmlFiles : File not found : "+diffFile);
+            _log.warn("prepareDailyHtmlFiles : File not found : {}", diffFile);
             return;
         }
         File dir = getHtmlPath(calendar);

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -323,7 +323,7 @@ public abstract class TransferManager extends AbstractCellComponent
             @Override
             public void run()
             {
-                log.error("timer for handler " + id + " has expired, killing");
+                log.error("timer for handler {} has expired, killing", id );
                 Object o = _moverTimeoutTimerTasks.remove(id);
                 if (o == null) {
                     log.error("TimerTask.run(): timer task for handler Id={} not found in moverTimoutTimerTasks hashtable", id);

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -201,7 +201,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void handle()
     {
-        log.debug("handling:  " + toString(true));
+        log.debug("handling:  {}", toString(true));
         int last_slash_pos = pnfsPath.lastIndexOf('/');
         if (last_slash_pos == -1) {
             transferRequest.setFailed(2,
@@ -409,7 +409,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                 : new PoolMgrSelectReadPoolMsg(fileAttributes, protocol_info, _readPoolSelectionContext);
         request.setBillingPath(pnfsPath);
         request.setSubject(transferRequest.getSubject());
-        log.debug("PoolMgrSelectPoolMsg: " + request);
+        log.debug("PoolMgrSelectPoolMsg: {}", request);
         setState(WAITING_FOR_POOL_INFO_STATE);
         manager.persist(this);
         CellStub.addCallback(manager.getPoolManagerStub().sendAsync(request), this, executor);
@@ -417,7 +417,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void poolInfoArrived(PoolMgrSelectPoolMsg pool_info)
     {
-        log.debug("poolManagerReply = " + pool_info);
+        log.debug("poolManagerReply = {}", pool_info);
 
         if (pool_info instanceof PoolMgrSelectReadPoolMsg) {
             _readPoolSelectionContext =
@@ -461,9 +461,9 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void poolFirstReplyArrived(PoolIoFileMessage poolMessage)
     {
-        log.debug("poolReply = " + poolMessage);
+        log.debug("poolReply = {}", poolMessage);
         info.setTimeQueued(info.getTimeQueued() + System.currentTimeMillis());
-        log.debug("Pool " + pool + " will deliver file " + pnfsId + " mover id is " + poolMessage.getMoverId());
+        log.debug("Pool {} will deliver file {} mover id is {}", pool, pnfsId, poolMessage.getMoverId());
         log.debug("Starting moverTimeout timer");
         manager.startTimer(id);
         setMoverId(poolMessage.getMoverId());
@@ -627,7 +627,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void sendSuccessReply()
     {
-        log.debug("sendSuccessReply for: " + toString(true));
+        log.debug("sendSuccessReply for: {}", toString(true));
         if (info.getTimeQueued() < 0) {
             info.setTimeQueued(info.getTimeQueued() + System
                     .currentTimeMillis());
@@ -668,7 +668,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
     void sendDoorRequestInfo(int code, String msg)
     {
         info.setResult(code, msg);
-        log.debug("Sending info: " + info);
+        log.debug("Sending info: {}", info);
         manager.getBillingStub().notify(info);
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/web/ContextPictureEngine.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/web/ContextPictureEngine.java
@@ -54,7 +54,7 @@ public class ContextPictureEngine implements HttpResponseEngine, DomainContextAw
       String [] tokens = request.getRequestTokens() ;
       int       offset = request.getRequestTokenOffset() ;
 
-      _log.info("Offset : "+offset);
+      _log.info("Offset : {}", offset);
       for( int i =0 ; i < tokens.length ;i++ ){
          _log.info(i + " -> " + tokens[i]);
       }

--- a/modules/dcache/src/main/java/diskCacheV111/services/web/PoolInfoObserverV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/web/PoolInfoObserverV3.java
@@ -65,9 +65,9 @@ public class PoolInfoObserverV3 extends AbstractCell
                             try {
                                 refresh();
                             } catch (CacheException | NoRouteToCellException e) {
-                                _log.error("Failed to update topology map: " + e.getMessage());
+                                _log.error("Failed to update topology map: {}", e.getMessage());
                             } catch (RuntimeException e) {
-                                _log.error("Failed to update topology map: " + e);
+                                _log.error("Failed to update topology map: {}", e.toString());
                             }
 
                             Thread.sleep(_interval * 1000);

--- a/modules/dcache/src/main/java/diskCacheV111/util/RunSystem.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/RunSystem.java
@@ -55,7 +55,7 @@ public class RunSystem implements Runnable {
 
     private void say(String str) {
         if (_log.isDebugEnabled()) {
-            _log.debug("[" + _id + "] " + str);
+            _log.debug("[{}] ", _id, str);
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
@@ -1392,7 +1392,7 @@ public class UniversalSpringCell
         {
             ChildData newData = _cache.getCurrentData();
             if (newData == null) {
-                LOGGER.error("Setup node " + _node + " in ZooKeeper disappeared. Service must be restarted.");
+                LOGGER.error("Setup node {} in ZooKeeper disappeared. Service must be restarted.", _node );
                 kill();
             } else if (newData.getStat().getVersion() > _current.getVersion()) {
                 apply(newData);

--- a/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
@@ -200,7 +200,7 @@ public class AuthenticationHandler extends HandlerWrapper {
         try {
             addresses.add(InetAddress.getByName(address));
         } catch (UnknownHostException e) {
-            LOG.warn("Failed to resolve " + address + ": " + e.getMessage());
+            LOG.warn("Failed to resolve {}: {}", address, e.getMessage());
             return;
         }
 

--- a/modules/dcache/src/main/java/org/dcache/missingfiles/MissingFileHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/missingfiles/MissingFileHandler.java
@@ -133,7 +133,7 @@ public class MissingFileHandler implements CellMessageReceiver
                 return false;
             } catch (ExecutionException e) {
                 Throwable t = e.getCause();
-                _log.error("Plugin bug: " + t.getMessage(),
+                _log.error("Plugin bug: {}", t.getMessage(),
                         t);
                 return true;
             }

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
@@ -219,7 +219,7 @@ public class PinRequestProcessor
                 RequestContainerV5.allStates :
                 RequestContainerV5.allStatesExceptStage;
         } catch (PatternSyntaxException | IOException ex) {
-            _log.error("Failed to check stage permission: " + ex);
+            _log.error("Failed to check stage permission: {}", ex.toString());
         }
         return RequestContainerV5.allStatesExceptStage;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
@@ -136,7 +136,7 @@ public abstract class AbstractMoverProtocolTransferService
                                 fileIoChannel.sync();
                             } catch (SyncFailedException e) {
                                 fileIoChannel.sync();
-                                LOGGER.info("First sync failed [" + e + "], but second sync suceeded");
+                                LOGGER.info("First sync failed [{}], but second sync suceeded", e );
                             }
                         }
                     } else {

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/NoCachedFilesSpaceSweeper.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/NoCachedFilesSpaceSweeper.java
@@ -81,7 +81,7 @@ public class NoCachedFilesSpaceSweeper
                 }
             }
         } catch (InterruptedException | CacheException e) {
-            _log.warn("Failed to remove entry from repository: " + e.getMessage() );
+            _log.warn("Failed to remove entry from repository: {}", e.getMessage() );
         }
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -1071,8 +1071,7 @@ public class PoolV4
                 && _poolMode.isDisabled(PoolV2Mode.DISABLED_FETCH))) {
 
             if (!msg.isForceSourceMode()) {
-                LOGGER.warn("PoolIoFileMessage request rejected due to "
-                            + _poolMode);
+                LOGGER.warn("PoolIoFileMessage request rejected due to {}", _poolMode);
                 throw new CacheException(CacheException.POOL_DISABLED, "Pool is disabled");
             }
         }
@@ -1085,8 +1084,7 @@ public class PoolV4
         throws CacheException, IOException, InterruptedException
     {
         if (_poolMode.isDisabled(PoolV2Mode.DISABLED_P2P_CLIENT)) {
-            LOGGER.warn("Pool2PoolTransferMsg request rejected due to "
-                        + _poolMode);
+            LOGGER.warn("Pool2PoolTransferMsg request rejected due to {}", _poolMode);
             throw new CacheException(CacheException.POOL_DISABLED, "Pool is disabled");
         }
 
@@ -1116,8 +1114,7 @@ public class PoolV4
         throws CacheException
     {
         if (_poolMode.isDisabled(PoolV2Mode.DISABLED_STAGE)) {
-            LOGGER.warn("PoolFetchFileMessage request rejected due to "
-                        + _poolMode);
+            LOGGER.warn("PoolFetchFileMessage request rejected due to {}", _poolMode);
             throw new CacheException(CacheException.POOL_DISABLED, "Pool is disabled");
         }
         if (!_hasTapeBackend) {
@@ -1175,8 +1172,7 @@ public class PoolV4
         throws CacheException
     {
         if (_poolMode.isDisabled(PoolV2Mode.DISABLED_STAGE)) {
-            LOGGER.warn("PoolRemoveFilesFromHsmMessage request rejected due to "
-                        + _poolMode);
+            LOGGER.warn("PoolRemoveFilesFromHsmMessage request rejected due to {}", _poolMode);
             throw new CacheException(CacheException.POOL_DISABLED, "Pool is disabled");
         }
         if (!_hasTapeBackend) {
@@ -1334,8 +1330,7 @@ public class PoolV4
         throws CacheException, InterruptedException
     {
         if (_poolMode.isDisabled(PoolV2Mode.DISABLED_STRICT)) {
-            LOGGER.warn("PoolSetStickyMessage request rejected due to "
-                        + _poolMode);
+            LOGGER.warn("PoolSetStickyMessage request rejected due to {}", _poolMode);
             throw new CacheException(CacheException.POOL_DISABLED, "Pool is disabled");
         }
 
@@ -1630,12 +1625,10 @@ public class PoolV4
                     _repository.setState(id, ReplicaState.REMOVED);
                     LOGGER.info("File not found in PNFS; removed {}", id);
                 } catch (InterruptedException | CacheException f) {
-                    LOGGER.error("File not found in PNFS, but failed to remove "
-                                 + id + ": " + f);
+                    LOGGER.error("File not found in PNFS, but failed to remove {}: {}", id, f);
                 }
             } catch (CacheException e) {
-                LOGGER.error("Cache location was not registered for "
-                             + id + ": " + e.getMessage());
+                LOGGER.error("Cache location was not registered for {}: {}", id , e.getMessage());
             }
         }
 
@@ -1687,11 +1680,10 @@ public class PoolV4
                 _hybridInventoryActive = false;
             }
 
-            LOGGER.info("Replica "
-                        + (_activate ? "registration" : "deregistration" )
-                        + " finished. " + _hybridCurrent
-                        + " replicas processed in "
-                        + (stopTime-startTime) + " msec");
+            LOGGER.info("Replica {} finished. {} replicas processed in {} msec",
+                    (_activate ? "registration" : "deregistration" ),
+                    _hybridCurrent,
+                    (stopTime-startTime));
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
@@ -322,7 +322,7 @@ public class Job
                     // File was removed before we got to it - not a
                     // problem.
                 } catch (CacheException e) {
-                    _log.error("Failed to load entry: " + e.getMessage());
+                    _log.error("Failed to load entry: {}", e.getMessage());
                 }
             }
         } catch (IllegalStateException e) {
@@ -561,13 +561,11 @@ public class Job
                 } catch (FileNotInCacheException e) {
                     _sizes.remove(pnfsId);
                 } catch (CacheException e) {
-                    _log.error("Migration job failed to read entry: " +
-                               e.getMessage());
+                    _log.error("Migration job failed to read entry: {}", e.getMessage());
                     setState(State.FAILED);
                     break;
                 } catch (InterruptedException e) {
-                    _log.error("Migration job was interrupted: " +
-                               e.getMessage());
+                    _log.error("Migration job was interrupted: {}", e.getMessage());
                     setState(State.FAILED);
                     break;
                 } finally {
@@ -936,8 +934,7 @@ public class Job
         } catch (IllegalTransitionException e) {
             // File is likely about to be removed. TODO: log it
         } catch (CacheException e) {
-            _log.error("Migration job failed to update source mode: " +
-                       e.getMessage());
+            _log.error("Migration job failed to update source mode: {}", e.getMessage());
             setState(State.FAILED);
         } catch (InterruptedException e) {
             _log.error("Migration job was interrupted");

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/PoolListFromPoolManager.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/PoolListFromPoolManager.java
@@ -53,6 +53,6 @@ public abstract class PoolListFromPoolManager
     @Override
     public void failure(int rc, Object error)
     {
-        _log.error("Failed to query pool manager (" + error + ")");
+        _log.error("Failed to query pool manager ({})", error );
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -319,9 +319,9 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
         try {
             return checksumModule.getProvidedChecksumsFactories(handle);
         } catch (NoSuchAlgorithmException e) {
-            LOGGER.error("Failed to instantiate mover due to unsupported checksum type: " + e.getMessage());
+            LOGGER.error("Failed to instantiate mover due to unsupported checksum type: {}", e.getMessage());
         } catch (CacheException e) {
-            LOGGER.error("Failed to instantiate mover: " + e.getMessage());
+            LOGGER.error("Failed to instantiate mover: {}", e.getMessage());
         }
         return null;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
@@ -191,10 +191,8 @@ public class RemoteGsiftpTransferProtocol
     {
         _pnfsId = fileAttributes.getPnfsId();
         if (_log.isDebugEnabled()) {
-            _log.debug("runIO()\n\tprotocol="
-                    + protocol + ",\n\tStorageInfo=" + StorageInfos.extractFrom(fileAttributes) + ",\n\tPnfsId="
-                    + _pnfsId + ",\n\taccess ="
-                    + access );
+            _log.debug("runIO()\n\tprotocol={},\n\tStorageInfo={},\n\tPnfsId={},\n\taccess ={}",
+                    protocol, StorageInfos.extractFrom(fileAttributes), _pnfsId, access );
         }
         if (!(protocol instanceof RemoteGsiftpTransferProtocolInfo)) {
             throw new CacheException("protocol info is not RemoteGsiftpransferProtocolInfo");
@@ -264,11 +262,10 @@ public class RemoteGsiftpTransferProtocol
             URI src_url = new URI(protocolInfo.getGsiftpUrl());
             boolean emode = protocolInfo.isEmode();
             long size = _client.getSize(src_url.getPath());
-            _log.debug(" received a file size info: " + size +
-                " allocating space on the pool");
-            _log.debug("ALLOC: " + _pnfsId + " : " + size );
+            _log.debug(" received a file size info: {} allocating space on the pool", size );
+            _log.debug("ALLOC: {} : {}", _pnfsId, size );
             allocator.allocate(size);
-            _log.debug(" allocated space " + size);
+            _log.debug(" allocated space {}", size);
             DiskDataSourceSink sink =
                 new DiskDataSourceSink(protocolInfo.getBufferSize(),
                                        false);
@@ -296,10 +293,10 @@ public class RemoteGsiftpTransferProtocol
 
             if (!checksums.isEmpty()){
                 Checksum checksum = checksums.iterator().next();
-                _log.debug("Will use " + checksum + " for transfer verification of "+_pnfsId);
+                _log.debug("Will use {} for transfer verification of {}", checksum, _pnfsId);
                 _client.setChecksum(checksum.getType().getName(), null);
             } else {
-                _log.debug("PnfsId "+_pnfsId+" does not have checksums");
+                _log.debug("PnfsId {} does not have checksums", _pnfsId);
             }
 
             URI dst_url =  new URI(protocolInfo.getGsiftpUrl());
@@ -327,7 +324,7 @@ public class RemoteGsiftpTransferProtocol
                 return ChecksumFactory.getFactory(ChecksumType.getChecksumType(_ftpCksm.type)).create(_ftpCksm.value);
             }
         } catch (NoSuchAlgorithmException | IllegalArgumentException e) {
-            _log.error("Checksum algorithm is not supported: " + e.getMessage());
+            _log.error("Checksum algorithm is not supported: {}", e.getMessage());
         }
         return null;
     }
@@ -367,17 +364,17 @@ public class RemoteGsiftpTransferProtocol
             _ftpCksm = _client.negotiateCksm(src_url.getPath());
             return ChecksumFactory.getFactory(ChecksumType.getChecksumType(_ftpCksm.type));
         } catch (NoSuchAlgorithmException | GridftpClient.ChecksumNotSupported | IllegalArgumentException e) {
-            _log.error("Checksum algorithm is not supported: " + e.getMessage());
+            _log.error("Checksum algorithm is not supported: {}", e.getMessage());
         } catch (IOException e) {
-            _log.error("I/O failure talking to FTP server: " + e.getMessage());
+            _log.error("I/O failure talking to FTP server: {}", e.getMessage());
         } catch (ServerException e) {
-            _log.error("GridFTP server failure: " + e.getMessage());
+            _log.error("GridFTP server failure: {}", e.getMessage());
         } catch (KeyStoreException e) {
-            _log.error("GridFTP authentication failure: " + e.getMessage());
+            _log.error("GridFTP authentication failure: {}", e.getMessage());
         } catch (URISyntaxException e) {
-            _log.error("Invalid GridFTP URL: " + e.getMessage());
+            _log.error("Invalid GridFTP URL: {}", e.getMessage());
         } catch (ClientException e) {
-            _log.error("GridFTP client failure: " + e.getMessage());
+            _log.error("GridFTP client failure: {}", e.getMessage());
         }
         return null;
     }
@@ -528,7 +525,7 @@ public class RemoteGsiftpTransferProtocol
                 }
             }
             catch(Exception e){
-                _log.error("could not get "+type+" from pnfs:");
+                _log.error("could not get {} from pnfs:", type);
                 _log.error(e.toString());
                 _log.error("ignoring this error");
 

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/AbstractBerkeleyDBReplicaStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/AbstractBerkeleyDBReplicaStore.java
@@ -145,7 +145,7 @@ public abstract class AbstractBerkeleyDBReplicaStore implements ReplicaStore, En
         try {
             database.close();
         } catch (DatabaseException e) {
-            LOGGER.error("Ignored: Could not close database: " + e.getMessage());
+            LOGGER.error("Ignored: Could not close database: {}", e.getMessage());
         }
     }
 
@@ -163,7 +163,7 @@ public abstract class AbstractBerkeleyDBReplicaStore implements ReplicaStore, En
 
             return true;
         } catch (IOException e) {
-            LOGGER.error("Failed to touch " + tmp + ": " + e.getMessage());
+            LOGGER.error("Failed to touch {}: {}", tmp, e.getMessage());
             return false;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
@@ -199,7 +199,7 @@ public class BerkeleyDBMetaDataRepository extends AbstractBerkeleyDBReplicaStore
         try {
             return _fileStore.getFreeSpace();
         } catch (IOException e) {
-            LOGGER.warn("Failed to query free space: " + e.toString());
+            LOGGER.warn("Failed to query free space: {}", e.toString());
             return 0;
         }
     }
@@ -214,7 +214,7 @@ public class BerkeleyDBMetaDataRepository extends AbstractBerkeleyDBReplicaStore
         try {
             return _fileStore.getTotalSpace();
         } catch (IOException e) {
-            LOGGER.warn("Failed to query total space: " + e.toString());
+            LOGGER.warn("Failed to query total space: {}", e.toString());
             return 0;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
@@ -154,7 +154,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
         try {
             return _state.isMutable() ? _repository.getFileSize(_pnfsId) : _size;
         } catch (IOException e) {
-            _log.error("Failed to read file size: " + e);
+            _log.error("Failed to read file size: {}", e.toString());
             return 0;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/ReplicaStoreDatabase.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/ReplicaStoreDatabase.java
@@ -53,7 +53,7 @@ public class ReplicaStoreDatabase
         envConfig.setExceptionListener(event -> {
             if (event.getException() instanceof EnvironmentFailureException && !env.isValid()) {
                 setFailed();
-                _log.error("Pool restart required due to Berkeley DB failure: " + event.getException().getMessage());
+                _log.error("Pool restart required due to Berkeley DB failure: {}", event.getException().getMessage());
             }
         });
 

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/CacheRepositoryEntryImpl.java
@@ -172,7 +172,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.Up
         } catch (NoSuchFileException e) {
             return 0;
         } catch (IOException e) {
-            LOGGER.error("Failed to read file size: " + e);
+            LOGGER.error("Failed to read file size: {}", e.toString());
             return 0;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
@@ -226,7 +226,7 @@ public class FileMetaDataRepository
         try {
             return _fileStore.getFreeSpace();
         } catch (IOException e) {
-            _log.warn("Failed to query free space: " + e.toString());
+            _log.warn("Failed to query free space: {}", e.toString());
             return 0;
         }
     }
@@ -241,7 +241,7 @@ public class FileMetaDataRepository
         try {
             return _fileStore.getTotalSpace();
         } catch (IOException e) {
-            _log.warn("Failed to query total space: " + e.toString());
+            _log.warn("Failed to query total space: {}", e.toString());
             return 0;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/mongo/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/mongo/CacheRepositoryEntryImpl.java
@@ -168,7 +168,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.Up
         } catch (NoSuchFileException e) {
             return 0;
         } catch (IOException e) {
-            LOGGER.error("Failed to read file size: " + e);
+            LOGGER.error("Failed to read file size: {}", e.toString());
             return 0;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/datanucleus/DataNucleusBillingInfo.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/db/impl/datanucleus/DataNucleusBillingInfo.java
@@ -192,8 +192,7 @@ public class DataNucleusBillingInfo extends AbstractBillingInfoAccess {
                             + type.getName());
             removed = (Long) query.execute();
             tx.commit();
-            logger.trace("successfully removed " + removed
-                            + " entries of type " + type);
+            logger.trace("successfully removed {} entries of type {}", removed, type);
             return removed;
         } finally {
             try {

--- a/modules/dcache/src/main/java/org/dcache/services/hsmcleaner/RequestTracker.java
+++ b/modules/dcache/src/main/java/org/dcache/services/hsmcleaner/RequestTracker.java
@@ -250,7 +250,7 @@ public class RequestTracker implements CellMessageReceiver
             /* If there is no available pool, then we report failure on
              * all files.
              */
-            _log.warn("No pools attached to " + hsm + " are available");
+            _log.warn("No pools attached to {} are available", hsm );
 
             Iterator<URI> i = _locationsToDelete.get(hsm).iterator();
             while (i.hasNext()) {
@@ -274,8 +274,7 @@ public class RequestTracker implements CellMessageReceiver
      */
     private synchronized void timeout(String hsm, String pool)
     {
-        _log.error("Timeout deleting files on HSM " + hsm
-                   + " attached to " + pool);
+        _log.error("Timeout deleting files on HSM {} attached to {}", hsm, pool);
         _poolRequests.remove(hsm);
         _pools.remove(pool);
         flush(hsm);
@@ -290,7 +289,7 @@ public class RequestTracker implements CellMessageReceiver
          * entries.
          */
         if (msg.getReturnCode() != 0) {
-            _log.error("Received failure from pool: " + msg.getErrorObject());
+            _log.error("Received failure from pool: {}", msg.getErrorObject());
             return;
         }
 
@@ -309,8 +308,7 @@ public class RequestTracker implements CellMessageReceiver
         }
 
         if (!failures.isEmpty()) {
-            _log.warn("Failed to delete " + failures.size()
-                    + " files from HSM " + hsm + ". Will try again later.");
+            _log.warn("Failed to delete {} files from HSM {}. Will try again later.", failures.size(), hsm );
         }
 
         for (URI location : success) {

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/Server.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/Server.java
@@ -49,7 +49,7 @@ public class Server extends org.eclipse.jetty.server.Server
         try {
             stop();
         } catch (Exception e) {
-            LOG.error("Web server shutdown failed: " + e);
+            LOG.error("Web server shutdown failed: {}", e.toString());
         }
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/AnsiTerminalCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/AnsiTerminalCommand.java
@@ -72,7 +72,7 @@ public class AnsiTerminalCommand implements Command, Runnable {
                 _history  = new FileHistory(historyFile);
                 _history.setMaxSize(historySize);
             } catch (IOException e) {
-                _logger.warn("History creation failed: " + e.getMessage());
+                _logger.warn("History creation failed: {}", e.getMessage());
             }
         }
     }
@@ -138,8 +138,7 @@ public class AnsiTerminalCommand implements Command, Runnable {
             try {
                 cleanUp();
             } catch (IOException e) {
-                _logger.warn("Failed to shutdown console cleanly: "
-                        + e.getMessage());
+                _logger.warn("Failed to shutdown console cleanly: {}", e.getMessage());
             }
             _exitCallback.onExit(0);
         }

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacyAdminShellCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacyAdminShellCommand.java
@@ -63,7 +63,7 @@ public class LegacyAdminShellCommand implements Command, Runnable
                 _history  = new FileHistory(historyFile);
                 _history.setMaxSize(historySize);
             } catch (IOException e) {
-                _logger.warn("History creation failed: " + e.getMessage());
+                _logger.warn("History creation failed: {}", e.getMessage());
             }
         }
     }
@@ -122,8 +122,8 @@ public class LegacyAdminShellCommand implements Command, Runnable
             try {
                 cleanUp();
             } catch (IOException e) {
-                _logger.warn("Failed to shutdown console cleanly: "
-                        + e.getMessage());
+                _logger.warn("Failed to shutdown console cleanly: {}"
+                        , e.getMessage());
             }
             _exitCallback.onExit(0);
         }

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -165,7 +165,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
         try {
             _server.stop();
         } catch (IOException e) {
-            _log.warn("SSH failure during shutdown: " + e.getMessage());
+            _log.warn("SSH failure during shutdown: {}", e.getMessage());
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/services/topology/AbstractCellsTopology.java
+++ b/modules/dcache/src/main/java/org/dcache/services/topology/AbstractCellsTopology.java
@@ -42,12 +42,12 @@ public class AbstractCellsTopology
     {
         List<CellTunnelInfo> tunnels = new ArrayList<>();
 
-        _log.debug("Sending topology info request to " + address);
+        _log.debug("Sending topology info request to {}", address);
         CellTunnelInfo[] infos =
             _stub.sendAndWait(new CellPath(address),
                               "getcelltunnelinfos",
                               CellTunnelInfo[].class);
-        _log.debug("Got reply from " + address);
+        _log.debug("Got reply from {}", address);
 
         for (CellTunnelInfo info: infos) {
             if (info.getRemoteCellDomainInfo() != null) {

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -1137,17 +1137,15 @@ public class Transfer implements Comparable<Transfer>
              * for the transfer confirmation.
              */
             if (millis > 0 && !waitForMover(millis)) {
-                _log.error("Failed to kill mover " + pool + "/" + moverId
-                           + ": Timeout");
+                _log.error("Failed to kill mover {}/{}: Timeout", pool, moverId);
             }
         } catch (CacheException e) {
             // Not surprising that the pool reported a failure
             // when we killed the mover.
-            _log.debug("Killed mover and pool reported: " +
+            _log.debug("Killed mover and pool reported: {}",
                        e.getMessage());
         } catch (InterruptedException e) {
-            _log.warn("Failed to kill mover " + pool + "/" + moverId
-                      + ": " + e.getMessage());
+            _log.warn("Failed to kill mover {}/{}: {}", pool, moverId, e.getMessage());
             Thread.currentThread().interrupt();
         } finally {
             setStatus(null);
@@ -1192,11 +1190,9 @@ public class Transfer implements Comparable<Transfer>
                 new PnfsHandler(_pnfs, Restrictions.none())
                         .deletePnfsEntry(pnfsId, _path.toString());
             } catch (FileNotFoundCacheException e) {
-                _log.debug("Failed to delete file after failed upload: " +
-                           _path + " (" + pnfsId + "): " + e.getMessage());
+                _log.debug("Failed to delete file after failed upload: {} ({}): {}", _path, pnfsId, e.getMessage());
             } catch (CacheException e) {
-                _log.error("Failed to delete file after failed upload: " +
-                           _path + " (" + pnfsId + "): " + e.getMessage());
+                _log.error("Failed to delete file after failed upload: {} ({}): {}", _path, pnfsId, e.getMessage());
             } finally {
                 setStatus(null);
             }

--- a/modules/dcache/src/main/java/org/dcache/util/list/ListDirectoryHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/util/list/ListDirectoryHandler.java
@@ -272,8 +272,7 @@ public class ListDirectoryHandler
                     }
                 }
             } catch (CacheException e) {
-                _log.error("Listing of " + _path + " incomplete: " +
-                           e.getMessage());
+                _log.error("Listing of {} incomplete: {}", _path, e.getMessage());
                 return false;
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
Motivation: with normal string concatenations in log-messages strings are always build, regardless if log-level is activated or not. with parameterized log-messages the strings only become build, when the log-level is activated;

Modification: using placeholder with parameterized messages instead of string concatenations

Result: gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>