### PR TITLE
spacemanager: add remote pool monitor debug logging

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/LinkGroupLoader.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/LinkGroupLoader.java
@@ -163,6 +163,8 @@ public class LinkGroupLoader
             for (PoolLinkGroupInfo info : linkGroupInfos) {
                 saveLinkGroup(currentTime, info);
             }
+        } else {
+            LOGGER.debug("In updateLinkGroups, poolMonitor updated no linkgroups");
         }
         latestUpdateTime = currentTime;
         return linkGroupInfos.size();

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
@@ -329,6 +329,11 @@ public class PoolManagerV5
             try {
                 limiter.acquire();
                 while (!Thread.interrupted()) {
+                    if (_log.isDebugEnabled()) { // For RT 9250.
+                        if (_poolMonitor.getPoolSelectionUnit().getLinkGroups().isEmpty()) {
+                            _log.debug("notifying with PoolMonitor that has empty linkgroups");
+                        }
+                    }
                     _poolMonitorTopic.notify(_poolMonitor);
                     waitUntilNextUpdate();
                     limiter.acquire();

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolMonitor.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/RemotePoolMonitor.java
@@ -38,9 +38,11 @@ import diskCacheV111.util.FileLocality;
 import diskCacheV111.vehicles.PoolManagerGetPoolMonitor;
 import diskCacheV111.vehicles.ProtocolInfo;
 
+import dmg.cells.nucleus.CellAddressCore;
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellInfoProvider;
 import dmg.cells.nucleus.CellLifeCycleAware;
+import dmg.cells.nucleus.CellMessage;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.NoRouteToCellException;
 
@@ -64,6 +66,7 @@ public class RemotePoolMonitor
     private CellStub poolManagerStub;
     private PoolMonitor poolMonitor;
     private long refreshCount;
+    private CellAddressCore previousMonitorSource;
 
     @Required
     public void setPoolManagerStub(CellStub stub)
@@ -93,7 +96,7 @@ public class RemotePoolMonitor
                                  @Override
                                  public void success(PoolManagerGetPoolMonitor message)
                                  {
-                                     messageArrived(message.getPoolMonitor());
+                                     acceptMonitor(message.getPoolMonitor());
                                  }
 
                                  @Override
@@ -113,7 +116,11 @@ public class RemotePoolMonitor
     @Override
     public PoolSelectionUnit getPoolSelectionUnit()
     {
-        return getPoolMonitor().getPoolSelectionUnit();
+        PoolSelectionUnit psu = getPoolMonitor().getPoolSelectionUnit();
+        if (LOGGER.isDebugEnabled() && psu.getLinkGroups().isEmpty()) {
+            LOGGER.debug("getPoolSelectionUnit returning no linkgroups");
+        }
+        return psu;
     }
 
     @Override
@@ -148,7 +155,7 @@ public class RemotePoolMonitor
 
     public void refresh() throws CacheException, InterruptedException, NoRouteToCellException
     {
-        messageArrived(poolManagerStub.sendAndWait(new PoolManagerGetPoolMonitor()).getPoolMonitor());
+        acceptMonitor(poolManagerStub.sendAndWait(new PoolManagerGetPoolMonitor()).getPoolMonitor());
     }
 
     public synchronized long getRefreshCount()
@@ -161,7 +168,19 @@ public class RemotePoolMonitor
         return lastRefreshTime;
     }
 
-    public synchronized void messageArrived(SerializablePoolMonitor monitor)
+    public void messageArrived(CellMessage envelope, SerializablePoolMonitor monitor)
+    {
+        if (LOGGER.isDebugEnabled()) {
+            if (!envelope.getSourceAddress().equals(previousMonitorSource)) {
+                LOGGER.debug("received PoolMonitor from {} with {} linkgroups",
+                        envelope.getSourceAddress(), monitor.getPoolSelectionUnit().getLinkGroups().size());
+            }
+            previousMonitorSource = envelope.getSourceAddress();
+        }
+        acceptMonitor(monitor);
+    }
+
+    private synchronized void acceptMonitor(SerializablePoolMonitor monitor)
     {
         poolMonitor = monitor;
         lastRefreshTime = System.currentTimeMillis();


### PR DESCRIPTION
Motivation:

We have reports of a problem that we don't understand.

Modification:

Add additional logging inspired by RT 9250.

Result:

dCache now provides additional logging that may help
in diagnosing problems with link groups disappearing.

Require-notes: yes
Require-book: no
Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9250
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9332
Patch: https://rb.dcache.org/r/10843
Acked-by: Albert Rossi