### PR TITLE
docker: Add a way to create docker image

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -70,6 +70,11 @@ module:
 
     mvn clean package -am -pl modules/tar
 
+The dCache docker image is build by packaging the _packages/docker_
+module:
+
+    mvn clean package -am -pl modules/docker
+
 It is a separate module from the RPM and DEB packages because the file
 layout is significantly different in the tarball.
 

--- a/packages/docker/Dockerfile
+++ b/packages/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:8-jdk
+
+MAINTAINER dCache "https://www.dcache.org"
+
+ENV DCACHE_HOME=/opt/dcache
+
+
+RUN groupadd -r dcache && useradd -r -g dcache dcache
+
+ADD target/dcache*.tar.gz  /opt/
+
+RUN mv /opt/dcache* /opt/dcache

--- a/packages/docker/pom.xml
+++ b/packages/docker/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.dcache</groupId>
+    <artifactId>packaging</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>dcache-docker</artifactId>
+  <packaging>pom</packaging>
+
+  <name>dCache docker packaging</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.dcache</groupId>
+            <artifactId>dcache-tar</artifactId>
+            <version>4.1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+  <build>
+      <plugins>
+
+          <plugin>
+              <artifactId>maven-resources-plugin</artifactId>
+              <version>2.5</version>
+              <executions>
+                  <execution>
+                      <phase>validate</phase>
+                      <goals>
+                          <goal>copy-resources</goal>
+                      </goals>
+                      <configuration>
+                          <outputDirectory>target</outputDirectory>
+                          <resources>
+                              <resource>
+                                  <directory>${basedir}/../tar/target</directory>
+                              </resource>
+                          </resources>
+                      </configuration>
+                  </execution>
+              </executions>
+          </plugin>
+
+          <plugin>
+              <groupId>com.spotify</groupId>
+              <artifactId>dockerfile-maven-plugin</artifactId>
+              <version>1.3.7</version>
+              <executions>
+                  <execution>
+                      <id>default</id>
+                      <goals>
+                          <goal>build</goal>
+                      </goals>
+                  </execution>
+              </executions>
+              <configuration>
+                  <repository>dcache/dcache</repository>
+                  <tag>${project.version}</tag>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+</project>

--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -221,6 +221,7 @@
   </dependencies>
 
   <modules>
+    <module>docker</module>
     <module>fhs</module>
     <module>tar</module>
     <module>system-test</module>


### PR DESCRIPTION
Motivation:
Simplify to create a docker image

Modification:
Added package docker to create a new docker image

Result:
Maven can now create a docker image

Fixes: #3789
Acked-by:
Target: master
Require-book: yes
Require-notes: yes
Signed-off-by: Martin Johnki <m.johnki@tarent.de>