### PR TITLE
alarms: fix natural order comparator to use timestamp first

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/alarms/LogEntry.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/LogEntry.java
@@ -104,9 +104,6 @@ public class LogEntry implements Comparable<LogEntry>, IRegexFilterable {
 
     @Override
     public int compareTo(LogEntry o) {
-        if (o == null) {
-            return -1;
-        }
         return ComparisonChain.start()
                               .compare(lastUpdate, o.lastUpdate)
                               .compare(firstArrived, o.firstArrived)

--- a/modules/dcache/src/main/java/org/dcache/alarms/LogEntry.java
+++ b/modules/dcache/src/main/java/org/dcache/alarms/LogEntry.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.alarms;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ComparisonChain;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -103,8 +104,14 @@ public class LogEntry implements Comparable<LogEntry>, IRegexFilterable {
 
     @Override
     public int compareTo(LogEntry o) {
-        Preconditions.checkNotNull(o, "alarm entry parameter was null");
-        return key.compareTo(o.key);
+        if (o == null) {
+            return -1;
+        }
+        return ComparisonChain.start()
+                              .compare(lastUpdate, o.lastUpdate)
+                              .compare(firstArrived, o.firstArrived)
+                              .compare(key, o.key)
+                              .result();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

The natural order sorting of alarms currently is
based on its key.  This will work for most types
of alarms because the timestamp is included in
the key string.  However, generic alarms
have a UUID as key, so sorting is suboptimal
in that case.

Modification:

Sort first on the last modified timestamp.  Should
those be equal, then try creation time, and only
thereafter use the key to sort them.

Result:

All alarms are implicitly ordered by at least
their latest modification timestamp.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: no
Require-book: no
Acked-by: Paul