### PR TITLE
dcache-webadmin: refactoring slf4j logging messages

### DIFF
--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardPoolGroupService.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardPoolGroupService.java
@@ -53,7 +53,7 @@ public class StandardPoolGroupService implements PoolGroupService {
                         currentPoolGroupName, domainMap, cellStates);
                 poolGroups.add(newPoolGroup);
             }
-            _log.debug("returned PoolGroupBeans: " + poolGroups.size());
+            _log.debug("returned PoolGroupBeans: {}", poolGroups.size());
             Collections.sort(poolGroups);
             return poolGroups;
         } catch (DAOException e) {

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardPoolQueuesService.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardPoolQueuesService.java
@@ -37,7 +37,7 @@ public class StandardPoolQueuesService implements PoolQueuesService {
 
         try {
             Set<Pool> pools = getPoolsDAO().getPools();
-            _log.debug("returned pools: " + pools.size());
+            _log.debug("returned pools: {}", pools.size());
             List<PoolQueueBean> poolQueues = new ArrayList<>(pools.size());
             Map<String, List<String>> domainMap = getDomainsDAO().getDomainsMap();
 
@@ -46,7 +46,7 @@ public class StandardPoolQueuesService implements PoolQueuesService {
                         domainMap);
                 poolQueues.add(newPoolQueueBean);
             }
-            _log.debug("returned PoolQueueBeans: " + poolQueues.size());
+            _log.debug("returned PoolQueueBeans: {}", poolQueues.size());
             Collections.sort(poolQueues);
             return poolQueues;
 

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardPoolSpaceService.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/controller/impl/StandardPoolSpaceService.java
@@ -40,7 +40,7 @@ public class StandardPoolSpaceService implements PoolSpaceService {
     public List<PoolSpaceBean> getPoolBeans() throws PoolSpaceServiceException {
         try {
             Set<Pool> pools = getPoolsDAO().getPools();
-            _log.debug("returned pools: " + pools.size());
+            _log.debug("returned pools: {}", pools.size());
             List<PoolSpaceBean> poolBeans = new ArrayList<>(pools.size());
             Map<String, List<String>> domainMap = getDomainsDAO().getDomainsMap();
 
@@ -48,7 +48,7 @@ public class StandardPoolSpaceService implements PoolSpaceService {
                 PoolSpaceBean newPoolBean = createPoolBean(currentPool, domainMap);
                 poolBeans.add(newPoolBean);
             }
-            _log.debug("returned PoolBeans: " + poolBeans.size());
+            _log.debug("returned PoolBeans: {}", poolBeans.size());
             Collections.sort(poolBeans);
             return poolBeans;
 

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolselectionsetup/PoolSelectionSetup.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/poolselectionsetup/PoolSelectionSetup.java
@@ -78,7 +78,7 @@ public class PoolSelectionSetup extends BasePage {
             return getPoolSelectionSetupService().getEntityContainer();
         } catch (PoolSelectionSetupServiceException ex) {
             error("No Data available yet, please reload page: " + ex.getMessage());
-            _log.debug("no Data: " + ex.getMessage());
+            _log.debug("no Data: {}", ex.getMessage());
             return new DCacheEntityContainerBean();
         }
     }


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>