### PR TITLE
system-test: enable only nfs41 file layout

### DIFF
--- a/packages/system-test/src/main/skel/etc/exports
+++ b/packages/system-test/src/main/skel/etc/exports
@@ -1,1 +1,1 @@
-/ *(rw) localhost(rw,no_root_squash)
+/ *(rw,lt=fsv4_1_files) localhost(rw,lt=fsv4_1_files,no_root_squash)


### PR DESCRIPTION
Motivation:
dCache offers nfs41_files and flex_files pnfs layout types. However,
not all clients support both layout types. Starting dcache 4.1 dCache
provides an export option to control which layout types are offered to
a client. As system test may run on an old linux host, offer only
nfs41_files layout type.

Modification:
update system-test's export file to offer only nfs41_files layout type

Result:
system test can be used to run nfsv4.1/pNFS with on older linux version.

(tested on HTW-Berlin workstations, which run Ubuntu with kernel 4.4)