### PR TITLE
BUILDING.md - installing a new Maven

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,10 @@
 Building dCache
 ===============
 
+To build dCache, you need Maven 3.1.1 or newer. Centos/Redhat 7 
+comes with version 3.0.5. See https://maven.apache.org/install.html 
+on how to install a newer version.
+
 dCache uses Maven as a build system and as a repository of Maven
 artifacts. A top level aggregator project allows all Maven modules to
 be build in one operation:


### PR DESCRIPTION
Centos 7 has an ancient version of Maven, surprise surprise. Here's a hint how to install a newer version.