### PR TITLE
packaging: check 'services.sh' after old rpm removed

### DIFF
--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -78,6 +78,7 @@ fi
 # fix file /var/lib/dcache directory ownership
 chown dcache:dcache /var/lib/dcache
 
+%posttrans
 if [ ! -f /usr/share/dcache/lib/services.sh ]; then
     ln -s /usr/share/dcache/lib/services-daemon.sh /usr/share/dcache/lib/services.sh
 fi


### PR DESCRIPTION
Motivation:

Upgrading to dCache v3.2 (or newer) results in a broken dCache
installation due to a missing 'services.sh' file.

With dCache v3.2, the 'services.sh' file is a symbolic link.  For
RPM-based distros, this should point to the existing implementation that
works with non-systemd systems, but duplicates some functionality of
systemd.

When upgrading dCache, the file- and scriptlet- order mean that the %pre
and %post scripts of the new package are run before removing files from
the earlier dCache RPM.  When the %post scriptlet checks, the
'services.sh' file exists, so it does not create the sym-link.  This
file is subsequently deleted when the old package files are removed.

Modification:

Use the %posttrans scriptlet to generate the symlink, if missing.

Result:

Upgrade to dCache v3.2 (or newer) from dCache v3.1 (or older) no longer
breaks dCache by removing /usr/share/dcache/lib/services.sh

Target: master
Request: 4.0
Request: 3.2
Closes: #3788
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10743/
Acked-by: Tigran Mkrtchyan