### PR TITLE
nfs: filter out IPv6 DS addresses if client connected with v4

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -523,6 +523,10 @@ public class NFSv41Door extends AbstractCellComponent implements
                 .filter(a -> !a.getAddress().isLoopbackAddress() || clientAddress.isLoopbackAddress())
                 .filter(a -> !a.getAddress().isLinkLocalAddress() || clientAddress.isLinkLocalAddress())
                 .filter(a -> !a.getAddress().isSiteLocalAddress() || clientAddress.isSiteLocalAddress())
+                // due to bug in linux kernel we need to filter out IPv6 addresses if client connected
+                // with IPv4.
+                // REVISIT: remove this workaround as soon as RHEL 7.5 is released.
+                .filter(a -> clientAddress.getAddress().length >= a.getAddress().getAddress().length)
                 .toArray(size -> new InetSocketAddress[size]);
 
         return layoutDriver.getDeviceAddress(usableAddresses);


### PR DESCRIPTION
Motivation:
prior version 4.12 Linux client which connects to IPv6 server and have only
IPv4 network configured tend to wait for NFS timeout*retry before an error is
propagated to upper layer. As a result, pNFS client will wait about 90s
before first byte is transferred, if dCache pool returns IPv6 and IPv4
addresses. While this is fixes in kernel 4.12:

https://github.com/torvalds/linux/commit/6ea44adce91526700535b3150f77f8639ae8c82d

The fix for RHEL7 is still pending to be released (expected in 7.5)
(https://bugzilla.redhat.com/show_bug.cgi?id=1536582)

Modification:
filter out IP addresses if they have bigger number of bytes (IPv4 - 4,
IPv6 - 16)

Result:
no delay on first IO.
NOTICE: setups, where nfs door has IPv4 only and pools IPv6+IPv6 will use IPv4
even if client supports both IPv6 and IPv4.

Acked-by: Paul Millar
Target: master, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit b18b4775ed5b64b97ebadc4b246dee5885f31a8d)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>