### PR TITLE
pool: retry request to pnfs manager if timed out

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
@@ -8,11 +8,13 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileCorruptedCacheException;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
+import diskCacheV111.util.TimeoutCacheException;
 
 import org.dcache.alarms.AlarmMarkerFactory;
 import org.dcache.alarms.PredefinedAlarm;
@@ -309,7 +311,23 @@ class WriteHandleImpl implements ReplicaDescriptor
             verifyFileSize(length);
             _fileAttributes.setSize(length);
 
-            registerFileAttributesInNameSpace();
+            boolean namespaceUpdated = false;
+            do {
+                /*
+                 * We may run into timeout if PnfsManager or network is down.
+                 * (NOTICE, that PnfsHandler converts NoRouteToCell into Timeout exception)
+                 * In such situations we should re-try the request. If timeout exception
+                 * is propagated, then file will be stored in error state, to recover it
+                 * during the next restart.
+                 */
+                try {
+                    registerFileAttributesInNameSpace();
+                    namespaceUpdated = true;
+                } catch (TimeoutCacheException e) {
+                    _log.warn("Failed to update namespace: {}. Retrying in 15 s", e.getMessage());
+                    TimeUnit.SECONDS.sleep(15);
+                }
+            } while (!namespaceUpdated);
 
             _entry.update(r -> {
                 r.setFileAttributes(_fileAttributes);


### PR DESCRIPTION
Motivation:
if due to network errors register file at PnfsManager fails with
timeout, then newly uploaded file will be marked as broken. As
network errors can't be avoid in distributed systems, dCache should
retry failed request.

Modification:
introduce a busy loop in WriteHandleImpl#commit to retry file
attributes update on timeout.

Result:
files are not marked as bad if namespace update did not happen
right away.

Acked-by: Paul Millar
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit 8c60877527869095acf23dd95f424d1df1e5b790)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>