### PR TITLE
Task 3 -  Modernizing: Replace Guava Methods with native Java

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode.java
@@ -16,8 +16,6 @@
  */
 package org.dcache.chimera;
 
-import com.google.common.primitives.Longs;
-
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -404,7 +402,7 @@ public class FsInode {
 
     @Override
     public int hashCode() {
-        return Longs.hashCode(_ino);
+        return Long.hashCode(_ino);
     }
     // only package classes allowed to use this
     private boolean _ioEnabled;

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
@@ -21,7 +21,6 @@ package org.dcache.chimera.nfsv41.door;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
-import com.google.common.primitives.Longs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -356,7 +355,7 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
         stat.setGid(pStat.getGid());
         stat.setUid(pStat.getUid());
         stat.setDev(pStat.getDev());
-        stat.setIno(Longs.hashCode(pStat.getIno()));
+        stat.setIno(Long.hashCode(pStat.getIno()));
         stat.setMode(pStat.getMode());
         stat.setNlink(pStat.getNlink());
         stat.setRdev(pStat.getRdev());

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfersPage.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/view/pages/activetransfers/ActiveTransfersPage.java
@@ -2,7 +2,6 @@ package org.dcache.webadmin.view.pages.activetransfers;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Ordering;
-import com.google.common.primitives.Longs;
 import org.apache.wicket.authroles.authorization.strategies.role.Roles;
 import org.apache.wicket.authroles.authorization.strategies.role.metadata.MetaDataRoleAuthorizationStrategy;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.DataTable;
@@ -211,7 +210,7 @@ public class ActiveTransfersPage extends BasePage
             @Override
             public int compare(ActiveTransfersBean o1, ActiveTransfersBean o2)
             {
-                return Longs.compare(o1.getSerialId(), o2.getSerialId());
+                return Long.compare(o1.getSerialId(), o2.getSerialId());
             }
         },
         PROTOCOL {
@@ -281,7 +280,7 @@ public class ActiveTransfersPage extends BasePage
             @Override
             public int compare(ActiveTransfersBean o1, ActiveTransfersBean o2)
             {
-                return Longs.compare(o1.getWaitingSince(), o2.getWaitingSince());
+                return Long.compare(o1.getWaitingSince(), o2.getWaitingSince());
             }
         },
         STATE {
@@ -295,21 +294,21 @@ public class ActiveTransfersPage extends BasePage
             @Override
             public int compare(ActiveTransfersBean o1, ActiveTransfersBean o2)
             {
-                return Longs.compare(o1.getBytesTransferred(), o2.getBytesTransferred());
+                return Long.compare(o1.getBytesTransferred(), o2.getBytesTransferred());
             }
         },
         RATE {
             @Override
             public int compare(ActiveTransfersBean o1, ActiveTransfersBean o2)
             {
-                return Longs.compare(o1.getTransferRate(), o2.getTransferRate());
+                return Long.compare(o1.getTransferRate(), o2.getTransferRate());
             }
         },
         JOB {
             @Override
             public int compare(ActiveTransfersBean o1, ActiveTransfersBean o2)
             {
-                return Longs.compare(o1.getMoverId(), o2.getMoverId());
+                return Long.compare(o1.getMoverId(), o2.getMoverId());
             }
         }
     }

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
@@ -4,7 +4,6 @@ package diskCacheV111.poolManager;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-import com.google.common.primitives.Ints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -415,7 +414,7 @@ public class PoolMonitorV5
                     {
                         String s1 = id + pool1;
                         String s2 = id + pool2;
-                        return Ints.compare(s1.hashCode(), s2.hashCode());
+                        return Integer.compare(s1.hashCode(), s2.hashCode());
                     }
                 };
 

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -20,7 +20,6 @@ package org.dcache.pool.nearline;
 import com.google.common.base.Functions;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Ordering;
-import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -537,7 +536,7 @@ public class NearlineStorageHandler
         @Override
         public int compareTo(AbstractRequest<K> o)
         {
-            return Longs.compare(createdAt, o.createdAt);
+            return Long.compare(createdAt, o.createdAt);
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -231,7 +231,7 @@ public class Transfer implements Comparable<Transfer>
     @Override
     public int compareTo(Transfer o)
     {
-        return Longs.compare(o.getId(), getId());
+        return Long.compare(o.getId(), getId());
     }
 
     /**

--- a/modules/dcache/src/test/java/org/dcache/pinmanager/PinManagerTests.java
+++ b/modules/dcache/src/test/java/org/dcache/pinmanager/PinManagerTests.java
@@ -1,7 +1,6 @@
 package org.dcache.pinmanager;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.Test;
 
@@ -669,7 +668,7 @@ class TestExecutor
         @Override
         public int compareTo(Delayed o)
         {
-            return Longs.compare(getDelay(TimeUnit.MILLISECONDS), o.getDelay(TimeUnit.MILLISECONDS));
+            return Long.compare(getDelay(TimeUnit.MILLISECONDS), o.getDelay(TimeUnit.MILLISECONDS));
         }
 
         @Override

--- a/modules/dcache/src/test/java/org/dcache/tests/cells/CellStubHelper.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/cells/CellStubHelper.java
@@ -1,6 +1,5 @@
 package org.dcache.tests.cells;
 
-import com.google.common.primitives.Ints;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
@@ -87,7 +86,7 @@ public abstract class CellStubHelper
         @Override
         public int compareTo(Handler handler)
         {
-            return Ints.compare(getStep(), handler.getStep());
+            return Integer.compare(getStep(), handler.getStep());
         }
 
         public CellMessage call(CellMessage msg)

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -69,7 +69,6 @@ package org.dcache.srm.scheduler;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
-import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -543,7 +542,7 @@ public class Scheduler <T extends Job>
         {
             this.formatter = new Formatter(appendable);
             this.fieldWidth = fieldWidth;
-            this.baseWidth = Ints.max(width1, width2 - fieldWidth - 4) + 1;
+            this.baseWidth = Integer.max(width1, width2 - fieldWidth - 4) + 1;
 
             this.field2 = String.format("    %%-%ds %%%dd     [%%s]\n", baseWidth + fieldWidth + 4, fieldWidth);
             this.field2NoState = String.format("    %%-%ds %%%dd\n", baseWidth + fieldWidth + 4, fieldWidth);
@@ -575,7 +574,7 @@ public class Scheduler <T extends Job>
         int fieldWidth = Math.max(3, String.valueOf(getMaxRequests()).length());
         InfoFormatter formatter =
                 new InfoFormatter(appendable, fieldWidth,
-                                  Ints.max(24, 20 + fieldWidth),
+                                  Integer.max(24, 20 + fieldWidth),
                                   28 + fieldWidth);
         formatter.field("Queued", getTotalQueued(), State.QUEUED);
         formatter.field("In progress (max " + getMaxInProgress() + ")", getTotalInprogress(), State.INPROGRESS);


### PR DESCRIPTION
Motivation:
Modernizing dCache code to reduce dependencies and rely on Native Java

Modification:
Remove Google Guava Methods and Replace with native methods.
Completely where possible, otherwise partially)

Result:
Reduces dependencies and calls to non-native classes.

Target: master

Signed-off-by: Robin Wenzel info@robin-wenzel.de