### PR TITLE
utils: ensure that pool and poolmanager subs set in Transfer.class

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -975,7 +975,7 @@ public abstract class AbstractFtpDoorV1
             setCheckStagePermission(_checkStagePermission);
             setOverwriteAllowed(_settings.isOverwrite());
             setPoolManagerStub(_poolManagerStub);
-            setPoolStub(_poolStub);
+            setPoolStub(AbstractFtpDoorV1.this._poolStub);
             setBillingStub(_billingStub);
             setAllocation(_allo);
             setIoQueue(_settings.getIoQueueName());

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -1253,6 +1253,9 @@ public class Transfer implements Comparable<Transfer>
 
     public ListenableFuture<Void> selectPoolAndStartMoverAsync(TransferRetryPolicy policy)
     {
+        checkNotNull(_poolStub, "Pool stub must be set");
+        checkNotNull(_poolManager, "PoolManager stub must be set");
+
         long deadLine = addWithInfinity(System.currentTimeMillis(), policy.getTotalTimeOut());
 
         AsyncFunction<Void, Void> selectPool =


### PR DESCRIPTION
Motivation:

Modification:

Result:

Fixes: #gh-issue
Ticket: #rt-number
Acked-by:
Target: master
Require-book: no
Require-notes: no