### PR TITLE
system: Don't log stack-trace on fatal JVM error

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
@@ -346,7 +346,7 @@ public class      SystemCell
             _log.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.FATAL_JVM_ERROR,
                                                     getCellDomainName(),
                                                     getCellName()),
-                       "Restarting due to fatal JVM error", e);
+                       "Restarting due to fatal JVM error: {}", e.toString());
             return;
         }
 


### PR DESCRIPTION
Motivation:

Currently, dCache logs a stack-trace if there is a VirtualMachineError.
This is unnecessary as dCache was (presumably) working fine until Java
discovered a problem.

Modification:

Log the Error's toString output.

Result:

dCache no longer logs a stack-trace if there is a critical JVM error.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Alert Rossi
Patch: https://rb.dcache.org/r/10603/