### PR TITLE
dcache-restful-api: add selection resource and providers

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/DcacheRestApplication.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/DcacheRestApplication.java
@@ -17,6 +17,7 @@ import org.dcache.restful.resources.cells.CellInfoResources;
 import org.dcache.restful.resources.namespace.FileResources;
 import org.dcache.restful.resources.pool.PoolInfoResources;
 import org.dcache.restful.resources.restores.RestoreResources;
+import org.dcache.restful.resources.selection.SelectionResources;
 import org.dcache.restful.resources.transfers.TransferResources;
 
 /**
@@ -39,6 +40,7 @@ public class DcacheRestApplication extends ResourceConfig
         register(RestoreResources.class);
         register(AlarmsResources.class);
         register(PoolInfoResources.class);
+        register(SelectionResources.class);
 
         //register filters
         register(ResponseHeaderFilter.class);

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Link.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Link.java
@@ -1,0 +1,124 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionLink;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPool;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPoolGroup;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionUnitGroup;
+
+public final class Link extends SelectionType {
+    private static final long serialVersionUID = 950577255687796590L;
+
+    private final String          tag;
+    private final UnitPreferences preferences;
+    private final List<String>    unitGroups;
+    private final List<String>    poolGroups;
+    private final List<String>    pools;
+
+    public Link() {
+        this.tag = null;
+        this.preferences = null;
+        this.unitGroups = null;
+        this.poolGroups = null;
+        this.pools = null;
+    }
+
+    public Link(SelectionLink link) {
+        super(link.getName());
+        tag = link.getTag();
+        preferences = new UnitPreferences(link.getPreferences());
+        pools = link.getPools()
+                    .stream()
+                    .map(SelectionPool::getName)
+                    .collect(Collectors.toList());
+        poolGroups = link.getPoolGroupsPointingTo()
+                         .stream()
+                         .map(SelectionPoolGroup::getName)
+                         .collect(Collectors.toList());
+        unitGroups = link.getUnitGroupsTargetedBy()
+                         .stream()
+                         .map(SelectionUnitGroup::getName)
+                         .collect(Collectors.toList());
+    }
+
+    public List<String> getPoolGroups() {
+        return poolGroups;
+    }
+
+    public List<String> getPools() {
+        return pools;
+    }
+
+    public UnitPreferences getPreferences() {
+        return preferences;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public List<String> getUnitGroups() {
+        return unitGroups;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Match.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Match.java
@@ -1,0 +1,127 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.io.Serializable;
+
+public final class Match implements Serializable {
+    private static final long serialVersionUID = -3298166715830066810L;
+
+    private String type      = "READ";
+    private String store     = "*";
+    private String dcache    = "*";
+    private String net       = "*";
+    private String protocol  = "*";
+    private String linkGroup = "none";
+
+    public String getDcache() {
+        return dcache;
+    }
+
+    public String getLinkGroup() {
+        return linkGroup;
+    }
+
+    public String getNet() {
+        return net;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getStore() {
+        return store;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setDcache(String dcache) {
+        this.dcache = dcache;
+    }
+
+    public void setLinkGroup(String linkGroup) {
+        this.linkGroup = linkGroup;
+    }
+
+    public void setNet(String net) {
+        this.net = net;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public void setStore(String store) {
+        this.store = store;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String toPoolManagerCommand() {
+        return "psux match " + type + " " + store + " " + dcache + " " + net
+                        + " " + protocol + (linkGroup.equals("none") ?
+                        "" : " -linkGroup=" + linkGroup);
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Partition.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Partition.java
@@ -1,0 +1,82 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+public final class Partition extends SelectionType {
+    private static final long serialVersionUID = -6863635493817332787L;
+
+    private final Map<String, String> properties;
+
+    public Partition() {
+        properties = null;
+    }
+
+    public Partition(Entry<String, org.dcache.poolmanager.Partition> entry) {
+        super(entry.getKey());
+        properties = entry.getValue().getAllProperties();
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Pool.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Pool.java
@@ -1,0 +1,99 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionLink;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPoolGroup;
+
+public final class Pool extends SelectionTypeWithLinks {
+    private static final long serialVersionUID = -6670696822057242568L;
+    private final List<String> groups;
+
+    public Pool() {
+        groups = null;
+    }
+
+    public Pool(String pool, PoolSelectionUnit psu) {
+        super(pool, psu);
+        groups = psu.getPoolGroupsOfPool(pool)
+                    .stream()
+                    .map(SelectionPoolGroup::getName)
+                    .collect(Collectors.toList());
+    }
+
+    @Override
+    protected List<String> extractLinks(PoolSelectionUnit psu) {
+        return psu.getPoolGroupsOfPool(name)
+                  .stream()
+                  .map(SelectionPoolGroup::getName)
+                  .map(psu::getLinksPointingToPoolGroup)
+                  .flatMap(links -> links.stream())
+                  .map(SelectionLink::getName)
+                  .collect(Collectors.toList());
+    }
+
+    public List<String> getGroups() {
+        return groups;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/PoolGroup.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/PoolGroup.java
@@ -1,0 +1,96 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionLink;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPool;
+
+public final class PoolGroup extends SelectionTypeWithLinks {
+    private static final long serialVersionUID = -3481667048585522521L;
+    private final  List<String> pools;
+
+    public PoolGroup() {
+        this.pools = null;
+    }
+
+    public PoolGroup(String group, PoolSelectionUnit psu) {
+        super(group, psu);
+        pools = psu.getPoolsByPoolGroup(name)
+                   .stream()
+                   .map(SelectionPool::getName)
+                   .collect(Collectors.toList());
+    }
+
+    @Override
+    protected List<String> extractLinks(PoolSelectionUnit psu) {
+        return psu.getLinksPointingToPoolGroup(name)
+                  .stream()
+                  .map(SelectionLink::getName)
+                  .collect(Collectors.toList());
+    }
+
+    public List<String> getPools() {
+        return pools;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/PreferenceResult.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/PreferenceResult.java
@@ -1,0 +1,89 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.io.Serializable;
+import java.util.List;
+
+import diskCacheV111.poolManager.PoolPreferenceLevel;
+
+public final class PreferenceResult implements Serializable {
+    private static final long serialVersionUID = -6647894964723072329L;
+    private final  List<String> pools;
+    private final  String       tag;
+
+    public PreferenceResult() {
+        tag = null;
+        pools = null;
+    }
+
+    public PreferenceResult(PoolPreferenceLevel poolPreferenceLevel) {
+        this.tag = poolPreferenceLevel.getTag();
+        this.pools = poolPreferenceLevel.getPoolList();
+    }
+
+    public List<String> getPools() {
+        return pools;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/SelectionType.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/SelectionType.java
@@ -1,0 +1,78 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.io.Serializable;
+
+public abstract class SelectionType implements Serializable {
+    protected final String name;
+
+    public SelectionType() {
+        name = null;
+    }
+
+    public SelectionType(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/SelectionTypeWithLinks.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/SelectionTypeWithLinks.java
@@ -1,0 +1,84 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.util.List;
+
+import diskCacheV111.poolManager.PoolSelectionUnit;
+
+public abstract class SelectionTypeWithLinks extends SelectionType {
+    protected final List<String> links;
+
+    public SelectionTypeWithLinks() {
+        super(null);
+        links = null;
+    }
+
+    public SelectionTypeWithLinks(String name, PoolSelectionUnit psu) {
+        super(name);
+        links = extractLinks(psu);
+    }
+
+    public List<String> getLinks() {
+        return links;
+    }
+
+    protected abstract List<String> extractLinks(PoolSelectionUnit psu);
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Unit.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/Unit.java
@@ -1,0 +1,94 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionUnitGroup;
+
+public final class Unit extends SelectionType {
+    private static final long serialVersionUID = 5839097559975700910L;
+    private final String       type;
+    private final List<String> groups;
+
+    public Unit() {
+        type = null;
+        groups = null;
+    }
+
+    public Unit(SelectionUnit unit) {
+        super(unit.getName());
+        type = unit.getUnitType();
+        groups = unit.getMemberOfUnitGroups()
+                     .stream()
+                     .map(SelectionUnitGroup::getName)
+                     .collect(Collectors.toList());
+    }
+
+    public List<String> getGroups() {
+        return groups;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/UnitGroup.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/UnitGroup.java
@@ -1,0 +1,98 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionLink;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionUnitGroup;
+
+public final class UnitGroup extends SelectionTypeWithLinks {
+    private static final long serialVersionUID = -5173508468206889927L;
+    private final List<String> units;
+
+    public UnitGroup() {
+        units = null;
+    }
+
+    public UnitGroup(SelectionUnitGroup group, PoolSelectionUnit psu) {
+        super(group.getName(), psu);
+        units = group.getMemeberUnits()
+                     .stream()
+                     .map(SelectionUnit::getName)
+                     .collect(Collectors.toList());
+    }
+
+    public List<String> getUnits() {
+        return units;
+    }
+
+    @Override
+    protected List<String> extractLinks(PoolSelectionUnit psu) {
+        return psu.getUnitGroups().get(name)
+                  .getLinksPointingTo()
+                  .stream()
+                  .map(SelectionLink::getName)
+                  .collect(Collectors.toList());
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/UnitPreferences.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/selection/UnitPreferences.java
@@ -1,0 +1,102 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.selection;
+
+import java.io.Serializable;
+
+import diskCacheV111.poolManager.LinkReadWritePreferences;
+
+public final class UnitPreferences implements Serializable {
+    private static final long serialVersionUID = 6866520870092665548L;
+    private final Integer read;
+    private final Integer write;
+    private final Integer restore;
+    private final Integer p2p;
+
+    public UnitPreferences() {
+        read = null;
+        write = null;
+        restore = null;
+        p2p = null;
+    }
+
+    public UnitPreferences(LinkReadWritePreferences preferences) {
+        read = preferences.getReadPref();
+        write = preferences.getWritePref();
+        restore = preferences.getRestorePref();
+        p2p = preferences.getP2pPref();
+    }
+
+    public Integer getP2p() {
+        return p2p;
+    }
+
+    public Integer getRead() {
+        return read;
+    }
+
+    public Integer getRestore() {
+        return restore;
+    }
+
+    public Integer getWrite() {
+        return write;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/selection/SelectionResources.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/selection/SelectionResources.java
@@ -1,0 +1,266 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.resources.selection;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONException;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import diskCacheV111.poolManager.PoolPreferenceLevel;
+import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.util.CacheException;
+import dmg.cells.nucleus.NoRouteToCellException;
+import org.dcache.cells.CellStub;
+import org.dcache.poolmanager.PoolMonitor;
+import org.dcache.restful.providers.selection.Link;
+import org.dcache.restful.providers.selection.Match;
+import org.dcache.restful.providers.selection.Partition;
+import org.dcache.restful.providers.selection.Pool;
+import org.dcache.restful.providers.selection.PoolGroup;
+import org.dcache.restful.providers.selection.PreferenceResult;
+import org.dcache.restful.providers.selection.Unit;
+import org.dcache.restful.providers.selection.UnitGroup;
+import org.dcache.restful.util.HttpServletRequests;
+import org.dcache.restful.util.ServletContextHandlerAttributes;
+
+/**
+ * <p>RESTful API to the {@link org.dcache.poolmanager.PoolMonitor}, in
+ * order to deliver pool selection and partition information.</p>
+ *
+ * @version v1.0
+ */
+@Path("/selection")
+public final class SelectionResources {
+    @Context
+    ServletContext ctx;
+
+    @Context
+    HttpServletRequest request;
+
+    @GET
+    @Path("/links")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Link> getLink() throws CacheException {
+        if (!HttpServletRequests.isAdmin(request)) {
+            throw new ForbiddenException(
+                            "Link info only accessible to admin users.");
+        }
+
+        PoolMonitor poolMonitor
+                        = ServletContextHandlerAttributes.getRemotePoolMonitor(
+                        ctx);
+
+        return poolMonitor.getPoolSelectionUnit().getLinks().values()
+                          .stream()
+                          .map(Link::new)
+                          .collect(Collectors.toList());
+    }
+
+    @GET
+    @Path("/partitions")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Partition> getPartitions() throws CacheException {
+        if (!HttpServletRequests.isAdmin(request)) {
+            throw new ForbiddenException(
+                            "Partition info only accessible to admin users.");
+        }
+
+        PoolMonitor poolMonitor
+                        = ServletContextHandlerAttributes.getRemotePoolMonitor(
+                        ctx);
+
+        return poolMonitor.getPartitionManager().getPartitions().entrySet()
+                                                .stream()
+                                                .map(Partition::new)
+                                                .collect(Collectors.toList());
+    }
+
+    @GET
+    @Path("/poolgroups")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<PoolGroup> getPoolGroups() throws CacheException {
+        if (!HttpServletRequests.isAdmin(request)) {
+            throw new ForbiddenException(
+                            "Pool group info only accessible to admin users.");
+        }
+
+        PoolMonitor poolMonitor
+                        = ServletContextHandlerAttributes.getRemotePoolMonitor(
+                        ctx);
+
+        PoolSelectionUnit psu = poolMonitor.getPoolSelectionUnit();
+
+        return psu.getPoolGroups().values()
+                                  .stream()
+                                  .map((g) -> new PoolGroup(g.getName(), psu))
+                                  .collect(Collectors.toList());
+    }
+
+    @GET
+    @Path("/pools")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Pool> getPools() throws CacheException {
+        if (!HttpServletRequests.isAdmin(request)) {
+            throw new ForbiddenException(
+                            "Pool info only accessible to admin users.");
+        }
+
+        PoolMonitor poolMonitor
+                        = ServletContextHandlerAttributes.getRemotePoolMonitor(
+                        ctx);
+
+        PoolSelectionUnit psu = poolMonitor.getPoolSelectionUnit();
+
+        return psu.getPools().values()
+                  .stream()
+                  .map((p) -> new Pool(p.getName(), psu))
+                  .collect(Collectors.toList());
+    }
+
+    @GET
+    @Path("/unitgroups")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<UnitGroup> getUnitGroups() throws CacheException {
+        if (!HttpServletRequests.isAdmin(request)) {
+            throw new ForbiddenException(
+                            "Unit group info only accessible to admin users.");
+        }
+
+        PoolMonitor poolMonitor
+                        = ServletContextHandlerAttributes.getRemotePoolMonitor(
+                        ctx);
+
+        PoolSelectionUnit psu = poolMonitor.getPoolSelectionUnit();
+
+        return poolMonitor.getPoolSelectionUnit().getUnitGroups().values()
+                          .stream()
+                          .map((g) -> new UnitGroup(g, psu))
+                          .collect(Collectors.toList());
+    }
+
+    @GET
+    @Path("/units")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Unit> getUnits() throws CacheException {
+        if (!HttpServletRequests.isAdmin(request)) {
+            throw new ForbiddenException(
+                            "Unit info only accessible to admin users.");
+        }
+
+        PoolMonitor poolMonitor
+                        = ServletContextHandlerAttributes.getRemotePoolMonitor(
+                        ctx);
+
+        return poolMonitor.getPoolSelectionUnit().getSelectionUnits().values()
+                          .stream()
+                          .map(Unit::new)
+                          .collect(Collectors.toList());
+    }
+
+    @POST
+    @Path("/match")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<PreferenceResult> match(String requestPayload)
+                    throws CacheException {
+        if (!HttpServletRequests.isAdmin(request)) {
+            throw new ForbiddenException(
+                            "Match info only accessible to admin users.");
+        }
+
+        try {
+            Match match = new ObjectMapper().readValue(requestPayload,
+                                                       Match.class);
+            CellStub poolManager
+                            = ServletContextHandlerAttributes.getPoolManger(ctx);
+            PoolPreferenceLevel[] poolPreferenceLevels =
+                            poolManager.sendAndWait(match.toPoolManagerCommand(),
+                                                    PoolPreferenceLevel[].class);
+
+            List<PreferenceResult> results = new ArrayList<>();
+
+            for (PoolPreferenceLevel level: poolPreferenceLevels) {
+                results.add(new PreferenceResult(level));
+            }
+
+            return results;
+        } catch (JSONException | IllegalArgumentException e) {
+            throw new BadRequestException(e);
+        } catch (IOException | CacheException | InterruptedException | NoRouteToCellException e) {
+            throw new InternalServerErrorException(e);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The new frontend should support the legacy pages found
on webadmin.  One of those allows one to navigate the
PoolSelectionUnit.

Modification:

Create the necessary RESTful interface to convey the data
necessary for constructing the current tables and views.
This includes a number of JSON providers which simplify
the data for this purpose, and the basic resource class.

Result:

Output such as that below is available.

Target: master
Request: 3.2
Require-book: no
Require-notes: yes
Acked-by: Paul