### PR TITLE
chimera: fix deadlock in Postgres driver

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/PgSQLFsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PgSQLFsSqlDriver.java
@@ -296,6 +296,28 @@ public class PgSQLFsSqlDriver extends FsSqlDriver {
     }
 
     @Override
+    void copyTags(FsInode orign, FsInode destination) {
+        _jdbc.queryForList("INSERT INTO t_tags (inumber,itagid,isorign,itagname) (SELECT ?,itagid,0,itagname FROM t_tags WHERE inumber=?) RETURNING itagid",
+                Long.class, destination.ino(), orign.ino()).
+                forEach(tagId -> {
+                    _jdbc.update("UPDATE t_tags_inodes SET inlink = inlink + 1 WHERE itagid=?", tagId);
+                });
+    }
+
+    @Override
+    void removeTag(FsInode dir) {
+        _jdbc.queryForList("DELETE FROM t_tags WHERE inumber=? RETURNING itagid", Long.class, dir.ino())
+                .forEach(tagId -> {
+                    // shortcut: delete right away, if there is only one reference left
+                    int n = _jdbc.update("DELETE FROM t_tags_inodes WHERE itagid=? AND inlink = 1", tagId);
+                    // if delete didn't happen, then just indicate that one reference in gone
+                    if (n == 0) {
+                        _jdbc.update("UPDATE t_tags_inodes SET inlink = inlink - 1 WHERE itagid=?", tagId);
+                    }
+                });
+    }
+
+    @Override
     void removeTag(FsInode dir, String tag) {
 
         Long tagId = _jdbc.query("DELETE FROM t_tags WHERE inumber=? AND itagname=? RETURNING *",


### PR DESCRIPTION
fixes: 2db31a0bd - chimera: keep track of tags usage

Motivation:
we observe db deadlocks with latest changes in directory tags tracking changes.
As dead lock was triggered by xfs-tests only, thenchanges was not integrated
into dCache. However, with cloud update to 3.2 we started to see them

Modification:
try to delete from t_tags fist and then update t_tags_inodes to avoid A,B-> B,A
situations. tested only for postgres.

Result:
the deadlock is not reproduced.

Acked-by: Paul Millar
Target: master, 3.2, 4.0
Require-book: no
Require-notes: yes
(cherry picked from commit 0010216f5ad0129c22f0a12c0cacab99d55d32d0)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>