### PR TITLE
ftp: always close proxied data connection if client closes their half

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/PassiveConnectionHandler.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/PassiveConnectionHandler.java
@@ -18,8 +18,12 @@
 package org.dcache.ftp.proxy;
 
 import com.google.common.base.Supplier;
+import com.google.common.io.BaseEncoding;
+import com.google.common.primitives.Ints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -28,6 +32,7 @@ import java.net.InetSocketAddress;
 import java.net.InterfaceAddress;
 import java.net.ProtocolFamily;
 import java.net.Socket;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ClosedSelectorException;
@@ -40,13 +45,18 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.dcache.ftp.door.AbstractFtpDoorV1.Protocol;
+import org.dcache.util.ByteUnit;
 import org.dcache.util.PortRange;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.find;
+import static java.util.Collections.synchronizedList;
+import static org.dcache.util.ByteUnit.KiB;
 
 /**
  * Takes responsibility for opening a ServerSocket and handling
@@ -56,22 +66,123 @@ import static com.google.common.collect.Iterables.find;
 public class PassiveConnectionHandler implements Closeable
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(PassiveConnectionHandler.class);
+    private static final ByteBuffer NO_DATA = ByteBuffer.allocate(0).asReadOnlyBuffer();
+
+    /**
+     * A channel that has received data from a client while
+     * PassiveConnectionHandler has state REAPER_ACTIVE or
+     * ACCEPT_SINGLESHOT_REAPER_ACTIVE.  Returned channels
+     * (see {@link #returnChannel(java.nio.channels.SocketChannel)) should not become active outside of a
+     * transfer; however, there is a race-condition between dCache replying to
+     * the client that an upload can proceed and calling
+     * {@link #accept(java.util.function.BiConsumer)}
+     * reacting to an upload command (STOR or PUT) and the client
+     * Such channels are supplied to the
+     * consumer (along with the data) after the transition to ACCEPT_WITH_REUSE
+     * state.
+     */
+    private class ActiveChannel
+    {
+        private final SocketChannel channel;
+        private final ByteBuffer activity;
+
+        public ActiveChannel(SocketChannel channel, ByteBuffer activity)
+        {
+            this.channel = channel;
+            this.activity = activity;
+        }
+    }
+
+    /**
+     * Possible states of this handler.  Supported transitions are:
+     * <pre>
+     *     +---------------------------------------------------------------+
+     *     |                       +------------------+                    |
+     *     v                       v                  |                    |
+     * NO_SERVER_SOCKET ---> SOCKET_OPENED -+-> ACCEPT_SINGLESHOT ------->-+
+     *                                      |                              |
+     *                                      +-> ACCEPT_WITH_REUSE ------->-+
+     *                                                ^    |               |
+     *                                                |    v               |
+     *                                            REAPER_ACTIVE --------->-+
+     *                                                ^    |               |
+     *                                                |    v               |
+     *                                  ACCEPT_SINGLESHOT_REAPER_ACTIVE ->-+
+     * </pre>
+     */
+    private enum State
+    {
+        /** No server socket is opened. */
+        NO_SERVER_SOCKET,
+
+        /** The server socket is opened but not listening for connections. */
+        SOCKET_OPENED,
+
+        /**
+         * The server socket is open and waiting for a single incoming
+         * connection.  Any established data connection is not returned, even if
+         * it becomes active.
+         */
+        ACCEPT_SINGLESHOT,
+
+        /**
+         * The server socket is open and accepting incoming connections.
+         * Established connections that become active are presented as if they
+         * were fresh connections.
+         */
+        ACCEPT_WITH_REUSE,
+
+        /**
+         * The server socket is open but without processing data.  If the
+         * remote party closes their half of an idle connection then dCache
+         * closes the corresponding half (so fully closing the connection).  If
+         * the client sends data in this state then it is queued.  Such data
+         * will be presented when next in state ACCEPT_WITH_REUSE or discarded
+         * if NO_SERVER_SOCKET.
+         */
+        REAPER_ACTIVE,
+
+        /**
+         * The server socket is open and waiting for a single incoming
+         * connection.  Any established connections are automatically closed if
+         * the remote party closes their half with any data queued.
+         */
+        ACCEPT_SINGLESHOT_REAPER_ACTIVE;
+    }
 
     private final InetAddress _address;
     private final PortRange _portRange;
-    private final List<SocketChannel> _activeChannels = new ArrayList<>();
-    private final List<SocketChannel> _idleChannels = new ArrayList<>();
-    private final List<SocketChannel> _toBeRegistered = new ArrayList<>();
+    private final List<SocketChannel> _activeChannels = synchronizedList(new ArrayList<>());
+    private final List<SocketChannel> _idleChannels = synchronizedList(new ArrayList<>());
+    private final List<SocketChannel> _toBeRegistered = synchronizedList(new ArrayList<>());
+    private final List<ActiveChannel> _backgroundActiveChannels = synchronizedList(new ArrayList<>());
+    private final AtomicInteger _singleUseAccepts = new AtomicInteger();
+    private final AtomicInteger _reuseableAccepts = new AtomicInteger();
+    private final AtomicInteger _connectionReuse = new AtomicInteger();
+    private final Object _selectorLock = new Object();
 
-    private Protocol _preferredProtocol;
-    private Supplier<Iterable<InterfaceAddress>> _addressSupplier;
+    @GuardedBy("this")
+    private State _state = State.NO_SERVER_SOCKET;
+
+    @GuardedBy("this")
+    private Selector _selector;
+
+    @GuardedBy("_selectorLock")
     private ServerSocketChannel _channel;
+
+    @GuardedBy("this")
+    private Supplier<Iterable<InterfaceAddress>> _addressSupplier;
+
+    @GuardedBy("this")
+    private Protocol _preferredProtocol;
+
+    @GuardedBy("this")
     private Consumer<String> _errorConsumer = (String s) -> {};
-    private volatile Selector _selector;
-    private volatile boolean _isAcceptFinished;
-    private int _singleUseAccepts;
-    private int _reuseableAccepts;
-    private int _connectionReuse;
+
+    @GuardedBy("this")
+    private ByteBuffer _data;
+
+    private volatile boolean _selectorFinishRequested;
 
     public PassiveConnectionHandler(InetAddress address, PortRange range)
     {
@@ -79,14 +190,16 @@ public class PassiveConnectionHandler implements Closeable
         _portRange = range;
     }
 
-    public synchronized InetSocketAddress getLocalAddress()
+    public InetSocketAddress getLocalAddress()
     {
-        return _channel == null ? null : (InetSocketAddress) _channel.socket().getLocalSocketAddress();
+        synchronized (_selectorLock) {
+            return _channel == null ? null : (InetSocketAddress) _channel.socket().getLocalSocketAddress();
+        }
     }
 
     public synchronized void setAddressSupplier(Supplier<Iterable<InterfaceAddress>> addressSupplier)
     {
-        checkState(_channel == null, "Cannot specify address supplier after socket opened.");
+        checkState(_state == State.NO_SERVER_SOCKET, "Cannot specify address supplier after socket opened.");
         _addressSupplier = addressSupplier;
     }
 
@@ -101,9 +214,13 @@ public class PassiveConnectionHandler implements Closeable
         checkState(_addressSupplier != null, "No address supplier provided");
         _preferredProtocol = preferred;
 
-        if (_channel != null) {
-            Protocol current = Protocol.fromAddress(_channel.socket().getInetAddress());
-            if (preferred != current) {
+        if (_state != State.NO_SERVER_SOCKET) {
+            Protocol current;
+            synchronized (_selectorLock) {
+                current = Protocol.fromAddress(_channel.socket().getInetAddress());
+            }
+
+            if (current != preferred) {
                 close();
             }
         }
@@ -122,55 +239,67 @@ public class PassiveConnectionHandler implements Closeable
     /**
      * Open a ServerSocket, based on the supplied preferred IP protocol
      * (if any) and desired port-range (if any).  This method may be called
-     * multiple times: only the first call has an effect.  This call may not
-     * be called after {@code #close} is called.
+     * multiple times: it only has effect if the first call or after close.
      */
     public synchronized void open() throws IOException
     {
-        if (_channel == null) {
+        LOGGER.trace("open");
+
+        if (_state == State.NO_SERVER_SOCKET) {
             InetAddress address = _address;
             if (_preferredProtocol != null && Protocol.fromAddress(address) != _preferredProtocol) {
                 Iterable<InterfaceAddress> addresses = _addressSupplier.get();
-                InterfaceAddress newAddress =
-                        find(addresses, (a) -> Protocol.fromAddress(a.getAddress()).equals(_preferredProtocol));
-                    address = newAddress.getAddress();
+                address = find(addresses, a -> Protocol.fromAddress(a.getAddress()).equals(_preferredProtocol))
+                        .getAddress();
             }
-            _channel = ServerSocketChannel.open();
-            _portRange.bind(_channel.socket(), address);
-            LOGGER.debug("Server socket opened {}", _channel);
+            synchronized (_selectorLock) {
+                _channel = ServerSocketChannel.open();
+                _portRange.bind(_channel.socket(), address);
+                LOGGER.debug("Server socket opened {}", _channel);
+            }
+            _state = State.SOCKET_OPENED;
         }
     }
 
     /**
      * Await for a TCP connection to be established.  The caller is
-     * responsible for calling {@code Socket#close}.  This should not be called
-     * at the same time as the other accept method.
+     * responsible for calling {@code Socket#close} on the returned value.  This
+     * may not be called at the same time as the other accept method is active.
      */
     public SocketChannel accept() throws IOException
     {
         ServerSocketChannel channel;
         synchronized (this) {
-            checkState(_channel != null, "failed to call open");
-            LOGGER.debug("Accepting output connection within ConnectionHandler on {}",
-                 _channel.socket().getLocalSocketAddress());
-            channel = _channel;
+            checkState(_state != State.NO_SERVER_SOCKET, "failed to call open");
+            checkState(_state != State.ACCEPT_WITH_REUSE, "cannot call both accept methods at the same time");
+            synchronized (_selectorLock) {
+                channel = _channel;
+            }
+            _state = _state == State.SOCKET_OPENED ? State.ACCEPT_SINGLESHOT : State.ACCEPT_SINGLESHOT_REAPER_ACTIVE;
         }
 
-        channel.configureBlocking(true);
-        SocketChannel socket = channel.accept();
+        LOGGER.debug("Accepting output connection within ConnectionHandler on {}",
+             channel.socket().getLocalSocketAddress());
+        boolean isBlocking = channel.isBlocking();
 
-        socket.socket().setKeepAlive(true);
+        try {
+            channel.configureBlocking(true);
+            SocketChannel socket = channel.accept();
 
-        synchronized (this) {
-            _singleUseAccepts++;
+            _singleUseAccepts.incrementAndGet();
+
+            socket.socket().setKeepAlive(true);
+            return socket;
+        } finally {
+            synchronized (this) {
+                _state = _state == State.ACCEPT_SINGLESHOT ? State.SOCKET_OPENED : State.REAPER_ACTIVE;
+                synchronized (_selectorLock) {
+                    if (_channel.isOpen()) {
+                        _channel.configureBlocking(isBlocking);
+                    }
+                }
+            }
         }
-
-        return socket;
-    }
-
-    private synchronized boolean isAcceptFinish()
-    {
-        return _isAcceptFinished;
     }
 
     /**
@@ -191,108 +320,152 @@ public class PassiveConnectionHandler implements Closeable
      * consumer may close the connection, if appropriate.  The consumer must
      * return the channel once no further activity is expected, using the
      * {@code #returnChannel} method.  The consumer itself must not block
-     * when presented with a channel.  The consumer may be called if an idle
-     * connection is closed by the client, with the first read returning -1.
+     * when presented with a channel.
+     * <p>
+     * After this method returns, any returned channel will be closed whenever
+     * the remote party has closed their end of the connection.  To achieve
+     * this, a background thread attempts to read data when the channel becomes
+     * active.  Any data read by the background thread is presented along with
+     * the channel at the next call to this method.
      * @param channelConsumer the object that will handle active channels.
      * @throws IOException if there is a problem while establishing connections.
      */
-    public void accept(Consumer<SocketChannel> channelConsumer) throws IOException
+    public void accept(BiConsumer<SocketChannel,ByteBuffer> channelConsumer)
+            throws IOException, InterruptedException
     {
+        LOGGER.trace("accept");
+
+        BiConsumer<SocketChannel,ByteBuffer> registeringChannelConsumer = (c,b) -> {
+                    _activeChannels.add(c);
+                    channelConsumer.accept(c, b);
+                };
+
         synchronized (this) {
-            checkState(_channel != null, "ServerSocket not opened");
-            checkState(_selector == null, "accept already running");
+            checkState(_state != State.NO_SERVER_SOCKET, "open not called");
+            checkState(_state != State.ACCEPT_WITH_REUSE, "accept already running");
+            checkState(_state != State.ACCEPT_SINGLESHOT
+                    && _state != State.ACCEPT_SINGLESHOT_REAPER_ACTIVE, "awaiting single-shot accept");
+
+            if (_state == State.REAPER_ACTIVE) {
+                stopSelectionLoop();
+            }
+            _state = State.ACCEPT_WITH_REUSE;
 
             LOGGER.debug("Accepting input connection on {}", getLocalAddress());
 
-            _selector = Selector.open();
-            _isAcceptFinished = false;
-
-            _channel.configureBlocking(false);
-            _channel.register(_selector, SelectionKey.OP_ACCEPT);
-            registerAll(_idleChannels);
+            synchronized (_selectorLock) {
+                assert _selector == null;
+                _selector = Selector.open();
+                _channel.configureBlocking(false);
+                _channel.register(_selector, SelectionKey.OP_ACCEPT);
+                registerAll(_idleChannels);
+                _selectorFinishRequested = false;
+            }
         }
 
-        List<SelectionKey> consumed = new ArrayList<>();
-        while (!Thread.currentThread().isInterrupted() && !isAcceptFinish()) {
-            _selector.select();
+        drainTo(_backgroundActiveChannels, ac -> registeringChannelConsumer.accept(ac.channel, ac.activity));
 
-            for (SelectionKey key : _selector.selectedKeys()) {
+        selectionLoop(c -> registeringChannelConsumer.accept(c, NO_DATA),
+                c -> registeringChannelConsumer.accept(c, NO_DATA));
+    }
+
+    private void selectionLoop(Consumer<SocketChannel> newChannels,
+            Consumer<SocketChannel> readableChannels) throws IOException
+    {
+        Selector selector;
+        ServerSocketChannel serverChannel;
+        synchronized (_selectorLock) {
+            selector = _selector;
+            serverChannel = _channel;
+        }
+
+        while (!Thread.currentThread().isInterrupted() && !_selectorFinishRequested) {
+            selector.select();
+            for (SelectionKey key : selector.selectedKeys()) {
                 if (key.isAcceptable()) {
-                    SocketChannel channel = _channel.accept();
-
-                    synchronized (this) {
-                        _activeChannels.add(channel);
-                        _reuseableAccepts++;
-                    }
-
-                    LOGGER.debug("Opened {}", channel.socket().toString());
-                    channel.socket().setKeepAlive(true);
-                    channelConsumer.accept(channel);
-                } else if (key.isReadable()) {
-                    SocketChannel channel = (SocketChannel) key.channel();
-                    LOGGER.debug("Idle channel became active: {}", channel);
-
-                    synchronized (this) {
-                        if (_idleChannels.remove(channel)) {
-                            _activeChannels.add(channel);
-                            key.interestOps(0);
-                            _connectionReuse++;
-                        } else {
-                            LOGGER.warn("Received SelectionKey isReadable event for non-idle channel");
-                            channel = null;
+                    try {
+                        SocketChannel newChannel = serverChannel.accept();
+                        _reuseableAccepts.incrementAndGet();
+                        try {
+                            newChannel.socket().setKeepAlive(true);
+                        } catch (IOException e) {
+                            LOGGER.warn("Unable to set KeepAlive: {}", e.toString());
                         }
-                    }
 
-                    if (channel != null) {
-                        channelConsumer.accept(channel);
+                        newChannels.accept(newChannel);
+                    } catch (IOException e) {
+                        LOGGER.warn("Failed to accept incoming connection: {}", e.toString());
                     }
-                } else {
-                    LOGGER.warn("Unknown SelectionKey event: {}", key.readyOps());
+                } else if (key.isReadable()) {
+                    SocketChannel activeChannel = (SocketChannel) key.channel();
+                    if (removeIdleChannel(activeChannel,
+                            "Received SelectionKey isReadable event for non-idle channel")) {
+                        _connectionReuse.incrementAndGet();
+                        key.interestOps(0);
+                        readableChannels.accept(activeChannel);
+                    }
                 }
-                consumed.add(key);
             }
-            _selector.selectedKeys().removeAll(consumed);
-            consumed.clear();
+            selector.selectedKeys().clear();
 
-            synchronized (this) {
-                registerAll(_toBeRegistered);
-                _idleChannels.addAll(_toBeRegistered);
-                _toBeRegistered.clear();
+            synchronized (_selectorLock) {
+                drainTo(_toBeRegistered, c -> {
+                            if (registerChannel(c)) {
+                                _idleChannels.add(c);
+                            } else {
+                                closeChannel(c, "Defensive close failed after failure to register channel");
+                            }
+                        });
             }
         }
 
-        synchronized (this) {
-            try {
-                _selector.close();
-            } finally {
-                _selector = null;
-                notifyAll();
-            }
+        synchronized (_selectorLock) {
+            _selectorLock.notifyAll();
         }
     }
 
+    private static <T> void drainTo(Collection<T> items, Consumer<T> consumer)
+    {
+        synchronized (items) {
+            items.forEach(consumer);
+            items.clear();
+        }
+    }
+
+    /**
+     * All elements in the collection are either registered in the selector or
+     * are closed and removed from the collection.
+     */
+    @GuardedBy("_selectorLock")
     private void registerAll(Collection<SocketChannel> channels)
     {
-        Iterator<SocketChannel> itr = channels.iterator();
-        while (itr.hasNext()) {
-            if (!registerChannel(itr.next())) {
-                itr.remove();
+        synchronized (channels) {
+            Iterator<SocketChannel> itr = channels.iterator();
+            while (itr.hasNext()) {
+                SocketChannel channel = itr.next();
+                if (!registerChannel(channel)) {
+                    itr.remove();
+                    closeChannel(channel, "Defensive close failed after failure to register channel");
+                }
             }
         }
     }
 
     /**
-     * Register a channel in the selector or close channel.  If a channel
+     * Try to register a channel in the selector.  If a channel
      * is already registered then OP_READ selection is enabled.
      * @return true if channel is successfully registered.
      */
+    @GuardedBy("_selectorLock")
     private boolean registerChannel(SelectableChannel channel)
     {
         try {
-            if (channel.isRegistered()) {
-                channel.keyFor(_selector).interestOps(SelectionKey.OP_READ);
+            channel.configureBlocking(false);
+            SelectionKey key = channel.keyFor(_selector);
+            if (key == null) {
+                channel.register(_selector, SelectionKey.OP_READ);
             } else {
-                channel.configureBlocking(false).register(_selector,  SelectionKey.OP_READ);
+                key.interestOps(SelectionKey.OP_READ);
             }
             return true;
         } catch (ClosedChannelException | ClosedSelectorException e) {
@@ -300,7 +473,6 @@ public class PassiveConnectionHandler implements Closeable
         } catch (IOException e) {
             LOGGER.warn("Failed to register channel in selector: {}", e.toString());
         }
-        closeChannel(channel);
         return false;
     }
 
@@ -314,56 +486,85 @@ public class PassiveConnectionHandler implements Closeable
      */
     public synchronized void returnChannel(SocketChannel channel)
     {
-        LOGGER.trace("Channel returned: {}", channel);
+        LOGGER.trace("returnChannel: {}", channel);
+
+        if (_state == State.NO_SERVER_SOCKET || _state == State.SOCKET_OPENED
+                || _state == State.ACCEPT_SINGLESHOT) {
+            LOGGER.warn("Channel returning when in state {}", _state);
+            tryCloseChannel(channel, "Defensive close due to unexpected state failed");
+            return;
+        }
 
         if (!_activeChannels.remove(channel)) {
             LOGGER.warn("returning channel that is not in active list.");
-            closeChannel(channel);
+            tryCloseChannel(channel, "Defentive close due to unknown channel failed");
             return;
         }
 
         Socket s = channel.socket();
-        if (_channel == null || s.isInputShutdown() || s.isOutputShutdown()) {
-            LOGGER.trace("Closing channel: {}", channel);
-            closeChannel(channel);
-        } else {
-            LOGGER.trace("Registering idle channel: {}", channel);
+        if (s.isInputShutdown() || s.isOutputShutdown()) {
+            closeChannel(channel, "Failed to close after remote party closed their half");
+            return;
+        }
 
-            if (_selector == null) {
-                _idleChannels.add(channel);
-            } else {
-                _toBeRegistered.add(channel);
-                _selector.wakeup();
-            }
+        _toBeRegistered.add(channel);
+
+        synchronized (_selectorLock) {
+            _selector.wakeup();
         }
     }
 
     /**
-     * Indicate that no further new connectors or
-     * idle-connectors becoming active is expected.  If a thread called
-     * {@code #accept(Consumer<SocketChannel>)} then it will return; if there
-     * is no such thread then this method does nothing.  No further calls to
-     * the {@literal Consumer<SocketChannel>} will be made once this method
-     * returns.
+     * Indicate that no further new connectors or idle-connectors becoming
+     * active is expected.  If a thread is calling
+     * {@code #accept(Consumer<SocketChannel>)} then calling this method
+     * triggers it to return; no further calls to the supplied Consumer will be
+     * made once this method returns.  If there is no such thread then this
+     * method does nothing.
      */
     public synchronized void finishAccept() throws InterruptedException
     {
-        LOGGER.trace("finishAccept called");
+        LOGGER.debug("finishAccept");
 
-        while (_selector != null) {
-            _isAcceptFinished = true;
-            _selector.wakeup();
-            LOGGER.trace("Awaiting accept loop to terminate");
-            wait();
+        if (_state == State.ACCEPT_WITH_REUSE) {
+            stopSelectionLoop();
+            startConnectionReaper();
+            _state = State.REAPER_ACTIVE;
         }
     }
 
-    private void closeChannel(Channel channel)
+    @GuardedBy("this")
+    private void stopSelectionLoop() throws InterruptedException
+    {
+        assert _state == State.ACCEPT_WITH_REUSE
+                    || _state == State.ACCEPT_SINGLESHOT_REAPER_ACTIVE
+                    || _state == State.REAPER_ACTIVE;
+
+        synchronized (_selectorLock) {
+            _selectorFinishRequested = true;
+            _selector.wakeup();
+            _selectorLock.wait();
+
+            try {
+                _selector.close();
+            } catch (IOException e) {
+                LOGGER.error("Error closing selector: {}", e.toString());
+            }
+            _selector = null;
+        }
+    }
+
+    /**
+     * Close the channel.  A failure is reported back to the error consumer.
+     * @param channel the channel to close.
+     */
+    @GuardedBy("this")
+    private void closeChannel(Channel channel, String message)
     {
         try {
             channel.close();
         } catch (IOException e) {
-            _errorConsumer.accept(e.getMessage());
+            _errorConsumer.accept(message + ": " + e);
         }
     }
 
@@ -375,44 +576,165 @@ public class PassiveConnectionHandler implements Closeable
     @Override
     public synchronized void close()
     {
-        try {
-            finishAccept();
-        } catch (InterruptedException e) {
-            LOGGER.warn("Interrupted while closing ConnectionHandler");
+        LOGGER.debug("close");
+
+        switch (_state) {
+        case NO_SERVER_SOCKET:
+            return;
+
+        case ACCEPT_SINGLESHOT_REAPER_ACTIVE:
+        case REAPER_ACTIVE:
+        case ACCEPT_WITH_REUSE:
+            try {
+                stopSelectionLoop();
+            } catch (InterruptedException e) {
+                LOGGER.warn("Interrupted while stopping selection loop");
+            }
+            break;
         }
 
         if (!_activeChannels.isEmpty()) {
-            LOGGER.warn("close#ConnectionHandler called with active connections");
-            _activeChannels.forEach(this::closeChannel);
-            _activeChannels.clear();
+            LOGGER.warn("Close called with active connections");
         }
 
-        _idleChannels.forEach(this::closeChannel);
-        _idleChannels.clear();
+        drainTo(_activeChannels, c -> closeChannel(c, "Failed to close still active channel"));
+        drainTo(_idleChannels, c -> closeChannel(c, "Failed to close idle channel"));
 
-        if (_channel != null) {
-            LOGGER.debug("Closing passive mode server socket: {}", _channel);
-            try {
-                _channel.close();
-            } catch (IOException e) {
-                LOGGER.warn("Failed to close passive mode server socket: {}",
-                        e.getMessage());
-            } finally {
+        if (!_backgroundActiveChannels.isEmpty()) {
+            LOGGER.warn("Close called with background active connections");
+        }
+
+        drainTo(_backgroundActiveChannels, bac -> closeChannel(bac.channel,
+                "Failed to close background active channel"));
+
+        synchronized (_selectorLock) {
+            if (_channel != null) {
+                closeChannel(_channel, "Failed to close listening socket");
                 _channel = null;
             }
         }
+
+        _state = State.NO_SERVER_SOCKET;
     }
 
     @Override
-    public synchronized String toString()
+    public String toString()
     {
-        return "ConnectionHandler[" + (_channel != null ? "L" : "-" ) +
-                (_selector != null ? "S" : "-") +
-                "; Conns (a:" + _activeChannels.size() +
-                ", i:" + _idleChannels.size() +
+        int activeChannelCount;
+        synchronized (_activeChannels) {
+            activeChannelCount = _activeChannels.size();
+        }
+
+        int idleChannelCount;
+        synchronized (_idleChannels) {
+            idleChannelCount = _idleChannels.size();
+        }
+
+        ServerSocketChannel channel;
+        Selector selector;
+        synchronized (_selectorLock) {
+            channel = _channel;
+            selector = _selector;
+        }
+
+        return "ConnectionHandler[" + (channel != null ? "L" : "-" ) +
+                (selector != null ? "S" : "-") +
+                "; Conns (a:" + activeChannelCount +
+                ", i:" + idleChannelCount +
                 "); Counters (su-accept: " + _singleUseAccepts +
                 ", reusable-accept: " + _reuseableAccepts +
                 ", conn-reuse: " + _connectionReuse +
                 ")]";
+    }
+
+    @GuardedBy("this")
+    private void startConnectionReaper()
+    {
+        LOGGER.trace("starting connection reaper");
+        assert _state != State.REAPER_ACTIVE;
+        assert _selector == null;
+
+        try {
+            synchronized (_selectorLock) {
+                _selector = Selector.open();
+                registerAll(_idleChannels);
+                _selectorFinishRequested = false;
+            }
+            Thread reaper = new Thread(this::reaper);
+            String id = BaseEncoding.base64().omitPadding().encode(Ints.toByteArray(reaper.hashCode()));
+            reaper.setName("ftp-reaper-" + id);
+            reaper.setDaemon(true);
+            reaper.start();
+            _state = State.REAPER_ACTIVE;
+        } catch (IOException e) {
+            LOGGER.error("Failed to establish connection reaper: {}", e.toString());
+        }
+    }
+
+    public void reaper()
+    {
+        try {
+            selectionLoop(c -> _backgroundActiveChannels.add(new ActiveChannel(c, NO_DATA)),
+                    channel -> {
+                            ByteBuffer writeableBuffer = ensureCapacity(16, KiB);
+                            try {
+                                int count = channel.read(writeableBuffer);
+                                if (count == -1) {
+                                    LOGGER.debug("Closed channel detected");
+                                    tryCloseChannel(channel, "Closing half-closed channel failed");
+                                } else {
+                                    ByteBuffer readableBuffer = detachForReading();
+                                    LOGGER.debug("Idle channel now active, read {} bytes", readableBuffer.remaining());
+                                    _backgroundActiveChannels.add(new ActiveChannel(channel, readableBuffer));
+                                }
+                            } catch (IOException e) {
+                                LOGGER.error("Read in reaper on {} failed: {}", channel, e.toString());
+                                tryCloseChannel(channel, "Defensive close after reaper read failure");
+                            }
+                        });
+        } catch (IOException e) {
+            LOGGER.error("Selector failed: {}", e.toString());
+        }
+    }
+
+    private ByteBuffer ensureCapacity(int size, ByteUnit units)
+    {
+        int byteCount = units.toBytes(size);
+        if (_data == null || _data.capacity() < byteCount) {
+            _data = ByteBuffer.allocate(byteCount);
+        }
+        return _data;
+    }
+
+    private ByteBuffer detachForReading()
+    {
+        ByteBuffer data = (ByteBuffer) _data.flip();
+        _data = null;
+        return data;
+    }
+
+    /**
+     * Close the channel.  Any fail is <emph>not</emph> reported to the error
+     * consumer.
+     * @param channel the channel to close
+     * @param message the message describing the failure -- this should not end
+     * with any punctuation.
+     */
+    private void tryCloseChannel(SocketChannel channel, String message)
+    {
+        try {
+            channel.close();
+        } catch (IOException ie) {
+            LOGGER.error("{}: {}", message, ie.toString());
+        }
+    }
+
+    private boolean removeIdleChannel(SocketChannel channel, String message)
+    {
+        if (!_idleChannels.remove(channel)) {
+            LOGGER.warn("{}: {}", message, channel);
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Motivation:

Commit eefb9641 introduces support for the data channel remaining open
between successive proxied MODE-E transfers.  This patch assumed that,
once a transfer completes, the client either issues another FTP command
(possibly initiating another transfer) or finishes the session.

When the client is another dCache (i.e., a third-party transfer) with
the active adapter then the client behavies differently from these two
options.  After a transfer completes, the client closes its half of the
data connection and waits for dCache to close its corresponding half.

Before commit eefb9641, such transfers would succeed since dCache always
closes proxy data connections once the transfer completed.  However,
with eefb9641, dCache does not react to the data connection being closed
once the transfer has completed.  Therefore, such transfers currently
hang once the transfer is complete.

Modification:

Update PassiveConnectionHandler so that, after a transfer completes, a
thread watches for connections becoming active.  By reading such
background-active connections, the thread discovers connections that the
client has closed and reacts accordingly.

Note that, if data is sent outside of a data transfer then subsequent
activity is ignored until a transfer is started.

Result:

Third-party transfers now succed if both endpoints are a dCache instance
that is proxying the data connections.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/10882