### PR TITLE
dcache-frontend: fix ConcurrentModificationException in ReadWriteData

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/collector/RequestFutureProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/util/collector/RequestFutureProcessor.java
@@ -65,9 +65,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -88,7 +88,7 @@ public abstract class RequestFutureProcessor<T extends Serializable, D> {
 
     protected final Map<String, ListenableFutureWrapper<D>> futureMap = new HashMap<>();
 
-    protected final Map<String, T> next = Collections.synchronizedMap(new HashMap<>());
+    protected final Map<String, T> next = new ConcurrentHashMap<>();
 
     protected Executor executor;
 


### PR DESCRIPTION
Motivation:

java.util.ConcurrentModificationException: null
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1442) ~[na:1.8.0_151]
	at java.util.HashMap$EntryIterator.next(HashMap.java:1476) ~[na:1.8.0_151]
	at java.util.HashMap$EntryIterator.next(HashMap.java:1474) ~[na:1.8.0_151]
	at java.util.HashMap.putMapEntries(HashMap.java:512) ~[na:1.8.0_151]
	at java.util.HashMap.putAll(HashMap.java:785) ~[na:1.8.0_151]
	at org.dcache.restful.util.admin.ReadWriteData.clearAndWrite(ReadWriteData.java:120) ~[dcache-frontend-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.dcache.restful.services.pool.PoolInfoServiceImpl.updateJsonData(PoolInfoServiceImpl.java:467) ~[dcache-frontend-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.dcache.restful.util.pool.PoolDataRequestProcessor.postProcess(PoolDataRequestProcessor.java:108) ~[dcache-frontend-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.dcache.util.collector.RequestFutureProcessor.waitUntilFinished(RequestFutureProcessor.java:231) ~[dcache-core-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) ~[dcache-common-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_151]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_151]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_151]

This is caused by the fact that the ReadWriteData calls putAll on the "next" map,
which uses the iterator, but the calling method waitUntilFinished then clears it
(on the same thread).

Modification:

Make all access to the 'next' map explicitly synchronized.

Result:

This above stack trace should not occur.

Target: master
Request: 3.2
Require-notes: no
Require-book: no
Acked-by: Paul