### PR TITLE
gplazma: oidc fix FullNamePrincipal creation

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/FullNamePrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/FullNamePrincipal.java
@@ -20,7 +20,8 @@ public class FullNamePrincipal implements Principal, Serializable
 
     public FullNamePrincipal(String givenName, String familyName)
     {
-        checkArgument(!givenName.isEmpty() || !familyName.isEmpty(), "No Names given");
+        checkArgument(!givenName.isEmpty(), "Missing given name");
+        checkArgument(!familyName.isEmpty(), "Missing family name");
         _fullName = Joiner.on(' ').skipNulls().join(givenName, familyName).trim();
     }
 

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
@@ -217,9 +217,9 @@ public class OidcAuthPlugin implements GPlazmaAuthenticationPlugin
 
         if (fullName != null && !fullName.asText().isEmpty()) {
             principals.add(new FullNamePrincipal(fullName.asText()));
-        } else {
-            principals.add(new FullNamePrincipal(givenName == null ? null : givenName.asText(),
-                    familyName == null ? null : familyName.asText()));
+        } else if (givenName != null && !givenName.asText().isEmpty()
+                && familyName != null && !familyName.asText().isEmpty()) {
+            principals.add(new FullNamePrincipal(givenName.asText(), familyName.asText()));
         }
     }
 


### PR DESCRIPTION
Motivation:

When authenticating with OIDC, the OP reply may contain optional
information ("claims") about the user.  Several of these claims are
standardised, including "name", "family_name", and "given_name".

The OidcAuthPlugin attempts to consume this information and provide a
name that may be used primarily to provide feedback on who is logged in.

The current implementation is buggy if the OP does not assert the "name"
claim, and does not assert both "family_name" and "given_name",
resulting in failed login and a NullPointerException:

    java.lang.NullPointerException: null
            at org.dcache.auth.FullNamePrincipal.<init>(FullNamePrincipal.java:23) ~[dcache-common-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.gplazma.oidc.OidcAuthPlugin.addNames(OidcAuthPlugin.java:256) ~[gplazma2-oidc-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.gplazma.oidc.OidcAuthPlugin.validateBearerTokenWithOpenIdProvider(OidcAuthPlugin.java:202) ~[gplazma2-oidc-5.0.0-SNAPSHOT.jar:5.0.0-S
            at org.dcache.gplazma.oidc.OidcAuthPlugin.authenticate(OidcAuthPlugin.java:163) ~[gplazma2-oidc-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.gplazma.strategies.DefaultAuthenticationStrategy.lambda$authenticate$0(DefaultAuthenticationStrategy.java:65) [gplazma2-5.0.0-SNAPSHO
            at org.dcache.gplazma.strategies.PAMStyleStrategy.callPlugins(PAMStyleStrategy.java:98) ~[gplazma2-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.gplazma.strategies.DefaultAuthenticationStrategy.authenticate(DefaultAuthenticationStrategy.java:55) [gplazma2-5.0.0-SNAPSHOT.jar:5.0
            at org.dcache.gplazma.GPlazma$Setup.doAuthPhase(GPlazma.java:553) [gplazma2-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.gplazma.GPlazma.login(GPlazma.java:265) [gplazma2-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.gplazma.GPlazma.login(GPlazma.java:225) [gplazma2-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.auth.Gplazma2LoginStrategy.login(Gplazma2LoginStrategy.java:156) [dcache-gplazma-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.services.login.MessageHandler.messageArrived(MessageHandler.java:69) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_181]
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_181]
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_181]
            at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_181]
            at org.dcache.cells.CellMessageDispatcher$LongReceiver.deliver(CellMessageDispatcher.java:304) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.cells.CellMessageDispatcher.call(CellMessageDispatcher.java:201) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.cells.AbstractCell.messageArrived(AbstractCell.java:331) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:890) [cells-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1211) [cells-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) [dcache-common-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_181]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_181]
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$4(CellNucleus.java:747) [cells-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_181]

Modification:

Update the OIDC plugin so that a FullNamePrincipal is only generated if
the "name" claim is provided, or both "given_name" and "family_name"
claims are asserted.  If "given_name" or "family_name" is missing (and
the OP does not assert the "name" claim) then no FullNamePrincipal is
provided.

Result:

Users whos OP does not claim "name", and does not claim "given_name" nor
"family_name" can use dCache.

Target: master
Require-notes: yes
Require-book: no
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Acked-by: Tigran Mkrtchyan
Patch: https://rb.dcache.org/r/11115/