### PR TITLE
srmclient: avoid stack-trace and repeated logging

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/Copier.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/Copier.java
@@ -96,6 +96,7 @@ import org.dcache.ftp.client.exception.UnexpectedReplyCodeException;
 import org.dcache.ftp.client.vanilla.Reply;
 import org.dcache.srm.Logger;
 import org.dcache.srm.util.GridftpClient;
+import org.dcache.util.Exceptions;
 import org.dcache.util.PortRange;
 
 import static org.dcache.util.ByteUnit.KiB;
@@ -294,8 +295,7 @@ public class Copier implements Runnable {
                             say("execution of "+nextJob+" completed");
                             break;
                         } catch(Exception e) {
-                            esay("copy failed with the error");
-                            esay(e);
+                            esay("copy failed: " + Exceptions.messageOrClassName(e));
                             throwIfPermanent(e);
                             if(i < retry_num) {
                                 i++;

--- a/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/util/GridftpClient.java
@@ -879,7 +879,6 @@ public class GridftpClient
 
             Exception e = getThrowable();
             if (e != null) {
-                logger.error(" transfer exception",e);
                 if (e instanceof ClientException) {
                     throw (ClientException)e;
                 } else if (e instanceof ServerException) {
@@ -936,7 +935,6 @@ public class GridftpClient
                     }
                 }
             } catch (IOException | ClientException | ServerException e) {
-                logger.error(e.toString());
                 _throwable = e;
             } finally {
                 done();


### PR DESCRIPTION
Motivation:

srmclient suffers from two problems with logging:

   1\. it logs server errors with a stack-trace,
   2\. it logs the same error multiple times.

Modification:

The first problem comes from logging the exception rather than the
exception's message.  The second comes from following the log-then-throw
anti-pattern.

The first problem is solved by solving the second problem.  Therefore,
this patch focuses on fixing the log-then-throw anti-pattern.

Result:

Errors are logged once and there are fewer stack-traces.

Target: master
Request: 3.2
Require-notes: no
Require-srm-notes: yes
Require-book: no
Fixes: #3655