### PR TITLE
srmmanager: provide better hints on obsolete properties

### DIFF
--- a/skel/share/defaults/srmmanager.properties
+++ b/skel/share/defaults/srmmanager.properties
@@ -1319,5 +1319,9 @@ srmmanager.expired-job-period = 10
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
 srmmanager.expired-job-period.unit = MINUTES
 
-(obsolete)srmmanager.net.port = value is auto-discovered
-(obsolete)srmmanager.net.local-hosts = value is auto-discovered
+(obsolete)srmmanager.net.port = this is now configured via \
+                              srm.loginbroker.port properties \
+                              (aggregating over all srm instances)
+(obsolete)srmmanager.net.local-hosts = this is now configured via \
+                              srm.loginbroker.address properties \
+			      (aggregating over all srm instances)


### PR DESCRIPTION
Motivation:

Support tickets indicate that dCache does not provide sufficient
information on how to fix a configuration that still has assignments for
either srmmanager.net.port or srmmanager.net.local-hosts.

Modification:

Describe to sites how to fix their configuration after upgrade.

Result:

Fewer support tickets.

Target: master
Request: 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10621/
Acked-by: Albert Rossi