### PR TITLE
pom: use nfs4j-0.17.3 bugfix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -736,7 +736,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.17.2</version>
+            <version>0.17.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
Motivation:
minot version update with bugfix:

Changelog for nfs4j-0.17.2..nfs4j-0.17.3
    * [83fdde8d] [maven-release-plugin] prepare for next development iteration
    * [44ba7542] nfs: fix ABBA dead lock during dead client cleanup
    * [30fc9111] [maven-release-plugin] prepare release nfs4j-0.17.3

Modification:
update pom to use new version of the library.

Result:
no deadlock in production

Acked-by: Marina Sahakyan
Target: master, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 09a45c33bee2e5b6b0f430da549ebfe4ea73b378)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>