### PR TITLE
dcache-resilience: repair over-aggressive handling of broken file mes…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -167,13 +167,18 @@ public class FileOperationHandler {
                             = FileUpdate.getAttributes(pnfsId, pool,
                                                        MessageType.CORRUPT_FILE,
                                                        namespace);
-            int actual = 0;
-            int countable = 0;
-
-            if (attributes != null) {
-                actual = attributes.getLocations().size();
-                countable = poolInfoMap.getCountableLocations(attributes.getLocations());
+            if (attributes == null) {
+                LOGGER.trace("{} not ONLINE.", pnfsId);
+                return;
             }
+
+            if (!poolInfoMap.isResilientPool(pool)) {
+                LOGGER.trace("{} not in resilient group.", pool);
+                return;
+            }
+
+            int actual = attributes.getLocations().size();
+            int countable = poolInfoMap.getCountableLocations(attributes.getLocations());
 
             if (actual <= 1) {
                 /*


### PR DESCRIPTION
…sages

Motivation:

While https://rb.dcache.org/r/10734 (commit a352dfcad686b71a37fb7d5c6edb9378c6e6df3b)
made some important repairs to the handling of broken files, it
did not recognize a bug which existed in the code path which
neglects to check that the file is actually ONLINE and the pool is resilient.

This results in nearly double the number of alarms reported (since
the message received probably was already associated with a BROKEN_FILE
alarm).

Modification:

Do the necessary checks.

Result:

Resilience should not be reporting on non-resilient files which have
been corrupted.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Acked-by: Dmitry
Require-notes: yes
Require-book: no