### PR TITLE
poolmanager: silence NoRouteToCell for stage queue topic

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
@@ -12,7 +12,7 @@
 
   <bean id="noroutetocell" class="org.dcache.cells.LogNoRouteToCellExceptionReceiver">
     <description>Undeliverable message logger</description>
-    <property name="excludedDestinations" value="${poolmanager.destination.pool-status},${poolmanager.pool-monitor.topic}"/>
+    <property name="excludedDestinations" value="${poolmanager.destination.pool-status},${poolmanager.pool-monitor.topic},${poolmanager.restore-requests.topic}"/>
     <property name="excludedMessages" value="org.dcache.poolmanager.PoolMgrGetUpdatedHandler"/>
   </bean>
 


### PR DESCRIPTION
Motivation:

Patch f06bbb74 introduced a new topic that PoolManager instances
broadcast their stage request queue periodically.

Unfortunately, the patch neglected to silence the NoRouteToHost messages
that are generated if no component is currently listening for these
messages.

Modification:

Add the topic to the list of destinations for which NoRouteToHost
messages are supressed.

Result:

No more "Failed to deliver PoolManagerGetRestoreHandlerInfo message"
entries in the log file.

Target: master
Request: 4.0
Request: 3.2
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9346
Patch: https://rb.dcache.org/r/10751/
Acked-by: Albert Rossi