### PR TITLE
dcache-resilience: repair handling of broken files*

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -62,6 +62,7 @@ package org.dcache.resilience.handlers;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.NoSuchElementException;
@@ -71,10 +72,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
-import dmg.cells.nucleus.CellPath;
-
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
+
+import dmg.cells.nucleus.CellPath;
 
 import org.dcache.alarms.AlarmMarkerFactory;
 import org.dcache.alarms.PredefinedAlarm;
@@ -166,24 +167,46 @@ public class FileOperationHandler {
                             = FileUpdate.getAttributes(pnfsId, pool,
                                                        MessageType.CORRUPT_FILE,
                                                        namespace);
-            if (attributes == null || attributes.getLocations().size() < 2) {
+            int actual = 0;
+            int countable = 0;
+
+            if (attributes != null) {
+                actual = attributes.getLocations().size();
+                countable = poolInfoMap.getCountableLocations(attributes.getLocations());
+            }
+
+            if (actual <= 1) {
                 /*
                  * This is the only copy, or it is not/no longer in the
-                 * namespace.  In either case, do nothing, but cancel
-                 * any running operations for this pnfsid.
+                 * namespace. In either case, do nothing.
                  */
-                fileOpMap.cancel(pnfsId, true);
+                LOGGER.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.INACCESSIBLE_FILE,
+                                                          pnfsId.toString()),
+                             "{}: Repair of broken replicas is not possible, "
+                                             + "file currently inaccessible", pnfsId);
                 return;
             }
 
             removeTarget(pnfsId, pool);
-            FileUpdate update = new FileUpdate(pnfsId, pool,
-                                               MessageType.CLEAR_CACHE_LOCATION, false);
 
-            /*
-             * Bypass the message guard check of CDC session.
-             */
-            handleLocationUpdate(update);
+            if (countable > 1) {
+                FileUpdate update = new FileUpdate(pnfsId, pool,
+                                                   MessageType.CLEAR_CACHE_LOCATION,
+                                                   false);
+                /*
+                 * Bypass the message guard check of CDC session.
+                 */
+                handleLocationUpdate(update);
+            } else {
+                /*
+                 *  No alternate readable source; cannot attempt to make
+                 *  any further replicas.
+                 */
+                LOGGER.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.INACCESSIBLE_FILE,
+                                                          pnfsId.toString()),
+                             "{}: Repair of broken replicas is not possible, "
+                                             + "file currently inaccessible", pnfsId);
+            }
         } catch (CacheException e) {
             LOGGER.error("Error during handling of broken file removal ({}, {}): {}",
                          pnfsId, pool, new ExceptionMessage(e));

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/CheckpointUtils.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/CheckpointUtils.java
@@ -118,7 +118,7 @@ public final class CheckpointUtils {
     /**
      * <p>Read back in from the checkpoint file operation records.
      *    These are converted to {@link FileUpdate} objects and passed
-     *    to {@link FileOperationHandler#handleBrokenFileLocation(PnfsId, String)}
+     *    to {@link FileOperationHandler#handleLocationUpdate(FileUpdate)}(PnfsId, String)}
      *    for registration.</p>
      *
      * <p>The file to be reloaded is renamed, so that any checkpointing

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/handlers/FileOperationHandlerTest.java
@@ -73,6 +73,7 @@ import diskCacheV111.vehicles.Message;
 import org.dcache.pool.migration.Task;
 import org.dcache.resilience.TestBase;
 import org.dcache.resilience.TestMessageProcessor;
+import org.dcache.resilience.TestSynchronousExecutor;
 import org.dcache.resilience.TestSynchronousExecutor.Mode;
 import org.dcache.resilience.data.FileOperation;
 import org.dcache.resilience.data.FileUpdate;
@@ -84,7 +85,11 @@ import org.dcache.resilience.util.ResilientFileTask;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.resilience.RemoveReplicaMessage;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public final class FileOperationHandlerTest extends TestBase
                 implements TestMessageProcessor {
@@ -296,8 +301,7 @@ public final class FileOperationHandlerTest extends TestBase
         whenVerifyIsRun();
         afterInspectingSourceAndTarget();
         whenOperationFailsWithBrokenFileError();
-        whenVerifyIsRun();
-        assertTrue(theNewSourceIsDifferent());
+        assertNotNull(repRmMessage);
     }
 
     @Test
@@ -643,6 +647,7 @@ public final class FileOperationHandlerTest extends TestBase
     }
 
     private void whenOperationFailsWithBrokenFileError() throws IOException {
+        fileOperationHandler.setTaskService(new TestSynchronousExecutor(Mode.RUN));
         fileOperationMap.scan();
         fileOperationMap.updateOperation(update.pnfsId,
                                          new CacheException(


### PR DESCRIPTION
Motivation:

When a checksum or broken file message/error is generated,
Resilience makes a best effort to (a) remove the broken
copy and (b) make another replica.

This, of course, is not always possible, particularly if
the broken file is the only accessible copy.

However, there is currently a logical error in how
the handler method determines whether it should remove
and reprocess the file.

Modifications:

Distinguish cases (a) when there are actually less than
two known locations and (b) when there is only one
readable location (which happens to be the corrupted one).

Result:

Faulty behavior, particularly the thrashing noted in
the case of a restaging operation which results in
a checksum error, no longer occurs.

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Tigran