### PR TITLE
dcap: add TTL information to dcap messages

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
@@ -126,9 +126,7 @@ public class PnfsHandler
      * Sends a PnfsMessage to PnfsManager.
      */
     public void send(PnfsMessage msg) {
-        if (_cellStub == null) {
-            throw new IllegalStateException("Missing endpoint");
-        }
+        checkState(_cellStub != null, "Missing endpoint");
 
         if (_subject != null) {
             msg.setSubject(_subject);
@@ -139,6 +137,29 @@ public class PnfsHandler
         }
 
         _cellStub.notify(msg);
+    }
+
+    /**
+     * Send a PnfsMessage to PnfsManager indicating that an expected response
+     * will be ignored after some timeout has elapsed.  This method exists
+     * primarily to support legacy code; new code should consider using the
+     * requestAsync method instead.
+     * @param msg The message to send
+     * @param timeout The duration, in milliseconds, after which any response
+     * will be ignored.
+     */
+    public void send(PnfsMessage msg, long timeout) {
+        checkState(_cellStub != null, "Missing endpoint");
+
+        if (_subject != null) {
+            msg.setSubject(_subject);
+        }
+
+        if (_restriction != null) {
+            msg.setRestriction(_restriction);
+        }
+
+        _cellStub.notify(msg, timeout);
     }
 
     /**


### PR DESCRIPTION
Motivation:

The dcap door implements asynchronous requests and includes support for
internal retries.  This means that, if the dcap-door timer indicates
a problem (e.g., a message being lost), the door will resend the message.

PoolManager will (by default) suspend requests for a data stored only on
offline pools.  The dcap door's internal retry will result in multiple
requests if the pool remains down for any appreciable length.
PoolManager will collapse all such requests into a single request
handler instance; so, apart from some additional memory overhead, this
does not present a problem.

The issue comes when the pool comes back up again.  PoolManager attempts
to deliver replies for all the requests.  If the pool has been offline
for some time, then some of clients will have disconnected, killing the
session-specific cell.

For these cells, the domain hosting the dcap door will be unable to
deliver the PoolMgrSelectReadPool response messages to the cell.  The
domain then generates an error message and delivers this back to
PoolManager.

Therefore, when a pool comes back up again, PoolManager becomes very
slow at responding while its message queue is swamped from failed
delivery messages, as it sends the backlog of PoolMgrSelectReadPool
replies.

Modification:

Include a TTL value in dcap messages to PnfsManager and PoolManager.

For PnfsManager, this will likely have no effect, but PoolManager will
remove expired messages periodically.  This will reduce the number of
replies PoolManager sends when the pool comes back up again.

Result:

Less impact from dcap users when an offline pool comes back up again.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9250

Conflicts:
	modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
	modules/dcache/src/main/java/org/dcache/poolmanager/PoolManagerStub.java