### PR TITLE
pool: fix double logging on remote FTP transfer error

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
@@ -258,7 +258,6 @@ public class RemoteGsiftpTransferProtocol
                 _client.close();
             }
         } catch (Exception e) {
-            _log.error(e.toString());
             throw new CacheException(e.toString());
         }
     }
@@ -294,7 +293,6 @@ public class RemoteGsiftpTransferProtocol
                 _client.close();
             }
         } catch (Exception e) {
-            _log.error(e.toString());
             throw new CacheException(e.toString());
         }
     }


### PR DESCRIPTION
Motivation:
    
For certain failures, the pool will log transfer failures twice.  This
is due to the code following the log-and-throw anti-pattern.
    
Modification:
    
Remove additional logging -- any failure will be logged at the
AbstractMover level.
    
Result:
    
Reduced log size and more consistent log files, with a single error
represented with a single log entry.
    
Target: master
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10627/
Acked-by: Albert Rossi