### PR TITLE
pools: fix NPE from info command at startup

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/HsmFlushController.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/HsmFlushController.java
@@ -208,8 +208,10 @@ public class HsmFlushController
         info.setFlushDelayOnError(_retryDelayOnError);
         info.setFlushInterval(_flushingInterval);
         info.setMaxActive(_maxActive);
-        info.setNextFlush(System.currentTimeMillis() +
-                                          _future.getDelay(TimeUnit.MILLISECONDS));
+        if (_future != null) {
+            info.setNextFlush(System.currentTimeMillis() +
+                                              _future.getDelay(TimeUnit.MILLISECONDS));
+        }
         return info;
     }
 


### PR DESCRIPTION
Motivation:

order to support JSON representations.  The
refactoring neglected to include a previous
null check on one of the HsmFlushController fields.

Modification:

Restore the null check.

Result:

An NPE should not be thrown on startup if the
info command is run on the pool. (See below).

Target: master
Request: 3.3
Request. 3.2
Fixes: #3752
Acked-by: Tigran
Require-notes: yes
Require-book: no