### PR TITLE
srm-common: refactoring slf4j logging messages

### DIFF
--- a/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
@@ -114,10 +114,10 @@ public class GridftpClient
     {
         if(bufferSize >0) {
             _bufferSize = bufferSize;
-            logger.debug("memory buffer size is set to "+bufferSize);
+            logger.debug("memory buffer size is set to {}", bufferSize);
         }
         _host = host;
-        logger.debug("connecting to "+_host+" on port "+port);
+        logger.debug("connecting to {} on port {}", _host, port);
 
         ClientGsiEngineDssContextFactory dssContextFactory =
                 new ClientGsiEngineDssContextFactory(
@@ -258,7 +258,7 @@ public class GridftpClient
         if(emode) {
             _client.setMode(GridFTPSession.MODE_EBLOCK);
             // adding parallelism
-            logger.debug("parallelism: " + _streamsNum);
+            logger.debug("parallelism: {}", _streamsNum);
             _client.setOptions(new RetrieveOptions(_streamsNum));
         }
         else {
@@ -269,7 +269,7 @@ public class GridftpClient
                 if(passive_server_mode){
                     logger.debug("server is passive");
                     HostPort serverHostPort = _client.setPassive();
-                    logger.debug("serverHostPort="+serverHostPort.getHost()+":"+serverHostPort.getPort());
+                    logger.debug("serverHostPort={}:{}", serverHostPort.getHost(), serverHostPort.getPort());
                     _client.setLocalActive();
                 }else{
                     logger.debug("server is active");
@@ -292,9 +292,9 @@ public class GridftpClient
         throws IOException, ServerException, FTPReplyParseException,
                UnexpectedReplyCodeException
     {
-        logger.debug(" sending wait command to ncsa host " + _host);
+        logger.debug(" sending wait command to ncsa host {}", _host);
         Reply reply = _client.quote("SITE WAIT");
-        logger.debug("Reply is "+reply);
+        logger.debug("Reply is {}", reply);
         if(Reply.isPositiveCompletion( reply)) {
             logger.debug("sending wait command successful");
         } else {
@@ -397,16 +397,16 @@ public class GridftpClient
             throw new IOException("we wrote more then file size!!!");
         }
 
-        logger.debug("gridFTPWrite() wrote "+sink.getTransfered()+"bytes");
+        logger.debug("gridFTPWrite() wrote {}bytes", sink.getTransfered());
 
         try {
           if ( _cksmType != null ) {
               verifyCksmValue(_current_source_sink, sourcepath);
           }
         } catch ( ChecksumNotSupported ex){
-          logger.error("Checksum is not supported:"+ex.toString());
+          logger.error("Checksum is not supported:{}", ex.toString());
         } catch ( ChecksumValueFormatException cvfe) {
-          logger.error("Checksum format is not valid:"+cvfe.toString());
+          logger.error("Checksum format is not valid:{}", cvfe.toString());
         }
 
         //make these remeber last values
@@ -500,7 +500,7 @@ public class GridftpClient
         throws InterruptedException, ClientException, ServerException,
                IOException, NoSuchAlgorithmException
     {
-        logger.debug("gridFTPWrite started, destination path is "+destinationpath);
+        logger.debug("gridFTPWrite started, destination path is {}", destinationpath);
 
         setCommonOptions(emode,passive_server_mode);
 
@@ -524,7 +524,7 @@ public class GridftpClient
             throw new IOException("we read more then file size!!!");
         }
 
-        logger.debug("gridFTPWrite() wrote "+source.getTransfered()+"bytes");
+        logger.debug("gridFTPWrite() wrote {}bytes", source.getTransfered());
         getTransfered();
         getLastTransferTime();
         _current_source_sink = null;
@@ -549,7 +549,7 @@ public class GridftpClient
             }
         } catch ( Exception ex ){
             // send cksm error is often expected for non dCache sites
-            logger.debug("Was not able to send checksum value:"+ex.toString());
+            logger.debug("Was not able to send checksum value:{}", ex.toString());
         }
     }
 
@@ -918,7 +918,7 @@ public class GridftpClient
         public void run() {
             try {
                 if(_read) {
-                    logger.debug("starting a transfer from "+_path);
+                    logger.debug("starting a transfer from {}", _path);
                     if(_client.isFeatureSupported("GETPUT")) {
                         _client.get2(_path, (_emode ? false: _passive_server_mode),
                                     _source_sink, null);
@@ -927,7 +927,7 @@ public class GridftpClient
                     }
                 }
                 else {
-                    logger.debug("starting a transfer to "+_path);
+                    logger.debug("starting a transfer to {}", _path);
                     if(_client.isFeatureSupported("GETPUT")) {
                         _client.put2(_path, (_emode ? true : _passive_server_mode),
                                     _source_sink, null);

--- a/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
@@ -397,16 +397,16 @@ public class GridftpClient
             throw new IOException("we wrote more then file size!!!");
         }
 
-        logger.debug("gridFTPWrite() wrote {}bytes", sink.getTransfered());
+        logger.debug("gridFTPWrite() wrote {} bytes", sink.getTransfered());
 
         try {
           if ( _cksmType != null ) {
               verifyCksmValue(_current_source_sink, sourcepath);
           }
         } catch ( ChecksumNotSupported ex){
-          logger.error("Checksum is not supported:{}", ex.toString());
+          logger.error("Checksum is not supported: {}", ex.toString());
         } catch ( ChecksumValueFormatException cvfe) {
-          logger.error("Checksum format is not valid:{}", cvfe.toString());
+          logger.error("Checksum format is not valid: {}", cvfe.toString());
         }
 
         //make these remeber last values
@@ -524,7 +524,7 @@ public class GridftpClient
             throw new IOException("we read more then file size!!!");
         }
 
-        logger.debug("gridFTPWrite() wrote {}bytes", source.getTransfered());
+        logger.debug("gridFTPWrite() wrote {} bytes", source.getTransfered());
         getTransfered();
         getLastTransferTime();
         _current_source_sink = null;
@@ -549,7 +549,7 @@ public class GridftpClient
             }
         } catch ( Exception ex ){
             // send cksm error is often expected for non dCache sites
-            logger.debug("Was not able to send checksum value:{}", ex.toString());
+            logger.debug("Was not able to send checksum value: {}", ex.toString());
         }
     }
 


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>