### PR TITLE
systemd: adding a global dcache.service which pulls in dcache@*.service

### DIFF
--- a/skel/lib/systemd/system-generators/dcache-generator
+++ b/skel/lib/systemd/system-generators/dcache-generator
@@ -4,6 +4,10 @@ set -e
 
 @DCACHE_LOAD_CONFIG@
 
+
+wantdir="$1/dcache.service.wants"
+mkdir "$wantdir"
+
 for domain in $(getProperty dcache.domains); do
     RESTART_DELAY="$(getProperty dcache.restart.delay "$domain")"
     USER="$(getProperty dcache.user "$domain")"
@@ -16,6 +20,9 @@ for domain in $(getProperty dcache.domains); do
 	[Unit]
 	Description=dCache $domain domain
 	After=network.target zookeeper.service
+	PartOf=dcache.service
+	ReloadPropagatedFrom=dcache.service
+	Before=dcache.service
 
 	[Service]
 	Type=simple
@@ -35,4 +42,6 @@ for domain in $(getProperty dcache.domains); do
 	[Install]
 	WantedBy=default.target
 	EOF
+
+    ln -s "$1/dcache@$domain.service" "$wantdir/dcache@$domain.service"
 done

--- a/skel/lib/systemd/system/dcache.service
+++ b/skel/lib/systemd/system/dcache.service
@@ -1,0 +1,14 @@
+#systemd service for managing all dCache domains on the system. This service is
+#actually a systemd target, but as targets cannot be reloaded a service is used.
+
+[Unit]
+Description=dCache
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+ExecReload=/bin/true
+RemainAfterExit=on
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Motivation:
It would be nice to have a “global” dcache.service, which can be used tostart/
stop/reaload/restart all the dcache@*.services (i.e. the single domains).

Also, it would be much better not to have to enable each dcache@*.service (which
all have different names) all the nodes of the cluster, just to get everything
started.
Enabling dcache.service can be used to have all dCache domains started, while
one can still fall back to only enable single dcache@*.service (and leave
dcache.service on a node).

Modification:
Introduce such a dcache.service unit, and modify the generated units, so that
they're “pulled in”.

Target: master
Require-notes: yes
Require-book: yes
Request: 3.2

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>