### PR TITLE
ftp-client: refactoring slf4j logging messages

### DIFF
--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/FTPClient.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/FTPClient.java
@@ -534,7 +534,7 @@ public class FTPClient
         while ((line = reader.readLine()) != null) {
             line = line.trim();
             if (logger.isDebugEnabled()) {
-                logger.debug("line ->,", line);
+                logger.debug("line ->{}", line);
             }
             if (line.equals("")) {
                 continue;

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/FTPClient.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/FTPClient.java
@@ -422,9 +422,8 @@ public class FTPClient
         {
             if (logger.isDebugEnabled()) {
                 logger.debug(
-                        "received "
-                        + buffer.getLength()
-                        + " bytes of directory listing");
+                        "received {} bytes of directory listing"
+                        , buffer.getLength());
             }
             this.received.write(buffer.getBuffer(), 0, buffer.getLength());
         }
@@ -535,7 +534,7 @@ public class FTPClient
         while ((line = reader.readLine()) != null) {
             line = line.trim();
             if (logger.isDebugEnabled()) {
-                logger.debug("line ->" + line);
+                logger.debug("line ->,", line);
             }
             if (line.equals("")) {
                 continue;
@@ -636,7 +635,7 @@ public class FTPClient
 
         while ((line = reader.readLine()) != null) {
             if (logger.isDebugEnabled()) {
-                logger.debug("line ->" + line);
+                logger.debug("line ->{}", line);
             }
 
             fileInfo = new FileInfo();
@@ -754,7 +753,7 @@ public class FTPClient
         while ((line = reader.readLine()) != null) {
 
             if (logger.isDebugEnabled()) {
-                logger.debug("line ->" + line);
+                logger.debug("line ->{}", line);
             }
 
             try {

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/MlsxEntry.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/MlsxEntry.java
@@ -101,7 +101,7 @@ public class MlsxEntry
 
                 //next fact
                 String fact = token;
-                logger.debug("fact: " + fact);
+                logger.debug("fact: {}", fact);
                 int equalSign = fact.indexOf('=');
                 String factName = fact.substring(0, equalSign).trim().toLowerCase();
                 String factValue =
@@ -114,7 +114,7 @@ public class MlsxEntry
                 // name: trim leading space
                 this.fileName = token.substring(1,
                                                 token.length());
-                logger.debug("name: " + fileName);
+                logger.debug("name: {}", fileName);
 
             }
         }

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/PerfMarker.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/PerfMarker.java
@@ -78,7 +78,7 @@ public class PerfMarker implements Marker
                 //last line
                 if (!name.startsWith("112")) {
                     //that wasn't a 112 message!
-                    logger.debug("ending line: ->" + name + "<-");
+                    logger.debug("ending line: ->{}<-", name);
                     badMsg("No ending '112' line", msg);
                 }
                 break;

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/AbstractDataChannel.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/AbstractDataChannel.java
@@ -122,7 +122,7 @@ public abstract class AbstractDataChannel implements DataChannel
 	}
 	*/
 
-        logger.debug("registering handler for class " + clazz.toString() + "; id = " + id);
+        logger.debug("registering handler for class {}; id = {}", clazz.toString(), id);
         dataHandlers.put(id, clazz);
     }
 
@@ -154,7 +154,7 @@ public abstract class AbstractDataChannel implements DataChannel
             throws Exception
     {
         String id = getHandlerID(session.transferMode, session.transferType, SOURCE);
-        logger.debug("type/mode: " + id);
+        logger.debug("type/mode: {}", id);
         Class clazz = (Class) dataHandlers.get(id);
         if (clazz == null) {
             throw new Exception("No data reader for type/mode" + id);

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/AbstractDataChannel.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/AbstractDataChannel.java
@@ -122,7 +122,7 @@ public abstract class AbstractDataChannel implements DataChannel
 	}
 	*/
 
-        logger.debug("registering handler for class {}; id = {}", clazz.toString(), id);
+        logger.debug("registering handler for class {}; id = {}", clazz, id);
         dataHandlers.put(id, clazz);
     }
 

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/EBlockImageDCReader.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/EBlockImageDCReader.java
@@ -89,8 +89,8 @@ public class EBlockImageDCReader
             context.eodTransferred();
             if (logger.isDebugEnabled()) {
                 logger.debug(
-                        "Received EOD. Still expecting: "
-                        + ((context.getEodsTotal() == EBlockParallelTransferContext.UNDEFINED)
+                        "Received EOD. Still expecting: {}",
+                        ((context.getEodsTotal() == EBlockParallelTransferContext.UNDEFINED)
                            ? "?"
                            : Integer.toString(
                                 context.eodsTotal - context.eodsTransferred)));
@@ -100,8 +100,8 @@ public class EBlockImageDCReader
         if (eof) {
             context.setEodsTotal((int) offset);
             if (logger.isDebugEnabled()) {
-                logger.debug("Received EODC. Expecting total EODs: "
-                             + context.getEodsTotal());
+                logger.debug("Received EODC. Expecting total EODs: {}",
+                        context.getEodsTotal());
             }
             return null;
 

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/EBlockImageDCWriter.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/EBlockImageDCWriter.java
@@ -48,9 +48,9 @@ public class EBlockImageDCWriter
         }
 
         output.writeByte(0);
-        logger.debug("buffer length: " + buf.getLength());
+        logger.debug("buffer length: {}", buf.getLength());
         output.writeLong(buf.getLength());
-        logger.debug("offset: " + offset);
+        logger.debug("offset: {}", offset);
         output.writeLong(offset);
         output.write(buf.getBuffer(), 0, buf.getLength());
         //output.flush();
@@ -71,8 +71,8 @@ public class EBlockImageDCWriter
                 output.writeByte(desc);
                 output.writeLong(0);
                 output.writeLong(context.eodsTotal);
-                logger.debug("wrote EOF (expected EODS: "
-                             + context.eodsTotal + ") and EOD");
+                logger.debug("wrote EOF (expected EODS: {}) and EOD",
+                             context.eodsTotal);
             } else {
                 desc = EOD;
                 output.writeByte(desc);

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/EBlockParallelTransferContext.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/EBlockParallelTransferContext.java
@@ -78,7 +78,7 @@ public class EBlockParallelTransferContext
     public synchronized Object getQuitToken()
     {
         logger.debug("checking if ready to quit");
-        logger.debug("eodsTotal = " + eodsTotal + "; eodsTransferred = " + eodsTransferred);
+        logger.debug("eodsTotal = {}; eodsTransferred = {}", eodsTotal, eodsTransferred);
         if (eodsTotal != UNDEFINED &&
             eodsTransferred == eodsTotal) {
             // ready to release the quit token. But make sure not to do it twice.

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/GridFTPActiveConnectTask.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/GridFTPActiveConnectTask.java
@@ -63,8 +63,8 @@ public class GridFTPActiveConnectTask extends Task
         Socket mySocket = null;
 
         if (logger.isDebugEnabled()) {
-            logger.debug("connecting new socket to: " +
-                         hostPort.getHost() + " " + hostPort.getPort());
+            logger.debug("connecting new socket to: {} {}",
+                         hostPort.getHost(), hostPort.getPort());
         }
 
         try {

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/GridFTPPassiveConnectTask.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/GridFTPPassiveConnectTask.java
@@ -99,8 +99,8 @@ public class GridFTPPassiveConnectTask extends PassiveConnectTask
         SocketPool socketPool = ((EBlockParallelTransferContext) context).getSocketPool();
         logger.debug("adding new socket to the pool");
         socketPool.add(sBox);
-        logger.debug("available cached sockets: " + socketPool.countFree()
-                     + "; busy: " + socketPool.countBusy());
+        logger.debug("available cached sockets: {} ; busy: {}", socketPool.countFree(),
+                     socketPool.countBusy());
 
         return sBox;
 

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/StripeContextManager.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/StripeContextManager.java
@@ -66,7 +66,7 @@ public class StripeContextManager
             if (contextList[i].getStripeQuitToken() != null) {
                 // obtained quit token from one stripe.
                 stripeQuitTokens++;
-                logger.debug("obtained stripe quit token. Total = {}; total needed = ",
+                logger.debug("obtained stripe quit token. Total = {}; total needed = {}",
                         stripeQuitTokens, stripes);
             }
             i++;

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/StripeContextManager.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/StripeContextManager.java
@@ -62,11 +62,12 @@ public class StripeContextManager
     {
         int i = 0;
         while (i < stripes) {
-            logger.debug("examining stripe " + i);
+            logger.debug("examining stripe {}", i);
             if (contextList[i].getStripeQuitToken() != null) {
                 // obtained quit token from one stripe.
                 stripeQuitTokens++;
-                logger.debug("obtained stripe quit token. Total = " + stripeQuitTokens + "; total needed = " + stripes);
+                logger.debug("obtained stripe quit token. Total = {}; total needed = ",
+                        stripeQuitTokens, stripes);
             }
             i++;
         }

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/StripeContextManager.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/StripeContextManager.java
@@ -66,6 +66,7 @@ public class StripeContextManager
             if (contextList[i].getStripeQuitToken() != null) {
                 // obtained quit token from one stripe.
                 stripeQuitTokens++;
+
                 logger.debug("obtained stripe quit token. Total = {}; total needed = {}",
                         stripeQuitTokens, stripes);
             }

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/StripeContextManager.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/StripeContextManager.java
@@ -66,7 +66,6 @@ public class StripeContextManager
             if (contextList[i].getStripeQuitToken() != null) {
                 // obtained quit token from one stripe.
                 stripeQuitTokens++;
-
                 logger.debug("obtained stripe quit token. Total = {}; total needed = {}",
                         stripeQuitTokens, stripes);
             }

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TaskThread.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TaskThread.java
@@ -74,9 +74,9 @@ public class TaskThread implements Runnable
             if (task == null) break;
             exception = null;
             try {
-                logger.debug("executing task: " + task.toString());
+                logger.debug("executing task: {}", task.toString());
                 task.execute();
-                logger.debug("finished task: " + task.toString());
+                logger.debug("finished task: {}", task.toString());
             } catch (Exception e) {
                 exception = e;
             }

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TransferSinkThread.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TransferSinkThread.java
@@ -118,8 +118,8 @@ public class TransferSinkThread extends TransferThread
             transferred += buf.getLength();
             sink.write(buf);
         }
-        logger.debug("finished receiving data; received " +
-                     transferred + " bytes");
+        logger.debug("finished receiving data; received {} bytes",
+                     transferred);
     }
 
     protected void shutdown(Object quitToken) throws IOException

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TransferSourceThread.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TransferSourceThread.java
@@ -55,7 +55,7 @@ public class TransferSourceThread extends TransferThread
         this.localControlChannel = localControlChannel;
         this.context = context;
         this.writer = dataChannel.getDataChannelSink(context);
-        logger.debug("using socket " + socketBox.getSocket().toString());
+        logger.debug("using socket {}", socketBox.getSocket().toString());
         writer.setDataStream(socketBox.getSocket().getOutputStream());
     }
 
@@ -76,8 +76,8 @@ public class TransferSourceThread extends TransferThread
                     writer.write(buf);
                 }
 
-                logger.debug("finished sending data; sent " +
-                             transferred + " bytes");
+                logger.debug("finished sending data; sent {} bytes",
+                             transferred);
 
             } catch (Exception e) {
                 // this happens also if thread gets interrupted

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TransferThreadManager.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TransferThreadManager.java
@@ -68,9 +68,8 @@ public class TransferThreadManager
             socketPool.add(sbox);
 
             logger.debug(
-                    "connecting active socket "
-                    + i
-                    + "; total cached sockets = "
+                    "connecting active socket {}; total cached sockets = {}",
+                    i
                     + socketPool.count());
 
             Task task =
@@ -140,12 +139,10 @@ public class TransferThreadManager
 
         for (int i = 0; i < connections; i++) {
             logger.debug(
-                    "checking out a socket; total cached sockets = "
-                    + socketPool.count()
-                    + "; free = "
-                    + socketPool.countFree()
-                    + "; busy = "
-                    + socketPool.countBusy());
+                    "checking out a socket; total cached sockets = {}; free = {}; busy = {}",
+                    socketPool.count(),
+                    socketPool.countFree()
+                    socketPool.countBusy());
 
             SocketBox sbox = socketPool.checkOut();
             if (sbox == null) {
@@ -192,12 +189,10 @@ public class TransferThreadManager
 
         for (int i = 0; i < connections; i++) {
             logger.debug(
-                    "checking out a socket; total cached sockets = "
-                    + socketPool.count()
-                    + "; free = "
-                    + socketPool.countFree()
-                    + "; busy = "
-                    + socketPool.countBusy());
+                    "checking out a socket; total cached sockets = {}; free = {}; busy = {}",
+                    socketPool.count(),
+                    socketPool.countFree(),
+                    socketPool.countBusy());
 
             SocketBox sbox = socketPool.checkOut();
             if (sbox == null) {
@@ -294,14 +289,14 @@ public class TransferThreadManager
     public synchronized void transferThreadStarting()
     {
         transferThreadCount++;
-        logger.debug("one transfer started, total active = " +
+        logger.debug("one transfer started, total active = {}",
                      transferThreadCount);
     }
 
     public synchronized void transferThreadTerminating()
     {
         transferThreadCount--;
-        logger.debug("one transfer terminated, total active = " +
+        logger.debug("one transfer terminated, total active = {}",
                      transferThreadCount);
     }
 

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TransferThreadManager.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/dc/TransferThreadManager.java
@@ -69,8 +69,8 @@ public class TransferThreadManager
 
             logger.debug(
                     "connecting active socket {}; total cached sockets = {}",
-                    i
-                    + socketPool.count());
+                    i,
+                    socketPool.count());
 
             Task task =
                     new GridFTPActiveConnectTask(
@@ -141,7 +141,7 @@ public class TransferThreadManager
             logger.debug(
                     "checking out a socket; total cached sockets = {}; free = {}; busy = {}",
                     socketPool.count(),
-                    socketPool.countFree()
+                    socketPool.countFree(),
                     socketPool.countBusy());
 
             SocketBox sbox = socketPool.checkOut();

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/extended/GridFTPServerFacade.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/extended/GridFTPServerFacade.java
@@ -94,7 +94,7 @@ public class GridFTPServerFacade extends FTPServerFacade
         if (opts instanceof RetrieveOptions) {
             gSession.parallel =
                     ((RetrieveOptions) opts).getStartingParallelism();
-            logger.debug("parallelism set to " + gSession.parallel);
+            logger.debug("parallelism set to {}", gSession.parallel);
         }
     }
 
@@ -147,7 +147,7 @@ public class GridFTPServerFacade extends FTPServerFacade
             throws UnknownHostException, ClientException, IOException
     {
         if (logger.isDebugEnabled()) {
-            logger.debug("hostport: " + hp.getHost() + " " + hp.getPort());
+            logger.debug("hostport: {} {}", hp.getHost(), hp.getPort());
         }
 
         if (session.serverMode == Session.SERVER_ACTIVE) {
@@ -233,7 +233,7 @@ public class GridFTPServerFacade extends FTPServerFacade
 
         gSession.serverAddressList.add(hp);
 
-        logger.debug("started single striped passive server at port " +
+        logger.debug("started single striped passive server at port {}",
                      gSession.serverAddressList.get(0).getPort());
 
         return gSession.serverAddressList;
@@ -305,9 +305,9 @@ public class GridFTPServerFacade extends FTPServerFacade
                     needNewConnections = gSession.parallel - willReuseConnections;
                 }
 
-                logger.debug("will reuse " + willReuseConnections +
-                             " connections and start " + needNewConnections +
-                             " new ones.");
+                logger.debug("will reuse {}  connections and start {}  new ones.",
+                        willReuseConnections,
+                        needNewConnections);
 
                 transferThreadManager.startTransfer(
                         sink,
@@ -384,9 +384,8 @@ public class GridFTPServerFacade extends FTPServerFacade
                 int willCloseConnections = (free > total) ? free - total : 0;
                 int needNewConnections = (total > free) ? total - free : 0;
 
-                logger.debug("will reuse " + willReuseConnections +
-                             " connections, start " + needNewConnections +
-                             " new ones, and close " + willCloseConnections);
+                logger.debug("will reuse {} connections, start {}  new ones, and close {}", willReuseConnections,
+                             needNewConnections, willCloseConnections);
 
                 if (needNewConnections > 0) {
                     transferThreadManager.activeConnect(this.remoteServerAddress,

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/FTPControlChannel.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/FTPControlChannel.java
@@ -137,8 +137,8 @@ public class FTPControlChannel extends BasicClientControlChannel
 
             while (!found) {
                 try {
-                    logger.debug("opening control channel to "
-                                 + allIPs[i] + " : " + port);
+                    logger.debug("opening control channel to {} : {}",
+                                 allIPs[i], port);
                     InetSocketAddress isa =
                             new InetSocketAddress(allIPs[i], port);
 
@@ -146,8 +146,8 @@ public class FTPControlChannel extends BasicClientControlChannel
                     socket.connect(isa);
                     found = true;
                 } catch (IOException ioEx) {
-                    logger.debug("failed connecting to  "
-                                 + allIPs[i] + " : " + port + ":" + ioEx);
+                    logger.debug("failed connecting to {} : {}:{}",
+                                 allIPs[i], port, ioEx.toString());
                     i++;
                     if (i == allIPs.length) {
                         if (firstPass) {
@@ -251,7 +251,7 @@ public class FTPControlChannel extends BasicClientControlChannel
                 done = true;
             } catch (SocketTimeoutException e) {
                 // timeouts will happen
-                logger.debug("temp timeout" + e);
+                logger.debug("temp timeout {}", e.toString());
             } catch (Exception e) {
                 throw new InterruptedException();
             } finally {
@@ -345,7 +345,7 @@ public class FTPControlChannel extends BasicClientControlChannel
         Reply reply = new Reply(ftpIn);
         //System.out.println("FTP IN string "+reply.toString());
         if (logger.isDebugEnabled()) {
-            logger.debug("Control channel received: " + reply);
+            logger.debug("Control channel received: {}", reply);
         }
         lastReply = reply;
         return reply;
@@ -371,7 +371,7 @@ public class FTPControlChannel extends BasicClientControlChannel
             throw new IllegalArgumentException("null argument: cmd");
         }
         if (logger.isDebugEnabled()) {
-            logger.debug("Control channel sending: " + cmd);
+            logger.debug("Control channel sending: {}", cmd);
         }
         ftpOut.write(cmd.toString().getBytes(StandardCharsets.US_ASCII));
         ftpOut.flush();

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/FTPServerFacade.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/FTPServerFacade.java
@@ -214,7 +214,7 @@ public class FTPServerFacade
                     new HostPort(address, localPort);
         }
 
-        logger.debug("started passive server at port " +
+        logger.debug("started passive server at port {}",
                      session.serverAddress.getPort());
         return session.serverAddress;
 
@@ -232,7 +232,7 @@ public class FTPServerFacade
             IOException
     {
         if (logger.isDebugEnabled()) {
-            logger.debug("hostport: " + hp.getHost() + " " + hp.getPort());
+            logger.debug("hostport: {} {}", hp.getHost(), hp.getPort());
         }
         session.serverMode = Session.SERVER_ACTIVE;
         this.remoteServerAddress = hp;
@@ -536,7 +536,7 @@ public class FTPServerFacade
                 if (aborted.flag) {
                     throw new InterruptedException();
                 }
-                logger.debug("slept " + i);
+                logger.debug("slept {}", i);
                 Thread.sleep(ioDelay);
                 i += ioDelay;
                 if (maxWait != WAIT_FOREVER

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/Reply.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/Reply.java
@@ -75,7 +75,7 @@ public class Reply
         logger.debug("read 1st line");
         String line = input.readLine();
         if (logger.isDebugEnabled()) {
-            logger.debug("1st line: " + line);
+            logger.debug("1st line: {}", line);
         }
 
         //end of stream
@@ -133,9 +133,9 @@ public class Reply
             String lineSeparator = System.getProperty("line.separator");
             if (logger.isDebugEnabled()) {
                 logger.debug(
-                        "multiline reply; last line should start with ->"
-                        + lastLineStarts + "<-");
-                logger.debug("lenght of line.separator on this OS: " +
+                        "multiline reply; last line should start with ->{}<-",
+                        lastLineStarts);
+                logger.debug("lenght of line.separator on this OS: {}",
                              lineSeparator.length());
             }
             StringBuilder buf = new StringBuilder(message);
@@ -152,7 +152,7 @@ public class Reply
                 //which is incorrectly inserting \0 between lines
                 line = ignoreLeading0(line);
                 if (logger.isDebugEnabled()) {
-                    logger.debug("line : ->" + line + "<-");
+                    logger.debug("line : ->{}<-", line);
                 }
                 buf.append(lineSeparator).append(line);
 
@@ -253,12 +253,12 @@ public class Reply
         if (line.length() > 0 && line.charAt(0) == 0) {
             logger.debug("WARNING: The first character of the reply is 0. Ignoring the character.");
         /*
-	    logger.debug( "\n\nWARNING:\n In the reply received from the server, the first character's code is 0! I will ignore it but this means the server is not following the protocol. Here's the details: \n first line of the reply ->" + line + "<-");
-	    logger.debug( "First 3 chars of reply->" +line.substring(0,3)+"<-"); 
-	    logger.debug( "char 0 ->" + line.charAt(0) + "<- code = " + (int)line.charAt(0));
-	    logger.debug( "char 1 ->" + line.charAt(1) + "<- code = " + (int)line.charAt(1));
-	    logger.debug( "char 2 ->" + line.charAt(2) + "<- code = " + (int)line.charAt(2));
-	    logger.debug( "char 3 ->" + line.charAt(3) + "<- code = " + (int)line.charAt(3));
+	    logger.debug( "\n\nWARNING:\n In the reply received from the server, the first character's code is 0! I will ignore it but this means the server is not following the protocol. Here's the details: \n first line of the reply ->{}<-", line);
+	    logger.debug( "First 3 chars of reply->{}<-", line.substring(0,3));
+	    logger.debug( "char 0 ->{}<- code = {}", line.charAt(0), (int)line.charAt(0));
+	    logger.debug( "char 1 ->{}<- code = ", line.charAt(1),  (int)line.charAt(1));
+	    logger.debug( "char 2 ->{}<- code = ", line.charAt(2), (int)line.charAt(2));
+	    logger.debug( "char 3 ->{}<- code = ", line.charAt(3), (int)line.charAt(3));
 	    */
             return line.substring(1, line.length());
         }

--- a/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/TransferMonitor.java
+++ b/modules/ftp-client/src/main/java/org/dcache/ftp/client/vanilla/TransferMonitor.java
@@ -134,8 +134,8 @@ public class TransferMonitor implements Runnable
                 throw new InterruptedException();
             }
 
-            logger.debug("waiting for 1st reply;  maxWait = " +
-                         maxWait + ", ioDelay = " + ioDelay);
+            logger.debug("waiting for 1st reply;  maxWait = {}, ioDelay = {}",
+                         maxWait, ioDelay);
             this.controlChannel.waitFor(aborted,
                                         ioDelay,
                                         maxWait);
@@ -148,7 +148,7 @@ public class TransferMonitor implements Runnable
             // 125 Data connection already open; transfer starting
             if (Reply.isPositivePreliminary(firstReply)) {
                 transferState.transferStarted();
-                logger.debug("first reply OK: " + firstReply.toString());
+                logger.debug("first reply OK: {}", firstReply.toString());
 
                 for (; ; ) {
 
@@ -160,7 +160,7 @@ public class TransferMonitor implements Runnable
 
                     //perf marker
                     if (nextReply.getCode() == 112) {
-                        logger.debug("marker arrived: " + nextReply.toString());
+                        logger.debug("marker arrived: {}", nextReply.toString());
                         if (mListener != null) {
                             mListener.markerArrived(
                                     new PerfMarker(nextReply.getMessage()));
@@ -170,7 +170,7 @@ public class TransferMonitor implements Runnable
 
                     //restart marker
                     if (nextReply.getCode() == 111) {
-                        logger.debug("marker arrived: " + nextReply.toString());
+                        logger.debug("marker arrived: {}", nextReply.toString());
                         if (mListener != null) {
                             mListener.markerArrived(
                                     new GridFTPRestartMarker(
@@ -182,12 +182,12 @@ public class TransferMonitor implements Runnable
                     //226 Transfer complete
                     if (nextReply.getCode() == 226) {
                         abortable = false;
-                        logger.debug("transfer complete: " + nextReply.toString());
+                        logger.debug("transfer complete: {}", nextReply.toString());
                         break;
                     }
 
                     // any other reply
-                    logger.debug("unexpected reply: " + nextReply.toString());
+                    logger.debug("unexpected reply: {}", nextReply.toString());
                     logger.debug("exiting the transfer thread");
                     ServerException e = ServerException.embedUnexpectedReplyCodeException(
                             new UnexpectedReplyCodeException(nextReply),
@@ -199,8 +199,8 @@ public class TransferMonitor implements Runnable
                 }
 
             } else {    //first reply negative
-                logger.debug("first reply bad: " + firstReply.toString());
-                logger.debug("category: " + firstReply.getCategory());
+                logger.debug("first reply bad: {}", firstReply.toString());
+                logger.debug("category: {}", firstReply.getCategory());
                 abortable = false;
                 ServerException e = ServerException.embedUnexpectedReplyCodeException(
                         new UnexpectedReplyCodeException(firstReply));

--- a/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/ByteRangeListTest.java
+++ b/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/ByteRangeListTest.java
@@ -253,13 +253,13 @@ public class ByteRangeListTest extends TestCase {
 
 	String vBefore = list.toFtpCmdArgument();
 	String rBefore = newRange.toString();
-	logger.info("merging range: " + vBefore + " + " + rBefore);
+	logger.info("merging range: {} + {}", vBefore, rBefore);
 
 	// test merge
 
 	list.merge(newRange);
 	String actualResult = list.toFtpCmdArgument();
-	logger.debug("  -> " + actualResult);
+	logger.debug("  -> {}", actualResult);
 	assertTrue(expectedResult.equals(actualResult));
 	logger.debug("ok, merged as expected.");
 
@@ -281,13 +281,13 @@ public class ByteRangeListTest extends TestCase {
      **/
     private void assertMerge(Vector v, String result) {
 	
-	logger.info("merging vector of ranges: " + result);
+	logger.info("merging vector of ranges: {}", result);
 
 	ByteRangeList list1 = new ByteRangeList();
 	for (int i=0; i<v.size(); i++) {
 	    list1.merge((ByteRange)v.elementAt(i));
 	}
-	logger.debug("    -> " + list1.toFtpCmdArgument());
+	logger.debug("    -> {}", list1.toFtpCmdArgument());
 	assertTrue(list1.toFtpCmdArgument().equals(result));
 
  	logger.debug("merging one by one again..");
@@ -295,14 +295,14 @@ public class ByteRangeListTest extends TestCase {
 	for (int i=0; i<v.size(); i++) {
 	    list3.merge((ByteRange)v.elementAt(i));
 	}
-	logger.debug(" .. -> " + list3.toFtpCmdArgument());
+	logger.debug(" .. -> {}", list3.toFtpCmdArgument());
 	assertTrue(list3.toFtpCmdArgument().equals(result));
 
 
 	logger.debug("merging vector at once");
 	ByteRangeList list2 = new ByteRangeList();
 	list2.merge(v);
-	logger.debug(" .. -> " + list2.toFtpCmdArgument());
+	logger.debug(" .. -> {}", list2.toFtpCmdArgument());
 	assertTrue(list2.toFtpCmdArgument().equals(result));    
 
     }

--- a/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/ByteRangeTest.java
+++ b/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/ByteRangeTest.java
@@ -102,21 +102,19 @@ public class ByteRangeTest extends TestCase {
 			     int from2, int to2,
 			     int from1after, int to1after,
 			     int expectedReturn) {
-	logger.debug("checking: (" 
-		     + from1 + ".." + to1 +") + ("
-		     + from2 + ".." + to2 +") = ("
-		     + from1after + ".." + to1after + ")");
+	logger.debug("checking: ({}..{}) + ({}..{}) = ({}..{})",
+		     from1, to1, from2, to2, from1after, to1after);
 	ByteRange br1 = new ByteRange(from1, to1);
 	ByteRange br2 = new ByteRange(from2, to2);
 	int ret = br1.merge(br2);
-	logger.debug("... -> (" + br1.from + ".." + br1.to + ")"); 
+	logger.debug("... -> ({}..{})", br1.from, br1.to);
 	assertTrue(ret == expectedReturn);
 	assertTrue(br1.from == from1after);
 	assertTrue(br1.to == to1after);
     }
 
     private void assertConstructorError(int from, int to) {
-	logger.debug("checking constructor: (" + from + "," + to + ")");
+	logger.debug("checking constructor: ({},{})", from, to);
 	boolean threwOk = false;
 	try {
 	    new ByteRange(from, to);

--- a/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/FeatureListTest.java
+++ b/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/FeatureListTest.java
@@ -98,11 +98,11 @@ public class FeatureListTest extends TestCase{
 	switch (expectedResult) {
 	case Y: 	    
 	    assertTrue(fl.contains(feature));
-	    logger.info("okay, contains " + feature);
+	    logger.info("okay, contains {}", feature);
 	    break;
 	case N:
 	    assertTrue( ! fl.contains(feature));
-	    logger.info("okay, does not contain " + feature);
+	    logger.info("okay, does not contain {}", feature);
 	    break;
 	case E:
 	    boolean threwOk = false;

--- a/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/GridFTPRestartMarkerTest.java
+++ b/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/GridFTPRestartMarkerTest.java
@@ -84,7 +84,7 @@ public class GridFTPRestartMarkerTest extends TestCase {
     }
 
     private void testConstruction(String in, String out) {
-	logger.info(" constructing: " + in + " -> " + out);
+	logger.info(" constructing: {} -> {}", in, out);
 	GridFTPRestartMarker m = 
 	    new GridFTPRestartMarker("Range Marker " + in);
 	ByteRangeList l = new ByteRangeList();
@@ -93,7 +93,7 @@ public class GridFTPRestartMarkerTest extends TestCase {
     }
 
     private void assertConstructorError(String arg) {
-	logger.info("constructing bad: " + arg);
+	logger.info("constructing bad: {}", arg);
 	boolean threwOk = false;
 	try {
 	    new GridFTPRestartMarker(arg);

--- a/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/HostPortListTest.java
+++ b/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/HostPortListTest.java
@@ -148,7 +148,7 @@ public class HostPortListTest extends TestCase {
 	make sure the constructor throws an exception.
     **/
     private void testConstructorError(String msg) {
-	logger.info("checking bad message: " + msg);
+	logger.info("checking bad message: {}", msg);
 	boolean threwOk = false;
 	try {
 	    new HostPortList(msg);

--- a/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/PerfMarkerTest.java
+++ b/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/PerfMarkerTest.java
@@ -210,7 +210,7 @@ public class PerfMarkerTest extends TestCase {
 				  boolean hasBT, long bt,
 				  boolean hasTSC, long tsc) 
     throws Exception{
-	logger.info("checking object:\n" + in);
+	logger.info("checking object:\n{}", in);
 	PerfMarker m = 
 	    new PerfMarker(in);
 
@@ -282,7 +282,7 @@ public class PerfMarkerTest extends TestCase {
        ensure that constructor throws IllegalArgumentException.
      **/
     private void assertConstructorError(String arg) {
-	logger.info("checking bad construction:\n" + arg);
+	logger.info("checking bad construction:\n{}", arg);
 	boolean threwOk = false;
 	try {
 	    new PerfMarker(arg);

--- a/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/ReplyTest.java
+++ b/modules/ftp-client/src/test/java/org/dcache/ftp/client/test/ReplyTest.java
@@ -93,7 +93,7 @@ public class ReplyTest extends TestCase {
     
     //check if bad reply gets detected
     private void parseBadReply(String s) {
-	logger.info("bad construction:" + s);
+	logger.info("bad construction:{}", s);
 	boolean thrown = false;
 	try {
 	    parseReply(s);
@@ -106,7 +106,7 @@ public class ReplyTest extends TestCase {
 
     // fully test reply; check if input values match parsed values
     private void testReply(String uReplyString, int uCode,  String uMessage, boolean uMultiline) {
-	logger.info("testing object: " + uReplyString);
+	logger.info("testing object: {}", uReplyString);
 	int uClass = uCode / 100;
 	try {
 	    Reply r = new Reply(new BufferedReader(new StringReader(uReplyString)));
@@ -132,7 +132,7 @@ public class ReplyTest extends TestCase {
 
     //only parse reply and see if an exception gets thrown
     private void parseReply(String uReplyString) {
-	logger.debug("parsing: " + uReplyString);
+	logger.debug("parsing: {}", uReplyString);
 	try {
 	    Reply r = new Reply(new BufferedReader(new StringReader(uReplyString)));
 	} catch (Exception e) {


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>