### PR TITLE
chimera: fixed database query for storing multiple checksums for a file.

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -1430,12 +1430,13 @@ public class FsSqlDriver {
      */
     void setInodeChecksum(FsInode inode, int type, String value) {
         _jdbc.update("INSERT INTO t_inodes_checksum (inumber,itype,isum) (SELECT * FROM (VALUES (?,?,?)) v WHERE NOT EXISTS " +
-                     "(SELECT 1 FROM t_inodes_checksum WHERE inumber=?))",
+                     "(SELECT 1 FROM t_inodes_checksum WHERE inumber=? AND itype=?))",
                      ps -> {
                          ps.setLong(1, inode.ino());
                          ps.setInt(2, type);
                          ps.setString(3, value);
                          ps.setLong(4, inode.ino());
+                         ps.setInt(5, type);
                      });
     }
 


### PR DESCRIPTION
The db query for setInodeChecksum would only store one checksum per
file. This caused a problem if the ChecksumChannel created and
sent multiple checksums for a file to the PnfsManager. The PnfsManager
would store only one of the checksums. The other checksums were ignored
and never stored.

Ticket:
Acked-by: Paul Millar <paul.millar@desy.de>
Target: master
Require-book:
Require-notes:
Request: 3.0
Request: 2.16
Request: 2.15
Request: 2.14
Request: 2.13
Patch: https://rb.dcache.org/r/10124/

Conflicts:
	modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java