### PR TITLE
pool: avoid 'null' and other nondescript error messages

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
@@ -36,8 +36,10 @@ import org.dcache.pool.repository.ReplicaDescriptor;
 import org.dcache.pool.repository.Repository;
 import org.dcache.pool.repository.Repository.OpenFlags;
 import org.dcache.util.Checksum;
+import org.dcache.util.Exceptions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 public class ChecksumScanner
     implements CellCommandListener, CellLifeCycleAware
@@ -133,13 +135,13 @@ public class ChecksumScanner
                         _unableCount++;
                     } catch (IOException e) {
                         _unableCount++;
-                        throw new IOException("failed to read " + id + ": " + e.getMessage(), e);
+                        throw new IOException("failed to read " + id + ": " + messageOrClassName(e), e);
                     }
                     _totalCount++;
                 }
             } catch (IOException e) {
-                _log.error("Aborting 'cms check' full-scan: {}", e.getMessage());
-                setAbortMessage("failure in underlying storage: " + e.getMessage());
+                _log.error("Aborting 'cms check' full-scan: {}", messageOrClassName(e));
+                setAbortMessage("failure in underlying storage: " + messageOrClassName(e));
             } finally {
                 startScrubber();
             }
@@ -248,7 +250,7 @@ public class ChecksumScanner
             try {
                 Files.write(line, _scrubberStateFile, Charset.defaultCharset());
             } catch (IOException e) {
-                _log.error("Failed to save scrubber state ({}) to {}: {}", line, _scrubberStateFile, e.getMessage());
+                _log.error("Failed to save scrubber state ({}) to {}: {}", line, _scrubberStateFile, messageOrClassName(e));
             }
         }
 
@@ -274,7 +276,7 @@ public class ChecksumScanner
                 return;
             } catch (IOException e) {
                 _log.error("Failed to read scrubber saved state from {}: {}",
-                          _scrubberStateFile, e.getMessage());
+                          _scrubberStateFile, messageOrClassName(e));
                 return;
             }
 
@@ -365,8 +367,8 @@ public class ChecksumScanner
                         }
                         isFinished = true;
                     } catch (IOException e) {
-                        _log.error("Aborting scrubber run: {}", e.getMessage());
-                        setAbortMessage("failure in underlying storage: " + e.getMessage());
+                        _log.error("Aborting scrubber run: {}", messageOrClassName(e));
+                        setAbortMessage("failure in underlying storage: " + messageOrClassName(e));
                         Thread.sleep(FAILURE_RATELIMIT_DELAY);
                     } catch (IllegalStateException e) {
                         _log.error("Aborting scrubber run: {}", e.getMessage());
@@ -458,7 +460,7 @@ public class ChecksumScanner
                     }
                 } catch (IOException e) {
                     _unableCount++;
-                    throw new IOException("Unable to read " + id + ": " + e.getMessage(), e);
+                    throw new IOException("Unable to read " + id + ": " + messageOrClassName(e), e);
                 } catch (FileNotInCacheException | NotInTrashCacheException e) {
                     /* It was removed before we could get it. No problem.
                      */

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -46,6 +46,8 @@ import org.dcache.util.CDCExecutorServiceDecorator;
 import org.dcache.util.FireAndForgetTask;
 import org.dcache.vehicles.FileAttributes;
 
+import static org.dcache.util.Exceptions.messageOrClassName;
+
 public class DefaultPostTransferService extends AbstractCellComponent implements PostTransferService
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPostTransferService.class);
@@ -120,7 +122,7 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
             } catch (IOException e) {
                 LOGGER.warn("Transfer failed in post-processing: {}", e.toString());
                 mover.setTransferStatus(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
-                                        "Transfer failed in post-processing: " + e.getMessage());
+                                        "Transfer failed in post-processing: " + messageOrClassName(e));
                 completionHandler.failed(e, null);
             } catch (RuntimeException e) {
                 LOGGER.error(

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
@@ -38,6 +38,7 @@ import org.dcache.vehicles.FileAttributes;
 
 import static org.dcache.pool.repository.EntryState.CACHED;
 import static org.dcache.pool.repository.EntryState.PRECIOUS;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * Server component of migration module.
@@ -314,7 +315,7 @@ public class MigrationModuleServer
                     break;
                 }
             } catch (IOException e) {
-                finished(new DiskErrorCacheException("I/O error during checksum calculation: " + e.getMessage()));
+                finished(new DiskErrorCacheException("I/O error during checksum calculation: " + messageOrClassName(e)));
             } catch (InterruptedException e) {
                 finished(new CacheException("Task was cancelled"));
             } catch (IllegalTransitionException e) {

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -54,6 +54,7 @@ import org.dcache.util.TryCatchTemplate;
 import org.dcache.vehicles.FileAttributes;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * Abstract base class for movers.
@@ -275,7 +276,8 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
             throw new InterruptedIOException("mover interrupted while opening file: " + Exceptions.messageOrClassName(e));
         } catch (IOException e) {
             throw new DiskErrorCacheException(
-                    "File could not be opened; please check the file system: " + e.getMessage(), e);
+                    "File could not be opened; please check the file system: "
+                    + messageOrClassName(e), e);
         }
         return channel;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
@@ -106,6 +106,8 @@ import org.dcache.util.ChecksumType;
 import org.dcache.util.PortRange;
 import org.dcache.vehicles.FileAttributes;
 
+import static org.dcache.util.Exceptions.messageOrClassName;
+
 public class RemoteGsiftpTransferProtocol
     implements MoverProtocol,ChecksumMover,DataBlocksRecipient
 {
@@ -343,7 +345,7 @@ public class RemoteGsiftpTransferProtocol
         } catch (NoSuchAlgorithmException | GridftpClient.ChecksumNotSupported | IllegalArgumentException e) {
             _log.error("Checksum algorithm is not supported: " + e.getMessage());
         } catch (IOException e) {
-            _log.error("I/O failure talking to FTP server: " + e.getMessage());
+            _log.error("I/O failure talking to FTP server: " + messageOrClassName(e));
         } catch (ServerException e) {
             _log.error("GridFTP server failure: " + e.getMessage());
         } catch (KeyStoreException e) {

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -104,6 +104,7 @@ import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Sets.newHashSet;
 import static com.google.common.util.concurrent.Futures.transformAsync;
 import static org.dcache.namespace.FileAttribute.*;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * Entry point to and management interface for the nearline storage subsystem.
@@ -1050,7 +1051,7 @@ public class NearlineStorageHandler extends AbstractCellComponent implements Cel
             } catch (NoSuchAlgorithmException e) {
                 error = new CacheException(1010, "Checksum calculation failed: " + e.getMessage(), e);
             } catch (IOException e) {
-                error = new DiskErrorCacheException("Checksum calculation failed due to I/O error: " + e.getMessage(), e);
+                error = new DiskErrorCacheException("Checksum calculation failed due to I/O error: " + messageOrClassName(e), e);
             } finally {
                 done(error);
             }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
@@ -32,6 +32,7 @@ import static org.dcache.namespace.FileAttribute.CHECKSUM;
 import static org.dcache.namespace.FileAttribute.RETENTION_POLICY;
 import static org.dcache.namespace.FileAttribute.SIZE;
 import static org.dcache.namespace.FileAttribute.STORAGEINFO;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * Wrapper for a MetaDataStore which encapsulates the logic for
@@ -152,7 +153,7 @@ public class ConsistentStore
 
                 entry = rebuildEntry(entry);
             } catch (IOException e) {
-                throw new DiskErrorCacheException("I/O error in healer: " + e.getMessage());
+                throw new DiskErrorCacheException("I/O error in healer: " + messageOrClassName(e));
             } catch (CacheException e) {
                 switch (e.getRc()) {
                 case CacheException.FILE_NOT_FOUND:

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
@@ -33,6 +33,7 @@ import org.dcache.pool.repository.MetaDataStore;
 import org.dcache.util.ConfigurationMapFactoryBean;
 
 import static java.util.Arrays.asList;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * BerkeleyDB based MetaDataRepository implementation.
@@ -261,7 +262,7 @@ public class BerkeleyDBMetaDataRepository
 
             return true;
         } catch (IOException e) {
-            _log.error("Failed to touch " + tmp + ": " + e.getMessage());
+            _log.error("Failed to touch " + tmp + ": " + messageOrClassName(e));
             return false;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/CacheRepositoryEntryImpl.java
@@ -29,6 +29,8 @@ import org.dcache.pool.repository.v3.RepositoryException;
 import org.dcache.pool.repository.v3.entry.CacheRepositoryEntryState;
 import org.dcache.vehicles.FileAttributes;
 
+import static org.dcache.util.Exceptions.messageOrClassName;
+
 public class CacheRepositoryEntryImpl implements MetaDataRecord
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CacheRepositoryEntryImpl.class);
@@ -187,7 +189,7 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
         try {
             _state.setState(state);
         } catch (IOException e) {
-            throw new DiskErrorCacheException(e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to set state: " + messageOrClassName(e), e);
         }
     }
 
@@ -197,7 +199,7 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
         try {
             return _state.removeExpiredStickyFlags();
         } catch (IOException e) {
-            throw new DiskErrorCacheException(e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to remove expired sticky flags: " + messageOrClassName(e), e);
         }
     }
 
@@ -210,7 +212,7 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
             return false;
 
         } catch (IllegalStateException | IOException e) {
-            throw new DiskErrorCacheException(e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to set sticky: " + messageOrClassName(e), e);
         }
     }
 
@@ -234,7 +236,8 @@ public class CacheRepositoryEntryImpl implements MetaDataRecord
                 setStorageInfo(null);
             }
         } catch (IOException e) {
-            throw new DiskErrorCacheException(_pnfsId + " " + e.getMessage(), e);
+            throw new DiskErrorCacheException("Failed to set file attributes for "
+                    + _pnfsId + ": " + messageOrClassName(e), e);
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
@@ -23,6 +23,7 @@ import org.dcache.pool.repository.v3.RepositoryException;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toSet;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  *
@@ -104,7 +105,7 @@ public class FileMetaDataRepository
                 } catch (IllegalArgumentException ignored) {
                 } catch (IOException e) {
                     throw new DiskErrorCacheException(
-                            "Failed to remove " + name + ": " + e.getMessage(), e);
+                            "Failed to remove " + name + ": " + messageOrClassName(e), e);
                 }
             }
         }
@@ -133,7 +134,7 @@ public class FileMetaDataRepository
             return new CacheRepositoryEntryImpl(id, controlFile, dataFile, siFile);
         } catch (IOException e) {
             throw new RepositoryException(
-                    "Failed to create new entry " + id + ": " + e.getMessage(), e);
+                    "Failed to create new entry " + id + ": " + messageOrClassName(e), e);
         }
     }
 
@@ -150,7 +151,7 @@ public class FileMetaDataRepository
             return new CacheRepositoryEntryImpl(id, controlFile, dataFile, siFile, entry);
         } catch (IOException e) {
             throw new RepositoryException(
-                    "Failed to create new entry " + id + ": " + e.getMessage(), e);
+                    "Failed to create new entry " + id + ": " + messageOrClassName(e), e);
         }
     }
 
@@ -168,7 +169,7 @@ public class FileMetaDataRepository
             return new CacheRepositoryEntryImpl(id, controlFile, dataFile, siFile);
         } catch (IOException e) {
             throw new DiskErrorCacheException(
-                    "Failed to read meta data for " + id + ": " + e.getMessage(), e);
+                    "Failed to read meta data for " + id + ": " + messageOrClassName(e), e);
         }
     }
 
@@ -189,7 +190,7 @@ public class FileMetaDataRepository
             Files.deleteIfExists(siFile.toPath());
         } catch (IOException e) {
             throw new DiskErrorCacheException(
-                    "Failed to remove meta data for " + id + ": " + e.getMessage(), e);
+                    "Failed to remove meta data for " + id + ": " + messageOrClassName(e), e);
         }
     }
 
@@ -211,7 +212,7 @@ public class FileMetaDataRepository
 
             return true;
         } catch (IOException e) {
-            _log.error("Failed to touch " + tmp + ": " + e.getMessage(), e);
+            _log.error("Failed to touch " + tmp + ": " + messageOrClassName(e), e);
             return false;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CheckHealthTask.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CheckHealthTask.java
@@ -19,6 +19,8 @@ import org.dcache.pool.repository.Account;
 import org.dcache.pool.repository.MetaDataStore;
 import org.dcache.pool.repository.SpaceRecord;
 
+import static org.dcache.util.Exceptions.messageOrClassName;
+
 class CheckHealthTask implements Runnable
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CheckHealthTask.class);
@@ -130,7 +132,7 @@ class CheckHealthTask implements Runnable
                 }
             } catch (IOException e) {
                 LOGGER.error("Failed to launch health check command '{}': {}",
-                        Arrays.toString(_commands), e.getMessage());
+                        Arrays.toString(_commands), messageOrClassName(e));
             } finally {
                 NDC.pop();
             }


### PR DESCRIPTION
Motivation:

A site reported problems with their pool disabling itself.  The problem
was logged only as:

    Fault occurred in transfer: File could not be opened;
    please check the file system: null.

This provides no guide as to what went wrong.  If the filesystem also
provides no indication then there is no way for the site to investigate
further.

Modification:

The problem comes from the JVM creating an IOException with no message,
perhaps because the exception type is deemed descriptive enough.

Therefore, use a wrapper method to use the message if a message is
provided, or the class name otherwise.

There are a few places where the IO message is copied directly into some
dCache-specific error without including a description about which action
was being attempted when the problem occurred.  These, too, are fixed.

Result:

Potentially more descriptive and useful error messages if a pool suffers
IO errors.

Target: master
Require-notes: yes
Require-book: no
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9269
Patch: https://rb.dcache.org/r/10490/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
	modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
	modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/AbstractBerkeleyDBReplicaStore.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/mongo/CacheRepositoryEntryImpl.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/mongo/MongoDbMetadataRepository.java

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
	modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
	modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
	modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentStore.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/AbstractBerkeleyDBReplicaStore.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/BerkeleyDBMetaDataRepository.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/CacheRepositoryEntryImpl.java
	modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java