### PR TITLE
statistics: avoid stack-trace on internal timeout

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -46,6 +46,7 @@ import dmg.util.CellCron;
 
 import org.dcache.cells.CellStub;
 import org.dcache.util.Args;
+import org.dcache.util.Exceptions;
 
 import static java.util.Arrays.asList;
 import static org.dcache.util.ByteUnit.KiB;
@@ -476,8 +477,8 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
                     resetBillingStatistics();
                 }
             } catch(Exception ee) {
-                _log.warn("Exception in full run for : "+path, ee);
-                //noinspection ResultOfMethodCallIgnored
+                _log.warn("Failed to create file {}: {}", path,
+                        Exceptions.messageOrClassName(ee));
                 path.delete();
             }
 


### PR DESCRIPTION
Motivation:

If there is a problem writing a file or contacting a connection, the
statistics service logs this with a stack-trace.

Modification:

Log a meaningful message without the stack-trace.

Result:

Timeout in contacting PoolManager no longer results in a stack-trace
being logged.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Closes: #3460
Patch: https://rb.dcache.org/r/10632/
Acked-by: Albert Rossi