### PR TITLE
dcache-frontend: adjust level of timeout logging

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/cells/CellInfoServiceImpl.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/cells/CellInfoServiceImpl.java
@@ -169,7 +169,7 @@ public class CellInfoServiceImpl extends
                 Arrays.sort(currentKnownCells);
             }
         } catch (IllegalStateException e) {
-            LOGGER.warn("Processing cycle has overlapped; you may wish to "
+            LOGGER.info("Processing cycle has overlapped; you may wish to "
                                         + "increase the interval between "
                                         + "collections, which is currently "
                                         + "set to {} {}.",

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/pool/PoolInfoServiceImpl.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/services/pool/PoolInfoServiceImpl.java
@@ -473,7 +473,7 @@ public class PoolInfoServiceImpl extends
         try {
             processor.process(data);
         } catch (IllegalStateException e) {
-            LOGGER.warn("Processing cycle for precessor has overlapped; you may wish to "
+            LOGGER.info("Processing cycle for processor has overlapped; you may wish to "
                                         + "increase the interval between pool "
                                         + "info collections, which is currently "
                                         + "set to {} {}.",

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/pool/PoolDataRequestProcessor.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/pool/PoolDataRequestProcessor.java
@@ -62,6 +62,7 @@ package org.dcache.restful.util.pool;
 import org.springframework.beans.factory.annotation.Required;
 
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.TimeoutCacheException;
 import dmg.cells.nucleus.NoRouteToCellException;
 import org.dcache.cells.json.CellData;
 import org.dcache.pool.json.PoolData;
@@ -130,12 +131,12 @@ public final class PoolDataRequestProcessor
 
         try {
             handler.addHistoricalData(info);
-        } catch (NoRouteToCellException | InterruptedException e) {
-            LOGGER.debug("Could not add historical data for {}: {}/ {}.",
-                     key, e.getMessage(), e.getCause());
+        } catch (NoRouteToCellException | InterruptedException | TimeoutCacheException e) {
+            LOGGER.debug("Could not add historical data for {}: {}.",
+                     key, e.getMessage());
         } catch (CacheException e) {
-            LOGGER.error("Could not add historical data for {}: {}/ {}.",
-                         key, e.getMessage(), e.getCause());
+            LOGGER.error("Could not add historical data for {}: {}.",
+                         key, e.getMessage());
         }
 
         return info;

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/pool/PoolHistoriesHandler.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/pool/PoolHistoriesHandler.java
@@ -71,6 +71,7 @@ import java.util.Set;
 import diskCacheV111.pools.json.PoolCostData;
 import diskCacheV111.pools.json.PoolSpaceData;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.TimeoutCacheException;
 import dmg.cells.nucleus.NoRouteToCellException;
 import org.dcache.cells.CellStub;
 import org.dcache.pool.classic.json.SweeperData;
@@ -207,12 +208,12 @@ public final class PoolHistoriesHandler extends PoolInfoAggregator
 
         try {
             addHistoricalData(group);
-        } catch (NoRouteToCellException | InterruptedException e) {
-            LOGGER.debug("Could not add historical data for {}: {}/ {}.",
-                         group, e.getMessage(), e.getCause());
+        } catch (NoRouteToCellException | InterruptedException | TimeoutCacheException e) {
+            LOGGER.debug("Could not add historical data for {}: {}.",
+                         group, e.getMessage());
         } catch (CacheException e) {
-            LOGGER.error("Could not add historical data for {}: {}/ {}.",
-                         group, e.getMessage(), e.getCause());
+            LOGGER.error("Could not add historical data for {}: {}.",
+                         group, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Motivation:

When service is not present or not responding, timeout exceptions
from data collection attempts can fill up the frontend log.

See issue #3623.

Modification:

Adjust to more appropriate log levels.

Result:

Should not see example below.

Target: master
Request: 3.2
Require-notes: no
Require-book: no
Acked-by: Paul