### PR TITLE
dcache-resilience: improve inaccessible file accounting

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
@@ -63,7 +63,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -835,34 +838,87 @@ public final class ResilienceCommands implements CellCommandListener {
     @Command(name = "inaccessible",
                     hint = "list pnfsids for a pool which "
                                     + "currently have no readable locations",
-                    description = "Issues a query to the namespace to scan the pool, "
+                    description = "With no options, issues a query to the "
+                                    + "namespace to scan the pool, "
                                     + "checking locations of each file with online "
                                     + "access latency; results are written to a  "
                                     + "file in resilience home named '"
                                     + INACCESSIBLE_PREFIX
-                                    + "' + pool. Executed asynchronously.")
+                                    + "' + pool. Executed asynchronously. Using "
+                                    + "the options, the scan status can be checked, "
+                                    + "scan canceled, and contents of file "
+                                    + "(pnfsid listing) displayed for single pools.")
     class InaccessibleFilesCommand extends ResilienceCommand {
-        @Option(name = "cancel", usage = "Cancel the running job.")
+        @Option(name = "status", usage = "Check status of scan.")
+        boolean status = false;
+
+        @Option(name = "list", usage = "List the inaccessible pnfsids.")
+        boolean list = false;
+
+        @Option(name = "delete", usage = "Delete scan file.")
+        boolean delete = false;
+
+        @Option(name = "cancel", usage = "Cancel the running scan job.")
         boolean cancel = false;
 
-        @Argument(usage = "A regular expression for pool names.")
-        String expression;
+        @Argument(usage = "With run and cancel, this can be a regular expression "
+                        + "for pool names; with the other options, it must be "
+                        + "a single pool name.")
+        String poolExpression;
 
         @Override
         protected String doCall() throws Exception {
+            if (status) {
+                return getStatus();
+            }
+
+            if (delete) {
+                return doDelete();
+            }
+
+            if (list) {
+                return getListing();
+            }
+
+            return doScan();
+        }
+
+        private String getStatus() {
+            if (futureMap.containsKey(poolExpression)) {
+                return "RUNNING";
+            }
+
+            if (getListingFile(poolExpression, resilienceDir).exists()) {
+                return "DONE";
+            }
+
+            return "NOT FOUND";
+        }
+
+        private String doDelete() {
+            File toDelete = getListingFile(poolExpression, resilienceDir);
+            if (toDelete.exists()) {
+                toDelete.delete();
+                return "Deleted " + toDelete;
+            }
+
+            return "Not found: " + toDelete;
+        }
+
+        private String doScan() {
             try {
                 StringBuilder builder = new StringBuilder();
-                Pattern pattern = Pattern.compile(expression);
+                Pattern pattern = Pattern.compile(poolExpression);
 
                 poolInfoMap.getResilientPools()
                            .stream()
                            .filter((pool) -> pattern.matcher(pool).find())
                            .forEach((pool) -> handleOption(cancel, pool, builder));
 
-                builder.insert(0, "Started jobs to write the lists "
-                                + "of inaccessible pnfsids "
-                                + "to the following files:\n\n");
-                builder.append("Check pinboard for progress.\n");
+                if (!cancel) {
+                    builder.insert(0, "Writing inaccessible pnfsids "
+                                    + "to the following files:\n\n");
+                }
 
                 return builder.toString();
             } catch (Exception e) {
@@ -877,13 +933,14 @@ public final class ResilienceCommands implements CellCommandListener {
                 Future<?> future = futureMap.remove(pool);
                 if (future != null) {
                     future.cancel(true);
+                    builder.append("Cancelled job for ")
+                           .append(pool).append("\n");
+                } else {
+                    builder.append("No running job for ")
+                           .append(pool).append("\n");
                 }
-
-                builder.append("cancelled job for ")
-                                .append(pool).append("\n");
             } else {
-                File file = printToFile(pool,
-                                resilienceDir);
+                File file = printToFile(pool, resilienceDir);
                 builder.append("   ")
                                 .append(file.getAbsolutePath())
                                 .append("\n");
@@ -891,7 +948,7 @@ public final class ResilienceCommands implements CellCommandListener {
         }
 
         private File printToFile(String pool, String dir) {
-            File file = new File(dir, INACCESSIBLE_PREFIX + pool);
+            File file = getListingFile(pool, dir);
             ListeningExecutorService decoratedExecutor
                             = MoreExecutors.listeningDecorator(executor);
 
@@ -919,6 +976,25 @@ public final class ResilienceCommands implements CellCommandListener {
             future.addListener(() -> futureMap.remove(pool),
                                      MoreExecutors.directExecutor());
             return file;
+        }
+
+        private String getListing() {
+            File file = getListingFile(poolExpression, resilienceDir);
+            if (!file.exists()) {
+                return "There is no current listing for " + poolExpression;
+            }
+            StringBuilder builder = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(
+                            new FileReader(getListingFile(poolExpression, resilienceDir)))) {
+                    reader.lines().forEach((l) -> builder.append(l).append("\n"));
+            } catch (IOException e) {
+                return "Trouble reading file for " + poolExpression + ": " + e.getMessage();
+            }
+            return builder.toString();
+        }
+
+        private File getListingFile(String pool, String dir) {
+            return new File(dir, INACCESSIBLE_PREFIX + pool);
         }
     }
 

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperationMap.java
@@ -396,6 +396,7 @@ public class FileOperationMap extends RunnableModule {
                                         .map(poolInfoMap::getPool)
                                         .collect(Collectors.toSet());
                         completionHandler.taskAborted(operation.getPnfsId(),
+                                                      pool,
                                                       poolInfoMap.getUnit(operation.getStorageUnit()),
                                                       tried,
                                                       operation.getRetried(),

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/db/LocalNamespaceAccess.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/db/LocalNamespaceAccess.java
@@ -67,7 +67,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.stream.Collectors;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import javax.sql.DataSource;
 
@@ -302,7 +304,10 @@ public class LocalNamespaceAccess implements NamespaceAccess {
                 throw new InterruptedException();
             }
 
+            LOGGER.info("executing {}.", statement);
             resultSet = statement.executeQuery();
+
+            LOGGER.info("starting check of pnfsids for {}.", location);
 
             while (resultSet.next()) {
                 if (Thread.interrupted()) {
@@ -311,14 +316,25 @@ public class LocalNamespaceAccess implements NamespaceAccess {
 
                 PnfsId pnfsId = new PnfsId(resultSet.getString(1));
                 try {
-                    if (getRequiredAttributes(pnfsId).getLocations().stream()
-                                    .map(poolInfoMap::getPoolIndex)
-                                    .filter((i) -> poolInfoMap.isPoolViable(i, false))
-                                    .collect(Collectors.toList()).isEmpty()) {
+                    FileAttributes attributes = getRequiredAttributes(pnfsId);
+                    Collection<String> locations = attributes.getLocations();
+                    for (Iterator<String> i = locations.iterator(); i.hasNext();) {
+                        String pool = i.next();
+                        try {
+                            int index = poolInfoMap.getPoolIndex(pool);
+                            if (!poolInfoMap.isPoolViable(index, false)) {
+                                i.remove();
+                            }
+                        } catch (NoSuchElementException e) {
+                            i.remove();
+                        }
+                    }
+                    if (locations.isEmpty()) {
                         writer.println(pnfsId);
+                        LOGGER.info("orphaned: {}.", pnfsId);
                     }
                 } catch (CacheException e) {
-                    LOGGER.debug("{}: {}", pnfsId, new ExceptionMessage(e));
+                    LOGGER.info("{}: {}", pnfsId, new ExceptionMessage(e));
                 }
             }
         } finally {

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileTaskCompletionHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileTaskCompletionHandler.java
@@ -82,7 +82,8 @@ import org.dcache.resilience.util.ExceptionMessage;
  */
 public final class FileTaskCompletionHandler implements TaskCompletionHandler {
     static final String ABORT_REPLICATION_LOG_MESSAGE
-                    = "Storage unit {}: aborted replication for {}; pools tried: {}; {}";
+                    = "Storage unit {}: aborted replication for {}; "
+                    + "referring pool {}; pools tried: {}; {}";
 
     static final String ABORT_REPLICATION_ALARM_MESSAGE
                     = "There are files in storage unit {} for which replication "
@@ -112,6 +113,7 @@ public final class FileTaskCompletionHandler implements TaskCompletionHandler {
     }
 
     public void taskAborted(PnfsId pnfsId,
+                            String pool,
                             String storageUnit,
                             Set<String> triedSources,
                             int retried,
@@ -144,7 +146,8 @@ public final class FileTaskCompletionHandler implements TaskCompletionHandler {
          *  Full info on the file is logged to the ".resilience" log.
          */
         ABORTED_LOGGER.error(ABORT_REPLICATION_LOG_MESSAGE, storageUnit, pnfsId,
-                     triedSources, new ExceptionMessage(e));
+                             pool == null ? "none" : pool, triedSources,
+                             new ExceptionMessage(e));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

When multiple pools go offline it is possible that
all replicas for a given resilient file become unreadable.
If the file is not CUSTODIAL, and thus cannot be restored
from tape, the discovery of such a file during scanning
will generate an error in the 'history errors' listing,
in the resilience domain .resilience log, and will also
raise a general alarm concerning the pool.

There currently exists a command, 'inaccessible', which
generates a listing of the pnfsids on a given pool
which in the current state of dCacche have no readable
replicas.  However, this command takes a while to complete
(asynchronously), and the output is written to a file
which must be viewed by logging in.

Modification:

1.  Add 'referring pool' to the error output to enable
    grep'ing the resilience log for a given scanned pool
    (see below).
2.  Add options to the existing command to check status
    of the job, to list the contents of the file for
    that pool, and to clean up/delete the file.

_Also fixes a bug (uncaught NoSuchElementException)
in the validation of the pools._

Result:

Hopefully enhanced information and usability of this
functionality.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Acked-by: Tigran