### PR TITLE
dcache-webdav: refactoring slf4j logging messages

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -580,7 +580,7 @@ public class DcacheResourceFactory
     public Resource getResource(String host, String requestPath)
     {
         if (_log.isDebugEnabled()) {
-            _log.debug("Resolving " + HttpManager.request().getAbsoluteUrl());
+            _log.debug("Resolving {}", HttpManager.request().getAbsoluteUrl());
         }
 
         FsPath dCachePath = _pathMapper.asDcachePath(ServletRequest.getRequest(),


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>