### PR TITLE
alarms: remove default value for LogEntry received

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/LogEntry.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/LogEntry.java
@@ -90,9 +90,9 @@ public class LogEntry implements Comparable<LogEntry>, IRegexFilterable {
     private String service;
     private String info;
     private String notes;
-    private Boolean closed = false;
-    private Boolean alarm = false;
-    private Integer received = 1;
+    private Boolean closed   = false;
+    private Boolean alarm    = false;
+    private Integer received;
 
     /*
      *  No longer used, but maintained for backward compatibility.

--- a/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/dao/impl/DataNucleusLogEntryStore.java
@@ -215,6 +215,7 @@ public final class DataNucleusLogEntryStore implements LogEntryDAO, Runnable {
                      */
                     logger.trace("makePersistent alarm, key={}",
                                  entry.getKey());
+                    entry.setReceived(1);
                     insertManager.makePersistent(entry);
                     logger.trace("committing");
                 }


### PR DESCRIPTION
Motivation:

The RESTful services are set to use an object mapper
which suppresses default values on the JSON objects
contained in an ArrayList.

Rather than check for undefined in the javascript
client, it makes more sense to set the value explicitly
rather than relying on the default.

Modification:

Remove the default value for the LogEntry received field
and set it in the DAO implementation.

Result:

The default value appears in the JSON object.

No visible changes to user.

Target: master
Request: 3.2
Require-notes: no
Require-book: no
Acked-by: Tigran