### PR TITLE
ftp: update exception logging to include context

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
@@ -344,15 +344,17 @@ public class NettyLineBasedDoor
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        if (cause instanceof ClosedChannelException) {
-            LOGGER.info("Connection closed");
-        } else if (cause instanceof RuntimeException || cause instanceof Error) {
-            Thread me = Thread.currentThread();
-            me.getUncaughtExceptionHandler().uncaughtException(me, cause);
-            ctx.close();
-        } else {
-            LOGGER.error(cause.toString());
-            ctx.close();
+        try (CDC ignored = cdc.restore()) {
+            if (cause instanceof ClosedChannelException) {
+                LOGGER.info("Connection closed");
+            } else if (cause instanceof RuntimeException || cause instanceof Error) {
+                Thread me = Thread.currentThread();
+                me.getUncaughtExceptionHandler().uncaughtException(me, cause);
+                ctx.close();
+            } else {
+                LOGGER.error(cause.toString());
+                ctx.close();
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

If an exception is thrown then it is logged; however, it is logged with
the context of LoginManager, rather than the context of the door
instance.  This makes it impossible to discover which FTP connection
triggered the exception.

Modification:

Establish the logging context before processing exceptions.

Result:

Exceptions are logged with their corresponding door/session information.

Target: master
Request: 3.1
Request: 3.0
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10419/
Acked-by: Albert Rossi