### PR TITLE
rpm: don't assume existing dcache user is member of dcache group

### DIFF
--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -41,11 +41,17 @@ fi
 
 /sbin/service dcache-server stop >/dev/null 2>&1
 
-# Make sure the administrative user exists
+# Make sure the system user and group exist, and that
+# the user is a member of the group.
 getent group dcache >/dev/null || groupadd -r dcache
-getent passwd dcache >/dev/null || \
+
+if getent passwd dcache >/dev/null; then
+    getent group dcache|grep -q '^[^:]*:[^:]*:[^:]*:[^:]*dcache\(,\|$\)' || \
+            usermod -a -G dcache dcache
+else
     useradd -r -g dcache -d /var/lib/dcache -s /bin/bash \
     -c "dCache administrator" dcache
+fi
 
 # check validity of dcache user and group
 if [ "`id -u dcache`" -eq 0 ]; then


### PR DESCRIPTION
Motivation:

As an extra security step, the RPM spec file will ensure any ssh host
private key it creates is owned by user 'root' and group 'dcache' with
640 permissions.  This means that the 'dcache' user can read the private
key but cannot modify it.

The RPM spec file also ensures that user 'dcache' and group 'dcache'
exist; however, it does not ensure that user 'dcache' is a member of
group 'dcache'.

Non-membership can arise from installing the RPM on a system where the
user 'dcache' exists but group 'dcache' does not exist (the RPM spec
file will create the group but not make user 'dcache' a member of group
'dcache'), or if both user 'dcache' and group 'dcache' exist with user
'dcache' being a member of group 'dcache' (the RPM spec file does
nothing).

This can leads to errors like:

06 Sep 2017 11:19:00 (System) [] URL [file:/usr/share/dcache/services/admin.batch]: line 33: Command failed ((3) permission denied: /etc/dcache/admin/ssh_host_rsa_key; caused by: permission denied: /etc/dcache/admin/ssh_host_rsa_key; caused by: permission denied: /etc/dcache/admin/ssh_host_rsa_key)

Modification:

Ensure user 'dcache' is a member of group 'dcache'.

Result:

Permissions work as expected.

Target: master
Require-notes: yes
Require-book: no
Closes: #3489