### PR TITLE
dcache-frontend: fix shutdown not to cause stack trace in collection …

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/cells/CellInfoCollector.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/cells/CellInfoCollector.java
@@ -103,7 +103,7 @@ public final class CellInfoCollector extends
                               GetAllDomainsReply.class).get();
         } catch (ExecutionException e) {
             LOGGER.error("Could not contact Routing Manager: {}, {}.",
-                         e.getMessage(), e.getCause());
+                         e.getMessage(), String.valueOf(e.getCause()));
             return Collections.EMPTY_MAP;
         }
 

--- a/modules/dcache/src/main/java/org/dcache/services/collector/CellDataCollectingService.java
+++ b/modules/dcache/src/main/java/org/dcache/services/collector/CellDataCollectingService.java
@@ -277,6 +277,12 @@ public abstract class CellDataCollectingService<D, C extends CellMessagingCollec
 
     @Override
     public void beforeStop() {
+        /*
+         * Make sure scheduled execution is interrupted.  This will
+         * prevent another pass of the collector, and thus potentially
+         * more cell messages from being sent.
+         */
+        interrupt();
         collector.shutdown();
     }
 


### PR DESCRIPTION
…services

Motivation:

Observed on shutdown:

19 Oct 2017 16:21:50 (Frontend-sisyphus) [] Could not contact Routing Manager: CacheException(rc=10006;msg=Request to [>RoutingMgr@local] timed out.), {}.
diskCacheV111.util.TimeoutCacheException: Request to [>RoutingMgr@local] timed out.
	at org.dcache.cells.FutureCellMessageAnswerable.answerTimedOut(FutureCellMessageAnswerable.java:60) ~[dcache-core-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at dmg.cells.nucleus.CellNucleus.lambda$timeOutMessage$11(CellNucleus.java:1086) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:435) ~[guava-20.0.jar:na]
	at dmg.cells.nucleus.CellNucleus.timeOutMessage(CellNucleus.java:1082) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at dmg.cells.nucleus.CellNucleus.sendMessage(CellNucleus.java:555) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at dmg.cells.nucleus.CellAdapter.sendMessage(CellAdapter.java:468) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.dcache.cells.CellStub.send(CellStub.java:418) ~[dcache-core-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.dcache.cells.CellStub.send(CellStub.java:401) ~[dcache-core-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.dcache.restful.util.cells.CellInfoCollector.collectData(CellInfoCollector.java:101) [dcache-frontend-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.dcache.restful.util.cells.CellInfoCollector.collectData(CellInfoCollector.java:89) [dcache-frontend-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.dcache.services.collector.CellDataCollectingService.run(CellDataCollectingService.java:221) [dcache-core-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_141]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_141]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_141]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [na:1.8.0_141]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_141]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_141]

Modification:

1.  Call interrupt on the scheduled task when shutdown() is called.
2.  Change the two-parameter logging statement to be string + string, not string + Throwable.

Result:

Hopefully the shutdown trace disappears.

Target: master
Request: 3.2
Acked-by: Tigran
Acked-by: Paul
Require-notes: no
Require-book: no