### PR TITLE
dcache-restful-api: return incomplete info instead of throwing NoSuch…

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/cells/CellInfoServiceImpl.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/cells/CellInfoServiceImpl.java
@@ -61,19 +61,18 @@ package org.dcache.restful.services.cells;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import dmg.cells.nucleus.CellInfo;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.util.command.Command;
-import org.dcache.services.collector.CellDataCollectingService;
+import org.dcache.cells.json.CellData;
 import org.dcache.restful.util.admin.ReadWriteData;
 import org.dcache.restful.util.cells.CellInfoCollector;
 import org.dcache.restful.util.cells.CellInfoFutureProcessor;
+import org.dcache.services.collector.CellDataCollectingService;
 import org.dcache.util.collector.ListenableFutureWrapper;
-import org.dcache.cells.json.CellData;
 
 /**
  * <p>Responsible for serving up data from the cache.</p>
@@ -134,7 +133,11 @@ public class CellInfoServiceImpl extends
     public CellData getCellData(String address) {
         CellData cached = cache.read(address);
         if (cached == null) {
-            throw new NoSuchElementException(address);
+            cached = new CellData();
+            String[] key = address.split("@");
+            cached.setCellName(key[0]);
+            cached.setDomainName(key[1]);
+            cached.setState(4); // "Unknown"
         }
         return cached;
     }

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/cells/CellInfoFutureProcessor.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/cells/CellInfoFutureProcessor.java
@@ -63,7 +63,6 @@ import org.springframework.beans.factory.annotation.Required;
 
 import dmg.cells.nucleus.CellInfo;
 import dmg.cells.nucleus.CellVersion;
-
 import org.dcache.cells.json.CellData;
 import org.dcache.restful.services.cells.CellInfoServiceImpl;
 import org.dcache.util.collector.RequestFutureProcessor;
@@ -106,11 +105,9 @@ public final class CellInfoFutureProcessor extends
     @Override
     protected CellData process(String key,
                                CellInfo received,
-                               long sent){
+                               long sent) {
         CellData cellData = new CellData();
-        if (cellData != null) {
-            cellData.setRoundTripTime(System.currentTimeMillis() - sent);
-        }
+        cellData.setRoundTripTime(System.currentTimeMillis() - sent);
         update(cellData, received);
         return cellData;
     }


### PR DESCRIPTION
…ElementException

Motivation:

It is possible under some circumstances that cell info cannot be
collected from a service that is mapped by the RoutingManager.

When this occurs, and the Frontend service tries to access the
missing info, the code currently throws a NoSuchElementException.
This behavior, unfortunately, nullifies the entire operation,
resulting in HTTP 500 error being reported in the browser.

A better solution would be to return a data object with an
"Unknown" state indicated for that service.

Modification:

Add the code to the service implementation to return this
placeholder.

The patch also removes an unnecessary null check in the code
which processes the returned future.

Result:

The stack trace below should not appear; the service should
be marked as in an unknown state on the frontend.

Target: master
Require-book: no
Require-notes: no
Request: 3.2
Acked-by: Tigran