### PR TITLE
dcache: release dcache-view version 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.6.0</version.wicket>
         <version.xrootd4j>3.2.2</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.4.1</version.dcache-view>
+        <version.dcache-view>1.4.2</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.4.1 to v1.4.2

- [d1cea7a](https://github.com/dCache/dcache-view/commit/d1cea7a) dcache-view: repair broken click/tap events
- [b484b03](https://github.com/dCache/dcache-view/commit/b484b03) dcache-view (namespace): fix the upload toast to show the current status
- [11ea12d](https://github.com/dCache/dcache-view/commit/11ea12d) dcache-view (namespace): live update of QoS when changed
- [374e45d](https://github.com/dCache/dcache-view/commit/374e45d) dcache-view (namespace): broadcast current path in view-file
- [113eef6](https://github.com/dCache/dcache-view/commit/113eef6) dcache-view (namespace): remove unnecessary semicolon
- [21d700b](https://github.com/dCache/dcache-view/commit/21d700b) dcache-view: fix regression regarding the processing of click events on vaadin-grid tables
- [25d06df](https://github.com/dCache/dcache-view/commit/25d06df) dcache-view (namespace): dispatch events for notification messages
- [f9c0f8f](https://github.com/dCache/dcache-view/commit/f9c0f8f) dcache-view (namespace): fix path request in view-file

Target: master
Request: 4.1
Require-book: no
Require-note: yes
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10974/

(cherry picked from commit e4b9f72b3896179614f189bbe4c1d5e9425cf09e)