### PR TITLE
pool: fix NPE on flush

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2014 - 2017 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2014 - 2018 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -826,8 +826,9 @@ public class NearlineStorageHandler
         public FlushRequestImpl(NearlineStorage nearlineStorage, PnfsId pnfsId) throws CacheException, InterruptedException
         {
             super(nearlineStorage);
-            infoMsg = new StorageInfoMessage(cellAddress, pnfsId, false);
             descriptor = repository.openEntry(pnfsId, NO_FLAGS);
+            infoMsg = new StorageInfoMessage(cellAddress, pnfsId, false);
+            infoMsg.setStorageInfo(descriptor.getFileAttributes().getStorageInfo());
             String path = descriptor.getFileAttributes().getStorageInfo().getKey("path");
             if (path != null) {
                 infoMsg.setBillingPath(path);


### PR DESCRIPTION
Motivation:
Due to missing storage info on flush, we get e NPE:

java.lang.NullPointerException
	at org.dcache.notification.StorageInfoMessageSerializer.serialize(StorageInfoMessageSerializer.java:60)
	at org.dcache.notification.StorageInfoMessageSerializer.serialize(StorageInfoMessageSerializer.java:30)
	at org.apache.kafka.common.serialization.ExtendedSerializer$Wrapper.serialize(ExtendedSerializer.java:65)
	at org.apache.kafka.common.serialization.ExtendedSerializer$Wrapper.serialize(ExtendedSerializer.java:55)
	at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:783)
	at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:760)
	at org.springframework.kafka.core.DefaultKafkaProducerFactory$CloseSafeProducer.send(DefaultKafkaProducerFactory.java:260)
	at org.springframework.kafka.core.KafkaTemplate.doSend(KafkaTemplate.java:316)
	at org.springframework.kafka.core.KafkaTemplate.send(KafkaTemplate.java:166)
	at org.springframework.kafka.core.KafkaTemplate.sendDefault(KafkaTemplate.java:145)
	at org.dcache.pool.nearline.NearlineStorageHandler$FlushRequestImpl.done(NearlineStorageHandler.java:1019)
	at org.dcache.pool.nearline.NearlineStorageHandler$FlushRequestImpl.failed(NearlineStorageHandler.java:898)
	at org.dcache.pool.nearline.AbstractBlockingNearlineStorage$Task.run(AbstractBlockingNearlineStorage.java:395)
	at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149)
	at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

Modification:
include storage info into flush message.

Result:
NPE is gone and billing record has the missing info:

08.24 15:24:41 [pool:dcache-lab002-A@dcache-lab002Domain:store] [00006BD12E8925744156AAE87641D4AF73BB,1362] [/] <Unknown> 100013 2 {10006:"Flush was cancelled."}

vs.

8.24 15:51:07 [pool:dcache-lab002-A@dcache-lab002Domain:store] [00005C1387649DD74E0491DFE9A98D97DC39,1362] [/] data:sla2@osm 100015 1 {10006:"Flush was cancelled."}

Acked-by: Paul Millar
Target: master, 4.2, 4.1
Require-book: no
Require-notes: yes
(cherry picked from commit 4e396b92346da9f4a08c78a47e956a7ded05e3f9)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>