### PR TITLE
ftp: ensure half-closed connections are fully closed on return

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/PassiveConnectionHandler.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/PassiveConnectionHandler.java
@@ -308,6 +308,9 @@ public class PassiveConnectionHandler implements Closeable
      * Register that no further activity is expected (in the immediate
      * future) for a given SocketChannel.  If the TCP connection
      * is left open by both ends then it is kept open for possible future use.
+     * If the remote end has closed the the connection (e.g.,
+     * SocketChannel#read returns -1) then SocketChannel#shutdownInput must be
+     * called before returning the channel.
      */
     public synchronized void returnChannel(SocketChannel channel)
     {

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/SocketAdapter.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/SocketAdapter.java
@@ -202,6 +202,7 @@ public class SocketAdapter implements Runnable, ProxyAdapter
                         reading = true;
                         buffer.clear();
                     }
+                    markInputClosed(_input);
                 } catch (IOException e) {
                     if (reading) {
                         setError("Error on socket to " + inputAddress + ": "
@@ -220,6 +221,15 @@ public class SocketAdapter implements Runnable, ProxyAdapter
                 }
             } catch (InterruptedException e) {
                 LOGGER.warn("Interrupted while waiting for accept loop to terminate");
+            }
+        }
+
+        private void markInputClosed(SocketChannel channel)
+        {
+            try {
+                channel.shutdownInput();
+            } catch (IOException e) {
+                LOGGER.error("Failed to mark socket {} closed: {}", channel, e.toString());
             }
         }
     }


### PR DESCRIPTION
Motivation:

PassiveConnectionHandler mistakenly believes that the
SocketChannel#isInputShutdown method returns true whenever the remote
connection has closed its half of the TCP connection.

In fact, Java provides no mechanism to discover whether a TCP connection
is (half-) closed.  The *only* way to discover this is by reading from
the channel and receiving the end-of-stream marker (typically, -1 is
returned).

Currently, the client closing their connection results in a loop.  The
connection is returned to PassiveConnectionHandler and added to the
idle-connections list.  The selector marks the connection as active and
a corresponding handler is created only for this handler to discover the
connection is closed.  The handler then returns the connection to the
PassiveConnectionHandler.

Modification:

Mark remote-closed connections as such, by calling
SocketChannel#shutdownInput.

Result:

Remote closed connections are handled correctly.

An unreleased regression is fixed.

Target: master
Request: 4.1
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/10818/
Acked-by: Tigran Mkrtchyan