### PR TITLE
dcache-restful-api: extract the locations from storage info and add t…

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/JsonFileAttributes.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/JsonFileAttributes.java
@@ -1,6 +1,7 @@
 package org.dcache.restful.providers;
 
 import java.net.FileNameMap;
+import java.net.URI;
 import java.net.URLConnection;
 import java.util.Collection;
 import java.util.List;
@@ -119,6 +120,11 @@ public class JsonFileAttributes
      * The storage info of a file.
      */
     private StorageInfo _storageInfo;
+
+    /**
+     * The storage uri list
+     */
+    private List<URI> _suris;
 
     /**
      * The storage class of a file.
@@ -320,6 +326,14 @@ public class JsonFileAttributes
 
     public void setStorageClass(String _storageClass) {
         this._storageClass = _storageClass;
+    }
+
+    public List<URI> getSuris() {
+        return _suris;
+    }
+
+    public void setSuris(List<URI> suris) {
+        this._suris = suris;
     }
 
     public String getHsm() {

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/namespace/NamespaceUtils.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/namespace/NamespaceUtils.java
@@ -8,6 +8,7 @@ import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileLocality;
 import diskCacheV111.util.PermissionDeniedCacheException;
+import diskCacheV111.vehicles.StorageInfo;
 import dmg.cells.nucleus.NoRouteToCellException;
 import org.dcache.auth.Subjects;
 import org.dcache.cells.CellStub;
@@ -227,7 +228,9 @@ public final class NamespaceUtils {
         }
 
         if (attributes.isDefined(FileAttribute.STORAGEINFO)) {
-            json.setStorageInfo(attributes.getStorageInfo());
+            StorageInfo info = attributes.getStorageInfo();
+            json.setStorageInfo(info);
+            json.setSuris(info.locations());
         }
     }
 


### PR DESCRIPTION
…o JSON attributes

Motivation:

StorageInfo has a List<URI> locations field, but no standard getter and setter.
However, the object is being used to populate the JSONAttributes returned
by the namespace service.  It is of interest to us to expose all known tape
URIs in dcache-view.

Modification:

Extract this list separately and set it on JSONAttibutes.

The alternative (which may be preferable to some) would be to change
the locations() method to getLocations() and add setLocations (currently
there is only addLocation(URI)).  However, this will make for a much
larger patch.

Result:

SURIs are now visible in the admin view.

Target: master
Request: 3.2
Require-notes: no
Require-book: no
Acked-by: Paul