### PR TITLE
frontend: add swagger Tag descriptions

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/ApiConfig.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/ApiConfig.java
@@ -25,6 +25,7 @@ import io.swagger.annotations.Info;
 import io.swagger.annotations.License;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.annotations.Tag;
 
 import javax.ws.rs.ext.Provider;
 
@@ -61,7 +62,19 @@ import javax.ws.rs.ext.Provider;
         ),
         consumes = {"application/json"},
         produces = {"application/json"},
-        externalDocs = @ExternalDocs(value = "Wiki", url = "https://github.com/dCache/dcache/wiki/Restful-API")
+        externalDocs = @ExternalDocs(value = "Wiki", url = "https://github.com/dCache/dcache/wiki/Restful-API"),
+        tags = {
+            @Tag(name = "alarms", description = "The log of internal problems"),
+            @Tag(name = "billing", description = "The log of (significant) client activity"),
+            @Tag(name = "cells", description = "The running components within dCache"),
+            @Tag(name = "identity", description = "Information about users"),
+            @Tag(name = "namespace", description = "Files, directories and similar objects"),
+            @Tag(name = "poolmanager", description = "Data placement and selection decisions"),
+            @Tag(name = "pools", description = "File data storage"),
+            @Tag(name = "qos", description = "Managing how data is stored and handled"),
+            @Tag(name = "spacemanager", description = "Ensuring enough capacity for uploads"),
+            @Tag(name = "transfers", description = "The movement of data between dCache and clients")
+        }
 )
 @Provider
 public interface ApiConfig


### PR DESCRIPTION
Motivation:

The @Api swagger annotation includes the concept of tags in order to
group together related operations.  The frontend simply uses these tags,
without prior definition.  Although this use is supported, such tags
then lack any corresponding description.  In the UI, the groups of
related operations are therefore shown without any context.

Modification:

Add definitions for the tags used by frontend that includes a short
description of which aspect of dCache is affected by these operations.

Result:

Improved REST API swagger documentation that describes which aspects of
dCache are affected by related operations.

Target: master
Request: 4.1
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10883/
Acked-by: Tigran Mkrtchyan
Acked-by: Albert Rossi