### PR TITLE
webdav: update default credential delegation for third-party copy

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -125,29 +125,20 @@ public class RemoteTransferHandler implements CellMessageReceiver
      * The different transport schemes supported.
      */
     public enum TransferType {
-        GSIFTP("gsiftp", GRIDSITE, EnumSet.noneOf(CredentialSource.class)),
-        HTTP(  "http",   NONE,     EnumSet.noneOf(CredentialSource.class)),
-        HTTPS( "https",  GRIDSITE, EnumSet.of(OIDC, NONE));
+        GSIFTP("gsiftp", EnumSet.of(GRIDSITE)),
+        HTTP(  "http",   EnumSet.of(NONE)),
+        HTTPS( "https",  EnumSet.of(GRIDSITE, OIDC, NONE));
 
         private static final ImmutableMap<String,TransferType> BY_SCHEME =
             ImmutableMap.of("gsiftp", GSIFTP, "http", HTTP, "https", HTTPS);
 
-        private final CredentialSource _defaultCredentialSource;
         private final EnumSet<CredentialSource> _supported;
         private final String _scheme;
 
-        TransferType(String scheme, CredentialSource defaultSource,
-                EnumSet<CredentialSource> additionalSources)
+        TransferType(String scheme, EnumSet<CredentialSource> supportedSources)
         {
-            _defaultCredentialSource = defaultSource;
-            _supported = EnumSet.copyOf(additionalSources);
-            _supported.add(defaultSource);
+            _supported = EnumSet.copyOf(supportedSources);
             _scheme = scheme;
-        }
-
-        public CredentialSource getDefaultCredentialSource()
-        {
-            return _defaultCredentialSource;
         }
 
         public boolean isSupported(CredentialSource source)


### PR DESCRIPTION
Motivation:

A third-party transfer may require authorisation; i.e., the pool may
require a credential.  If specified, the 'Credential' HTTP header
controls where this credential comes from.  If not specified then some
default policy is used.

The current default policy is based on the transfer protocol: the
protocol used by the pool to obtaining or send the file.  For 'https'
transfers, the default is to use GridSite delegation, unless the client
used some bearer token, in which case OpenID-Connect delegation is used.

If the client uses a macaroon to authorise the third-party copy then the
request has a bearer token, but OpenID-Connect delegation cannot work --
therefore the default behaviour is broken.

Modification:

Update the default policy to base the decision on how the user is
authenticated:

  OpenID-Connect -->  use OpenID-Connect delegation
  X.509          -->  use GridSite delegation
  anything else  -->  does not fetch a credential.

As before, the client may override this by specifying the Credential
header.

Result:

Requesting a third-party copy using a macaroon does not trigger a failed
attempt to OpenID-Connect delegation.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9474
Require-notes: yes
Require-book: yes
Patch: https://rb.dcache.org/r/11093/
Acked-by: Tigran Mkrtchyan