### PR TITLE
maven: include dcache.service in Debian packages

### DIFF
--- a/packages/fhs/src/main/assembly/deb.xml
+++ b/packages/fhs/src/main/assembly/deb.xml
@@ -8,8 +8,8 @@
             <filtered>true</filtered>
         </fileSet>
         <fileSet>
-            <directory>${filtered-skel}/lib/systemd/system-generators</directory>
-            <outputDirectory>lib/systemd/system-generators</outputDirectory>
+            <directory>${filtered-skel}/lib/systemd</directory>
+            <outputDirectory>lib/systemd</outputDirectory>
             <excludes>
                 <exclude>**/.empty-dir</exclude>
             </excludes>


### PR DESCRIPTION
Apparently the build system doesn't just pick up the skeleton directories and
include them in the packages (not sure why, cause this is what it should
probably just do).
This causes the new global dcache.service from commit
3bc9c497f194cfdcdf0515775d538ec53967685e to be missing from the built packages.

This commit tells it to at least pick up the whole “skel/lib/systemd/” instead
of just “skel/lib/systemd/system-generators/”.

Target: master
Require-notes: yes
Require-book: no
Request: 3.2

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>