### PR TITLE
ftp: log failures to wrap/encrypt responses

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
@@ -83,11 +83,11 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
     @Override
     protected void secure_reply(String answer, String code)
     {
-        answer = answer + "\r\n";
-        byte[] data = answer.getBytes(UTF8);
+        byte[] data = (answer + "\r\n").getBytes(UTF8);
         try {
             data = context.wrap(data, 0, data.length);
         } catch (IOException e) {
+            LOGGER.error("Failed to encrypt reply '{}': {}", answer, e.toString());
             reply("500 Reply encryption error: " + e);
             return;
         }


### PR DESCRIPTION
Motivation:

A support ticket points to a FTP response being lost.  Although there is
no evidence pointing to a problem encrypting the response, this could
explain the apparent behaviour and we currently have no way to exclude
that possibility.

Modification:

Log if the FTP door is unable to encrypt a response.

Result:

A possible failure mode when the FTP door is replying is logged, to aid
diagnosing problems.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9392
Acked-by: Albert Rossi
Acked-by: Jürgen Starek (verbally)

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java

Conflicts:
	modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java