### PR TITLE
resilience: force tag partition checking on scans from admin command …

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -329,9 +329,10 @@ public final class FileUpdate {
         /*
          * Files may be in need of migration even if the correct number
          * exist.  Force the file operation into the table if the
-         * storage unit matches the modified one.
+         * storage unit matches the modified one, or if this is a periodic
+         * or admin initiated scan.
          */
-        if (unitIndex.equals(storageUnit)) {
+        if (storageUnit == ScanSummary.ALL_UNITS || unitIndex.equals(storageUnit)) {
             /*
              * The maximum number of steps required to redistribute all files
              * would be (required - 1) removes + (required - 1) copies.
@@ -373,8 +374,7 @@ public final class FileUpdate {
 
         /**
          * Multiple copies per update are set only when the file is a new
-         * entry in the namespace, or when the scan of the pool is periodic or
-         * forced by an admin command. A pool status change or clear cache
+         * entry in the namespace. A pool status change or clear cache
          * location message will trigger only a single migration or single
          * remove.
          */

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperation.java
@@ -95,7 +95,8 @@ public final class PoolOperation {
     long                    lastUpdate;
     long                    lastScan;
     Integer                 group;         // Only set when the psuAction != NONE
-    Integer                 unit;          // Only set when the psuAction == MODIFY
+    Integer                 unit;          // Set when unit has changed, or scan
+                                           // is periodic or initiated by command
     State                   state;
     SelectionAction         psuAction;
     PoolStatusForResilience lastStatus;

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
@@ -83,6 +83,7 @@ import org.dcache.alarms.AlarmMarkerFactory;
 import org.dcache.alarms.PredefinedAlarm;
 import org.dcache.resilience.data.PoolOperation.NextAction;
 import org.dcache.resilience.data.PoolOperation.State;
+import org.dcache.resilience.db.ScanSummary;
 import org.dcache.resilience.handlers.PoolOperationHandler;
 import org.dcache.resilience.util.CheckpointUtils;
 import org.dcache.resilience.util.ExceptionMessage;
@@ -491,7 +492,12 @@ public class PoolOperationMap extends RunnableModule {
                          *  true overrides considerations of whether
                          *  the pool has already been scanned because
                          *  it is down, or has been excluded.
+                         *
+                         *  Since this is an admin command, we force the
+                         *  check on partitions as well.
                          */
+                        operation.unit = ScanSummary.ALL_UNITS;
+
                         if (doScan(poolInfoMap.getPoolState(pool), true)) {
                             reply.append("\t").append(pool).append("\n");
                         }
@@ -913,6 +919,10 @@ public class PoolOperationMap extends RunnableModule {
                     i.remove();
                     operation.forceScan = true;
                     operation.state = State.WAITING;
+                    /*
+                     *  This is a periodic scan, so check for repartitioning.
+                     */
+                    operation.unit = ScanSummary.ALL_UNITS;
                     waiting.put(pool, operation);
                 } else {
                     /**

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolStateUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolStateUpdate.java
@@ -76,7 +76,7 @@ import org.dcache.resilience.util.PoolSelectionUnitDecorator.SelectionAction;
  * @see PoolInfoMap#getPoolState(String, Integer, Integer, String)
  * @see PoolInformation#updateState(PoolStateUpdate)
  * @see PoolOperationMap#update(PoolStateUpdate)
- * @see PoolOperationMap#scan(PoolStateUpdate)
+ * @see PoolOperationMap#scan(PoolStateUpdate, boolean)
  * @see PoolOperationHandler#handlePoolStatusChange(PoolStateUpdate)
  * @see ResilienceMessageHandler#handleInternalMessage(PoolStateUpdate)
  */

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/db/ScanSummary.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/db/ScanSummary.java
@@ -67,6 +67,8 @@ import org.dcache.resilience.util.PoolSelectionUnitDecorator.SelectionAction;
  *    namespace access.</p>
  */
 public final class ScanSummary {
+    public static final Integer ALL_UNITS = -1;
+
     private final String          pool;
     private final MessageType     type;
     private final SelectionAction action;


### PR DESCRIPTION
…and periodic checks

Motivation:

One of the features of resilience is the enforcement of file
partioning on pools according to pool tags.   The pool tag
restrictions are observed whenever a file is copied.  In
addition, it is rechecked when a storage unit is updated,
in order to make sure the files are distributed correctly
according to the new requirements.  This is done by
removing the offending copies and recopying them in
a new location.

Should files get redistributed, however, by rebalancing or
a migration job, it is possible that the partitioning will
be violated, since only resilience observes it.

For this reason, resilience ought to check for these anomalies
regularly in order to rectify them.  This should be done
during the periodic scan.

Modification:

Add to the current triggering of checks for partitioning
a condition associated with periodic scans and those forced
by the admin command.

Result:

The behavior of resilience can be summarized as follows:

1.  new file:      make all necessary copies, properly distributed by tags
2.  pool up/down:  replace the missing copy or remove the excess one, observing the tags
3.  change to storage unit:  run the scan repartitioning if necessary and adding or removing files as necessary
4.  periodic scan & admin scan:  as with (3), run a total check, including on paritioning constraints.

This patch has added (4).

Target: master
Require-notes: yes
Require-book: yes
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Acked-by: Dmitry