### PR TITLE
httpd: do not log an exception if info cell not running

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/InfoHttpEngine.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/InfoHttpEngine.java
@@ -141,6 +141,9 @@ public class InfoHttpEngine implements HttpResponseEngine, CellMessageSender
                             "long to reply, suspect trouble (" +
                             cause.getMessage() + ")");
                 }
+                if (cause instanceof NoRouteToCellException) {
+                    throw new HttpException(503, "Unable to locate the info cell");
+                }
                 if (cause instanceof CacheException) {
                     throw new HttpException(500, "Error when requesting " +
                             "info from info cell. (" + cause.getMessage() + ")");


### PR DESCRIPTION
Motivation:

Commit e8e729ef seperated out NoRouteToCellException from
TimeoutCacheException with the idea that, although in most cases these
are handled in the same way, there are situations where the distinction
matters.

The commit attempted to update dCache so that (almost) all code that
caught TimeoutCacheException would also catch NoRouteToCellException.
Unfortunate, it failed to update InfoHttpEngine correctly, resulting in
dCache logging a stack-trace if the info cell is not running when a
request is made.

Modification:

Add missing code to handle NoRouteToCellException.

Result:

With this patch, dCache will no longer log a stack-trace if HTTP
requests are made asking for information from the info service when the
info service is not running.

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9347
Patch: https://rb.dcache.org/r/10752/
Acked-by: Albert Rossi