### PR TITLE
webdav.properties: warn about redirects to http.

### DIFF
--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -302,6 +302,10 @@ webdav.authz.allowed-paths = /
 #   HTTPS, a server certificate and a trust store need to be
 #   created. By default these are stored under /etc/grid-security/.
 #
+#   WARNING: when https is specified and redirects are enabled, 
+#   authentication will be done over https but files will be
+#   transferred over http.
+#
 (one-of?http|https)webdav.authn.protocol = http
 
 (immutable)webdav.authn.connector-for-http = PLAIN


### PR DESCRIPTION
I've submitted a feature request at https://github.com/dCache/dcache/issues/3736 to enable redirects to https, but I don't expect it to be implemented soon; therefore this pull request for a warning.