### PR TITLE
spacemanager: allow SRM clients to specify linkgroup in reserve requests

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/SrmReserveSpaceCompanion.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/SrmReserveSpaceCompanion.java
@@ -142,6 +142,7 @@ public final class SrmReserveSpaceCompanion
             String retentionPolicyString,
             String accessLatencyString,
             String description,
+            String linkgroup,
             SrmReserveSpaceCallback callback,
             CellStub spaceManagerStub,
             Executor executor)
@@ -173,6 +174,7 @@ public final class SrmReserveSpaceCompanion
 
         Reserve reserve =
                 new Reserve(
+                        linkgroup,
                         sizeInBytes,
                         retentionPolicy,
                         accessLatency,

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -2086,12 +2086,14 @@ public final class Storage
             String retentionPolicy,
             String accessLatency,
             String description,
+            Map<String,String> extraInfo,
             SrmReserveSpaceCallback callback) {
         if (_isSpaceManagerEnabled) {
             try {
                 SrmReserveSpaceCompanion.reserveSpace(asDcacheUser(user).getSubject(),
                                                       sizeInBytes, spaceReservationLifetime, retentionPolicy,
-                                                      accessLatency, description, new SrmReserveSpaceCallback()
+                                                      accessLatency, description, extraInfo.get("linkgroup"),
+                                                      new SrmReserveSpaceCallback()
                         {
                             public void failed(String reason)
                             {

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/services/space/message/Reserve.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/services/space/message/Reserve.java
@@ -31,8 +31,10 @@ public class Reserve extends Message{
     private final long lifetime;
     private long expirationTime;
     private final String description;
+    private final String linkgroupName;
 
     public Reserve(
+            String linkgroupName,
             long sizeInBytes,
             RetentionPolicy retentionPolicy,
             AccessLatency accessLatency,
@@ -43,6 +45,7 @@ public class Reserve extends Message{
         this.accessLatency = accessLatency;
         this.retentionPolicy = checkNotNull(retentionPolicy);
         this.description = description;
+        this.linkgroupName = linkgroupName;
         setReplyRequired(true);
     }
 
@@ -81,5 +84,9 @@ public class Reserve extends Message{
 
     public String getDescription() {
         return description;
+    }
+
+    public String getLinkgroupName() {
+        return linkgroupName;
     }
 }

--- a/modules/srm-server/src/main/java/org/dcache/srm/AbstractStorageElement.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/AbstractStorageElement.java
@@ -523,6 +523,7 @@ public interface AbstractStorageElement {
                          String retentionPolicy,
                          String accessLatency,
                          String description,
+                         Map<String,String> extraInfo,
                          SrmReserveSpaceCallback callbacks);
 
     /**

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/ReserveSpaceRequest.java
@@ -76,6 +76,7 @@ import org.apache.axis.types.UnsignedLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.dcache.srm.SRMInvalidRequestException;
@@ -113,6 +114,7 @@ public final class ReserveSpaceRequest extends Request {
     private long sizeInBytes ;
     private final TRetentionPolicy retentionPolicy;
     private final TAccessLatency accessLatency;
+    private final Map<String,String> extraInfo;
     private String spaceToken;
     private long spaceReservationLifetime;
 
@@ -127,13 +129,15 @@ public final class ReserveSpaceRequest extends Request {
             TRetentionPolicy retentionPolicy,
             TAccessLatency accessLatency,
             String description,
-            String clienthost) {
+            String clienthost,
+            Map<String,String> extraInfo) {
         super(user, max_update_period, lifetime, description, clienthost);
 
         this.sizeInBytes = sizeInBytes ;
         this.retentionPolicy = retentionPolicy;
         this.accessLatency = accessLatency;
         this.spaceReservationLifetime = spaceReservationLifetime;
+        this.extraInfo = extraInfo;
     }
 
     /** this constructor is used for restoring the previously
@@ -161,6 +165,7 @@ public final class ReserveSpaceRequest extends Request {
             String accessLatency,
             String description,
             String clienthost,
+            Map<String,String> extraInfo,
             String statusCodeString) {
                 super(id,
                       nextJobId,
@@ -184,6 +189,7 @@ public final class ReserveSpaceRequest extends Request {
         this.retentionPolicy = retentionPolicy == null?null: TRetentionPolicy.fromString(retentionPolicy);
         this.accessLatency = accessLatency == null ?null :TAccessLatency.fromString(accessLatency);
         this.spaceReservationLifetime = spaceReservationLifetime;
+        this.extraInfo = extraInfo;
 
         logger.debug("restored");
     }
@@ -250,6 +256,7 @@ public final class ReserveSpaceRequest extends Request {
                     retentionPolicy == null ? null : retentionPolicy.getValue(),
                     accessLatency == null ? null : accessLatency.getValue(),
                     getDescription(),
+                    extraInfo,
                     callbacks);
         }
     }
@@ -465,6 +472,10 @@ public final class ReserveSpaceRequest extends Request {
 
     public TAccessLatency getAccessLatency() {
         return accessLatency;
+    }
+
+    public Map<String,String> getExtraInfo() {
+        return extraInfo;
     }
 
     public String getSpaceToken() {

--- a/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-4.0.xml
+++ b/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-4.0.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="0" author="paul">
+        <comment>Allow storage of TExtraInfo in ReserveSpace requests</comment>
+
+	<addColumn tableName="reservespacerequests">
+	  <column name="extrainfo" type="varchar(32762)"/>
+	</addColumn>
+
+        <rollback>
+	  <dropColumn columnName="extrainfo"
+		      tableName="reservespacerequests"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-master.xml
+++ b/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-master.xml
@@ -3,4 +3,5 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
     <include file="org/dcache/srm/request/sql/srm.changelog-2.14.xml"/>
+    <include file="org/dcache/srm/request/sql/srm.changelog-4.0.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Motivation:

dCache supports space reservation through linkgroups: each space
reservation is bound to a particular linkgroup.  Uploads involving a
reservation automatically select that linkgroup.

Each linkgroup has an independent set of links.  The set of links within
a single linkgroup may be configured to accept only a subset of all
upload requests; for example, only uploads into a particular path (i.e.,
a specific storage class).

If dCache is configured with more than one linkgroup then it is possible
that an upload is allowed by one linkgroup, but is not acceptable to
another.  Attempts to upload with a reservation made from the "wrong"
linkgroup will fail. Therefore, the user may care from which linkgroup a
reservation is made.

The SRM protocol has no concept that describes the resources a space
reservation is made (in dCache, the linkgroup).  Therefore, there is no
standard mechanism to allow clients to specify from which linkgroup the
reservation should be made.

Currently, given multiple linkgroups, dCache chooses the linkgroup with
the largest free capacity.  However, this may not correspond to the
user's expectation.

Modification:

Add support for 'storageSystemInfo' in an SRM reserve space request,
which is an arbitrary array of key-value strings.  This information is
preserved in the database and available to the SE-specific backend.

Update dCache plugin to support the "linkgroup" key with the value being
a linkgroup name.  If this key is provided then either the reservation
is made from that linkgroup or the request fails.

Result:

dCache now allows an SRM client to specifying from which linkgroup a
reservation should be made.

Target: master
Request: 3.2
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9299
Patch: https://rb.dcache.org/r/10646/
Acked-by: Tigran Mkrtchyan