### PR TITLE
apache sshd: upgrade to 1.3.0 due to security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
             <dependency>
                 <groupId>org.apache.sshd</groupId>
                 <artifactId>sshd-core</artifactId>
-                <version>1.2.0</version>
+                <version>1.3.0</version>
             </dependency>
             <dependency>
                 <!-- Newer versions have two problems. A performance regression causes it to block on non-responding network


### PR DESCRIPTION
Fermilab CST flagged dCache admin port as vulnerable due to 👍 

The remote host is running a version of SSH that is older than (or as old as) version 1.2.23.

The remote version of this software is vulnerable to a known plaintext attack, which could allow an attacker to insert encrypted packets in the client - server stream that will be deciphered by the server, thus allowing the attacker to execute arbitrary commands on the remote server

Solution: Upgrade to version 1.2.25 of SSH which solves this problem.

The upgrade to 1.3.0 apache sshd solves the problem.