### PR TITLE
frontend.authn.protocol by default https

### DIFF
--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -159,7 +159,7 @@ frontend.net.listen = ${dcache.net.listen}
 #   HTTPS, a server certificate and a trust store need to be
 #   created. By default these are stored under /etc/grid-security/.
 
-(one-of?http|https)frontend.authn.protocol = http
+(one-of?http|https)frontend.authn.protocol = https
 
 (immutable)frontend.authn.connector-for-http = PLAIN
 (immutable)frontend.authn.connector-for-https = TLS


### PR DESCRIPTION
I think it's safer if the frontend interface is https by default, not http, especially now that it is going to have more admin capabilities.