### PR TITLE
nfs: return LAYOUTUNAVAILABLE for DOT files

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -166,11 +166,6 @@ public class NFSv41Door extends AbstractCellComponent implements
      */
     private final PoolDeviceMap _poolDeviceMap = new PoolDeviceMap();
 
-    /*
-     * reserved device for IO through MDS (for pnfs dot files)
-     */
-    private static final deviceid4 MDS_ID = PoolDeviceMap.deviceidOf(0);
-
     private final Map<stateid4, NfsTransfer> _ioMessages = new ConcurrentHashMap<>();
 
     /**
@@ -508,11 +503,6 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         LayoutDriver layoutDriver = getLayoutDriver(layoutType);
 
-        /* in case of MDS access we return the same interface which client already connected to */
-        if (deviceId.equals(MDS_ID)) {
-            return layoutDriver.getDeviceAddress(context.getRpcCall().getTransport().getLocalSocketAddress());
-        }
-
         PoolDS ds = _poolDeviceMap.getByDeviceId(deviceId);
         if( ds == null) {
             return null;
@@ -572,58 +562,54 @@ public class NFSv41Door extends AbstractCellComponent implements
                     /*
                      * all non regular files ( AKA pnfs dot files ) provided by door itself.
                      */
-                    deviceid = MDS_ID;
-
-                    // there are no associated transfer. create a dummy stateid.
-                    layoutStateId = client.createState(openStateId.getStateOwner(), openStateId);
-                } else {
-
-                    final InetSocketAddress remote = context.getRpcCall().getTransport().getRemoteSocketAddress();
-                    final NFS4ProtocolInfo protocolInfo = new NFS4ProtocolInfo(remote,
-                                new org.dcache.chimera.nfs.v4.xdr.stateid4(stateid),
-                                nfsInode.toNfsHandle()
-                            );
-
-                    NfsTransfer transfer = _ioMessages.get(openStateId.stateid());
-                    if (transfer == null) {
-                        transfer = new NfsTransfer(_pnfsHandler, client, openStateId, nfsInode,
-                                context.getRpcCall().getCredential().getSubject(), ioMode);
-
-                        transfer.setProtocolInfo(protocolInfo);
-                        transfer.setCellAddress(getCellAddress());
-                        transfer.setBillingStub(_billingStub);
-                        transfer.setPoolStub(_poolStub);
-                        transfer.setPoolManagerStub(_poolManagerStub);
-                        transfer.setPnfsId(pnfsId);
-                        transfer.setClientAddress(remote);
-                        transfer.setIoQueue(_ioQueue);
-
-                        /*
-                         * As all our layouts marked 'return-on-close', stop mover when
-                         * open-state disposed on CLOSE.
-                         */
-                        final NfsTransfer t = transfer;
-                        openStateId.addDisposeListener(state -> {
-                            /*
-                             * Cleanup transfer when state invalidated.
-                             */
-                            t.shutdownMover();
-                            if (t.isWrite()) {
-                                /* write request keep in the message map to
-                                 * avoid re-creates and trigger errors.
-                                 */
-                                _ioMessages.remove(openStateId.stateid());
-                            }
-                        });
-
-                         _ioMessages.put(openStateId.stateid(), transfer);
-                    }
-
-                    layoutStateId = transfer.getStateid();
-
-                    PoolDS ds = transfer.getPoolDataServer(NFS_REQUEST_BLOCKING);
-                    deviceid = ds.getDeviceId();
+                    throw new LayoutUnavailableException("special DOT file");
                 }
+
+                final InetSocketAddress remote = context.getRpcCall().getTransport().getRemoteSocketAddress();
+                final NFS4ProtocolInfo protocolInfo = new NFS4ProtocolInfo(remote,
+                            new org.dcache.chimera.nfs.v4.xdr.stateid4(stateid),
+                            nfsInode.toNfsHandle()
+                        );
+
+                NfsTransfer transfer = _ioMessages.get(openStateId.stateid());
+                if (transfer == null) {
+                    transfer = new NfsTransfer(_pnfsHandler, client, openStateId, nfsInode,
+                            context.getRpcCall().getCredential().getSubject(), ioMode);
+
+                    transfer.setProtocolInfo(protocolInfo);
+                    transfer.setCellAddress(getCellAddress());
+                    transfer.setBillingStub(_billingStub);
+                    transfer.setPoolStub(_poolStub);
+                    transfer.setPoolManagerStub(_poolManagerStub);
+                    transfer.setPnfsId(pnfsId);
+                    transfer.setClientAddress(remote);
+                    transfer.setIoQueue(_ioQueue);
+
+                    /*
+                     * As all our layouts marked 'return-on-close', stop mover when
+                     * open-state disposed on CLOSE.
+                     */
+                    final NfsTransfer t = transfer;
+                    openStateId.addDisposeListener(state -> {
+                        /*
+                         * Cleanup transfer when state invalidated.
+                         */
+                        t.shutdownMover();
+                        if (t.isWrite()) {
+                            /* write request keep in the message map to
+                             * avoid re-creates and trigger errors.
+                             */
+                            _ioMessages.remove(openStateId.stateid());
+                        }
+                    });
+
+                     _ioMessages.put(openStateId.stateid(), transfer);
+                }
+
+                layoutStateId = transfer.getStateid();
+
+                PoolDS ds = transfer.getPoolDataServer(NFS_REQUEST_BLOCKING);
+                deviceid = ds.getDeviceId();
             }
 
             //  -1 is special value, which means entire file


### PR DESCRIPTION
Motivation:
as IO requests on magic DOT files can't to be sent to the pools, NFS
door is redirecting to itself. While this approach works well, it forces
door to support the same layout driver as pools do, which is not always
possible, for instance, with flexfile layout type with IO over nfsv3.

To avoid such requirement, NFS spec (rfc5661) defines is a special
error code to tell client that pNFS operations are not available for a
particular file:

15.1.10.4.  NFS4ERR_LAYOUTUNAVAILABLE (Error Code 10059)

   Returned when layouts are not available for the current file system
   or the particular specified file.

Modification:
Update NFS door to return NFS4ERR_LAYOUTUNAVAILABLE for DOT files.
Remove logic treat door as a special data server.

Result:
IO operation on DOT files does not require nfs door to support IO with
all layout types offered to the client.

Acked-by: Paul Millar
Target: master, 4.0, 3.2, 3.1, 3.0
Require-book: no
Require-notes: yes
(cherry picked from commit 5ad6fff79c0857ef4f994cd0b86e0d6ee8d2e63e)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>