### PR TITLE
srm: fix stacktrace on database failure

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/Job.java
@@ -69,6 +69,7 @@ import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.transaction.TransactionException;
 
 import javax.annotation.Nonnull;
 
@@ -213,7 +214,7 @@ public abstract class Job  {
             boolean isFinalState = this.getState().isFinal();
             getJobStorage().saveJob(this, isFinalState || force);
             savedInFinalState = isFinalState;
-        } catch (DataAccessException e) {
+        } catch (TransactionException e) {
             // if saving fails we do not want to fail the request
             logger.error("Failed to save SQL request to database: {}", e.toString());
         } catch (RuntimeException e) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseJobStorage.java
@@ -72,6 +72,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.sql.Connection;
@@ -234,7 +235,7 @@ public abstract class DatabaseJobStorage<J extends Job> implements JobStorage<J>
 
 
     @Override
-    public void saveJob(final Job job, boolean force) throws DataAccessException
+    public void saveJob(final Job job, boolean force) throws TransactionException
     {
         List<Job.JobHistory> savedHistory =
                 transactionTemplate.execute(status -> jdbcTemplate.execute((Connection con) -> {

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/AsynchronousSaveJobStorage.java
@@ -3,6 +3,7 @@ package org.dcache.srm.scheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.transaction.TransactionException;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -64,6 +65,7 @@ public class AsynchronousSaveJobStorage<J extends Job> implements JobStorage<J>
         return storage.getJobs(scheduler, state);
     }
 
+    @Override
     public void saveJob(final J job, final boolean force)
     {
         UpdateState existingState;
@@ -89,7 +91,7 @@ public class AsynchronousSaveJobStorage<J extends Job> implements JobStorage<J>
                                 UpdateState state = states.put(job.getId(), UpdateState.PROCESSING);
                                 try {
                                     storage.saveJob(job, state == UpdateState.QUEUED_FORCED);
-                                } catch (DataAccessException e) {
+                                } catch (TransactionException e) {
                                     LOGGER.error("SQL statement failed: {}", e.getMessage());
                                 } catch (Throwable e) {
                                     Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), e);

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/CanonicalizingJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/CanonicalizingJobStorage.java
@@ -2,6 +2,7 @@ package org.dcache.srm.scheduler;
 
 import com.google.common.collect.MapMaker;
 import org.springframework.dao.DataAccessException;
+import org.springframework.transaction.TransactionException;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -97,7 +98,7 @@ public class CanonicalizingJobStorage<J extends Job> implements JobStorage<J>
     }
 
     @Override
-    public void saveJob(J job, boolean force) throws DataAccessException
+    public void saveJob(J job, boolean force) throws TransactionException
     {
         Job other = map.putIfAbsent(job.getId(), job);
         if (other != null && other != job) {

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/ForceOnlyJobStorageDecorator.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/ForceOnlyJobStorageDecorator.java
@@ -1,6 +1,7 @@
 package org.dcache.srm.scheduler;
 
 import org.springframework.dao.DataAccessException;
+import org.springframework.transaction.TransactionException;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -46,7 +47,7 @@ public class ForceOnlyJobStorageDecorator<J extends Job> implements JobStorage<J
     }
 
     @Override
-    public void saveJob(J job, boolean force) throws DataAccessException {
+    public void saveJob(J job, boolean force) throws TransactionException {
         if (force) {
             jobStorage.saveJob(job, force);
         }

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/JobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/JobStorage.java
@@ -73,6 +73,7 @@ COPYRIGHT STATUS:
 package org.dcache.srm.scheduler;
 
 import org.springframework.dao.DataAccessException;
+import org.springframework.transaction.TransactionException;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -96,10 +97,10 @@ public interface JobStorage<J extends Job> {
      * @param job Job to save
      * @param force if this is false and monitoring jdbc login
      *         disabled, this operation will be ignored
-     * @throws SQLException
+     * @throws TransactionException if there was a problem
      */
     void saveJob(J job, boolean force)
-            throws DataAccessException;
+            throws TransactionException;
 
     Set<Long> getLatestCompletedJobIds(int maxNum) throws DataAccessException;
     Set<Long> getLatestDoneJobIds(int maxNum) throws DataAccessException;

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/SharedMemoryCacheJobStorage.java
@@ -1,6 +1,7 @@
 package org.dcache.srm.scheduler;
 
 import org.springframework.dao.DataAccessException;
+import org.springframework.transaction.TransactionException;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -93,7 +94,7 @@ public class SharedMemoryCacheJobStorage<J extends Job> implements JobStorage<J>
     }
 
     @Override
-    public void saveJob(J job, boolean force) throws DataAccessException
+    public void saveJob(J job, boolean force) throws TransactionException
     {
         storage.saveJob(job, force);
         sharedMemoryCache.update(job);


### PR DESCRIPTION
Motivation:

A log file indicated a stacktrace like

    20 Oct 2017 10:56:25 (SrmManager) [DoM:20480104:srm2:ls:1530164743:1530164744 DoM:20480104:srm2:ls SRM-srm] Uncaught exception in thread pool-11-thread-28281
    org.springframework.transaction.CannotCreateTransactionException: Could not open JDBC Connection for transaction; nested exception is java.sql.SQLException: HikariPool-1 - Interrupted during connection acquisition
            at org.springframework.jdbc.datasource.DataSourceTransactionManager.doBegin(DataSourceTransactionManager.java:245) ~[spring-jdbc-4.2.6.RELEASE.jar:4.2.6.RELEASE]
            at org.springframework.transaction.support.AbstractPlatformTransactionManager.getTransaction(AbstractPlatformTransactionManager.java:373) ~[spring-tx-4.2.6.RELEASE.jar:4.2.6.RELEASE]
            at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:130) ~[spring-tx-4.2.6.RELEASE.jar:4.2.6.RELEASE]
            at org.dcache.srm.request.sql.DatabaseJobStorage.saveJob(DatabaseJobStorage.java:242) ~[srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.scheduler.AsynchronousSaveJobStorage$1.run(AsynchronousSaveJobStorage.java:91) ~[srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.scheduler.AsynchronousSaveJobStorage.saveJob(AsynchronousSaveJobStorage.java:110) [srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.scheduler.ForceOnlyJobStorageDecorator.saveJob(ForceOnlyJobStorageDecorator.java:51) [srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.scheduler.SharedMemoryCacheJobStorage.saveJob(SharedMemoryCacheJobStorage.java:98) [srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.scheduler.CanonicalizingJobStorage.saveJob(CanonicalizingJobStorage.java:106) [srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.request.Job.saveJob(Job.java:215) [srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.request.Job.setState(Job.java:300) [srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.request.LsFileRequest.fail(LsFileRequest.java:228) [srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.request.LsFileRequest.run(LsFileRequest.java:209) [srm-server-2.16.42.jar:2.16.42]
            at org.dcache.srm.scheduler.Scheduler$JobWrapper.run(Scheduler.java:401) [srm-server-2.16.42.jar:2.16.42]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_131]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_131]
            at java.lang.Thread.run(Thread.java:748) [na:1.8.0_131]
    Caused by: java.sql.SQLException: HikariPool-1 - Interrupted during connection acquisition
            at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:182) ~[HikariCP-2.4.6.jar:na]
            at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:147) ~[HikariCP-2.4.6.jar:na]
            at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:83) ~[HikariCP-2.4.6.jar:na]
            at org.dcache.db.AlarmEnabledDataSource.getConnection(AlarmEnabledDataSource.java:151) ~[dcache-common-2.16.42.jar:2.16.42]
            at org.springframework.jdbc.datasource.DataSourceTransactionManager.doBegin(DataSourceTransactionManager.java:204) ~[spring-jdbc-4.2.6.RELEASE.jar:4.2.6.RELEASE]
            ... 16 common frames omitted
    Caused by: java.lang.InterruptedException: null
            at java.util.concurrent.locks.AbstractQueuedLongSynchronizer.doAcquireSharedNanos(AbstractQueuedLongSynchronizer.java:817) ~[na:1.8.0_131]
            at java.util.concurrent.locks.AbstractQueuedLongSynchronizer.tryAcquireSharedNanos(AbstractQueuedLongSynchronizer.java:1106) ~[na:1.8.0_131]
            at com.zaxxer.hikari.util.QueuedSequenceSynchronizer.waitUntilSequenceExceeded(QueuedSequenceSynchronizer.java:92) ~[HikariCP-2.4.6.jar:na]
            at com.zaxxer.hikari.util.ConcurrentBag.borrow(ConcurrentBag.java:169) ~[HikariCP-2.4.6.jar:na]
            at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:165) ~[HikariCP-2.4.6.jar:na]
            ... 20 common frames omitted

Modification:

The problem comes about from commit b77d5328, which changed the save to
happen within a transaction.  This changed the nature of the exceptions
being thrown.

This patch updates the throws annotation and catch statements to match
the newer Exception type.

Result:

No more stack-trace when SRM fails to write to the database.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9284
Issue: https://github.com/dCache/dcache/issues/3613
Patch: https://rb.dcache.org/r/10569/
Closes: #3613
Acked-by: Tigran Mkrtchyan