### PR TITLE
common: fix time computation in TimeseriesHistogramTest

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/histograms/TimeseriesHistogram.java
+++ b/modules/common/src/main/java/org/dcache/util/histograms/TimeseriesHistogram.java
@@ -251,7 +251,7 @@ public class TimeseriesHistogram extends HistogramModel
                     break;
             }
 
-            metadata.updateStatistics(value, System.currentTimeMillis());
+            metadata.updateStatistics(value, timestamp);
         }
     }
 }

--- a/modules/common/src/test/java/org/dcache/util/histograms/TimeseriesHistogramTest.java
+++ b/modules/common/src/test/java/org/dcache/util/histograms/TimeseriesHistogramTest.java
@@ -80,6 +80,7 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
 
     TimeseriesHistogram timeseriesHistogram;
     HistogramModel      originalModel;
+    long                now;
 
     @Test
     public void buildShouldSucceedForTimeseriesHistogramWithFileSizeValues()
@@ -245,11 +246,10 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
 
     private void assertThatUpdateAveragesLastValue() {
         Double[][] values = values();
-        Double[] last = values[values.length - 1];
-        double lastValue = last[1];
+        double lastValue = values[values.length - 1][1];
         double newValue = lastValue * 3;
         double average = (lastValue + newValue) / 2;
-        timeseriesHistogram.average(newValue, System.currentTimeMillis());
+        timeseriesHistogram.average(newValue, now);
         values = values();
         assertTrue("value was not replaced",
                    lastValue != values[values.length - 1][1]);
@@ -259,10 +259,9 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
 
     private void assertThatUpdateReplacesLastValue() {
         Double[][] values = values();
-        Double[] last = values[values.length - 1];
-        double lastValue = last[1];
+        double lastValue = values[values.length - 1][1];
         double newValue = lastValue * 3;
-        timeseriesHistogram.replace(newValue, System.currentTimeMillis());
+        timeseriesHistogram.replace(newValue, now);
         values = values();
         assertTrue("value was not replaced",
                    lastValue != values[values.length - 1][1]);
@@ -272,7 +271,6 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
 
     private void assertThatUpdateRotatesBuffer(int units) {
         Double[][] originals = values();
-        long now = System.currentTimeMillis();
 
         timeseriesHistogram.average(2.53, now);
         timeseriesHistogram.average(5.71, now);
@@ -304,10 +302,9 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
 
     private void assertThatUpdateSumsLastValue() {
         Double[][] values = values();
-        Double[] last = values[values.length - 1];
-        double lastValue = last[1];
+        double lastValue = values[values.length - 1][1];
         double newValue = lastValue * 3;
-        timeseriesHistogram.add(newValue, System.currentTimeMillis());
+        timeseriesHistogram.add(newValue, now);
         values = values();
         assertTrue("value was not replaced",
                    lastValue != values[values.length - 1][1]);
@@ -318,7 +315,7 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
     private double getHoursInThePastFromNow(int hours) {
         Calendar calendar = Calendar.getInstance();
         long diff = TimeUnit.HOURS.toMillis(hours);
-        calendar.setTimeInMillis(System.currentTimeMillis() - diff);
+        calendar.setTimeInMillis(now - diff);
         calendar.set(Calendar.MINUTE, 0);
         calendar.set(Calendar.SECOND, 0);
         calendar.set(Calendar.MILLISECOND, 0);
@@ -369,6 +366,7 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
         }
 
         model = timeseriesHistogram;
+        now = System.currentTimeMillis();
     }
 
     private void givenValidTimeframeSpecification() {


### PR DESCRIPTION
Motivation:

Recently we observed a failure of one of the unit tests
for the TimeseriesHistogram (stack trace given in the
testing section).

Examination of the code has not revealed the cause of the failure,
which so far has not been systematically reproducible.

However, a similar potential bug does exist regarding
the computation of 'now', which is inconsistent and may
occasionally create a situation when the buffer is
erroneously rotated during the test.

Modification:

Make sure that the time of the last bin matches the
update time exactly by initializing a single "now"
and reusing it.

Result:

This fixes the (unobserved, potential) bug.
Whether it also fixes the observed failure remains to
be seen.

Target: master
Request: 3.2
Require-book: no
Require-notes: no
Acked-by: Paul