### PR TITLE
resilience: handle all cases where no locations for file may be disco…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -406,20 +406,44 @@ public class FileOperationHandler {
             return Type.VOID;
         }
 
-        Collection<String> locations
-                        = poolInfoMap.getMemberLocations(gindex,
-                                                         attributes.getLocations());
+        Collection<String> locations = attributes.getLocations();
+
+        LOGGER.trace("handleVerification {}, locations from namespace: {}",
+                     pnfsId, locations);
+
         /*
-         * Once again, if all the locations are pools now missing
-         * from the group, this is a NOP.
+         * Somehow, all the cache locations for this file have been removed.
          */
         if (locations.isEmpty()) {
+            LOGGER.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.INACCESSIBLE_FILE,
+                                                      pnfsId.toString()),
+                         "{} has no locations in the namespace. "
+                                         + "Administrator intervention is required.", pnfsId);
+            String error = String.format("%s has no locations.", pnfsId);
+            CacheException exception
+                            = CacheExceptionUtils.getCacheException(
+                            CacheException.PANIC,
+                            FileTaskCompletionHandler.VERIFY_FAILURE_MESSAGE,
+                            pnfsId, error, null);
+            completionHandler.taskFailed(pnfsId, exception);
             return Type.VOID;
         }
 
-        LOGGER.trace("handleVerification {}, locations {}", pnfsId, locations);
+        locations = poolInfoMap.getMemberLocations(gindex, locations);
 
-         /*
+        LOGGER.trace("handleVerification {}, valid group member locations {}",
+                     pnfsId, locations);
+
+        /*
+         * If all the locations are pools no longer belonging to the group,
+         * the operation should be voided.
+         */
+        if (locations.isEmpty()) {
+            fileOpMap.voidOperation(pnfsId);
+            return Type.VOID;
+        }
+
+        /*
          *  If we have arrived here, we are expecting there to be an
          *  available source file.  So we need the strictly readable
          *  locations, not just "countable" ones.

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestBase.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestBase.java
@@ -72,6 +72,7 @@ import diskCacheV111.poolManager.Pool;
 import diskCacheV111.poolManager.PoolSelectionUnitV2;
 import diskCacheV111.pools.PoolV2Mode;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.Message;
 import org.dcache.pool.classic.Cancellable;
 import org.dcache.pool.migration.ProportionalPoolSelectionStrategy;
@@ -353,6 +354,14 @@ public abstract class TestBase implements Cancellable {
         newPoolMonitor = new TestPoolMonitor();
         newPoolMonitor.setCostModule(newCostModule);
         newPoolMonitor.setSelectionUnit(newSelectionUnit);
+    }
+
+    protected void deleteAllLocationsForFile(PnfsId pnfsid) {
+        testNamespaceAccess.delete(pnfsid, true);
+    }
+
+    protected void deleteFileFromNamespace(PnfsId pnfsid) {
+        testNamespaceAccess.delete(pnfsid, false);
     }
 
     protected PoolSelectionUnitV2 getUpdatedPsu() {

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestNamespaceAccess.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestNamespaceAccess.java
@@ -69,6 +69,7 @@ import java.util.Map;
 
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.util.RetentionPolicy;
 import org.dcache.resilience.data.FileUpdate;
@@ -111,7 +112,10 @@ public final class TestNamespaceAccess extends LocalNamespaceAccess {
     @Override
     public FileAttributes getRequiredAttributes(PnfsId pnfsId)
                     throws CacheException {
-        return fileAttributes.get(pnfsId);
+        if (fileAttributes.containsKey(pnfsId)) {
+            return fileAttributes.get(pnfsId);
+        }
+        throw new FileNotFoundCacheException(pnfsId.toString());
     }
 
     @Override
@@ -141,6 +145,9 @@ public final class TestNamespaceAccess extends LocalNamespaceAccess {
             attributes.setRetentionPolicy(stored.getRetentionPolicy());
             attributes.setStorageClass(stored.getStorageClass());
             attributes.setLocations(stored.getLocations());
+        } else {
+            throw new FileNotFoundCacheException(attributes.getPnfsId().toString(),
+                                                 new Exception("test simulation"));
         }
     }
 

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
@@ -110,6 +110,21 @@ public final class FileOperationHandlerTest extends TestBase
     }
 
     @Test
+    public void shouldAbortOperationWhenFileWasDeletedAfterAddCacheMessageProcessed()
+                    throws CacheException, IOException, InterruptedException {
+        setUpTest(false);
+        givenAFileUpdateForANewFileOnAPoolWithNoTags();
+        whenHandleUpdateIsCalled();
+        whenVerifyIsRun();
+        givenFileIsDeleted();
+        whenScanIsRun();
+        whenTaskIsCreatedAndCalled();
+        assertTrue(theOperationFailed());
+        whenScanIsRun();
+        assertNull(fileOperationMap.getOperation(update.pnfsId));
+    }
+
+    @Test
     public void shouldCreateMigrationTaskWhenVerifyResultIsCopy()
                     throws CacheException, IOException, InterruptedException {
         setUpTest(false);
@@ -143,6 +158,16 @@ public final class FileOperationHandlerTest extends TestBase
         whenOperationFailsWithNewTargetError();
         whenVerifyIsRun();
         whenScanIsRun();
+        assertNull(fileOperationMap.getOperation(update.pnfsId));
+    }
+
+    @Test
+    public void shouldNotProcessFileNotInNamespace()
+                    throws CacheException, IOException, InterruptedException {
+        setUpTest(false);
+        givenAFileUpdateForANewFileOnAPoolWithNoTags();
+        givenFileIsDeleted();
+        whenHandleUpdateIsCalled();
         assertNull(fileOperationMap.getOperation(update.pnfsId));
     }
 
@@ -220,7 +245,8 @@ public final class FileOperationHandlerTest extends TestBase
         givenUpdateHasBeenAddedToMapWithCountOf(1);
         whenVerifyIsRun();
         assertEquals("REMOVE", verifyType);
-        assertEquals(2, fileOperationMap.getOperation(update.pnfsId).getOpCount());
+        assertEquals(2,
+                     fileOperationMap.getOperation(update.pnfsId).getOpCount());
     }
 
     @Test
@@ -344,6 +370,21 @@ public final class FileOperationHandlerTest extends TestBase
         assertTrue(theOperationCountIs(1));
     }
 
+    @Test
+    public void shouldVoidOperationWhenFileNotDeletedButNoLocationsFound()
+                    throws CacheException, IOException, InterruptedException {
+        setUpTest(false);
+        givenAFileUpdateForANewFileOnAPoolWithNoTags();
+        whenHandleUpdateIsCalled();
+        whenVerifyIsRun();
+        givenAllLocationsAreRemoved();
+        whenScanIsRun();
+        whenTaskIsCreatedAndCalled();
+        assertTrue(theOperationFailed());
+        whenScanIsRun();
+        assertNull(fileOperationMap.getOperation(update.pnfsId));
+    }
+
     private void afterInspectingSourceAndTarget() {
         FileOperation operation = fileOperationMap.getOperation(update.pnfsId);
         originalSource = operation.getSource();
@@ -354,37 +395,6 @@ public final class FileOperationHandlerTest extends TestBase
         Task inner = task.getMigrationTask();
         assertNotNull(inner);
         assertEquals(inner.getPnfsId(), update.pnfsId);
-    }
-
-    private void givenACustodialFileUpdateFromAPoolScan()
-                    throws CacheException {
-        loadNewFilesOnPoolsWithHostAndRackTags();
-        setUpdateWithGroup(aCustodialOnlineFile(), MessageType.POOL_STATUS_DOWN,
-                           SelectionAction.NONE);
-    }
-
-    private void givenANewLocationForFile() throws CacheException {
-        Integer pool = poolInfoMap.getPoolIndex(update.pool);
-        Integer group = poolInfoMap.getResilientPoolGroup(pool);
-        Collection<Integer> pools = poolInfoMap.getPoolsOfGroup(group);
-        for (Integer p : pools) {
-            if (p != pool) {
-                attributes.getLocations().add(poolInfoMap.getPool(p));
-                setUpdate(attributes, MessageType.ADD_CACHE_LOCATION);
-                break;
-            }
-        }
-    }
-
-    private void givenANewTagRequirementForFileStorageUnit() {
-        Integer unit = poolInfoMap.getStorageUnitIndex(attributes);
-        StorageUnitConstraints constraints
-                        = poolInfoMap.getStorageUnitConstraints(unit);
-        int req = constraints.getRequired();
-        storageUnit = poolInfoMap.getUnit(unit);
-        poolInfoMap.setUnitConstraints(storageUnit, req,
-                                       ImmutableList.of("hostname","rack"));
-
     }
 
     private void givenAFileUpdateClearCacheLocationForAFileWithNoLocationsInNamespace()
@@ -405,7 +415,7 @@ public final class FileOperationHandlerTest extends TestBase
                     throws CacheException {
         loadFilesWithExcessLocations();
         setUpdate(aFileWithAReplicaOnAllResilientPools(),
-                        MessageType.POOL_STATUS_UP);
+                  MessageType.POOL_STATUS_UP);
     }
 
     private void givenAFileUpdateForAFileWithNoLocationsYetInAttributes()
@@ -427,7 +437,7 @@ public final class FileOperationHandlerTest extends TestBase
                     throws CacheException {
         loadFilesWithRequiredLocations();
         setUpdate(aReplicaOnlineFileWithNoTags(),
-                        MessageType.POOL_STATUS_UP);
+                  MessageType.POOL_STATUS_UP);
     }
 
     private void givenAFileUpdateForANewFileOnAPoolWithHostAndRackTags()
@@ -454,7 +464,7 @@ public final class FileOperationHandlerTest extends TestBase
                     throws CacheException {
         loadNewFilesOnPoolsWithHostAndRackTags();
         setUpdate(aReplicaOnlineFileWithBothTags(),
-                        MessageType.ADD_CACHE_LOCATION);
+                  MessageType.ADD_CACHE_LOCATION);
         String key = attributes.getStorageClass() + "@" + attributes.getHsm();
         makeNonResilient(key);
     }
@@ -472,11 +482,32 @@ public final class FileOperationHandlerTest extends TestBase
                            MessageType.POOL_STATUS_UP, SelectionAction.ADD);
     }
 
-    private void givenAFileUpdateFromAPoolScanForPoolRemovedFromGroup()
-                    throws CacheException {
-        loadNewFilesOnPoolsWithHostAndRackTags();
-        setUpdateWithGroup(aReplicaOnlineFileWithBothTags(),
-                        MessageType.POOL_STATUS_DOWN, SelectionAction.REMOVE);
+    private void givenANewLocationForFile() throws CacheException {
+        Integer pool = poolInfoMap.getPoolIndex(update.pool);
+        Integer group = poolInfoMap.getResilientPoolGroup(pool);
+        Collection<Integer> pools = poolInfoMap.getPoolsOfGroup(group);
+        for (Integer p : pools) {
+            if (p != pool) {
+                attributes.getLocations().add(poolInfoMap.getPool(p));
+                setUpdate(attributes, MessageType.ADD_CACHE_LOCATION);
+                break;
+            }
+        }
+    }
+
+    private void givenANewTagRequirementForFileStorageUnit() {
+        Integer unit = poolInfoMap.getStorageUnitIndex(attributes);
+        StorageUnitConstraints constraints
+                        = poolInfoMap.getStorageUnitConstraints(unit);
+        int req = constraints.getRequired();
+        storageUnit = poolInfoMap.getUnit(unit);
+        poolInfoMap.setUnitConstraints(storageUnit, req,
+                                       ImmutableList.of("hostname", "rack"));
+
+    }
+
+    private void givenAllLocationsAreRemoved() {
+        deleteAllLocationsForFile(attributes.getPnfsId());
     }
 
     private void givenAllPoolsOfflineExceptSourceAndTarget()
@@ -487,6 +518,14 @@ public final class FileOperationHandlerTest extends TestBase
                 shutPoolDown(p);
             }
         });
+    }
+
+    private void givenFileIsDeleted() {
+        deleteFileFromNamespace(attributes.getPnfsId());
+    }
+
+    private void givenSourcePoolIsDown() {
+        shutPoolDown(update.pool);
     }
 
     private void givenUpdateHasBeenAddedToMapWithCountOf(int count)
@@ -501,10 +540,6 @@ public final class FileOperationHandlerTest extends TestBase
                                 pool, group, unit, attributes);
         update.setCount(count);
         fileOperationMap.register(update);
-    }
-
-    private void givenSourcePoolIsDown() {
-        shutPoolDown(update.pool);
     }
 
     private boolean noOperationHasBeenAdded() {
@@ -536,7 +571,8 @@ public final class FileOperationHandlerTest extends TestBase
         poolOperationMap.setRescanWindow(Integer.MAX_VALUE);
         poolOperationMap.setDownGracePeriod(0);
         poolOperationMap.loadPools();
-        fileOperationMap.initialize(()-> {});
+        fileOperationMap.initialize(() -> {
+        });
         fileOperationMap.reload();
     }
 
@@ -552,7 +588,7 @@ public final class FileOperationHandlerTest extends TestBase
     }
 
     private void setUpdateWithGroup(FileAttributes attributes, MessageType type,
-                    SelectionAction action) {
+                                    SelectionAction action) {
         this.attributes = attributes;
         PnfsId pnfsId = attributes.getPnfsId();
         Iterator<String> iterator = attributes.getLocations().iterator();
@@ -568,7 +604,7 @@ public final class FileOperationHandlerTest extends TestBase
 
     private void shutPoolDown(String pool) {
         PoolStateUpdate update = new PoolStateUpdate(pool,
-                        new PoolV2Mode(PoolV2Mode.DISABLED_DEAD));
+                                                     new PoolV2Mode(PoolV2Mode.DISABLED_DEAD));
         poolInfoMap.updatePoolStatus(update);
     }
 
@@ -588,6 +624,11 @@ public final class FileOperationHandlerTest extends TestBase
         return operation != null && operation.getOpCount() == count;
     }
 
+    private boolean theOperationFailed() {
+        FileOperation operation = fileOperationMap.getOperation(update.pnfsId);
+        return operation != null && operation.getStateName().equals("FAILED");
+    }
+
     private void whenHandleUpdateIsCalled() throws CacheException {
         fileOperationHandler.handleLocationUpdate(update);
     }
@@ -595,24 +636,27 @@ public final class FileOperationHandlerTest extends TestBase
     private void whenOperationFailsFatally() throws IOException {
         fileOperationMap.scan();
         fileOperationMap.updateOperation(update.pnfsId,
-                                         new CacheException(CacheException.DEFAULT_ERROR_CODE,
-                                        FORCED_FAILURE.toString()));
+                                         new CacheException(
+                                                         CacheException.DEFAULT_ERROR_CODE,
+                                                         FORCED_FAILURE.toString()));
         fileOperationMap.scan();
     }
 
     private void whenOperationFailsWithBrokenFileError() throws IOException {
         fileOperationMap.scan();
         fileOperationMap.updateOperation(update.pnfsId,
-                                         new CacheException(CacheException.FILE_CORRUPTED,
-                                        "broken"));
+                                         new CacheException(
+                                                         CacheException.FILE_CORRUPTED,
+                                                         "broken"));
         fileOperationMap.scan();
     }
 
     private void whenOperationFailsWithNewTargetError() throws IOException {
         fileOperationMap.scan();
         fileOperationMap.updateOperation(update.pnfsId,
-                                         new CacheException(CacheException.FILE_IN_CACHE,
-                                        FORCED_FAILURE.toString()));
+                                         new CacheException(
+                                                         CacheException.FILE_IN_CACHE,
+                                                         FORCED_FAILURE.toString()));
         fileOperationMap.scan();
     }
 
@@ -634,7 +678,7 @@ public final class FileOperationHandlerTest extends TestBase
         fileOperationMap.scan();
     }
 
-    private void whenScanIsRun() throws IOException{
+    private void whenScanIsRun() throws IOException {
         fileOperationMap.scan();
         /*
          *  Also force a save.


### PR DESCRIPTION
…vered

Motivation:

When resilience discovers that there are currently no replicas
for a file which is still in the namespace, it should take action
(depending on the inaccessible file handler implementation).

One common cause for this may be that all the pools containing
these replicas may be offline.  But there are also conditions
in which a query of the namespace may return zero locations;
whether this is a bug or not, resilience should not fail or
become blocked under these circumstances.

Modification:

Add the necessary code paths for handling the missing conditions.
This includes an additional method on the inaccessible file handler.

JUnit tests have been adjusted to account for a fuller range of
situations when all replicas are missing.

Result:

Fuller coverage for handling this potential condition without
blocking the operation.

Target:  master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Tigran