### PR TITLE
chimera: update schema migration when creating 'lost+found' directory.

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.15.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.15.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet id="1" author="behrmann">
+    <changeSet id="1.1" author="behrmann">
         <preConditions onFail="MARK_RAN" onFailMessage="Not creating lost+found as it already exists (this is not an error)">
             <sqlCheck expectedResult="0">
                 SELECT count(*) FROM t_inodes WHERE ipnfsid='000000000000000000000000000000000001'
@@ -17,7 +17,7 @@
         <insert tableName="t_inodes">
             <column name="ipnfsid" value="000000000000000000000000000000000001"/>
             <column name="itype" valueNumeric="16384"/>
-            <column name="imode" valueNumeric="700"/>
+            <column name="imode" valueNumeric="448"/> <!-- 0700 -->
             <column name="inlink" valueNumeric="2"/>
             <column name="iuid" valueNumeric="0"/>
             <column name="igid" valueNumeric="0"/>


### PR DESCRIPTION
Motivation:

The intention was to create a lost+found directory that only root can
access: permissions 700.  Unfortunately, this number was written in
octal and liquibase only accepts numerical values in decimal.  The
result is that lost+found is created with a very weird set of
permissions.

Modification:

Given we cannot know if the current permissions in lost+found are
intended, this patch does not modify any existing lost+found directory
permissions.

Instead, this patch modifies the erroneous changeset to create the
directory with the correct permissions.

Result:

Instances that already running dCache 2.15 or newer are unaffected by
this patch.

Instances that are upgrading to dCache v2.15 (or later) and newly
created instances will have a lost+found directory with the correct
permissions.

Target: master
Require-notes: yes
Require-book: no
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9282
Patch: https://rb.dcache.org/r/10586/
Acked-by: Dmitry Litvintsev