### PR TITLE
gplazma2: refactoring slf4j logging messages

### DIFF
--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/configuration/parser/PAMStyleConfigurationParser.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/configuration/parser/PAMStyleConfigurationParser.java
@@ -127,7 +127,7 @@ public class PAMStyleConfigurationParser implements ConfigurationParser {
         }
 
         String[] splitLine = trimmed.split("\\s+",SPLIT_LIMIT);
-        logger.debug("splitLine = "+Arrays.toString(splitLine));
+        logger.debug("splitLine = {}", Arrays.toString(splitLine));
 
         if(splitLine.length == 0) {
             return null;

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/PAMStyleStrategy.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/strategies/PAMStyleStrategy.java
@@ -137,7 +137,7 @@ public class PAMStyleStrategy<T extends GPlazmaPlugin>
         }
 
         if(firstRequiredPluginException != null) {
-            logger.info("all session plugins ran, at least one required failed, throwing exception : "+
+            logger.info("all session plugins ran, at least one required failed, throwing exception : {}",
                     firstRequiredPluginException);
             throw firstRequiredPluginException;
         }

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/configuration/parser/ConfigurationParserTests.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/configuration/parser/ConfigurationParserTests.java
@@ -158,7 +158,7 @@ public class ConfigurationParserTests
         ConfigurationParser parser = pamConfigParserFactory.newConfigurationParser();
         Configuration configuration =
                 parser.parse(INVALID_CONFIG);
-        logger.error("Parsed INVALID_CONFIG is \n"+configuration);
+        logger.error("Parsed INVALID_CONFIG is \n{}", configuration);
 
 
     }
@@ -169,7 +169,7 @@ public class ConfigurationParserTests
         ConfigurationParser parser = pamConfigParserFactory.newConfigurationParser();
         Configuration configuration =
                 parser.parse(INVALID_CONFIG_WRONG_TYPE);
-        logger.error("Parsed INVALID_CONFIG_WRONG_TYPE is \n"+configuration);
+        logger.error("Parsed INVALID_CONFIG_WRONG_TYPE is \n{}", configuration);
 
     }
 
@@ -179,7 +179,7 @@ public class ConfigurationParserTests
         ConfigurationParser parser = pamConfigParserFactory.newConfigurationParser();
         Configuration configuration =
                 parser.parse(INVALID_CONFIG_WRONG_CONTROL);
-        logger.error("Parsed INVALID_CONFIG_WRONG_CONTROL is \n"+configuration);
+        logger.error("Parsed INVALID_CONFIG_WRONG_CONTROL is \n{}", configuration);
 
     }
 
@@ -195,7 +195,7 @@ public class ConfigurationParserTests
         ConfigurationItem[] configItemArray =
                 configItemList
                         .toArray(new ConfigurationItem[configItemList.size()]);
-        logger.debug("Parsed TEST_CONFIG is \n"+configuration);
+        logger.debug("Parsed TEST_CONFIG is \n{}", configuration);
 
         assertArrayEquals(TEST_CONFIG_ARRAY, configItemArray);
     }


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>