### PR TITLE
dcache-frontend: provide default sorting on RESTful admin data fields

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/Link.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/Link.java
@@ -62,6 +62,7 @@ package org.dcache.restful.providers.selection;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -105,14 +106,17 @@ public final class Link extends SelectionType {
         preferences = new UnitPreferences(link.getPreferences());
         pools = link.getPools()
                     .stream()
+                    .sorted(Comparator.comparing(SelectionPool::getName))
                     .map(SelectionPool::getName)
                     .collect(Collectors.toList());
         poolGroups = link.getPoolGroupsPointingTo()
                          .stream()
+                         .sorted(Comparator.comparing(SelectionPoolGroup::getName))
                          .map(SelectionPoolGroup::getName)
                          .collect(Collectors.toList());
         unitGroups = link.getUnitGroupsTargetedBy()
                          .stream()
+                         .sorted(Comparator.comparing(SelectionUnitGroup::getName))
                          .map(SelectionUnitGroup::getName)
                          .collect(Collectors.toList());
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/LinkGroup.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/LinkGroup.java
@@ -62,6 +62,7 @@ package org.dcache.restful.providers.selection;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -129,6 +130,7 @@ public final class LinkGroup extends SelectionTypeWithLinks {
         return psu.getLinkGroupByName(name)
                   .getLinks()
                   .stream()
+                  .sorted(Comparator.comparing(SelectionLink::getName))
                   .map(SelectionLink::getName)
                   .collect(Collectors.toList());
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/Pool.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/Pool.java
@@ -62,6 +62,7 @@ package org.dcache.restful.providers.selection;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -95,6 +96,7 @@ public final class Pool extends SelectionTypeWithLinks {
                   .map(SelectionPoolGroup::getName)
                   .map(psu::getLinksPointingToPoolGroup)
                   .flatMap(links -> links.stream())
+                  .sorted(Comparator.comparing(SelectionLink::getName))
                   .map(SelectionLink::getName)
                   .collect(Collectors.toList());
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/PoolGroup.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/PoolGroup.java
@@ -62,6 +62,7 @@ package org.dcache.restful.providers.selection;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -84,6 +85,7 @@ public final class PoolGroup extends SelectionTypeWithLinks {
         super(group, psu);
         pools = psu.getPoolsByPoolGroup(name)
                    .stream()
+                   .sorted(Comparator.comparing(SelectionPool::getName))
                    .map(SelectionPool::getName)
                    .collect(Collectors.toList());
     }
@@ -96,6 +98,7 @@ public final class PoolGroup extends SelectionTypeWithLinks {
     protected List<String> extractLinks(PoolSelectionUnit psu) {
         return psu.getLinksPointingToPoolGroup(name)
                   .stream()
+                  .sorted(Comparator.comparing(SelectionLink::getName))
                   .map(SelectionLink::getName)
                   .collect(Collectors.toList());
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/PreferenceResult.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/PreferenceResult.java
@@ -64,6 +64,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import diskCacheV111.poolManager.PoolPreferenceLevel;
 
@@ -88,7 +89,8 @@ public final class PreferenceResult implements Serializable {
     }
 
     public List<String> getPools() {
-        return pools;
+        return pools == null? null :
+                        pools.stream().sorted().collect(Collectors.toList());
     }
 
     public String getTag() {

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/Unit.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/Unit.java
@@ -62,6 +62,7 @@ package org.dcache.restful.providers.selection;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -90,6 +91,7 @@ public final class Unit extends SelectionType {
         type = unit.getType().name();
         groups = unit.getMemberOfUnitGroups()
                      .stream()
+                     .sorted(Comparator.comparing(SelectionUnitGroup::getName))
                      .map(SelectionUnitGroup::getName)
                      .collect(Collectors.toList());
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/UnitGroup.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/UnitGroup.java
@@ -62,6 +62,7 @@ package org.dcache.restful.providers.selection;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -86,6 +87,7 @@ public final class UnitGroup extends SelectionTypeWithLinks {
         super(group.getName(), psu);
         units = group.getMemeberUnits()
                      .stream()
+                     .sorted(Comparator.comparing(SelectionUnit::getName))
                      .map(SelectionUnit::getName)
                      .collect(Collectors.toList());
     }
@@ -99,6 +101,7 @@ public final class UnitGroup extends SelectionTypeWithLinks {
         return psu.getUnitGroups().get(name)
                   .getLinksPointingTo()
                   .stream()
+                  .sorted(Comparator.comparing(SelectionLink::getName))
                   .map(SelectionLink::getName)
                   .collect(Collectors.toList());
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/billing/BillingResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/billing/BillingResources.java
@@ -151,6 +151,7 @@ public class BillingResources {
                                              @ApiParam("Only select reads requested by the client.")
                                              @QueryParam("client") String client,
                                              @ApiParam("How to sort responses.")
+                                             @DefaultValue("date")
                                              @QueryParam("sort") String sort) {
         try {
             if (!HttpServletRequests.isAdmin(request)) {
@@ -210,6 +211,7 @@ public class BillingResources {
                                               @ApiParam("Only select writes requested by the client.")
                                               @QueryParam("client") String client,
                                               @ApiParam("How to sort responses.")
+                                              @DefaultValue("date")
                                               @QueryParam("sort") String sort) {
         try {
             if (!HttpServletRequests.isAdmin(request)) {
@@ -269,6 +271,7 @@ public class BillingResources {
                                            @ApiParam("Only select transfers triggered by the specified client.")
                                            @QueryParam("client") String client,
                                            @ApiParam("How to sort responses.")
+                                           @DefaultValue("date")
                                            @QueryParam("sort") String sort) {
         try {
             if (!HttpServletRequests.isAdmin(request)) {
@@ -324,6 +327,7 @@ public class BillingResources {
                                              @ApiParam("Only select tape writes involving the specified pool.")
                                              @QueryParam("pool") String pool,
                                              @ApiParam("How to sort responses.")
+                                             @DefaultValue("date")
                                              @QueryParam("sort") String sort) {
         try {
             if (!HttpServletRequests.isAdmin(request)) {
@@ -377,6 +381,7 @@ public class BillingResources {
                                                @ApiParam("Only select tape reads involving the specified pool.")
                                                @QueryParam("pool") String pool,
                                                @ApiParam("How to sort responses.")
+                                               @DefaultValue("date")
                                                @QueryParam("sort") String sort) {
         try {
             if (!HttpServletRequests.isAdmin(request)) {
@@ -406,7 +411,8 @@ public class BillingResources {
 
 
     @GET
-    @ApiOperation("Provide the full \"grid\" of time series data in one pass.")
+    @ApiOperation("Provide the full \"grid\" of time series data in one pass. "
+                    + "Data is sorted lexicographically by key.")
     @ApiResponses({
                 @ApiResponse(code = 500, message = "Internal Server Error"),
             })
@@ -420,6 +426,7 @@ public class BillingResources {
                    .getDataGrid()
                    .keySet()
                    .stream()
+                   .sorted()
                    .forEach((key) -> {
                        try {
                            gridData.add(service.getHistogram(key));

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/cells/CellInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/cells/CellInfoResources.java
@@ -78,6 +78,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.stream.Collectors;
 
 import diskCacheV111.util.CacheException;
@@ -138,7 +139,8 @@ public final class CellInfoResources {
 
 
     @GET
-    @ApiOperation("Provide information about all cells.  Requires admin role.")
+    @ApiOperation("Provide information about all cells.  Requires admin role. "
+                    + "Results sorted lexicographically by cell name.")
     @ApiResponses({
                 @ApiResponse(code = 403, message = "Cell info service only accessible to admin users."),
             })
@@ -151,6 +153,10 @@ public final class CellInfoResources {
 
         return Arrays.stream(service.getAddresses())
                      .map(service::getCellData)
-                     .collect(Collectors.toList()).toArray(new CellData[0]);
+                     .collect(Collectors.toList())
+                     .stream()
+                     .sorted(Comparator.comparing(CellData::getCellName))
+                     .collect(Collectors.toList())
+                     .toArray(new CellData[0]);
     }
 }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolGroupInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolGroupInfoResources.java
@@ -77,10 +77,12 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPoolGroup;
 
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.restful.providers.pool.PoolGroupInfo;
@@ -107,7 +109,8 @@ public final class PoolGroupInfoResources {
     private PoolMonitor poolMonitor;
 
     @GET
-    @ApiOperation("Get a list of poolgroups.  Requires admin role.")
+    @ApiOperation("Get a list of poolgroups.  Requires admin role."
+                    + " Results sorted lexicographically by group name.")
     @ApiResponses({
         @ApiResponse(code = 403, message = "Pool group info only accessible to admin users."),
     })
@@ -122,6 +125,7 @@ public final class PoolGroupInfoResources {
 
         return psu.getPoolGroups().values()
                   .stream()
+                  .sorted(Comparator.comparing(SelectionPoolGroup::getName))
                   .map((g) -> new PoolGroup(g.getName(), psu))
                   .collect(Collectors.toList());
     }
@@ -147,7 +151,8 @@ public final class PoolGroupInfoResources {
     @GET
     @Path("/{group}/pools")
     @ApiOperation("Get a list of pools that are a member of a poolgroup.  If no "
-            + "poolgroup is specified then all pools are listed.")
+            + "poolgroup is specified then all pools are listed. "
+                    + "Results sorted lexicographically by pool name.")
     @Produces(MediaType.APPLICATION_JSON)
     public String[] getPoolsOfGroup(@ApiParam("The poolgroup to be described.")
                                     @PathParam("group") String group) {

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
@@ -92,10 +92,12 @@ import javax.ws.rs.core.Response;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPool;
 import diskCacheV111.pools.PoolV2Mode;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
@@ -158,7 +160,7 @@ public final class PoolInfoResources {
 
     @GET
     @ApiOperation("Get information about all pools (name, group membership, links).  "
-                    + "Requires admin role.")
+                    + "Requires admin role.  Results sorted lexicographically by pool name.")
     @ApiResponses({
         @ApiResponse(code = 403, message = "Pool info only accessible to admin users."),
     })
@@ -173,6 +175,7 @@ public final class PoolInfoResources {
 
         return psu.getPools().values()
                   .stream()
+                  .sorted(Comparator.comparing(SelectionPool::getName))
                   .map((p) -> new Pool(p.getName(), psu))
                   .collect(Collectors.toList());
     }
@@ -316,6 +319,7 @@ public final class PoolInfoResources {
                                      @ApiParam("Select movers with a specific storage class.")
                                      @QueryParam("storageClass") String storageClass,
                                      @ApiParam("How returned items should be sorted.")
+                                     @DefaultValue("door,startTime")
                                      @QueryParam("sort") String sort) {
         if (!HttpServletRequests.isAdmin(request)) {
             throw new ForbiddenException(
@@ -396,6 +400,7 @@ public final class PoolInfoResources {
                                                 @ApiParam("Select only operations of this storage class.")
                                                 @QueryParam("storageClass") String storageClass,
                                                 @ApiParam("How the returned values should be sorted.")
+                                                @DefaultValue("class,created")
                                                 @QueryParam("sort") String sort) {
         if (!HttpServletRequests.isAdmin(request)) {
             throw new ForbiddenException(

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
@@ -68,6 +68,7 @@ import io.swagger.annotations.Authorization;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
@@ -130,6 +131,7 @@ public final class RestoreResources {
                                                  @ApiParam("Select only restores with this status.")
                                                  @QueryParam("status") String status,
                                                  @ApiParam("A comma-seperated list of fields on which to sort the results.")
+                                                 @DefaultValue("pool,started")
                                                  @QueryParam("sort") String sort) {
         try {
             return service.get(token,

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/LinkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/LinkResources.java
@@ -75,10 +75,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionLink;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionLinkGroup;
 
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.restful.providers.selection.Link;
@@ -103,7 +106,8 @@ public final class LinkResources {
 
 
     @GET
-    @ApiOperation("Get information about all links.  Requires admin role.")
+    @ApiOperation("Get information about all links.  Requires admin role."
+                    + " Results sorted lexicographically by link name.")
     @ApiResponses({
         @ApiResponse(code = 403, message = "Link info only accessible to admin users."),
     })
@@ -116,12 +120,14 @@ public final class LinkResources {
 
         return poolMonitor.getPoolSelectionUnit().getLinks().values()
                           .stream()
+                          .sorted(Comparator.comparing(SelectionLink::getName))
                           .map(Link::new)
                           .collect(Collectors.toList());
     }
 
     @GET
-    @ApiOperation("Get information about all linkgroups.  Requires admin role.")
+    @ApiOperation("Get information about all linkgroups.  Requires admin role."
+                    + " Results sorted lexicographically by link group name.")
     @ApiResponses({
         @ApiResponse(code = 403, message = "Link group info only accessible to admin users."),
     })
@@ -137,6 +143,7 @@ public final class LinkResources {
 
         return psu.getLinkGroups().values()
                   .stream()
+                  .sorted(Comparator.comparing(SelectionLinkGroup::getName))
                   .map((g) -> new LinkGroup(g, psu))
                   .collect(Collectors.toList());
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/PartitionResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/PartitionResources.java
@@ -75,7 +75,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.dcache.poolmanager.PoolMonitor;
@@ -100,7 +102,8 @@ public final class PartitionResources {
 
 
     @GET
-    @ApiOperation("Get information about all partitions.  Requires admin role.")
+    @ApiOperation("Get information about all partitions.  Requires admin role."
+                    + " Results sorted lexicographically by partition name.")
     @ApiResponses({
         @ApiResponse(code = 403, message = "Partition info only accessible to admin users."),
     })
@@ -113,6 +116,7 @@ public final class PartitionResources {
 
         return poolMonitor.getPartitionManager().getPartitions().entrySet()
                           .stream()
+                          .sorted(Comparator.comparing(Entry::getKey))
                           .map(Partition::new)
                           .collect(Collectors.toList());
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/UnitResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/UnitResources.java
@@ -75,10 +75,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionUnit;
+import diskCacheV111.poolManager.PoolSelectionUnit.SelectionUnitGroup;
 
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.restful.providers.selection.Unit;
@@ -102,7 +105,8 @@ public final class UnitResources {
     private PoolMonitor poolMonitor;
 
     @GET
-    @ApiOperation("List all units.  Requires admin role.")
+    @ApiOperation("List all units.  Requires admin role."
+                    + " Results sorted lexicographically by unit name.")
     @ApiResponses({
         @ApiResponse(code = 403, message = "Unit info only accessible to admin users."),
     })
@@ -115,13 +119,15 @@ public final class UnitResources {
 
         return poolMonitor.getPoolSelectionUnit().getSelectionUnits().values()
                           .stream()
+                          .sorted(Comparator.comparing(SelectionUnit::getName))
                           .map(Unit::new)
                           .collect(Collectors.toList());
     }
 
 
     @GET
-    @ApiOperation("List all unitgroups.  Requires admin role.")
+    @ApiOperation("List all unitgroups.  Requires admin role."
+                    + " Results sorted lexicographically by unit group name.")
     @ApiResponses({
         @ApiResponse(code = 403, message = "Unit info only accessible to admin users."),
     })
@@ -137,6 +143,7 @@ public final class UnitResources {
 
         return poolMonitor.getPoolSelectionUnit().getUnitGroups().values()
                           .stream()
+                          .sorted(Comparator.comparing(SelectionUnitGroup::getName))
                           .map((g) -> new UnitGroup(g, psu))
                           .collect(Collectors.toList());
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/space/SpaceManagerResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/space/SpaceManagerResources.java
@@ -80,6 +80,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -123,7 +124,8 @@ public final class SpaceManagerResources {
     private boolean spaceReservationEnabled;
 
     @GET
-    @ApiOperation("Get information about link groups.  Requires admin role.")
+    @ApiOperation("Get information about link groups.  Requires admin role."
+                    + " Results sorted lexicographically by link group name.")
     @ApiResponses({
         @ApiResponse(code = 400, message = "Bad Request Error"),
         @ApiResponse(code = 403, message = "Link group info only accessible to admin users."),
@@ -177,6 +179,7 @@ public final class SpaceManagerResources {
 
             return reply.getLinkGroups()
                         .stream()
+                        .sorted(Comparator.comparing(LinkGroup::getName))
                         .filter(filter)
                         .map(LinkGroupInfo::new)
                         .collect(Collectors.toList());
@@ -187,7 +190,7 @@ public final class SpaceManagerResources {
 
     @GET
     @ApiOperation("Get information about space tokens.  "
-                    + "Requires admin role.")
+                    + "Requires admin role.  Results sorted by token id.")
     @ApiResponses({
         @ApiResponse(code = 403, message = "Space token info only accessible to admin users."),
         @ApiResponse(code = 404, message = "DCache not configured for space management."),
@@ -237,6 +240,7 @@ public final class SpaceManagerResources {
 
             return reply.getSpaceTokenSet()
                         .stream()
+                        .sorted(Comparator.comparing(Space::getId))
                         .filter(filter)
                         .map(SpaceToken::new)
                         .collect(Collectors.toList());

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
@@ -68,6 +68,7 @@ import io.swagger.annotations.Authorization;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
@@ -143,6 +144,7 @@ public final class TransferResources {
                                                    @ApiParam("Select transfers involving this client.")
                                                    @QueryParam("client") String client,
                                                    @ApiParam("A comma-seperated list of fields to sort the responses.")
+                                                   @DefaultValue("door,waiting")
                                                    @QueryParam("sort") String sort) {
         try {
             return service.get(token,

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/billing/BillingInfoService.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/billing/BillingInfoService.java
@@ -61,11 +61,11 @@ package org.dcache.restful.services.billing;
 
 import java.text.ParseException;
 
-import dmg.cells.nucleus.NoRouteToCellException;
-
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.PnfsId;
+
+import dmg.cells.nucleus.NoRouteToCellException;
 
 import org.dcache.restful.providers.PagedList;
 import org.dcache.restful.providers.billing.BillingDataGrid;

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/billing/BillingInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/billing/BillingInfoServiceImpl.java
@@ -59,6 +59,8 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.services.billing;
 
+import com.google.common.base.Strings;
+
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,14 +72,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileNotFoundCacheException;
+import diskCacheV111.util.PnfsId;
+
 import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.util.command.Argument;
 import dmg.util.command.Command;
 import dmg.util.command.Option;
-
-import diskCacheV111.util.CacheException;
-import diskCacheV111.util.FileNotFoundCacheException;
-import diskCacheV111.util.PnfsId;
 
 import org.dcache.restful.providers.PagedList;
 import org.dcache.restful.providers.billing.BillingDataGrid;
@@ -274,6 +276,10 @@ public class BillingInfoServiceImpl
                     throws FileNotFoundCacheException, ParseException,
                     CacheException, NoRouteToCellException,
                     InterruptedException {
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "date";
+        }
+
         TransferRecordRequestMessage message
                         = new TransferRecordRequestMessage(pnfsid,
                                                            getDate(before),
@@ -305,7 +311,8 @@ public class BillingInfoServiceImpl
         return getDoorTransfers(Type.READ, pnfsid, before, after,
                                 limit, offset, door, pool, client, sort);
     }
-                                                              @Override
+
+    @Override
     public PagedList<HSMTransferRecord> getRestores(PnfsId pnfsid,
                                                     String before, String after,
                                                     Integer limit, int offset,
@@ -385,6 +392,10 @@ public class BillingInfoServiceImpl
                     throws FileNotFoundCacheException, ParseException,
                     CacheException, NoRouteToCellException,
                     InterruptedException {
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "date";
+        }
+
         TransferRecordRequestMessage message
                         = new TransferRecordRequestMessage(pnfsid,
                                                            getDate(before),
@@ -415,6 +426,10 @@ public class BillingInfoServiceImpl
                     throws FileNotFoundCacheException, ParseException,
                     CacheException, NoRouteToCellException,
                     InterruptedException {
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "date";
+        }
+
         StorageRecordRequestMessage message
                         = new StorageRecordRequestMessage(pnfsid,
                                                           getDate(before),
@@ -424,6 +439,7 @@ public class BillingInfoServiceImpl
                                                           limit,
                                                           offset,
                                                           sort);
+
         message = collector.sendRecordRequest(message);
         List<HSMTransferRecord> list = message.getRecords()
                                               .stream().map(HSMTransferRecord::new)

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/cells/CellInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/cells/CellInfoServiceImpl.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.restful.services.cells;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
@@ -67,6 +68,7 @@ import java.util.stream.Collectors;
 import dmg.cells.nucleus.CellInfo;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.util.command.Command;
+
 import org.dcache.cells.json.CellData;
 import org.dcache.restful.util.admin.ReadWriteData;
 import org.dcache.restful.util.cells.CellInfoCollector;
@@ -108,6 +110,7 @@ public class CellInfoServiceImpl extends
         public String call() throws Exception {
             return Arrays.stream(getAddresses())
                          .map(CellInfoServiceImpl.this::getCellData)
+                         .sorted(Comparator.comparing(CellData::getCellName))
                          .map(CellData::toString)
                          .collect(Collectors.joining("\n"));
         }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/pool/PoolInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/pool/PoolInfoServiceImpl.java
@@ -59,17 +59,15 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.services.pool;
 
+import com.google.common.base.Strings;
 import org.springframework.beans.factory.annotation.Required;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-
-import dmg.cells.nucleus.CellMessageReceiver;
-import dmg.cells.nucleus.NoRouteToCellException;
-import dmg.util.command.Command;
 
 import diskCacheV111.poolManager.PoolSelectionUnit;
 import diskCacheV111.poolManager.PoolSelectionUnit.SelectionLink;
@@ -78,6 +76,10 @@ import diskCacheV111.pools.json.PoolCostData;
 import diskCacheV111.pools.json.PoolSpaceData;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
+
+import dmg.cells.nucleus.CellMessageReceiver;
+import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.util.command.Command;
 
 import org.dcache.cells.json.CellData;
 import org.dcache.pool.json.PoolData;
@@ -302,6 +304,10 @@ public class PoolInfoServiceImpl extends
                                        String storageClass,
                                        String sort) throws InterruptedException,
                     NoRouteToCellException, CacheException {
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "class,created";
+        }
+
         PoolFlushListingMessage message
                         = new PoolFlushListingMessage(offset,
                                                       Math.min(limit, maxPoolActivityListSize),
@@ -375,6 +381,10 @@ public class PoolInfoServiceImpl extends
                                           String storageClass,
                                           String sort) throws InterruptedException,
                      NoRouteToCellException, CacheException {
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "door,startTime";
+        }
+
         PoolMoverListingMessage message
                         = new PoolMoverListingMessage(offset,
                                                       Math.min(limit, maxPoolActivityListSize),
@@ -403,6 +413,10 @@ public class PoolInfoServiceImpl extends
                                   String storageClass,
                                   String sort) throws InterruptedException,
                     NoRouteToCellException, CacheException {
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "door,startTime";
+        }
+
         PoolP2PListingMessage message
                         = new PoolP2PListingMessage(offset,
                                                     Math.min(limit, maxPoolActivityListSize),
@@ -479,6 +493,10 @@ public class PoolInfoServiceImpl extends
                                                        state,
                                                        storageClass,
                                                        sort);
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "class,created";
+        }
+
         ListenableFutureWrapper<PoolRemoveListingMessage> wrapper
                         = collector.sendRequestToPool(pool, message);
         return getNearlineData(pool, wrapper);
@@ -500,6 +518,10 @@ public class PoolInfoServiceImpl extends
                                             String storageClass,
                                             String sort) throws InterruptedException,
                     NoRouteToCellException, CacheException {
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "class,created";
+        }
+
         PoolStageListingMessage message
                         = new PoolStageListingMessage(offset,
                                                       Math.min(limit, maxPoolActivityListSize),

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/restores/RestoresInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/restores/RestoresInfoServiceImpl.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.restful.services.restores;
 
 import com.google.common.base.Strings;
+
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -70,10 +71,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import dmg.util.command.Command;
-
 import diskCacheV111.util.CacheException;
 import diskCacheV111.vehicles.RestoreHandlerInfo;
+
+import dmg.util.command.Command;
 
 import org.dcache.restful.providers.SnapshotList;
 import org.dcache.restful.providers.restores.RestoreInfo;
@@ -188,12 +189,14 @@ public final class RestoresInfoServiceImpl extends
                                          String sort)
                     throws CacheException {
         Predicate<RestoreInfo> filter = getFilter(pnfsid, subnet, pool, status);
-        List<FieldSort> fields = null;
-        if (sort != null) {
-            fields= Arrays.stream(sort.split(","))
-                          .map(FieldSort::new)
-                          .collect(Collectors.toList());
+
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "pool,started";
         }
+
+        List<FieldSort> fields= Arrays.stream(sort.split(","))
+                                      .map(FieldSort::new)
+                                      .collect(Collectors.toList());
         Comparator<RestoreInfo> sorter
                         = FieldSort.getSorter(fields, nextComparator());
         return access.getSnapshot(token, offset, limit, filter, sorter);

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoServiceImpl.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.restful.services.transfers;
 
 import com.google.common.base.Strings;
+
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -72,12 +73,12 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import dmg.util.command.Command;
-import dmg.util.command.Option;
-
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.TransferInfo;
 import diskCacheV111.util.TransferInfo.MoverState;
+
+import dmg.util.command.Command;
+import dmg.util.command.Option;
 
 import org.dcache.restful.providers.SnapshotList;
 import org.dcache.restful.util.admin.SnapshotDataAccess;
@@ -422,12 +423,13 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
         Predicate<TransferInfo> filter = getFilter(state, door, domain, protocol,
                                                    uid, gid, vomsgroup,
                                                    pnfsid, pool, client);
-        List<FieldSort> fields = null;
-        if (sort != null) {
-            fields = Arrays.stream(sort.split(","))
-                           .map(FieldSort::new)
-                           .collect(Collectors.toList());
+        if (Strings.isNullOrEmpty(sort)) {
+            sort = "door,waiting";
         }
+
+        List<FieldSort> fields = Arrays.stream(sort.split(","))
+                                       .map(FieldSort::new)
+                                       .collect(Collectors.toList());
         Comparator<TransferInfo> sorter
                         = FieldSort.getSorter(fields, nextComparator());
         SnapshotList<TransferInfo> snapshotList =

--- a/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
+++ b/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
@@ -65,6 +65,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -244,6 +245,7 @@ public final class PoolInfoCollectorUtils {
 
         return poolSelectionUnit.getPoolGroups().values()
                                 .stream()
+                                .sorted(Comparator.comparing(SelectionPoolGroup::getName))
                                 .map(SelectionPoolGroup::getName)
                                 .toArray(String[]::new);
     }
@@ -258,6 +260,7 @@ public final class PoolInfoCollectorUtils {
 
         return poolSelectionUnit.getPools().values()
                                 .stream()
+                                .sorted(Comparator.comparing(SelectionPool::getName))
                                 .map(SelectionPool::getName)
                                 .toArray(String[]::new);
     }
@@ -276,6 +279,7 @@ public final class PoolInfoCollectorUtils {
 
         return poolSelectionUnit.getPoolsByPoolGroup(group)
                                 .stream()
+                                .sorted(Comparator.comparing(SelectionPool::getName))
                                 .map(SelectionPool::getName)
                                 .toArray(String[]::new);
     }


### PR DESCRIPTION
Motivation:

Requested by admin users at dCache User Workshop (2018).

Modification:

Sorting by comparator on streams is added in most
pertinent cases.  Where there are backend sort lists
generated from parameters on the REST API, the
default fields are added when the sort parameter is
undefined.

Sorted results and default sorting on parameters
have been indicated via Swagger annotation.

Result:

Lists of pools, groups, units, etc., are now
sorted by default.

Target: master
Request: 4.2
Issue: https://github.com/dCache/dcache-view/issues/90
Acked-by: Paul