### PR TITLE
overhaul logroation on Debian

### DIFF
--- a/packages/fhs/src/main/deb/dcache.logrotate
+++ b/packages/fhs/src/main/deb/dcache.logrotate
@@ -1,7 +1,26 @@
+#Note: The following may work only for dCache logs managed by rsyslog (i.e. not for its access- and event logs, which are managed by logback)!
+
+
+
+
 /var/log/dcache/*.log {
-    compress
-    weekly
-    rotate 52
-    missingok
-    copytruncate
+	create
+	nocopy
+	nocopytruncate
+	missingok
+	
+	#Note: “delaycompress” is important for how the rsyslog-managed logs are rotated.
+	delaycompress
+	
+	postrotate
+		if [ -x /usr/lib/rsyslog/rsyslog-rotate ]; then
+			/usr/lib/rsyslog/rsyslog-rotate
+		else
+			#TODO: Remove this (and the surrounding “if”) once rsyslog versions < 8.27.0-4 are no longer in use (which is still the case in Debian stretch).
+			invoke-rc.d rsyslog rotate > /dev/null
+		fi
+	endscript
+	
+	
+	notifempty
 }


### PR DESCRIPTION
The current logrotate script has some issues and space for improvements.

First, there is no reason, that dCache sets “weekly”, “compress”, “rotate 52”
(especially why 52?) - these should be taken from the global settings, so an
admin can easily define when he wants rotation and whether and which compression
he wants to have used (e.g. not the standard poor gzip that “compress” implies
but maybe XZ).
If an admin wants to override the global defaults, he still can do so in the
logration configuration for dCache.

Second, in the default configuration, log messages are written to stdout/err,
from where they get collected by journald, from where rsyslogd picks them up and
writes them into files in “/var/log/dcache”.
Because rsyslogd now manages “/var/log/dcache/*.log” we no longer need to use
the “copytruncate”, which is prone to loosing messages (between the copy and the
truncate). Instead, we let rsyslog rotate the file (and it’s important to not
have it compressed already here, so “delaycompress” is set), “create” a new log
file and then we send HUP to rsyslog (or rather some Debian script does this the
correct way for us) to have it opening the new log files.
Thus we shouldn’t loose any messages (and it’s faster too).

“missingok” is left in place, simply because the package doesn’t (and cannot
reliably) create the log files.

I’ve also added “notifempty” which is for some reason not the global default in
Debian. I know, this is the same evil than overriding the global settings with
e.g. “weekly” but I bet that simply everyone wants to have this.

Last but not least I’ve added some warnings that this may possibly not work for
other non-rsyslogd-managed log files (e.g. the access and event logs).

Target: master
Require-notes: yes
Require-book: possibly
Request: 3.2

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>