### PR TITLE
libs: update jetty to version 9.4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.aspectj>1.8.10</version.aspectj>
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
-        <version.jetty>9.4.6.v20170531</version.jetty>
+        <version.jetty>9.4.11.v20180605</version.jetty>
         <version.wicket>7.6.0</version.wicket>
         <version.xrootd4j>3.2.2</version.xrootd4j>
         <version.jersey>2.26</version.jersey>


### PR DESCRIPTION
CVE-2017-7656

Acked-by: Paul Millar
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit ee3eaf4331f5e38fe66c3fb40b240c613363e5c5)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>