### PR TITLE
pool: fix log and alarms duplication when rebuilding broken entry

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentReplicaStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentReplicaStore.java
@@ -212,15 +212,8 @@ public class ConsistentReplicaStore
              * may thus safe some time for incomplete files.
              */
             if (attributesInNameSpace.isDefined(FileAttribute.SIZE) && attributesInNameSpace.getSize() != length) {
-                String message = String.format(BAD_SIZE_MSG,
-                                               id,
-                                               attributesInNameSpace.getSize(),
-                                               length);
-                _log.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.BROKEN_FILE,
-                                                        id.toString(),
-                                                        _poolName),
-                                                        message);
-                throw new CacheException(message);
+                throw new CacheException(String.format(BAD_SIZE_MSG, id,
+                        attributesInNameSpace.getSize(), length));
             }
 
             /* Verify checksum. Will fail if there is a mismatch.
@@ -253,10 +246,7 @@ public class ConsistentReplicaStore
                      */
                     FileAttributes attributesOnPool = entry.getFileAttributes();
                     if (attributesOnPool.isUndefined(ACCESS_LATENCY)) {
-                        String message = String.format(MISSING_ACCESS_LATENCY, id);
-                        _log.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.BROKEN_FILE, id.toString(),
-                                        _poolName), message);
-                        throw new CacheException(message);
+                        throw new CacheException(String.format(MISSING_ACCESS_LATENCY, id));
                     }
 
                     AccessLatency accessLatency = attributesOnPool.getAccessLatency();
@@ -271,10 +261,7 @@ public class ConsistentReplicaStore
                      */
                     FileAttributes attributesOnPool = entry.getFileAttributes();
                     if (attributesOnPool.isUndefined(RETENTION_POLICY)) {
-                        String message = String.format(MISSING_RETENTION_POLICY, id);
-                        _log.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.BROKEN_FILE, id.toString(),
-                                        _poolName), message);
-                        throw new CacheException(message);
+                        throw new CacheException(String.format(MISSING_RETENTION_POLICY, id));
                     }
 
                     RetentionPolicy retentionPolicy = attributesOnPool.getRetentionPolicy();


### PR DESCRIPTION
Motivation:

The ConsistentReplicaStore, which attempts to recover broken entries,
contains examples of the log-and-throw anti-pattern.  This anti-pattern
can lead to duplicate (or very similar) error messages, which is the
case here: a recovered entry is logged twice and two alarms are sent.

Modification:

Remove the first logging invocation, relying on the second to indicate
that there is a problem.

Result:

Fix duplicate logging of files that are marked broken during pool
startup.

Fix duplicate alarms for files that are marked broken during pool
startup.

Target: master
Require-notes: yes
Require-book: no
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Patch: https://rb.dcache.org/r/10487/
Acked-by: Albert Rossi