### PR TITLE
alarms: fix shutdown timeout

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/alarms/logback/alarms.xml
+++ b/modules/dcache/src/main/resources/org/dcache/alarms/logback/alarms.xml
@@ -56,7 +56,7 @@
         <property name="access" ref="alarmStore"/>
         <property name="map" ref="priorityMap"/>
         <property name="executor">
-            <bean class="org.dcache.util.BoundedCachedExecutor">
+            <bean class="org.dcache.util.BoundedCachedExecutor" destroy-method="shutdown">
                 <constructor-arg value="${alarms.limits.message-threads}"/>
             </bean>
         </property>


### PR DESCRIPTION
Motivation:

Commit 50f32f57 introduced an ExecutorService but mistakenly omitted to
shut it down when dCache is terminating.  After a grace period, the
system infrastructure determines that there is a problem and forcefully
kills off the affending threads, logging the problem with messages like:

16 Oct 2017 14:14:00 (alarms) [] Forcefully interrupting thread pool-6-thread-1 during shutdown.

Apart from slowing down admin and development activity, this delay
increases the likelihood that the 'daemon' script will explicitly kill
the JVM process, which could lead to improper shutdown and subsequent
increased start-up time as services attempt to recover.

Modification:

Shut down ExecutorService when dCache is shutting down.

Result:

The 'dcache stop' command is much faster.

No more "Forcefully interrupting thread ... during shutdown." messages.

Target: master
Request: 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10545/
Acked-by: Albert Rossi