### PR TITLE
nfs: fix ServerFault on FileNotFoundHimeraFsException

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -63,6 +63,7 @@ import java.util.stream.Collectors;
 
 import org.dcache.auth.Subjects;
 import org.dcache.cells.CellStub;
+import org.dcache.chimera.ChimeraFsException;
 import org.dcache.chimera.FsInode;
 import org.dcache.chimera.FsInodeType;
 import org.dcache.chimera.JdbcFs;
@@ -530,12 +531,13 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         LayoutDriver layoutDriver = getLayoutDriver(layoutType);
 
-        FsInode inode = _chimeraVfs.inodeFromBytes(nfsInode.getFileId());
-        PnfsId pnfsId = new PnfsId(inode.getId());
-        Transfer.initSession(false, false);
-        NDC.push(pnfsId.toString());
-        NDC.push(context.getRpcCall().getTransport().getRemoteSocketAddress().toString());
         try {
+
+            FsInode inode = _chimeraVfs.inodeFromBytes(nfsInode.getFileId());
+            PnfsId pnfsId = new PnfsId(inode.getId());
+            Transfer.initSession(false, false);
+            NDC.push(pnfsId.toString());
+            NDC.push(context.getRpcCall().getTransport().getRemoteSocketAddress().toString());
 
             deviceid4 deviceid;
 
@@ -628,7 +630,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
             return new Layout(true, layoutStateId.stateid(), new layout4[]{layout});
 
-        } catch (CacheException | TimeoutException | ExecutionException e) {
+        } catch (CacheException | ChimeraFsException | TimeoutException | ExecutionException e) {
             throw asNfsException(e, LayoutTryLaterException.class);
         } catch (InterruptedException e) {
             throw new LayoutTryLaterException(e.getMessage(), e);


### PR DESCRIPTION
Motivation:
since introduction of inumber, converting file handle into
pnfsid may throw FileNotFoundHimeraFsException, which it
propagated to the nfs server.

Modification:
extend try-catch block to include nfs file handle to pnfsid
conversion. Convert ChimeraFsException into corresponding
ChimeraNFSException.

Result:
no serverfault on FileNotFoundHimeraFsException

Acked-by: Paul Millar
Target: master, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit 77d82c0c724cef0f83b841202180068fcf7360e0)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>