### PR TITLE
dcache-restful-api: avoid NPE in PoolDataRequestProcessor

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/pool/PoolDataRequestProcessor.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/pool/PoolDataRequestProcessor.java
@@ -112,7 +112,8 @@ public final class PoolDataRequestProcessor
                                       long sent) {
         PoolData poolData = message.getData();
 
-        CellData cellData = poolData.getCellData();
+        CellData cellData = poolData == null ? null : poolData.getCellData();
+
         if (cellData != null) {
             cellData.setRoundTripTime(System.currentTimeMillis() - sent);
         }


### PR DESCRIPTION
Motivation:

If the top-level PoolData is undefined, accessing it for
CellData can cause the NPE (as below).

Modification:

Add a guard.

Result:

No NPE.

Target: master
Request: 3.2
Require-notes: no
Require-book: no
Acked-by: Tigran