### PR TITLE
cells: add explicit ZooKeeper/Curator monitoring

### DIFF
--- a/modules/dcache/src/test/java/org/dcache/boot/DomainConfigurationTest.java
+++ b/modules/dcache/src/test/java/org/dcache/boot/DomainConfigurationTest.java
@@ -1,9 +1,11 @@
 package org.dcache.boot;
 
 import com.google.common.base.Throwables;
-import org.junit.After;
+import org.apache.curator.framework.listen.Listenable;
+import org.apache.curator.framework.CuratorFramework;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.io.LineNumberReader;
@@ -44,9 +46,18 @@ public class DomainConfigurationTest
         "b=2\n" +
         "c=5\n";
 
-    private final static SystemCell system = SystemCell.create(DOMAIN_NAME, null);
+    private final static SystemCell system;
 
     static {
+        CuratorFramework mockCurator = Mockito.mock(CuratorFramework.class);
+        Mockito.when(mockCurator.getConnectionStateListenable())
+                .thenReturn(Mockito.mock(Listenable.class));
+        Mockito.when(mockCurator.getCuratorListenable())
+                .thenReturn(Mockito.mock(Listenable.class));
+        Mockito.when(mockCurator.getUnhandledErrorListenable())
+                .thenReturn(Mockito.mock(Listenable.class));
+        system = SystemCell.create(DOMAIN_NAME, mockCurator);
+
         try {
             system.start().get();
         } catch (Exception e) {

--- a/skel/etc/logback.xml
+++ b/skel/etc/logback.xml
@@ -106,6 +106,18 @@
     </encoder>
   </appender>
 
+  <appender name="zookeeper" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${dcache.log.dir}/${dcache.domain.name}.zookeeper</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${dcache.log.dir}/${dcache.domain.name}.zookeeper.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <maxHistory>${dcache.log.zookeeper.max-history}</maxHistory>
+    </rollingPolicy>
+    <encoder>
+       <!-- Log of all ZooKeeper events. -->
+      <pattern>%d %m%n</pattern>
+    </encoder>
+  </appender>
+
   <!-- The conditional is to avoid an infinite retry of a non-existent connection
        by the socket appender if an alarms service is not running, which,
        for example, is the case when remote logging is left off system-wide. -->
@@ -141,6 +153,11 @@
     <appender-ref ref="access"/>
   </logger>
 
+  <logger name="org.dcache.zookeeper" additivity="false">
+    <appender-ref ref="zookeeper"/>
+  </logger>
+
+
   <!-- Nothing is logged to this logger. Its sole purpose is to list
        all appenders available; this ensures that the appenders are
        available in the dCache admin interface. -->
@@ -149,6 +166,7 @@
     <appender-ref ref="pinboard"/>
     <appender-ref ref="events"/>
     <appender-ref ref="access"/>
+    <appender-ref ref="zookeeper"/>
     <if condition='!"${dcache.log.level.remote}".equals("off")'>
       <then>
         <appender-ref ref="remote"/>
@@ -244,6 +262,12 @@
       <appender>access</appender>
       <logger>org.dcache.access</logger>
       <level>${dcache.log.level.access}</level>
+    </threshold>
+
+    <threshold>
+      <appender>zookeeper</appender>
+      <logger>org.dcache.zookeeper</logger>
+      <level>${dcache.log.level.zookeeper}</level>
     </threshold>
   </turboFilter>
 </configuration>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -71,9 +71,13 @@
 (not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.remote=off
 (not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.events=off
 (not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.access=info
+(not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.zookeeper=info
 
 # How many days to keep access logs
 dcache.log.access.max-history=30
+
+# How many days to keep zookeeper logs
+dcache.log.zookeeper.max-history=30
 
 # Host on which the remote log server will run
 # relative to this dCache installation


### PR DESCRIPTION
Motivation:

We have unexplained failures in dCache that seem to come from bad
interactions with ZooKeeper/Curator.  These errors are sporadic,
unpredictable and (so far) unreproducible by members of the dCache team.
Therefore, our only option is to try to acquire more information.

Modification:

Introduce a specific log file that logs ZooKeeper and Curator events.
Add listeners to log event details to that log file.

Result:

Events generated by ZooKeeper and Curator are now logged in a new,
separate log file (/var/log/dcache/<domain>.zookeeper by default) that
is automatically rotated.  This additional information may help diagnose
problems that are suspected to come from bad ZooKeeper interaction.

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no