### PR TITLE
PoolManager : set return code to CacheException.PERMISSION_DENIED if …

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -1227,7 +1227,7 @@ public class RequestContainerV5
                     _forceContinue = true;
                     _status = "Failed";
                     _log.debug("Subject is not authorized to stage");
-                    _currentRc = CacheException.FILE_NOT_ONLINE;
+                    _currentRc = CacheException.PERMISSION_DENIED;
                     _currentRm = "File not online. Staging not allowed.";
                     sendInfoMessage(
                             _currentRc , "Permission denied." + _currentRm);


### PR DESCRIPTION
…staging is not allowed due to stage protection.

Motivation:

If stage protection is enabled the return code
CacheException.FILE_NOT_ONLINE is used in reply to the doors
causing them to retry multiple times. A fail fast is desired in
these cases.

Modification:

Replace CacheException.FILE_NOT_ONLINE w/ CacheException.PERMISSION_DENIED.

Result:

Clients fail fast w/ permission denied on attemot to access NEARLINE
file if stage protection does not allow it.

Target: master
Request: 3.0
Request: 2.16
Acjed-by: Tigran Mkrtchyan
Patch: https://rb.dcache.org/r/9907/
(cherry picked from commit f70172aefe49e6f69cde914146c5c76d98204a22)