### PR TITLE
systemtest: work with new OpenSSL DN format

### DIFF
--- a/packages/system-test/src/main/bin/populate
+++ b/packages/system-test/src/main/bin/populate
@@ -15,15 +15,19 @@ lib="$(getProperty dcache.paths.share.lib)"
 
 cd @TARGET@/dcache
 
+dn() { # $1 - path to X.509 certificate
+    openssl x509 -in "$1" -subject -noout -nameopt compat | sed 's:subject= *\+:/:;s:, :/:g'
+}
+
 if [ ! -f etc/dcache.kpwd ]; then
     if [ -f ~/.globus/dcache-systemtest-usercert.pem ]; then
-        DN=$(openssl x509 -in ~/.globus/dcache-systemtest-usercert.pem -subject -noout | sed -e 's/subject= *//')
+        DN=$(dn ~/.globus/dcache-systemtest-usercert.pem)
         bin/dcache kpwd dcuseradd -u $uid -g $gid -h / -r / -f / \
             -w read-write -p password -s "$DN" system-test
         bin/dcache kpwd dcmapadd "$DN" system-test
     fi
     if [ -f ~/.globus/usercert.pem ]; then
-        DN=$(openssl x509 -in ~/.globus/usercert.pem -subject -noout | sed -e 's/subject= *//')
+        DN=$(dn ~/.globus/usercert.pem)
         bin/dcache kpwd dcuseradd -u $uid -g $gid -h / -r / -f / \
             -w read-write -p password -s "$DN" "$username"
         bin/dcache kpwd dcmapadd "$DN" "$username"


### PR DESCRIPTION
Motivation:

At some point (perhaps with v1.1.0), OpenSSL changed the format it uses
when showing distinguished names.  The old format is /-seperated; for
example:

    /DC=org/DC=dCache/CN=Bernd das Brot

The new format is comma-separate; for example:

    DC = org, DC = dCache, CN = Bernd das Brot

The openssl command allows some customisatin of the format; however, no
option or combination of options allows the new versions of OpenSSL to
show DNs using the /-separated format.

Various dCache files currently require DNs to be written the /-seperated
format.  This results in system-test no longer working on platforms with
new enough versions of OpenSSL.

Modification:

Add simple text manipulation to provide DNs in the expected format.  The
updated commands are backwards compatible: by specifying the 'nameopt'
argument, OpenSSL uses the comma-separate format.

Result:

The system-test deployment works with newer OpenSSL versions.

Target: master
Require-notes: no
Require-book: no
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Patch: https://rb.dcache.org/r/10648/
Acked-by: Tigran Mkrtchyan

Conflicts:
	packages/system-test/src/main/bin/populate