### PR TITLE
pool: ceph: ignore file-not-found on remove

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ceph/CephFileStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ceph/CephFileStore.java
@@ -224,6 +224,12 @@ public class CephFileStore implements FileStore {
         try {
             rbd.remove(imageName);
         } catch (RadosException e) {
+
+            // ignore file-not-found error code (negative number).
+            if (Errno.valueOf(Math.abs(e.getErrorCode())) == Errno.ENOENT) {
+                return;
+            }
+
             throwIfMappable(e, "Failed to remove file: " + imageName);
             throw e;
         }


### PR DESCRIPTION
Motivation:
In some cases pool may ask back end store to remove a files, which don't
exists. In such cases, we have to suppress errors and prevent pool from
panic.

Modification:
suppress file-not-found error on remove

Result:
pool does not panic if remove is issued

Acked-by: Albert Rossi
Target: master, 3.2
Require-book: no
Require-notes: no
(cherry picked from commit 3d265c0333922d6635443e827e6ac9a10b22858e)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>