### PR TITLE
dcache-resilience: fix wrong assumption about error type in Message

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -62,8 +62,6 @@ package org.dcache.resilience.handlers;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.NoSuchElementException;
@@ -73,9 +71,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import dmg.cells.nucleus.CellPath;
+
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
-import dmg.cells.nucleus.CellPath;
+
 import org.dcache.cells.CellStub;
 import org.dcache.pool.migration.PoolMigrationCopyFinishedMessage;
 import org.dcache.pool.migration.PoolSelectionStrategy;
@@ -98,6 +98,7 @@ import org.dcache.resilience.util.LocationSelector;
 import org.dcache.resilience.util.RemoveLocationExtractor;
 import org.dcache.resilience.util.ResilientFileTask;
 import org.dcache.resilience.util.StaticSinglePoolList;
+import org.dcache.util.CacheExceptionFactory;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.resilience.RemoveReplicaMessage;
 
@@ -623,12 +624,14 @@ public class FileOperationHandler {
                             pnfsId, target, e);
         }
 
-        Serializable exception = msg.getErrorObject();
+        CacheException exception = msg.getErrorObject() == null ? null :
+                        CacheExceptionFactory.exceptionOf(msg);
+
         if (exception != null && !CacheExceptionUtils.replicaNotFound(exception)) {
             throw CacheExceptionUtils.getCacheException(
                             CacheException.SELECTED_POOL_FAILED,
                             FileTaskCompletionHandler.FAILED_REMOVE_MESSAGE,
-                            pnfsId, target, (Exception) exception);
+                            pnfsId, target, exception);
         }
     }
 


### PR DESCRIPTION
Motivation:

1:01:36 PM [pool-9-thread-154] [] Uncaught exception in thread pool-9-thread-154java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Exception
	at org.dcache.resilience.handlers.FileOperationHandler.removeTarget(FileOperationHandler.java:668) ~[dcache-resilience-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.resilience.handlers.FileOperationHandler.handleRemoveOneCopy(FileOperationHandler.java:384) ~[dcache-resilience-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.resilience.util.ResilientFileTask.runRemove(ResilientFileTask.java:309) ~[dcache-resilience-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.resilience.util.ResilientFileTask.lambda$call$21(ResilientFileTask.java:203) ~[dcache-resilience-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) ~[dcache-common-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149) [dcache-core-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	...

Modification:

Add guard to prevent incorrect cast of serializable object.

Result:

No uncaught exception thrown.

Target: master
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-book: no
Require-notes: yes
Acked-by: Paul