### PR TITLE
webdav: support multiple RFC 3230 'Want-Digest' headers

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheFileResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheFileResource.java
@@ -199,8 +199,8 @@ public class DcacheFileResource
 
     public Optional<String> getRfc3230Digest()
     {
-        String wantDigest = ServletRequest.getRequest().getHeader("Want-Digest");
-        return Checksums.digestHeader(wantDigest, _attributes);
+        return DcacheResourceFactory.wantDigest()
+                .flatMap(h -> Checksums.digestHeader(h, _attributes));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Currently dCache only accepts the first 'Want-Digest' request header and
ignores all subsequent 'Want-Digest' headers.

The Apache httpd module that implements RFC 3230 provides different
behaviour: it accepts multiple 'Want-Digest' request headers and process
them as if the client supplied an equivalent comma-seperated list value.

Although RFC 3230 is vague on the behaviour with multiple headers,
there's at least one developer who expected Apache-like behaviour.

Modification:

Update webdav door and pool to accept multiple 'Want-Digest' headers by
building the equivalent comma-seperated list.

Result:

Support RFC 3230 clients that request digests using multiple HTTP
headers.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: yes
Patch: https://rb.dcache.org/r/10808/
Acked-by: Tigran Mkrtchyan