### PR TITLE
nfs: shutdown callback ScheduledExecutorService on shutdown

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
@@ -129,6 +130,7 @@ import org.dcache.xdr.gss.GssSessionManager;
 import static java.util.stream.Collectors.toList;
 
 import java.util.stream.Stream;
+
 import javax.annotation.concurrent.GuardedBy;
 
 import org.dcache.auth.attributes.Restrictions;
@@ -248,8 +250,8 @@ public class NFSv41Door extends AbstractCellComponent implements
     /**
      * {@link ExecutorService} used to issue call-backs to the client.
      */
-    private final CDCScheduledExecutorServiceDecorator<ScheduledExecutorService> _callbackExecutor =
-            new CDCScheduledExecutorServiceDecorator<>(Executors.newScheduledThreadPool(1));
+    private final ScheduledExecutorService _callbackExecutor =
+            new CDCScheduledExecutorServiceDecorator<>(Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setNameFormat("callback-%d").build()));
 
     /**
      * Exception thrown by transfer if accessed after mover have finished.
@@ -358,6 +360,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
     public void destroy() throws IOException {
         _rpcService.stop();
+        _callbackExecutor.shutdown();
         if (_nfs4 != null) {
             _nfs4.getStateHandler().shutdown();
             _proxyIoFactory.shutdown();


### PR DESCRIPTION
Motivation:

The nfs doors do not shut down cleanly, but rely on the cell
infrastructure to kill off threads that may have been started.  This
slows down the shutdown sequence, which risks the daemon script killing
the process outright.

Modification:

Shutdown the ScheduledExecutorService as part of the NFS door shutdown
sequence.

The Threads that are created for this are given a more descriptive name.

Result:

dCache shutdown is faster and less likely to suffer problems.

Target: master
Request: 3.2
Request: 3.1
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10447/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java