### PR TITLE
nfs: fix documentation of nfs.enable.pnfsmanager-query-on-move

### DIFF
--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -173,7 +173,7 @@ nfs.fs-stat-cache.time = 3600
 #  ---- Whether to enable contacting PnfsManager on move
 #
 # Currently this option makes sense only if
-# pnfsmanager.enable.move-to-directory-with-different-tags
+# pnfsmanager.enable.move-to-directory-with-different-storageclass
 # is set to false. See pnfsmanager properties file for description
 #
 (one-of?true|false)nfs.enable.pnfsmanager-query-on-move = false


### PR DESCRIPTION
Motivation:

Commit 09abff11 introduced the option to prevent files from being moved
into directories with a different storage-class.  The documentation for
the corresponding NFS part was inaccurate as it referred to a
PnfsManager property that does not exist.

Modification:

Update documentation to refer to the intended property.

Result:

Fewer support tickets.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Require-notes: yes
Require-book: no
Closes: #3409
Patch: https://rb.dcache.org/r/10633/
Acked-by: Dmitry Litvintsev