### PR TITLE
cells: add handling of RemoteProxyFailureException nested Interrupted…

### DIFF
--- a/modules/cells/pom.xml
+++ b/modules/cells/pom.xml
@@ -31,6 +31,10 @@
         <artifactId>curator-recipes</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
         <groupId>jline</groupId>
         <artifactId>jline</artifactId>
     </dependency>

--- a/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/SystemCell.java
@@ -1,14 +1,13 @@
 package dmg.cells.nucleus ;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.remoting.RemoteProxyFailureException;
 
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
@@ -16,16 +15,12 @@ import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import dmg.util.AuthorizedString;
@@ -36,10 +31,7 @@ import dmg.util.logback.FilterShell;
 import org.dcache.alarms.AlarmMarkerFactory;
 import org.dcache.alarms.PredefinedAlarm;
 
-import static com.google.common.util.concurrent.Futures.allAsList;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
-import static org.bouncycastle.asn1.x500.style.RFC4519Style.name;
 import static org.dcache.util.ByteUnit.MiB;
 
 /**
@@ -350,6 +342,17 @@ public class      SystemCell
                                                     getCellDomainName(),
                                                     getCellName()),
                        "Restarting due to fatal JVM error: {}", e.toString());
+            return;
+        }
+
+        /*
+         *  The RemotePoolMonitor wraps interrupted exceptions in a
+         *  runtime exception.  These should not cause a stack trace to
+         *  be printed.
+         */
+        if (e instanceof RemoteProxyFailureException &&
+                        e.getCause() instanceof InterruptedException) {
+            _log.warn("{} interrupted.", t.getName());
             return;
         }
 


### PR DESCRIPTION
…Exception to UncaughtException handler

Motivation:

The RemotePoolMonitor nests any InterruptedException thrown
in a spring RemoteProxyFailureException (RuntimeException).
This is done in order to preserve the original PoolMonitor
API, whose methods do not declare checked exceptions.

Not handling this special case can produce unnecessary
stack traces on shutdown (see Testing).

While the referencenced issue concerns the History
service, the problem is more widespread.  Of all
the instances where this could potentially occur,
only one handles it.

Modification:

Instead of wrapping each individual site with
a try catch which would result in a rethrow
if the nested exception is not an InterruptedException
(an anti-pattern), an if-clause is added
to the SystemCell uncaughtException method.

Result:

There should not be any stack traces resulting
from RemotePoolMonitor thread interruptions.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Bug: #4083
Acked-by: Tigran