### PR TITLE
dcache-restful-api: fix aggregation issues for pool info and move agg…

### DIFF
--- a/modules/dcache-history/src/main/java/org/dcache/services/history/pools/PoolTimeseriesServiceImpl.java
+++ b/modules/dcache-history/src/main/java/org/dcache/services/history/pools/PoolTimeseriesServiceImpl.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
+import diskCacheV111.poolManager.PoolSelectionUnit;
 import diskCacheV111.vehicles.Message;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.Reply;
@@ -106,15 +107,11 @@ public final class PoolTimeseriesServiceImpl extends
         }
     }
 
-    public Map<TimeseriesType, TimeseriesHistogram> getTimeseries(String pool,
+    public Map<TimeseriesType, TimeseriesHistogram> getTimeseries(String key,
                                                                   Set<TimeseriesType> types) {
         Map<TimeseriesType, TimeseriesHistogram> histograms = new HashMap<>();
 
-        PoolInfoWrapper info = null;
-
-        synchronized (cache) {
-            info = cache.get(pool);
-        }
+        PoolInfoWrapper info = getWrapper(key);
 
         if (info != null) {
             histograms.put(TimeseriesType.ACTIVE_FLUSH, info.getActiveFlush());
@@ -130,7 +127,7 @@ public final class PoolTimeseriesServiceImpl extends
             histograms.put(TimeseriesType.QUEUED_P2P, info.getQueuedP2P());
             histograms.put(TimeseriesType.QUEUED_P2P_CLIENT,
                            info.getQueuedP2PClient());
-            histograms.put(TimeseriesType.QUEUED_STAGE, info.getActiveStage());
+            histograms.put(TimeseriesType.QUEUED_STAGE, info.getQueuedStage());
             histograms.put(TimeseriesType.FILE_LIFETIME_MAX,
                            info.getFileLiftimeMax());
             histograms.put(TimeseriesType.FILE_LIFETIME_AVG,
@@ -142,6 +139,16 @@ public final class PoolTimeseriesServiceImpl extends
         }
 
         return histograms;
+    }
+
+    public PoolInfoWrapper getWrapper(String key) {
+        synchronized (cache) {
+            return cache.get(key);
+        }
+    }
+
+    public PoolSelectionUnit getSelectionUnit() {
+        return monitor.getPoolSelectionUnit();
     }
 
     @Override

--- a/modules/dcache-history/src/main/resources/org/dcache/services/history/history.xml
+++ b/modules/dcache-history/src/main/resources/org/dcache/services/history/history.xml
@@ -59,11 +59,17 @@
     <property name="poolManagerStub" ref="pool-manager-stub"/>
   </bean>
 
+  <bean id="pool-histories-handler" class="org.dcache.util.collector.pools.PoolHistoriesAggregator">
+    <description>Aggregates data for pool groups</description>
+    <property name="service" ref="pool-timeseries-service"/>
+  </bean>
+
   <bean id="pool-request-processor" class="org.dcache.services.history.pools.PoolHistoriesRequestProcessor">
       <description>Processes, caches and stores the live data collected from the pools</description>
       <property name="executor" ref="pool-listener-executor"/>
       <property name="service" ref="pool-timeseries-service"/>
       <property name="storageDir" value="${history.service.pools.storage-dir}"/>
+      <property name="handler" ref="pool-histories-handler"/>
   </bean>
 
   <bean id="pool-data-collector" class="org.dcache.util.collector.pools.PoolLiveDataCollector">

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/pool/PoolInfoServiceImpl.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/pool/PoolInfoServiceImpl.java
@@ -147,6 +147,10 @@ public class PoolInfoServiceImpl extends
      */
     private int maxPoolActivityListSize;
 
+    public ReadWriteData<String, PoolInfoWrapper> getCache() {
+        return cache;
+    }
+
     /**
      * <p>Synchronous.</p>
      */

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -148,6 +148,7 @@
 
   <bean id="pool-histories-handler" class="org.dcache.restful.util.pool.PoolHistoriesHandler">
     <property name="historyService" ref="pool-history-service"/>
+    <property name="poolInfoService" ref="pool-info-service"/>
   </bean>
 
   <bean id="pool-info-collector" class="org.dcache.restful.util.pool.PoolDiagnosticInfoCollector">


### PR DESCRIPTION
…regation to history service

Motivation:

In making the pool info service stateless, collection of timeseries
information for queue status and file lifetime on the pools was
moved into a separate service (history).

This, however, introduced several regressions.  The first was
that new containers were being created for both pools and
pool groups at each pass of the collection, so that the
data was never being updated, simply overwritten.
The second, however, was the oversight in having all
the aggregation still occur in the frontend service. This
means that the timeseries data for individual pools survives
service restarts, but the aggregated data does not.

Modification:

The minor bugs concerning updating vs overwriting have
been repaired.  But more importantly, the aggregation of
mover request and file lifetime histogram data is now
all done in the history service, and is simple requested
by the pool info service (frontend).  This modification
entailed factoring out some methods into common utilities,
the creation of another abstract class with two different
implementations (frontend vs history), and a number of
other attendant changes.

Note that the frontend service still aggregates space
data, since this data can always be reconstructed and
is not persisted to disk by the history service.

Result:

The proper behavior with respect to aggregated (pool group)
timeseries data is now observed.

Target: master
Request: 3.2
Require-notes: no
Require-book: no
Acked-by: Tigran