### PR TITLE
resilience: use scheduled executor to provide optional task launch delay

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
@@ -399,20 +399,27 @@ public final class ResilienceCommands implements CellCommandListener {
         String arg = "INFO";
 
         @Option(name = "checkpoint",
-                        usage = "With reset mode (one of checkpoint|sweep). "
+                        usage = "With reset mode (one of checkpoint|sweep|delay). "
                                         + "Interval length between checkpointing "
                                         + "of the file operation data.")
         Long checkpoint;
 
         @Option(name = "sweep",
-                        usage = "With reset mode (one of checkpoint|sweep). "
+                        usage = "With reset mode (one of checkpoint|sweep|delay). "
                                         + "Minimal interval between sweeps of "
                                         + "the file operations.")
         Long sweep;
 
+        @Option(name = "delay",
+                        usage = "With reset mode (one of checkpoint|sweep|delay). "
+                                        + "Delay before actual execution of a task "
+                                        + "which has been set to the running state.")
+        Long delay;
+
         @Option(name = "unit",
                         valueSpec = "SECONDS|MINUTES|HOURS",
-                        usage = "Checkpoint or sweep interval unit.") TimeUnit unit;
+                        usage = "Checkpoint, sweep or delay interval unit.")
+        TimeUnit unit;
 
         @Option(name = "retries",
                         usage = "Maximum number of retries on a failed operation.")
@@ -476,6 +483,11 @@ public final class ResilienceCommands implements CellCommandListener {
                         if (unit != null) {
                             fileOperationMap.setTimeoutUnit(unit);
                         }
+                    } else if (delay != null) {
+                        fileOperationHandler.setLaunchDelay(delay);
+                        if (unit != null) {
+                            fileOperationHandler.setLaunchDelayUnit(unit);
+                        }
                     }
 
                     if (retries != null) {
@@ -508,6 +520,9 @@ public final class ResilienceCommands implements CellCommandListener {
                                       fileOperationMap.getCheckpointExpiry(),
                                       fileOperationMap.getCheckpointExpiryUnit(),
                                       fileOperationMap.getCheckpointFilePath()));
+            info.append(String.format("task launch delay %s %s\n",
+                                      fileOperationHandler.getLaunchDelay(),
+                                      fileOperationHandler.getLaunchDelayUnit()));
             counters.getFileOpSweepInfo(info);
             counters.getCheckpointInfo(info);
             return info.toString();

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -69,9 +69,9 @@ import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
@@ -139,17 +139,28 @@ public class FileOperationHandler {
 
     private CellStub                  pinManager;
     private CellStub                  pools;
-    private ExecutorService           taskService;
-    private ScheduledExecutorService  scheduledService;
+    private ScheduledExecutorService  taskService;
+    private ScheduledExecutorService  migrationTaskService;
     private FileTaskCompletionHandler completionHandler;
     private InaccessibleFileHandler   inaccessibleFileHandler;
 
-    public ExecutorService getTaskService() {
+    private long        launchDelay       =  0L;
+    private TimeUnit    launchDelayUnit   = TimeUnit.SECONDS;
+
+    public ScheduledExecutorService getTaskService() {
         return taskService;
     }
 
     public ScheduledExecutorService getRemoveService() {
-        return scheduledService;
+        return migrationTaskService;
+    }
+
+    public long getLaunchDelay() {
+       return launchDelay;
+    }
+
+    public TimeUnit getLaunchDelayUnit() {
+        return launchDelayUnit;
     }
 
     public void handleBrokenFileLocation(PnfsId pnfsId, String pool) {
@@ -316,7 +327,7 @@ public class FileOperationHandler {
                         pools,
                         null,   // PnfsManager cell stub not used
                         pinManager,
-                        scheduledService,
+                        migrationTaskService,
                         taskSelectionStrategy,
                         list,
                         false,  // eager; update should not happen
@@ -470,6 +481,14 @@ public class FileOperationHandler {
         this.inaccessibleFileHandler = inaccessibleFileHandler;
     }
 
+    public void setLaunchDelay(long launchDelay) {
+        this.launchDelay = launchDelay;
+    }
+
+    public void setLaunchDelayUnit(TimeUnit launchDelayUnit) {
+        this.launchDelayUnit = launchDelayUnit;
+    }
+
     public void setLocationSelector(LocationSelector locationSelector) {
         this.locationSelector = locationSelector;
     }
@@ -490,11 +509,11 @@ public class FileOperationHandler {
         this.pools = pools;
     }
 
-    public void setScheduledService(ScheduledExecutorService scheduledService) {
-        this.scheduledService = scheduledService;
+    public void setMigrationTaskService(ScheduledExecutorService migrationTaskService) {
+        this.migrationTaskService = migrationTaskService;
     }
 
-    public void setTaskService(ExecutorService taskService) {
+    public void setTaskService(ScheduledExecutorService taskService) {
         this.taskService = taskService;
     }
 

--- a/modules/dcache-resilience/src/main/resources/org/dcache/resilience/resilience.xml
+++ b/modules/dcache-resilience/src/main/resources/org/dcache/resilience/resilience.xml
@@ -113,11 +113,11 @@
       </constructor-arg>
     </bean>
 
-    <bean id="FileOpExecutor" class="org.dcache.util.CDCExecutorServiceDecorator">
+    <bean id="FileOpExecutor" class="org.dcache.util.CDCScheduledExecutorServiceDecorator">
       <description>Thread pool service for executing verification of individual pnfs operations</description>
       <constructor-arg>
-        <bean class="org.dcache.util.BoundedCachedExecutor"
-              destroy-method="shutdownNow">
+        <bean class="java.util.concurrent.Executors" factory-method="newScheduledThreadPool"
+                                                     destroy-method="shutdownNow">
           <constructor-arg value="${resilience.limits.file.operation-threads}"/>
         </bean>
       </constructor-arg>
@@ -230,8 +230,10 @@
       <property name="fileOpMap" ref="FileOpMap"/>
       <property name="poolInfoMap" ref="PoolInfoMap"/>
       <property name="locationSelector" ref="LocationSelector"/>
-      <property name="scheduledService" ref="MigrationExecutor"/>
+      <property name="migrationTaskService" ref="MigrationExecutor"/>
       <property name="taskService" ref="FileOpExecutor"/>
+      <property name="launchDelay" value="${resilience.limits.copy-launch-delay}"/>
+      <property name="launchDelayUnit" value="${resilience.limits.copy-launch-delay.unit}"/>
     </bean>
 
     <bean id="PoolOpHandler" class="org.dcache.resilience.handlers.PoolOperationHandler">

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestBase.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/TestBase.java
@@ -508,7 +508,7 @@ public abstract class TestBase implements Cancellable {
         fileOperationHandler.setLocationSelector(locationSelector);
         fileOperationHandler.setFileOpMap(fileOperationMap);
         fileOperationHandler.setTaskService(longJobExecutor);
-        fileOperationHandler.setScheduledService(scheduledExecutorService);
+        fileOperationHandler.setMigrationTaskService(scheduledExecutorService);
         fileOperationHandler.setPoolStub(testPoolStub);
     }
 

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -241,7 +241,7 @@
       <constructor-arg>
           <bean class="java.util.concurrent.Executors"
                 factory-method="newScheduledThreadPool"
-                destroy-method="shutdown">
+                 destroy-method="shutdown">
               <constructor-arg value="${pool.limits.worker-threads}"/>
               <property name="executeExistingDelayedTasksAfterShutdownPolicy"
                         value="false"/>

--- a/skel/share/defaults/resilience.properties
+++ b/skel/share/defaults/resilience.properties
@@ -259,6 +259,17 @@ resilience.limits.pool.restart-grace-period=6
 resilience.limits.startup-delay=30
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)resilience.limits.startup-delay.unit=SECONDS
 
+# ---- Task launch
+#
+#      Scheduling the task can include a delay between when it has been selected to run
+#      and when it actually starts to execute.  This may be useful in some situations
+#      to avoid races between PnfsManager and resilience in terms of the intial
+#      write to a pool.  This property can also be configured from the admin
+#      interface using file ctrl reset.
+#
+resilience.limits.copy-launch-delay=0
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)resilience.limits.copy-launch-delay.unit=SECONDS
+
 # ---- Copy/migration target selection.
 #
 #      Strategy implementation used to select among available/eligible

--- a/skel/share/services/resilience.batch
+++ b/skel/share/services/resilience.batch
@@ -45,6 +45,8 @@ check -strong resilience.limits.pool.restart-grace-period.unit
 check -strong resilience.limits.pool.scan-threads
 check -strong resilience.limits.startup-delay
 check -strong resilience.limits.startup-delay.unit
+check -strong resilience.limits.copy-launch-delay
+check -strong resilience.limits.copy-launch-delay.unit
 check -strong resilience.pool-selection-strategy
 check -strong resilience.watchdog.scan.period
 check -strong resilience.watchdog.scan.period.unit


### PR DESCRIPTION
Motivation:

One of the issues which the current implementation of
resilience encounters is a race with PnfsManager on the
first write of a file to pool.  Depending on the timing,
resilience may receive the AddCacheLocation message and
react to it, either by a call to force the sticky flag,
or actually initiating the file copy task, before the
pool is actually finished with the write.

In the most benign scenario, this simply causes a retry
by the resilience service.  It may be desirable to
throttle these retries by scheduling the task with a
delay so that it does not react immediately to the
AddCacheLocation message.

Modification:

Change the executor service which runs the ResilienceTask
to a scheduled one, and add a delay configuration.  The
arbitrary delay on retries which is built in to the task
thus may be merged with the new semantics.

The delay is configurable as a property, but also via
the file ctrl reset command, so that it can be dynamically
altered if necessary.

Result:

The ability to throttle launches of copy tasks and
thereby make resilience play a little more nicely
with the pools.

Target: master
Request: 3.2
Require-notes: yes
Require-book: yes
Acked-by: Tigran