### PR TITLE
libs: update nfs4j to version 0.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -804,7 +804,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.15.1</version>
+            <version>0.15.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
Motivation:
minor performance-fix version

Changelog for nfs4j-0.15.1..nfs4j-0.15.2
    * [decd2229] [maven-release-plugin] prepare for next development iteration
    * [661b4c4a] nfs4: return a hard coded value for time_delta attribute
    * [68c6d441] nfs4: provide best possible directory change id on remove
    * [3a275141] [maven-release-plugin] prepare release nfs4j-0.15.2

Modification:
update pom to use nfs4j-0.15.2

Result:
Less GETATTR and ACCESS requests on remove/rename

Acked-by: Paul Millar
Target: master, 3.2
Require-book: no
Require-notes: no
(cherry picked from commit 9d763ab983c70585aa8f3211b03dcf0ad9bf5df3)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>