### PR TITLE
dcache-frontend: avoid null dereferencing for incomplete pool history…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/pool/PoolHistoriesHandler.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/pool/PoolHistoriesHandler.java
@@ -72,7 +72,9 @@ import diskCacheV111.pools.json.PoolCostData;
 import diskCacheV111.pools.json.PoolSpaceData;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.TimeoutCacheException;
+
 import dmg.cells.nucleus.NoRouteToCellException;
+
 import org.dcache.cells.CellStub;
 import org.dcache.pool.classic.json.SweeperData;
 import org.dcache.pool.json.PoolData;
@@ -189,8 +191,11 @@ public final class PoolHistoriesHandler extends PoolInfoAggregator
         groupCost.setSpace(groupSpace);
         pools.stream()
              .map(PoolInfoWrapper::getInfo)
+             .filter(Objects::nonNull)
              .map(PoolData::getDetailsData)
+             .filter(Objects::nonNull)
              .map(PoolDataDetails::getCostData)
+             .filter(Objects::nonNull)
              .map(PoolCostData::getSpace)
              .filter(Objects::nonNull)
              .forEach(groupSpace::aggregateData);

--- a/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoAggregator.java
+++ b/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoAggregator.java
@@ -62,6 +62,7 @@ package org.dcache.util.collector.pools;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import diskCacheV111.poolManager.PoolSelectionUnit;
@@ -137,7 +138,7 @@ public abstract class PoolInfoAggregator {
         return pools.stream()
                     .map(SelectionPool::getName)
                     .map(data::get)
-                    .filter((e) -> e != null)
+                    .filter(Objects::nonNull)
                     .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
… data

Motivation:

If the history service is not running or there are other issues
with pool connectivity, this could lead to incomplete or missing
JSON data from the history service.

Currently there is a nonNull filter in place, but it is not
sufficient.  Each map operation which accesses the next
child element must do the same.

Modification:

Add the missing filters.

Also, a similar filter in a related class has been
changed from (e) -> e != null to Objects::nonNull
for the sake of consistency.

Result:

Peaceful behavior in the absence of data.

Target: master
Request: 4.1
Request: 4.0
Require-notes: yes
Require-book: no
Acked-by: Paul