### PR TITLE
pool: fix stack-trace when closing dcap mover connection

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/net/ProtocolConnectionPool.java
+++ b/modules/dcache/src/main/java/org/dcache/net/ProtocolConnectionPool.java
@@ -11,9 +11,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.net.Socket;
-import java.nio.channels.AsynchronousCloseException;
-import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.HashMap;
@@ -233,7 +231,7 @@ public class ProtocolConnectionPool implements Runnable {
                     }
                 }
             }
-        } catch (AsynchronousCloseException e) {
+        } catch (ClosedChannelException e) {
             // Ignore thread stopped by interrupting or by closing the channel
         } catch (IOException e) {
             _logSocketIO.error("Accept loop", e);


### PR DESCRIPTION
Motivation:

Observed a stack-trace in the log file while exercising system-test.
This indicated a ClosedChannelException, which is a broader exception
from the currently expected AsynchronousCloseException.

Modification:

Catch ClosedChannelException (instead of AsynchronousCloseException) as
the "expected exception".

Result:

Fewer stack-traces in dCache log files.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10623/
Acked-by: Albert Rossi