### PR TITLE
webdav: adjust header parsing to be case insensitive

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import eu.emi.security.authn.x509.X509Credential;
 import io.milton.http.Response;
-import io.milton.http.Response.Status;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.HttpConnection;
 import org.slf4j.Logger;
@@ -181,17 +180,13 @@ public class RemoteTransferHandler implements CellMessageReceiver
     private static final Logger LOG =
             LoggerFactory.getLogger(RemoteTransferHandler.class);
     private static final long DUMMY_LONG = 0;
-    private static final String REQUEST_HEADER_VERIFICATION =
-            "RequireChecksumVerification";
     private static final String REQUEST_HEADER_TRANSFER_HEADER_PREFIX =
-            "TransferHeader";
+            "transferheader";
 
     private final HashMap<Long,RemoteTransfer> _transfers = new HashMap<>();
 
-    private boolean _defaultVerification;
     private long _performanceMarkerPeriod;
     private CellStub _transferManager;
-
 
     @Required
     public void setTransferManagerStub(CellStub stub)
@@ -210,24 +205,14 @@ public class RemoteTransferHandler implements CellMessageReceiver
         return _performanceMarkerPeriod;
     }
 
-    @Required
-    public void setDefaultVerification(boolean verify)
-    {
-        _defaultVerification = verify;
-    }
-
-    public boolean isDefaultVerification()
-    {
-        return _defaultVerification;
-    }
-
     public void acceptRequest(OutputStream out, Map<String,String> requestHeaders,
             Subject subject, Restriction restriction, FsPath path, URI remote,
-            X509Credential credential, Direction direction)
+            X509Credential credential, Direction direction, boolean verification)
             throws ErrorResponseException, InterruptedException
     {
-        EnumSet<TransferFlag> flags = EnumSet.noneOf(TransferFlag.class);
-        flags = addVerificationFlag(flags, requestHeaders);
+        EnumSet<TransferFlag> flags = verification
+                ? EnumSet.of(TransferFlag.REQUIRE_VERIFICATION)
+                : EnumSet.noneOf(TransferFlag.class);
         ImmutableMap<String,String> transferHeaders = buildTransferHeaders(requestHeaders);
         RemoteTransfer transfer = new RemoteTransfer(out, subject, restriction,
                 path, remote, credential, flags, transferHeaders, direction);
@@ -248,44 +233,13 @@ public class RemoteTransferHandler implements CellMessageReceiver
         }
     }
 
-    private EnumSet<TransferFlag> addVerificationFlag(EnumSet<TransferFlag> existingFlags,
-            Map<String,String> headers) throws ErrorResponseException
-    {
-        String header = headers.get(REQUEST_HEADER_VERIFICATION);
-
-        boolean verification;
-        if (header == null) {
-            verification = _defaultVerification;
-        } else {
-            switch (header) {
-            case "true":
-                verification = true;
-                break;
-            case "false":
-                verification = false;
-                break;
-            default:
-                throw new ErrorResponseException(Status.SC_BAD_REQUEST,
-                        "HTTP request header '" + REQUEST_HEADER_VERIFICATION + "' " +
-                                "has unknown value \"" + header + "\": " +
-                                "valid values are true or false");
-            }
-        }
-
-        EnumSet<TransferFlag> result = EnumSet.copyOf(existingFlags);
-        if (verification) {
-            result.add(TransferFlag.REQUIRE_VERIFICATION);
-        }
-        return result;
-    }
-
     private ImmutableMap<String,String> buildTransferHeaders(Map<String,String> requestHeaders)
     {
         ImmutableMap.Builder<String,String> builder = ImmutableMap.builder();
 
         for (Map.Entry<String,String> header : requestHeaders.entrySet()) {
             String key = header.getKey();
-            if (key.startsWith(REQUEST_HEADER_TRANSFER_HEADER_PREFIX)) {
+            if (key.toLowerCase().startsWith(REQUEST_HEADER_TRANSFER_HEADER_PREFIX)) {
                 builder.put(key.substring(REQUEST_HEADER_TRANSFER_HEADER_PREFIX.length()),
                         header.getValue());
             }

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -136,7 +136,6 @@
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
                      ${webdav.third-party-transfers.performance-marker-period},
                      '${webdav.third-party-transfers.performance-marker-period.unit}')}" />
-      <property name="defaultVerification" value="${webdav.enable.third-party.requiring-verification-by-default}"/>
   </bean>
 
   <bean id="3rd-party-copy-filter" class="org.dcache.webdav.transfer.CopyFilter">
@@ -146,6 +145,7 @@
       <property name="pnfsStub" ref="pnfs-stub"/>
       <property name="remoteTransferHandler" ref="remote-transfer-handler"/>
       <property name="pathMapper" ref="path-mapper"/>
+      <property name="defaultVerification" value="${webdav.enable.third-party.requiring-verification-by-default}"/>
   </bean>
 
   <bean id="dispatch-filter"


### PR DESCRIPTION
Motivation:

In RFC 7230, section 3.2, it states that HTTP header names should be
case insensitive.  Despite this, the standard milton mechanism for
acquiring header information is case sensitive, which (in turn) means
that several HTTP header values in dCache are similarly case sensitive.
Affected headers are RequireChecksumVerification, Credential,
Authorization (only when used to auto-select OIDC delegation) and the
TransferHeader prefix.

We have received reports that this case sensitivity has caused problems
with certain clients (e.g., go).

Modification:

Switch to using the HttpServletRequest object to acquire header
information, which is documented as case insensitive.  Additionally, the
parsing of RequireChecksumVerification is moved from
RemoteTransferHandler to CopyFilter.

Result:

Headers that control third-party transfers are now case insensitive, so
should work with more clients.

Target: master
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10414/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
	modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
	modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml