### PR TITLE
httpd: restore millis to transfer time for transfers.txt

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
@@ -74,29 +74,27 @@ public class TransferInfo implements Serializable {
     private static final long serialVersionUID = 7303353263666911507L;
 
     protected static String getTimeString(long time, boolean display) {
+        if (!display) {
+            return String.valueOf(time);
+        }
+
         DurationParser durations = new DurationParser(time,
                                                       TimeUnit.MILLISECONDS).parseAll();
 
-        if (display) {
-            return String.format("%d+%02d:%02d:%02d",
-                            durations.get(TimeUnit.DAYS),
-                            durations.get(TimeUnit.HOURS),
-                            durations.get(TimeUnit.MINUTES),
-                            durations.get(TimeUnit.SECONDS));
-        }
+        return String.format("%d+%02d:%02d:%02d",
+                             durations.get(TimeUnit.DAYS),
+                             durations.get(TimeUnit.HOURS),
+                             durations.get(TimeUnit.MINUTES),
+                             durations.get(TimeUnit.SECONDS));
+    }
 
-        if (durations.get(TimeUnit.DAYS) > 0) {
-            return String.format("%d d %02d:%02d:%02d",
-                            durations.get(TimeUnit.DAYS),
-                            durations.get(TimeUnit.HOURS),
-                            durations.get(TimeUnit.MINUTES),
-                            durations.get(TimeUnit.SECONDS));
-        }
+    public enum MoverState {
+        NOTFOUND, STAGING, QUEUED, RUNNING, CANCELED, DONE
+    }
 
-        return String.format("%02d:%02d:%02d",
-                        durations.get(TimeUnit.HOURS),
-                        durations.get(TimeUnit.MINUTES),
-                        durations.get(TimeUnit.SECONDS));
+    public enum TransferField {
+        DOMAIN, PROT, UID, GID, VOMSGROUP, PROC, PNFSID,
+        POOL, HOST, STATUS, STATE, WAITING, MOVER
     }
 
     protected String cellName   = "";


### PR DESCRIPTION
Motivation:

Due to a misunderstanding, changes to the transfer info and
transfer observer classes between 2.13 and 2.16
altered the datatype/format for the elapsed time fields
in the transfers.txt (ascii) output.

Modification:

Restore the correct values.

Result:

Older scripts which relied on parsing transfers.txt should not break.

Fixes: #9272 Change of format in transfers.txt after upgrading from 2.13 to 2.16

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
RT: #9272
Acked-by: Dmitry