### PR TITLE
cells: refactoring slf4j logging messages

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
@@ -518,9 +518,9 @@ public class CellAdapter
      * @param msg the reference to message arrived.
      */
     public void messageArrived(CellMessage msg) {
-        _log.info(" CellMessage From   : " + msg.getSourcePath());
-        _log.info(" CellMessage To     : " + msg.getDestinationPath());
-        _log.info(" CellMessage Object : " + msg.getMessageObject());
+        _log.info(" CellMessage From   : {}", msg.getSourcePath());
+        _log.info(" CellMessage To     : {}", msg.getDestinationPath());
+        _log.info(" CellMessage Object : {}", msg.getMessageObject());
 
     }
     /**
@@ -808,7 +808,7 @@ public class CellAdapter
      */
     @Override
     public void   exceptionArrived(ExceptionEvent ce) {
-        _log.info(" exceptionArrived "+ce);
+        _log.info(" exceptionArrived {}", ce);
     }
 
     /**

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellAdapter.java
@@ -808,7 +808,7 @@ public class CellAdapter
      */
     @Override
     public void   exceptionArrived(ExceptionEvent ce) {
-        _log.info(" exceptionArrived {}", ce);
+        _log.info(" exceptionArrived {}", ce.toString());
     }
 
     /**

--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
@@ -581,7 +581,7 @@ public class CellShell extends CommandInterpreter
           try{
             _log.warn( "waitForCell : Sending request" ) ;
               answer = _nucleus.sendAndWait(new CellMessage(destination , message), ((long) check) * 1000);
-            _log.warn( "waitForCell : got "+answer ) ;
+            _log.warn( "waitForCell : got {}", answer ) ;
          } catch (NoRouteToCellException e) {
             noRoute = true ;
          } catch (ExecutionException ignored) {

--- a/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
@@ -283,10 +283,10 @@ public class      SystemCell
 
    @Override
    public void messageArrived( CellMessage msg ){
-        _log.info( "Message arrived : "+msg ) ;
+        _log.info( "Message arrived : {}", msg ) ;
         _packetsReceived ++ ;
         if( msg.isReply() ){
-            _log.warn("Seems to a bounce : "+msg);
+            _log.warn("Seems to a bounce : {}", msg);
             return ;
         }
         Object obj  = msg.getMessageObject() ;
@@ -309,7 +309,7 @@ public class      SystemCell
            if( command.length() < 1 ) {
                return;
            }
-           _log.info( "Command(p="+as.getAuthorizedPrincipal()+") : "+command ) ;
+           _log.info( "Command(p={}) : {}", as.getAuthorizedPrincipal(), command ) ;
            reply = _cellShell.objectCommand2( command ) ;
         } else {
             return;

--- a/modules/cells/src/main/java/dmg/cells/services/MemoryWatch.java
+++ b/modules/cells/src/main/java/dmg/cells/services/MemoryWatch.java
@@ -52,7 +52,7 @@ public class MemoryWatch extends CellAdapter implements Runnable {
             try {
                 _update = Integer.parseInt(var);
             } catch (Exception ee) {
-                _log.warn("Update not accepted : " + var);
+                _log.warn("Update not accepted : {}", var);
             }
         }
         //
@@ -62,7 +62,7 @@ public class MemoryWatch extends CellAdapter implements Runnable {
             try {
                 _maxFileSize = Integer.parseInt(var);
             } catch (Exception ee) {
-                _log.warn("New 'maxFilesize' not accepted : " + var);
+                _log.warn("New 'maxFilesize' not accepted : {}", var);
             }
         }
         //
@@ -72,7 +72,7 @@ public class MemoryWatch extends CellAdapter implements Runnable {
             try {
                 _generations = Integer.parseInt(var);
             } catch (Exception ee) {
-                _log.warn("New 'generations' not accepted : " + var);
+                _log.warn("New 'generations' not accepted : {}", var);
             }
         }
         if ((var = _args.getOpt("output")) != null) {

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginCell.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginCell.java
@@ -106,7 +106,7 @@ public class      LoginCell
      Constructor<?> con = null ;
      Object      o;
      for( int i = 0 ; i < args.argc() ; i++ ){
-        _log.info( "Trying to load shell : "+args.argv(i) ) ;
+        _log.info( "Trying to load shell : {}", args.argv(i) ) ;
         try{
            c = Class.forName( args.argv(i) ) ;
            int j ;
@@ -124,12 +124,12 @@ public class      LoginCell
 
            o = con.newInstance( objList[j] ) ;
            addCommandListener( o ) ;
-           _log.info( "Added : "+args.argv(i) ) ;
+           _log.info( "Added : {}", args.argv(i) ) ;
         }catch(Exception ee ){
-           _log.warn( "Failed to load shell : "+args.argv(i)+" : "+ee ) ;
+           _log.warn( "Failed to load shell : {} : {}", args.argv(i), ee.toString() ) ;
            if( ee instanceof InvocationTargetException ){
-              _log.warn( "   -> Problem in constructor : "+
-                ((InvocationTargetException)ee).getTargetException() ) ;
+              _log.warn( "   -> Problem in constructor : {}",
+                ((InvocationTargetException)ee).getTargetException().toString() ) ;
            }
         }
 
@@ -157,10 +157,10 @@ public class      LoginCell
                   print( prompt() ) ;
                }
            }catch( IOException e ){
-              _log.info("EOF Exception in read line : "+e ) ;
+              _log.info("EOF Exception in read line : {}", e.toString() ) ;
               break ;
            }catch( Exception e ){
-              _log.info("I/O Error in read line : "+e ) ;
+              _log.info("I/O Error in read line : {}", e.toString() ) ;
               break ;
            }
 

--- a/modules/cells/src/main/java/dmg/cells/services/login/StreamEngineFactory.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/StreamEngineFactory.java
@@ -34,7 +34,7 @@ public abstract class StreamEngineFactory {
             break;
         case "telnet": {
             TelnetServerAuthentication auth = new TelnetSAuth_A(endpoint, argsForAuth);
-            _log.info("Using authentication Module : " + TelnetSAuth_A.class);
+            _log.info("Using authentication Module : {}", TelnetSAuth_A.class);
             engine = new TelnetStreamEngine(socket, auth);
             break;
         }

--- a/modules/cells/src/main/java/dmg/cells/services/login/TelnetSAuth_A.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/TelnetSAuth_A.java
@@ -130,7 +130,7 @@ public class      TelnetSAuth_A
              }
              return true ;
          }catch( Exception e ){
-            _log.info( "Exception in TelnetSAuth_A : "+ e ) ;
+            _log.info( "Exception in TelnetSAuth_A : {}", e ) ;
             return false ;
          }
       }else if( __passwordFile !=  null ){

--- a/modules/cells/src/main/java/dmg/cells/services/login/TelnetSAuth_A.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/TelnetSAuth_A.java
@@ -130,7 +130,7 @@ public class      TelnetSAuth_A
              }
              return true ;
          }catch( Exception e ){
-            _log.info( "Exception in TelnetSAuth_A : {}", e ) ;
+            _log.info( "Exception in TelnetSAuth_A : {}", e.toString() ) ;
             return false ;
          }
       }else if( __passwordFile !=  null ){

--- a/modules/cells/src/main/java/dmg/cells/services/login/UserMgrCell.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/UserMgrCell.java
@@ -98,7 +98,7 @@ public class       UserMgrCell
       Serializable answer;
 
       try{
-         _log.info( "Message : "+obj.getClass() ) ;
+         _log.info( "Message : {}", obj.getClass() ) ;
          if( ( ! ( obj instanceof Object [] ) ) ||
              (  ((Object[])obj).length < 3 )    ||
              ( !((Object[])obj)[0].equals("request") ) ){
@@ -138,7 +138,7 @@ public class       UserMgrCell
       try{
          sendMessage( msg ) ;
       }catch( RuntimeException ioe ){
-         _log.warn( "Can't send acl_response : "+ioe ) ;
+         _log.warn( "Can't send acl_response : {}", ioe.toString() ) ;
       }
   }
   private String createMethodName( String com ){

--- a/modules/cells/src/main/java/dmg/cells/services/login/user/AclCell.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/user/AclCell.java
@@ -67,11 +67,11 @@ public class       AclCell
         String tmp;
         if ((tmp = args.getOpt("syspassword")) != null) {
             _sysPassword = new UserPasswords(new File(tmp));
-            _log.info("using as SystemPasswordfile : " + tmp);
+            _log.info("using as SystemPasswordfile : {}", tmp);
         }
         if ((tmp = args.getOpt("egpassword")) != null) {
             _egPassword = new UserPasswords(new File(tmp));
-            _log.info("using as EgPasswordfile : " + tmp);
+            _log.info("using as EgPasswordfile : {}", tmp);
         }
     }
 
@@ -84,7 +84,7 @@ public class       AclCell
       Serializable answer;
 
       try{
-         _log.info( "Message type : "+obj.getClass() ) ;
+         _log.info( "Message type : {}", obj.getClass() ) ;
          if( ( obj instanceof Object []              )  &&
              (  ((Object[])obj).length >= 3          )  &&
              (  ((Object[])obj)[0].equals("request") ) ){
@@ -324,7 +324,7 @@ public class       AclCell
 
          }
       }catch( Throwable t ){
-         _log.warn( "Found : "+t ) ;
+         _log.warn( "Found : {}", t.toString() ) ;
       }
       return false ;
   }
@@ -334,14 +334,14 @@ public class       AclCell
             _sysPassword.update();
         }
      }catch(Exception ee ){
-        _log.warn( "Updating failed : "+_sysPassword ) ;
+        _log.warn( "Updating failed : {}", _sysPassword ) ;
      }
      try{
         if( _egPassword != null ) {
             _egPassword.update();
         }
      }catch(Exception ee ){
-        _log.warn( "Updating failed : "+_egPassword ) ;
+        _log.warn( "Updating failed : {}", _egPassword ) ;
      }
    }
 

--- a/modules/cells/src/main/java/dmg/cells/services/login/user/UserSecurityCell.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/user/UserSecurityCell.java
@@ -69,7 +69,7 @@ public class       UserSecurityCell
       Serializable answer;
 
       try{
-         _log.info( "Message type : "+obj.getClass() ) ;
+         _log.info( "Message type : {}", obj.getClass() ) ;
          if( ( obj instanceof Object []              )  &&
              (  ((Object[])obj).length >= 3          )  &&
              (  ((Object[])obj)[0].equals("request") ) ){
@@ -200,7 +200,7 @@ public class       UserSecurityCell
           throw new Exception("Not authenticated");
       }
       String command = args.argv(0) ;
-      _log.info( "show all : mode="+command+";user=user") ;
+      _log.info( "show all : mode={};user=user", command) ;
       if( command.equals("exception") ) {
           throw new
                   Exception("hallo otto");

--- a/modules/cells/src/main/java/dmg/util/DummyStreamEngine.java
+++ b/modules/cells/src/main/java/dmg/util/DummyStreamEngine.java
@@ -79,7 +79,7 @@ public class DummyStreamEngine implements StreamEngine
                 try {
                     _inputStream = _socket.getInputStream();
                 } catch (IOException e) {
-                    _logger.error("Could not create input stream: " + e.getMessage());
+                    _logger.error("Could not create input stream: {}", e.getMessage());
                 }
             } else {
                 _inputStream = Channels.newInputStream(_channel);
@@ -96,7 +96,7 @@ public class DummyStreamEngine implements StreamEngine
                 try {
                     _outputStream = _socket.getOutputStream();
                 } catch (IOException e) {
-                    _logger.error("Could not create output stream: " + e.getMessage());
+                    _logger.error("Could not create output stream: {}", e.getMessage());
                 }
             } else {
                 _outputStream = Channels.newOutputStream(_channel);


### PR DESCRIPTION
Motivation:
With normal string concatenations in log-messages strings are always build,
regardless if log-level is activated or not. with parameterized log-messages
the strings only become build, when the log-level is activated;

Modification:
Using placeholder with parameterized messages instead of string concatenations

Result:
Gained efficiency

Signed-off-by: marisanest <marisanest@mailbox.org>