### PR TITLE
alarms: fix broken path

### DIFF
--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -238,7 +238,7 @@ alarms.db.name=${alarms.db.name-when-type-is-${alarms.db.type}}
 alarms.plugin!plugins=@dcache.paths.plugins@
 alarms.plugin!etc=@dcache.paths.etc@
 alarms.plugin!admin=@dcache.paths.admin@
-alarms.plugin!grid-security=@dcache.paths.grid-security@
+alarms.plugin!grid-security=${dcache.paths.grid-security}
 alarms.plugin!alarms=${alarms.dir}
 
 # ---- JDBC Url


### PR DESCRIPTION
Motivation:

Commit 4e58e4c6 introduced additional configuration parameters that are
available to custom alarm log entry listeners.  The patch provides a
default value that uses a primitive path referenced (enclosing in '@').

However, 'dcache.paths.grid-security' is not a primative path but is
defined within paths.properties file.  Therefore, this reference isn't
expanded and the default value is copied as a literal string.

Modification:

Update default value to take the correct reference.

Result:

Custom Alarm listeners that require the grid-security path now have
access to that value.

Target: master
Require-notes: yes
Require-book: no
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Patch: https://rb.dcache.org/r/10794/
Acked-by: Albert Rossi