### PR TITLE
dcache: release dcache-view version 1.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.6.0</version.wicket>
         <version.xrootd4j>3.2.2</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.3.1</version.dcache-view>
+        <version.dcache-view>1.3.2</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
 


### PR DESCRIPTION
Changelog from v1.3.1 to v1.3.2

- [94f4778](dCache/dcache-view@94f4778) dcache-view (authentication): remove state from the required parameter
- [9c0a2aa](dCache/dcache-view@9c0a2aa) dcache-view (namespace): fix issue with role assertion
- [3083394](dCache/dcache-view@3083394) dcache-view (user): make user-profile page aware of asserted roles
- [ea3625b](dCache/dcache-view@ea3625b) dcache-view (namespace): remove unnecessary semicolon
- [bddb7d8](dCache/dcache-view@bddb7d8) dcache-view (user): set css overflow-y property to auto
- [e9bc3bf](dCache/dcache-view@e9bc3bf) dcache-view: prevent file removal when dnd is cancelled
- [ddc076a](dCache/dcache-view@ddc076a) dcache-view: change menu tooltip names

Request: 4.0
Request: 3.2
Require-book: no
Require-note: yes
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11123/

(cherry picked from commit 4857f8c81376247ebf339f6957c487304da2ff02)