### PR TITLE
scripts: update reference to JDK to avoid mentioning specific java ve…

### DIFF
--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -608,10 +608,10 @@ case "$1" in
                 file="$(printCanonicalPath $file)" || fail 1 "Failed to resolve $file."
 
                 findJavaTool jmap ||
-                fail 1 "Could not find the jmap command, part of the Java 6
-                        JDK. This command is required for producing a heap
-                        dump. Please ensure that either jmap is in the path
-                        or update JAVA_HOME."
+                fail 1 "Could not find the jmap command, which is part of the
+                        Java Development Kit (JDK) package. This command is
+                        required for producing a heap dump. Please ensure that
+                        either jmap is in the path or update JAVA_HOME."
 
                 if [ -f ${file} ]; then
                     fail 1 "${file} already exists. Heap not dumped."

--- a/skel/man/man8/dcache.8
+++ b/skel/man/man8/dcache.8
@@ -334,7 +334,8 @@ If the domain hangs, then the dump may fail. In those cases the
 quite as useful, as it will also contain objects that are no longer in
 use.
 
-This feature requires that the Java 6 JDK is installed.
+This feature requires that the Java Development Kit (JDK) package is
+installed.
 
 .TP
 .B dump threads [SERVICE|DOMAIN] ...


### PR DESCRIPTION
…rsion

Motivation:

By mentioning a specific JDK version, dCache gives the impression that
newer versions of Java are not supported.  In fact, the reverse is
true -- the java version mentioned is actually no longer supported.

Modification:

Rephrase mentions of Java 6 JDK to make it clearer.

Result:

Fewer support tickets

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9276
Patch: https://rb.dcache.org/r/10670/
Acked-by: Tigran Mkrtchyan