### PR TITLE
cells: better error reporting to ensure bugs are understood

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
@@ -1797,7 +1797,7 @@ public class CellShell extends CommandInterpreter
                     } else if (!(error instanceof CommandEvaluationException)) {
                         String msg =
                             Exceptions.getMessageWithCauses(error);
-                        println(err, String.format("%s: line %d: Command failed (%s)",
+                        println(err, String.format("%s: line %d: Command failed: %s",
                                                    source, no, msg));
                     }
                 }

--- a/modules/cells/src/main/java/dmg/util/Exceptions.java
+++ b/modules/cells/src/main/java/dmg/util/Exceptions.java
@@ -3,6 +3,8 @@ package dmg.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
@@ -17,16 +19,28 @@ public class Exceptions
     {
     }
 
+    private static String meaningfulMessage(Throwable t)
+    {
+        return t.getMessage() != null ? t.getMessage() : t.getClass().getName();
+    }
+
     /**
      * Returns the message string of the Throwable and that of all its
      * causes.
      */
     public static String getMessageWithCauses(Throwable t)
     {
-        StringBuilder msg = new StringBuilder(t.getMessage());
+        StringBuilder msg = new StringBuilder(meaningfulMessage(t));
         t = t.getCause();
         while (t != null) {
-            msg.append("; caused by: ").append(t.getMessage());
+            msg.append("; caused by: ");
+            if (t instanceof RuntimeException) {
+                StringWriter w = new StringWriter();
+                t.printStackTrace(new PrintWriter(w));
+                msg.append(w.getBuffer());
+                break; // printStackTrace includes all subsequent causes
+            }
+            msg.append(meaningfulMessage(t));
             t = t.getCause();
         }
         return msg.toString();


### PR DESCRIPTION
Motivation:

Observed the following error on prometheus:

    18 Sep 2017 09:40:55 (System) [] URL [file:/usr/share/dcache/services/zookeeper.batch]: line 42: Command failed ((3) null; caused by: null)

This is problematic as the error message provides almost no information
on what went wrong -- making it almost impossible to understand or fix.

Modification:

Ensure that 'null' message is never logged -- if the message contains
nothing useful, show the class name instead.

The above example could be due to a RuntimeException (e.g., an NPE)
being wrapped with another exception.  Wrapping a RuntimeException is
itself a bug, but one that is compensated for by checking each cause and
showing the normal stack-trace if one is found.

Result:

Better error reporting for certain failure modes.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10469/
Acked-by: Tigran Mkrtchyan