### PR TITLE
dcache: fix bug in PoolSelectionUnitV2 match()

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -568,9 +568,9 @@ public class PoolSelectionUnitV2
     public PoolPreferenceLevel[] match(DirectionType type,  String netUnitName, String protocolUnitName,
                     FileAttributes fileAttributes, String linkGroupName) {
 
-        String storeUnitName = fileAttributes.getStorageClass()+"@"+fileAttributes.getHsm();
-        String dCacheUnitName = fileAttributes.getCacheClass();
         StorageInfo storageInfo = fileAttributes.getStorageInfo();
+        String storeUnitName = storageInfo.getStorageClass()+"@"+storageInfo.getHsm();
+        String dCacheUnitName = storageInfo.getCacheClass();
 
         Map<String, String> variableMap = storageInfo.getMap();
 


### PR DESCRIPTION
Motivation:

See issue #3547.

Manifested by the broken commands psu / psux match as well
as on the Pool Selection Setup pages (httpd and webadmin).

The problem lies in the FileAttributes being created using
a StorageUnit; hence the STORAGECLASS, HSM and CACHECLASS
attributes are never defined.

Modification:

Obtain storage class, hsm and cache class from the storage
unit, not directly from the attributes.

Result:

The exception is no longer thrown and matching can
proceed as normal.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Bug: #3547
Acked-by: Tigran