### PR TITLE
pool: fix logging of replica-store on start-up

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/statistics/IoStatisticsReplicaStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/statistics/IoStatisticsReplicaStore.java
@@ -62,4 +62,10 @@ public class IoStatisticsReplicaStore extends ForwardingReplicaStore
     {
         return new IoStatisticsReplicaRecord(super.create(id, flags));
     }
+
+    @Override
+    public String toString()
+    {
+        return inner.toString();
+    }
 }


### PR DESCRIPTION
Motivation:

Commit 1d2f7ee1908 introduced the IoStatisticsReplicaStore, which wraps
some other ReplicaStore and provides IO-statistics.  Unfortunately, this
left the default toString method, resulting in the pool logging somewhat
useless information during start-up:

    07 May 2018 23:35:34 (pool_read) [] Reading inventory from org.dcache.pool.statistics.IoStatisticsReplicaStore@15d99a44.

instead of:

    07 May 2018 23:38:40 (pool_write) [] Reading inventory from [data=/home/paul/git/dCache/packages/system-test/target/dcache/var/pools/pool_write/data;meta=/home/paul/git/dCache/packages/system-test/target/dcache/var/pools/pool_write/control].

Modification:

Delegate the toString method to the inner class.

Result:

During the pool's start-up, the replica store's locations are logged, as
prior to the regression.

Target: master
Request: 4.1
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10942/
Acked-by: Tigran Mkrtchyan