### PR TITLE
pool: fix regression in GridFTP OPTS CKSM command

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
@@ -20,6 +20,7 @@ package org.dcache.pool.movers;
 import com.google.common.base.Optional;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import diskCacheV111.vehicles.PoolIoFileMessage;
@@ -66,6 +67,21 @@ public class MoverProtocolMover extends AbstractMover<ProtocolInfo, MoverProtoco
     public long getLastTransferred()
     {
         return _moverProtocol.getLastTransferred();
+    }
+
+    @Override
+    public Set<Checksum> getActualChecksums() {
+        if (_moverProtocol instanceof ChecksumMover) {
+            Checksum checksum = ((ChecksumMover)_moverProtocol).getActualChecksum();
+            if (checksum != null) {
+                Set<Checksum> checksums = new HashSet<>();
+                checksums.addAll(super.getActualChecksums());
+                checksums.add(checksum);
+                return checksums;
+            }
+        }
+
+        return super.getActualChecksums();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

The 'OPTS CKSM' command allows the client to request that the GridFTP
server calculates a specific type of checksum for subsequent uploads.

Additionally, the Globus transfer service requires MD5 checksum values.
Although it does not make this requirement explicit, the door identifies
the client and acts as if the client issued an 'OPTS CKSM MD5' command.

Commit 7e25b6b8f introduced a regression where, although the desired
checksum was calculated, the value was subsequently discarded and not
available to the client.

Modification:

Update pool to include checksums calculated by the mover.

Result:

The GridFTP 'OPTS CKSM' command is supported again.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10461
Acked-by: Albert Rossi

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java