### PR TITLE
skel: replaced dead links to antlr documentation

### DIFF
--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -98,11 +98,11 @@ billing.text.dir = ${dcache.paths.billing}
 # For advanced customizing, consult the StringTemplate v4
 # documentation at
 #
-#  http://www.antlr.org/wiki/display/ST4/StringTemplate+4+Documentation
+# https://github.com/antlr/stringtemplate4/blob/master/doc/index.md
 #
 # or the cheat sheet at
 #
-#  http://www.antlr.org/wiki/display/ST4/StringTemplate+cheat+sheet
+# https://github.com/antlr/stringtemplate4/blob/master/doc/cheatsheet.md
 #
 #
 #  Message: InfoMessage


### PR DESCRIPTION
Replaced dead links to antlr documenation with their new counterparts.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Require-notes: no
Require-book: no

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>