### PR TITLE
cells,dcap,ftp: Support for accepting connections from an allowed lis…

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/LocationManager.java
@@ -81,7 +81,6 @@ import org.dcache.util.Args;
 import org.dcache.util.ColumnWriter;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static dmg.cells.nucleus.CellDomainRole.CORE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -381,7 +380,7 @@ public class LocationManager extends CellAdapter
         public static CoreDomains createWithMode(String domainName, CuratorFramework client, String mode)
                 throws BadConfigException
         {
-            LOGGER.error("Creating CoreDomains: {}, {}", domainName, mode);
+            LOGGER.info("Creating CoreDomains: {}, {}", domainName, mode);
             ConnectionType type = ConnectionType.fromConfig(mode).orElseThrow(() -> new BadConfigException("Bad mode " + mode));
 
             switch (type) {
@@ -808,7 +807,9 @@ public class LocationManager extends CellAdapter
         private void startListenerWithTcp()
                 throws ExecutionException, InterruptedException, UnknownHostException
         {
-            String cellArgs = args.argv(0);
+            String cellArgs = String.format("%s -netmask='%s'",
+                                            args.argv(0),
+                                            args.getOption("netmask", ""));
             lmPlain = startListener(cellArgs);
             LOGGER.info("lmPlain: {}; port; {} ", lmPlain, lmPlain.getListenPort());
             info.addCore("tcp", InetAddress.getLocalHost().getCanonicalHostName(), lmPlain.getListenPort());

--- a/skel/share/cells/tunnel-core.fragment
+++ b/skel/share/cells/tunnel-core.fragment
@@ -16,6 +16,7 @@ create -- dmg.cells.services.CoreRoutingManager RoutingMgr "-role=core"
 create -- dmg.cells.services.LocationManager lm \
                     "-role=core \
                     -mode='${dcache.broker.core.client.channel.security}' \
+                    -netmask='${dcache.broker.core.allowed-subnets}' \
                     -socketfactory='org.dcache.ssl.CanlSslServerSocketCreator \
                                         -service_key="${dcache.broker.channel.credential.key}" \
                                         -service_cert="${dcache.broker.channel.credential.cert}" \

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1117,6 +1117,27 @@ dcache.macaroons.default-lifetime.unit = DAYS
 (immutable)dcache.net.ports.tcp=${dcache.net.ports.tcp-when-scheme-is-${dcache.broker.scheme}}
 (immutable)dcache.net.ports.udp=${dcache.net.ports.udp-when-scheme-is-${dcache.broker.scheme}}
 
+
+#  -----------------------------------------------------------------------
+#         List of Subnets allowed to connect
+#  -----------------------------------------------------------------------
+#  Space separated list of subnets (in CIDR notation) and IP addresses.
+#  Both IPv4 and IPv6 subnets and addresses are supported.
+#  Clients connecting from IP addresses outside these subnets are rejected.
+#
+#  e.g.
+#
+#  172.16.0.0/255.240.0.0   64:ff9b::/96  198.18.0.0/15
+dcache.net.allowed-subnets=
+
+
+#  -----------------------------------------------------------------------
+#         List of Subnets allowed to connect to the CoreDomain.
+#  -----------------------------------------------------------------------
+#  Setting this property restricts unencrypted cell communication originating
+#  from satellite domains within the allowed subnets.
+dcache.broker.core.allowed-subnets=${dcache.net.allowed-subnets}
+
 # OpenID Connect hostnames
 #
 # Space separated list of multiple hostnames

--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -185,4 +185,11 @@ dcap.limits.client-version =
 #
 (immutable)dcap.net.ports.tcp=${dcap.net.port}
 
+#  -----------------------------------------------------------------------
+#         List of Subnets allowed to connect to the dCap Door
+#  -----------------------------------------------------------------------
+#  Space separated list of subnets (in CIDR notation) and IP addresses
+#  See dcache.net.allowed-subnets for details
+dcap.net.allowed-subnets=${dcache.net.allowed-subnets}
+
 (obsolete)dcap.cell.export = See dcap.cell.consume

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -298,5 +298,12 @@ ftp.loginbroker.root = ${ftp.root}
 #  Document which TCP ports are opened
 (immutable)ftp.net.ports.tcp=${ftp.net.port} ${ftp.net.port-range}
 
+#  -----------------------------------------------------------------------
+#         List of Subnets allowed to connect to the FTP Door
+#  -----------------------------------------------------------------------
+#  Space separated list of subnets (in CIDR notation) and IP addresses
+#  See dcache.net.allowed-subnets for details
+ftp.net.allowed-subnets=${dcache.net.allowed-subnets}
+
 (forbidden)ftp.authz.upload-directory=See gplazma.authz.upload-directory
 (obsolete)ftp.cell.export = See ftp.cell.consume

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -117,5 +117,6 @@ create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
              -io-queue-overwrite=${dcap.authz.mover-queue-overwrite} \
              -anonymous-access=${dcap.authz.anonymous-operations} \
              -clientVersion=\"${dcap.limits.client-version}\" \
+             -netmask=\"${dcap.net.allowed-subnets}\" \
              ${arguments-${dcap.authn.protocol}} \
              "

--- a/skel/share/services/ftp.batch
+++ b/skel/share/services/ftp.batch
@@ -121,4 +121,5 @@ create dmg.cells.services.login.LoginManager ${ftp.cell.name} \
    -cipher-flags=\"${ftp.authn.ciphers}\" \
    -key-cache-lifetime=\"${ftp.authn.gsi.delegation.cache.lifetime}\" \
    -key-cache-lifetime-unit=\"${ftp.authn.gsi.delegation.cache.lifetime.unit}\" \
+   -netmask=\"${ftp.net.allowed-subnets}\" \
    "


### PR DESCRIPTION
…t of subnets and IP addresses

Motivation:

To disallow incoming connections from clients or satellite domains which
are not in the list of configured allowed-subnets. This can be
additionally used to accept unencrypted connections from only trusted subnets.

Modification:

Both IPv4 and IPv6 subnets and addresses are be supported.

To use configure,

1. dcache.broker.core.allowed-subnets: Allowed subnets to connect to CoreDomain
2. ftp.net.allowed-subnets:    Allowed subnets to connect to ftp door
3. dcap.net.allowed-subnets:   Allowed subnets to connect to dcap door

Ticket:
Acked-by: Paul Millar <paul.millar@desy.de>
Target: master
Request: 3.2
Require-book: no
Require-notes: no
Patch: https://rb.dcache.org/r/10392/