### PR TITLE
cells: don't log stack-trace on starting cell with same name as runni…

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
@@ -1020,6 +1020,10 @@ public class CellShell extends CommandInterpreter
                InstantiationException, IllegalAccessException, InvocationTargetException,
                ClassCastException, CommandException, InterruptedException
        {
+           if (_nucleus.getCellInfo(cellName) != null) {
+               throw new CommandException("Cell " + cellName +" already exists.");
+           }
+
            Constructor<? extends CellAdapter> constructor =
                    Class.forName(className).asSubclass(CellAdapter.class).getConstructor(String.class, String.class);
            try {


### PR DESCRIPTION
…ng cell

Motivation:

A relatively common mistake is to update a layout file to start an
additional service of the same type, without giving the additional
service a distinct `<service>.cell.name`.  This currently results in a
stacktrace like:

    04 Sep 2017 10:01:25 (System) [] Bug detected in dCache; please report this to <support@dcache.org> with the following information.
    dmg.util.CommandPanicException: (1) Command failed: java.lang.IllegalStateException: Cell GFTP-celebrimbor already exists.
            at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:156) ~[common-cli-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at org.dcache.util.cli.CommandInterpreter$CommandEntry.execute(CommandInterpreter.java:230) ~[common-cli-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at org.dcache.util.cli.CommandInterpreter.doExecute(CommandInterpreter.java:143) ~[common-cli-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at org.dcache.util.cli.CommandInterpreter.command(CommandInterpreter.java:129) ~[common-cli-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellShell.objectCommand2(CellShell.java:245) [cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellShell.execute(CellShell.java:1751) [cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellShell.execute(CellShell.java:1711) [cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at org.dcache.boot.Domain.executeBatchFile(Domain.java:301) [dcache-core-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at org.dcache.boot.Domain.executeService(Domain.java:247) [dcache-core-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at org.dcache.boot.Domain.start(Domain.java:137) [dcache-core-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at org.dcache.boot.BootLoader.main(BootLoader.java:125) [dcache-core-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
    Caused by: java.lang.IllegalStateException: Cell GFTP-celebrimbor already exists.
            at dmg.cells.nucleus.CellGlue.registerCell(CellGlue.java:136) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellNucleus.<init>(CellNucleus.java:205) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellAdapter.<init>(CellAdapter.java:186) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellAdapter.<init>(CellAdapter.java:160) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellAdapter.<init>(CellAdapter.java:147) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.services.login.LoginManager.<init>(LoginManager.java:115) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.services.login.LoginManager.<init>(LoginManager.java:110) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_131]
            at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_131]
            at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_131]
            at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_131]
            at dmg.cells.nucleus.CellShell$CreateCommand.call(CellShell.java:1079) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellShell$CreateCommand.call(CellShell.java:1045) ~[cells-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:145) ~[common-cli-4.0.0-SNAPSHOT.jar:4.0.0-SNAPSHOT]
            ... 10 common frames omitted

Modification:

Add a check in the command responsible for creating a new cell that this
cell does not already exist.  This allows dCache to log a more friendly
error message.

Result:

Configuring dCache to run multiple cells with the same name is reported
as an error, rather than as a bug.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Closes: #3483
Patch: https://rb.dcache.org/r/10631/
Acked-by: Albert Rossi