### PR TITLE
ftp: ensure adapter is closed

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1198,12 +1198,15 @@ public abstract class AbstractFtpDoorV1
                 }
 
                 if (adapter != null) {
-                    LOGGER.info("Waiting for adapter to finish.");
-                    adapter.join(300000); // 5 minutes
-                    checkFTPCommand(!adapter.isAlive(), 451, "FTP proxy did not shut down");
-                    checkFTPCommand(!adapter.hasError(), 451, "FTP proxy failed: %s", adapter.getError());
-                    LOGGER.debug("Closing adapter");
-                    adapter.close();
+                    try {
+                        LOGGER.info("Waiting for adapter to finish.");
+                        adapter.join(300000); // 5 minutes
+                        checkFTPCommand(!adapter.isAlive(), 451, "FTP proxy did not shut down");
+                        checkFTPCommand(!adapter.hasError(), 451, "FTP proxy failed: %s", adapter.getError());
+                    } finally {
+                        LOGGER.debug("Closing adapter");
+                        adapter.close();
+                    }
                 }
 
                 synchronized (this) {


### PR DESCRIPTION
Motivation:

The two FTP ProxyAdapter implementations (SocketAdapter and
ActiveAdapter) require the ProxyAdapter#close method is always called.
Failing to do so will result in a leak of listening TCP sockets and
(likely) established TCP connections in the CLOSE_WAIT state.

Certain transfer failures resulted in the method not being called,
resulting in TCP sockets being leaked over time.

Modification:

Ensure that the ProxyAdapter#close method is always called.

Result:

Fix a potential leak of TCP sockets when the FTP door is proxying data
between pool and client if there is a problem with the client.

Target: master
Require-notes: yes
Require-book: no
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9189 (partial)
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9341 (partial)