### PR TITLE
srmclient: remove non-functioning script with BASH dependencies

### DIFF
--- a/modules/srm-client/src/main/bin/srmcp
+++ b/modules/srm-client/src/main/bin/srmcp
@@ -2,31 +2,6 @@
 
 @INIT_SCRIPT@
 
-args=$*
-
-error() {
-    echo "Can't copy from \"${1}\" protocol to \"${2}\"  protocol"
-    exit 1
-}
-
-check_protocols() {
-    case "$1" in
-	gsiftp)
-	    ;;
-	enstore)
-	    ;;
-	dcap)
-	    ;;
-	file)
-	    ;;
-	*)
-	    echo "Unsupported protocol: \"$1\""
-	    exit 1
-    esac
-}
-
-skip=0
-
 ##  haveSrm is a boolean variable that describes whether either of the
 ##  two transfer URLs involved in the transfer uses the 'srm' schema
 ##  (i.e., starts 'srm:').  A value of '0' indicates that neither URL
@@ -47,170 +22,41 @@ delegationMakesSense=0
 ##  option.
 haveDelegate=0
 
-i=0
-fargs=
+for arg in "$@"; do
+    case "${arg}" in
+        -copyjobfile*)
+            hasThirdPartyTransfer=0
+            copyJobFile="${arg##-copyjobfile=}"
+            if [ -r "$copyJobFile" ]; then
+                hasThirdPartyTransfer=1
+                grep -E -e '^ *(srm|gsiftp|gridftp|https):[^ ]* (srm|gsiftp|gridftp|https):' "$copyJobFile" >/dev/null || hasThirdPartyTransfer=0
+            fi
+            if [ $hasThirdPartyTransfer -eq 1 ]; then
+                delegationMakesSense=1
+            fi
+            ;;
 
-for arg in $args;
-  do
-  case "${arg}" in
-      -help|-version|--help)
-	  skip=1
-	  continue
-	  ;;
-      -copyjobfile*)
-	  hasThirdPartyTransfer=0
-	  copyJobFile="${arg##-copyjobfile=}"
-	  if [ -r "$copyJobFile" ]; then
-	      hasThirdPartyTransfer=1
-	      grep -E -e '^ *(srm|gsiftp|gridftp|https):[^ ]* (srm|gsiftp|gridftp|https):' "$copyJobFile" >/dev/null || hasThirdPartyTransfer=0
-	  fi
-	  if [ $hasThirdPartyTransfer -eq 1 ]; then
-	      delegationMakesSense=1
-	  fi
-	  skip=1
-	  continue
-	  ;;
-      srm:*)
-          if [ "$haveSrm" = 0 ]; then
-	      haveSrm=1
-          else
-              delegationMakesSense=1
-          fi
-	  skip=1
-	  continue
-	  ;;
-      file:*|http:*)
-	  skip=1
-	  continue
-	  ;;
-      gsiftp:*|gridftp:*|https:*)
-	  delegationMakesSense=1
-	  skip=1
-	  continue
-	  ;;
-      -delegate|-delegate=*)
-          haveDelegate=1
-          continue
-          ;;
-      *=*|-*)
-	  continue
-	  ;;
-  esac
-  fargs[i]=${arg}
-  i=$((${i}+1))
+        srm:*)
+            if [ "$haveSrm" = 0 ]; then
+                haveSrm=1
+            else
+                delegationMakesSense=1
+            fi
+            ;;
+
+        gsiftp:*|gridftp:*|https:*)
+            delegationMakesSense=1
+            ;;
+
+        -delegate|-delegate=*)
+            haveDelegate=1
+            ;;
+    esac
 done
 
 
-#
-# if any of the input args contain srm or help - fall through to standard java call
-#
-
-length=${#fargs[*]}
-last=$((${length}-1))
-first=${#fargs[0]}
-
-cmd=""
-if [ "${skip}" -eq 0 ]
-    then
-    if [ ${length} -lt 2 ]; then
-	exec "${SRM_PATH}/lib/srm" -copy "$@"
-    else
-	i=0
-	src_protocols=
-	src_files=
-	while [ $i -lt ${last} ]
-	do
-	  src_protocols[$i]=`echo ${fargs[$i]} | grep ":" | cut -d":" -f1`
-	  i=$((${i}+1))
-	done
-	n_src_protocols=`echo  ${src_protocols[@]} | tr A-Z a-z | tr ' ' '\012' | sort | uniq | wc -l`
-	if [  ${n_src_protocols} -ne 1 ]
-	    then
-	    echo "Wrong number of input protocols:  ${n_src_protocols}"
-	    echo "    0 - check validity of URL spelling"
-	    echo "   >1 - mixture of protocols is not supported "
-	    exit 1
-	else
-	    src_protocol=${src_protocols[0]}
-	    dst_protocol=`echo ${fargs[${last}]} | grep ":" | cut -d":" -f1`
-	    check_protocols ${src_protocol}
-	    check_protocols ${dst_protocol}
-	    if [ "${src_protocol}" = "${dst_protocol}" ]
-		then
-		case "${src_protocol}" in
-		    gsiftp)
-			cmd="globus-url-copy ${fargs[*]}"
-			;;
-		    file)
-			cmd="cp `echo ${fargs[*]} | sed -e "s/${src_protocol}://g"`"
-			;;
-		    *)
-			error ${src_protocol}  ${dst_protocol}
-		esac
-	    else
-
-		if [ "${src_protocol}" = "gsiftp" -o "${dst_protocol}" = "gsiftp" ]
-		    then
-		    cmd="globus-url-copy ${fargs[*]}"
-		fi
-
-		if [ "${src_protocol}" = "enstore" -o "${dst_protocol}" = "enstore" ]
-		    then
-		    cmd="encp `echo ${fargs[*]} | sed -e "s/${src_protocol}://g" | sed -e "s/${dst_protocol}://g"`"
-		fi
-
-
-		if [ "${src_protocol}" = "dcap" -o  "${dst_protocol}" = "dcap" ]
-		    then
-		    if [ "${src_protocol}" = "file" ]
-			then
-			cmd="dccp `echo ${fargs[*]:0:${last}} | sed -e "s/${src_protocol}://g"` ${fargs[*]:${last}}"
-		    else
-			cmd="dccp `echo ${fargs[*]:0:${last}}` `echo ${fargs[*]:${last}} | sed -e "s/${dst_protocol}://g"`"
-		    fi
-		fi
-
-		#
-		# all bad cases go here
-		#
-
-		if [ "${src_protocol}" = "gsiftp" -a "${dst_protocol}" = "enstore" ]
-		    then
-		    error ${src_protocol} ${dst_protocol}
-		fi
-
-		if [ "${dst_protocol}" = "gsiftp" -a "${src_protocol}" = "enstore" ]
-		    then
-		    error ${src_protocol} ${dst_protocol}
-		fi
-
-
-		if [ "${src_protocol}" = "dcap" -a "${dst_protocol}" = "gsiftp" ]
-		    then
-		    error ${src_protocol} ${dst_protocol}
-		fi
-
-		if [ "${dst_protocol}" = "dcap" -a "${src_protocol}" = "gsiftp" ]
-		    then
-		    error ${src_protocol} ${dst_protocol}
-		fi
-
-		if [ "${src_protocol}" = "dcap" -a "${dst_protocol}" = "enstore" ]
-		    then
-		    error ${src_protocol} ${dst_protocol}
-		fi
-
-		if [ "${dst_protocol}" = "dcap" -a "${src_protocol}" = "enstore" ]
-		    then
-		    error ${src_protocol} ${dst_protocol}
-		fi
-	    fi
-	    exec $cmd
-	fi
-    fi
-else
-    if [ "$delegationMakesSense" = 1 ] && [ "$haveDelegate" = 0 ]; then
-        delegate=-delegate=true
-    fi
-    exec "${SRM_PATH}/lib/srm" -copy $delegate "$@"
+if [ "$delegationMakesSense" = 1 ] && [ "$haveDelegate" = 0 ]; then
+    delegate=-delegate=true
 fi
+
+exec "${SRM_PATH}/lib/srm" -copy $delegate "$@"


### PR DESCRIPTION
Motivation:

The srmcp script contains some BASHisms that prevent it from being
used in environments where /bin/sh is not bash.

Modification:

Since the BASH-specific features (arrays) were limited to some
functionality that was actually broken, this patch simply removed the
offending part and refactors the argument parsing accordingly.

Result:

Much simpler code that is also POSIX compliant.

Target: master
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9256
Request: 3.2
Request: 3.1
Patch: https://rb.dcache.org/r/10434/
Acked-by: Dmitry Litvintsev
Require-notes: no
Require-srmclient-notes: yes
Require-book: no