### PR TITLE
systemd: do not explicitly set StandardOutput=

### DIFF
--- a/skel/lib/systemd/system-generators/dcache-generator
+++ b/skel/lib/systemd/system-generators/dcache-generator
@@ -26,7 +26,6 @@ for domain in $(getProperty dcache.domains); do
 	ProtectSystem=full
 	ProtectHome=true
 	NoNewPrivileges=true
-	StandardOutput=journal
 	SyslogIdentifier=dcache@$domain
 	Environment="CLASSPATH=$CLASSPATH" "LD_LIBRARY_PATH=$JAVA_LIBRARY_PATH"
 	$( [ -z "$USER" ] || echo "User=$USER" )


### PR DESCRIPTION
StandardOutput= defaults to DefaultStandardOutput, which already defaults to
journal.
It doesn't make that much sense to explicitly set it here again (to make sure
it's always "journal") and most services I've seen here on Debian don't
(explicitly) set it either.

If we would want to set it explicitly, we should also do so for
StandardError=inherit.

Target: master
Request: 3.2
Require-notes: yes
Require-book: no

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>