### PR TITLE
dcache-resilience: define non-writable pool to mean p2p-client is dis…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInfoMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInfoMap.java
@@ -651,7 +651,8 @@ public class PoolInfoMap {
         try {
             PoolInformation info = poolInfo.get(pool);
             return info != null && info.isInitialized()
-                            && (writable ? info.canWrite() : info.canRead());
+                            && (writable ? info.canRead() && info.canWrite()
+                                : info.canRead());
         } finally {
             read.unlock();
         }

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInformation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolInformation.java
@@ -91,10 +91,15 @@ final class PoolInformation {
     private long lastUpdate;
 
     PoolInformation(String name, Integer key) {
+        this(name, key, null);
+    }
+
+    PoolInformation(String name, Integer key, PoolV2Mode mode) {
         this.name = name;
         this.key = key;
         lastUpdate = System.currentTimeMillis();
         excluded = false;
+        this.mode = mode;
     }
 
     public synchronized String toString() {
@@ -110,12 +115,17 @@ final class PoolInformation {
 
     synchronized boolean canRead() {
         return mode != null
-                        && (mode.isEnabled()
-                        || mode.getMode() == PoolV2Mode.DISABLED_RDONLY);
+                         && mode.getMode() != PoolV2Mode.DISABLED
+                         && !mode.isDisabled(PoolV2Mode.DISABLED_DEAD)
+                         && !mode.isDisabled(PoolV2Mode.DISABLED_FETCH)
+                         && !mode.isDisabled(PoolV2Mode.DISABLED_P2P_SERVER);
     }
 
     synchronized boolean canWrite() {
-        return mode != null && mode.isEnabled();
+        return mode != null
+                         && mode.getMode() != PoolV2Mode.DISABLED
+                         && !mode.isDisabled(PoolV2Mode.DISABLED_DEAD)
+                         && !mode.isDisabled(PoolV2Mode.DISABLED_P2P_CLIENT);
     }
 
     synchronized PoolCostInfo getCostInfo() {

--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolInformationTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/PoolInformationTest.java
@@ -1,0 +1,208 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.resilience.data;
+
+import org.junit.Test;
+
+import diskCacheV111.pools.PoolV2Mode;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * <p>Tests the mode changes for correct readable and writable classification.</p>
+ */
+public class PoolInformationTest {
+
+    PoolInformation poolInformation;
+    PoolV2Mode poolV2Mode;
+
+    @Test
+    public void shouldBeReadableWhenEnabled() {
+        whenPoolModeIs(PoolV2Mode.ENABLED);
+        assertThatReadableIs(true);
+    }
+
+    @Test
+    public void shouldBeWritableWhenEnabled() {
+        whenPoolModeIs(PoolV2Mode.ENABLED);
+        assertThatWritableIs(true);
+    }
+
+    @Test
+    public void shouldNotBeReadableWhenDisabled() {
+        whenPoolModeIs(PoolV2Mode.DISABLED);
+        assertThatReadableIs(false);
+    }
+
+    @Test
+    public void shouldNotBeWritableWhenDisabled() {
+        whenPoolModeIs(PoolV2Mode.DISABLED);
+        assertThatWritableIs(false);
+    }
+
+    @Test
+    public void shouldNotBeReadableWhenDisabledFetch() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_FETCH);
+        assertThatReadableIs(false);
+    }
+
+    @Test
+    public void shouldBeWritableWhenDisabledFetch() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_FETCH);
+        assertThatWritableIs(true);
+    }
+
+    @Test
+    public void shouldBeReadableWhenDisabledStore() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_STORE);
+        assertThatReadableIs(true);
+    }
+
+    @Test
+    public void shouldBeWritableWhenDisabledStore() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_STORE);
+        assertThatWritableIs(true);
+    }
+
+    @Test
+    public void shouldBeReadableWhenDisabledStage() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_STAGE);
+        assertThatReadableIs(true);
+    }
+
+    @Test
+    public void shouldBeWritableWhenDisabledStage() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_STAGE);
+        assertThatWritableIs(true);
+    }
+
+    @Test
+    public void shouldBeReadableWhenDisabledP2pClient() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_P2P_CLIENT);
+        assertThatReadableIs(true);
+    }
+
+    @Test
+    public void shouldNotBeWritableWhenDisabledP2pClient() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_P2P_CLIENT);
+        assertThatWritableIs(false);
+    }
+
+    @Test
+    public void shouldNotBeReadableWhenDisabledP2pServer() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_P2P_SERVER);
+        assertThatReadableIs(false);
+    }
+
+    @Test
+    public void shouldBeWritableWhenDisabledP2pServer() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_P2P_SERVER);
+        assertThatWritableIs(true);
+    }
+
+    @Test
+    public void shouldNotBeReadableWhenDisabledDead() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_DEAD);
+        assertThatReadableIs(false);
+    }
+
+    @Test
+    public void shouldNotBeWritableWhenDisabledDead() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_DEAD);
+        assertThatWritableIs(false);
+    }
+
+    @Test
+    public void shouldNotBeReadableWhenDisabledStrict() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_STRICT);
+        assertThatReadableIs(false);
+    }
+
+    @Test
+    public void shouldNotBeWritableWhenDisabledStrict() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_STRICT);
+        assertThatWritableIs(false);
+    }
+
+    @Test
+    public void shouldBeReadableWhenDisabledRdOnly() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_RDONLY);
+        assertThatReadableIs(true);
+    }
+
+    @Test
+    public void shouldNotBeWritableWhenDisabledRdOnly() {
+        whenPoolModeIs(PoolV2Mode.DISABLED_RDONLY);
+        assertThatWritableIs(false);
+    }
+
+    private void whenPoolModeIs(int mode) {
+        poolV2Mode = new PoolV2Mode(mode);
+        poolInformation = new PoolInformation("test", -1, poolV2Mode);
+    }
+
+    private void assertThatReadableIs(boolean b) {
+        assertEquals(b, poolInformation.canRead());
+    }
+
+    private void assertThatWritableIs(boolean b) {
+        assertEquals(b, poolInformation.canWrite());
+    }
+}


### PR DESCRIPTION
…abled

Modification:

When choosing pools on which to make copies, Resilience checks the pool
mode to see that it is a viable choice.   Currently, it considers the pool
viable for a write only if it is fully enabled.

However, there are cases when it may be desirable to allow p2ps to the pool
while disallowing external client writes (STORES).

(This is actually a bug, because the code currently looks for an
equavalence with 'read-only', when disabling only fetch on a pool
should effectively trigger resilience into action.)

Modification:

Change the definition of writable to mean p2p-client is not disabled.

Result:

It should be possible for Resilience to use pools blocked only for
writes from doors.

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Tigran