### PR TITLE
resilience: add pool operation logging

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperation.java
@@ -59,6 +59,9 @@ documents or software obtained from this server.
  */
 package org.dcache.resilience.data;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import diskCacheV111.util.CacheException;
 import org.dcache.resilience.util.ExceptionMessage;
 import org.dcache.resilience.util.PoolScanTask;
@@ -67,6 +70,8 @@ import org.dcache.resilience.util.PoolScanTask;
  * <p>Object stored in the {@link PoolOperationMap}.</p>
  */
 public final class PoolOperation {
+    private static final Logger LOGGER    = LoggerFactory.getLogger(PoolOperation.class);
+
     private static final String TO_STRING = "(completed: %s / %s : %s%%) – "
                     + "(updated: %s)(scanned: %s)(prev %s)(curr %s)(%s) %s";
 
@@ -190,13 +195,20 @@ public final class PoolOperation {
     }
 
     synchronized void incrementCompleted() {
+        LOGGER.debug("entering incrementCompleted, state {}, children {}, completed = {}.",
+                     state, children, completed );
         if (state == State.RUNNING) {
             ++completed;
         }
+        LOGGER.debug("leaving incrementCompleted, state {}, children {}, completed = {}.",
+                     state, children, completed );
     }
 
     synchronized boolean isComplete() {
-        return children > 0 && children == completed;
+        boolean isComplete = children > 0 && children == completed;
+        LOGGER.debug("isComplete {}, children {}, completed = {}.",
+                     isComplete, children, completed );
+        return isComplete;
     }
 
     synchronized void resetChildren() {

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
@@ -649,7 +649,7 @@ public class PoolOperationMap extends RunnableModule {
      * <p>Called by the {@link FileOperationMap ) when a child operation completes.</p>
      */
     public void update(String pool, PnfsId pnfsId) {
-        LOGGER.trace("Parent {}, child operation for {} has completed.", pool,
+        LOGGER.debug("Parent {}, child operation for {} has completed.", pool,
                      pnfsId);
         lock.lock();
         try {
@@ -671,6 +671,8 @@ public class PoolOperationMap extends RunnableModule {
     public void update(String pool,
                        int children,
                        CacheException exception) {
+        LOGGER.debug("Pool {}, operation update, children {}.", pool,
+                     children);
         lock.lock();
         try {
             PoolOperation operation = get(pool);
@@ -981,6 +983,7 @@ public class PoolOperationMap extends RunnableModule {
     }
 
     private void terminate(String pool, PoolOperation operation) {
+        LOGGER.debug("terminate, pool {}, {}.", pool, operation);
         String operationType = Operation.get(operation.currStatus).name();
 
         if (operation.exception != null) {

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/db/LocalNamespaceAccess.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/db/LocalNamespaceAccess.java
@@ -62,13 +62,13 @@ package org.dcache.resilience.db;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.stream.Collectors;
-import javax.sql.DataSource;
 
 import diskCacheV111.namespace.NameSpaceProvider;
 import diskCacheV111.util.CacheException;
@@ -80,10 +80,10 @@ import org.dcache.resilience.data.FileOperationMap;
 import org.dcache.resilience.data.FileUpdate;
 import org.dcache.resilience.data.MessageType;
 import org.dcache.resilience.data.PoolInfoMap;
+import org.dcache.resilience.data.PoolOperation.SelectionAction;
 import org.dcache.resilience.handlers.FileOperationHandler;
 import org.dcache.resilience.handlers.PoolOperationHandler;
 import org.dcache.resilience.util.ExceptionMessage;
-import org.dcache.resilience.data.PoolOperation.SelectionAction;
 import org.dcache.vehicles.FileAttributes;
 
 import static org.dcache.util.SqlHelper.tryToClose;
@@ -254,9 +254,11 @@ public class LocalNamespaceAccess implements NamespaceAccess {
                 FileUpdate data = new FileUpdate(pnfsId, pool, type, action,
                                                  group, full);
                 try {
+                    LOGGER.debug("checking {}, {}.", pool, pnfsId);
                     if (handler.handleScannedLocation(data, storageUnit)) {
                         scan.incrementCount();
                     }
+                    LOGGER.debug("after checking {}, {}, count is {}.", pool, pnfsId, scan.getCount());
                 } catch (CacheException e) {
                     LOGGER.debug("{}: {}", data, new ExceptionMessage(e));
                 }

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -255,7 +255,7 @@ public class FileOperationHandler {
      */
     public boolean handleScannedLocation(FileUpdate data, Integer storageUnit)
                     throws CacheException {
-        LOGGER.trace("handleScannedLocation {}", data);
+        LOGGER.debug("handleScannedLocation {}", data);
 
         /*
          * These must be true during a pool scan.
@@ -270,7 +270,8 @@ public class FileOperationHandler {
             return false;
         }
 
-        LOGGER.trace("handleLocationUpdate, update to be registered: {}", data);
+        LOGGER.debug("handleScannedLocation, update to be registered: {}", data);
+        
         return fileOpMap.register(data);
     }
 


### PR DESCRIPTION
Motivation:

There is adequate logging to debug individual file operations
in Resilience.  For pool operations (scans), however, there is
practically nothing.  The absence of the ability to track
operation counter updates is particularly egregious.

Modification:

Add some minimal logging to achieve the above.

Result:

Debug output tracking updates and completion of the operation
is available.

No visible change to user.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-book: no
Require-notes: no
Acked-by: Tigran