### PR TITLE
webdav: adjust header parsing to be case insensitive

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
@@ -100,6 +100,7 @@ public class CopyFilter implements Filter
 
     private static final String QUERY_KEY_ASKED_TO_DELEGATE = "asked-to-delegate";
     private static final String REQUEST_HEADER_CREDENTIAL = "Credential";
+    private static final String REQUEST_HEADER_VERIFICATION = "RequireChecksumVerification";
     private static final Set<AccessMask> READ_ACCESS_MASK =
             EnumSet.of(AccessMask.READ_DATA);
     private static final Set<AccessMask> WRITE_ACCESS_MASK =
@@ -153,6 +154,7 @@ public class CopyFilter implements Filter
     private CredentialServiceClient _credentialService;
     private PathMapper _pathMapper;
     private RemoteTransferHandler _remoteTransfers;
+    private boolean _defaultVerification;
 
     @Required
     public void setPathMapper(PathMapper mapper)
@@ -176,6 +178,17 @@ public class CopyFilter implements Filter
     public void setRemoteTransferHandler(RemoteTransferHandler handler)
     {
         _remoteTransfers = handler;
+    }
+
+    @Required
+    public void setDefaultVerification(boolean verify)
+    {
+        _defaultVerification = verify;
+    }
+
+    public boolean isDefaultVerification()
+    {
+        return _defaultVerification;
     }
 
     @Override
@@ -217,6 +230,12 @@ public class CopyFilter implements Filter
         // Note that each invocation of Request#getHeaders creates a HashMap
         // and populates it with all headers.  Therefore, we use ServletRequest
         // which Milton only makes available via a ThreadLocal.
+
+        // Note that HttpSerlvetRequest#getHeader is case insensitive, as
+        // required by:
+        //
+        //     https://tools.ietf.org/html/rfc7230#section-3.2
+        //
         HttpServletRequest servletRequest = ServletRequest.getRequest();
 
         String pullUrl = servletRequest.getHeader(Direction.PULL.getHeaderName());
@@ -280,14 +299,19 @@ public class CopyFilter implements Filter
         } else {
             _remoteTransfers.acceptRequest(response.getOutputStream(),
                     request.getHeaders(), getSubject(), getRestriction(), path,
-                    remote, credential, direction);
+                    remote, credential, direction, isVerificationRequired());
         }
     }
 
     private CredentialSource getCredentialSource(Request request, TransferType type)
             throws ErrorResponseException
     {
-        String headerValue = request.getHeaders().get(REQUEST_HEADER_CREDENTIAL);
+        // Note that HttpSerlvetRequest#getHeader is case insensitive, as
+        // required by:
+        //
+        //     https://tools.ietf.org/html/rfc7230#section-3.2
+        //
+        String headerValue = ServletRequest.getRequest().getHeader(REQUEST_HEADER_CREDENTIAL);
 
         CredentialSource source = headerValue != null ?
                 CredentialSource.forHeaderValue(headerValue) :
@@ -490,5 +514,31 @@ public class CopyFilter implements Filter
     {
         HttpServletRequest servletRequest = ServletRequest.getRequest();
         return (Restriction) servletRequest.getAttribute(AuthenticationHandler.DCACHE_RESTRICTION_ATTRIBUTE);
+    }
+
+    private boolean isVerificationRequired() throws ErrorResponseException
+    {
+        // Note that HttpSerlvetRequest#getHeader is case insensitive, as
+        // required by:
+        //
+        //     https://tools.ietf.org/html/rfc7230#section-3.2
+        //
+        String header = ServletRequest.getRequest().getHeader(REQUEST_HEADER_VERIFICATION);
+
+        if (header == null) {
+            return _defaultVerification;
+        }
+
+        switch (header) {
+        case "true":
+            return true;
+        case "false":
+            return false;
+        default:
+            throw new ErrorResponseException(Status.SC_BAD_REQUEST,
+                    "HTTP request header '" + REQUEST_HEADER_VERIFICATION + "' " +
+                            "has unknown value \"" + header + "\": " +
+                            "valid values are true or false");
+        }
     }
 }

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -136,7 +136,6 @@
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
                      ${webdav.third-party-transfers.performance-marker-period},
                      '${webdav.third-party-transfers.performance-marker-period.unit}')}" />
-      <property name="defaultVerification" value="${webdav.enable.third-party.requiring-verification-by-default}"/>
   </bean>
 
   <bean id="3rd-party-copy-filter" class="org.dcache.webdav.transfer.CopyFilter">
@@ -146,6 +145,7 @@
       <property name="pnfsStub" ref="pnfs-stub"/>
       <property name="remoteTransferHandler" ref="remote-transfer-handler"/>
       <property name="pathMapper" ref="path-mapper"/>
+      <property name="defaultVerification" value="${webdav.enable.third-party.requiring-verification-by-default}"/>
   </bean>
 
   <bean id="dispatch-filter"


### PR DESCRIPTION
Motivation:

In RFC 7230, section 3.2, it states that HTTP header names should be
case insensitive.  Despite this, the standard milton mechanism for
acquiring header information is case sensitive, which (in turn) means
that several HTTP header values in dCache are similarly case sensitive.
Affected headers are RequireChecksumVerification, Credential,
Authorization (only when used to auto-select OIDC delegation) and the
TransferHeader prefix.

We have received reports that this case sensitivity has caused problems
with certain clients (e.g., go).

Modification:

Switch to using the HttpServletRequest object to acquire header
information, which is documented as case insensitive.  Additionally, the
parsing of RequireChecksumVerification is moved from
RemoteTransferHandler to CopyFilter.

Result:

Headers that control third-party transfers are now case insensitive, so
should work with more clients.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10414/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
	modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
	modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml