### PR TITLE
core: ensure pool/poolmanager communication receives errors

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/PoolManagerStub.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/PoolManagerStub.java
@@ -118,6 +118,7 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
      */
     public <T extends PoolIoFileMessage> ListenableFuture<T> startAsync(CellAddressCore pool, T msg, long timeout)
     {
+        msg.setReplyRequired(true);
         long boundedTimeout = Math.min(timeout, maxPoolTimeoutUnit.toMillis(maxPoolTimeout));
         return handler.startAsync(endpoint, pool, msg, boundedTimeout);
     }
@@ -131,6 +132,7 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
      */
     public <T extends PoolIoFileMessage> ListenableFuture<T> startAsync(CellAddressCore pool, T msg)
     {
+        msg.setReplyRequired(true);
         return handler.startAsync(endpoint, pool, msg, maxPoolTimeoutUnit.toMillis(maxPoolTimeout));
     }
 
@@ -143,6 +145,7 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
      */
     public <T extends PoolManagerMessage> ListenableFuture<T> sendAsync(T msg, long timeout)
     {
+        msg.setReplyRequired(true);
         long boundedTimeout = Math.min(timeout, maxPoolManagerTimeoutUnit.toMillis(maxPoolManagerTimeout));
         return handler.sendAsync(endpoint, msg, boundedTimeout);
     }
@@ -155,6 +158,7 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
      */
     public <T extends PoolManagerMessage> ListenableFuture<T> sendAsync(T msg)
     {
+        msg.setReplyRequired(true);
         return handler.sendAsync(endpoint, msg, maxPoolManagerTimeoutUnit.toMillis(maxPoolManagerTimeout));
     }
 
@@ -170,6 +174,9 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
      */
     public void start(CellAddressCore pool, PoolIoFileMessage msg)
     {
+        // This method is only used by DCapDoorInterpreterV3, which is
+        // expecting a reply.
+        msg.setReplyRequired(true);
         CellMessage envelope = new CellMessage(pool);
         envelope.addSourceAddress(address);
         handler.start(endpoint, envelope, msg);
@@ -186,6 +193,9 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
      */
     public void send(PoolManagerMessage msg)
     {
+        // This method is only used by DCapDoorInterpreterV3, which is
+        // expecting a reply.
+        msg.setReplyRequired(true);
         CellMessage envelope = new CellMessage();
         envelope.addSourceAddress(address);
         handler.send(endpoint, envelope, msg);
@@ -204,6 +214,9 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
      */
     public void send(PoolManagerMessage msg, long timeout)
     {
+        // This method is only used by DCapDoorInterpreterV3, which is
+        // expecting a reply.
+        msg.setReplyRequired(true);
         CellMessage envelope = new CellMessage();
         envelope.addSourceAddress(address);
         envelope.setTtl(timeout);


### PR DESCRIPTION
Motivation:

Commit 0b94ca04 updated the doors to use PoolManagerStub, instead of a
CellStub, when sending messages to pool-manager and pool (when starting
a mover).

Unlike CellStub, the PoolManagerStub neglected to set the reply-required
flag.  This results in some error responses (such as running out of
capacity in a space reservation) being simply being discarded.  The
corresponding transfer then times out with a generic error, rather than
indicating that there was a problem.  Typical error message:

    Request to [>SpaceManager@local ... ] timed out.

Modification:

Update PoolManagerStub so it adds the reply-required flag when accepting
a messages.

Result:

Fix the problem where certain transfer failures, such as attempting to
use a space-reservation that has insufficient capacity, resulted in the
door eventually reporting a time-out problem to the client.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/11105
Acked-by: Albert Rossi