### PR TITLE
ftp: returned error is too vague for meaningful investigation

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -71,6 +71,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Range;
@@ -309,6 +310,10 @@ public abstract class AbstractFtpDoorV1
 {
     private static final long MINIMUM_PERFORMANCE_MARKER_PERIOD = 2;
     private static final long MAXIMUM_PERFORMANCE_MARKER_PERIOD = TimeUnit.MINUTES.toSeconds(5);
+    private static final ImmutableMap<ProtocolFamily,String> PROTOCOLFAMILY_TO_STRING = ImmutableMap.<ProtocolFamily,String>builder()
+            .put(StandardProtocolFamily.INET, "IP v4")
+            .put(StandardProtocolFamily.INET6, "IP v6")
+            .build();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFtpDoorV1.class);
     private static final Timer TIMER = new Timer("Performance marker timer", true);
@@ -2350,10 +2355,21 @@ public abstract class AbstractFtpDoorV1
             _mode = Mode.PASSIVE;
             return _clientConnectionHandler.getLocalAddress();
         } catch (NoSuchElementException e) {
+            InetAddress address = _localSocketAddress.getAddress();
+            String iface;
+            try {
+                iface = "Interface " + NetworkInterface.getByInetAddress(address).getName();
+            } catch (SocketException se) {
+                LOGGER.warn("Unable to discover interface for address {}: {}",
+                        InetAddresses.toUriString(address), se.toString());
+                iface = "Interface";
+            }
+            ProtocolFamily family = _clientConnectionHandler.getPreferredProtocolFamily();
+            String ipVersion = PROTOCOLFAMILY_TO_STRING.getOrDefault(family, family.name());
             _mode = Mode.ACTIVE;
             _clientConnectionHandler.close();
             _sessionAllPassive = false; // REVISIT see RFC 2428 Section 4.
-            throw new FTPCommandException(522, "Protocol family not supported");
+            throw new FTPCommandException(522, iface + " does not support " + ipVersion + " addresses");
         } catch (IOException e) {
             _mode = Mode.ACTIVE;
             _clientConnectionHandler.close();


### PR DESCRIPTION
Motivation:

dCache will fail a command if a client requests a different IP version
(e.g., IPv4 instead of IPv6) and that interface has no such interface.

The returned error is so vague that the cause is completely unclear.

Modification:

Update error message to provide a reasonable summary of the problem.

Result:

Problems where a client requests an IP-version that isn't supported will
generate an error message that better describes the problem.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9388