### PR TITLE
statistics: fix race in "create stat" admin command

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -756,9 +756,9 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
                         public void run() {
                             try {
                                 _log.info("Starting internal Manual run");
-                                synchronized(this) { _recentPoolStatistics = null; }
+                                synchronized(PoolStatisticsV0.this) { _recentPoolStatistics = null; }
                                 Map<String,Map<String,long[]>> map = createStatisticsMap();
-                                synchronized(this) { _recentPoolStatistics = map; }
+                                synchronized(PoolStatisticsV0.this) { _recentPoolStatistics = map; }
                                 _log.info("Finishing internal Manual run");
                             } catch(Exception e) {
                                 _log.info("Aborting internal Manual run "+e);


### PR DESCRIPTION
Motivation:

The synchronized statement in this command is wrong as it synchronises
on the anonymous inner class.  This can lead to the apparent failure of
the "create stat" command to update the stored information.

Modification:

Use correct object when synchronising.

Result:

The "create stat" admin command is more reliable.

Target: master
Require-notes: yes
Require-book: no
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Patch: https://rb.dcache.org/r/10561/
Acked-by: Albert Rossi