### PR TITLE
srm-server: refactoring slf4j logging messages

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SRM.java
@@ -220,7 +220,7 @@ public class SRM implements CellLifeCycleAware
             //already initialized
         }
 
-        logger.debug("srm started :\n\t" + configuration.toString());
+        logger.debug("srm started :\n\t{}", configuration.toString());
     }
 
     public void setSchedulers(SchedulerContainer schedulers)
@@ -440,7 +440,7 @@ public class SRM implements CellLifeCycleAware
             sb.append(r.toString(false)).append('\n');
         } catch (IllegalStateTransition ist) {
             sb.append("Illegal State Transition : ").append(ist.getMessage());
-            logger.error("Illegal State Transition : " +ist.getMessage());
+            logger.error("Illegal State Transition : {}", ist.getMessage());
         }
     }
 
@@ -513,7 +513,7 @@ public class SRM implements CellLifeCycleAware
                     try {
                         job.setState(State.CANCELED, "Canceled by admin through cancelall command.");
                     } catch (IllegalStateTransition ist) {
-                        logger.error("Illegal State Transition : " +ist.getMessage());
+                        logger.error("Illegal State Transition : {}", ist.getMessage());
                     }
                 }).start();
             } catch(SRMInvalidRequestException e) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/SrmCommandLineInterface.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/SrmCommandLineInterface.java
@@ -174,32 +174,32 @@ public class SrmCommandLineInterface
             String pattern = args.argv(0);
             StringBuilder sb = new StringBuilder();
             if (get) {
-                logger.debug("calling srm.cancelAllGetRequest(\"" + pattern + "\")");
+                logger.debug("calling srm.cancelAllGetRequest(\"{}\")", pattern);
                 srm.cancelAllGetRequest(sb, pattern);
             }
             if (bring) {
-                logger.debug("calling srm.cancelAllBringOnlineRequest(\"" + pattern + "\")");
+                logger.debug("calling srm.cancelAllBringOnlineRequest(\"{}\")", pattern);
                 srm.cancelAllBringOnlineRequest(sb, pattern);
             }
             if (put) {
-                logger.debug("calling srm.cancelAllPutRequest(\"" + pattern + "\")");
+                logger.debug("calling srm.cancelAllPutRequest(\"{}\")", pattern);
                 srm.cancelAllPutRequest(sb, pattern);
             }
             if (copy) {
-                logger.debug("calling srm.cancelAllCopyRequest(\"" + pattern + "\")");
+                logger.debug("calling srm.cancelAllCopyRequest(\"{}\")", pattern);
                 srm.cancelAllCopyRequest(sb, pattern);
             }
             if (reserve) {
-                logger.debug("calling srm.cancelAllReserveSpaceRequest(\"" + pattern + "\")");
+                logger.debug("calling srm.cancelAllReserveSpaceRequest(\"{}\")", pattern);
                 srm.cancelAllReserveSpaceRequest(sb, pattern);
             }
             if (ls) {
-                logger.debug("calling srm.cancelAllLsRequests(\"" + pattern + "\")");
+                logger.debug("calling srm.cancelAllLsRequests(\"{}\")", pattern);
                 srm.cancelAllLsRequests(sb, pattern);
             }
             return sb.toString();
         } catch (DataAccessException | SRMException e) {
-            logger.warn("Failure in cancelall: " + e.getMessage());
+            logger.warn("Failure in cancelall: {}", e.getMessage());
             return e.toString();
         }
     }
@@ -558,7 +558,7 @@ public class SrmCommandLineInterface
         }
         int value = Integer.parseInt(args.argv(0));
         srm.setPutMaxReadyJobs(value);
-        logger.info("put-req-max-ready-requests=" + value);
+        logger.info("put-req-max-ready-requests={}", value);
         return "put-req-max-ready-requests=" + value;
     }
 
@@ -573,7 +573,7 @@ public class SrmCommandLineInterface
         }
         int value = Integer.parseInt(args.argv(0));
         srm.setGetMaxReadyJobs(value);
-        logger.info("get-req-max-ready-requests=" + value);
+        logger.info("get-req-max-ready-requests={}", value);
         return "get-req-max-ready-requests=" + value;
     }
 
@@ -588,7 +588,7 @@ public class SrmCommandLineInterface
         }
         int value = Integer.parseInt(args.argv(0));
         srm.setBringOnlineMaxReadyJobs(value);
-        logger.info("bring-online-req-max-ready-requests=" + value);
+        logger.info("bring-online-req-max-ready-requests={}", value);
         return "bring-online-req-max-ready-requests=" + value;
     }
 
@@ -613,7 +613,7 @@ public class SrmCommandLineInterface
         }
         int value = Integer.parseInt(args.argv(0));
         srm.setLsMaxReadyJobs(value);
-        logger.info("ls-request-max-ready-requests=" + value);
+        logger.info("ls-request-max-ready-requests={}", value);
         return "ls-request-max-ready-requests=" + value;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/client/RemoteTurlGetterV2.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/client/RemoteTurlGetterV2.java
@@ -158,7 +158,7 @@ public final class RemoteTurlGetterV2 extends TurlGetterPutter {
             logger.error("srmReleaseFiles return status is null");
             return;
         }
-        logger.debug("srmReleaseFilesResponse status code="+returnStatus.getStatusCode());
+        logger.debug("srmReleaseFilesResponse status code={}", returnStatus.getStatusCode());
 
     }
 
@@ -169,7 +169,7 @@ public final class RemoteTurlGetterV2 extends TurlGetterPutter {
             logger.debug("number_of_file_reqs is 0, nothing to do");
             return;
         }
-        logger.debug("SURLs[0] is "+SURLs[0]);
+        logger.debug("SURLs[0] is {}", SURLs[0]);
         try {
             srmv2 = new SRMClientV2(URIs.createWithDefaultPort(SURLs[0]),
                                     credential.getDelegatedCredential(),
@@ -238,7 +238,7 @@ public final class RemoteTurlGetterV2 extends TurlGetterPutter {
                         statusCode+" explanation="+status.getExplanation());
             }
             requestToken = srmPrepareToGetResponse.getRequestToken();
-            logger.debug(" srm returned requestToken = "+requestToken);
+            logger.debug(" srm returned requestToken = {}", requestToken);
             ArrayOfTGetRequestFileStatus arrayOfTGetRequestFileStatus  =
                 srmPrepareToGetResponse.getArrayOfFileStatuses();
             if(arrayOfTGetRequestFileStatus == null  ) {
@@ -267,8 +267,7 @@ public final class RemoteTurlGetterV2 extends TurlGetterPutter {
                     }
                     String surl_string = surl.toString();
                     if(!pendingSurlsToIndex.containsKey(surl_string)) {
-                        logger.error("invalid getRequestFileStatus, surl = "+surl_string+
-                        " not found");
+                        logger.error("invalid getRequestFileStatus, surl = {} not found", surl_string);
                         continue;
                     }
                     TReturnStatus fileStatus = getRequestFileStatus.getStatus();
@@ -297,7 +296,7 @@ public final class RemoteTurlGetterV2 extends TurlGetterPutter {
                             size = getRequestFileStatus.getFileSize().longValue();
                         }
                         else {
-                            logger.error("size is not set in FileStatus for SURL="+SURLs[indx]);
+                            logger.error("size is not set in FileStatus for SURL={}", SURLs[indx]);
                         }
                         notifyOfTURL(SURLs[indx], transferUrl, requestToken,null,size );
                         haveCompletedFileRequests = true;
@@ -321,7 +320,7 @@ public final class RemoteTurlGetterV2 extends TurlGetterPutter {
                 }
                 try {
 
-                    logger.debug("sleeping "+estimatedWaitInSeconds+" seconds ...");
+                    logger.debug("sleeping {} seconds ...", estimatedWaitInSeconds);
                     Thread.sleep(estimatedWaitInSeconds * 1000);
                 }
                 catch(InterruptedException ie) {
@@ -429,6 +428,6 @@ public final class RemoteTurlGetterV2 extends TurlGetterPutter {
             logger.error("srmReleaseFiles return status is null");
             return;
         }
-        logger.debug("srmReleaseFilesResponse status code="+returnStatus.getStatusCode());
+        logger.debug("srmReleaseFilesResponse status code={}", returnStatus.getStatusCode());
     }
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/client/RemoteTurlPutterV2.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/client/RemoteTurlPutterV2.java
@@ -189,7 +189,7 @@ public final class RemoteTurlPutterV2 extends TurlGetterPutter
             logger.error("srmPutDone return status is null");
             return;
         }
-        logger.debug("srmPutDone status code="+returnStatus.getStatusCode());
+        logger.debug("srmPutDone status code={}", returnStatus.getStatusCode());
     }
 
     @Override
@@ -276,7 +276,7 @@ public final class RemoteTurlPutterV2 extends TurlGetterPutter
                         statusCode+" explanation="+status.getExplanation());
             }
             requestToken = srmPrepareToPutResponse.getRequestToken();
-            logger.debug(" srm returned requestToken = "+requestToken+" one of remote surls = "+SURLs[0]);
+            logger.debug(" srm returned requestToken = {} one of remote surls = {}", requestToken, SURLs[0]);
 
             ArrayOfTPutRequestFileStatus arrayOfTPutRequestFileStatus =
                 srmPrepareToPutResponse.getArrayOfFileStatuses();
@@ -308,7 +308,7 @@ public final class RemoteTurlPutterV2 extends TurlGetterPutter
                     }
                     String surl_string = surl.toString();
                     if(!pendingSurlsToIndex.containsKey(surl_string)) {
-                        logger.error("invalid putRequestFileStatus, surl = "+surl_string+" not found");
+                        logger.error("invalid putRequestFileStatus, surl = {} not found", surl_string);
                         continue;
                     }
                     TReturnStatus fileStatus = putRequestFileStatus.getStatus();
@@ -353,7 +353,7 @@ public final class RemoteTurlPutterV2 extends TurlGetterPutter
                 }
                 try {
 
-                    logger.debug("sleeping "+estimatedWaitInSeconds+" seconds ...");
+                    logger.debug("sleeping {} seconds ...", estimatedWaitInSeconds);
                     Thread.sleep(estimatedWaitInSeconds * 1000);
                 }
                 catch(InterruptedException ie) {
@@ -477,6 +477,6 @@ public final class RemoteTurlPutterV2 extends TurlGetterPutter
             logger.error("srmPutDone return status is null");
             return;
         }
-        logger.debug("srmPutDone status code="+returnStatus.getStatusCode());
+        logger.debug("srmPutDone status code={}", returnStatus.getStatusCode());
     }
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/client/TurlGetterPutter.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/client/TurlGetterPutter.java
@@ -90,7 +90,7 @@ public abstract class TurlGetterPutter implements Runnable {
     private final PropertyChangeSupport changeSupport = new PropertyChangeSupport(this);
 
     public void notifyOfTURL(String SURL,String TURL,String requestId, String fileId,Long size) {
-        logger.debug("notifyOfTURL( surl="+SURL+" , turl="+TURL+")");
+        logger.debug("notifyOfTURL( surl={} , turl={})", SURL, TURL);
         changeSupport.firePropertyChange(new TURLsArrivedEvent(this,SURL,TURL,requestId,fileId,size));
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/qos/QOSPluginFactory.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/qos/QOSPluginFactory.java
@@ -21,7 +21,7 @@ public class QOSPluginFactory {
 								qosPluginClass).asSubclass(QOSPlugin.class);
 				qosPlugin = pluginClass.newInstance();
 				qosPlugin.setSrm(srm);
-				logger.debug("Created new qos plugin of type " + qosPluginClass);
+				logger.debug("Created new qos plugin of type {}", qosPluginClass);
 			} catch (Exception e) {
 				logger.error("Could not create class " + qosPluginClass, e);
 			}

--- a/modules/srm-server/src/main/java/org/dcache/srm/qos/lambdastation/LambdaStationPlugin.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/qos/lambdastation/LambdaStationPlugin.java
@@ -105,7 +105,7 @@ public class LambdaStationPlugin implements QOSPlugin {
 			LambdaStationTicket	ls_ticket = (LambdaStationTicket)qosTicket;
 			boolean sEnabled = ls_ticket.srcEnabled();
 			boolean dEnabled = ls_ticket.dstEnabled();
-			logger.debug("src enabled="+sEnabled+" dst enabled="+dEnabled);
+			logger.debug("src enabled={} dst enabled={}", sEnabled, dEnabled);
 			return sEnabled && dEnabled && ls_ticket.getLocalTicketID() != 0;
 		}
 		else {
@@ -121,7 +121,7 @@ public class LambdaStationPlugin implements QOSPlugin {
 				Date now = new Date();
 				long t = now.getTime();
 				long time_left = ls_ticket.getActualEndTime() - t/1000;
-				logger.debug("End time="+ls_ticket.getActualEndTime()+" Travel Time="+ls_ticket.TravelTime+" now="+t+" expires in "+time_left);
+				logger.debug("End time={} Travel Time={} now={} expires in {}", ls_ticket.getActualEndTime(), ls_ticket.TravelTime, t, time_left);
 				// try to calculate transfer time assuming 1Gb local connection
 				long transfer_time = 0l;
 				long rate_MB = 100000000l; // 1Gb means 100MB
@@ -130,7 +130,7 @@ public class LambdaStationPlugin implements QOSPlugin {
 				}
 				long extend_time = Math.max(transfer_time, 600l);
 				if (time_left - extend_time < 0) {
-					logger.debug("AM: will extend end time by "+extend_time);
+					logger.debug("AM: will extend end time by {}", extend_time);
 				}
 				else {
 					logger.debug("AM: no need to extend end time");

--- a/modules/srm-server/src/main/java/org/dcache/srm/qos/terapaths/TerapathsPlugin.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/qos/terapaths/TerapathsPlugin.java
@@ -272,7 +272,7 @@ public class TerapathsPlugin implements QOSPlugin {
                                             .getBandwidth()
                                             .getBandwidth();
 
-                                    logger.debug("Submitted qos request " + tpTicket.id);
+                                    logger.debug("Submitted qos request {}", tpTicket.id);
                                     successFlag = true;
                                     break;
                                 }
@@ -307,15 +307,15 @@ public class TerapathsPlugin implements QOSPlugin {
 		//	Date now = new Date();
 		//	long now = now.getTime();
 		//	long timeLeft = tpTicket.endTime - now;
-		//	logger.debug("End time="+(tpTicket.endTime/1000)+"s now="+(now/1000)+"s expires in "+(timeLeft/1000)+"s");
+		//	logger.debug("End time={}s now={}s expires in {}s", (tpTicket.endTime/1000), (now/1000), (timeLeft/1000));
 		//	long transferTimeLeft = 0;
 		//	if (tpTicket.bytes!=-1 && tpTicket.bandwidth!=-1)
 		//		transferTimeLeft = tpTicket.bytes/(tpTicket.bandwidth*8); // TODO: change bytes to remaining bytes
 		//	if (timeLeft - transferTime < 0)
-		//		logger.debug("AM: will extend end time by "+extendTime);
+		//		logger.debug("AM: will extend end time by {}", extendTime);
 		//	else
 		//		logger.debug("AM: no need to extend end time");
-		//	logger.debug("Ticket "+tpTicket.id+" enabled");
+		//	logger.debug("Ticket {} enabled", tpTicket.id);
 		//}
 	}
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
@@ -125,7 +125,7 @@ public final class BringOnlineFileRequest extends FileRequest<BringOnlineRequest
     public BringOnlineFileRequest(long requestId, URI surl, long lifetime)
     {
         super(requestId, lifetime);
-        logger.debug("BringOnlineFileRequest, requestId="+requestId+" fileRequestId = "+getId());
+        logger.debug("BringOnlineFileRequest, requestId={} fileRequestId = {}", requestId, getId());
         this.surl = surl;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/ContainerRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/ContainerRequest.java
@@ -333,7 +333,7 @@ public abstract class ContainerRequest<R extends FileRequest<?>> extends Request
                 }
             }
         } catch (IllegalStateTransition e) {
-            logger.error("Illegal State Transition : " + e.getMessage());
+            logger.error("Illegal State Transition : {}", e.getMessage());
         } finally {
             wunlock();
         }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/CopyFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/CopyFileRequest.java
@@ -434,7 +434,7 @@ public final class CopyFileRequest extends FileRequest<CopyRequest> implements D
                                       srme.getMessage(),
                                       TStatusCode.SRM_INVALID_PATH);
             } catch (IllegalStateTransition ist) {
-                LOG.error("Illegal State Transition : " +ist.getMessage());
+                LOG.error("Illegal State Transition : {}", ist.getMessage());
             }
             return;
         }
@@ -532,10 +532,10 @@ public final class CopyFileRequest extends FileRequest<CopyRequest> implements D
                 try {
                     getContainerRequest().fileRequestCompleted();
                 } catch (SRMInvalidRequestException ire) {
-                    LOG.error("Failed to find container request: " + ire.toString());
+                    LOG.error("Failed to find container request: {}", ire.toString());
                 }
             } catch (IllegalStateTransition ist) {
-                LOG.error("Failed to set copy file request state to DONE: "  +
+                LOG.error("Failed to set copy file request state to DONE: {}",
                         ist.getMessage());
             }
         }
@@ -550,10 +550,10 @@ public final class CopyFileRequest extends FileRequest<CopyRequest> implements D
                 try {
                     getContainerRequest().fileRequestCompleted();
                 } catch (SRMInvalidRequestException e) {
-                    LOG.error("Failed to find container request: " + e);
+                    LOG.error("Failed to find container request: {}", e.toString());
                 }
             } catch (IllegalStateTransition ist) {
-                LOG.error("Failed to set copy file request state to FAILED: " +
+                LOG.error("Failed to set copy file request state to FAILED: {}",
                         ist.getMessage());
             }
         }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/CopyRequest.java
@@ -701,7 +701,7 @@ public final class CopyRequest extends ContainerRequest<CopyFileRequest>
                         request.setState(state, "Request now " + state);
                     }
                 } catch (IllegalStateTransition ist) {
-                    LOG.error("Illegal State Transition : " + ist.getMessage());
+                    LOG.error("Illegal State Transition : {}", ist.getMessage());
                 }
             }
         }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/FileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/FileRequest.java
@@ -191,7 +191,7 @@ public abstract class FileRequest<R extends ContainerRequest> extends Job {
     }
 
     public void setStatus(SRMUser user, String status) throws SRMException {
-        logger.debug("("+status+")");
+        logger.debug("({})", status);
         try {
             wlock();
             try {

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/GetFileRequest.java
@@ -124,7 +124,7 @@ public final class GetFileRequest extends FileRequest<GetRequest> {
                           long lifetime)
     {
         super(requestId, lifetime);
-        logger.debug("GetFileRequest, requestId="+requestId+" fileRequestId = "+getId());
+        logger.debug("GetFileRequest, requestId={} fileRequestId = {}", requestId, getId());
         this.surl = surl;
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -951,7 +951,7 @@ public abstract class Job  {
                 break;
             }
         } catch (IllegalStateTransition e) {
-            logger.error("Failed to restore job: " + e.getMessage());
+            logger.error("Failed to restore job: {}", e.getMessage());
         } finally {
             wunlock();
         }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/LsFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/LsFileRequest.java
@@ -161,7 +161,7 @@ public final class LsFileRequest extends FileRequest<LsRequest> {
                                                        parent.getLongFormat());
                     }
                     if (logger.isDebugEnabled()) {
-                        logger.debug("LsFileRequest.run(), TOOK " + (System.currentTimeMillis() - t0));
+                        logger.debug("LsFileRequest.run(), TOOK {}", (System.currentTimeMillis() - t0));
                     }
                     try {
                         getContainerRequest().resetRetryDeltaTime();
@@ -208,7 +208,7 @@ public final class LsFileRequest extends FileRequest<LsRequest> {
 
     @Override
         protected void stateChanged(State oldState) {
-                logger.debug("State changed from "+oldState+" to "+getState());
+                logger.debug("State changed from {} to {}", oldState, getState());
                 super.stateChanged(oldState);
         }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/LsRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/LsRequest.java
@@ -175,7 +175,7 @@ public final class LsRequest extends ContainerRequest<LsFileRequest> {
                                                 fr.setState(state, "Changing file state because request state has changed.");
                                         }
                                 } catch(IllegalStateTransition ist) {
-                                        logger.error("Illegal State Transition : " +ist.getMessage());
+                                        logger.error("Illegal State Transition : {}", ist.getMessage());
                                 } finally {
                                     fr.wunlock();
                                 }
@@ -376,7 +376,7 @@ public final class LsRequest extends ContainerRequest<LsFileRequest> {
                                        setState(State.DONE, "Operation completed.");
                                  }
                                  catch(IllegalStateTransition ist) {
-                                         logger.error("Illegal State Transition : " +ist.getMessage());
+                                         logger.error("Illegal State Transition : {}", ist.getMessage());
                                  }
                          }
                          return new TReturnStatus(TStatusCode.SRM_SUCCESS, null);
@@ -406,7 +406,7 @@ public final class LsRequest extends ContainerRequest<LsFileRequest> {
                                          setState(State.DONE,State.DONE.toString());
                                  }
                                  catch(IllegalStateTransition ist) {
-                                         logger.error("Illegal State Transition : " +ist.getMessage());
+                                         logger.error("Illegal State Transition : {}", ist.getMessage());
                                  }
                             }
                             return new TReturnStatus(TStatusCode.SRM_PARTIAL_SUCCESS,
@@ -418,7 +418,7 @@ public final class LsRequest extends ContainerRequest<LsFileRequest> {
                                          setState(State.FAILED,State.FAILED.toString());
                                  }
                                  catch(IllegalStateTransition ist) {
-                                         logger.error("Illegal State Transition : " +ist.getMessage());
+                                         logger.error("Illegal State Transition : {}", ist.getMessage());
                                  }
                             }
                             return new TReturnStatus(TStatusCode.SRM_FAILURE, "All ls requests failed in some way or another");

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/PutFileRequest.java
@@ -349,7 +349,7 @@ public final class PutFileRequest extends FileRequest<PutRequest> {
     @Override
     protected void stateChanged(State oldState) {
         State state = getState();
-        logger.debug("State changed from "+oldState+" to "+getState());
+        logger.debug("State changed from {} to {}", oldState, getState());
         if(state == State.READY) {
             try {
                 getContainerRequest().resetRetryDeltaTime();

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
@@ -352,10 +352,10 @@ public final class ReserveSpaceRequest extends Request {
             try {
                 request.setState(State.FAILED,reason);
             } catch(IllegalStateTransition ist) {
-                logger.error("Illegal State Transition : " +ist.getMessage());
+                logger.error("Illegal State Transition : {}", ist.getMessage());
             }
 
-            logger.error("ReserveSpace error: "+ reason);
+            logger.error("ReserveSpace error: {}", reason);
         }
 
         @Override
@@ -371,10 +371,10 @@ public final class ReserveSpaceRequest extends Request {
             try {
                 request.setStateAndStatusCode(State.FAILED,reason,TStatusCode.SRM_NO_FREE_SPACE);
             } catch(IllegalStateTransition ist) {
-                logger.error("Illegal State Transition : " +ist.getMessage());
+                logger.error("Illegal State Transition : {}", ist.getMessage());
             }
 
-            logger.error("ReserveSpace failed (NoFreeSpace), no free space : "+reason);
+            logger.error("ReserveSpace failed (NoFreeSpace), no free space : {}", reason);
         }
 
         @Override
@@ -390,7 +390,7 @@ public final class ReserveSpaceRequest extends Request {
             try {
                 request.setState(State.FAILED,e.getMessage());
             } catch(IllegalStateTransition ist) {
-              logger.error("Illegal State Transition : " +ist.getMessage());
+              logger.error("Illegal State Transition : {}", ist.getMessage());
             }
 
             logger.error("ReserveSpace exception: ",e);
@@ -434,7 +434,7 @@ public final class ReserveSpaceRequest extends Request {
                     request.setState(State.DONE,"space reservation succeeded" );
                 }
             } catch(IllegalStateTransition ist) {
-                logger.error("Illegal State Transition : " +ist.getMessage());
+                logger.error("Illegal State Transition : {}", ist.getMessage());
             } finally {
                 wunlock();
             }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseRequestCredentialStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseRequestCredentialStorage.java
@@ -118,12 +118,11 @@ public class DatabaseRequestCredentialStorage implements RequestCredentialStorag
       File dir = new File(credentialsDirectory);
       if(!dir.exists()) {
           if(!dir.mkdir()) {
-              logger.error("failed to create directory "+credentialsDirectory);
+              logger.error("failed to create directory {}", credentialsDirectory);
           }
       }
       if(!dir.isDirectory() || !dir.canWrite()) {
-          logger.error("credential directory "+credentialsDirectory+
-                  " does not exist or is not writable");
+          logger.error("credential directory {} does not exist or is not writable", credentialsDirectory);
       }
       dbInit();
    }
@@ -156,7 +155,7 @@ public class DatabaseRequestCredentialStorage implements RequestCredentialStorag
                if (!tableRs.next()) {
                    // Table does not exist
                    try (Statement s = con.createStatement()) {
-                       logger.debug("dbInit trying " + createRequestCredentialTable);
+                       logger.debug("dbInit trying {}", createRequestCredentialTable);
                        s.executeUpdate(createRequestCredentialTable);
                    }
                }

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/GetRequestStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/GetRequestStorage.java
@@ -162,7 +162,7 @@ public class GetRequestStorage extends DatabaseContainerRequestStorage<GetReques
         String sqlStatementString = "SELECT PROTOCOL FROM " + getProtocolsTableName() +
                 " WHERE RequestID="+ID;
         Statement sqlStatement = _con.createStatement();
-        logger.debug("executing statement: "+sqlStatementString);
+        logger.debug("executing statement: {}", sqlStatementString);
         ResultSet fileIdsSet = sqlStatement.executeQuery(sqlStatementString);
         List<String> protocols = new ArrayList<>();
         while(fileIdsSet.next()) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/PutRequestStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/PutRequestStorage.java
@@ -163,7 +163,7 @@ public class PutRequestStorage extends DatabaseContainerRequestStorage<PutReques
         String sqlStatementString = "SELECT PROTOCOL FROM " + getProtocolsTableName() +
                 " WHERE RequestID="+ID;
         Statement sqlStatement = _con.createStatement();
-        logger.debug("executing statement: "+sqlStatementString);
+        logger.debug("executing statement: {}", sqlStatementString);
         ResultSet fileIdsSet = sqlStatement.executeQuery(sqlStatementString);
         List<String> protocols = new ArrayList<>();
         while(fileIdsSet.next()) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -317,7 +317,7 @@ public class Scheduler <T extends Job>
 
                         synchronized (this) {
                             if (!hasBeenNotified) {
-                                //logger.debug("Scheduler(id="+getId()+").run() waiting for events...");
+                                logger.debug("Scheduler(id={}"getId()+").run() waiting for events...");
                                 wait(queuesUpdateMaxWait);
                             }
                             hasBeenNotified = false;

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -317,7 +317,7 @@ public class Scheduler <T extends Job>
 
                         synchronized (this) {
                             if (!hasBeenNotified) {
-                                logger.debug("Scheduler(id={}"getId()+").run() waiting for events...");
+                                // logger.debug("Scheduler(id={}"getId()+").run() waiting for events...");
                                 wait(queuesUpdateMaxWait);
                             }
                             hasBeenNotified = false;

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCache.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCache.java
@@ -95,7 +95,7 @@ public class SharedMemoryCache {
     }
 
     public Job getJob(long jobId) {
-        _log.debug("getJob ( "+jobId + " ) ");
+        _log.debug("getJob ( {} ) ", jobId);
        sharedMemoryReadLock.lock();
        try {
             return sharedMemoryCache.get(jobId);

--- a/modules/srm-server/src/main/java/org/dcache/srm/util/Pgpass.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/util/Pgpass.java
@@ -117,10 +117,10 @@ public class Pgpass {
 
             //             System.out.println("mode: '"+reply+"'");
             if (reply==null) {
-                _logger.error("Cannot stat '"+_pwdfile+"'");
+                _logger.error("Cannot stat '{}'", _pwdfile);
                 throw new IOException("Cannot stat '"+_pwdfile+"'");
             } else if (!reply.equals("'600'")) {
-                _logger.error("Protection for '"+_pwdfile+"' must be '600'");
+                _logger.error("Protection for '{}' must be '600'", _pwdfile);
                 throw new IOException("Protection for '"+_pwdfile+"' must be '600'");
             }
             /*


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>