### PR TITLE
resilience: handle file deletion during scan correctly

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -131,8 +131,18 @@ public final class FileUpdate {
                     return null;
                 }
 
+                if (messageType != MessageType.ADD_CACHE_LOCATION) {
+                    /*
+                     * Since the scan began or the broken file reported,
+                     * the file has been removed.
+                     */
+                    throw new FileNotFoundCacheException
+                                    (String.format("File no longer found: %s"
+                                                    , pnfsId));
+                }
+
                 /*
-                 *  Due to a possible race between PnfsManager and resilience
+                 *  May be due to a race between PnfsManager and resilience
                  *  to process the message into/from the namespace.
                  *
                  *  We can assume here that this is a new file, so
@@ -150,10 +160,6 @@ public final class FileUpdate {
                          attributes.getLocations());
             return attributes;
         } catch (FileNotFoundCacheException e) {
-            /*
-             * Most likely we received a PnfsClearCacheLocationMessage
-             * as the result of a file deletion.
-             */
             LOGGER.debug("{}; {} has likely been deleted from the namespace.",
                          e.getMessage(),
                          pnfsId);

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -267,10 +267,16 @@ public class FileOperationHandler {
         LOGGER.trace("handleScannedLocation {}", data);
 
         /*
-         * These must be true during a pool scan.
+         * Prefetch all necessary file attributes, including current locations.
          */
+        if (!data.validateAttributes(namespace)) {
+            /*
+             * Could be the result of deletion from namespace during the scan.
+             */
+            return false;
+        }
+
         data.verifyPoolGroup(poolInfoMap);
-        data.validateAttributes(namespace);
 
         /*
          *  Determine if action needs to be taken.


### PR DESCRIPTION
Motivation:

Resilience must be able to handle correctly any situation in which
an ongoing operation discovers that the file in question has been
deleted from the namespace.

Corrections have been recently made to guarantee this for individual
file operations.  But it is still possible for pool scans to fail
because this situation is not properly detected (resulting eventually
in a NullPointerException which breaks the scan).

Modification:

1. Modifies the getAttributes method so that it distinguishes between
   scan and ADD_CACHE_LOCATION when the location list comes up empty.

2. Modifies the handleScanned method so that it immediately returns
   false if the attribute validation fails.

Result:

When the scan operation encounters a deleted file (either generating a
FileNotFoundException or an empty list of locations), it skips it,
rather than being subject to an uncaught RuntimeException and exiting
without terminating peacefully.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-book: no
Require-notes: yes
Acked-by: Tigran