### PR TITLE
webdav: adjust header parsing to be case insensitive

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
@@ -72,8 +72,6 @@ import org.dcache.webdav.transfer.RemoteTransferHandler.TransferType;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.dcache.auth.attributes.LoginAttributes.getUserRoot;
-import static org.dcache.http.AuthenticationHandler.getLoginAttributes;
 import static org.dcache.namespace.FileAttribute.PNFSID;
 import static org.dcache.namespace.FileAttribute.TYPE;
 
@@ -113,6 +111,7 @@ public class CopyFilter implements Filter
     private static final String QUERY_KEY_ASKED_TO_DELEGATE = "asked-to-delegate";
     private static final String REQUEST_HEADER_CREDENTIAL = "Credential";
     private static final String REQUEST_HEADER_AUTHORIZATION = "Authorization";
+    private static final String REQUEST_HEADER_VERIFICATION = "RequireChecksumVerification";
     private static final String SCHEME_AUTHORIZATION_BEARER_WITH_SPACE = "BEARER ";
 
     private static final Set<AccessMask> READ_ACCESS_MASK =
@@ -125,6 +124,7 @@ public class CopyFilter implements Filter
     private ImmutableMap<String,String> _clientIds;
     private ImmutableMap<String,String> _clientSecrets;
     private ImmutableMap<String, OpenIdClientSecret> _oidcClientCredentials = ImmutableMap.of();
+    private boolean _defaultVerification;
 
     /**
      * Describes where to fetch the delegated credential, if at all.
@@ -199,6 +199,17 @@ public class CopyFilter implements Filter
     public void setRemoteTransferHandler(RemoteTransferHandler handler)
     {
         _remoteTransfers = handler;
+    }
+
+    @Required
+    public void setDefaultVerification(boolean verify)
+    {
+        _defaultVerification = verify;
+    }
+
+    public boolean isDefaultVerification()
+    {
+        return _defaultVerification;
     }
 
     public void setOidClientIds(ImmutableMap<String,String> clientIds)
@@ -295,6 +306,12 @@ public class CopyFilter implements Filter
         // Note that each invocation of Request#getHeaders creates a HashMap
         // and populates it with all headers.  Therefore, we use ServletRequest
         // which Milton only makes available via a ThreadLocal.
+
+        // Note that HttpSerlvetRequest#getHeader is case insensitive, as
+        // required by:
+        //
+        //     https://tools.ietf.org/html/rfc7230#section-3.2
+        //
         HttpServletRequest servletRequest = ServletRequest.getRequest();
 
         String pullUrl = servletRequest.getHeader(Direction.PULL.getHeaderName());
@@ -364,14 +381,19 @@ public class CopyFilter implements Filter
         } else {
             _remoteTransfers.acceptRequest(response.getOutputStream(),
                     request.getHeaders(), getSubject(), getRestriction(), path,
-                    remote, credential, direction);
+                    remote, credential, direction, isVerificationRequired());
         }
     }
 
     private CredentialSource getCredentialSource(Request request, TransferType type)
             throws ErrorResponseException
     {
-        String headerValue = request.getHeaders().get(REQUEST_HEADER_CREDENTIAL);
+        // Note that HttpSerlvetRequest#getHeader is case insensitive, as
+        // required by:
+        //
+        //     https://tools.ietf.org/html/rfc7230#section-3.2
+        //
+        String headerValue = ServletRequest.getRequest().getHeader(REQUEST_HEADER_CREDENTIAL);
         CredentialSource source;
 
         if (headerValue != null) {
@@ -595,13 +617,43 @@ public class CopyFilter implements Filter
 
     private boolean isAuthorizationHeaderBearer(Request request)
     {
-        return Strings.nullToEmpty(request.getHeaders()
-                                          .get(REQUEST_HEADER_AUTHORIZATION))
+        // Note that HttpSerlvetRequest#getHeader is case insensitive, as
+        // required by:
+        //
+        //     https://tools.ietf.org/html/rfc7230#section-3.2
+        //
+        return Strings.nullToEmpty(ServletRequest.getRequest().getHeader(REQUEST_HEADER_AUTHORIZATION))
                       .toUpperCase()
                       .startsWith(SCHEME_AUTHORIZATION_BEARER_WITH_SPACE);
     }
 
     private static <T> Predicate<T> not(Predicate<T> t) {
         return t.negate();
+    }
+
+    private boolean isVerificationRequired() throws ErrorResponseException
+    {
+        // Note that HttpSerlvetRequest#getHeader is case insensitive, as
+        // required by:
+        //
+        //     https://tools.ietf.org/html/rfc7230#section-3.2
+        //
+        String header = ServletRequest.getRequest().getHeader(REQUEST_HEADER_VERIFICATION);
+
+        if (header == null) {
+            return _defaultVerification;
+        }
+
+        switch (header) {
+        case "true":
+            return true;
+        case "false":
+            return false;
+        default:
+            throw new ErrorResponseException(Status.SC_BAD_REQUEST,
+                    "HTTP request header '" + REQUEST_HEADER_VERIFICATION + "' " +
+                            "has unknown value \"" + header + "\": " +
+                            "valid values are true or false");
+        }
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import eu.emi.security.authn.x509.X509Credential;
 import io.milton.http.Response;
-import io.milton.http.Response.Status;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.HttpConnection;
 import org.slf4j.Logger;
@@ -61,7 +60,6 @@ import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.NoRouteToCellException;
 
 import org.dcache.auth.OpenIdCredential;
-import org.dcache.auth.StaticOpenIdCredential;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.cells.CellStub;
 import org.dcache.util.URIs;
@@ -180,17 +178,13 @@ public class RemoteTransferHandler implements CellMessageReceiver
     private static final Logger LOG =
             LoggerFactory.getLogger(RemoteTransferHandler.class);
     private static final long DUMMY_LONG = 0;
-    private static final String REQUEST_HEADER_VERIFICATION =
-            "RequireChecksumVerification";
     private static final String REQUEST_HEADER_TRANSFER_HEADER_PREFIX =
-            "TransferHeader";
+            "transferheader";
 
     private final HashMap<Long,RemoteTransfer> _transfers = new HashMap<>();
 
-    private boolean _defaultVerification;
     private long _performanceMarkerPeriod;
     private CellStub _transferManager;
-
 
     @Required
     public void setTransferManagerStub(CellStub stub)
@@ -209,28 +203,18 @@ public class RemoteTransferHandler implements CellMessageReceiver
         return _performanceMarkerPeriod;
     }
 
-    @Required
-    public void setDefaultVerification(boolean verify)
-    {
-        _defaultVerification = verify;
-    }
-
-    public boolean isDefaultVerification()
-    {
-        return _defaultVerification;
-    }
-
     public void acceptRequest(OutputStream out, Map<String,String> requestHeaders,
             Subject subject, Restriction restriction, FsPath path, URI remote,
-            Object credential, Direction direction)
+            Object credential, Direction direction, boolean verification)
             throws ErrorResponseException, InterruptedException
     {
         checkArgument(credential == null
                 || credential instanceof X509Credential
                 || credential instanceof OpenIdCredential,
                 "Credential not supported for Third-Party Transfer");
-        EnumSet<TransferFlag> flags = EnumSet.noneOf(TransferFlag.class);
-        flags = addVerificationFlag(flags, requestHeaders);
+        EnumSet<TransferFlag> flags = verification
+                ? EnumSet.of(TransferFlag.REQUIRE_VERIFICATION)
+                : EnumSet.noneOf(TransferFlag.class);
         ImmutableMap<String,String> transferHeaders = buildTransferHeaders(requestHeaders);
         RemoteTransfer transfer = new RemoteTransfer(out, subject, restriction,
                 path, remote, credential, flags, transferHeaders, direction);
@@ -251,44 +235,13 @@ public class RemoteTransferHandler implements CellMessageReceiver
         }
     }
 
-    private EnumSet<TransferFlag> addVerificationFlag(EnumSet<TransferFlag> existingFlags,
-            Map<String,String> headers) throws ErrorResponseException
-    {
-        String header = headers.get(REQUEST_HEADER_VERIFICATION);
-
-        boolean verification;
-        if (header == null) {
-            verification = _defaultVerification;
-        } else {
-            switch (header) {
-            case "true":
-                verification = true;
-                break;
-            case "false":
-                verification = false;
-                break;
-            default:
-                throw new ErrorResponseException(Status.SC_BAD_REQUEST,
-                        "HTTP request header '" + REQUEST_HEADER_VERIFICATION + "' " +
-                                "has unknown value \"" + header + "\": " +
-                                "valid values are true or false");
-            }
-        }
-
-        EnumSet<TransferFlag> result = EnumSet.copyOf(existingFlags);
-        if (verification) {
-            result.add(TransferFlag.REQUIRE_VERIFICATION);
-        }
-        return result;
-    }
-
     private ImmutableMap<String,String> buildTransferHeaders(Map<String,String> requestHeaders)
     {
         ImmutableMap.Builder<String,String> builder = ImmutableMap.builder();
 
         for (Map.Entry<String,String> header : requestHeaders.entrySet()) {
             String key = header.getKey();
-            if (key.startsWith(REQUEST_HEADER_TRANSFER_HEADER_PREFIX)) {
+            if (key.toLowerCase().startsWith(REQUEST_HEADER_TRANSFER_HEADER_PREFIX)) {
                 builder.put(key.substring(REQUEST_HEADER_TRANSFER_HEADER_PREFIX.length()),
                         header.getValue());
             }

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -128,7 +128,6 @@
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
                      ${webdav.third-party-transfers.performance-marker-period},
                      '${webdav.third-party-transfers.performance-marker-period.unit}')}" />
-      <property name="defaultVerification" value="${webdav.enable.third-party.requiring-verification-by-default}"/>
   </bean>
 
   <bean id="oidc-client-ids"
@@ -150,6 +149,7 @@
       <property name="pathMapper" ref="path-mapper"/>
       <property name="oidClientIds" ref="oidc-client-ids"/>
       <property name="oidClientSecrets" ref="oidc-client-secrets"/>
+      <property name="defaultVerification" value="${webdav.enable.third-party.requiring-verification-by-default}"/>
   </bean>
 
   <bean id="dispatch-filter"


### PR DESCRIPTION
Motivation:

In RFC 7230, section 3.2, it states that HTTP header names should be
case insensitive.  Despite this, the standard milton mechanism for
acquiring header information is case sensitive, which (in turn) means
that several HTTP header values in dCache are similarly case sensitive.
Affected headers are RequireChecksumVerification, Credential,
Authorization (only when used to auto-select OIDC delegation) and the
TransferHeader prefix.

We have received reports that this case sensitivity has caused problems
with certain clients (e.g., go).

Modification:

Switch to using the HttpServletRequest object to acquire header
information, which is documented as case insensitive.  Additionally, the
parsing of RequireChecksumVerification is moved from
RemoteTransferHandler to CopyFilter.

Result:

Headers that control third-party transfers are now case insensitive, so
should work with more clients.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10414/
Acked-by: Tigran Mkrtchyan