### PR TITLE
vehicles: fail-fast on invalid path

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PnfsMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PnfsMessage.java
@@ -12,6 +12,7 @@ import org.dcache.acl.enums.AccessMask;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.auth.attributes.Restrictions;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -34,7 +35,11 @@ public class PnfsMessage extends Message {
 
     public PnfsMessage(){ }
 
-    public void setPnfsPath( String pnfsPath ){ _path = pnfsPath ; }
+    public void setPnfsPath(String pnfsPath) {
+        checkArgument(pnfsPath == null || pnfsPath.charAt(0) == '/');
+        _path = pnfsPath;
+    }
+
     public String getPnfsPath(){ return _path ;}
 
     public FsPath getFsPath()


### PR DESCRIPTION
Motivation:

Commit 63917eba introduced the possibility to get the FsPath
corresponding to the supplied path.  This requires that the path is
absolute; i.e., it starts with a '/'.

Although this is generally true, there is a bug somewhere in frontend
where it sends a GetFileAttributes message with a path that doesn't
start with a '/'.

Since GetFileAttributes message (and PnfsMessage in general) does not
protect itself against receiving invalid input, the stack-trace is only
within pnfsmanager, so cannot help in figuring out where is the bug in
frontend.

Modification:

Add a condition in PnfsMessage that rejects non-absolute paths.

Result:

Bugs that request file attributes with a non-absolute path now trigger a
stack-trace showing the bug, rather than in PnfsManager.

Target: master
Require-notes: yes
Require-book: no
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/10971/
Acked-by: Albert Rossi