### PR TITLE
spacemanager: provide space-specific error message on bad upload

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -910,10 +910,8 @@ public final class SpaceManagerService
                 return null;
             }
 
-            String hostName = (protocolInfo instanceof IpProtocolInfo)
-                ? ((IpProtocolInfo) protocolInfo).getSocketAddress().getAddress().getHostAddress()
-                : null;
-            String protocol = protocolInfo.getProtocol() + '/' + protocolInfo.getMajorVersion();
+            String hostName = hostnameFrom(protocolInfo);
+            String protocol = protocolFrom(protocolInfo);
             throw new NoPoolConfiguredSpaceException("Unable to reserve space: " +
                     "no write link in linkgroups " + linkGroupNames + " for " +
                     "writing a file with [net=" + hostName + ",protocol=" + protocol +
@@ -935,11 +933,8 @@ public final class SpaceManagerService
     private String findLinkGroupForWrite(ProtocolInfo protocolInfo, FileAttributes fileAttributes,
                                                Iterable<String> linkGroups)
     {
-        String protocol = protocolInfo.getProtocol() + '/' + protocolInfo.getMajorVersion();
-        String hostName =
-                (protocolInfo instanceof IpProtocolInfo)
-                ? ((IpProtocolInfo) protocolInfo).getSocketAddress().getAddress().getHostAddress()
-                : null;
+        String protocol = protocolFrom(protocolInfo);
+        String hostName = hostnameFrom(protocolInfo);
 
         for (String linkGroup : linkGroups) {
             PoolPreferenceLevel[] levels =
@@ -955,17 +950,36 @@ public final class SpaceManagerService
         return null;
     }
 
-    private boolean isWriteableOutsideLinkgroup(ProtocolInfo info, FileAttributes attributes)
-            throws NoFreeSpaceException
+    private String hostnameFrom(ProtocolInfo info)
     {
-        String protocol = info.getProtocol() + '/' + info.getMajorVersion();
-        String hostname = (info instanceof IpProtocolInfo)
+        return (info instanceof IpProtocolInfo)
                 ? ((IpProtocolInfo) info).getSocketAddress().getAddress().getHostAddress()
                 : null;
+    }
+
+    private String protocolFrom(ProtocolInfo info)
+    {
+        return info.getProtocol() + '/' + info.getMajorVersion();
+    }
+
+    private String storageFrom(FileAttributes attributes)
+    {
+        return attributes.getStorageClass() + '@' + attributes.getHsm();
+    }
+
+    private boolean isWriteableOutsideLinkgroup(ProtocolInfo info, FileAttributes attributes)
+    {
+        return isWriteableInLinkgroup(info, attributes, null);
+    }
+
+    private boolean isWriteableInLinkgroup(ProtocolInfo info, FileAttributes attributes, String linkGroup)
+    {
+        String protocol = protocolFrom(info);
+        String hostname = hostnameFrom(info);
 
         PoolPreferenceLevel[] levels = poolMonitor.getPoolSelectionUnit().
                 match(PoolSelectionUnit.DirectionType.WRITE, hostname, protocol,
-                        attributes, null);
+                        attributes, linkGroup);
 
         return levels.length != 0;
     }
@@ -1000,6 +1014,7 @@ public final class SpaceManagerService
     {
         LOGGER.trace("selectPool({})", selectWritePool);
         FileAttributes fileAttributes = selectWritePool.getFileAttributes();
+        ProtocolInfo protocolInfo = selectWritePool.getProtocolInfo();
         String defaultSpaceToken = fileAttributes.getStorageInfo().getMap().get("writeToken");
         Subject subject = selectWritePool.getSubject();
 
@@ -1015,6 +1030,16 @@ public final class SpaceManagerService
             }
             LinkGroup linkGroup = db.getLinkGroup(space.getLinkGroupId());
             String linkGroupName = linkGroup.getName();
+            if (!isWriteableInLinkgroup(protocolInfo, fileAttributes, linkGroupName)) {
+                // FIXME provide better information for the user
+                throw new NoPoolConfiguredSpaceException("Space reservation "
+                        + defaultSpaceToken + " may not be used for this write "
+                        + "request [net=" + hostnameFrom(protocolInfo)
+                        + ",protocol=" + protocolFrom(protocolInfo)
+                        + ",store=" + storageFrom(fileAttributes)
+                        + ",cache=" + nullToEmpty(fileAttributes.getCacheClass())
+                        + ",linkgroup=" + nullToEmpty(linkGroupName) + "]");
+            }
             selectWritePool.setLinkGroup(linkGroupName);
 
             StorageInfo storageInfo = selectWritePool.getStorageInfo();
@@ -1040,16 +1065,15 @@ public final class SpaceManagerService
         } else if (allowUnreservedUploadsToLinkGroups) {
             LOGGER.trace("Upload outside a reservation, identifying appropriate linkgroup");
 
-            LinkGroup linkGroup =
-                    findLinkGroupForWrite(subject, selectWritePool
-                            .getProtocolInfo(), fileAttributes, selectWritePool.getPreallocated());
+            LinkGroup linkGroup = findLinkGroupForWrite(subject, protocolInfo,
+                    fileAttributes, selectWritePool.getPreallocated());
             if (linkGroup != null) {
                 String linkGroupName = linkGroup.getName();
                 selectWritePool.setLinkGroup(linkGroupName);
                 fileAttributes.getStorageInfo().setKey("LinkGroupId", Long.toString(linkGroup.getId()));
                 LOGGER.trace("selectPool: found linkGroup = {}, forwarding message", linkGroupName);
             }
-        } else if (isWriteableOutsideLinkgroup(selectWritePool.getProtocolInfo(), fileAttributes)) {
+        } else if (isWriteableOutsideLinkgroup(protocolInfo, fileAttributes)) {
             LOGGER.debug("Upload proceeding outside of any linkgroup.");
         } else {
             throw new NoPoolConfiguredSpaceException("No write pools configured outside of a linkgroup.");


### PR DESCRIPTION
Motivation:

If the user tries to upload into dCache using a space-token where there
is no selectable link for this operation then the user is presented with
a generic error message; for example,

    No write links configured for [net=131.169.71.98,protocol=GFtp/2,store=dot:user@osm,cache=,linkgroup=]

This provides no feedback that the problem is to do with their space
reservation.

Modification:

Check whether the upload will select any pools within space-manager.
This allows for a more specific error message, detailing that the
problem is the combination of the user's choice of space-reservation and
aspects of the upload.

The error message is still bad, but at least it now includes some
feedback that the problem may be to do with the space reservation.

Result:

An improved error message is returned to the user if they attempt an
upload data into dCache using a space-reservation in a way where
poolmanager configuration prevents the upload.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9299
Patch: https://rb.dcache.org/r/10643/
Acked-by: Tigran Mkrtchyan