### PR TITLE
pool: fix data integrity regression for 3rd-party GridFTP pull transfers

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
@@ -203,22 +203,10 @@ public class RemoteGsiftpTransferProtocol
         RemoteGsiftpTransferProtocolInfo remoteGsiftpProtocolInfo
             = (RemoteGsiftpTransferProtocolInfo) protocol;
 
-        /* If on transfer checksum calculation is enabled, check if
-         * we have a protocol specific preferred algorithm.
-         */
-        if (_checksumFactories != null) {
-            ChecksumFactory factory = getChecksumFactory(remoteGsiftpProtocolInfo);
-            if (factory != null) {
-                _checksumFactories = new HashSet<>(Arrays.asList(factory));
-            }
-            _transferMessageDigests = _checksumFactories.stream()
-                                                        .collect(Collectors.toMap(f -> f.getType(),
-                                                                                  f -> f.create()));
-        }
-
         createFtpClient(remoteGsiftpProtocolInfo);
 
         if (access.contains(StandardOpenOption.WRITE)) {
+            getChecksumFactory(remoteGsiftpProtocolInfo); // fetches checksum as side-effect
             gridFTPRead(remoteGsiftpProtocolInfo, allocator);
         } else {
             gridFTPWrite(remoteGsiftpProtocolInfo);
@@ -383,11 +371,6 @@ public class RemoteGsiftpTransferProtocol
     public void enableTransferChecksum(ChecksumType suggestedAlgorithm)
             throws NoSuchAlgorithmException
     {
-        _checksumFactories = new HashSet<>(Arrays.asList(ChecksumFactory.getFactory(suggestedAlgorithm)));
-        _transferMessageDigests =
-                (_checksumFactories != null) ?  _checksumFactories.stream().collect(Collectors.toMap(f -> f.getType(),
-                                                                                                     f -> f.create()))
-                                             : null;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

dCache supports "delegated" 3rd-party GridFTP copy.  This is where
dCache acts as a GridFTP client and communicates directly (and solely)
with some 3rd-party GridFTP server.

In dCache v2.13 and earlier, the pool receiving a file through GridFTP
would try to acquire the file's checksum from the remote server and use
this to ensure data integrity.  Commit 7e25b6b8f resulted in the
enableTransferChecksum method no longer being called, which
unfortunately also stopped the pool from requesting the file's checksum.

Modification:

Update the code so the mover always attempts to find out the file's
checksum from the remote server.

Result:

Fix regression with third-party pull transfers using GridFTP, with
dCache acting as the GridFTP client that prevented data integrity
checks.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Previously: https://rb.dcache.org/r/10451/