### PR TITLE
nfs41: invalidate open-state on layoutget if file is removed

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -54,6 +54,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -88,6 +90,9 @@ import org.dcache.nfs.status.NfsIoException;
 import org.dcache.nfs.status.NoMatchingLayoutException;
 import org.dcache.nfs.status.BadStateidException;
 import org.dcache.nfs.status.ServerFaultException;
+import org.dcache.nfs.status.StaleException;
+import org.dcache.nfs.status.UnknownLayoutTypeException;
+import org.dcache.nfs.status.PermException;
 import org.dcache.nfs.v3.MountServer;
 import org.dcache.nfs.v3.NfsServerV3;
 import org.dcache.nfs.v3.xdr.mount_prot;
@@ -539,6 +544,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         LayoutDriver layoutDriver = getLayoutDriver(layoutType);
 
+        NFS4Client client = null;
         try {
 
             FsInode inode = _chimeraVfs.inodeFromBytes(nfsInode.getFileId());
@@ -549,7 +555,6 @@ public class NFSv41Door extends AbstractCellComponent implements
 
             deviceid4 deviceid;
 
-            final NFS4Client client;
             if (context.getMinorversion() == 0) {
                 /* if we need to run proxy-io with NFSv4.0 */
                 client = context.getStateHandler().getClientIdByStateId(stateid);
@@ -634,6 +639,18 @@ public class NFSv41Door extends AbstractCellComponent implements
 
             return new Layout(true, layoutStateId.stateid(), new layout4[]{layout});
 
+        } catch (FileNotFoundCacheException e) {
+            /*
+             * The file is removed before we was able to start a mover.
+             * Invalidate state as client will not send CLOSE for a stale file
+             * handle.
+             *
+             * NOTICE: according POSIX, the opened file must be still accessible
+             * after remove as long as it not closed. We violate that requirement
+             * in favor of dCache shared state simplicity.
+             */
+            Objects.requireNonNull(client).releaseState(stateid);
+            throw new StaleException("File is removed", e);
         } catch (CacheException | ChimeraFsException | TimeoutException | ExecutionException e) {
             throw asNfsException(e, LayoutTryLaterException.class);
         } catch (InterruptedException e) {


### PR DESCRIPTION
Motivation:
When a file, opened by client-A get delete by client-B before LAYOUTGET
is called, then dCache server puts the transfer record into the list of
active transfers and returns NFS4ERR_NOENT (spec requires NFS4ERR_STALE).
Due to client optimization a corresponding CLOSE is never send and, as a
result, such entries are never removed and stay in the transfer list (a leak!).

Modification:
remove open-state if layoutget fail with FileNotFoundCacheException. Return
NFS4ERR_STALE to the client.

Result:
transfer records for remove files are not accumulated.

Fixes: #4145
Acked-by: Paul Millar
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit 5d4515d87a597fb59fcea4130024319a56a20862)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>