### PR TITLE
poolmanager: fix NullPointerException when staging files and reportin…

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -1447,7 +1447,7 @@ public class RequestContainerV5
                           suspendIfEnabled("Suspended (pool unavailable)");
                        }
                        if (_sendHitInfo && _poolCandidate == null) {
-                           sendHitMsg(_bestPool.info(), false);   //VP
+                           sendHitMsg(_bestPool == null ? null : _bestPool.info(), false);   //VP
                        }
                        //
                     }else if( rc == RequestStatusCode.NOT_PERMITTED ){


### PR DESCRIPTION
…g hits

Motivation:

Commit 4a70ec140a7 updated RequestContainerV5 _bestPool to hold a
PoolInfo object, which contains that field-member's former SelectedPool
information.

Unfortunately, this commit failed to take into account that _bestPool
may be null, so simply dereferencing _bestPool can lead to the following
NPE when staging files back from tape and
poolmanager.enable.cache-hit-message is true.

    java.lang.NullPointerException: null
            at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.stateEngine(RequestContainerV5.java:1440) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.stateLoop(RequestContainerV5.java:1192) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler.access$1700(RequestContainerV5.java:758) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at diskCacheV111.poolManager.RequestContainerV5$PoolRequestHandler$RunEngine.run(RequestContainerV5.java:1123) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) [dcache-common-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_181]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_181]
            at java.lang.Thread.run(Thread.java:748) [na:1.8.0_181]

Modification:

Check whether _bestPool is null before dereferencing it.

Result:

No more NPE when staging back from tape and the
poolmanager.enable.cache-hit-message configuration property is true.

Target: master
Requires-notes: yes
Requires-book: no
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11119/
Acked-by: Tigran Mkrtchyan