### PR TITLE
info: allow admin to control whether non-VO / non-FQAN identities are…

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/LinkgroupDetailsMsgHandler.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/LinkgroupDetailsMsgHandler.java
@@ -30,9 +30,21 @@ public class LinkgroupDetailsMsgHandler implements MessageHandler
 
     private final StateUpdateManager _sum;
 
+    private boolean _showOnlyVoAuthz;
+
     public LinkgroupDetailsMsgHandler(StateUpdateManager sum)
     {
         _sum = sum;
+    }
+
+    public void setShowOnlyVoAuthz(boolean isLimited)
+    {
+        _showOnlyVoAuthz = isLimited;
+    }
+
+    public boolean isShowOnlyVoAuthz()
+    {
+        return _showOnlyVoAuthz;
     }
 
     @Override
@@ -85,8 +97,11 @@ public class LinkgroupDetailsMsgHandler implements MessageHandler
 
             if (voInfo.length > 0) {
                 for (VOInfo thisVO : voInfo) {
-                    addVoInfo(update, vosPath.newChild(thisVO
-                            .toString()), thisVO, metricLifetime, lgid);
+                    String group = thisVO.getVoGroup();
+                    if (!_showOnlyVoAuthz || group == null || group.startsWith("/")) {
+                        addVoInfo(update, vosPath.newChild(thisVO
+                                .toString()), thisVO, metricLifetime, lgid);
+                    }
                 }
             } else {
                 // Ensure the VOs branch exists.

--- a/modules/dcache-info/src/main/resources/org/dcache/services/info/info.xml
+++ b/modules/dcache-info/src/main/resources/org/dcache/services/info/info.xml
@@ -123,6 +123,7 @@
               </bean>
               <bean class="org.dcache.services.info.gathers.LinkgroupDetailsMsgHandler">
                   <constructor-arg ref="state-update-manager"/>
+                  <property name="showOnlyVoAuthz" value="${info.limits.show-only-vo-authz}"/>
               </bean>
               <bean class="org.dcache.services.info.gathers.SrmSpaceDetailsMsgHandler">
                   <constructor-arg ref="state-update-manager"/>

--- a/skel/share/defaults/info.properties
+++ b/skel/share/defaults/info.properties
@@ -63,6 +63,17 @@ info.net.backlog=5
 info.loginbroker.update-topic=${dcache.loginbroker.update-topic}
 
 #
+#  Part of the information the info services collects is who is
+#  authorised to reserve space from the various linkgroups.  This may
+#  include FQANs (such as complete VOs), usernames and gids.
+#
+#  Exposing usernames and gids may be sensitive information, in some
+#  environments, therefore this option controls whether non-FQAN
+#  principals are shown.
+#
+(one-of?true|false)info.limits.show-only-vo-authz = false
+
+#
 #   Document which TCP ports are opened
 #
 (immutable)info.net.ports.tcp = ${info.net.port}


### PR DESCRIPTION
… shown

Motivation:

The info service collects information on who is allowed to reserve
space.  This may include VOs / FQANs, usernames and gids.  The latter
two may be considered sensitive information and publishing them
considered leaking internal information.

Modification:

Add a configuration option describing whether authz information should
be limited to only VOs/FQANs or should also include username and gid
information.

Although excluding usernames and gids is the safer option, this patch
uses a default value where these identifiers are still published.  This
is so the patch may be back-ported to the stable branches without
affecting current users.

Result:

The admin has control over whether username and gids are published in
the info service.

Target: master
Require-notes: yes
Require-book: no
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9311
Patch: https://rb.dcache.org/r/10672
Acked-by: Tigran Mkrtchyan