### PR TITLE
admin: add kerberos authentication support to admin ssh server

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/ssh2/ssh2Admin.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/ssh2/ssh2Admin.xml
@@ -117,5 +117,7 @@
         </property>
         <property name="idleTimeout" value="#{T(org.dcache.util.Strings).parseLong('${admin.ssh.idle-timeout}')}" />
         <property name="idleTimeoutUnit" value="${admin.ssh.idle-timeout.unit}" />
+	<property name="enabledAuthenticationMechanisms" value="${admin.ssh.authn.enabled}"/>
+        <property name="keyTabFile" value="${admin.ssh.authn.kerberos.keytab-file}" />
     </bean>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -536,7 +536,7 @@
             <dependency>
                 <groupId>org.apache.sshd</groupId>
                 <artifactId>sshd-core</artifactId>
-                <version>1.6.0</version>
+                <version>1.6.0-dcache</version>
             </dependency>
             <dependency>
                 <!-- Newer versions have two problems. A performance regression causes it to block on non-responding network

--- a/skel/share/defaults/admin.properties
+++ b/skel/share/defaults/admin.properties
@@ -65,6 +65,15 @@ admin.paths.authorized-keys = ${dcache.paths.admin}/authorized_keys2
 (obsolete)admin.paths.dsa-host-key.public = No longer used
 admin.paths.host-keys = ${dcache.paths.admin}/ssh_host_rsa_key
 
+#  ---- Authentication mechanisms
+#
+# Supported ssh authentication mechanisms : kerberos, password, publickey
+#
+(any-of?kerberos|password|publickey)admin.ssh.authn.enabled = password,publickey
+
+# location of keytab file needed if kerberos authentication mechanism is used
+admin.ssh.authn.kerberos.keytab-file = /etc/krb5.keytab
+
 # Cell addresses and timeouts of other services
 admin.service.gplazma=${dcache.service.gplazma}
 admin.service.gplazma.timeout=30000

--- a/skel/share/services/admin.batch
+++ b/skel/share/services/admin.batch
@@ -20,6 +20,8 @@ check -strong admin.service.pnfsmanager.timeout.unit
 check -strong admin.service.acm
 check -strong admin.service.acm.timeout
 check -strong admin.service.acm.timeout.unit
+check -string admin.ssh.authn.enabled
+check -strong admin.ssh.authn.kerberos.keytab-file
 check admin.loginbroker.request-topic
 check -strong admin.authz.gid
 check admin.paths.authorized-keys


### PR DESCRIPTION
Motivation:

Existing admin ssh server supports only password and public key
authentication mechanisms. Both are considered a violation of computer
security policy at Fermilab (and possibly elsewhere), whereas kerberos
authentication is allowed.

Modification:

Implemented kerberos authentication mechanism in admin ssh server. Added
ability to enable desired authentication mechanism(s).

Target: master
Request: 4.2.0
RB: https://rb.dcache.org/r/10979/
Acked-by: Paul
Require-notes: yes
Require-book: yes

RELEASE NOTES:

dCache admin ssh server now supports kerberos authentication mechanism and
abilty to enable desired set of authentication mechanism(s). The following
variables are added to configure admin ssh server authentication:

Supported ssh authentication mechanisms : kerberos, password, publickey

(any-of?kerberos|password|publickey)admin.ssh.authn.enabled = password,publickey

Location of keytab file which is needed when kerberos authentication
mechanism is enabled

admin.ssh.authn.kerberos.keytab-file = /etc/krb5.keytab