### PR TITLE
httpd, dcache-frontend: support requests for restore listing when the…

### DIFF
--- a/modules/dcache-vehicles/src/main/java/org/dcache/poolmanager/PoolManagerGetRestoreHandlerInfo.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/poolmanager/PoolManagerGetRestoreHandlerInfo.java
@@ -20,20 +20,27 @@ package org.dcache.poolmanager;
 
 import java.util.List;
 
+import dmg.cells.nucleus.CellAddressCore;
+
 import diskCacheV111.vehicles.PoolManagerMessage;
 import diskCacheV111.vehicles.RestoreHandlerInfo;
 
 /**
  * Request information about current request container tasks.
  */
-public class PoolManagerGetRestoreHandlerInfo extends PoolManagerMessage
-{
+public class PoolManagerGetRestoreHandlerInfo extends PoolManagerMessage {
     private static final long serialVersionUID = 765552672615264580L;
 
+    private String poolManagerKey;
     private List<RestoreHandlerInfo> result;
 
     public PoolManagerGetRestoreHandlerInfo()
     {
+    }
+
+    public PoolManagerGetRestoreHandlerInfo(CellAddressCore address)
+    {
+        poolManagerKey = address.getCellName() + "@" + address.getCellDomainName();
     }
 
     public PoolManagerGetRestoreHandlerInfo(List<RestoreHandlerInfo> result)
@@ -41,13 +48,23 @@ public class PoolManagerGetRestoreHandlerInfo extends PoolManagerMessage
         this.result = result;
     }
 
-    public void setResult(List<RestoreHandlerInfo> result)
+    public String getPoolManagerKey()
     {
-        this.result = result;
+        return poolManagerKey;
     }
 
     public List<RestoreHandlerInfo> getResult()
     {
         return result;
+    }
+
+    public void setPoolManagerKey(String poolManagerKey)
+    {
+        this.poolManagerKey = poolManagerKey;
+    }
+
+    public void setResult(List<RestoreHandlerInfo> result)
+    {
+        this.result = result;
     }
 }

--- a/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/communication/collectors/RestoreHandlerCollector.java
+++ b/modules/dcache-webadmin/src/main/java/org/dcache/webadmin/model/dataaccess/communication/collectors/RestoreHandlerCollector.java
@@ -1,70 +1,41 @@
 package org.dcache.webadmin.model.dataaccess.communication.collectors;
 
-import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
+import java.util.stream.Collectors;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import diskCacheV111.util.CacheException;
-import diskCacheV111.vehicles.RestoreHandlerInfo;
-
-import dmg.cells.nucleus.CellPath;
-import dmg.cells.nucleus.NoRouteToCellException;
+import diskCacheV111.poolManager.RestoreRequestsReceiver;
 
 import org.dcache.util.backoff.IBackoffAlgorithm.Status;
 import org.dcache.webadmin.model.businessobjects.RestoreInfo;
 import org.dcache.webadmin.model.dataaccess.communication.ContextPaths;
 
 /**
- *
  * @author jans
  */
 public class RestoreHandlerCollector extends Collector {
-
-    private String _poolManagerName;
-    private static final long CONSIDERED_NEW_INTERVAL = TimeUnit.MINUTES.toMillis(2L);
-    private static final Logger _log = LoggerFactory.getLogger(RestoreHandlerCollector.class);
-
-    private void collectRestores() throws InterruptedException, CacheException, NoRouteToCellException
-    {
-        RestoreHandlerInfo[] restores = _cellStub.sendAndWait(new CellPath(
-                        _poolManagerName), "xrc ls", RestoreHandlerInfo[].class);
-        List<RestoreInfo> agedList = filterOutNewRestores(restores);
-        _pageCache.put(ContextPaths.RESTORE_INFOS,
-                        ImmutableSet.copyOf(agedList));
-
-    }
-
-    private List<RestoreInfo> filterOutNewRestores(RestoreHandlerInfo[] restores) {
-        List<RestoreInfo> aged = new ArrayList<>();
-        long cut = System.currentTimeMillis() - (CONSIDERED_NEW_INTERVAL);
-        for (RestoreHandlerInfo info : restores) {
-            if ((info.getStartTime() < cut)) {
-                RestoreInfo restoreInfo = new RestoreInfo(info);
-                aged.add(restoreInfo);
-            }
-        }
-        return aged;
-    }
-
-    public void setPoolManagerName(String poolManagerName) {
-        _poolManagerName = poolManagerName;
-    }
+    private static final Logger _log
+                    = LoggerFactory.getLogger(RestoreHandlerCollector.class);
+    private RestoreRequestsReceiver receiver;
 
     @Override
     public Status call() throws InterruptedException {
-        try {
-            collectRestores();
-        } catch (CacheException | NoRouteToCellException ex) {
-            _log.debug("Could not retrieve restoreHandlerInfos from {}",
-                            _poolManagerName);
-            _pageCache.remove(ContextPaths.RESTORE_INFOS);
-            return Status.FAILURE;
-        }
-
+        _pageCache.put(ContextPaths.RESTORE_INFOS,
+                       (receiver.getAllRequests().stream()
+                                .map(RestoreInfo::new)
+                                .collect(Collectors.toSet())));
         return Status.SUCCESS;
+    }
+
+    @Override
+    public void initialize() {
+        receiver.initialize();
+        super.initialize();
+    }
+
+    @Required
+    public void setReceiver(RestoreRequestsReceiver receiver) {
+        this.receiver = receiver;
     }
 }

--- a/modules/dcache-webadmin/src/main/webapp/WEB-INF/WebAdminInterface.xml
+++ b/modules/dcache-webadmin/src/main/webapp/WEB-INF/WebAdminInterface.xml
@@ -18,6 +18,7 @@
     <context:annotation-config/>
 
     <jee:jndi-lookup id="PoolMonitor" jndi-name="java:comp/env/poolMonitor"/>
+    <jee:jndi-lookup id="RestoresRequestReceiver" jndi-name="java:comp/env/restoresRequestReceiver"/>
 
     <bean id="PoolCellStub" class="org.dcache.cells.CellStub">
         <property name="timeout" value="${httpd.service.pool.timeout}"/>
@@ -201,10 +202,10 @@
                     init-method="initialize">
                     <property name="cellStub" ref="RestoreHandlerCollectorCellStub"/>
                     <property name="name" value="RestoreHandler Collector"/>
-                    <property name="poolManagerName" value="${httpd.service.poolmanager}"/>
                     <property name="sleepInterval" value="${httpd.service.restorehandler-collector.period}"/>
                     <property name="sleepIntervalUnit" value="${httpd.service.restorehandler-collector.period.unit}"/>
                     <property name="algorithmFactory" ref="ExponentialBackoff"/>
+                    <property name="receiver" ref="RestoresRequestReceiver"/>
                 </bean>
             </list>
         </constructor-arg>

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/frontend.xml
@@ -236,7 +236,12 @@
   <bean id="restores-collector" class="org.dcache.restful.util.restores.RestoreCollector">
     <description>Collects staging request info from from pool manager.</description>
     <property name="pnfsStub" ref="pnfs-stub"/>
-    <property name="poolManagerPath" value="${frontend.service.poolmanager}"/>
+    <property name="receiver">
+      <bean class="diskCacheV111.poolManager.RestoreRequestsReceiver">
+        <property name="lifetime" value="${frontend.restore-requests.lifetime}"/>
+        <property name="lifetimeUnit" value="${frontend.restore-requests.lifetime.unit}"/>
+      </bean>
+    </property>
   </bean>
 
   <bean id="restore-info-service" class="org.dcache.restful.services.restores.RestoresInfoServiceImpl">

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -7,7 +7,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -27,6 +26,18 @@ import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import dmg.cells.nucleus.AbstractCellComponent;
+import dmg.cells.nucleus.CDC;
+import dmg.cells.nucleus.CellAddressCore;
+import dmg.cells.nucleus.CellCommandListener;
+import dmg.cells.nucleus.CellInfoProvider;
+import dmg.cells.nucleus.CellMessage;
+import dmg.cells.nucleus.CellMessageReceiver;
+import dmg.cells.nucleus.CellPath;
+import dmg.cells.nucleus.CellSetupProvider;
+import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.cells.nucleus.UOID;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.CheckStagePermission;
@@ -51,18 +62,6 @@ import diskCacheV111.vehicles.ProtocolInfo;
 import diskCacheV111.vehicles.RestoreHandlerInfo;
 import diskCacheV111.vehicles.StorageInfo;
 import diskCacheV111.vehicles.WarningPnfsFileInfoMessage;
-
-import dmg.cells.nucleus.AbstractCellComponent;
-import dmg.cells.nucleus.CDC;
-import dmg.cells.nucleus.CellAddressCore;
-import dmg.cells.nucleus.CellCommandListener;
-import dmg.cells.nucleus.CellInfoProvider;
-import dmg.cells.nucleus.CellMessage;
-import dmg.cells.nucleus.CellMessageReceiver;
-import dmg.cells.nucleus.CellPath;
-import dmg.cells.nucleus.CellSetupProvider;
-import dmg.cells.nucleus.NoRouteToCellException;
-import dmg.cells.nucleus.UOID;
 
 import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.Partition;
@@ -614,14 +613,17 @@ public class RequestContainerV5
     }
 
     public PoolManagerGetRestoreHandlerInfo messageArrived(PoolManagerGetRestoreHandlerInfo msg) {
-        List<RestoreHandlerInfo> requests;
-        Map<String, PoolRequestHandler> handlerHash = _handlerHash;
-        synchronized (handlerHash) {
-            requests = handlerHash.values().stream().filter(Objects::nonNull).map(
-                    PoolRequestHandler::getRestoreHandlerInfo).collect(toList());
-        }
-        msg.setResult(requests);
+        msg.setResult(getRestoreHandlerInfo());
         return msg;
+    }
+
+    public List<RestoreHandlerInfo> getRestoreHandlerInfo() {
+        List<RestoreHandlerInfo> requests;
+        synchronized (_handlerHash) {
+            requests = _handlerHash.values().stream().filter(Objects::nonNull).map(
+                            PoolRequestHandler::getRestoreHandlerInfo).collect(toList());
+        }
+        return requests;
     }
 
     public static final String hh_xrc_ls = " # lists pending requests (binary)" ;

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/WebAppHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/WebAppHandler.java
@@ -20,12 +20,14 @@ package org.dcache.services.httpd.handlers;
 import org.eclipse.jetty.plus.jndi.EnvEntry;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Required;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 
+import javax.naming.NamingException;
 import java.util.Map;
 import java.util.Properties;
-import javax.naming.NamingException;
 
+import diskCacheV111.poolManager.RestoreRequestsReceiver;
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellMessageSender;
 import dmg.cells.nucleus.EnvironmentAware;
@@ -38,6 +40,7 @@ public class WebAppHandler extends WebAppContext
     public static final String JNDI_ARGS = "jndiArgs";
     public static final String POOL_MONITOR = "poolMonitor";
     public static final String BEAN_FACTORY = "beanFactory";
+    public static final String REQUEST_RECEIVER = "restoresRequestReceiver";
 
     private static final String[] CONFIGURATION_CLASSES = {
             "org.eclipse.jetty.webapp.WebInfConfiguration",
@@ -55,6 +58,7 @@ public class WebAppHandler extends WebAppContext
     private Map<String, Object> environment;
     private CellEndpoint endpoint;
     private RemotePoolMonitor remotePoolMonitor;
+    private RestoreRequestsReceiver receiver;
 
     public WebAppHandler()
     {
@@ -73,8 +77,14 @@ public class WebAppHandler extends WebAppContext
         this.endpoint = endpoint;
     }
 
+    @Required
     public void setPoolMonitor(RemotePoolMonitor remotePoolMonitor) {
         this.remotePoolMonitor = remotePoolMonitor;
+    }
+
+    @Required
+    public void setReceiver(RestoreRequestsReceiver receiver) {
+        this.receiver = receiver;
     }
 
     @Override
@@ -92,6 +102,7 @@ public class WebAppHandler extends WebAppContext
         new EnvEntry(this, CELL_ENDPOINT, endpoint, true);
         new EnvEntry(this, POOL_MONITOR, remotePoolMonitor, true);
         new EnvEntry(this, BEAN_FACTORY, beanFactory, true);
+        new EnvEntry(this, REQUEST_RECEIVER, receiver, true);
 
         Properties properties = new Properties();
         for (Map.Entry<String, Object> entry : environment.entrySet()) {

--- a/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
@@ -83,6 +83,17 @@
       <property name="destination" value="${poolmanager.pool-monitor.topic}"/>
   </bean>
 
+  <bean id="rc-restores-topic" class="org.dcache.cells.CellStub">
+    <description>Periodic notifications of restore request listings published to this topic.</description>
+    <property name="destination" value="${poolmanager.restore-requests.topic}"/>
+  </bean>
+
+  <bean id="rc-notify-scheduler" class="java.util.concurrent.ScheduledThreadPoolExecutor"
+        destroy-method="shutdownNow">
+    <description>Used to execute periodic notification of restore request listing.</description>
+    <constructor-arg value="1"/>
+  </bean>
+
   <bean id="rc-pool" class="org.dcache.util.CDCExecutorServiceDecorator"
           destroy-method="shutdownNow">
       <constructor-arg>
@@ -102,6 +113,15 @@
     <property name="hitInfoMessages" value="${poolmanager.enable.cache-hit-message}"/>
     <property name="billing" ref="billing-stub"/>
     <property name="poolStub" ref="pool-stub"/>
+  </bean>
+
+  <bean id="rc-request-notifier" class="diskCacheV111.poolManager.RestoreRequestsNotifier">
+    <description>Publishes restore request listings to the request topic.</description>
+    <property name="executorService" ref="rc-notify-scheduler"/>
+    <property name="requestContainer" ref="rc"/>
+    <property name="restoreRequests" ref="rc-restores-topic"/>
+    <property name="timeout" value="${poolmanager.request-notifier.timeout}"/>
+    <property name="timeoutUnit" value="${poolmanager.request-notifier.timeout.unit}"/>
   </bean>
 
   <bean id="rebalance" class="org.dcache.poolmanager.Rebalancer">

--- a/modules/dcache/src/main/resources/org/dcache/services/httpd/httpd.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/httpd/httpd.xml
@@ -41,10 +41,16 @@
 
     <bean id="delegator" class="org.dcache.services.httpd.handlers.HandlerDelegator"/>
 
+    <bean id="restores-request-receiver" class="diskCacheV111.poolManager.RestoreRequestsReceiver">
+        <property name="lifetime" value="${httpd.service.restore-requests.lifetime}"/>
+        <property name="lifetimeUnit" value="${httpd.service.restore-requests.lifetime.unit}"/>
+    </bean>
+
     <bean id="webapp-handler" class="org.dcache.services.httpd.handlers.WebAppHandler" scope="prototype">
         <property name="defaultsDescriptor" value="${httpd.container.default-webapp}"/>
         <property name="extractWAR" value="false"/>
         <property name="poolMonitor" ref="pool-monitor"/>
+        <property name="receiver" ref="restores-request-receiver"/>
     </bean>
 
     <bean id="jetty" class="org.dcache.services.httpd.Server">

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -538,6 +538,9 @@ dcache.topic.billing = BillingTopic
 # Upload cancelations are announced on this topic
 dcache.topic.upload-cancelled = UploadCancelledTopic
 
+# PoolManager request container publishes restore requests on the topic
+dcache.restore-requests.topic = RestoresRequestTopic
+
 #  ---- Topic for loginbroker update
 #
 # Doors periodically publish information about themselves on this topic, and other

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -37,7 +37,7 @@ frontend.cell.name=Frontend-${host.name}
 #
 frontend.cell.consume=${frontend.cell.name}
 
-frontend.cell.subscribe=${frontend.pool-monitor.topic},${frontend.loginbroker.update-topic}
+frontend.cell.subscribe=${frontend.pool-monitor.topic},${frontend.loginbroker.update-topic},${frontend.restore-requests.topic}
 
 # Cell address of alarms service
 frontend.service.alarms=${dcache.service.alarms}
@@ -129,6 +129,9 @@ frontend.service.pool-info.maxPoolActivityListSize=1000
 
 # Topic on which to expect pool monitor updates
 frontend.pool-monitor.topic = ${dcache.pool-monitor.topic}
+
+# Topic on which to expect request handler updates for restore requests
+frontend.restore-requests.topic = ${dcache.restore-requests.topic}
 
 #  ---- TCP port to listen on
 #
@@ -329,6 +332,11 @@ frontend.limits.threads.idle-time.unit=SECONDS
 # further TCP connections.
 #
 frontend.limits.queue-length=500
+
+# ---- Cache lifetime for evicting stale lists of pool manager restore requests
+#
+frontend.restore-requests.lifetime=1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.restore-requests.lifetime.unit = HOURS
 
 # ---- Shutdown timeout
 #

--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -5,7 +5,7 @@
 
 httpd.cell.name=httpd
 
-httpd.cell.subscribe=${httpd.loginbroker.update-topic},${httpd.pool-monitor-topic}
+httpd.cell.subscribe=${httpd.loginbroker.update-topic},${httpd.pool-monitor-topic},${httpd.restore-requests.topic}
 
 #
 #    Optional config file for configurig the httpd
@@ -31,6 +31,8 @@ httpd.loginbroker.update-topic=${dcache.loginbroker.update-topic}
 httpd.loginbroker.request-topic=${dcache.loginbroker.request-topic}
 
 httpd.pool-monitor-topic=${dcache.pool-monitor.topic}
+
+httpd.restore-requests.topic = ${dcache.restore-requests.topic}
 
 httpd.net.port = 2288
 
@@ -210,6 +212,8 @@ httpd.service.restorehandler-collector.timeout=5000
 (one-of?MILLISECONDS|SECONDS|MINUTES)httpd.service.restorehandler-collector.timeout.unit=MILLISECONDS
 httpd.service.restorehandler-collector.period=10000
 (one-of?MILLISECONDS|SECONDS|MINUTES)httpd.service.restorehandler-collector.period.unit=MILLISECONDS
+httpd.service.restore-requests.lifetime=1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)httpd.service.restore-requests.lifetime.unit=HOURS
 
 httpd.alarms.db.type = ${alarms.db.type}
 httpd.alarms.db.url = ${alarms.db.url}

--- a/skel/share/defaults/poolmanager.properties
+++ b/skel/share/defaults/poolmanager.properties
@@ -97,5 +97,12 @@ poolmanager.pool-monitor.update-period.unit = ${dcache.pool-monitor.update-perio
 
 poolmanager.pool-monitor.max-updates-per-second = ${dcache.pool-monitor.max-updates-per-second}
 
+#
+#  Publication of restore request listings
+#
+poolmanager.restore-requests.topic = ${dcache.restore-requests.topic}
+poolmanager.request-notifier.timeout=1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)poolmanager.request-notifier.timeout.unit=MINUTES
+
 (obsolete)poolmanager.cell.export = See poolmanager.cell.consume
 (forbidden)poolmanager.plugins.selection-unit =

--- a/skel/share/services/frontend.batch
+++ b/skel/share/services/frontend.batch
@@ -66,6 +66,9 @@ check -strong frontend.limits.queue-length
 check -strong frontend.limits.graceful-shutdown
 check -strong frontend.limits.graceful-shutdown.unit
 check -strong frontend.loginbroker.request-topic
+check -strong frontend.restore-requests.topic
+check -strong frontend.restore-requests.lifetime
+check -strong frontend.restore-requests.lifetime.unit
 check -strong frontend.dcache-view.dir
 
 check -strong frontend.static!dcache-view.endpoints.webapi

--- a/skel/share/services/httpd.batch
+++ b/skel/share/services/httpd.batch
@@ -34,6 +34,7 @@ check -strong httpd.service.spacemanager
 check httpd.loginbroker.update-topic
 check httpd.loginbroker.request-topic
 check httpd.pool-monitor-topic
+check httpd.restore-requests.topic
 check -strong httpd.limits.idle-time
 check -strong httpd.limits.idle-time.unit
 check -strong httpd.limits.threads
@@ -178,7 +179,9 @@ define context ${httpd.cell.name}Setup endDefine
    set alias cellInfo  context cellInfoTable.html  -onError=offline
    set alias usageInfo context poolUsageTable.html -onError=offline
    set alias queueInfo context poolQueueTable.html -onError=offline
-   set alias poolInfo class diskCacheV111.poolManager.HttpPoolMgrEngineV3 -- -poolmanager=${httpd.service.poolmanager} -pnfsmanager=${httpd.service.pnfsmanager}
+   set alias poolInfo class diskCacheV111.poolManager.HttpPoolMgrEngineV3 -- -poolmanager=${httpd.service.poolmanager} \
+        -pnfsmanager=${httpd.service.pnfsmanager} -cacheLifetime=${httpd.service.restore-requests.lifetime} \
+        -cacheLifetimeUnit=${httpd.service.restore-requests.lifetime.unit}
    set alias billing class diskCacheV111.cells.HttpBillingEngine -- -billing=${httpd.service.billing}
    set alias flushManager class diskCacheV111.hsmControl.flush.HttpHsmFlushMgrEngineV1 mgr=hfc css=default
    set alias pools class diskCacheV111.services.web.PoolInfoObserverEngineV2 showPoolGroupUsage=true

--- a/skel/share/services/poolmanager.batch
+++ b/skel/share/services/poolmanager.batch
@@ -16,6 +16,9 @@ check -strong poolmanager.pool-monitor.topic
 check -strong poolmanager.pool-monitor.update-period
 check -strong poolmanager.pool-monitor.update-period.unit
 check -strong poolmanager.pool-monitor.max-updates-per-second
+check -strong poolmanager.restore-requests.topic
+check -strong poolmanager.request-notifier.timeout
+check -strong poolmanager.request-notifier.timeout.unit
 check poolmanager.setup.file
 check poolmanager.setup.zookeeper
 


### PR DESCRIPTION
…re are multiple pool managers

Motivation:

With high availability, it is now possible to run redundant
services.  In the case of Pool Manager, restore requests
are distributed to the separate instances using rendez-vous hashing,
so as to avoid staging the same file twice.

This means, however, that the full list of current restore requests
is partitioned among the pool manager instances.  To receive a full
listing, it is no longer possible to query for them on the named
PoolManager queue, since this means the response will be from
the first responder only.

Modification:

The solution adopted here is as follows:

(a) each RequestContainer / PoolManager publishes periodically its
    stage request queue on a dedicated topic.
(b) frontend clients subscribe to this topic, and maintain the
    current lists.
(c) when an http request is made to them, they merge the current
    lists and return the results for display.

To facilitate these changes, a request notifier has been created
   which has the RequestContainer injected into to.  A frontend
   plugin receiver hashes the message lists according to the
   address of the pool manager sending the notification.  It then
   merges them into a single list when returning them to the caller.
   The receiver uses a cache with an after-write expiration to
   make sure that pool manager instances no longer publishing
   are removed.

Several properties affecting the cache lifetime and timeouts have
been added to the httpd and frontend services.

Note:  given that we are using a cache, it is no longer necessary
to maintain an aged list in the httpd clients (which, in fact, was
not being done anyway at least in the HttpPoolMgrEngine), so that
code has been eliminated.

Result:

All current http services report all restore requests.

Target: master
Request: 3.2
Require-notes: yes
Require-book: no
Acked-by: Dmitry