### PR TITLE
pool: fix metadata migration tool to use Path

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCopyTool.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCopyTool.java
@@ -3,9 +3,10 @@ package org.dcache.pool.repository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.EnumSet;
 
@@ -17,12 +18,12 @@ public class MetaDataCopyTool
         LoggerFactory.getLogger(MetaDataCopyTool.class);
 
     static ReplicaStore createStore(Class<? extends ReplicaStore> clazz,
-                                    FileStore fileStore, File poolDir, boolean readOnly)
+                                    FileStore fileStore, Path poolDir, boolean readOnly)
         throws NoSuchMethodException, InstantiationException,
                IllegalAccessException, InvocationTargetException
     {
         Constructor<? extends ReplicaStore> constructor =
-            clazz.getConstructor(FileStore.class, File.class, Boolean.TYPE);
+            clazz.getConstructor(FileStore.class, Path.class, Boolean.TYPE);
         return constructor.newInstance(fileStore, poolDir, readOnly);
     }
 
@@ -37,7 +38,7 @@ public class MetaDataCopyTool
             System.exit(1);
         }
 
-        File poolDir = new File(args[0]);
+        Path poolDir = FileSystems.getDefault().getPath(args[0]);
         FileStore fromFileStore = new DummyFileStore(DummyFileStore.Mode.ALL_EXIST);
         FileStore toFileStore = new DummyFileStore(DummyFileStore.Mode.NONE_EXIST);
         try (ReplicaStore fromStore =


### PR DESCRIPTION
Motivation:

Commit 8ebdb0df refactored the pool code to use Path instead of File.
This patch mistakenly omitted to adjust MetaDataCopyTool, which uses
reflection to create the desired ReplicaStore object.

Modification:

Update the constructor to use Path.

Result:

The "dcache pool convert" command works in 3.0 and 3.1.  It is still
broken in later dCache versions because of another problem.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9443
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9440
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/11002/
Acked-by: Tigran Mkrtchyan