### PR TITLE
star: fix printing exception error message

### DIFF
--- a/skel/bin/dcache-star
+++ b/skel/bin/dcache-star
@@ -278,7 +278,7 @@ def main():
         write_records(now)
         update_last_update(now)
     except Exception as e:
-        sys.stderr.write("dcache-star: Problem detected: %s" % e.message)
+        sys.stderr.write("dcache-star: Problem detected: %s" % e)
         sys.exit(1)
 
 


### PR DESCRIPTION
Motivation:

PEP 352 involves restructuring the exception hierarcy in Python.  As
part of this, there is a plan to phase out the 'message' attribute over
various Python versions.

Despite PEP 352 existing for some time, the StAR produce erroneously
used the 'message' attribute when printing an error message.  This
results in no error message being reported with sufficiently recent
versions of Python.

Modification:

Remove 'message' attribute reference; instead, use the implicit string
conversion.

Result:

The dcache-star script should show meaningful error messages if there's
a problem when run with newer versions of Python.

Target: master
Require-notes: yes
Require-book: no
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9323