### PR TITLE
dcap: add TTL information to dcap messages

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
@@ -131,9 +131,7 @@ public class PnfsHandler implements CellMessageSender
      * Sends a PnfsMessage to PnfsManager.
      */
     public void send(PnfsMessage msg) {
-        if (_cellStub == null) {
-            throw new IllegalStateException("Missing endpoint");
-        }
+        checkState(_cellStub != null, "Missing endpoint");
 
         if (_subject != null) {
             msg.setSubject(_subject);
@@ -144,6 +142,29 @@ public class PnfsHandler implements CellMessageSender
         }
 
         _cellStub.notify(msg);
+    }
+
+    /**
+     * Send a PnfsMessage to PnfsManager indicating that an expected response
+     * will be ignored after some timeout has elapsed.  This method exists
+     * primarily to support legacy code; new code should consider using the
+     * requestAsync method instead.
+     * @param msg The message to send
+     * @param timeout The duration, in milliseconds, after which any response
+     * will be ignored.
+     */
+    public void send(PnfsMessage msg, long timeout) {
+        checkState(_cellStub != null, "Missing endpoint");
+
+        if (_subject != null) {
+            msg.setSubject(_subject);
+        }
+
+        if (_restriction != null) {
+            msg.setRestriction(_restriction);
+        }
+
+        _cellStub.notify(msg, timeout);
     }
 
     /**

--- a/modules/dcache/src/main/java/org/dcache/cells/CellStub.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/CellStub.java
@@ -28,6 +28,7 @@ import dmg.cells.nucleus.NoRouteToCellException;
 import org.dcache.util.CacheExceptionFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -428,10 +429,20 @@ public class CellStub
      */
     public void notify(Serializable message)
     {
-        if (_destination == null) {
-            throw new IllegalStateException("Destination must be specified");
-        }
+        checkState(_destination != null, "Destination must be specified");
         notify(_destination, message);
+    }
+
+    /**
+     * Sends {@literal message} to the predefined destination specifying a
+     * timeout.  This is used primarily to support legacy cell code that has
+     * explicit asynchronous message handling; newer code should use the
+     * ListenableFuture from the equivalent send method.
+     */
+    public void notify(Serializable message, long timeout)
+    {
+        checkState(_destination != null, "Destination must be specified");
+        notify(_destination, message, timeout);
     }
 
     /**
@@ -439,8 +450,23 @@ public class CellStub
      */
     public void notify(CellPath destination, Serializable message)
     {
+        notify(destination, message, Long.MAX_VALUE);
+    }
+
+    /**
+     * Sends {@literal message} to {@literal destination} specifying a
+     * timeout.  This is used primarily to support legacy cell code that has
+     * explicit asynchronous message handling; newer code should use the
+     * ListenableFuture from the equivalent send method.
+     */
+    public void notify(CellPath destination, Serializable message, long timeout)
+    {
         _rateLimiter.acquire();
-        _endpoint.sendMessage(new CellMessage(destination, message));
+        CellMessage envelope = new CellMessage(destination, message);
+        if (timeout < Long.MAX_VALUE) {
+            envelope.setTtl(timeout);
+        }
+        _endpoint.sendMessage(envelope);
     }
 
     @Override

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/PoolManagerStub.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/PoolManagerStub.java
@@ -159,11 +159,14 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
     }
 
     /**
-     * Submit a request to start a mover to the named pool.
+     * Submit a request to start a mover to the named pool.  Any response
+     * message is handled explicitly within the cell code.
+     *
+     * This method exists primarily to support legacy code; new code should
+     * consider using the startAsync method instead.
      *
      * @param pool The address of the pool
      * @param msg  The mover creation request
-     * @return An asynchronous reply
      */
     public void start(CellAddressCore pool, PoolIoFileMessage msg)
     {
@@ -173,15 +176,37 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
     }
 
     /**
-     * Submit a request to pool manager.
+     * Submit a request to pool manager.  Any response message is handled
+     * explicitly within the cell code.
+     *
+     * This method exists primarily to support legacy code; new code should
+     * consider using the sendAsync method instead.
      *
      * @param msg The pool manager request
-     * @return An asynchronous reply
      */
     public void send(PoolManagerMessage msg)
     {
         CellMessage envelope = new CellMessage();
         envelope.addSourceAddress(address);
+        handler.send(endpoint, envelope, msg);
+    }
+
+    /**
+     * Submit a request to pool manager, indicating that the response will be
+     * ignored after some timeout.  Any response message is handled explicitly
+     * within the cell code.
+     *
+     * This method exists primarily to support legacy code; new code should
+     * consider using the sendAsync method instead.
+     *
+     * @param msg The pool manager request
+     * @param timeout How long before PoolManager should discard this request
+     */
+    public void send(PoolManagerMessage msg, long timeout)
+    {
+        CellMessage envelope = new CellMessage();
+        envelope.addSourceAddress(address);
+        envelope.setTtl(timeout);
         handler.send(endpoint, envelope, msg);
     }
 


### PR DESCRIPTION
Motivation:

The dcap door implements asynchronous requests and includes support for
internal retries.  This means that, if the dcap-door timer indicates
a problem (e.g., a message being lost), the door will resend the message.

PoolManager will (by default) suspend requests for a data stored only on
offline pools.  The dcap door's internal retry will result in multiple
requests if the pool remains down for any appreciable length.
PoolManager will collapse all such requests into a single request
handler instance; so, apart from some additional memory overhead, this
does not present a problem.

The issue comes when the pool comes back up again.  PoolManager attempts
to deliver replies for all the requests.  If the pool has been offline
for some time, then some of clients will have disconnected, killing the
session-specific cell.

For these cells, the domain hosting the dcap door will be unable to
deliver the PoolMgrSelectReadPool response messages to the cell.  The
domain then generates an error message and delivers this back to
PoolManager.

Therefore, when a pool comes back up again, PoolManager becomes very
slow at responding while its message queue is swamped from failed
delivery messages, as it sends the backlog of PoolMgrSelectReadPool
replies.

Modification:

Include a TTL value in dcap messages to PnfsManager and PoolManager.

For PnfsManager, this will likely have no effect, but PoolManager will
remove expired messages periodically.  This will reduce the number of
replies PoolManager sends when the pool comes back up again.

Result:

Less impact from dcap users when an offline pool comes back up again.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9250