### PR TITLE
dcache-restful-api: lower collector timeout defaults

### DIFF
--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -71,8 +71,8 @@ frontend.service.poolmanager.timeout = 300000
 
 # Timeout for billing requests
 # These properties can also be set interactively through the admin door
-frontend.service.billing.timeout = 300000
-(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.billing.timeout.unit=MILLISECONDS
+frontend.service.billing.timeout = 5
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.billing.timeout.unit=MINUTES
 
 # Timeout for gplazma requests
 frontend.service.gplazma.timeout = 180000
@@ -80,13 +80,13 @@ frontend.service.gplazma.timeout = 180000
 
 # Timeout for transfer info collection
 # These properties can also be set interactively through the admin door
-frontend.service.transfers.timeout=120000
-(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.transfers.timeout.unit=MILLISECONDS
+frontend.service.transfers.timeout=1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.transfers.timeout.unit=MINUTES
 frontend.service.transfers.maxCacheSize=1000
 
 # Timeout for cell info collection
 # These properties can also be set interactively through the admin door
-frontend.service.cell-info.timeout=5
+frontend.service.cell-info.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.cell-info.timeout.unit=MINUTES
 
 # Used for processing updates on messages returned from cells
@@ -94,24 +94,24 @@ frontend.service.cell-info.update-threads=10
 
 # Timeout for restore info collection
 # These properties can also be set interactively through the admin door
-frontend.service.restores.timeout=120000
-(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.restores.timeout.unit=MILLISECONDS
+frontend.service.restores.timeout=1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.restores.timeout.unit=MINUTES
 frontend.service.restores.maxCacheSize=1000
 
 # Timeout for alarms info collection
 # These properties can also be set interactively through the admin door
-frontend.service.alarms.timeout=120000
-(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.alarms.timeout.unit=MILLISECONDS
+frontend.service.alarms.timeout=1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.alarms.timeout.unit=MINUTES
 
 # Timeout for pool info collection
 # These properties can also be set interactively through the admin door
-frontend.service.pool-info.timeout=5
+frontend.service.pool-info.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pool-info.timeout.unit=MINUTES
 
-# Timeout for pool info collection
+# Timeout for pool history info collection
 # These properties can also be set interactively through the admin door
-frontend.service.pool-history.timeout=30
-(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pool-history.timeout.unit=SECONDS
+frontend.service.pool-history.timeout=1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pool-history.timeout.unit=MINUTES
 
 # Name of pool history service
 frontend.service.pool-history=${dcache.service.history}

--- a/skel/share/defaults/history.properties
+++ b/skel/share/defaults/history.properties
@@ -40,7 +40,7 @@ history.service.pools.storage-dir=@dcache.paths.pool-history@
 
 #  ---- Wait interval between successive sweeps of the collector
 #
-history.service.pools.timeout=3
+history.service.pools.timeout=2
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)history.service.pools.timeout.unit=MINUTES
 
 #  ---- Pool manager endpoint
@@ -48,6 +48,6 @@ history.service.pools.timeout=3
 history.service.poolmanager=${dcache.service.poolmanager}
 
 # Timeout for poolmanager requests
-history.service.poolmanager.timeout=5
+history.service.poolmanager.timeout=2
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)history.service.poolmanager.timeout.unit=MINUTES
 


### PR DESCRIPTION
Motivation:

The current periodic timeouts (intervals) for most collectors
run by the frontend services are unnecessarily long.  This
is also true for the history service.

Modification:

Adjust the defaults to 1 minute for most of the frontend
collectors, and 2 for the history service, since it needs
to ping all the pools.

Result:

More immediate change information on the frontend.

Target: master
Request: 3.2
Require-notes: yes
Require-book: no
Acked-by: Tigran