### PR TITLE
common: fix bug in histogram max index computation

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/histograms/CountingHistogram.java
+++ b/modules/common/src/main/java/org/dcache/util/histograms/CountingHistogram.java
@@ -111,8 +111,8 @@ public class CountingHistogram extends HistogramModel {
          *  Lowest value is always 0.  Bin width can only have integer
          *  values that are multiples of the bin unit.
          */
-        Double max = metadata.getMaxValue().orElse(Double.MAX_VALUE);
-        double maxValueIndex = FastMath.floor(max / binSize);
+        Double max = metadata.getMaxValue().orElse(null);
+        double maxValueIndex = max == null ? binCount - 1 : FastMath.floor(max / binSize);
         binWidth = (int) FastMath.ceil(maxValueIndex / (binCount - 1));
 
         /**


### PR DESCRIPTION
Motivation:

The configure method for CountingHistograms sets
the highest bin value on the basis of the largest
value in the dataset.  If this is undefined, Double.MAX_VALUE
is used.  This, however, results in an effective infinity
as the highest index, and results in aggregate plots
where all the values are squashed into the first bin.

Modification:

If the metadata max value is undefined (because the dataset
is empty), set the max index to the preset number of bins - 1.

Result:

Plots created from data aggregation where some of the set
members may be empty do not result in an x-axis
with the highest value being infinity.

Target: master
Require-notes: yes
Require-book: no
Request: 3.2
Acked-by: Tigran