### PR TITLE
admin: fix regression in startup

### DIFF
--- a/skel/share/services/admin.batch
+++ b/skel/share/services/admin.batch
@@ -20,7 +20,7 @@ check -strong admin.service.pnfsmanager.timeout.unit
 check -strong admin.service.acm
 check -strong admin.service.acm.timeout
 check -strong admin.service.acm.timeout.unit
-check -string admin.ssh.authn.enabled
+check -strong admin.ssh.authn.enabled
 check -strong admin.ssh.authn.kerberos.keytab-file
 check admin.loginbroker.request-topic
 check -strong admin.authz.gid


### PR DESCRIPTION
Motivation:

Commit 64ea49e6 introduced a regression where, on startup, dCache logs
the error:

25 Jun 2018 14:52:32 (System) [] URL [file:/.../share/services/admin.batch]: line 23: Command failed: (2) Unknown option: string

Modification:

Fix the typo.

Result:

An unreleased regression is fixed and dCache starts without this error.

Target: master
Request: 4.2
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/11019/
Acked-by: Tigran Mkrtchyan