### PR TITLE
maven: fix dcache.service permissions

### DIFF
--- a/packages/fhs/src/main/assembly/deb.xml
+++ b/packages/fhs/src/main/assembly/deb.xml
@@ -8,8 +8,14 @@
             <filtered>true</filtered>
         </fileSet>
         <fileSet>
-            <directory>${filtered-skel}/lib/systemd</directory>
-            <outputDirectory>lib/systemd</outputDirectory>
+            <directory>${filtered-skel}/lib/systemd/system</directory>
+            <outputDirectory>lib/systemd/system</outputDirectory>
+            <fileMode>0644</fileMode>
+            <directoryMode>0755</directoryMode>
+        </fileSet>
+        <fileSet>
+            <directory>${filtered-skel}/lib/systemd/system-generators</directory>
+            <outputDirectory>lib/systemd/system-generators</outputDirectory>
             <excludes>
                 <exclude>**/.empty-dir</exclude>
             </excludes>


### PR DESCRIPTION
This fixes my commit 62ca394df9147a0e900f5047114abeaccfb26143 in which I didn’t
notice that maven sets the file permission bits of all the files of that set to
0755.

systemd however complains about unit files that have the executable bit set
with:
>systemd[1]: Configuration file /lib/systemd/system/dcache.service is marked
>executable. Please remove executable permission bits. Proceeding anyway.

Target: master
Require-notes: no
Require-book: no
Request: 3.2

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>