### PR TITLE
skel: remove extraneous cell-info dir

### DIFF
--- a/packages/fhs/src/main/deb/postinst
+++ b/packages/fhs/src/main/deb/postinst
@@ -35,7 +35,6 @@ Please fix this and reinstall this package." >&2
 
     # protect directories that only dCache should access
     chmod 700 /var/lib/dcache/alarms
-    chmod 700 /var/lib/dcache/cell-info
     chmod 700 /var/lib/dcache/credentials
     chmod 700 /var/lib/dcache/httpd
     chmod 700 /var/lib/dcache/plots

--- a/packages/tar/src/main/assembly/tar.xml
+++ b/packages/tar/src/main/assembly/tar.xml
@@ -95,7 +95,6 @@
             <outputDirectory></outputDirectory>
             <includes>
                 <include>var/alarms/**</include>
-                <include>var/cell-info/**</include>
                 <include>var/credentials/**</include>
                 <include>var/httpd/**</include>
                 <include>var/log/**</include>


### PR DESCRIPTION
Motivation:

An early version of frontend services used
a special directory for storing cell info json.

This was eliminated by the introduction of the
history service in 4.0.  The /var/lib path
construction was eliminated from the rpm spec
but evidently never removed from the maven
build.

Modification:

Remove the unnecessary directory.

Result:

No unused directory in /var.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: no
Require-book: no
Acked-by: Paul