### PR TITLE
dcache-resilience: handle properly RuntimeExceptions from tasks

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
@@ -391,6 +391,7 @@ public final class FileOperation {
 
     public synchronized void submit() {
         if (task != null) {
+            task.setErrorHandler(this::updateOperation);
             task.submit();
         }
     }

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
@@ -986,6 +986,7 @@ public class PoolOperationMap extends RunnableModule {
         operation.state = State.RUNNING;
         operation.lastUpdate = System.currentTimeMillis();
         operation.lastStatus = operation.currStatus;
+        operation.task.setErrorHandler(e -> update(pool, 0, e));
         operation.resetChildren();
         running.put(pool, operation);
         LOGGER.trace("Submitting pool scan task for {}.", pool);

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/PoolScanTask.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/PoolScanTask.java
@@ -59,21 +59,19 @@ documents or software obtained from this server.
  */
 package org.dcache.resilience.util;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 
 import org.dcache.pool.classic.Cancellable;
 import org.dcache.resilience.data.MessageType;
+import org.dcache.resilience.data.PoolOperation.SelectionAction;
 import org.dcache.resilience.db.ScanSummary;
 import org.dcache.resilience.handlers.PoolOperationHandler;
-import org.dcache.resilience.data.PoolOperation.SelectionAction;
 
 /**
  * <p>Simple wrapper for calling the {@link PoolOperationHandler) method.
  *      The task is cancellable through its {@link Future}.</p>
  */
-public final class PoolScanTask implements Cancellable, Callable<Void> {
+public final class PoolScanTask extends ErrorAwareTask implements Cancellable {
     private final PoolOperationHandler handler;
     private final ScanSummary scan;
     private Future future;
@@ -95,6 +93,7 @@ public final class PoolScanTask implements Cancellable, Callable<Void> {
             MessageGuard.setResilienceSession();
             handler.handlePoolScan(scan);
         }
+
         return null;
     }
 
@@ -107,6 +106,7 @@ public final class PoolScanTask implements Cancellable, Callable<Void> {
     }
 
     public void submit() {
-        future = handler.getScanService().submit(new FutureTask<>(this));
+        future = handler.getScanService()
+                        .submit(createFireAndForgetTask());
     }
 }


### PR DESCRIPTION
Motivation:

A RuntimeException may be lost; specifically, the error is not logged
and does not result in the task being removed from the queue.

Modification:

Add wrapper class to ensure that a RuntimeException is logged.  (This has been
turned into an abstract class, ResilientTask, to hold code in common.) The task
also reports this error back to the containing object so the status is updated.
This allows the existing task removal process to remove it from the list of running tasks.

Also applied, for consistency, to the BrokenFileTask, even though no special
handling of the error is required.

Result:

Bugs are handled correctly.

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul