### PR TITLE
dcache-xrootd: repair handling of delayed sync errors to client

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -177,6 +177,12 @@ public final class TpcWriteDescriptor extends WriteDescriptor
     public synchronized XrootdResponse<StatRequest> handleStat(StatRequest msg)
                     throws XrootdException
     {
+        if (client.getError() != null) {
+            return new ErrorResponse<>(msg,
+                                       client.getErrno(),
+                                       client.getError());
+        }
+
         int fd = msg.getFhandle();
         NettyMoverChannel channel = getChannel();
         FileStatus fileStatus;
@@ -268,6 +274,12 @@ public final class TpcWriteDescriptor extends WriteDescriptor
     public synchronized XrootdResponse<SyncRequest> sync(SyncRequest syncRequest)
                     throws IOException, InterruptedException
     {
+        if (client.getError() != null) {
+            return new ErrorResponse<>(syncRequest,
+                                       client.getErrno() ,
+                                       client.getError());
+        }
+
         LOGGER.trace("Request to sync ({}) is for third-party write.",
                      syncRequest);
 
@@ -293,9 +305,6 @@ public final class TpcWriteDescriptor extends WriteDescriptor
              * Not yet terminated.  Wait for fireDelayedSync call.
              */
             this.syncRequest = syncRequest;
-            if (client.getErrno() != kXR_ok) {
-                fireDelayedSync(client.getErrno(), client.getError());
-            }
             return null;
         }
 


### PR DESCRIPTION
Motivation:

Depending on timing, errors reported to the user client
through fireDelayedSync (third-party client) currently
may not appear.  This is particularly the case when
there is an error set on the tpc client before the first
sync call from the user client.  One example of this
is when there is no authentication module to handle
the gsi authentication request.

Modification:

Check first for tpc client errors being set on all incoming
user client requests, and report them immediately.

Result:

The correct error message will reach the user client.

Target: master
Request: 4.2
Acked-by: Tigran