### PR TITLE
srmclient: add support for specifying linkgroup when reserving space

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/Configuration.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/Configuration.java
@@ -1634,6 +1634,25 @@ public class Configuration extends ConnectionConfiguration {
         this.cksm_value = value;
     }
 
+    @Option(
+            name = "linkgroup",
+            description = "the name of the linkgroup from which space will be "
+                    + "reserved.  This value is honoured by dCache v3.2 or "
+                    + "newer; older dCache instances and non-dCache SRM "
+                    + "instances will ignore this value.",
+            required = false,
+            log = true
+    )
+    private String linkgroup;
+
+    public String getLinkgroup() {
+        return linkgroup;
+    }
+
+    public void setLinkgroup(String value) {
+        linkgroup = value;
+    }
+
     private String arrayOfRequestTokens[];
 
     @Option(
@@ -1940,7 +1959,8 @@ public class Configuration extends ConnectionConfiguration {
                     "connection_type",
                     "desired_size",
                     "guaranteed_size",
-            "lifetime")+
+                    "lifetime",
+                    "linkgroup")+
             printMandatoryOptions("retention_policy","guaranteed_size");
             return
             "\nUsage: srm-reserve-space [command line options]  srmUrl\n\n"+

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReserveSpaceClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReserveSpaceClientV2.java
@@ -93,6 +93,7 @@ import org.dcache.srm.request.AccessLatency;
 import org.dcache.srm.request.RetentionPolicy;
 import org.dcache.srm.util.RequestStatusTool;
 import org.dcache.srm.v2_2.ArrayOfString;
+import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
 import org.dcache.srm.v2_2.ISRM;
 import org.dcache.srm.v2_2.SrmAbortRequestRequest;
 import org.dcache.srm.v2_2.SrmAbortRequestResponse;
@@ -103,6 +104,7 @@ import org.dcache.srm.v2_2.SrmStatusOfReserveSpaceRequestResponse;
 import org.dcache.srm.v2_2.TAccessLatency;
 import org.dcache.srm.v2_2.TAccessPattern;
 import org.dcache.srm.v2_2.TConnectionType;
+import org.dcache.srm.v2_2.TExtraInfo;
 import org.dcache.srm.v2_2.TRetentionPolicy;
 import org.dcache.srm.v2_2.TRetentionPolicyInfo;
 import org.dcache.srm.v2_2.TReturnStatus;
@@ -191,6 +193,10 @@ public class SRMReserveSpaceClientV2 extends SRMClient implements Runnable {
                     tp.setArrayOfTransferProtocols(new ArrayOfString(configuration.getProtocols()));
                 }
                 request.setTransferParameters(tp);
+            }
+            if (configuration.getLinkgroup() != null) {
+                TExtraInfo linkgroupSelector = new TExtraInfo("linkgroup", configuration.getLinkgroup());
+                request.setStorageSystemInfo(new ArrayOfTExtraInfo(new TExtraInfo[]{linkgroupSelector}));
             }
             hook = new Thread(this);
             Runtime.getRuntime().addShutdownHook(hook);


### PR DESCRIPTION
Motivation:

Although the SRM specification provides no standard mechanism to specify
from which resource a space reservation should be made, there is the
possibility to include arbitrary key-value pairs with the request.

A new patch adds support in dCache to react to the key "linkgroup" by
accepting the corresponding value as the name of the linkgroup from
which the reservation is to be made.

Modification:

Optionally send TExtraInfo as part of the reserve space request.

Result:

The srm-reserve-space command now supports a user choosing from which
linkgroup a reservation should be made, provided the corresponding
dCache also supports this.

Target: master
Request: 3.2
Require-notes: no
Require-srmclient-notes: yes
Require-book: yes
Patch: https://rb.dcache.org/r/10647/
Acked-by: Tigran Mkrtchyan