### PR TITLE
nearline-provides: do not interrupt processing thread on cancel

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -504,7 +504,12 @@ public class NearlineStorageHandler
         protected synchronized <T> ListenableFuture<T> register(ListenableFuture<T> future)
         {
             if (state.get() == State.CANCELED) {
-                future.cancel(true);
+                /*
+                 * do not interrupt thread as we don't know how
+                 * it will react on it (BerkeleyDB will require
+                 * to re-open db).
+                 */
+                future.cancel(false);
             } else {
                 asyncTasks.add(future);
             }
@@ -538,7 +543,12 @@ public class NearlineStorageHandler
                 storage.cancel(uuid);
                 synchronized(this) {
                     for (Future<?> task : asyncTasks) {
-                        task.cancel(true);
+                        /*
+                         * do not interrupt thread as we don't know how
+                         * it will react on it (BerkeleyDB will require
+                         * to re-open db).
+                         */
+                        task.cancel(false);
                     }
                 }
             }


### PR DESCRIPTION
Motivation:
When a task in hsm provides provider get canceled due to timeout or an
exception, then we cancel associated Future and allow thread interruption.
However, at that point we have no idea what interrupted thread is doing.
If interruption hits processing thread during BerkeleyDB operation, then
DB environment marked as invalid. This required you that db must closed
and re-open it before using it again.:

27 Aug 2018 12:09:33 (cat2_lhcbtape) [Frontend-dcacheview PoolDataRequest] Fault occurred in repository: Internal repository error. Pool restart required: : CacheExcept
ion(rc=204;msg=Meta data lookup failed and a pool restart is required: (JE 7.3.7) Environment must be closed, caused by: com.sleepycat.je.ThreadInterruptedException: En
vironment invalid because of previous exception: (JE 7.3.7) /space/lhcb/tape/pool/meta java.lang.InterruptedException THREAD_INTERRUPTED: InterruptedException may cause
 incorrect internal state, unable to continue. Environment is invalid and must be closed.)
27 Aug 2018 12:09:33 (cat2_lhcbtape) [Frontend-dcacheview PoolDataRequest] Pool mode changed to disabled(fetch,store,stage,p2p-client,p2p-server,dead): Pool restart req
uired: Internal repository error

Modification:
Do not interrupt thread when canceling nearline task.

Result:
BerkeleyDB survives legal situations, like file removal while being in a
flush queue.

Ticket: #9482, #9401
Acked-by: Paul Millar
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit 5069488e797baeefc139ad9378d4e43391a79372)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>