### PR TITLE
nfs: change the way how directory cookies are generated

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
@@ -263,7 +263,7 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
                 e -> new DirectoryEntry(e.getName(),
                         toInode(e.getInode()),
                         fromChimeraStat(e.getStat(), e.getInode().ino()),
-                        e.getStat().getIno()));
+                        direcotryCookieOf(e.getStat(), e.getName())));
 
         return new DirectoryStream(currentVerifier, list);
     }
@@ -692,4 +692,12 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
     }
 
 
+    /**
+     * Generate directory cookie for a given entry.
+     */
+    private long direcotryCookieOf(org.dcache.chimera.posix.Stat stat, String name) {
+        // to avoid collisions when on hard links, generate cookie based on inumber and name hash
+        // reset upper bit to have only positive numbers
+        return (stat.getIno() << 32 | name.hashCode()) & 0x7FffffffffffffffL;
+    }
 }


### PR DESCRIPTION
Motivation:
Directory cookies used by clients to identify a file in the directory
listing. They expected to be permanent and unique per file per directory.
As dCache uses file inumber as a directory cookie, in case of hard-links
in the same directory we get two files files with the same cookie. This
confuses a) TreeSet, as both entries are treated as the same, b) nfs client,
as it expects then to be unique.

Modification:
To avoid chimera db schema change, we introduce a cookie which are a combination
of file's inumber + names hash. This guarantees, that newly created entries will
have higher cookie number. To avoid negative numbers, the higher bit is
set to zero (0).

Result:
dCache correctly lists directory with hard links in it.

Acked-by: Paul Millar
Target: master, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit f2f9e624a6d0f97125059c0fb6830aca0552a010)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>