### PR TITLE
webdav: pass on status message phrase to client

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -16,11 +16,12 @@ import com.google.common.net.InetAddresses;
 import io.milton.http.HttpManager;
 import io.milton.http.Request;
 import io.milton.http.ResourceFactory;
+import io.milton.http.ResponseStatus;
+import io.milton.http.exceptions.BadRequestException;
 import io.milton.resource.Resource;
 import io.milton.servlet.ServletRequest;
 import io.milton.servlet.ServletResponse;
 import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -695,7 +696,7 @@ public class DcacheResourceFactory
      */
     public DcacheResource createFile(FsPath path, InputStream inputStream, Long length)
             throws CacheException, InterruptedException, IOException,
-                   URISyntaxException
+                   URISyntaxException, BadRequestException
     {
         Subject subject = getSubject();
         Restriction restriction = getRestriction();
@@ -720,6 +721,11 @@ public class DcacheResourceFactory
                     transfer.notifyBilling(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
                                            "Error relaying data: " + message);
                     transfer.killMover("door experienced error relaying data: " + message);
+                    throw e;
+                } catch (BadRequestException e) {
+                    transfer.notifyBilling(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
+                                           e.getMessage());
+                    transfer.killMover("pool reported bad request: " + e.getMessage());
                     throw e;
                 } catch (CacheException e) {
                     transfer.notifyBilling(e.getRc(), e.getMessage());
@@ -1606,7 +1612,7 @@ public class DcacheResourceFactory
         }
 
         public void relayData(InputStream inputStream)
-                throws IOException, CacheException, InterruptedException
+                throws IOException, CacheException, InterruptedException, BadRequestException
         {
             setStatus("Mover " + getPool() + "/" + getMoverId() +
                     ": Opening data connection");
@@ -1630,7 +1636,12 @@ public class DcacheResourceFactory
                         ByteStreams.copy(inputStream, outputStream);
                         outputStream.flush();
                     }
-                    if (connection.getResponseCode() != HttpResponseStatus.CREATED.code()) {
+                    switch (connection.getResponseCode()) {
+                    case ResponseStatus.SC_CREATED:
+                        break;
+                    case ResponseStatus.SC_BAD_REQUEST:
+                        throw new BadRequestException(connection.getResponseMessage());
+                    default:
                         throw new CacheException(connection.getResponseMessage());
                     }
                 } finally {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
@@ -12,8 +12,13 @@ import io.milton.http.exceptions.NotAuthorizedException;
 import io.milton.http.exceptions.NotFoundException;
 import io.milton.http.quota.StorageChecker;
 import io.milton.http.webdav.WebDavResponseHandler;
+import io.milton.servlet.ServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
 
 /**
  * Custom StandardFilter for Milton.
@@ -67,6 +72,8 @@ public class DcacheStandardFilter implements Filter
             }
         } catch (BadRequestException e) {
             responseHandler.respondBadRequest(e.getResource(), response, request);
+            // Work-around: milton doesn't allow non-standard text, so we update the value here.
+            ServletResponse.getResponse().setStatus(HttpServletResponse.SC_BAD_REQUEST, e.getReason());
         } catch (UncheckedBadRequestException e) {
             log.debug("Client supplied bad request parameters: {}", e.getMessage());
             responseHandler.respondBadRequest(e.getResource(), response, request);


### PR DESCRIPTION
Motivation:

When the WebDAV door is proxying a transfer and that transfer fails, that
failure could be due to some aspect of the client request (i.e., a 400
status code).

Currently the WebDAV door always returns a status "500 Internal Error" to
the client if a transfer fails.  This is true even if the pool returns a
400 status code (indicating the client did something wrong).  This is
both uninformative and fails to convey that the problem is with the
client's request.

Modification:

Update door to return a 400 error if a proxied transfer fails with the
pool returning a 400 error.  The status message is also relayed back to
the client.

Result:

Clients receive better feedback if a proxy transfer failed due to bad
client interaction.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/11039/
Acked-by: Tigran Mkrtchyan