### PR TITLE
resilience: distinguish correctly between file not in repository and …

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -270,7 +270,7 @@ public class FileOperationHandler {
             return false;
         }
 
-        LOGGER.trace("handleLocationUpdate, update to be registered: {}", data);
+        LOGGER.trace("handleScannedLocation, update to be registered: {}", data);
         return fileOpMap.register(data);
     }
 
@@ -389,8 +389,7 @@ public class FileOperationHandler {
         try {
             namespace.refreshLocations(attributes);
         } catch (CacheException e) {
-            CacheException exception = CacheExceptionUtils.getCacheException(
-                            CacheException.DEFAULT_ERROR_CODE,
+            CacheException exception = CacheExceptionUtils.getCacheException(e.getRc(),
                             FileTaskCompletionHandler.VERIFY_FAILURE_MESSAGE,
                             pnfsId, null, e.getCause());
             completionHandler.taskFailed(pnfsId, exception);

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -270,7 +270,7 @@ public class FileOperationHandler {
             return false;
         }
 
-        LOGGER.trace("handleScannedLocation, update to be registered: {}", data);
+        LOGGER.debug("handleScannedLocation, update to be registered: {}", data);
         return fileOpMap.register(data);
     }
 

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/CacheExceptionUtils.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/CacheExceptionUtils.java
@@ -130,7 +130,6 @@ public final class CacheExceptionUtils {
             case CacheException.BROKEN_ON_TAPE:
                 return FailureType.BROKEN;
             case CacheException.FILE_NOT_IN_REPOSITORY:
-            case CacheException.FILE_NOT_FOUND:
                 if (isCopyOperation) {
                     /*
                      * The source for a copy is missing.
@@ -178,6 +177,8 @@ public final class CacheExceptionUtils {
             case CacheException.SERVICE_UNAVAILABLE:
             case CacheException.TIMEOUT:
                 return FailureType.RETRIABLE;
+
+            case CacheException.FILE_NOT_FOUND:
             default:
                 return FailureType.FATAL;
         }

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
@@ -630,7 +630,7 @@ public final class FileOperationHandlerTest extends TestBase
         fileOperationMap.scan();
         fileOperationMap.updateOperation(update.pnfsId,
                                          new CacheException(
-                                                         CacheException.FILE_NOT_FOUND,
+                                                         CacheException.FILE_NOT_IN_REPOSITORY,
                                                          "Source pool failed"));
         fileOperationMap.scan();
     }


### PR DESCRIPTION
…file not found

Motivation:

If resilience tries to copy or remove a file, and it is no longer
in the namespace, this should be a fatal error, differently from
the discovery that a replica is no longer in cache.  These two
errors, however, are currently treated the same way.

Modification:

Make FileNotFound always a fatal error.

Result:

Correct behavior (immediate abort of operation) when
file is not in namespace.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Tigran