### PR TITLE
srmclient: parameterise shell path of srmclient utilities

### DIFF
--- a/modules/srm-client/pom.xml
+++ b/modules/srm-client/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <raw-files>${project.basedir}/src/main</raw-files>
         <filtered-files>${project.build.directory}/filtered-files</filtered-files>
+        <SHELL_PATH>/bin/sh</SHELL_PATH>
     </properties>
 
     <dependencies>

--- a/modules/srm-client/src/main/bin/adler32
+++ b/modules/srm-client/src/main/bin/adler32
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/delegation
+++ b/modules/srm-client/src/main/bin/delegation
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/gridftpcopy
+++ b/modules/srm-client/src/main/bin/gridftpcopy
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!@SHELL_PATH@
 
 command=`which $0`
 commanddir=`dirname $command`

--- a/modules/srm-client/src/main/bin/gridftplist
+++ b/modules/srm-client/src/main/bin/gridftplist
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!@SHELL_PATH@
 
 command=`which $0`
 commanddir=`dirname $command`

--- a/modules/srm-client/src/main/bin/srm-abort-files
+++ b/modules/srm-client/src/main/bin/srm-abort-files
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-abort-request
+++ b/modules/srm-client/src/main/bin/srm-abort-request
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-advisory-delete
+++ b/modules/srm-client/src/main/bin/srm-advisory-delete
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-bring-online
+++ b/modules/srm-client/src/main/bin/srm-bring-online
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-check-permissions
+++ b/modules/srm-client/src/main/bin/srm-check-permissions
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-extend-file-lifetime
+++ b/modules/srm-client/src/main/bin/srm-extend-file-lifetime
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-get-metadata
+++ b/modules/srm-client/src/main/bin/srm-get-metadata
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-get-permissions
+++ b/modules/srm-client/src/main/bin/srm-get-permissions
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-get-request-status
+++ b/modules/srm-client/src/main/bin/srm-get-request-status
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-get-request-summary
+++ b/modules/srm-client/src/main/bin/srm-get-request-summary
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-get-request-tokens
+++ b/modules/srm-client/src/main/bin/srm-get-request-tokens
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-get-space-metadata
+++ b/modules/srm-client/src/main/bin/srm-get-space-metadata
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-get-space-tokens
+++ b/modules/srm-client/src/main/bin/srm-get-space-tokens
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-release-files
+++ b/modules/srm-client/src/main/bin/srm-release-files
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-release-space
+++ b/modules/srm-client/src/main/bin/srm-release-space
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-reserve-space
+++ b/modules/srm-client/src/main/bin/srm-reserve-space
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-set-permissions
+++ b/modules/srm-client/src/main/bin/srm-set-permissions
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srm-storage-element-info
+++ b/modules/srm-client/src/main/bin/srm-storage-element-info
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srmcp
+++ b/modules/srm-client/src/main/bin/srmcp
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srmfs
+++ b/modules/srm-client/src/main/bin/srmfs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srmls
+++ b/modules/srm-client/src/main/bin/srmls
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srmmkdir
+++ b/modules/srm-client/src/main/bin/srmmkdir
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srmmv
+++ b/modules/srm-client/src/main/bin/srmmv
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srmping
+++ b/modules/srm-client/src/main/bin/srmping
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srmrm
+++ b/modules/srm-client/src/main/bin/srmrm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srmrmdir
+++ b/modules/srm-client/src/main/bin/srmrmdir
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/bin/srmstage
+++ b/modules/srm-client/src/main/bin/srmstage
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 @INIT_SCRIPT@
 

--- a/modules/srm-client/src/main/lib/srm
+++ b/modules/srm-client/src/main/lib/srm
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!@SHELL_PATH@
 
 #DEBUG=true
 #SECURITY_DEBUG=true

--- a/modules/srm-client/src/main/lib/url-copy.sh
+++ b/modules/srm-client/src/main/lib/url-copy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 #if script returns to quickly java does not see error code!!!
 sleep 1
 #default values

--- a/modules/srm-client/src/main/sbin/f-srmcp-prepare-and-make-in-user-space
+++ b/modules/srm-client/src/main/sbin/f-srmcp-prepare-and-make-in-user-space
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 ########################################################################
 # Script: f-srmcp-prepare_package  major_version  minor_version release_number
 #

--- a/modules/srm-client/src/main/sbin/make-srmcp-rpm
+++ b/modules/srm-client/src/main/sbin/make-srmcp-rpm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 ########################################################################
 # Script: srmcp-prepare_package  major_version  minor_version release_number
 #

--- a/modules/srm-client/src/main/sbin/make_release.sh
+++ b/modules/srm-client/src/main/sbin/make_release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 
 version=$1
 if [ "$version" = "" ]

--- a/modules/srm-client/src/main/sbin/timeout.sh
+++ b/modules/srm-client/src/main/sbin/timeout.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL_PATH@
 # script to execute a program with a timeout
 #
 # usage: timeout.sh [-debug] timeout program [program arguments]


### PR DESCRIPTION
Motivation:

Some distributions use bash (or similar feature-rich shell) as their
default shell (i.e., /bin/sh).  This means that developers risk
introducing "bashisms" into our scripts: places where a script depends
on bash, rather than working with any POSIX compliant shell.

Modification:

Support building srm-client scripts with an alternative shell.  By
default, srm-client is built so the scripts use /bin/sh, as before.
With this patch, an alternative shell path may be defined during the
build process; e.g.,

    mvn -am -pl modules/srm-client -DSHELL_PATH=/bin/dash

Result:

Developers have the ability to build srm-client scripts with an
alternative shell, allowing for POSIX-compliance testing.

Target: master
Request: 3.2
Require-notes: no
Require-srmclient-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/10431/
Acked-by: Tigran Mkrtchyan