### PR TITLE
dcache-xrootd: refactoring slf4j logging messages

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -541,7 +541,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
             openFlags += " kXR_retstat";
         }
 
-        _log.debug("open flags: "+openFlags);
+        _log.debug("open flags: {}", openFlags);
 
         int mode = req.getUMask();
         String s = "";


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>