### PR TITLE
history: do not block on startup if PoolManager is not running

### DIFF
--- a/modules/dcache-history/src/main/java/org/dcache/services/history/pools/PoolHistoriesRequestProcessor.java
+++ b/modules/dcache-history/src/main/java/org/dcache/services/history/pools/PoolHistoriesRequestProcessor.java
@@ -127,7 +127,6 @@ public final class PoolHistoriesRequestProcessor extends
         Map<String, PoolInfoWrapper> values = new HashMap<>();
 
         File[] files = storageDir.listFiles(filter);
-        Set<String> validKeys = service.validKeys();
 
         PoolInfoWrapper info;
         String key;
@@ -143,12 +142,7 @@ public final class PoolHistoriesRequestProcessor extends
                     key = key.substring(0, key.lastIndexOf("."));
                 }
 
-                /*
-                 *  Do not reload data for pools or groups which have been removed.
-                 */
-                if (validKeys.contains(key)) {
-                    values.put(key, info);
-                }
+                values.put(key, info);
             } catch (IOException e) {
                 LOGGER.warn("There was a problem deserializing json file {}: "
                                             + "{}, {}",


### PR DESCRIPTION
Motivation:

Currently, the history service will block dCache startup for
history.service.poolmanager.timeout (2 minutes) if the service is
started while PoolManager is not running.

This results in dCache start-up being blocked on this:

"history-0" #36 prio=5 os_prio=0 tid=0x00007fad38297000 nid=0x7b35 in Object.wait() [0x00007fad2040d000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        - waiting on <0x0000000080a0a468> (a org.dcache.poolmanager.RemotePoolMonitor)
        at org.dcache.poolmanager.RemotePoolMonitor.getPoolMonitor(RemotePoolMonitor.java:178)
        - locked <0x0000000080a0a468> (a org.dcache.poolmanager.RemotePoolMonitor)
        at org.dcache.poolmanager.RemotePoolMonitor.getPoolSelectionUnit(RemotePoolMonitor.java:116)
        at org.dcache.services.history.pools.PoolTimeseriesServiceImpl.validKeys(PoolTimeseriesServiceImpl.java:173)
        at org.dcache.services.history.pools.PoolHistoriesRequestProcessor.readFromDisk(PoolHistoriesRequestProcessor.java:130)
        at org.dcache.services.history.pools.PoolTimeseriesServiceImpl.configure(PoolTimeseriesServiceImpl.java:108)
        - locked <0x0000000080db97c0> (a java.util.HashMap)
        at org.dcache.services.collector.CellDataCollectingService.afterStart(CellDataCollectingService.java:209)
        at org.dcache.cells.UniversalSpringCell.started(UniversalSpringCell.java:260)
        at dmg.cells.nucleus.CellAdapter.postStartup(CellAdapter.java:741)
        at dmg.cells.nucleus.CellNucleus.doStart(CellNucleus.java:938)
        at dmg.cells.nucleus.CellNucleus$$Lambda$25/1783463798.call(Unknown Source)
        at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$5(CellNucleus.java:763)
        at dmg.cells.nucleus.CellNucleus$$Lambda$26/283923004.call(Unknown Source)
        at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:111)
        at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:58)
        at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:75)
        at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$4(CellNucleus.java:754)
        at dmg.cells.nucleus.CellNucleus$$Lambda$27/173059685.run(Unknown Source)
        at java.lang.Thread.run(Thread.java:748)

Modification:

Remove the attempt to filter any pools that PoolManager does not know
about when loading data from disk.

Under normal circumstances, this change will have no effect as the
normal update cycle is triggered to run during the start-up.  This
should provide the same level of filtering.

Result:

The history service no longer blocks dCache startup for
history.service.poolmanager.timeout (2 minutes, by default) if
PoolManager is currently not running.

Target: master
Request: 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10597/
Acked-by: Albert Rossi