### PR TITLE
Motivation:

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/httpd/HttpdRequestLog.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/HttpdRequestLog.java
@@ -28,20 +28,17 @@ import org.slf4j.LoggerFactory;
 class HttpdRequestLog extends AbstractLifeCycle
     implements RequestLog
 {
-    //private static final Logger LOGGER = LoggerFactory.getLogger(HttpdRequestLog.class);
 
-
-    private static final Logger ACCESS_LOGGER = LoggerFactory.getLogger("org.dcache.services.httpd");
+    private static final Logger ACCESS_LOGGER = LoggerFactory.getLogger("org.dcache.access.httpd");
 
 
     public void log(Request request, Response response)
     {
         if(ACCESS_LOGGER.isInfoEnabled()){
-            NetLoggerBuilder log = new NetLoggerBuilder(NetLoggerBuilder.Level.TRACE, "org.dcache.services.httpRequestLog").omitNullValues();
+            NetLoggerBuilder log = new NetLoggerBuilder(NetLoggerBuilder.Level.TRACE, "org.dcache.httpd.request").omitNullValues();
             log.add("request: ", request);
             log.add("response: ", response);
             log.toLogger(ACCESS_LOGGER);
-        //LOGGER.trace("request: {}; response: {}", request, response);
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/HttpdRequestLog.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/HttpdRequestLog.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.services.httpd;
 
+import org.dcache.util.NetLoggerBuilder;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
@@ -27,11 +28,23 @@ import org.slf4j.LoggerFactory;
 class HttpdRequestLog extends AbstractLifeCycle
     implements RequestLog
 {
-    private static final Logger LOGGER
-            = LoggerFactory.getLogger(HttpdRequestLog.class);
+    //private static final Logger LOGGER = LoggerFactory.getLogger(HttpdRequestLog.class);
+
+
+    private static final Logger ACCESS_LOGGER = LoggerFactory.getLogger("org.dcache.services.httpd");
+
 
     public void log(Request request, Response response)
     {
-        LOGGER.trace("request: {}; response: {}", request, response);
+        if(ACCESS_LOGGER.isInfoEnabled()){
+            NetLoggerBuilder log = new NetLoggerBuilder(NetLoggerBuilder.Level.TRACE, "org.dcache.services.httpRequestLog").omitNullValues();
+            log.add("request: ", request);
+            log.add("response: ", response);
+            log.toLogger(ACCESS_LOGGER);
+        //LOGGER.trace("request: {}; response: {}", request, response);
+        }
     }
+
+
+
 }


### PR DESCRIPTION
The class HttpdRequestLog does not use the special log target which prodcues xxx.access. There are
already some dCache components which are using it. The HttpdRequestLog class should also use it
to produce common logs.

Modification:
The class got updated by using the NetLoggerBuilder class to log request and response events

Result:
Logs events with the usage of NetLoggerBuilder class

Signed-off by: Martin Buerger <martin-buerger91@live.de>