### PR TITLE
cells: add explicit ZooKeeper/Curator monitoring

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -8,6 +8,9 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +38,7 @@ class CellGlue
 {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(CellGlue.class);
+    private static final Logger EVENT_LOGGER = LoggerFactory.getLogger("org.dcache.zookeeper");
 
     private final String _cellDomainName;
     private final ConcurrentMap<String, CellNucleus> _cellList = new ConcurrentHashMap<>();
@@ -68,7 +72,7 @@ class CellGlue
                     System.currentTimeMillis();
         }
         _cellDomainName = cellDomainNameLocal;
-        _curatorFramework = curatorFramework;
+        _curatorFramework = withMonitoring(curatorFramework);
         _domainAddress = new CellAddressCore("*", _cellDomainName);
         _masterThreadGroup = new ThreadGroup("Master-Thread-Group");
         _killerThreadGroup = new ThreadGroup("Killer-Thread-Group");
@@ -86,6 +90,37 @@ class CellGlue
                                        killerThreadFactory);
         emergencyKillerExecutor.prestartCoreThread();
         _emergencyKillerExecutor = MoreExecutors.listeningDecorator(emergencyKillerExecutor);
+    }
+
+    private static CuratorFramework withMonitoring(CuratorFramework curator)
+    {
+        curator.getConnectionStateListenable().addListener((c,s) -> {
+                    EVENT_LOGGER.info("[CURATOR: {}] connection state now {}",
+                            c.getState(), s);
+
+                    if (s == ConnectionState.CONNECTED) {
+                        try {
+                            ZooKeeper zk = c.getZookeeperClient().getZooKeeper();
+                            zk.register((WatchedEvent event) -> {
+                                        EVENT_LOGGER.info("[ZOOKEEPER] event "
+                                                + "type={}, state={}, path={}",
+                                                event.getType(), event.getState(),
+                                                event.getPath());
+                                    });
+                        } catch (Exception e) {
+                            EVENT_LOGGER.error("Failed to register ZK logging", e);
+                        }
+                    }
+                });
+        curator.getCuratorListenable().addListener((c,e) ->
+                    EVENT_LOGGER.info("[CURATOR: {}] event: type={}, name={}, "
+                            + "path={}, rc={}, children={}",
+                            c.getState(), e.getType(), e.getName(), e.getPath(),
+                            e.getResultCode(), e.getChildren()));
+        curator.getUnhandledErrorListenable().addListener((m,e) ->
+                    EVENT_LOGGER.warn("[CURATOR: {}] unhandled error \"{}\": {}",
+                            curator.getState(), m, e.getMessage()));
+        return curator;
     }
 
     static Thread newThread(ThreadGroup threadGroup, Runnable r)

--- a/modules/dcache/src/test/java/org/dcache/boot/DomainConfigurationTest.java
+++ b/modules/dcache/src/test/java/org/dcache/boot/DomainConfigurationTest.java
@@ -1,9 +1,11 @@
 package org.dcache.boot;
 
 import com.google.common.base.Throwables;
-import org.junit.After;
+import org.apache.curator.framework.listen.Listenable;
+import org.apache.curator.framework.CuratorFramework;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.io.LineNumberReader;
@@ -44,9 +46,18 @@ public class DomainConfigurationTest
         "b=2\n" +
         "c=5\n";
 
-    private final static SystemCell system = SystemCell.create(DOMAIN_NAME, null);
+    private final static SystemCell system;
 
     static {
+        CuratorFramework mockCurator = Mockito.mock(CuratorFramework.class);
+        Mockito.when(mockCurator.getConnectionStateListenable())
+                .thenReturn(Mockito.mock(Listenable.class));
+        Mockito.when(mockCurator.getCuratorListenable())
+                .thenReturn(Mockito.mock(Listenable.class));
+        Mockito.when(mockCurator.getUnhandledErrorListenable())
+                .thenReturn(Mockito.mock(Listenable.class));
+        system = SystemCell.create(DOMAIN_NAME, mockCurator);
+
         try {
             system.start().get();
         } catch (Exception e) {

--- a/skel/etc/logback.xml
+++ b/skel/etc/logback.xml
@@ -106,6 +106,18 @@
     </encoder>
   </appender>
 
+  <appender name="zookeeper" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${dcache.log.dir}/${dcache.domain.name}.zookeeper</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${dcache.log.dir}/${dcache.domain.name}.zookeeper.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <maxHistory>${dcache.log.zookeeper.max-history}</maxHistory>
+    </rollingPolicy>
+    <encoder>
+       <!-- Log of all ZooKeeper events. -->
+      <pattern>%d %m%n</pattern>
+    </encoder>
+  </appender>
+
   <!-- The conditional is to avoid an infinite retry of a non-existent connection
        by the socket appender if an alarms service is not running, which,
        for example, is the case when remote logging is left off system-wide. -->
@@ -143,6 +155,11 @@
     <appender-ref ref="access"/>
   </logger>
 
+  <logger name="org.dcache.zookeeper" additivity="false">
+    <appender-ref ref="zookeeper"/>
+  </logger>
+
+
   <!-- Nothing is logged to this logger. Its sole purpose is to list
        all appenders available; this ensures that the appenders are
        available in the dCache admin interface. -->
@@ -151,6 +168,7 @@
     <appender-ref ref="pinboard"/>
     <appender-ref ref="events"/>
     <appender-ref ref="access"/>
+    <appender-ref ref="zookeeper"/>
     <if condition='!"${dcache.log.level.remote}".equals("off")'>
       <then>
         <appender-ref ref="remote"/>
@@ -246,6 +264,12 @@
       <appender>access</appender>
       <logger>org.dcache.access</logger>
       <level>${dcache.log.level.access}</level>
+    </threshold>
+
+    <threshold>
+      <appender>zookeeper</appender>
+      <logger>org.dcache.zookeeper</logger>
+      <level>${dcache.log.level.zookeeper}</level>
     </threshold>
   </turboFilter>
 </configuration>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -71,9 +71,13 @@
 (not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.remote=off
 (not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.events=off
 (not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.access=info
+(not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.zookeeper=info
 
 # How many days to keep access logs
 dcache.log.access.max-history=30
+
+# How many days to keep zookeeper logs
+dcache.log.zookeeper.max-history=30
 
 # Host on which the remote log server will run
 # relative to this dCache installation


### PR DESCRIPTION
Motivation:

We have unexplained failures in dCache that seem to come from bad
interactions with ZooKeeper/Curator.  These errors are sporadic,
unpredictable and (so far) unreproducible by members of the dCache team.
Therefore, our only option is to try to acquire more information.

Modification:

Introduce a specific log file that logs ZooKeeper and Curator events.
Add listeners to log event details to that log file.

Result:

Events generated by ZooKeeper and Curator are now logged in a new,
separate log file (/var/log/dcache/<domain>.zookeeper by default) that
is automatically rotated.  This additional information may help diagnose
problems that are suspected to come from bad ZooKeeper interaction.

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no