### PR TITLE
pool: fix stacktrace on FaultEvent logging

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -553,8 +553,7 @@ public class PoolV4
         if (cause != null) {
             _log.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.POOL_DISABLED,
                             _poolName),
-                            message,
-                            cause);
+                    "{}: {}", message, cause.toString());
         } else {
             _log.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.POOL_DISABLED,
                             _poolName),


### PR DESCRIPTION
Motivation:

If the pool suffers some failure that results in the pool changing state then
a stack-trace is logged if a Throwable is logged.

Modification:

Update logging so it does not log a stack-trace.

Result:

The pool does not log a stack-trace when suffering a FaultEvent.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9288

Conflicts:
	modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java