### PR TITLE
no longer disable Java ECC algorithms

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -891,7 +891,7 @@ dcache.authn.ocsp-mode=IGNORE
 #   By specifying DISABLE_RC4, dCache prevents RC4 from being used
 #   under any circumstances, as required by RFC 7465.
 #
-(any-of?DISABLE_EC|DISABLE_RC4)dcache.authn.ciphers = DISABLE_EC,DISABLE_RC4
+(any-of?DISABLE_EC|DISABLE_RC4)dcache.authn.ciphers = DISABLE_RC4
 
 #  ---- Whether to overwrite existing files on upload
 #


### PR DESCRIPTION
By now everyone should have been able to install a current version of JDK in
which ECC algorithms are properly supported.
There's no reason to keep the far more secure algorithms for anyone else per
default, just because a minority might not yet have upgraded.

Thus, changed the default of not using ECC algorithms.

Target: master
Request: 4.1
Request: 4.0
Require-notes: yes
Require-book: no

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>