### PR TITLE
pool: fix stack-trace on bad command input

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
@@ -217,25 +217,24 @@ public class SpaceSweeper2
     public class sweeperFreeCommand implements Callable<String>
     {
         @Argument(usage = "Specify amount of space in bytes.")
-        String bytesToFree;
+        long bytesToFree;
 
         @Override
         public String call()
         {
-            final long toFree = Long.parseLong(bytesToFree);
             new Thread("sweeper-free") {
                 @Override
                 public void run()
                 {
                     try {
-                        long bytes = reclaim(toFree);
-                        _log.info("'sweeper free {}' reclaimed {} bytes.", toFree, bytes);
+                        long bytes = reclaim(bytesToFree);
+                        _log.info("'sweeper free {}' reclaimed {} bytes.", bytesToFree, bytes);
                     } catch (InterruptedException e) {
                     }
                 }
             }.start();
 
-            return String.format("Reclaiming %d bytes", toFree);
+            return String.format("Reclaiming %d bytes", bytesToFree);
         }
     }
 


### PR DESCRIPTION
Motivation:

If an admin supplies bad input to the "sweeper free" command
then dCache will log a stack-trace like:

    26 Oct 2017 10:15:38 (c3se_chalmers_se_017) [admin] Command failed due to a bug, please contact support@dcache.org.
    dmg.util.CommandPanicException: (1) Command failed: java.lang.NumberFormatException: For input string: "200G"
    	at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:155) ~[common-cli-2.16.47.jar:2.16.47]
    	at org.dcache.util.cli.CommandInterpreter$CommandEntry.execute(CommandInterpreter.java:263) ~[common-cli-2.16.47.jar:2.16.47]
    	at org.dcache.util.cli.CommandInterpreter.doExecute(CommandInterpreter.java:176) ~[common-cli-2.16.47.jar:2.16.47]
    	at dmg.cells.nucleus.CellAdapter$1.doExecute(CellAdapter.java:102) ~[cells-2.16.47.jar:2.16.47]
    	at org.dcache.util.cli.CommandInterpreter.command(CommandInterpreter.java:162) ~[common-cli-2.16.47.jar:2.16.47]
    	at dmg.cells.nucleus.CellAdapter$1.command(CellAdapter.java:119) ~[cells-2.16.47.jar:2.16.47]
    	at dmg.cells.nucleus.CellAdapter.command(CellAdapter.java:220) ~[cells-2.16.47.jar:2.16.47]
    	at dmg.cells.nucleus.CellAdapter.executeLocalCommand(CellAdapter.java:901) ~[cells-2.16.47.jar:2.16.47]
    	at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:838) ~[cells-2.16.47.jar:2.16.47]
    	at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1156) [cells-2.16.47.jar:2.16.47]
    	at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:241) [dcache-common-2.16.47.jar:2.16.47]
    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_151]
    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_151]
    	at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$2(CellNucleus.java:780) [cells-2.16.47.jar:2.16.47]
    	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_151]
    Caused by: java.lang.NumberFormatException: For input string: "200G"
    	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65) ~[na:1.8.0_151]
    	at java.lang.Long.parseLong(Long.java:589) ~[na:1.8.0_151]
    	at java.lang.Long.parseLong(Long.java:631) ~[na:1.8.0_151]
    	at org.dcache.pool.classic.SpaceSweeper2$sweeperFreeCommand.call(SpaceSweeper2.java:225) ~[dcache-core-2.16.47.jar:2.16.47]
    	at org.dcache.pool.classic.SpaceSweeper2$sweeperFreeCommand.call(SpaceSweeper2.java:214) ~[dcache-core-2.16.47.jar:2.16.47]
    	at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:144) ~[common-cli-2.16.47.jar:2.16.47]
    	... 14 common frames omitted

Modification:

Move responsibility for parsing the user-supplied argument into the
command framework.  This has correct handling of badly formed input.

Result:

The "sweeper free" command no longer logs a stack-trace on bad input.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9288
Patch: https://rb.dcache.org/r/10599/
Acked-by: Tigran Mkrtchyan