### PR TITLE
spacemanager: add remote pool monitor debug logging

### DIFF
--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/LinkGroupLoader.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/LinkGroupLoader.java
@@ -168,6 +168,8 @@ public class LinkGroupLoader
             for (PoolLinkGroupInfo info : linkGroupInfos) {
                 saveLinkGroup(currentTime, info);
             }
+        } else {
+            LOGGER.debug("In updateLinkGroups, poolMonitor updated no linkgroups");
         }
         latestUpdateTime = currentTime;
         return linkGroupInfos.size();

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
@@ -309,6 +309,11 @@ public class PoolManagerV5
             try {
                 limiter.acquire();
                 while (!Thread.interrupted()) {
+                    if (_log.isDebugEnabled()) { // For RT 9250.
+                        if (_poolMonitor.getPoolSelectionUnit().getLinkGroups().isEmpty()) {
+                            _log.debug("notifying with PoolMonitor that has empty linkgroups");
+                        }
+                    }
                     _poolMonitorTopic.notify(_poolMonitor);
                     waitUntilNextUpdate();
                     limiter.acquire();


### PR DESCRIPTION
Motivation:

We have reports of a problem that we don't understand.

Modification:

Add additional logging inspired by RT 9250.

Result:

dCache now provides additional logging that may help
in diagnosing problems with link groups disappearing.

Require-notes: yes
Require-book: no
Target: master
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9250
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9332
Patch: https://rb.dcache.org/r/10843
Acked-by: Albert Rossi