### PR TITLE
ftp: remove rare NullPointerException when proxying data

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -954,8 +954,8 @@ public abstract class AbstractFtpDoorV1
                     adapter.join(300000); // 5 minutes
                     if (adapter.isAlive()) {
                         throw new FTPCommandException(451, "FTP proxy did not shut down");
-                    } else if (_adapter.hasError()) {
-                        throw new FTPCommandException(451, "FTP proxy failed: " + _adapter.getError());
+                    } else if (adapter.hasError()) {
+                        throw new FTPCommandException(451, "FTP proxy failed: " + adapter.getError());
                     }
 
                     LOGGER.debug("Closing adapter");


### PR DESCRIPTION
Motivation:

Commit 59a67f4a1 introduced a regression where a field member is
accessed outside of a synchronized block. Therefore it is theoretically
possible for the door to experience a NullPointerException when a
proxyed transfer has completed.

Modification:

Use the copy of the adapter object to avoid NPE.

Result:

A rare (unobserved) bug has been fixed

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10765/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java