### PR TITLE
systemtest: authorise developer to login as 'admin' via ssh

### DIFF
--- a/packages/system-test/src/main/bin/populate
+++ b/packages/system-test/src/main/bin/populate
@@ -54,7 +54,7 @@ fi
 if [ ! -f etc/admin/authorized_keys2 ]; then
     for pubkey in id_rsa.pub id_dsa.pub; do
         if [ -f ~/.ssh/$pubkey ]; then
-            cat ~/.ssh/$pubkey >> etc/admin/authorized_keys2
+            awk '{print $1,$2,"admin@localhost"}' ~/.ssh/$pubkey >> etc/admin/authorized_keys2
         fi
     done
 fi


### PR DESCRIPTION
Motivation:

Since support was added to restrict users to access dCache admin
interface only with the user described in the comment, the ssh comment
has become significant.

This means that the populate script could result in a broken setup, with
the user being unable to log in via ssh.

Modification:

Hardcode the username 'admin' in the ssh public-key comment field.

Result:

Developers can log into systemtest admin interface again.

Target: master
Require-notes: no
Require-book: no
Request: 3.2
Patch: https://rb.dcache.org/r/10493/