### PR TITLE
gplazma2-grid: refactoring slf4j logging messages

### DIFF
--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/util/GridMapFile.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/util/GridMapFile.java
@@ -47,7 +47,7 @@ public class GridMapFile
 
             }
         } catch (IOException e) {
-            _log.error("Failed to load grid-mapfile: " + e.getMessage());
+            _log.error("Failed to load grid-mapfile: {}", e.getMessage());
         }
     }
 


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>