### PR TITLE
ftp: avoid NPE if connection is closed.

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/PassiveConnectionHandler.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/PassiveConnectionHandler.java
@@ -81,7 +81,7 @@ public class PassiveConnectionHandler implements Closeable
 
     public synchronized InetSocketAddress getLocalAddress()
     {
-        return (InetSocketAddress) _channel.socket().getLocalSocketAddress();
+        return _channel == null ? null : (InetSocketAddress) _channel.socket().getLocalSocketAddress();
     }
 
     public synchronized void setAddressSupplier(Supplier<Iterable<InterfaceAddress>> addressSupplier)


### PR DESCRIPTION
Motivation:

Calling getLocalAddress before open or after close results in a NPE.

Modification:

Return null if the ServerSocketChannel is not selected.

Result:

A potential null pointer exception is avoided.

Target: master
Require: 4.1
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/10856/
Acked-by: Albert Rossi