### PR TITLE
doors: support advertising multiple addresses in LoginBroker

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
@@ -3,6 +3,7 @@ package dmg.cells.services.login;
 import com.google.common.base.Splitter;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.net.InetAddresses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -307,16 +309,8 @@ public class LoginBrokerPublisher
     {
         if (host == null) {
             setAddressSupplier(createAnyAddressSupplier());
-        } else if (NetworkUtils.isInetAddress(host)) {
-            InetAddress address = InetAddresses.forString(host);
-            checkArgument(!address.isMulticastAddress());
-            if (address.isAnyLocalAddress()) {
-                setAddressSupplier(createAnyAddressSupplier());
-            } else {
-                setAddressSupplier(createSingleAddressSupplier(NetworkUtils.withCanonicalAddress(address)));
-            }
         } else {
-            setAddressSupplier(createSingleAddressSupplier(InetAddress.getByName(host)));
+            setAddressSupplier(NetworkUtils.hostListAddressSupplier(host));
         }
     }
 
@@ -552,85 +546,6 @@ public class LoginBrokerPublisher
             return () -> address;
         }
 
-        return new AnyAddressSupplier();
-    }
-
-    public static class AnyAddressSupplier implements Supplier<List<InetAddress>>
-    {
-        private List<InetAddress> _previous = Collections.emptyList();
-
-        @Override
-        public List<InetAddress> get()
-        {
-            NDC.push("NIC auto-discovery");
-            try {
-                ArrayList<InetAddress> addresses = new ArrayList<>();
-                Stopwatch stopwatch = Stopwatch.createStarted();
-                try {
-                    Enumeration<NetworkInterface> interfaces =
-                            NetworkInterface.getNetworkInterfaces();
-                    while (interfaces.hasMoreElements()) {
-                        NetworkInterface i = interfaces.nextElement();
-                        try {
-                            if (i.isUp() && !i.isLoopback()) {
-                                Enumeration<InetAddress> e = i.getInetAddresses();
-                                while (e.hasMoreElements()) {
-                                    addresses.add(NetworkUtils.withCanonicalAddress(e.nextElement()));
-                                }
-                            }
-                        } catch (SocketException e) {
-                            _log.warn("Not publishing NIC {}: {}", i.getName(), e.getMessage());
-                        }
-                    }
-                } catch (SocketException e) {
-                    _log.warn("Not publishing NICs: {}", e.getMessage());
-                }
-
-                _log.debug("Scan took {}", stopwatch);
-                logChanges(addresses);
-                return addresses;
-            } finally {
-                NDC.pop();
-            }
-        }
-
-        private synchronized void logChanges(List<InetAddress> addresses)
-        {
-            if (!_previous.equals(addresses)) {
-                List<InetAddress> added = addresses.stream().filter(a -> !_previous.contains(a)).collect(toList());
-                List<InetAddress> removed = _previous.stream().filter(a -> !addresses.contains(a)).collect(toList());
-
-                boolean adding = !added.isEmpty();
-                boolean removing = !removed.isEmpty();
-
-                if (removing || adding) {
-                    StringBuilder sb = new StringBuilder();
-                    if (removing) {
-                        sb.append("Removing ").append(describeList(removed));
-                    }
-
-                    if (adding) {
-                        if (removing) {
-                            sb.append(", adding ");
-                        } else {
-                            sb.append("Adding ");
-                        }
-                        sb.append(describeList(added));
-                    }
-                    _log.warn(sb.toString());
-                }
-
-                _previous = new ArrayList<>(addresses);
-            }
-        }
-
-        private static String describeList(List<InetAddress> addresses)
-        {
-            if (addresses.size() == 1) {
-                return addresses.get(0).toString();
-            } else {
-                return addresses.stream().map(NetworkUtils::toString).collect(joining(", ", "[", "]"));
-            }
-        }
+        return NetworkUtils.anyAddressSupplier();
     }
 }

--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -139,6 +139,17 @@ dcap.loginbroker.family.auth=dcap
 dcap.loginbroker.family.gsi=gsidcap
 dcap.loginbroker.family.kerberos=dcap
 dcap.loginbroker.version=1.3.0
+
+##  This property is a space-separated list of hostnames or IP
+##  addresses to publish for this door.  Hostnames are resolved to an
+##  IP address on start-up, but not subsequently.  Non-wildcard IP
+##  addresses are resolved to canonical name on start-up, but not
+##  subsequently.  Wildcard IP addresses (0.0.0.0 or ::) are replaced
+##  by a dynamically discovered list of IP addresses, based on which
+##  network interfaces are "up".  These are resolved, with the
+##  corresponding hostnames cached for a configurable period (see
+##  'networkaddress.cache.ttl' system property).  An empty value is
+##  equivalent to "0.0.0.0".
 dcap.loginbroker.address = ${dcap.net.listen}
 dcap.loginbroker.port = ${dcap.net.port}
 

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -300,6 +300,17 @@ ftp.loginbroker.family.gsi=gsiftp
 ftp.loginbroker.version.gsi=1.0.0
 ftp.loginbroker.family.kerberos=gkftp
 ftp.loginbroker.version.kerberos=1.0.0
+
+##  This property is a space-separated list of hostnames or IP
+##  addresses to publish for this door.  Hostnames are resolved to an
+##  IP address on start-up, but not subsequently.  Non-wildcard IP
+##  addresses are resolved to canonical name on start-up, but not
+##  subsequently.  Wildcard IP addresses (0.0.0.0 or ::) are replaced
+##  by a dynamically discovered list of IP addresses, based on which
+##  network interfaces are "up".  These are resolved, with the
+##  corresponding hostnames cached for a configurable period (see
+##  'networkaddress.cache.ttl' system property).  An empty value is
+##  equivalent to "0.0.0.0".
 ftp.loginbroker.address = ${ftp.net.listen}
 ftp.loginbroker.port = ${ftp.net.port}
 ftp.loginbroker.root = ${ftp.root}

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -95,6 +95,17 @@ nfs.loginbroker.update-period=${dcache.loginbroker.update-period}
 nfs.loginbroker.update-threshold=${dcache.loginbroker.update-threshold}
 nfs.loginbroker.family = file
 nfs.loginbroker.version = nfs4.1
+
+##  This property is a space-separated list of hostnames or IP
+##  addresses to publish for this door.  Hostnames are resolved to an
+##  IP address on start-up, but not subsequently.  Non-wildcard IP
+##  addresses are resolved to canonical name on start-up, but not
+##  subsequently.  Wildcard IP addresses (0.0.0.0 or ::) are replaced
+##  by a dynamically discovered list of IP addresses, based on which
+##  network interfaces are "up".  These are resolved, with the
+##  corresponding hostnames cached for a configurable period (see
+##  'networkaddress.cache.ttl' system property).  An empty value is
+##  equivalent to "0.0.0.0".
 nfs.loginbroker.address =
 nfs.loginbroker.port = ${nfs.net.port}
 

--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -170,6 +170,17 @@ srm.loginbroker.update-threshold = ${dcache.loginbroker.update-threshold}
 srm.loginbroker.version = 1.1.1
 srm.loginbroker.family = srm
 srm.loginbroker.root = ${dcache.srm-root}
+
+##  This property is a space-separated list of hostnames or IP
+##  addresses to publish for this door.  Hostnames are resolved to an
+##  IP address on start-up, but not subsequently.  Non-wildcard IP
+##  addresses are resolved to canonical name on start-up, but not
+##  subsequently.  Wildcard IP addresses (0.0.0.0 or ::) are replaced
+##  by a dynamically discovered list of IP addresses, based on which
+##  network interfaces are "up".  These are resolved, with the
+##  corresponding hostnames cached for a configurable period (see
+##  'networkaddress.cache.ttl' system property).  An empty value is
+##  equivalent to "0.0.0.0".
 srm.loginbroker.address = ${srm.net.listen}
 srm.loginbroker.port = ${srm.net.port}
 

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -135,6 +135,17 @@ webdav.loginbroker.version=1.1
 webdav.loginbroker.family=${webdav.loginbroker.family-${webdav.authn.protocol}}
 (immutable)webdav.loginbroker.family-http=http
 (immutable)webdav.loginbroker.family-https=https
+
+##  This property is a space-separated list of hostnames or IP
+##  addresses to publish for this door.  Hostnames are resolved to an
+##  IP address on start-up, but not subsequently.  Non-wildcard IP
+##  addresses are resolved to canonical name on start-up, but not
+##  subsequently.  Wildcard IP addresses (0.0.0.0 or ::) are replaced
+##  by a dynamically discovered list of IP addresses, based on which
+##  network interfaces are "up".  These are resolved, with the
+##  corresponding hostnames cached for a configurable period (see
+##  'networkaddress.cache.ttl' system property).  An empty value is
+##  equivalent to "0.0.0.0".
 webdav.loginbroker.address = ${webdav.net.listen}
 webdav.loginbroker.port = ${webdav.net.port}
 webdav.loginbroker.root = ${webdav.root}

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -103,6 +103,17 @@ xrootd.loginbroker.update-threshold=${dcache.loginbroker.update-threshold}
 xrootd.loginbroker.version=2.4
 xrootd.loginbroker.family=root
 xrootd.loginbroker.root = ${xrootd.root}
+
+##  This property is a space-separated list of hostnames or IP
+##  addresses to publish for this door.  Hostnames are resolved to an
+##  IP address on start-up, but not subsequently.  Non-wildcard IP
+##  addresses are resolved to canonical name on start-up, but not
+##  subsequently.  Wildcard IP addresses (0.0.0.0 or ::) are replaced
+##  by a dynamically discovered list of IP addresses, based on which
+##  network interfaces are "up".  These are resolved, with the
+##  corresponding hostnames cached for a configurable period (see
+##  'networkaddress.cache.ttl' system property).  An empty value is
+##  equivalent to "0.0.0.0".
 xrootd.loginbroker.address = ${xrootd.net.listen}
 xrootd.loginbroker.port = ${xrootd.net.port}
 


### PR DESCRIPTION
Motivation:

By default, Login Broker advertises all available interfaces.

However, if additional interfaces should be published (e.g., DNS
aliases) then a door is limited to a single hostname.

Modification:

Add support for a door advertising multiple hostnames or IP addresses.
This change is designed to be backwards compatible with the existing
file format.

Add documentation describing the format of a property that is currently
poorly described.

Result:

dCache doors can advertise multiple interfaces, including DNS aliases.

Target: master
Request: 4.1
Request: 4.0
Request: 3.2
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9410
Require-notes: yes
Require-book: yes
Patch: https://rb.dcache.org/r/10962
Acked-by: Tigran Mkrtchyan