### PR TITLE
pom: use nfs4j-0.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -829,7 +829,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.16.0</version>
+            <version>0.16.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
Motivation:
the nfs4j-0.16.0 have introduced en export option to control pnfs layout
types offered to the clients. However, it nothing was specified, server
is offering all supported layout types, which confuses some clients.

The 0.16.1 returns only nfsv41_files layout type if nothing is
specified.

Full changelog:

Changelog for nfs4j-0.16.0..nfs4j-0.16.1
    * [6c69928b] [maven-release-plugin] prepare for next development iteration
    * [42642cd1] nfs4: fix NPE in OperationCOMMIT
    * [25a9e8d4] nfs4: add offset+len overflow check on COMMIT
    * [8888ceef] nfsv41: fall back to nfs41_files layout type if nothing is specified
    * [e18be9ad] [maven-release-plugin] prepare release nfs4j-0.16.1

Modification:
update pom to use nfs4j-0.16.1

Result:
old clients not surprised any more.

Acked-by: Paul Millar
Target: master, 4.1
Require-book: no
Require-notes: no
(cherry picked from commit 64300b79f67f47967d181ef67fd80cc7361530e9)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>