### PR TITLE
dcache-xrootd: Fix login handshake to support xrootd clients (> 4.7.0)

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -52,6 +52,7 @@ import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.XrootdProtocolInfo;
 import org.dcache.xrootd.AbstractXrootdRequestHandler;
 import org.dcache.xrootd.core.XrootdException;
+import org.dcache.xrootd.core.XrootdSessionIdentifier;
 import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.dcache.xrootd.protocol.messages.AuthenticationRequest;
 import org.dcache.xrootd.protocol.messages.CloseRequest;
@@ -59,6 +60,7 @@ import org.dcache.xrootd.protocol.messages.DirListRequest;
 import org.dcache.xrootd.protocol.messages.EndSessionRequest;
 import org.dcache.xrootd.protocol.messages.GenericReadRequestMessage.EmbeddedReadRequest;
 import org.dcache.xrootd.protocol.messages.LoginRequest;
+import org.dcache.xrootd.protocol.messages.LoginResponse;
 import org.dcache.xrootd.protocol.messages.MkDirRequest;
 import org.dcache.xrootd.protocol.messages.MvRequest;
 import org.dcache.xrootd.protocol.messages.OpenRequest;
@@ -80,6 +82,7 @@ import org.dcache.xrootd.protocol.messages.XrootdResponse;
 import org.dcache.xrootd.util.FileStatus;
 import org.dcache.xrootd.util.OpaqueStringParser;
 import org.dcache.xrootd.util.ParseException;
+
 
 import static org.dcache.xrootd.protocol.XrootdProtocol.*;
 
@@ -213,9 +216,9 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
     }
 
     @Override
-    protected XrootdResponse<LoginRequest> doOnLogin(ChannelHandlerContext ctx, LoginRequest msg)
-    {
-        return withOk(msg);
+    protected XrootdResponse<LoginRequest> doOnLogin(ChannelHandlerContext ctx, LoginRequest msg) {
+        XrootdSessionIdentifier sessionId = new XrootdSessionIdentifier();
+        return new LoginResponse(msg, sessionId, "");
     }
 
     @Override


### PR DESCRIPTION
Motivation:

In the 4.7 releases, xrootd client started enforcing protocol requirements
for kXR_login which, unfortunately, broke access to dCache.
xrootd client expects an answer with a 16-character session ID from the door and then
the pool after the redirection.

The login spec can be found at: http://xrootd.org/doc/dev45/XRdv310.htm#_Toc464248819

Without it, the 4.7.0 client declared an error and retries after a while. This will also
fail and so we go into what appears to be a hang. Eventually (after several minutes)
the login will fail with an error.

Modification:

The login answer following the spec has been added in the xrootd pool.

Result:

It works for both xrootd 4.6.1 and 4.7.0.

Target: master
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10510
Committed: master@