### PR TITLE
packaging: add missing chown and chmod on pool-history

### DIFF
--- a/packages/fhs/src/main/deb/postinst
+++ b/packages/fhs/src/main/deb/postinst
@@ -27,6 +27,7 @@ Please fix this and reinstall this package." >&2
     chown dcache:dcache /var/lib/dcache/billing
     chown dcache:dcache /var/lib/dcache/httpd
     chown dcache:dcache /var/lib/dcache/plots
+    chown dcache:dcache /var/lib/dcache/pool-history
     chown dcache:dcache /var/lib/dcache/statistics
     chown dcache:dcache /var/lib/dcache/credentials
     chown dcache:dcache /var/lib/dcache/star
@@ -39,6 +40,7 @@ Please fix this and reinstall this package." >&2
     chmod 700 /var/lib/dcache/credentials
     chmod 700 /var/lib/dcache/httpd
     chmod 700 /var/lib/dcache/plots
+    chmod 700 /var/lib/dcache/pool-history
     chmod 700 /var/lib/dcache/resilience
     chmod 700 /var/lib/dcache/statistics
 

--- a/packages/tar/src/main/assembly/tar.xml
+++ b/packages/tar/src/main/assembly/tar.xml
@@ -100,6 +100,7 @@
                 <include>var/httpd/**</include>
                 <include>var/log/**</include>
                 <include>var/plots/**</include>
+                <include>var/pool-history/**</include>
                 <include>var/resilience/**</include>
                 <include>var/run/**</include>
                 <include>var/statistics/**</include>


### PR DESCRIPTION
Motivation:

With the history service, pool-history was added
to /var/lib and to the rmp spec, but was not
accounted for in tar or debian builds.

Modification:

Add the necessary chown and chmod configuration.

Result:

Correct directory config in all builds.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: no
Require-book: no
Acked-by: Paul