### PR TITLE
admin: do not report attempts to connect to missing cell as a bug

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -567,7 +567,7 @@ public class UserAdminShell
         String user;
 
         @Override
-        public String call() throws Exception
+        public String call() throws AclException, InterruptedException, CommandException
         {
             String oldUser = _user;
             try {
@@ -584,14 +584,14 @@ public class UserAdminShell
                 checkCdPermission(name);
                 _currentPosition = resolve(name);
                 _completer = null;
-            } catch (Throwable e) {
+            } catch (AclException | InterruptedException | RuntimeException | CommandException e) {
                 _user = oldUser;
                 throw e;
             }
             return "";
         }
 
-        private Position resolve(String cell) throws InterruptedException
+        private Position resolve(String cell) throws InterruptedException, CommandException
         {
             CellPath path = new CellPath(cell);
             try {
@@ -625,7 +625,7 @@ public class UserAdminShell
                 }
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof NoRouteToCellException) {
-                    throw new IllegalArgumentException("Cell does not exist.");
+                    throw new CommandException(1, "Cell does not exist.");
                 }
                 // Some other failure, but apparently the cell exists
                 _log.info("Cell probe failed: {}", e.getCause().toString());


### PR DESCRIPTION
Motivation:

The admin interface responds to an attempt to connect to an absent cell
as if a bug was detected; e.g.,

    [ani] (local) admin > \c NFS-ani
    Command '\c NFS-ani' triggered a bug (java.lang.IllegalArgumentException: Cell does not exist.); the service log file contains additional information. Please contact support@dcache.org.
    [ani] (local) admin >

Modification:

Throw the correct exception.

Result:

Attempts to connect to a missing cell are logged as that, without any
indication of there being a bug.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Closes: #3370
Patch: https://rb.dcache.org/r/10634/
Acked-by: Albert Rossi

Conflicts:
	modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java