### PR TITLE
dcache-xrootd:  Add support to the xrootd (kxr_)posc flag in (kX…R_)open.

### DIFF
--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -27,6 +27,15 @@
       <property name="excludedDestinations" value="${xrootd.loginbroker.update-topic}"/>
   </bean>
 
+  <bean id="pnfs-stub" class="org.dcache.cells.CellStub">
+    <description>PNFS manager communication stub</description>
+    <property name="destination" value="${xrootd.service.pnfsmanager}"/>
+    <property name="timeout" value="${xrootd.service.pnfsmanager.timeout}"/>
+    <property name="timeoutUnit" value="${xrootd.service.pnfsmanager.timeout.unit}"/>
+    <property name="flags" value="#{ T(dmg.cells.nucleus.CellEndpoint.SendFlag).RETRY_ON_NO_ROUTE_TO_CELL }"/>
+  </bean>
+
+
   <bean id="pool-stub" class="org.dcache.cells.CellStub">
     <description>Pool cell stub</description>
     <property name="timeout" value="${xrootd.service.pool.timeout}"/>
@@ -120,6 +129,7 @@
 
   <bean id="door" class="org.dcache.xrootd.door.XrootdDoor">
     <description>Gateway between xrootd protocol handler and dCache</description>
+    <property name="pnfsStub" ref="pnfs-stub"/>
     <property name="poolStub" ref="pool-stub"/>
     <property name="poolManagerStub">
       <bean class="org.dcache.poolmanager.PoolManagerStub">

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -70,6 +70,14 @@ xrootd.service.poolmanager.timeout = 5400000
 # Cell address of pnfsmanager service
 xrootd.service.pnfsmanager=${dcache.service.pnfsmanager}
 
+# Timeout for pnfsmanager requests
+xrootd.service.pnfsmanager.timeout = 120
+(one-of?MILLISECONDS|\
+	SECONDS|\
+	MINUTES|\
+	HOURS|DAYS)\
+xrootd.service.pnfsmanager.timeout.unit=SECONDS
+
 # Cell address of gplazma service
 xrootd.service.gplazma=${dcache.service.gplazma}
 


### PR DESCRIPTION
Motivation:

The xrootd protocol has a kxr_posc flag(enabling persist on successful close semantics)
in kXR_open. If the file isn’t explicitly closed, it is
not persisted (i.e., automatically deleted).

Modification:

The plan is to do something similar to what SRM does if the kxr_posc flag is set:
- create a temporary upload file (from the door)
- then move the file into the proper place after successful close (from the door)

Result:

The file will be visible and persisted when closed.

Target: master
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9195
Patch: https://rb.dcache.org/r/10374
Committed: master@8xxxxx
Acked-by: Tigran