### PR TITLE
httpd: return 404 status code on an unknown page

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/httpd/HttpdCommandLineInterface.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/HttpdCommandLineInterface.java
@@ -74,7 +74,7 @@ public class HttpdCommandLineInterface
             + "   file               <fullFilePath> <arguments> <...>\n"
             + "   class              <fullClassName> <...>\n"
             + "   context            [options] <context> or  <contextNameStart>*\n"
-            + "                       options : -overwrite=<alias> -onError=<alias>\n"
+            + "                       options : -overwrite=<alias> -onError=<alias> -status=<HTTP status code>\n"
             + "   webapp             <warPath> <...> \n"
             + "   redirect           <forward-to-context>\n"
             + "   predefined alias : <home>    =  default for http://host:port/ \n"
@@ -123,7 +123,10 @@ public class HttpdCommandLineInterface
             entry.setStatusMessage(alias + " -> " + aliasType.getType() + "(" + specific + ")");
             break;
         case CONTEXT:
-            handler = (Handler) beanFactory.initializeBean(new ContextHandler(specific), alias);
+            Handler rawHandler = args.hasOption("status")
+                    ? new ContextHandler(specific, args.getIntOption("status"))
+                    : new ContextHandler(specific);
+            handler = (Handler) beanFactory.initializeBean(rawHandler, alias);
             entry = new AliasEntry(alias, aliasType, handler, specific);
             entry.setOnError(args.getOpt("onError"));
             entry.setOverwrite(args.getOpt("overwrite"));

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/ContextHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/ContextHandler.java
@@ -28,9 +28,15 @@ public class ContextHandler extends AbstractHandler implements DomainContextAwar
 {
     private final String specificName;
     private Map<String, Object> context;
+    private final int status;
 
     public ContextHandler(String specificName) {
+        this(specificName, HttpServletResponse.SC_OK);
+    }
+
+    public ContextHandler(String specificName, int status) {
         this.specificName = specificName;
+        this.status = status;
     }
 
     @Override
@@ -65,6 +71,7 @@ public class ContextHandler extends AbstractHandler implements DomainContextAwar
             }
             String html = String.valueOf(value);
 
+            response.setStatus(status);
             proxy.getPrintWriter().println(html);
             proxy.getPrintWriter().flush();
             baseRequest.setHandled(true);

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -165,7 +165,7 @@ exec env defineEmptyStatisticsAlias.exe -ifnotok=have_stats_loc
 define context ${httpd.cell.name}Setup endDefine
    set alias webadmin webapp ${httpd.container.webapps.dir}/webadmin.war
    set alias <home> redirect webadmin
-   set alias <default> context missing.html
+   set alias <default> context missing.html -status=404
    set alias old file ${httpd.static-content.index} -onError=default
    set alias offline context offline.html
    set alias context context *


### PR DESCRIPTION
Motivation:

The httpd service provides a configurable web server, which includes the
ability to return a custom response as a default response if no specific
rule matches.  Unfortunately, this returns a 200 OK response code,
despite the 404 NOT FOUND response code being a closer fit.

Modification:

Allow the configuration to specific which HTTP status should be
returned.  Update configuration so the default response includes a 404
status code.

Result:

Requests to httpd that target an unknown resource generate a response
that includes the expected 404 HTTP status code.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9298
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10625/
Acked-by: Albert Rossi