### PR TITLE
gplazma-fermi: add mapping plugin to support VO group and username fr…

### DIFF
--- a/modules/gplazma2-fermi/pom.xml
+++ b/modules/gplazma2-fermi/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>dcache-parent</artifactId>
+    <groupId>org.dcache</groupId>
+    <version>4.2.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>gplazma2-fermi</artifactId>
+  <packaging>jar</packaging>
+
+  <name>gPlazma 2 Fermi plugin</name>
+
+  <dependencies>
+        <dependency>
+            <groupId>org.dcache</groupId>
+            <artifactId>gplazma2</artifactId>
+            <version>4.2.0-SNAPSHOT</version>
+        </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.8.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>2.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+      </dependency>
+    </dependencies>
+</project>

--- a/modules/gplazma2-fermi/pom.xml
+++ b/modules/gplazma2-fermi/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>dcache-parent</artifactId>
     <groupId>org.dcache</groupId>
-    <version>4.2.0-SNAPSHOT</version>
+    <version>4.1.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>gplazma2</artifactId>
-            <version>4.2.0-SNAPSHOT</version>
+            <version>4.1.2-SNAPSHOT</version>
         </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/modules/gplazma2-fermi/src/main/java/org/dcache/gplazma/plugins/FileBackedVOGroupMap.java
+++ b/modules/gplazma2-fermi/src/main/java/org/dcache/gplazma/plugins/FileBackedVOGroupMap.java
@@ -1,0 +1,141 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.gplazma.plugins;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.dcache.gplazma.AuthenticationException;
+
+/**
+ * <p>In-memory version of the VO Group map file.  Loads once, and thereafter
+ * anytime the timestamp of lastModified has changed.  Timestamp is
+ * checked on each get().</p>
+ */
+public class FileBackedVOGroupMap {
+    private static final Logger LOGGER
+                    = LoggerFactory.getLogger(FileBackedVOGroupMap.class);
+
+    private final Map<String, VOGroupEntry> cache = new HashMap<>();
+    private final File file;
+    private final Path path;
+    private long lastModified;
+    private long reloadCount;
+
+    public FileBackedVOGroupMap(String path) {
+        this.path = Paths.get(path);
+        this.file = this.path.toFile();
+    }
+
+    public VOGroupEntry get(String fqan) throws AuthenticationException {
+        synchronized (cache) {
+            checkFile();
+            if (!cache.containsKey(fqan)) {
+                throw new AuthenticationException("No VO group entry matching FQAN: "
+                                                                  + fqan);
+            }
+
+            return cache.get(fqan);
+        }
+    }
+
+    @VisibleForTesting
+    long getReloadCount() {
+        synchronized (cache) {
+            return reloadCount;
+        }
+    }
+
+    @GuardedBy("cache")
+    private void checkFile() {
+        if (!file.exists() || !file.canRead()) {
+            LOGGER.error("RELOAD FAILED: Could not read {}.",
+                         file.getAbsolutePath());
+        } else if (lastModified < file.lastModified()) {
+            cache.clear();
+            GsonBuilder builder = new GsonBuilder();
+            try (FileReader reader = new FileReader(file)) {
+                VOGroupEntry[] info = builder.create()
+                                             .fromJson(reader,
+                                                       VOGroupEntry[].class);
+                Stream.of(info).forEach(e -> cache.put(e.getFqan(), e));
+                lastModified = file.lastModified();
+                ++reloadCount;
+            } catch (IOException e) {
+                LOGGER.error("There was a problem deserializing {}: {}, {}",
+                             file, e.getMessage(), Throwables.getRootCause(e));
+            }
+        }
+    }
+}

--- a/modules/gplazma2-fermi/src/main/java/org/dcache/gplazma/plugins/VOGroupEntry.java
+++ b/modules/gplazma2-fermi/src/main/java/org/dcache/gplazma/plugins/VOGroupEntry.java
@@ -1,0 +1,104 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.gplazma.plugins;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+
+/**
+ * <p>Container for VO Group authorization data.</p>
+ */
+public class VOGroupEntry implements Serializable {
+    private static final long serialVersionUID = -4348326595015055203L;
+
+    @SerializedName("fqan")
+    private String fqan;
+
+    @SerializedName("mapped_uname")
+    private String mappedUname;
+
+    @SerializedName("mapped_gid")
+    private String mappedGid;
+
+    public String getFqan() {
+        return fqan;
+    }
+
+    public String getMappedGid() {
+        return mappedGid;
+    }
+
+    public String getMappedUname() {
+        return mappedUname;
+    }
+
+    public void setFqan(String fqan) {
+        this.fqan = fqan;
+    }
+
+    public void setMappedGid(String mappedGid) {
+        this.mappedGid = mappedGid;
+    }
+
+    public void setMappedUname(String mappedUname) {
+        this.mappedUname = mappedUname;
+    }
+}

--- a/modules/gplazma2-fermi/src/main/java/org/dcache/gplazma/plugins/VOGroupPlugin.java
+++ b/modules/gplazma2-fermi/src/main/java/org/dcache/gplazma/plugins/VOGroupPlugin.java
@@ -1,0 +1,137 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.gplazma.plugins;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+
+import java.security.Principal;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.Set;
+
+import org.dcache.auth.FQANPrincipal;
+import org.dcache.auth.GidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
+import org.dcache.gplazma.AuthenticationException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * <p>Mapping plugin which requires FQANPrincipal, and adds a GIDPrincioal
+ *    and possibly a UserNamePrincipal.</p>
+ *
+ * <p>If there is no FQAN, the plugin fails.  Otherwise it will always
+ *    add the mapped GIDPrincipal as primary.</p>
+ *
+ * <p>Adding of a UserNamePrincipal is optional; hence, the plugin
+ *    should be run as optional if the setup depends on a UserName principal
+ *    being added here or downstream.</p>
+ *
+ * <p>If a UserNamePrincipal already exists, the UserNamePrincipal
+ *    matched by this plugin to an FQAN will be substituted for it.</p>
+ */
+public class VOGroupPlugin implements GPlazmaMappingPlugin {
+    private static final String VO_GROUP_PATH_PROPERY = "vo-group-path";
+
+    private final FileBackedVOGroupMap map;
+
+    public VOGroupPlugin(Properties properties) {
+        String path = properties.getProperty(VO_GROUP_PATH_PROPERY, null);
+        checkArgument(path != null, VO_GROUP_PATH_PROPERY
+                        + " argument must be specified");
+        map = new FileBackedVOGroupMap(path);
+    }
+
+    @VisibleForTesting
+    VOGroupPlugin(FileBackedVOGroupMap map) {
+        this.map = map;
+    }
+
+    @Override
+    public void map(Set<Principal> principals) throws AuthenticationException {
+        FQANPrincipal fqan
+                        =  principals.stream()
+                                     .filter(FQANPrincipal.class::isInstance)
+                                     .map(FQANPrincipal.class::cast)
+                                     .filter(FQANPrincipal::isPrimaryGroup)
+                                     .findFirst()
+                                     .orElseThrow(() -> new AuthenticationException("No subjects found with an FQAN."));
+
+        VOGroupEntry voGroupEntry = map.get(fqan.getName());
+
+        principals.add(new GidPrincipal(voGroupEntry.getMappedGid(), true));
+
+        String mappedUname = voGroupEntry.getMappedUname();
+
+        if (Strings.isNullOrEmpty(mappedUname)) {
+            return;
+        }
+
+        for (Iterator<Principal> i = principals.iterator(); i.hasNext();) {
+            Principal principal = i.next();
+            if (principal instanceof  UserNamePrincipal) {
+                i.remove();
+            }
+        }
+
+        principals.add(new UserNamePrincipal(mappedUname));
+    }
+}

--- a/modules/gplazma2-fermi/src/main/resources/META-INF/gplazma-plugins.xml
+++ b/modules/gplazma2-fermi/src/main/resources/META-INF/gplazma-plugins.xml
@@ -1,0 +1,6 @@
+<plugins>
+    <plugin>
+        <name>vogroup</name>
+        <class>org.dcache.gplazma.plugins.VOGroupPlugin</class>
+    </plugin>
+</plugins>

--- a/modules/gplazma2-fermi/src/test/java/org/dcache/gplazma/plugins/VOGroupPluginTest.java
+++ b/modules/gplazma2-fermi/src/test/java/org/dcache/gplazma/plugins/VOGroupPluginTest.java
@@ -68,6 +68,7 @@ import java.security.Principal;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.dcache.auth.FQANPrincipal;
 import org.dcache.auth.GidPrincipal;
@@ -89,6 +90,7 @@ public class VOGroupPluginTest {
     public void setUp() throws Exception {
         URL url = ClassLoader.getSystemResource(TEST_FIXTURE);
         file = new File(url.toURI());
+        file.setLastModified(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1));
         map = new FileBackedVOGroupMap(file.getAbsolutePath());
         plugin = new VOGroupPlugin(map);
     }

--- a/modules/gplazma2-fermi/src/test/java/org/dcache/gplazma/plugins/VOGroupPluginTest.java
+++ b/modules/gplazma2-fermi/src/test/java/org/dcache/gplazma/plugins/VOGroupPluginTest.java
@@ -1,0 +1,249 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.gplazma.plugins;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.security.Principal;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.dcache.auth.FQANPrincipal;
+import org.dcache.auth.GidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
+import org.dcache.gplazma.AuthenticationException;
+
+import static org.junit.Assert.*;
+
+public class VOGroupPluginTest {
+    private final static String TEST_FIXTURE = "org/dcache/gplazma/plugins/vo-group.json";
+
+    File                 file;
+    FileBackedVOGroupMap map;
+    VOGroupPlugin        plugin;
+    Set<Principal>          principals = new HashSet<>();
+    AuthenticationException exception  = null;
+
+    @Before
+    public void setUp() throws Exception {
+        URL url = ClassLoader.getSystemResource(TEST_FIXTURE);
+        file = new File(url.toURI());
+        map = new FileBackedVOGroupMap(file.getAbsolutePath());
+        plugin = new VOGroupPlugin(map);
+    }
+
+    @Test
+    public void shouldAddGidPrincipalAndUserNameIfPresent() throws Exception {
+        givenFQAN(anFqanWithUname());
+        whenMapIsCalled();
+        assertThatGidPrincipalWasAdded();
+        assertThatUnamePrincipalWasAdded();
+    }
+
+    @Test
+    public void shouldAddGidPrincipalIfNoUserNamePresent() throws Exception {
+        givenFQAN(anFqanWithoutUname());
+        whenMapIsCalled();
+        assertThatGidPrincipalWasAdded();
+    }
+
+    @Test
+    public void shouldFailIfNoFQAN() throws Exception {
+        whenMapIsCalled();
+        assertThatPluginFailed();
+    }
+
+    @Test
+    public void shouldNotFailIfNoUserNamePresent() throws Exception {
+        givenFQAN(anFqanWithoutUname());
+        whenMapIsCalled();
+        assertThatPluginSucceeded();
+    }
+
+    @Test
+    public void shouldFindThePrimaryFQANWhenMultipleArePresent()
+                    throws Exception {
+        givenNonPrimaryFQAN(aSecondFqan());
+        givenNonPrimaryFQAN(aThirdFqan());
+        givenFQAN(anFqanWithUname());
+        whenMapIsCalled();
+        assertThatUnamePrincipalWasFromPrimary();
+    }
+
+    @Test
+    public void shouldNotFailIfUserNamePresent() throws Exception {
+        givenFQAN(anFqanWithUname());
+        whenMapIsCalled();
+        assertThatPluginSucceeded();
+    }
+
+    @Test
+    public void shouldReloadAgainAfterTimestampUpdate() throws Exception {
+        givenFQAN(anFqanWithUname());
+        givenMapIsCalled();
+        givenFileUpdated();
+        whenMapIsCalledAgain();
+        assertThatReloadWasCalledTwice();
+    }
+
+    @Test
+    public void shouldReloadOnlyOnceWithoutTimestampChange() throws Exception {
+        givenFQAN(anFqanWithUname());
+        givenMapIsCalled();
+        whenMapIsCalledAgain();
+        assertThatReloadWasCalledOnce();
+    }
+
+    private String aSecondFqan() {
+        return "/fermilab/annie/Role=None";
+    }
+
+    private String aThirdFqan() {
+        return "/fermilab/Role=admin";
+    }
+
+    private String anFqanWithUname() {
+        return "/fermilab/accelerator/Role=Production";
+    }
+
+    private String anFqanWithoutUname() {
+        return "/fermilab/accelerator/Role=None";
+    }
+
+    private void assertThatGidPrincipalWasAdded() {
+        Optional<GidPrincipal> gidPrincipal
+                        = principals.stream()
+                                    .filter(p -> p instanceof GidPrincipal)
+                                    .map(p -> (GidPrincipal) p)
+                                    .findFirst();
+        assertTrue("Gid Principal is missing!",
+                   gidPrincipal.isPresent());
+    }
+
+    private void assertThatPluginFailed() {
+        assertNotNull("Mapping should have failed, but did not.",
+                      exception);
+    }
+
+    private void assertThatPluginSucceeded() {
+        assertNull("Mapping should not have failed, but did.",
+                   exception);
+    }
+
+    private void assertThatReloadWasCalledOnce() {
+        assertEquals("file reloaded wrong number of times",
+                     1, map.getReloadCount());
+    }
+
+    private void assertThatReloadWasCalledTwice() {
+        assertEquals("file reloaded wrong number of times",
+                     2, map.getReloadCount());
+    }
+
+    private String assertThatUnamePrincipalWasAdded() {
+        Optional<UserNamePrincipal> userNamePrincipal
+                        = principals.stream()
+                                    .filter(p -> p instanceof UserNamePrincipal)
+                                    .map(p -> (UserNamePrincipal) p)
+                                    .findFirst();
+        assertTrue("UserName Principal is missing!",
+                   userNamePrincipal.isPresent());
+        return userNamePrincipal.get().getName();
+    }
+
+    private void assertThatUnamePrincipalWasFromPrimary() {
+        assertEquals("Wrong user name!", "accelpro",
+                     assertThatUnamePrincipalWasAdded());
+    }
+
+    private void givenFQAN(String fqan) {
+        principals.add(new FQANPrincipal(fqan, true));
+    }
+
+    private void givenFileUpdated() {
+        file.setLastModified(System.currentTimeMillis());
+    }
+
+    private void givenMapIsCalled() {
+        whenMapIsCalled();
+    }
+
+    private void givenNonPrimaryFQAN(String fqan) {
+        principals.add(new FQANPrincipal(fqan, false));
+    }
+
+    private void whenMapIsCalled() {
+        try {
+            plugin.map(principals);
+        } catch (AuthenticationException e) {
+            exception = e;
+        }
+    }
+
+    private void whenMapIsCalledAgain() {
+        principals.clear();
+        principals.add(new FQANPrincipal(anFqanWithUname(), true));
+        whenMapIsCalled();
+    }
+}

--- a/modules/gplazma2-fermi/src/test/resources/org/dcache/gplazma/plugins/vo-group.json
+++ b/modules/gplazma2-fermi/src/test/resources/org/dcache/gplazma/plugins/vo-group.json
@@ -1,0 +1,47 @@
+[
+  {
+    "fqan": "/GLOW/Role=None",
+    "mapped_uname": "glow",
+    "mapped_gid": "9784"
+  },
+  {
+    "fqan": "/fermilab/Role=None",
+    "mapped_uname": "",
+    "mapped_gid": "9767"
+  },
+  {
+    "fqan": "/fermilab/accelerator/Role=None",
+    "mapped_uname": "",
+    "mapped_gid": "1570"
+  },
+  {
+    "fqan": "/fermilab/accelerator/Role=Production",
+    "mapped_uname": "accelpro",
+    "mapped_gid": "1570"
+  },
+  {
+    "fqan": "/fermilab/Role=admin",
+    "mapped_uname": "fgadmin",
+    "mapped_gid": "9767"
+  },
+  {
+    "fqan": "/fermilab/annie/Role=None",
+    "mapped_uname": "",
+    "mapped_gid": "9467"
+  },
+  {
+    "fqan": "/fermilab/annie/Role=Analysis",
+    "mapped_uname": "",
+    "mapped_gid": "9467"
+  },
+  {
+    "fqan": "/fermilab/annie/Role=pilot",
+    "mapped_uname": "anniegli",
+    "mapped_gid": "9467"
+  },
+  {
+    "fqan": "/fermilab/annie/Role=Production",
+    "mapped_uname": "anniepro",
+    "mapped_gid": "9467"
+  }
+]

--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -97,6 +97,11 @@
         <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.dcache</groupId>
+      <artifactId>gplazma2-fermi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
         <groupId>org.dcache</groupId>
         <artifactId>gplazma2-grid</artifactId>
         <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1331,6 +1331,7 @@
         <module>modules/cells</module>
         <module>modules/gplazma2</module>
         <module>modules/gplazma2-argus</module>
+        <module>modules/gplazma2-fermi</module>
         <module>modules/gplazma2-grid</module>
         <module>modules/gplazma2-krb5</module>
         <module>modules/gplazma2-jaas</module>


### PR DESCRIPTION
…om file

Motivation:

Fermilab's authorization system has decided to move
away from the centralized GUMS-XACML interaction and
substitute for it reliance on .json file which is
refreshed periodically from a service by a system
cron.

Modification:

Add a mapping plugin to capture the FQAN to GID
mapping, and optionally, to user name.

If no FQAN is present, it fails.  Otherwise
it adds the GID.  If it finds a username,
it also add that, replacing any previous
username in the set of principals.

For this reason, it should be run as optional,
with other mapping plugins (such as the gridmap)
serving as failover for the missing username.

A Junit test is included.

Result:

Authorization should work (with the example
conf file) so that, depending on how
the FQAN is mapped, a user can get
access either as part of a group user
or as individual user.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 2.16
Acked-by: Dmitry
Require-notes: yes
Require-book: yes