### PR TITLE
pool: fix error message for failed active FTP transfers

### DIFF
--- a/modules/cells/src/main/java/dmg/util/Exceptions.java
+++ b/modules/cells/src/main/java/dmg/util/Exceptions.java
@@ -58,14 +58,17 @@ public class Exceptions
      * enclosingType is reached.  If enclosingType does not support wrapping
      * then {@literal cause} is returned and a warning is logged.
      * <p />
-     * Note that the wrapped exception will contain only a message and possibly
-     * the {@literal cause} as the triggering exception; in particular, any
-     * additional information from {@literal cause} is not copied into the
-     * wrapped exception.
+     * Note that the wrapping exception will have a message constructed by
+     * concatenating the prefix, the String literal ": ", and a cause-specific
+     * message.  If the cause has a non-null message then this is used as the
+     * cause-specific message, otherwise the cause class simple name is used.
      */
-    public static <T extends Exception> T wrap(String message, T cause, Class<T> enclosingType)
+    public static <T extends Exception> T wrap(String prefix, T cause, Class<T> enclosingType)
     {
         ReflectiveOperationException lastException = null;
+
+        String causeMessage = cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
+        String message = prefix + ": " + causeMessage;
 
         Class type = cause.getClass();
         while (enclosingType.isAssignableFrom(type)) {

--- a/modules/cells/src/test/java/dmg/util/ExceptionsTests.java
+++ b/modules/cells/src/test/java/dmg/util/ExceptionsTests.java
@@ -49,7 +49,7 @@ public class ExceptionsTests
         IOException wrapped = Exceptions.wrap("Wrapped message", cause, IOException.class);
 
         assertThat(wrapped, is(notNullValue()));
-        assertThat(wrapped.getMessage(), is(equalTo("Wrapped message")));
+        assertThat(wrapped.getMessage(), is(equalTo("Wrapped message: Something went wrong")));
         assertThat(wrapped.getCause(), is(cause));
         assertThat(wrapped.getClass(), is(equalTo(IOException.class)));
 
@@ -64,7 +64,7 @@ public class ExceptionsTests
         Exception wrapped = Exceptions.wrap("Wrapped message", cause, Exception.class);
 
         assertThat(wrapped, is(notNullValue()));
-        assertThat(wrapped.getMessage(), is(equalTo("Wrapped message")));
+        assertThat(wrapped.getMessage(), is(equalTo("Wrapped message: Something went wrong")));
         assertThat(wrapped.getCause(), is(cause));
         assertThat(wrapped.getClass(), is(equalTo(IOException.class)));
 
@@ -82,7 +82,7 @@ public class ExceptionsTests
         Exception wrapped = Exceptions.wrap("Wrapped message", cause, SocketException.class);
 
         assertThat(wrapped, is(notNullValue()));
-        assertThat(wrapped.getMessage(), is(equalTo("Wrapped message")));
+        assertThat(wrapped.getMessage(), is(equalTo("Wrapped message: Something went wrong")));
         assertThat(wrapped.getCause(), is(nullValue()));
         assertThat(wrapped.getClass(), is(equalTo(SocketException.class)));
 
@@ -99,7 +99,7 @@ public class ExceptionsTests
         Exception wrapped = Exceptions.wrap("Wrapped message", cause, Exception.class);
 
         assertThat(wrapped, is(notNullValue()));
-        assertThat(wrapped.getMessage(), is(equalTo("Wrapped message")));
+        assertThat(wrapped.getMessage(), is(equalTo("Wrapped message: " + cause.getMessage())));
         assertThat(wrapped.getCause(), is(cause));
         assertThat(wrapped.getClass(), is(equalTo(Exception.class)));
 

--- a/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
@@ -310,12 +310,10 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         } catch (BindException | ConnectException | NoRouteToHostException |
                 PortUnreachableException | UnknownHostException e) {
             throw Exceptions.wrap("Failed to connect " +
-                    mode.getRemoteAddressDescription() + ": " + e.getMessage(),
-                    e, IOException.class);
+                    mode.getRemoteAddressDescription(), e, IOException.class);
         } catch (IOException e) {
             throw Exceptions.wrap("Problem while connected to " +
-                    mode.getRemoteAddressDescription() + ": " + e.getMessage(),
-                    e, IOException.class);
+                    mode.getRemoteAddressDescription(), e, IOException.class);
         } finally {
             _inProgress = false;
 


### PR DESCRIPTION
Motivation:

Active transfers (as opposed to passive) has dCache establish the TCP
connection with the data recipient, over which the file's content will
flow.  Under ideal circumstances, the dCache pool will establish this
connection, rather than the door establishing the connection and
proxying the data.  If the pool experiences a problem establishing the
TCP connection, an IOException is caught a propagated to the door,
although the message sent wraps the original IOException to provide
additional context information (e.g., address & port number).

Unfortunately, the IOExceptions from OpenJDK often fail to include a
message, resulting error responses like:

    451 General problem: Problem while connected to [2001:67c:1148:200::111]:20276: null

Modification:

Update wrap method to build a suitable message by using the cause class
simple name if the message is null: this is often enough to identify the
nature of the problem.

Result:

Provide a more complete error message should the pool fail to connect to
the remote party as part of an active (i.e., non-passive) FTP transfer.

Target: master
Require-notes: true
Require-book: false
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16