### PR TITLE
dcache: fix NPE bug in TransferInfo.toFormattedString

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
@@ -302,10 +302,10 @@ public class TransferInfo implements Serializable {
 
         if (moverStatus != null) {
             state = moverStatus.name();
-            size = String.valueOf(bytesTransferred);
-            speed = transferTime > 0 ?
-                            String.valueOf((1000 * bytesTransferred)/(1024 * transferTime))
-                            : "-";
+            if (bytesTransferred != null) {
+                size = String.valueOf(bytesTransferred);
+            }
+            speed = String.valueOf(getTransferRate());
         }
 
         return String.format(FORMAT,


### PR DESCRIPTION
Motivation:

java.lang.NullPointerException: null
        at diskCacheV111.util.TransferInfo.toFormattedString(TransferInfo.java:306)
        ...

Modification:

Add the necessary null check.

Also adjusted size value for similar condition.

Result:

No NPE.

Target: master
Request: 3.2
Acked-by: Tigran
Require-notes: no
Require-book: no