### PR TITLE
dcache-xrootd: add necessary gsi properties for tpc credentials

### DIFF
--- a/skel/share/defaults/xrootd-gsi.properties
+++ b/skel/share/defaults/xrootd-gsi.properties
@@ -8,6 +8,30 @@ xrootd.gsi.hostcert.cert=${dcache.authn.hostcert.cert}
 xrootd.gsi.hostcert.refresh=${dcache.authn.hostcert.refresh}
 xrootd.gsi.hostcert.refresh.unit=${dcache.authn.hostcert.refresh.unit}
 xrootd.gsi.hostcert.verify=${dcache.authn.hostcert.verify}
+
+##
+#  These properties have to do with the third-party client on the pool.
+#  Currently, its credential defaults to the host credential, but
+#  there may be a need to give it something more specific to the
+#  the organization.  Note:  this is a temporary workaround for
+#  a problem which will be solved in a more general fashion, either
+#  by proxy delegation or by eliminating the server-to-server authentication
+#  requirement.
+##
+xrootd.gsi.tpc.cred.key=${xrootd.gsi.hostcert.key}
+xrootd.gsi.tpc.cred.cert=${xrootd.gsi.hostcert.cert}
+xrootd.gsi.tpc.cred.refresh=${xrootd.gsi.hostcert.refresh}
+xrootd.gsi.tpc.cred.refresh.unit=${xrootd.gsi.hostcert.refresh.unit}
+xrootd.gsi.tpc.cred.verify=${xrootd.gsi.hostcert.verify}
+
+##
+#  A specific proxy credential can be set.  This will override the
+#  use of a proxy automatically generated from the PEM credential
+#  indicated by the key/cert properties above.  The presumption is
+#  that any such externally generated proxy will also be externally refreshed.
+##
+xrootd.gsi.tpc.proxy.path=
+
 xrootd.gsi.ca.path=${dcache.authn.capath}
 xrootd.gsi.ca.refresh=${dcache.authn.capath.refresh}
 xrootd.gsi.ca.refresh.unit=${dcache.authn.capath.refresh.unit}


### PR DESCRIPTION
To support changes to xrootd4j cab10fa67939cd4b16c60f0051304fc91cf64fa8

New properties for the tpc client credential independent from the host credential.

Target: master
Request: 4.2
Acked-by: Dmitry