### PR TITLE
webdav: return 507 Insufficient Storage when dCache is full

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
@@ -12,6 +12,7 @@ import io.milton.http.Response;
 import io.milton.http.exceptions.BadRequestException;
 import io.milton.http.exceptions.NotAuthorizedException;
 import io.milton.http.exceptions.NotFoundException;
+import io.milton.http.quota.StorageChecker;
 import io.milton.http.values.ValueAndType;
 import io.milton.http.webdav.PropFindResponse;
 import io.milton.http.webdav.PropFindResponse.NameAndError;
@@ -72,6 +73,7 @@ public class DcacheResponseHandler extends AbstractWrappingResponseHandler
         .put(SC_UNAUTHORIZED, "UNAUTHORIZED")
         .put(SC_METHOD_NOT_ALLOWED, "METHOD NOT ALLOWED")
         .put(SC_NOT_FOUND, "FILE NOT FOUND")
+        .put(SC_INSUFFICIENT_STORAGE, "INSUFFICIENT STORAGE")
         .build();
 
     private AuthenticationService _authenticationService;
@@ -190,6 +192,12 @@ public class DcacheResponseHandler extends AbstractWrappingResponseHandler
     public void respondForbidden(Resource resource, Response response, Request request)
     {
         errorResponse(request, response, SC_FORBIDDEN);
+    }
+
+    @Override
+    public void respondInsufficientStorage(Request request, Response response, StorageChecker.StorageErrorReason storageErrorReason)
+    {
+        errorResponse(request, response, SC_INSUFFICIENT_STORAGE);
     }
 
     private void errorResponse(Request request, Response response, Response.Status status)

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
@@ -10,7 +10,8 @@ import io.milton.http.exceptions.BadRequestException;
 import io.milton.http.exceptions.ConflictException;
 import io.milton.http.exceptions.NotAuthorizedException;
 import io.milton.http.exceptions.NotFoundException;
-import io.milton.http.http11.Http11ResponseHandler;
+import io.milton.http.quota.StorageChecker;
+import io.milton.http.webdav.WebDavResponseHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,7 @@ public class DcacheStandardFilter implements Filter
     public void process(FilterChain chain, Request request, Response response)
     {
         HttpManager manager = chain.getHttpManager();
-        Http11ResponseHandler responseHandler = manager.getResponseHandler();
+        WebDavResponseHandler responseHandler = (WebDavResponseHandler) manager.getResponseHandler();
 
         try {
             Request.Method method = request.getMethod();
@@ -69,6 +70,8 @@ public class DcacheStandardFilter implements Filter
         } catch (UncheckedBadRequestException e) {
             log.debug("Client supplied bad request parameters: {}", e.getMessage());
             responseHandler.respondBadRequest(e.getResource(), response, request);
+        } catch (InsufficientStorageException e) {
+            responseHandler.respondInsufficientStorage(request, response, StorageChecker.StorageErrorReason.SER_DISK_FULL);
         } catch (ConflictException e) {
             responseHandler.respondConflict(e.getResource(), response, request, e.getMessage());
         } catch (NotAuthorizedException e) {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/InsufficientStorageException.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/InsufficientStorageException.java
@@ -1,0 +1,15 @@
+package org.dcache.webdav;
+
+import io.milton.resource.Resource;
+
+/**
+ * Indicates that the server should response with status code
+ * 507 Insufficient Storage (see RFC 4918).
+ */
+public class InsufficientStorageException extends WebDavException
+{
+    public InsufficientStorageException(String message, Throwable cause, Resource resource)
+    {
+        super(message, cause, resource);
+    }
+}


### PR DESCRIPTION
Motivation:

The WebDAV protocol includes a special return code to indicate that a
PUT request was denied because the filesystem is full: 507 Insufficient
Storage.  This has the following semantics (from RFC 4918)

   The 507 (Insufficient Storage) status code means the method could not
   be performed on the resource because the server is unable to store
   the representation needed to successfully complete the request.  This
   condition is considered to be temporary.  If the request that
   received this status code was the result of a user action, the
   request MUST NOT be repeated until it is requested by a separate user
   action.

Currently dCache returns "500 Internal Error" which provides no such
semantics.

Modification:

Introduce a new WebDavException, InsufficientStorageException, to allow
dCache to present the problem to milton.

Unfortunately, PoolManager does not return sufficient information to
distinguish between dCache being full and other failures; therefore, a
rather ugly work-around is employed that compares the String message
with known messages.

Result:

A full dCache results the expected 507 Insufficient Storage HTTP status.

Target: master
Require-notes: yes
Require-book: no
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Patch: https://rb.dcache.org/r/10638/
Acked-by: Tigran Mkrtchyan