### PR TITLE
poolmanager: fix migration command if named pool is removed

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
@@ -559,7 +559,9 @@ public class PoolManagerV5
         List<String> offlinePools = new ArrayList<>();
         for (String name: msg.getPoolNames()) {
             PoolSelectionUnit.SelectionPool pool = _selectionUnit.getPool(name);
-            getPoolInformation(pool, onlinePools, offlinePools);
+            if (pool != null) {
+                getPoolInformation(pool, onlinePools, offlinePools);
+            }
         }
         msg.setPools(onlinePools);
         msg.setOfflinePools(offlinePools);


### PR DESCRIPTION
Motivation:

Commit 23cfdc51 introduced a regression by not considering that an incoming
PoolManagerGetPoolsByNameMessage request could target pools that are not just
offline, but are actually unknown.  This triggers a NPE.

Such a scenario could happen if a migration copy/move command is targeting specific
pools and one of those pools is removed from pool-manager.

Modification:

When information is requested about specific pools, filter out from the
response those pool names that are unknown.

Result:

migration move/copy commands that target specific pools do not trigger a
NullPointerException if one of the pools is removed from pool-manager.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: yes
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9379
Patch: https://rb.dcache.org/r/10872/
Acked-by: Albert Rossi