### PR TITLE
dcache-ftp: refactoring slf4j logging messages

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1102,7 +1102,7 @@ public abstract class AbstractFtpDoorV1
                         _tLog.begin(user, _tlogName, isWrite() ? "write" : "read",
                                 _path.toString(), _remoteSocketAddress.getAddress());
                     } catch (NoSuchElementException | IllegalArgumentException e) {
-                        LOGGER.error("Could not start tLog: " + e.getMessage());
+                        LOGGER.error("Could not start tLog: {}", e.getMessage());
                     }
                 }
             }

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/ChecksumCalculatingTransfer.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/ChecksumCalculatingTransfer.java
@@ -61,7 +61,7 @@ public class ChecksumCalculatingTransfer extends Transfer
         portRange.bind(ssc.socket());
         setAdditionalAttributes(EnumSet.of(FileAttribute.CHECKSUM));
         readNameSpaceEntry(false);
-        LOGGER.debug("calculating checksum using port " + ssc.getLocalAddress());
+        LOGGER.debug("calculating checksum using port {}", ssc.getLocalAddress());
         setProtocolInfo(new GFtpProtocolInfo("GFtp", 1, 0,
                 (InetSocketAddress) ssc.getLocalAddress(), 1, 1, 1,
                 MiB.toBytes(1), 0, getFileAttributes().getSize()));

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/ActiveAdapter.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/ActiveAdapter.java
@@ -215,11 +215,11 @@ public class ActiveAdapter implements Runnable, ProxyAdapter
     }
 
     protected void say(String s) {
-        _log.info("ActiveAdapter: " + s);
+        _log.info("ActiveAdapter: {}", s);
     }
 
     protected void esay(String s) {
-        _log.error("ActiveAdapter: " + s);
+        _log.error("ActiveAdapter: {}", s);
     }
 
     protected void esay(Throwable t) {

--- a/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
@@ -687,7 +687,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         if (position > _reservedSpace) {
             long additional = Math.max(position - _reservedSpace, SPACE_INC);
             _status = "WaitingForSpace(" + additional + ")";
-            _logSpaceAllocation.debug("ALLOC: " + additional );
+            _logSpaceAllocation.debug("ALLOC: {}", additional );
             _allocator.allocate(additional);
             _status = "None";
             _reservedSpace += additional;


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>