### PR TITLE
dcache-resilience: fix bug in source handling with Clear Cache Locati…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
@@ -770,7 +770,7 @@ public class FileOperationMap extends RunnableModule {
                                                     data.getSelectionAction(),
                                                     data.getCount(),
                                                     data.getSize());
-        operation.setParentOrSource(data.getPoolIndex(), data.isParent);
+        operation.setParentOrSource(data.getSourceIndex(), data.isParent());
         operation.setVerifySticky(data.shouldVerifySticky());
         FileAttributes attributes = data.getAttributes();
         operation.setRetentionPolicy(attributes.getRetentionPolicy().toString());

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -86,6 +86,7 @@ import static org.dcache.resilience.data.MessageType.ADD_CACHE_LOCATION;
 import static org.dcache.resilience.data.MessageType.CLEAR_CACHE_LOCATION;
 import static org.dcache.resilience.data.MessageType.CORRUPT_FILE;
 import static org.dcache.resilience.data.MessageType.POOL_STATUS_DOWN;
+import static org.dcache.resilience.data.MessageType.POOL_STATUS_UP;
 
 /**
  * <p>A transient encapsulation of pertinent configuration data regarding
@@ -265,7 +266,7 @@ public final class FileUpdate {
     }
 
     public boolean isParent() {
-        return type == POOL_STATUS_DOWN || type == POOL_STATUS_DOWN;
+        return type == POOL_STATUS_DOWN || type == POOL_STATUS_UP;
     }
 
     public void setCount(Integer count) {

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -338,7 +338,8 @@ public class FileOperationHandler {
                              EntryState.CACHED, ONLINE_STICKY_RECORD,
                              Collections.EMPTY_LIST, attributes,
                              attributes.getAccessTime());
-        LOGGER.trace("Created migration task for {}: {}.", pnfsId, task);
+        LOGGER.trace("Created migration task for {}: source {}, list {}.",
+                     pnfsId, source, list);
 
         return task;
     }


### PR DESCRIPTION
…on messages

Motivation:

When a PnfsClearCacheLocationMessage arrives and file attribute
locations are not empty, Resilience needs to see if it can
react or repair the situation.  However, it must not consider
the pool reported in the message (obviously) as a valid source
for file replication.   There is a mistake in the code which
allows this to happen.

Modification:

Fix it so that the pool does not become the source file
of the operation.

Result:

No unnecessary Migration Task exceptions resulting from
source pools with no replica in the repository.

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul