### PR TITLE
authentication: update multimap to cooperate in generating primary gids

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/GidPrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/GidPrincipal.java
@@ -1,6 +1,7 @@
 package org.dcache.auth;
 
 import java.io.Serializable;
+import java.security.Principal;
 
 /**
  * This Principal represents the GID of a person.  The GID represents a group
@@ -22,6 +23,10 @@ public class GidPrincipal implements GroupPrincipal, Serializable
 
     private final long _gid;
     private final boolean _isPrimaryGroup;
+
+    public static boolean isPrimaryGid(Principal principal) {
+        return principal instanceof GidPrincipal && ((GidPrincipal)principal).isPrimaryGroup();
+    }
 
     public GidPrincipal(long gid, boolean isPrimary) {
         if (gid < 0) {

--- a/modules/gplazma2-multimap/src/main/java/org/dcache/gplazma/plugins/GplazmaMultiMapPlugin.java
+++ b/modules/gplazma2-multimap/src/main/java/org/dcache/gplazma/plugins/GplazmaMultiMapPlugin.java
@@ -3,10 +3,13 @@ package org.dcache.gplazma.plugins;
 import com.google.common.base.Strings;
 
 import org.dcache.gplazma.AuthenticationException;
+
 import java.security.Principal;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.dcache.auth.GidPrincipal;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -38,6 +41,16 @@ public class GplazmaMultiMapPlugin implements GPlazmaMappingPlugin
                                                     .collect(Collectors.toSet());
 
         checkAuthentication(!mappedPrincipals.isEmpty(), "no mappable principals");
+
+        if (principals.stream().anyMatch(GidPrincipal::isPrimaryGid)
+                && mappedPrincipals.stream().anyMatch(GidPrincipal::isPrimaryGid)) {
+            mappedPrincipals = mappedPrincipals.stream()
+                    .map(p -> GidPrincipal.isPrimaryGid(p)
+                            ? new GidPrincipal(((GidPrincipal)p).getGid(), false)
+                            : p)
+                    .collect(Collectors.toSet());
+        }
+
         principals.addAll(mappedPrincipals);
     }
 }


### PR DESCRIPTION
Motivation:

A previous commit d1aaa0c introduced the concept of plugins cooperating
in generating primary gids.  This is achieved by checking whether the
user already has a primary gid and, if so, only introducing secondary
gids.

Unfortunately, this patch forgot to update the multimap plugin.

Modification:

Check whether the user already has a primary gid and the mapped
principals also has a primary gid; if so, convert all of the new
principals that are primary gids into non-primary gids.

Result:

The multimap plugin may be used in differential authentication
environments.

Target: master
Require-notes: yes
Require-book: yes
Request: 4.0
Patch: https://rb.dcache.org/r/10662/
Acked-by: Tigran Mkrtchyan