### PR TITLE
many: add diagnostic information about remote pool monitor

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolMonitor.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolMonitor.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Required;
 import org.springframework.remoting.RemoteConnectFailureException;
 import org.springframework.remoting.RemoteProxyFailureException;
 
+import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
@@ -38,11 +39,13 @@ import diskCacheV111.vehicles.PoolManagerGetPoolMonitor;
 import diskCacheV111.vehicles.ProtocolInfo;
 
 import dmg.cells.nucleus.CellEndpoint;
+import dmg.cells.nucleus.CellInfoProvider;
 import dmg.cells.nucleus.CellLifeCycleAware;
 import dmg.cells.nucleus.CellMessageReceiver;
 
 import org.dcache.cells.AbstractMessageCallback;
 import org.dcache.cells.CellStub;
+import org.dcache.util.TimeUtils;
 import org.dcache.vehicles.FileAttributes;
 
 import static org.dcache.util.MathUtils.addWithInfinity;
@@ -52,7 +55,7 @@ import static org.dcache.util.MathUtils.subWithInfinity;
  * PoolMonitor that delegates to a PoolMonitor obtained from pool manager.
  */
 public class RemotePoolMonitor
-        implements PoolMonitor, CellLifeCycleAware, CellMessageReceiver
+        implements PoolMonitor, CellLifeCycleAware, CellMessageReceiver, CellInfoProvider
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(RemotePoolMonitor.class);
 
@@ -66,6 +69,19 @@ public class RemotePoolMonitor
     {
         poolManagerStub = stub;
     }
+
+    @Override
+    public void getInfo(PrintWriter pw)
+    {
+        if (lastRefreshTime > 0) {
+            pw.println("last refreshed = " +
+                    TimeUtils.relativeTimestamp(lastRefreshTime, System.currentTimeMillis()));
+
+        }
+        pw.println("refresh count = " + refreshCount);
+        pw.println("active refresh target = " + poolManagerStub);
+    }
+
 
     @Override
     public synchronized void afterStart()


### PR DESCRIPTION
Motivation:

Many dCache components use RemotePoolMonitor to provide fast access to
the information that PoolManager has about pools.  In some cases,
accessing information to help diagnose problems is difficult or
impossible.

Modification:

Add information to the 'info' admin command that describes the current
status of the RemotePoolMonitor.

Result:

Hopefully more information when diagnosing problems to do with
remote-pool-monitor.

Target: master
Require-notes: yes
Require-book: yes
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Patch: https://rb.dcache.org/r/10492/
Acked-by: Tigran Mkrtchyan