### PR TITLE
dcache: add elapsed time to NearlineData JSON

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -519,6 +519,10 @@ public class NearlineStorageHandler
             info.setActivated(activatedAt);
             info.setCreated(createdAt);
             info.setState(state.get().name());
+            long now = System.currentTimeMillis();
+            info.setTotalElapsed(now-createdAt);
+            info.setRunning(now-activatedAt);
+            info.setUuid(String.valueOf(getId()));
             return info;
         }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/json/NearlineData.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/json/NearlineData.java
@@ -77,6 +77,8 @@ public class NearlineData implements Serializable {
     private String uri;
     private long   created;
     private long   activated;
+    private long   running;
+    private long   totalElapsed;
 
     public long getActivated() {
         return activated;
@@ -90,12 +92,20 @@ public class NearlineData implements Serializable {
         return pnfsId;
     }
 
+    public long getRunning() {
+        return running;
+    }
+
     public String getState() {
         return state;
     }
 
     public String getStorageClass() {
         return storageClass;
+    }
+
+    public long getTotalElapsed() {
+        return totalElapsed;
     }
 
     public String getType() {
@@ -122,12 +132,20 @@ public class NearlineData implements Serializable {
         this.pnfsId = pnfsId;
     }
 
+    public void setRunning(long running) {
+        this.running = running;
+    }
+
     public void setState(String state) {
         this.state = state;
     }
 
     public void setStorageClass(String storageClass) {
         this.storageClass = storageClass;
+    }
+
+    public void setTotalElapsed(long totalElapsed) {
+        this.totalElapsed = totalElapsed;
     }
 
     public void setType(String type) {


### PR DESCRIPTION
Motivation:

Meet request that elapsed time be displayed for nearline movers.

Modification:

Add two fields to the JSON data and set them in the NearlineStorageHandler.
Also set missing id.

Result:

Frontend now has elapsed time computing using backend (pool) clock.

Target:  master
Request: 3.2
Require-notes: no
Require-book: no
Acked-by: Tigran