### PR TITLE
systemd: stop all dCache service units in Debian prerm

### DIFF
--- a/packages/fhs/src/main/deb/prerm
+++ b/packages/fhs/src/main/deb/prerm
@@ -1,7 +1,9 @@
 #!/bin/sh -e
 
 if type "systemctl" > /dev/null 2>&1; then
-        systemctl stop dcache@*
+	#Note: Users may have overriden the units and changed the dependencies between them, thus stop both, the “global” and the instance units.
+        systemctl stop dcache.service
+        systemctl stop dcache@*.service
 else
         invoke-rc.d dcache stop || :
 fi


### PR DESCRIPTION
The Debian package’s prerm maintainer script only stopped “dcache@*” units.

First, I think it’s better to really explicitly stop “dcache@*.service” as these
are the only ones we create at the moment and why should we stop anything of
similar names that the user may have created himself.

Second, it didn’t stop the later introduced “dcache.service”. I forgot to add
this, cause normally on proper Debian source packages this would be added
automatically by Debhelper.

Target: master
Request: 3.2
Require-notes: no
Require-book: no

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>