### PR TITLE
pnfsmanager: fix digest name handling in `get file checksum` command

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -892,11 +892,12 @@ public class PnfsManagerV3
         @Argument(index = 1,
                   usage = "The checksums type of the file. These following checksums " +
                           "are supported: adler32, md5 and md4.")
-        ChecksumType type;
+        String typeArg;
 
         @Override
         public String call() throws CacheException, NoSuchAlgorithmException
         {
+            ChecksumType type = ChecksumType.getChecksumType(typeArg);
             return getChecksums(ROOT, pnfsId).stream()
                     .filter(c -> c.getType() == type)
                     .map(Checksum::toString)


### PR DESCRIPTION
Motivation:
dcache's admin command builder can convert string values into
corresponding enum values. This works well for cases where enum name and
string name are the same, like "ADLER32" and ADLER32. However it's not
always the case: "MD5" and MD5_TYPE.

Modification:
update `get file checksum` command to accept string as an argument and
use  ChecksumType#getChecksumType method to convert digest name to a
corresponding ChecksumType enum.

Result:
`get file checksum` works as expected.

Fixes: #4064
Acked-by: Paul Millar
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: no
(cherry picked from commit 9914d17687cce041454862a991a9640026c00945)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>