### PR TITLE
dcache-restful-api: add offset and limit to fetch of alarms

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/alarms/AlarmsResources.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/resources/alarms/AlarmsResources.java
@@ -106,6 +106,8 @@ public final class AlarmsResources {
      *
      * <p>The Alarms endpoint returns a (filtered) list of alarms.</p>
      *
+     * @param offset specifying the index at which to begin.
+     * @param limit  maximum number of alarms to include.
      * @param after  Return no alarms before this datestamp.
      * @param before Return no alarms after this datestamp.
      * @param type   Return only alarms of this type.
@@ -115,7 +117,9 @@ public final class AlarmsResources {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public List<LogEntry> getAlarms(@QueryParam("after") Long after,
+    public List<LogEntry> getAlarms(@QueryParam("offset") Long offset,
+                                    @QueryParam("limit") Long limit,
+                                    @QueryParam("after") Long after,
                                     @QueryParam("before") Long before,
                                     @QueryParam("type") String type) {
         if (!HttpServletRequests.isAdmin(request)) {
@@ -125,9 +129,8 @@ public final class AlarmsResources {
 
         try {
             return ServletContextHandlerAttributes.getAlarmsInfoService(ctx)
-                                                  .get(after,
-                                                       before,
-                                                       type);
+                                                  .get(offset, limit,
+                                                       after, before, type);
         } catch (IllegalArgumentException | CacheException e) {
             throw new BadRequestException(e);
         } catch (Exception e) {

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/alarms/AlarmsInfoService.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/alarms/AlarmsInfoService.java
@@ -74,14 +74,17 @@ public interface AlarmsInfoService {
      *
      * <p>This method should fetch the list synchronously
      * and throw an exception if it fails.</p>
-     *
+     * @param offset into result list
+     * @param limit max entries to return
      * @param after  no alarms before this datestamp
      * @param before no alarms after this datestamp
      * @param type   only alarms of this type
      * @return list of {@link LogEntry} beans.
      * @throws CacheException if the fetch operation fails.
      */
-    List<LogEntry> get(Long after,
+    List<LogEntry> get(Long offset,
+                       Long limit,
+                       Long after,
                        Long before,
                        String type) throws CacheException, InterruptedException;
 

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/alarms/AlarmsInfoServiceImpl.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/alarms/AlarmsInfoServiceImpl.java
@@ -82,10 +82,10 @@ import org.dcache.vehicles.alarms.AlarmsUpdateMessage;
 
 /**
  * <p>Service layer responsible for querying the alarm service.</p>
- * <p>
+ *
  * <p>Provides several admin commands for diagnostics, as well as
  * implementing the fetch, update and delete methods.</p>
- * <p>
+ *
  * <p>All synchronization is done on the object reference rather
  * than the main map and snapshot cache, in order to
  * allow the cache to be rebuilt.</p>
@@ -129,10 +129,15 @@ public final class AlarmsInfoServiceImpl extends
                                         + "default is all.")
         String type;
 
+        @Option(name = "offset",
+                        usage = "List alarms starting at this index of the result; "
+                                        + "default is 0.")
+        Long offset = 0L;
+
         @Option(name = "limit",
                         usage = "List at most this number of alarms; "
                                         + "default is all.")
-        Integer limit = Integer.MAX_VALUE;
+        Long limit = Long.MAX_VALUE;
 
         @Override
         public String call() throws Exception {
@@ -149,7 +154,8 @@ public final class AlarmsInfoServiceImpl extends
                 beforeInMs = date.getTime();
             }
 
-            List<LogEntry> snapshot = get(afterInMs, beforeInMs, type);
+            List<LogEntry> snapshot = get(offset, limit,
+                                          afterInMs, beforeInMs, type);
 
             StringBuilder builder = new StringBuilder();
             snapshot.stream()
@@ -177,9 +183,12 @@ public final class AlarmsInfoServiceImpl extends
     }
 
     @Override
-    public List<LogEntry> get(Long after, Long before, String type)
+    public List<LogEntry> get(Long offset, Long limit,
+                              Long after, Long before, String type)
                     throws CacheException, InterruptedException {
         AlarmsRequestMessage message = new AlarmsRequestMessage();
+        message.setOffset(offset);
+        message.setLimit(limit);
         message.setAfter(after);
         message.setBefore(before);
         message.setType(type);

--- a/modules/dcache/src/main/java/org/dcache/vehicles/alarms/AlarmsRequestMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/vehicles/alarms/AlarmsRequestMessage.java
@@ -68,9 +68,11 @@ import org.dcache.alarms.LogEntry;
  * <p>Request for list of alarms filtered by date range and/or type.</p>
  */
 public class AlarmsRequestMessage extends Message {
-    private Long before;
-    private Long after;
-    private String type;
+    private Long           limit;
+    private Long           offset;
+    private Long           before;
+    private Long           after;
+    private String         type;
     private List<LogEntry> alarms;
 
     public Long getAfter() {
@@ -83,6 +85,14 @@ public class AlarmsRequestMessage extends Message {
 
     public Long getBefore() {
         return before;
+    }
+
+    public Long getLimit() {
+        return limit;
+    }
+
+    public Long getOffset() {
+        return offset;
     }
 
     public String getType() {
@@ -99,6 +109,14 @@ public class AlarmsRequestMessage extends Message {
 
     public void setBefore(Long before) {
         this.before = before;
+    }
+
+    public void setLimit(Long limit) {
+        this.limit = limit;
+    }
+
+    public void setOffset(Long offset) {
+        this.offset = offset;
     }
 
     public void setType(String type) {


### PR DESCRIPTION
Motivation:

The number of alarms pulled by a filtered fetch is usually not
high, but it is possible for a flurry of alarms to occur and
result in the return of larger lists.

Modification:

Allow the frontend to fetch the alarms in batches by adding
offset and limit to the api.

Result:

Alarm requests can be scaled in batches if necessary.

Target: master
Request: 3.2
Acked-by: Tigran
Require-notes: yes
Require-book: no