### PR TITLE
nfs: fix transfer leak, if the door failed to start a mover

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -929,10 +929,11 @@ public class NFSv41Door extends AbstractCellComponent implements
         }
     }
 
-    private static class NfsTransfer extends RedirectedTransfer<PoolDS> {
+    private class NfsTransfer extends RedirectedTransfer<PoolDS> {
 
         private final Inode _nfsInode;
         private final NFS4State _stateid;
+        private final NFS4State _openStateid;
         private ListenableFuture<Void> _redirectFuture;
         private AtomicReference<ChimeraNFSException> _errorHolder = new AtomicReference<>();
         private final NFS4Client _client;
@@ -944,6 +945,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
             // layout, or a transfer in dCache language, must have a unique stateid
             _stateid = client.createState(openStateId.getStateOwner(), openStateId);
+            _openStateid = openStateId;
             _client = client;
         }
 
@@ -1039,6 +1041,8 @@ public class NFSv41Door extends AbstractCellComponent implements
         public synchronized void shutdownMover() throws NfsIoException, DelayException {
 
             if (!hasMover()) {
+                // the mover clean-up will not be called, thus we have to clean manually
+                _ioMessages.remove(_openStateid.stateid());
                 return;
             }
 


### PR DESCRIPTION
Motivation:
the mapping between nfs state-id and NfsTransfer object is removed when
mover it finished. However, if no mover was created due to an error,
then such mapping is never removed by producing a memory leak as well as
confusing admins with non existing transfers.

Modification:
manually remove state-id <=> NfsTransfer mapping when no mover exist.

Result:
no memory leak, less opportunities to confuse the admins.

Acked-by: Paul Millar
Acked-by: Albert Rossi
Target: master, 3.2, 3.1, 2.16
Require-book: no
Require-notes: no
(cherry picked from commit 7bedc8c95658557975e2bd7659e695085e893683)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>