### PR TITLE
dcache-restful-api: fix configuration bug in billing collection utils

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/billing/BillingInfoCollectionUtils.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/billing/BillingInfoCollectionUtils.java
@@ -236,7 +236,7 @@ public final class BillingInfoCollectionUtils {
                         msg.setType(type);
                         messages.add(msg);
                         msg = new BillingDataRequestMessage();
-                        msg.setDataType(SeriesDataType.MAXSECS);
+                        msg.setDataType(SeriesDataType.MINSECS);
                         msg.setTimeFrame(timeFrame);
                         msg.setType(type);
                         messages.add(msg);


### PR DESCRIPTION
Motivation:

Connection plots should have MAX, AVG, MIN types.

Modification:

Correct cut-and-paste error duplicating MAX and leaving out MIN.

Result:

Full data for connection plots is returned.

Target: master
Request: 3.2
Acked-by: Tigran