### PR TITLE
ftp: remove rare NullPointerException when proxying data

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1201,7 +1201,7 @@ public abstract class AbstractFtpDoorV1
                     LOGGER.info("Waiting for adapter to finish.");
                     adapter.join(300000); // 5 minutes
                     checkFTPCommand(!adapter.isAlive(), 451, "FTP proxy did not shut down");
-                    checkFTPCommand(!_adapter.hasError(), 451, "FTP proxy failed: %s", _adapter.getError());
+                    checkFTPCommand(!adapter.hasError(), 451, "FTP proxy failed: %s", adapter.getError());
                     LOGGER.debug("Closing adapter");
                     adapter.close();
                 }


### PR DESCRIPTION
Motivation:

Commit 59a67f4a1 introduced a regression where a field member is
accessed outside of a synchronized block. Therefore it is theoretically
possible for the door to experience a NullPointerException when a
proxyed transfer has completed.

Modification:

Use the copy of the adapter object to avoid NPE.

Result:

A rare (unobserved) bug has been fixed

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10765/
Acked-by: Tigran Mkrtchyan