### PR TITLE
dcache-xrootd: fix third-party billing records

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/vehicles/XrootdProtocolInfo.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/vehicles/XrootdProtocolInfo.java
@@ -28,8 +28,6 @@ public class XrootdProtocolInfo implements IpProtocolInfo {
 
     private final int _major;
 
-    private final InetSocketAddress _clientSocketAddress;
-
     private final CellPath _pathToDoor;
 
     private final PnfsId _pnfsId;
@@ -41,6 +39,8 @@ public class XrootdProtocolInfo implements IpProtocolInfo {
     private final InetSocketAddress _doorAddress;
 
     private final EnumSet<Flags> _flags;
+
+    private InetSocketAddress _clientSocketAddress;
 
     public XrootdProtocolInfo(String protocol,  int major,int minor,
         InetSocketAddress clientAddress, CellPath pathToDoor, PnfsId pnfsID,
@@ -109,6 +109,11 @@ public class XrootdProtocolInfo implements IpProtocolInfo {
     public InetSocketAddress getSocketAddress()
     {
         return _clientSocketAddress;
+    }
+
+    public void setSocketAddress(InetSocketAddress address)
+    {
+        _clientSocketAddress = address;
     }
 
     public EnumSet<Flags> getFlags()

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -66,6 +66,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -148,6 +149,15 @@ public final class TpcWriteDescriptor extends WriteDescriptor
         if (cksum != null) {
             channel.addChecksumType(ChecksumType.getChecksumType(cksum.toUpperCase()));
         }
+
+        /*
+         * For dcache as destination, the transfer is initiated by the
+         * user client, but we want the mover billing record to reflect
+         * the source IP, so we overwrite the protocol info client (unused).
+         */
+        getChannel().getProtocolInfo()
+                    .setSocketAddress(new InetSocketAddress(info.getSrcHost(),
+                                                            info.getSrcPort()));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Because of the peculiar way the xrootd client interacts with
source and destination when following the third-party copy protocol,
the 'client' IP reflected in the billing records is currently
inconsistent.  Both the billinginfo (mover info) and doorinfo
tables have the same client, but this varies as to whether the
transfer is a READ (dCache as source, client is the remote server
or dCache pool) or WRITE (dCache is destination, client is
initiating user client).

This is not intuitive, and also does not give a good indication
as to whether the transfer was indeed third-party (particularly
in the case of WRITE).

Modification:

Selectively overwrite client information according to case.

When the transfer is third-party write (= destination),
the protocol info client can be changed to reflect the actual
source IP.

When the transfer is third-party read (= source), the transfer
client can be changed to reflect the initiating user IP.

Hence door client will always be the initiating user, and
the mover will be either the source or destination endpoint.

In the case of dCache to dCache transfers, the read client
will be a pool (where the embedded tpc client lives),
while the write client (the initiator of the transfer)
will be a door.

Result:

More intuitive billing records which also allow quick
verification that the transfer was third-party
(door client != mover client).

Target: master
Request: 4.2
Acked-by: Dmitry