### PR TITLE
resilience: handle storage unit NoSuchElement failure

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -66,18 +66,20 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.NoSuchElementException;
 
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.PnfsId;
+import org.dcache.resilience.data.PoolOperation.SelectionAction;
 import org.dcache.resilience.db.LocalNamespaceAccess;
 import org.dcache.resilience.db.NamespaceAccess;
 import org.dcache.resilience.db.ScanSummary;
 import org.dcache.resilience.handlers.FileOperationHandler;
 import org.dcache.resilience.handlers.ResilienceMessageHandler;
+import org.dcache.resilience.util.ExceptionMessage;
 import org.dcache.resilience.util.LocationSelector;
-import org.dcache.resilience.data.PoolOperation.SelectionAction;
 import org.dcache.vehicles.FileAttributes;
 
 /**
@@ -294,7 +296,13 @@ public final class FileUpdate {
          * Storage unit is not recorded in checkpoint, so it should
          * be set here.
          */
-        unitIndex = poolInfoMap.getStorageUnitIndex(attributes);
+        try {
+            unitIndex = poolInfoMap.getStorageUnitIndex(attributes);
+        } catch (NoSuchElementException e) {
+            LOGGER.error("validateForAction, cannot handle {}: {}.",
+                         pnfsId, new ExceptionMessage(e));
+            return false;
+        }
 
         LOGGER.trace("validateForAction {} got unit from attributes {}.",
                      pnfsId, unitIndex);


### PR DESCRIPTION
Motivation:

When doing a pool scan, the storage unit information must be
recovered for each file.  This is done from the chimera attributes.
The code checks an internal map for an index number corresponding
to the unit it knows about from the PoolMonitor.

However, if the pool selection unit configuration changes such that
a storage unit is eliminated, that mapping will also be deleted
from resilience.  In the case that the attributes stored in
Chimera still have the older storage class information, there
will be a NoSuchElementException thrown.

The code, however, neglects to handle this special case.  The
exception seems to be thrown and never caught, not even as
a RuntimeException.  This prevents the scan from completing.

Modification:

Catch the NoSuchElementException and return false so that
the namespace scanning can skip it and move on.

Result:

Pool scans that encounter this situation do not get stuck
forever in the queue.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Tigran