### PR TITLE
dcache-resilience: handle properly RuntimeExceptions from tasks

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
@@ -391,6 +391,7 @@ public final class FileOperation {
 
     public synchronized void submit() {
         if (task != null) {
+            task.setErrorHandler(this::updateOperation);
             task.submit();
         }
     }

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
@@ -989,6 +989,7 @@ public class PoolOperationMap extends RunnableModule {
         operation.state = State.RUNNING;
         operation.lastUpdate = System.currentTimeMillis();
         operation.lastStatus = operation.currStatus;
+        operation.task.setErrorHandler(e -> update(pool, 0, e));
         operation.resetChildren();
         running.put(pool, operation);
         LOGGER.trace("Submitting pool scan task for {}.", pool);

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/BrokenFileTask.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/BrokenFileTask.java
@@ -59,21 +59,20 @@ documents or software obtained from this server.
  */
 package org.dcache.resilience.util;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.FutureTask;
-
 import diskCacheV111.util.PnfsId;
+
 import org.dcache.resilience.handlers.FileOperationHandler;
 
 /**
  * <p>Simple wrapper for calling the {@link FileOperationHandler ) method.</p>
  */
-public final class BrokenFileTask implements Callable<Void> {
+public final class BrokenFileTask extends ErrorAwareTask {
     private final PnfsId               pnfsId;
     private final String               pool;
     private final FileOperationHandler handler;
 
-    public BrokenFileTask(PnfsId pnfsId, String pool, FileOperationHandler handler) {
+    public BrokenFileTask(PnfsId pnfsId, String pool,
+                          FileOperationHandler handler) {
         this.pnfsId = pnfsId;
         this.pool = pool;
         this.handler = handler;
@@ -87,6 +86,6 @@ public final class BrokenFileTask implements Callable<Void> {
     }
 
     public void submit() {
-        handler.getTaskService().submit(new FutureTask<>(this));
+        handler.getTaskService().submit(createFireAndForgetTask());
     }
 }

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/PoolScanTask.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/PoolScanTask.java
@@ -63,7 +63,6 @@ import java.util.concurrent.Future;
 
 import org.dcache.pool.classic.Cancellable;
 import org.dcache.resilience.data.MessageType;
-import org.dcache.resilience.data.PoolOperation.SelectionAction;
 import org.dcache.resilience.db.ScanSummary;
 import org.dcache.resilience.handlers.PoolOperationHandler;
 import org.dcache.resilience.util.PoolSelectionUnitDecorator.SelectionAction;

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/ResilientFileTask.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/ResilientFileTask.java
@@ -62,13 +62,12 @@ package org.dcache.resilience.util;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.PnfsId;
+
 import org.dcache.pool.classic.Cancellable;
 import org.dcache.pool.migration.PoolMigrationCopyFinishedMessage;
 import org.dcache.pool.migration.Task;
@@ -89,7 +88,7 @@ import org.dcache.vehicles.FileAttributes;
  *      from the pool is relayed by this task object to the internal migration
  *      task object.</p>
  */
-public final class ResilientFileTask implements Cancellable, Callable<Void> {
+public final class ResilientFileTask extends ErrorAwareTask implements Cancellable {
     private static final String STAT_FORMAT
                     = "%-28s | %25s %25s | %25s %25s %25s | %9s %9s %9s | %15s\n";
 
@@ -197,9 +196,9 @@ public final class ResilientFileTask implements Cancellable, Callable<Void> {
                 }
 
                 startSubTask = System.currentTimeMillis();
-                this.handler.getRemoveService()
-                            .schedule(new FireAndForgetTask(() -> runRemove(attributes)),
-                                      0, TimeUnit.MILLISECONDS);
+                handler.getRemoveService()
+                       .schedule(new FireAndForgetTask(() -> runRemove(attributes)),
+                                 0, TimeUnit.MILLISECONDS);
                 break;
         }
 
@@ -279,18 +278,18 @@ public final class ResilientFileTask implements Cancellable, Callable<Void> {
 
         migrationTask.messageArrived(message);
 
-        inCopy = System.currentTimeMillis() - startSubTask;
         endTime = System.currentTimeMillis();
+        inCopy = endTime - startSubTask;
     }
 
     public void submit() {
-        future = this.handler.getTaskService().submit(new FutureTask<>(this));
+        future = this.handler.getTaskService().submit(createFireAndForgetTask());
     }
 
     void runRemove(FileAttributes attributes) {
         MessageGuard.setResilienceSession();
         handler.handleRemoveOneCopy(attributes);
-        inRemove = System.currentTimeMillis() - startSubTask;
         endTime = System.currentTimeMillis();
+        inRemove = endTime - startSubTask;
     }
 }


### PR DESCRIPTION
Motivation:

A RuntimeException may be lost; specifically, the error is not logged
and does not result in the task being removed from the queue.

Modification:

Add wrapper class to ensure that a RuntimeException is logged.  (This has been
turned into an abstract class, ResilientTask, to hold code in common.) The task
also reports this error back to the containing object so the status is updated.
This allows the existing task removal process to remove it from the list of running tasks.

Also applied, for consistency, to the BrokenFileTask, even though no special
handling of the error is required.

Result:

Bugs are handled correctly.

Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Acked-by: Paul