### PR TITLE
nfs: add commands to reactivate stale transfers

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -74,6 +74,7 @@ import org.dcache.chimera.nfsv41.mover.NFS4ProtocolInfo;
 import org.dcache.commons.stats.RequestExecutionTimeGauges;
 import org.dcache.poolmanager.PoolManagerStub;
 import org.dcache.namespace.FileAttribute;
+import org.dcache.utils.Bytes;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.ExportFile;
 import org.dcache.nfs.FsExport;
@@ -1037,6 +1038,58 @@ public class NFSv41Door extends AbstractCellComponent implements
             return  waitForRedirect(NFS_REQUEST_BLOCKING);
         }
 
+        /**
+         * Retry transfer.
+         */
+        private String retry() {
+
+            /*
+             * client re-try will trigger transfer
+             */
+            if (_redirectFuture == null) {
+                return "Nothing to do.";
+            }
+
+            /*
+             * The transfer is in the middle of an action
+             */
+            String s = getStatus();
+            if (s != null) {
+                return "Can't reset transfer in action: " + s;
+            }
+
+            /*
+             * Reply from pool selection is lost. It's safe to start over.
+             */
+            if (getPool() == null) {
+                _redirectFuture = null;
+                return "Restarting from pool selection";
+            }
+
+            /*
+             * Mover id is lost. it's ok to start it again, as pool will start
+             * mover for given transfer only once.
+             */
+            if (!hasMover()) {
+                _redirectFuture = startMoverAsync(NFS_REQUEST_BLOCKING);
+                return "Re-activating mover on: " + getPool();
+            }
+
+            /*
+             * Redirect is complete.
+             */
+            if (getRedirect() != null) {
+                return "Can't re-try complete mover.";
+            }
+
+            /**
+             * Redirect is lost
+             */
+            // currently there are no possiblitilies to force too to re-send redirect.
+
+            return "Lost redirect...";
+        }
+
         public synchronized void shutdownMover() throws NfsIoException, DelayException {
 
             if (!hasMover()) {
@@ -1205,6 +1258,51 @@ public class NFSv41Door extends AbstractCellComponent implements
         public String call() {
             long n = recallLayouts(pool);
             return n + " layouts scheduled for recall.";
+        }
+    }
+
+    @Command(name = "transfer retry", hint = "retry transfer for given open state.",
+        description = "Retry pool selection or mover creation for a given transfer. "
+                + "this can be necessary if components involved in selection "
+                + "process were restarted before a reply was deliverd to the door.")
+    public class TransferRetryCmd implements Callable<String> {
+
+        @Argument(metaVar = "stateid")
+        String os;
+
+        @Override
+        public String call() {
+            stateid4 stateid = new stateid4(Bytes.fromHexString(os), 0);
+            NfsTransfer t = _ioMessages.get(stateid);
+            if (t == null) {
+                return "No matching transfer";
+            }
+            return t.retry();
+        }
+    }
+
+    @Command(name = "transfer forget", hint = "remove transfer for a given open state.",
+        description = "Remove transfer from the list of active transfers. If client retry the"
+            + "request, then a new transfer will be created.")
+    public class TransferForgetCmd implements Callable<String> {
+
+        @Argument(metaVar = "stateid", usage = "nfs open state id assosiated with the transfer.")
+        String os;
+
+        @Option(name = "kill-mover", usage = "try to kill mover, if exists.")
+        boolean killMover;
+
+        @Override
+        public String call() {
+            stateid4 stateid = new stateid4(Bytes.fromHexString(os), 0);
+            NfsTransfer t = _ioMessages.remove(stateid);
+            if (t == null) {
+                return "No matching transfer";
+            }
+            if (killMover) {
+                t.killMover(0, TimeUnit.SECONDS, "manual transfer termination");
+            }
+            return "Removed: " + t;
         }
     }
 


### PR DESCRIPTION
Motivation:
In situations when selection process incomplete, due to PoolManager restart
we need a way to trigger a new selection. One option is to manually re-activate
existing transfer by re-trying selection process. The other possibility is
to completely 'forget' the stale transfer and let client to trigger a fresh
selection process.

Modification:
Add two new commands to nfs door:

  transfer retry
  transfer forget

Result:
situations, where transfer end up into situation where selection process is
incomplete can be manually recovered.

Acked-by: Albert Rossi
Target: master, 4.1, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit bf2b3c38ae992937dc66b3b57d21dd0ceb38c8ce)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>