### PR TITLE
dcache-restful-api: Add POST for enable/disable or kill mover to pool…

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/pool/PoolKillMover.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/pool/PoolKillMover.java
@@ -1,0 +1,98 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.pool;
+
+import java.io.Serializable;
+
+/**
+ * <p>Encapsulates information for killing a mover on the pool.</p>
+ */
+public class PoolKillMover implements Serializable {
+    private static final long serialVersionUID = 4199793636351366103L;
+    private static final String DEFAULT_REASON = "Killed by user.";
+
+    private String  pool;
+    private Integer moverId;
+    private String  reason = DEFAULT_REASON;
+
+    public Integer getMoverId() {
+        return moverId;
+    }
+
+    public String getPool() {
+        return pool;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setMoverId(Integer moverId) {
+        this.moverId = moverId;
+    }
+
+    public void setPool(String pool) {
+        this.pool = pool;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/pool/PoolModeUpdate.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/providers/pool/PoolModeUpdate.java
@@ -1,0 +1,121 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.providers.pool;
+
+import java.io.Serializable;
+
+import diskCacheV111.pools.PoolV2Mode;
+
+/**
+ * <p>Encapsulates information for modifying the mode of a given pool.</p>
+ * <p>The operations are limited to enabled, disabled rdonly and disabled strict.
+ *    In addition, the flag can be set to exclude resilience from processing
+ *    the change or not.</p>
+ */
+public class PoolModeUpdate implements Serializable {
+    private static final long serialVersionUID = 4199793636351366103L;
+
+    private String  pool;
+    private boolean strict;
+    private boolean rdonly;
+    private boolean resilience;
+
+    public String getPool() {
+        return pool;
+    }
+
+    public boolean isRdonly() {
+        return rdonly;
+    }
+
+    public boolean isResilience() {
+        return resilience;
+    }
+
+    public boolean isStrict() {
+        return strict;
+    }
+
+    public int mode() {
+        if (rdonly) {
+            return PoolV2Mode.DISABLED_RDONLY;
+        } else if (strict) {
+            return PoolV2Mode.DISABLED_STRICT;
+        }
+
+        return PoolV2Mode.ENABLED;
+    }
+
+    public void setPool(String pool) {
+        this.pool = pool;
+    }
+
+    public void setRdonly(boolean rdonly) {
+        this.rdonly = rdonly;
+    }
+
+    public void setResilience(boolean resilience) {
+        this.resilience = resilience;
+    }
+
+    public void setStrict(boolean strict) {
+        this.strict = strict;
+    }
+}

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/HandlerBuilders.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/HandlerBuilders.java
@@ -34,7 +34,7 @@ public class HandlerBuilders
 {
     public static PnfsHandler pnfsHandler(ServletContext ctx, HttpServletRequest request)
     {
-        CellStub cellStub = ServletContextHandlerAttributes.getCellStub(ctx);
+        CellStub cellStub = ServletContextHandlerAttributes.getPnfsManager(ctx);
         PnfsHandler handler = new PnfsHandler(cellStub);
         handler.setSubject(ServletContextHandlerAttributes.getSubject());
         handler.setRestriction(HttpServletRequests.getRestriction(request));

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/ServletContextHandlerAttributes.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/ServletContextHandlerAttributes.java
@@ -16,18 +16,19 @@ import org.dcache.restful.services.transfers.TransferInfoService;
 import org.dcache.util.list.ListDirectoryHandler;
 
 public class ServletContextHandlerAttributes {
-    public final static String AL = "org.dcache.restful.AL";
-    public final static String BL = "org.dcache.restful.BL";
-    public final static String DL = "org.dcache.restful";
-    public final static String CI = "org.dcache.restful.CI";
-    public final static String CS = "org.dcache.restful.CS";
+    public final static String AL           = "org.dcache.restful.AL";
+    public final static String BL           = "org.dcache.restful.BL";
+    public final static String DL           = "org.dcache.restful";
+    public final static String CI           = "org.dcache.restful.CI";
+    public final static String PNFS_MANAGER = "org.dcache.restful.PNFS_MANAGER";
     public final static String POOL_MANAGER = "org.dcache.restful.PoolManager";
-    public final static String PI =  "org.dcache.restful.PI";
-    public final static String PM = "org.dcache.restful.PM";
-    public final static String RS = "org.dcache.restful.RS";
-    public final static String TF = "org.dcache.restful.TF";
-    public final static String PinMngStub = "org.dcache.restful.PinMngStub";
-    public final static String PathMapper = "org.dcache.restful.PathMapper";
+    public final static String PI           =  "org.dcache.restful.PI";
+    public final static String PM           = "org.dcache.restful.PM";
+    public final static String RS           = "org.dcache.restful.RS";
+    public final static String TF           = "org.dcache.restful.TF";
+    public final static String PIN_MANAGER  = "org.dcache.restful.PIN_MANAGER";
+    public final static String POOL_STUB = "org.dcache.restful.POOL_STUB";
+    public final static String PathMapper   = "org.dcache.restful.PathMapper";
 
     public static Subject getSubject()
     {
@@ -39,9 +40,9 @@ public class ServletContextHandlerAttributes {
         return (ListDirectoryHandler) (ctx.getAttribute(DL));
     }
 
-    public static CellStub getCellStub(ServletContext ctx)
+    public static CellStub getPoolStub(ServletContext ctx)
     {
-        return (CellStub) (ctx.getAttribute(CS));
+        return (CellStub) ctx.getAttribute(POOL_STUB);
     }
 
     public static RemotePoolMonitor getRemotePoolMonitor(ServletContext ctx)
@@ -51,8 +52,12 @@ public class ServletContextHandlerAttributes {
 
     public static CellStub getPinManager(ServletContext ctx)
     {
-        CellStub cellStub = (CellStub) (ctx.getAttribute(PinMngStub));
-        return cellStub;
+        return (CellStub) (ctx.getAttribute(PIN_MANAGER));
+    }
+
+    public static CellStub getPnfsManager(ServletContext ctx)
+    {
+        return (CellStub) (ctx.getAttribute(PNFS_MANAGER));
     }
 
     public static PathMapper getPathMapper(ServletContext ctx)
@@ -67,8 +72,7 @@ public class ServletContextHandlerAttributes {
 
     public static CellStub getPoolManger(ServletContext ctx)
     {
-        CellStub cellStub = (CellStub) ctx.getAttribute(POOL_MANAGER);
-        return cellStub;
+        return (CellStub) ctx.getAttribute(POOL_MANAGER);
     }
 
     public static BillingInfoService getBillingInfoService(ServletContext ctx)

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -56,6 +56,12 @@
       <property name="timeoutUnit" value="${frontend.service.poolmanager.timeout.unit}"/>
   </bean>
 
+  <bean id="pool-stub" class="org.dcache.cells.CellStub">
+    <description>Pool communication stub</description>
+    <property name="timeout" value="${frontend.service.pool.timeout}"/>
+    <property name="timeoutUnit" value="${frontend.service.pool.timeout.unit}"/>
+  </bean>
+
   <bean id="login-stub" class="org.dcache.cells.CellStub">
       <description>Login service communication stub</description>
       <property name="destination" value="${frontend.service.gplazma}"/>
@@ -308,7 +314,7 @@
                                                     <map>
                                                         <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).DL}"
                                                                value-ref="list-handler"/>
-                                                        <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).CS}"
+                                                        <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).PNFS_MANAGER}"
                                                                value-ref="pnfs-stub"/>
                                                         <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).POOL_MANAGER}"
                                                                value-ref="pool-manager-stub"/>
@@ -326,8 +332,10 @@
                                                                value-ref="alarms-info-service"/>
                                                         <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).PI}"
                                                               value-ref="pool-info-service"/>
-                                                        <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).PinMngStub}"
+                                                        <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).PIN_MANAGER}"
                                                                value-ref= "pinManagerStub"/>
+                                                        <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).POOL_STUB}"
+                                                             value-ref= "pool-stub"/>
                                                         <entry key="#{ T(org.dcache.restful.util.ServletContextHandlerAttributes).PathMapper}"
                                                                value-ref= "path-mapper"/>
                                                     </map>

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -57,6 +57,10 @@ frontend.service.gplazma=${dcache.service.gplazma}
 # Cell address of billing service
 frontend.service.billing=${dcache.queue.billing}
 
+# Timeout for pool cell stub requests
+frontend.service.pool.timeout=300000
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pool.timeout.unit=MILLISECONDS
+
 # Timeout for pinmanager requests
 frontend.service.pinmanager.timeout=300000
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pinmanager.timeout.unit=MILLISECONDS

--- a/skel/share/services/frontend.batch
+++ b/skel/share/services/frontend.batch
@@ -9,6 +9,8 @@ check frontend.cell.subscribe
 check -strong frontend.net.port
 check -strong frontend.net.listen
 check -strong frontend.service.alarms
+check -strong frontend.service.pool.timeout
+check -strong frontend.service.pool.timeout.unit
 check -strong frontend.service.pnfsmanager
 check -strong frontend.service.pnfsmanager.timeout
 check -strong frontend.service.pnfsmanager.timeout.unit


### PR DESCRIPTION
… info service

Motivation:

As a concession to legacy support of commands issued
through the webadmin interface, it has been agreed that
the new RESTful API will also allow disabling and enabling
of pools as well as killing movers from the active transfers
page.

Modification:

Add the necessary code to the frontend service to support
this.

Result:

These legacy commands are supported in the new frontend.

Target: master
Request: 3.2
Acked-by: Paul
Require-notes: yes
Require-book: yes