### PR TITLE
poolmanager: fix poolmanager startup with certain poolmanager.conf co…

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -160,6 +160,15 @@ public class RequestContainerV5
         this(DEFAULT_TICKER_INTERVAL);
     }
 
+    @Override
+    public CellSetupProvider mock()
+    {
+        RequestContainerV5 mock = new RequestContainerV5();
+        mock.setPartitionManager(new PartitionManager());
+        return mock;
+    }
+
+
     public void start()
     {
         _tickerThread = new Thread(this, "Container-ticker");
@@ -349,6 +358,7 @@ public class RequestContainerV5
 
     public static final String hh_rc_set_sameHostCopy =
         STRING_NEVER+"|"+STRING_BESTEFFORT+"|"+STRING_NOTCHECKED;
+    @AffectsSetup
     public String ac_rc_set_sameHostCopy_$_1(Args args)
     {
         _partitionManager.setProperties("default", ImmutableMap.of("sameHostCopy", args.argv(0)));
@@ -357,6 +367,7 @@ public class RequestContainerV5
 
     public static final String hh_rc_set_sameHostRetry =
         STRING_NEVER+"|"+STRING_BESTEFFORT+"|"+STRING_NOTCHECKED;
+    @AffectsSetup
     public String ac_rc_set_sameHostRetry_$_1(Args args)
     {
         _partitionManager.setProperties("default", ImmutableMap.of("sameHostRetry", args.argv(0)));


### PR DESCRIPTION
…ntent

Motivation:

Commit adb5c04c introduced checking whether new configuration is fully
correct before applying it.  This prevents the live system accepting
partial changes if there are some errors.  To achieve this, the new
configuration is applied to a mock object; if that is successful then it
is applied to the "live" object.

Unfortunately this patch introduced a regression because certain
commands ("rc set sameHostCopy" and "rc set sameHostRetry") affect the
partionmanager, which the mock RequestContainerV5 object does not
contain, resulting in a NPE.  This bug preventing dCache from starting.

Modification:

Add custom mock method in RequestContainerV5 that includes an empty
PartitionManager.

The two methods are also updated with annotation that identifies that
running them may affect configuration.

Result:

Fix regression, introduced in dCache 3.0, where a dCache domain does not
start up if it hosts a poolmanager with poolmanager.conf containing
either the "rc set sameHostCopy" or the "rc set sameHostRetry" command.

Target: master
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9345
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10750/
Acked-by: Albert Rossi