### PR TITLE
star: support PostgreSQL running on non-standard TCP ports

### DIFF
--- a/skel/bin/dcache-star
+++ b/skel/bin/dcache-star
@@ -172,11 +172,12 @@ def build_id(group, media, now):
 
 
 def query_chimera(query):
-    db_name = properties.get('chimera.db.name')
-    db_host = properties.get('chimera.db.host')
-    db_user = properties.get('chimera.db.user')
-    db_pw = properties.get('chimera.db.password')
-    conn = psycopg2.connect(database=db_name, user=db_user, host=db_host, password=db_pw)
+    db_name = properties.get('star.db.name')
+    db_host = properties.get('star.db.host')
+    db_user = properties.get('star.db.user')
+    db_pw = properties.get('star.db.password')
+    db_port = properties.get('star.db.port')
+    conn = psycopg2.connect(database=db_name, user=db_user, host=db_host, password=db_pw, port=db_port)
     try:
        cur = conn.cursor()
        try:

--- a/skel/share/defaults/star.properties
+++ b/skel/share/defaults/star.properties
@@ -124,3 +124,12 @@ star.gid-mapping =
 #  in a record without a StorageShare element.
 #
 star.storage-share-mapping =
+
+#
+#  Database connection parameters used by StAR generation script
+#
+star.db.name = ${chimera.db.name}
+star.db.host = ${chimera.db.host}
+star.db.port = 5432
+star.db.user = ${chimera.db.user}
+star.db.password = ${chimera.db.password}


### PR DESCRIPTION
Motivation:

A site is running PosgreSQL on a non-standard TCP port.

Modification:

Introduce star.db.* properties, which should have been present to begin
with.

Add the star.db.port property to allow TCP port number configuration.

Update star script to make use of this property.

Result:

Sites with PostgreSQL running on non-standard ports can use StAR.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: yes
Closes: #3570
Patch: https://rb.dcache.org/r/10629/
Acked-by: Albert Rossi