### PR TITLE
ftp: fix scope of used pool stub

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -975,7 +975,7 @@ public abstract class AbstractFtpDoorV1
             setCheckStagePermission(_checkStagePermission);
             setOverwriteAllowed(_settings.isOverwrite());
             setPoolManagerStub(_poolManagerStub);
-            setPoolStub(_poolStub);
+            setPoolStub(AbstractFtpDoorV1.this._poolStub);
             setBillingStub(_billingStub);
             setAllocation(_allo);
             setIoQueue(_settings.getIoQueueName());

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -79,6 +79,7 @@ import org.dcache.poolmanager.PoolManagerStub;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.PnfsGetFileAttributes;
 
+import static java.util.Objects.requireNonNull;
 import static com.google.common.base.Preconditions.*;
 import static com.google.common.util.concurrent.Futures.*;
 import static org.dcache.namespace.FileAttribute.*;
@@ -266,7 +267,7 @@ public class Transfer implements Comparable<Transfer>
      */
     public synchronized void setPoolManagerStub(PoolManagerStub stub)
     {
-        _poolManager = stub;
+        _poolManager = requireNonNull(stub, "PoolManager stub can't be null");
     }
 
     /**
@@ -274,7 +275,7 @@ public class Transfer implements Comparable<Transfer>
      */
     public synchronized void setPoolStub(CellStub stub)
     {
-        _poolStub = stub;
+        _poolStub = requireNonNull(stub, "Pool stub can't be null");
     }
 
     /**
@@ -282,7 +283,7 @@ public class Transfer implements Comparable<Transfer>
      */
     public synchronized void setBillingStub(CellStub stub)
     {
-        _billing = stub;
+        _billing = requireNonNull(stub, "Billing stub can't be null");
     }
 
     public synchronized void setKafkaSender(Consumer<DoorRequestInfoMessage> kafkaSender)
@@ -1253,6 +1254,7 @@ public class Transfer implements Comparable<Transfer>
 
     public ListenableFuture<Void> selectPoolAndStartMoverAsync(TransferRetryPolicy policy)
     {
+
         long deadLine = addWithInfinity(System.currentTimeMillis(), policy.getTotalTimeOut());
 
         AsyncFunction<Void, Void> selectPool =


### PR DESCRIPTION
utils: ensure that pool and poolmanager subs set in Transfer.class

Motivation:
The FtpTransfer should use pool stub of outer class when setPoolSub method
is called. However due to name conflict the Transfers class internal _poolSub
is used and, as a result, the desired value is not set.

To operate correctly Transfer class requires pool and poolmanagers stubs
to be initialized other wise a NPE will be triggered and a stacktrace
will be logged. However, as to start a mover a callback thread is used,
the original source of the non initialized value is lost.

Modification:
Ensure that _poolSub of AbstractFtpDoorV1 is used when setPoolSub is called.
Check for non null values at the client code facing point.

Result:
the non initialized values are detected when door tries to use not fully
initialized Transfer class.

Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit 8e02472d6313886f8776b37df90e1c0021e5b781)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>