### PR TITLE
frontend: add targetQoS for not-yet-flushed tape files

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java
@@ -44,10 +44,7 @@ import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
-
-import org.dcache.cells.CellStub;
-import org.dcache.poolmanager.RemotePoolMonitor;
-
+import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.vehicles.HttpProtocolInfo;
 
 import dmg.cells.nucleus.NoRouteToCellException;
@@ -118,6 +115,10 @@ public class QosManagementNamespace {
                     break;
                 case ONLINE:
                     response.setQoS(QosManagement.DISK);
+                    if (fileAttributes.isDefined(FileAttribute.RETENTION_POLICY)
+                            && fileAttributes.getRetentionPolicy() == RetentionPolicy.CUSTODIAL) {
+                        response.setTargetQoS(QosManagement.TAPE);
+                    }
                     break;
                 case ONLINE_AND_NEARLINE:
                     /* When the locality of the file is  NEARLINE_ONLINE and

--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/namespace/NamespaceUtils.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/util/namespace/NamespaceUtils.java
@@ -7,6 +7,7 @@ import javax.ws.rs.InternalServerErrorException;
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileLocality;
+import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.vehicles.StorageInfo;
 import dmg.cells.nucleus.NoRouteToCellException;
@@ -20,7 +21,6 @@ import org.dcache.restful.providers.JsonFileAttributes;
 import org.dcache.restful.qos.QosManagement;
 import org.dcache.restful.util.ServletContextHandlerAttributes;
 import org.dcache.vehicles.FileAttributes;
-
 /**
  * <p>Utilities for obtaining and returning file attributes and qos
  *    information.</p>
@@ -63,6 +63,10 @@ public final class NamespaceUtils {
 
             case ONLINE:
                 json.setCurrentQos(QosManagement.DISK);
+                if (attributes.isDefined(FileAttribute.RETENTION_POLICY)
+                        && attributes.getRetentionPolicy() == RetentionPolicy.CUSTODIAL) {
+                    json.setTargetQos(QosManagement.TAPE);
+                }
                 break;
 
             case ONLINE_AND_NEARLINE:


### PR DESCRIPTION
Motivation:

dCache (correctly) reports files that should go to tape but not yet
written as QoS 'disk', but does not include that dCache is in the
process of transitioning the QoS to 'tape'.

Therefore, a client that has just written the file into a "tape"
directory will believe the file has QoS "disk"; i.e., an error.

Modification:

Update the QoS reporting so that if the file is currently on disk but
has RetentionPolicy of CUSTODIAL then the targetQoS is recorded as
'tape'.

Result:

Frontend will now report that files written into a directory that
targets 'tape' QoS are in transition to QoS 'tape'.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/11110/
Acked-by: Tigran Mkrtchyan

Conflicts:
	modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagementNamespace.java