### PR TITLE
scripts: update reference to configuration property

### DIFF
--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -281,8 +281,8 @@ poolConvertMeta() # $1 = domain, $2 = cell, $3 = type
            "The pool meta data database of '$name' was converted from
             type $src to type $3. Note that to use the new meta data
             store, the pool configuration must be updated by adjusting
-            the metaDataRepository property, eg, in the layout file:" \
-           "metaDataRepository=$3"
+            the pool.plugins.meta property, eg, in the layout file:" \
+           "pool.plugins.meta=$3"
 
     exit 0
 }


### PR DESCRIPTION
Motivation:

The 'dcache pool convert' script requires the admin to make manual
changes to the layout file.  To facilitate this, the command returns a
description detailing what changes are needed.  These instructions refer
to a configuration property that is no longer supported.

Modification:

Update instructions to refer to the correct configuration property name.

Result:

The instructions that are printed out once 'dcache pool convert'
completes successfully now correctly describes which property must be
updated.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Request: 3.1
Request: 3.0
Request: 2.16
Patch: https://rb.dcache.org/r/11006/
Acked-by: Tigran Mkrtchyan