### PR TITLE
ftp: add detailed information about proxy status

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/ColumnWriter.java
+++ b/modules/common/src/main/java/org/dcache/util/ColumnWriter.java
@@ -502,10 +502,17 @@ public class ColumnWriter
     public static class TabulatedRow implements Row
     {
         private final Map<String, Object> values = new HashMap<>();
+        private final Map<String, String> fills = new HashMap<>();
 
         public TabulatedRow value(String column, Object value)
         {
             values.put(column, value);
+            return this;
+        }
+
+        public TabulatedRow fill(String column, String value)
+        {
+            fills.put(column, value);
             return this;
         }
 
@@ -526,7 +533,15 @@ public class ColumnWriter
                 }
                 Column column = columns.get(i);
                 Object value = values.get(column.name());
-                column.render(value, widths.get(i), out);
+                int width = widths.get(i);
+                if (value == null) {
+                    String fill = fills.get(column.name());
+                    if (fill != null) {
+                        int count = (width + width % fill.length())/fill.length();
+                        value = Strings.repeat(fill, count).subSequence(0, width);
+                    }
+                }
+                column.render(value, width, out);
             }
             out.print(endOfLine);
         }

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1330,7 +1330,7 @@ public abstract class AbstractFtpDoorV1
             }
             ProxyAdapter adapter = _adapter;
             if (adapter != null) {
-                pw.println("         Proxy  : " + adapter);
+                adapter.getInfo(pw);
             }
         }
     }

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/ProxyAdapter.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/ProxyAdapter.java
@@ -1,6 +1,9 @@
 package org.dcache.ftp.proxy;
 
+import java.io.PrintWriter;
 import java.net.InetSocketAddress;
+
+import dmg.cells.nucleus.CellInfoProvider;
 
 /**
  * A ProxyAdaper implementation is responsible for relaying an FTP data
@@ -18,7 +21,7 @@ import java.net.InetSocketAddress;
  * has returned.  This has two effects: it forcing the adapter to stop any active
  * transfer and allowing the proxy adapter to clean up any remaining state.
  */
-public interface ProxyAdapter
+public interface ProxyAdapter extends CellInfoProvider
 {
     /**
      * The direction in which data will flow for this transfer.

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/ProxyPrinter.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/ProxyPrinter.java
@@ -1,0 +1,162 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 1998 - 2018 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.ftp.proxy;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.util.EnumSet;
+import java.util.stream.Collectors;
+
+import org.dcache.util.ColumnWriter;
+import org.dcache.util.ColumnWriter.TabulatedRow;
+
+/**
+ * Provide an ASCII-art description of the current state of a proxy.
+ */
+public class ProxyPrinter
+{
+    private enum ConnectionState {
+        ESTABLISHED, HALF_CLOSED, CLOSED
+    }
+
+    private final EnumSet<ConnectionState> connectionStates = EnumSet.noneOf(ConnectionState.class);
+    private final ColumnWriter table;
+
+    private Socket client;
+    private Socket pool;
+
+    public ProxyPrinter()
+    {
+        table = new ColumnWriter()
+                .right("client-remote")
+                .centre("client-net")
+                .left("client-local")
+                .centre("proxy")
+                .right("pool-local")
+                .centre("pool-net")
+                .left("pool-remote");
+        table.row()
+                .value("client-remote", "Client")
+                .value("client-net", "        +-")
+                .fill("client-local", "-")
+                .value("proxy", "-Adapter-")
+                .fill("pool-local", "-")
+                .value("pool-net", "-+        ")
+                .value("pool-remote", "Pool");
+    }
+
+    public ProxyPrinter client(Socket connection)
+    {
+        client = connection;
+        return this;
+    }
+
+    public ProxyPrinter pool(Socket connection)
+    {
+        pool = connection;
+        return this;
+    }
+
+    public ProxyPrinter add()
+    {
+        TabulatedRow row = table.row();
+
+        if (client == null) {
+            row.value("client-net", "        | ");
+        } else {
+            row.value("client-remote", format(client.getRemoteSocketAddress()))
+                    .value("client-net", networkConnection(client, true))
+                    .value("client-local", format(client.getLocalSocketAddress()));
+        }
+
+        if (pool == null) {
+            row.value("pool-net", " |        ");
+        } else {
+            row.value("pool-local", format(pool.getLocalSocketAddress()))
+                .value("pool-net", networkConnection(pool, false))
+                .value("pool-remote", format(pool.getRemoteSocketAddress()));
+        }
+
+        client = null;
+        pool = null;
+        return this;
+    }
+
+    private String format(SocketAddress sa)
+    {
+        if (sa instanceof InetSocketAddress) {
+            InetSocketAddress isa = (InetSocketAddress)sa;
+            return isa.getAddress().getHostAddress() + ":" + isa.getPort();
+        } else {
+            return sa.toString();
+        }
+    }
+
+    private String networkConnection(Socket s, boolean isRemoteLeft)
+    {
+        if (s.isInputShutdown() && s.isOutputShutdown()) {
+            connectionStates.add(ConnectionState.CLOSED);
+            return isRemoteLeft ? "........| " : " |........";
+        } else if (!s.isInputShutdown() && !s.isOutputShutdown()) {
+            connectionStates.add(ConnectionState.ESTABLISHED);
+            return isRemoteLeft ? "========| " : " |========";
+        } else if (!s.isInputShutdown() && isRemoteLeft) {
+            connectionStates.add(ConnectionState.HALF_CLOSED);
+            return "-->-->--| ";
+        } else if (!s.isOutputShutdown() && !isRemoteLeft) {
+            connectionStates.add(ConnectionState.HALF_CLOSED);
+            return " |-->-->--";
+        } else {
+            connectionStates.add(ConnectionState.HALF_CLOSED);
+            return isRemoteLeft ? "--<--<--| " : " |--<--<--";
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        table.row()
+                .value("client-net", "        +-")
+                .fill("client-local", "-")
+                .value("proxy", "---------")
+                .fill("pool-local", "-")
+                .value("pool-net", "-+        ");
+
+        return connectionStates.isEmpty()
+                ? table.toString()
+                : table + connectionStates.stream()
+                        .sorted()
+                        .map(ProxyPrinter::legend)
+                        .collect(Collectors.joining(", ", "\nTCP states: ", ""));
+    }
+
+    private static String legend(ConnectionState state)
+    {
+        switch (state) {
+        case ESTABLISHED:
+            return "\"========\" means Established";
+        case HALF_CLOSED:
+            return "\"--------\" means Half-closed (arrows show open dirn)";
+        case CLOSED:
+            return "\"........\" means Closed";
+        }
+        throw new RuntimeException("Unknown state " + state);
+    }
+}


### PR DESCRIPTION
Motivation:

Proxy current status is difficult to discover.  This inhibits diagnosing
problems.

Modification:

Make ProxyAdapter a CellInfoProvider.  Update the door to include
ProxyAdapter instances as part of its status information.

Add an ASCII-art diagram, showing the adapter's current status.

Result:

Network status of proxy adapter is available to admin interface.

Target: master
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/10857/
Acked-by: Albert Rossi