### PR TITLE
resilience: fix bug in formatting and handling of cache exception types

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -614,7 +614,7 @@ public class FileOperationHandler {
         }
 
         Serializable exception = msg.getErrorObject();
-        if (exception != null && !CacheExceptionUtils.fileNotFound(exception)) {
+        if (exception != null && !CacheExceptionUtils.replicaNotFound(exception)) {
             throw CacheExceptionUtils.getCacheException(
                             CacheException.SELECTED_POOL_FAILED,
                             FileTaskCompletionHandler.FAILED_REMOVE_MESSAGE,

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileTaskCompletionHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileTaskCompletionHandler.java
@@ -79,25 +79,18 @@ import org.dcache.resilience.util.ExceptionMessage;
  *      Also implements the migration task termination logic.</p>
  */
 public final class FileTaskCompletionHandler implements TaskCompletionHandler {
-    static final String WILL_RETRY_LATER
-                    = "A best effort at retry will be made "
-                    + "during the next periodic scan.";
-
     static final String ABORT_REPLICATION_LOG_MESSAGE
-                    = "Aborting replication for {}; pools tried: {}; {} "
-                    + WILL_RETRY_LATER;
+                    = "Aborting replication for {}; pools tried: {}; {}";
 
     static final String VERIFY_FAILURE_MESSAGE
-                    = "Processing for pnfsId %s failed during verify; %s "
-                    + WILL_RETRY_LATER;
+                    = "Processing for %s failed during verify. %s%s";
 
     static final String FAILED_COPY_MESSAGE
-                    = "Migration task for %s failed: %s.";
+                    = "Migration task for %s failed. %s%s.";
 
     static final String FAILED_REMOVE_MESSAGE
                     = "Failed to remove %s from %s; %s. "
-                    + "This means that an unnecessary copy may still exist; "
-                    + WILL_RETRY_LATER;
+                    + "This means that an unnecessary copy may still exist.";
 
     private static final Logger LOGGER
                     = LoggerFactory.getLogger(FileTaskCompletionHandler.class);


### PR DESCRIPTION
Motivation:

The utility which returns a CacheException object with
an appropriate message and type based on the failure type
and operation uses string formatting to process arguments.
The way the code is written, however, is subject to bad
formatting exceptions, particularly if there are unexpected
null values passed in as parameters (for instance, if
an exception cause is null).  In some of these cases,
the actual exception is masked because of the formatting
exception, causing the removal of the operation from
the map to fail.

Modification:

Change the method such that it accounts for nulls; this
also requires respecting the contract that the format
strings used will always have three % placeholders.

In addition to this, the "Will retry" message appended
to the failure message should not be included if the
error is fatal.

Result:

Correct formatting will not block proper removal
from the operation map and potentially freeze
progress in the resilience service as a whole.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Tigran