### PR TITLE
pool: dont disable pool if mover cancelled before open

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.nio.channels.CompletionHandler;
 
 import diskCacheV111.util.CacheException;
@@ -85,9 +86,10 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
      * Enable access with this mover.
      * @param completionHandler to be called when mover finishes.
      * @return handle to cancel mover if needed
+     * @throws InterruptedIOException if mover was cancelled
      * @throws DiskErrorCacheException
      */
-    public Cancellable enable(final CompletionHandler<Void,Void> completionHandler) throws DiskErrorCacheException {
+    public Cancellable enable(final CompletionHandler<Void,Void> completionHandler) throws DiskErrorCacheException, InterruptedIOException {
 
         open();
         _completionHandler = completionHandler;

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Required;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.BindException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -222,7 +223,7 @@ public class NfsTransferService
              * message when the file is closed).
              */
             return cancellableMover;
-        } catch (DiskErrorCacheException | SocketException | RuntimeException e) {
+        } catch (DiskErrorCacheException | InterruptedIOException | SocketException | RuntimeException e) {
             completionHandler.failed(e, null);
         }
         return null;

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -28,6 +28,7 @@ import javax.security.auth.Subject;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.CompletionHandler;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -48,6 +49,7 @@ import org.dcache.pool.classic.TransferService;
 import org.dcache.pool.repository.ReplicaDescriptor;
 import org.dcache.pool.repository.RepositoryChannel;
 import org.dcache.util.Checksum;
+import org.dcache.util.Exceptions;
 import org.dcache.util.TryCatchTemplate;
 import org.dcache.vehicles.FileAttributes;
 
@@ -250,9 +252,10 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
      * TODO: Consider moving this method to RepositoryChannel.
      *
      * @return An open RepositoryChannel to the replica of this mover
+     * @throws InterruptedIOException if the mover was cancelled
      * @throws DiskErrorCacheException If the file could not be opened
      */
-    public RepositoryChannel openChannel() throws DiskErrorCacheException {
+    public RepositoryChannel openChannel() throws DiskErrorCacheException, InterruptedIOException {
         RepositoryChannel channel;
         try {
             channel = _handle.createChannel();
@@ -271,6 +274,8 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
                     Throwables.propagate(t);
                 }
             }
+        } catch (AsynchronousCloseException e) {
+            throw new InterruptedIOException("mover interrupted while opening file: " + Exceptions.messageOrClassName(e));
         } catch (IOException e) {
             throw new DiskErrorCacheException(
                     "File could not be opened; please check the file system: " + e.getMessage(), e);

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannelMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannelMover.java
@@ -18,6 +18,7 @@
 package org.dcache.pool.movers;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 
 import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.vehicles.PoolIoFileMessage;
@@ -79,10 +80,11 @@ public abstract class MoverChannelMover<P extends ProtocolInfo, M extends MoverC
      * about the progress of the transfer.
      *
      * @return an open MoverChannel
+     * @throws InterruptedIOException if the mover was cancelled
      * @throws DiskErrorCacheException if the file could not be opened
      * @throws IllegalStateException if called more than once
      */
-    public synchronized MoverChannel<P> open() throws DiskErrorCacheException
+    public synchronized MoverChannel<P> open() throws DiskErrorCacheException, InterruptedIOException
     {
         checkState(_wrappedChannel == null);
         _wrappedChannel = new MoverChannel<>(this, openChannel(), _allocatorMode);


### PR DESCRIPTION
Motivation:

A bug in gfal2 results in FTP transfers being aborted some 50 ms after
being initiated.  This results in the door killing the mover shortly
after the pool received the PoolDeliverFile message.  If the mover is
not queued, but not yet fully started, the file open results in an
AsynchronousCloseException being thrown.  As an IOException, this is
treated as a problem with the repository.  The result is the pool will
disabling itself.

Modification:

Adjust the open semantics to include the possibility of a mover being
cancelled.  This is represented by an InterruptedIOException.

Result:

A pool no longer disables itself if the client aborts a transfer shortly
after initiating it.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9269
Patch: https://rb.dcache.org/r/10498/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannelMover.java