### PR TITLE
dcache-dcap: refactoring slf4j logging messages

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/pools/DirectoryLookUpPool.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/pools/DirectoryLookUpPool.java
@@ -341,7 +341,7 @@ public class DirectoryLookUpPool extends AbstractCell
                         }
 
                         long numberOfEntries = cntIn.readLong();
-                        _log.debug("requested " + numberOfEntries + " bytes");
+                        _log.debug("requested {} bytes", numberOfEntries);
 
                         cntOut.writeACK(DCapConstants.IOCMD_READ);
                         index += doReadDir(cntOut, ostream, dirList, index,


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>