### PR TITLE
webdav: always respond to OPTIONS request

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceHandlerHelper.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceHandlerHelper.java
@@ -50,7 +50,14 @@ public class DcacheResourceHandlerHelper extends ResourceHandlerHelper
             /* Bypass check to see if file exists: our CopyFilter will handle the request */
             handler.processResource(manager, request, response, resource);
         } else if (request.getMethod() == Request.Method.OPTIONS) {
-            Resource resource = manager.getResourceFactory().getResource(host, url);
+            Resource resource;
+            try {
+                resource = manager.getResourceFactory().getResource(host, url);
+            } catch (WebDavException e) {
+                // Treat all errors as if there was no such file.  We should
+                // always provide a successful response to a CORS request.
+                resource = null;
+            }
             if (resource == null) {
                 // Milton ResourceHandlerHelper returns 404 for OPTIONS request
                 // targeting non-existing entity.  This breaks CORS uploads.


### PR DESCRIPTION
Motivation:

Web clients (such as web-browsers) make OPTIONS pre-flight requests to
discover what they are allowed to do, according to the CORS standard.
Such clients will fail the request if the server fails that request.

If the client targets a protected resource then credentials are needed
to discover information about the resource and therefore, to build the
complete OPTIONS response.

Unfortunately, some web-browsers make the OPTIONS request without
presenting any credentials.  If the resource is within a protected
directory then dCache currently fails the OPTIONS request.

Modification:

Update the OPTIONS response so that any error results in the default set
of information.

Result:

Unauthenticated OPTIONS requests will always succeed, allowing
web-browser pre-flight requests to succeed.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11129/
Acked-by: Tigran Mkrtchyan