### PR TITLE
skel: make deprecated alarms properties forbidden

### DIFF
--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -18,7 +18,6 @@ alarms.cell.name=alarms
 #
 alarms.cell.consume=${alarms.cell.name}
 
-
 #  ---- Host on which this service is running
 alarms.net.host=${dcache.log.server.host}
 
@@ -32,8 +31,6 @@ alarms.dir=@dcache.paths.alarms@
 #  ---- Server root log level.
 #
 (one-of?off|error|warn|info|debug)alarms.log.root-level=warn
-
-(deprecated)alarms.custom-definitions.path=No longer used.
 
 #  ---- Server side file for recording customized priority mappings
 #       written as a simple properties file.
@@ -184,28 +181,10 @@ alarms.email.buffer-size=1
 #
 alarms.email.encoding-pattern=%d{dd MMM yyyy HH:mm:ss} %X{type} \\(%X{host}\\)\\(%X{service}\\)\\(%X{domain}\\)\\(%X{org.dcache.ndc}\\) %m%n
 
-(deprecated)alarms.history.threshold=History file is now redundant; support has been removed.
-
-(deprecated)alarms.history.encoding-pattern=History file is now redundant; support has been removed.
-
-(deprecated)alarms.history.log-path=History file is now redundant; support has been removed.
-
-(deprecated)alarms.history.log-file.pattern=History file is now redundant; support has been removed.
-
-(deprecated)alarms.history.max-file-size=History file is now redundant; support has been removed.
-
-(deprecated)alarms.history.min-index=History file is now redundant; support has been removed.
-
-(deprecated)alarms.history.max-index=History file is now redundant; support has been removed.
-
 #  ---- Defines what kind of database (currently either XML or Postgres)
 #       "off" deactivates all attempted connections to the store
 #
 (one-of?off|xml|rdbms)alarms.db.type=off
-
-#  ---- Only store alarms to the persistent store.
-#
-(deprecated)alarms.db.alarms-only=no longer used; only alarms are stored
 
 # ---- XML database
 #
@@ -234,8 +213,6 @@ alarms.db.password = ${dcache.db.password}
 (immutable)alarms.db.name-when-type-is-xml=
 (immutable)alarms.db.name-when-type-is-rdbms=alarms
 alarms.db.name=${alarms.db.name-when-type-is-${alarms.db.type}}
-
-(deprecated)alarms.enable.history=History file is now redundant; support has been removed.
 
 #  ---- Make some standard paths available to the plugins
 #
@@ -285,5 +262,14 @@ alarms.db.schema.changelog=${alarms.db.changelog-when-type-is-${alarms.db.type}}
 #  Document which TCP ports are opened
 (immutable)alarms.net.ports.tcp=${alarms.net.port}
 
-
-(obsolete)alarms.db.rdbms.type = Use alarms.db.url
+(forbidden)alarms.db.rdbms.type = Use alarms.db.url
+(forbidden)alarms.custom-definitions.path=Support for server-side regex alarm definitions has been eliminated.
+(forbidden)alarms.history.threshold=Only alarms are now stored in the database, so a separate file listing only alarms (history) is no longer necessary.
+(forbidden)alarms.history.encoding-pattern=Only alarms are now stored in the database, so a separate file listing only alarms (history) is no longer necessary.
+(forbidden)alarms.history.log-path=Only alarms are now stored in the database, so a separate file listing only alarms (history) is no longer necessary.
+(forbidden)alarms.history.log-file.pattern=Only alarms are now stored in the database, so a separate file listing only alarms (history) is no longer necessary.
+(forbidden)alarms.history.max-file-size=Only alarms are now stored in the database, so a separate file listing only alarms (history) is no longer necessary.
+(forbidden)alarms.history.min-index=Only alarms are now stored in the database, so a separate file listing only alarms (history) is no longer necessary.
+(forbidden)alarms.history.max-index=Only alarms are now stored in the database, so a separate file listing only alarms (history) is no longer necessary.
+(forbidden)alarms.db.alarms-only=Only alarms are now stored in the database, so this option is no longer supported.
+(forbidden)alarms.enable.history=Only alarms are now stored in the database, so a separate file listing only alarms (history) is no longer necessary.

--- a/skel/var/alarms/alarms-custom-definitions.xml
+++ b/skel/var/alarms/alarms-custom-definitions.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
-<definitions>
-    <!-- custom definitions determine which events are to be interpreted as alarms -->
-</definitions>


### PR DESCRIPTION
Motivation:

The custom definition (regex) server-side alarms
and the history file were eliminated in the 3.1
release.  At that time, all the associated properties
were marked deprecated.

Modification:

Mark the properties as forbidden.  Remove the
custom xml template file in /var/lib/alarms.

Result:

Alarms config is cleaned up.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Require-notes: no
Require-book: no
Acked-by: Paul