### PR TITLE
pool: dont disable pool if mover cancelled before open

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/Exceptions.java
+++ b/modules/common/src/main/java/org/dcache/util/Exceptions.java
@@ -1,0 +1,41 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+/**
+ * Utility class for handling exceptions.
+ */
+public class Exceptions
+{
+    private Exceptions()
+    {
+        // prevent instantiation.
+    }
+
+    /**
+     * Return an Exception's message, if it was constructed with one, otherwise
+     * return the Exception's class name.  This method is intended to handle
+     * describing problems (e.g., for logging) identified by an Exception that
+     * was created outside dCache's control.
+     */
+    public static String messageOrClassName(Exception e)
+    {
+        String message = e.getMessage();
+        return message == null ? e.getClass().getName() : message;
+    }
+}

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.nio.channels.CompletionHandler;
 
 import diskCacheV111.util.CacheException;
@@ -84,9 +85,10 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
      * Enable access with this mover.
      * @param completionHandler to be called when mover finishes.
      * @return handle to cancel mover if needed
+     * @throws InterruptedIOException if mover was cancelled
      * @throws DiskErrorCacheException
      */
-    public Cancellable enable(final CompletionHandler<Void,Void> completionHandler) throws DiskErrorCacheException {
+    public Cancellable enable(final CompletionHandler<Void,Void> completionHandler) throws DiskErrorCacheException, InterruptedIOException {
 
         open();
         _completionHandler = completionHandler;

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Required;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.BindException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -216,7 +217,7 @@ public class NfsTransferService extends AbstractCellComponent
             _faultListener.faultOccurred(new FaultEvent("repository", FaultAction.DISABLED,
                     e.getMessage(), e));
             completionHandler.failed(e, null);
-        } catch (SocketException e) {
+        } catch (SocketException | InterruptedIOException e) {
             completionHandler.failed(e, null);
         }
         return null;

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannelMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannelMover.java
@@ -18,6 +18,7 @@
 package org.dcache.pool.movers;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 
 import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.vehicles.PoolIoFileMessage;
@@ -79,10 +80,11 @@ public abstract class MoverChannelMover<P extends ProtocolInfo, M extends MoverC
      * about the progress of the transfer.
      *
      * @return an open MoverChannel
+     * @throws InterruptedIOException if the mover was cancelled
      * @throws DiskErrorCacheException if the file could not be opened
      * @throws IllegalStateException if called more than once
      */
-    public synchronized MoverChannel<P> open() throws DiskErrorCacheException
+    public synchronized MoverChannel<P> open() throws DiskErrorCacheException, InterruptedIOException
     {
         checkState(_wrappedChannel == null);
         _wrappedChannel = new MoverChannel<>(this, openChannel(), _allocatorMode);


### PR DESCRIPTION
Motivation:

A bug in gfal2 results in FTP transfers being aborted some 50 ms after
being initiated.  This results in the door killing the mover shortly
after the pool received the PoolDeliverFile message.  If the mover is
not queued, but not yet fully started, the file open results in an
AsynchronousCloseException being thrown.  As an IOException, this is
treated as a problem with the repository.  The result is the pool will
disabling itself.

Modification:

Adjust the open semantics to include the possibility of a mover being
cancelled.  This is represented by an InterruptedIOException.

Result:

A pool no longer disables itself if the client aborts a transfer shortly
after initiating it.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9269
Patch: https://rb.dcache.org/r/10498/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannelMover.java

Conflicts:
	modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java