### PR TITLE
webdav: fix regression in OPTIONS response

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
@@ -138,11 +138,6 @@ public class MiltonHandler
             case "USERINFO":
                 response.sendError(501, "Not implemented");
                 break;
-            case "OPTIONS":
-                if (isOriginAllow) {
-                    setCORSHeaders(request, response);
-                }
-                break;
             default:
                 Subject subject = Subject.getSubject(AccessController.getContext());
                 ServletRequest req = new DcacheServletRequest(request, context);


### PR DESCRIPTION
Motivation:

Commit 9969b3b7 introduced a regression where the response from the
OPTIONS method was truncated.  Here is a typical response for dCache
v2.16:

    paul@celebrimbor:~$ curl -sSv -X OPTIONS http://release-2-16:2880/ 2>&1 | sed -n 's/^< //p'
    HTTP/1.1 200 OK
    Date: Wed, 20 Sep 2017 12:34:50 GMT
    Server: dCache/2.16.48-SNAPSHOT
    DAV: 1, 2
    MS-Author-Via: DAV
    Accept-Ranges: bytes
    ETag: "000000000000000000000000000000000000_-1799844283"
    Allow: GET, HEAD, MKCOL, PROPFIND, OPTIONS, PUT, DELETE, MOVE, GET, HEAD, PROPPATCH
    Content-Length: 0

and here is the response from dCache v3.0:

    paul@celebrimbor:~$ curl -sSv -X OPTIONS http://release-3-0:2880/ 2>&1 | sed -n 's/^< //p'
    HTTP/1.1 200 OK
    Date: Wed, 20 Sep 2017 12:36:39 GMT
    Server: dCache/3.0.29-SNAPSHOT
    Transfer-Encoding: chunked

Modification:

Remove OPTIONS-specific behaviour, since it is causing the problem (the
'break' prevents falling through to standard behaviour) and an earlier
call already adds the CORS headers.

Result:

Fix regression in OPTIONS output.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9267
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10481/
Acked-by: Tigran Mkrtchyan