### PR TITLE
pool: avoid 'null' and other nondescript error messages

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
@@ -37,8 +37,10 @@ import org.dcache.pool.repository.ReplicaDescriptor;
 import org.dcache.pool.repository.Repository;
 import org.dcache.pool.repository.Repository.OpenFlags;
 import org.dcache.util.Checksum;
+import org.dcache.util.Exceptions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 public class ChecksumScanner
     implements CellCommandListener, CellLifeCycleAware
@@ -145,13 +147,13 @@ public class ChecksumScanner
                         _unableCount++;
                     } catch (IOException e) {
                         _unableCount++;
-                        throw new IOException("failed to read " + id + ": " + e.getMessage(), e);
+                        throw new IOException("failed to read " + id + ": " + messageOrClassName(e), e);
                     }
                     _totalCount++;
                 }
             } catch (IOException e) {
-                _log.error("Aborting 'cms check' full-scan: {}", e.getMessage());
-                setAbortMessage("failure in underlying storage: " + e.getMessage());
+                _log.error("Aborting 'cms check' full-scan: {}", messageOrClassName(e));
+                setAbortMessage("failure in underlying storage: " + messageOrClassName(e));
             } finally {
                 startScrubber();
             }
@@ -260,7 +262,7 @@ public class ChecksumScanner
             try {
                 Files.write(line, _scrubberStateFile, Charset.defaultCharset());
             } catch (IOException e) {
-                _log.error("Failed to save scrubber state ({}) to {}: {}", line, _scrubberStateFile, e.getMessage());
+                _log.error("Failed to save scrubber state ({}) to {}: {}", line, _scrubberStateFile, messageOrClassName(e));
             }
         }
 
@@ -286,7 +288,7 @@ public class ChecksumScanner
                 return;
             } catch (IOException e) {
                 _log.error("Failed to read scrubber saved state from {}: {}",
-                          _scrubberStateFile, e.getMessage());
+                          _scrubberStateFile, messageOrClassName(e));
                 return;
             }
 
@@ -377,8 +379,8 @@ public class ChecksumScanner
                         }
                         isFinished = true;
                     } catch (IOException e) {
-                        _log.error("Aborting scrubber run: {}", e.getMessage());
-                        setAbortMessage("failure in underlying storage: " + e.getMessage());
+                        _log.error("Aborting scrubber run: {}", messageOrClassName(e));
+                        setAbortMessage("failure in underlying storage: " + messageOrClassName(e));
                         Thread.sleep(FAILURE_RATELIMIT_DELAY);
                     } catch (IllegalStateException e) {
                         _log.error("Aborting scrubber run: {}", e.getMessage());
@@ -470,7 +472,7 @@ public class ChecksumScanner
                     }
                 } catch (IOException e) {
                     _unableCount++;
-                    throw new IOException("Unable to read " + id + ": " + e.getMessage(), e);
+                    throw new IOException("Unable to read " + id + ": " + messageOrClassName(e), e);
                 } catch (FileNotInCacheException | NotInTrashCacheException e) {
                     /* It was removed before we could get it. No problem.
                      */

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -46,6 +46,8 @@ import org.dcache.util.CDCExecutorServiceDecorator;
 import org.dcache.util.FireAndForgetTask;
 import org.dcache.vehicles.FileAttributes;
 
+import static org.dcache.util.Exceptions.messageOrClassName;
+
 public class DefaultPostTransferService extends AbstractCellComponent implements PostTransferService, CellInfoProvider
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPostTransferService.class);
@@ -106,7 +108,7 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
             } catch (IOException e) {
                 LOGGER.warn("Transfer failed in post-processing: {}", e.toString());
                 mover.setTransferStatus(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
-                                        "Transfer failed in post-processing: " + e.getMessage());
+                                        "Transfer failed in post-processing: " + messageOrClassName(e));
                 completionHandler.failed(e, null);
             } catch (RuntimeException e) {
                 LOGGER.error(

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
@@ -39,6 +39,7 @@ import org.dcache.vehicles.FileAttributes;
 
 import static org.dcache.pool.repository.ReplicaState.CACHED;
 import static org.dcache.pool.repository.ReplicaState.PRECIOUS;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * Server component of migration module.
@@ -315,7 +316,7 @@ public class MigrationModuleServer
                     break;
                 }
             } catch (IOException e) {
-                finished(new DiskErrorCacheException("I/O error during checksum calculation: " + e.getMessage()));
+                finished(new DiskErrorCacheException("I/O error during checksum calculation: " + messageOrClassName(e)));
             } catch (InterruptedException e) {
                 finished(new CacheException("Task was cancelled"));
             } catch (IllegalTransitionException e) {

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -54,6 +54,7 @@ import org.dcache.util.TryCatchTemplate;
 import org.dcache.vehicles.FileAttributes;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * Abstract base class for movers.
@@ -278,7 +279,8 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
             throw new InterruptedIOException("mover interrupted while opening file: " + Exceptions.messageOrClassName(e));
         } catch (IOException e) {
             throw new DiskErrorCacheException(
-                    "File could not be opened; please check the file system: " + e.getMessage(), e);
+                    "File could not be opened; please check the file system: "
+                    + messageOrClassName(e), e);
         }
         return channel;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
@@ -108,6 +108,7 @@ import org.dcache.util.URIs;
 import org.dcache.vehicles.FileAttributes;
 
 import static org.dcache.util.ByteUnit.KiB;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 public class RemoteGsiftpTransferProtocol
     implements MoverProtocol,ChecksumMover,DataBlocksRecipient
@@ -344,7 +345,7 @@ public class RemoteGsiftpTransferProtocol
         } catch (NoSuchAlgorithmException | GridftpClient.ChecksumNotSupported | IllegalArgumentException e) {
             _log.error("Checksum algorithm is not supported: " + e.getMessage());
         } catch (IOException e) {
-            _log.error("I/O failure talking to FTP server: " + e.getMessage());
+            _log.error("I/O failure talking to FTP server: " + messageOrClassName(e));
         } catch (ServerException e) {
             _log.error("GridFTP server failure: " + e.getMessage());
         } catch (KeyStoreException e) {

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -107,6 +107,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.transform;
 import static com.google.common.util.concurrent.Futures.transformAsync;
 import static org.dcache.namespace.FileAttribute.*;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * Entry point to and management interface for the nearline storage subsystem.
@@ -1067,7 +1068,7 @@ public class NearlineStorageHandler
             } catch (NoSuchAlgorithmException e) {
                 error = new CacheException(1010, "Checksum calculation failed: " + e.getMessage(), e);
             } catch (IOException e) {
-                error = new DiskErrorCacheException("Checksum calculation failed due to I/O error: " + e.getMessage(), e);
+                error = new DiskErrorCacheException("Checksum calculation failed due to I/O error: " + messageOrClassName(e), e);
             } finally {
                 done(error);
             }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentReplicaStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentReplicaStore.java
@@ -33,6 +33,7 @@ import org.dcache.vehicles.FileAttributes;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.isEmpty;
 import static org.dcache.namespace.FileAttribute.*;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * Wrapper for a ReplicaStore which encapsulates the logic for
@@ -155,7 +156,7 @@ public class ConsistentReplicaStore
 
                 entry = rebuildEntry(entry);
             } catch (IOException e) {
-                throw new DiskErrorCacheException("I/O error in healer: " + e.getMessage(), e);
+                throw new DiskErrorCacheException("I/O error in healer: " + messageOrClassName(e), e);
             } catch (FileNotFoundCacheException e) {
                 _replicaStore.remove(id);
                 _log.warn(String.format(FILE_NOT_FOUND_MSG, id));

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/AbstractBerkeleyDBReplicaStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/AbstractBerkeleyDBReplicaStore.java
@@ -46,6 +46,8 @@ import org.dcache.pool.repository.ReplicaStore;
 import org.dcache.pool.repository.RepositoryChannel;
 import org.dcache.util.ConfigurationMapFactoryBean;
 
+import static org.dcache.util.Exceptions.messageOrClassName;
+
 /**
  * Base class for BerkeleyDB backed ReplicaStore implementations.
  *
@@ -162,7 +164,7 @@ public abstract class AbstractBerkeleyDBReplicaStore implements ReplicaStore, En
 
             return true;
         } catch (IOException e) {
-            LOGGER.error("Failed to touch " + tmp + ": " + e.getMessage());
+            LOGGER.error("Failed to touch " + tmp + ": " + messageOrClassName(e));
             return false;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
@@ -28,6 +28,7 @@ import org.dcache.pool.repository.Repository;
 import org.dcache.pool.repository.RepositoryChannel;
 
 import static java.util.Arrays.asList;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * BerkeleyDB based MetaDataRepository implementation.
@@ -99,7 +100,7 @@ public class BerkeleyDBMetaDataRepository extends AbstractBerkeleyDBReplicaStore
         } catch (OperationFailureException e) {
             throw new CacheException("Meta data lookup failed: " + e.getMessage(), e);
         } catch (IOException e) {
-            throw new DiskErrorCacheException("Meta data lookup failed and a pool restart is required: " + e.getMessage(), e);
+            throw new DiskErrorCacheException("Meta data lookup failed and a pool restart is required: " + messageOrClassName(e), e);
         }
     }
 
@@ -123,7 +124,7 @@ public class BerkeleyDBMetaDataRepository extends AbstractBerkeleyDBReplicaStore
         } catch (NoSuchFileException | FileNotFoundException e) {
             return null;
         } catch (IOException e) {
-            throw new CacheException("Failed to read " + id + ": " + e.getMessage(), e);
+            throw new CacheException("Failed to read " + id + ": " + messageOrClassName(e), e);
         }
     }
 
@@ -147,7 +148,7 @@ public class BerkeleyDBMetaDataRepository extends AbstractBerkeleyDBReplicaStore
             return new CacheRepositoryEntryImpl(this, id);
         } catch (IOException e) {
             throw new DiskErrorCacheException(
-                    "Failed to create new entry " + id + ": " + e.getMessage(), e);
+                    "Failed to create new entry " + id + ": " + messageOrClassName(e), e);
         }
     }
 
@@ -158,7 +159,7 @@ public class BerkeleyDBMetaDataRepository extends AbstractBerkeleyDBReplicaStore
         try {
             _fileStore.remove(id);
         } catch (IOException e) {
-            throw new DiskErrorCacheException("Failed to delete " + id);
+            throw new DiskErrorCacheException("Failed to delete " + id + ": " + messageOrClassName(e), e);
         }
         try {
             views.getStorageInfoMap().remove(id.toString());

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/CacheRepositoryEntryImpl.java
@@ -34,6 +34,8 @@ import org.dcache.pool.repository.StickyRecord;
 import org.dcache.pool.repository.v3.entry.CacheRepositoryEntryState;
 import org.dcache.vehicles.FileAttributes;
 
+import static org.dcache.util.Exceptions.messageOrClassName;
+
 public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.UpdatableRecord
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CacheRepositoryEntryImpl.class);
@@ -151,7 +153,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.Up
                     .getFileAttributeView(_pnfsId)
                     .setTimes(FileTime.fromMillis(time), null, null);
         } catch (IOException e) {
-            throw new DiskErrorCacheException("Failed to set modification time: " + _pnfsId, e);
+            throw new DiskErrorCacheException("Failed to set modification time for " + _pnfsId + ": " + messageOrClassName(e), e);
         }
         _lastAccess = System.currentTimeMillis();
     }
@@ -201,7 +203,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.Up
             }
             _state.setState(state);
         } catch (IOException e) {
-            throw new DiskErrorCacheException(e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to set state: " + messageOrClassName(e), e);
         }
         return null;
     }
@@ -212,7 +214,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.Up
         try {
             return _state.removeExpiredStickyFlags();
         } catch (IOException e) {
-            throw new DiskErrorCacheException(e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to remove expired sticky flags: " + messageOrClassName(e), e);
         }
     }
 
@@ -225,7 +227,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.Up
             return false;
 
         } catch (IllegalStateException | IOException e) {
-            throw new DiskErrorCacheException(e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to set sticky: " + messageOrClassName(e), e);
         }
     }
 
@@ -248,7 +250,8 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.Up
                 setStorageInfo(null);
             }
         } catch (IOException e) {
-            throw new DiskErrorCacheException(_pnfsId + " " + e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to set file attributes for "
+                    + _pnfsId + ": " + messageOrClassName(e), e);
         }
         return null;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
@@ -26,6 +26,7 @@ import org.dcache.pool.repository.Repository;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  *
@@ -112,7 +113,7 @@ public class FileMetaDataRepository
             }
             return files;
         } catch (IOException e) {
-            throw new DiskErrorCacheException("Meta data lookup failed and a pool restart is required: " + e.getMessage(), e);
+            throw new DiskErrorCacheException("Meta data lookup failed and a pool restart is required: " + messageOrClassName(e), e);
         }
     }
 
@@ -141,7 +142,7 @@ public class FileMetaDataRepository
             return new CacheRepositoryEntryImpl(id, controlFile, _fileStore, siFile);
         } catch (IOException e) {
             throw new DiskErrorCacheException(
-                    "Failed to create new entry " + id + ": " + e.getMessage(), e);
+                    "Failed to create new entry " + id + ": " + messageOrClassName(e), e);
         }
     }
 
@@ -158,7 +159,7 @@ public class FileMetaDataRepository
             return new CacheRepositoryEntryImpl(id, controlFile, _fileStore, siFile);
         } catch (IOException e) {
             throw new DiskErrorCacheException(
-                    "Failed to read meta data for " + id + ": " + e.getMessage(), e);
+                    "Failed to read meta data for " + id + ": " + messageOrClassName(e), e);
         }
     }
 
@@ -169,7 +170,7 @@ public class FileMetaDataRepository
         try {
             _fileStore.remove(id);
         } catch (IOException e) {
-            throw new DiskErrorCacheException("Failed to remove " + id + ": " + e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to remove " + id + ": " + messageOrClassName(e), e);
         }
         deleteIfExists(_metadir.resolve(id.toString()));
         deleteIfExists(_metadir.resolve("SI-" + id.toString()));
@@ -180,7 +181,7 @@ public class FileMetaDataRepository
         try {
             Files.deleteIfExists(path);
         } catch (IOException e) {
-            throw new DiskErrorCacheException("Failed to remove " + path + ": " + e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to remove " + path + ": " + messageOrClassName(e), e);
         }
     }
 
@@ -196,7 +197,7 @@ public class FileMetaDataRepository
             Files.createFile(tmp);
             return true;
         } catch (IOException e) {
-            _log.error("Failed to touch " + tmp + ": " + e.getMessage(), e);
+            _log.error("Failed to touch " + tmp + ": " + messageOrClassName(e), e);
             return false;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CheckHealthTask.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CheckHealthTask.java
@@ -19,6 +19,8 @@ import org.dcache.pool.repository.Account;
 import org.dcache.pool.repository.ReplicaStore;
 import org.dcache.pool.repository.SpaceRecord;
 
+import static org.dcache.util.Exceptions.messageOrClassName;
+
 class CheckHealthTask implements Runnable
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CheckHealthTask.class);
@@ -130,7 +132,7 @@ class CheckHealthTask implements Runnable
                 }
             } catch (IOException e) {
                 LOGGER.error("Failed to launch health check command '{}': {}",
-                        Arrays.toString(_commands), e.getMessage());
+                        Arrays.toString(_commands), messageOrClassName(e));
             } finally {
                 NDC.pop();
             }


### PR DESCRIPTION
Motivation:

A site reported problems with their pool disabling itself.  The problem
was logged only as:

    Fault occurred in transfer: File could not be opened;
    please check the file system: null.

This provides no guide as to what went wrong.  If the filesystem also
provides no indication then there is no way for the site to investigate
further.

Modification:

The problem comes from the JVM creating an IOException with no message,
perhaps because the exception type is deemed descriptive enough.

Therefore, use a wrapper method to use the message if a message is
provided, or the class name otherwise.

There are a few places where the IO message is copied directly into some
dCache-specific error without including a description about which action
was being attempted when the problem occurred.  These, too, are fixed.

Result:

Potentially more descriptive and useful error messages if a pool suffers
IO errors.

Target: master
Require-notes: yes
Require-book: no
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9269
Patch: https://rb.dcache.org/r/10490/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
	modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
	modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/AbstractBerkeleyDBReplicaStore.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/mongo/CacheRepositoryEntryImpl.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/mongo/MongoDbMetadataRepository.java