### PR TITLE
dcache: fix remote pool monitor wait bug

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolMonitor.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolMonitor.java
@@ -225,10 +225,12 @@ public class RemotePoolMonitor
     {
         try {
             if (poolMonitor == null) {
-                long deadline = addWithInfinity(System.currentTimeMillis(), poolManagerStub.getTimeoutInMillis());
+                long now = System.currentTimeMillis();
+                long deadline = addWithInfinity(now, poolManagerStub.getTimeoutInMillis());
                 do {
-                    wait(subWithInfinity(deadline, System.currentTimeMillis()));
-                } while (poolMonitor == null || deadline <= System.currentTimeMillis());
+                    wait(subWithInfinity(deadline, now));
+                    now = System.currentTimeMillis();
+                } while (poolMonitor == null || deadline <= now);
                 if (poolMonitor == null) {
                     throw new RemoteConnectFailureException("Cached pool information is not yet available.", null);
                 }


### PR DESCRIPTION
Motivation:

12:48:35 PM [pool-6-thread-1] [] Uncaught exception in thread pool-6-thread-1java.lang.IllegalArgumentException: timeout value is negative
	at java.lang.Object.wait(Native Method) ~[na:1.8.0_91]
	at org.dcache.poolmanager.RemotePoolMonitor.getPoolMonitor(RemotePoolMonitor.java:178) ~[dcache-core-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.poolmanager.RemotePoolMonitor.getPoolSelectionUnit(RemotePoolMonitor.java:116) ~[dcache-core-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.services.history.pools.PoolTimeseriesServiceImpl.listPools(PoolTimeseriesServiceImpl.java:168) ~[dcache-history-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.util.collector.pools.PoolInfoCollector.collectData(PoolInfoCollector.java:101) ~[dcache-core-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.util.collector.pools.PoolInfoCollector.collectData(PoolInfoCollector.java:82) ~[dcache-core-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.services.collector.CellDataCollectingService.run(CellDataCollectingService.java:221) ~[dcache-core-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_91]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_91]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_91]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [na:1.8.0_91]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_91]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_91]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_91]

There is a possibility, due to a possible race from the time-slicing of the wait,
for the current system time to be, for instance, one millisecond less than the deadline
when the while condition is checked, but then advance to > deadline by a millisecond
when wait() is called.  This would cause the value of the wait to be negative.

Modification:

Used a fixed value for 'now' between the conditional check and the next wait.

Result:

The above exception should not occur.

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Bug: #3791
Require-book: no
Require-notes: yes
Acked-by: Paul