### PR TITLE
pool: fix NullPointerException

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -101,6 +101,7 @@ import dmg.util.command.Option;
 
 import org.dcache.alarms.AlarmMarkerFactory;
 import org.dcache.alarms.PredefinedAlarm;
+import org.dcache.auth.Subjects;
 import org.dcache.cells.CellStub;
 import org.dcache.cells.MessageReply;
 import org.dcache.pool.FaultEvent;
@@ -663,6 +664,7 @@ public class PoolV4
                     new RemoveFileInfoMessage(getCellAddress(), entry.getPnfsId());
                 msg.setFileSize(entry.getReplicaSize());
                 msg.setStorageInfo(entry.getFileAttributes().getStorageInfo());
+                msg.setSubject(Subjects.ROOT);
                 _billingStub.notify(msg);
 
                 _kafkaSender.accept(msg);

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -90,6 +90,7 @@ import diskCacheV111.util.TimeoutCacheException;
 import diskCacheV111.vehicles.StorageInfo;
 import diskCacheV111.vehicles.StorageInfoMessage;
 
+import org.dcache.auth.Subjects;
 import org.dcache.cells.CellStub;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.pool.PoolDataBeanProvider;
@@ -114,6 +115,7 @@ import org.dcache.pool.repository.StickyChangeEvent;
 import org.dcache.util.CacheExceptionFactory;
 import org.dcache.util.Checksum;
 import org.dcache.vehicles.FileAttributes;
+
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -1106,6 +1108,7 @@ public class NearlineStorageHandler
             infoMsg = new StorageInfoMessage(cellAddress, pnfsId, true);
             infoMsg.setStorageInfo(fileAttributes.getStorageInfo());
             infoMsg.setFileSize(fileAttributes.getSize());
+            infoMsg.setSubject(Subjects.ROOT);
             descriptor =
                     repository.createEntry(
                             fileAttributes,


### PR DESCRIPTION
Motivation

in InfoMessage getSubject() method has been modified in https://rb.dcache.org/r/11080/.

As a result  both in RemoveFileInfoMessageSerializer and StorageInfoMessageSerializer  data.getSubject().getPrincipals() return null.

java.lang.NullPointerException: null
    at org.dcache.notification.RemoveFileInfoMessageSerializer.serialize(RemoveFileInfoMessageSerializer.java:56) ~[dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
    at org.dcache.notification.RemoveFileInfoMessageSerializer.serialize(RemoveFileInfoMessageSerializer.java:32) ~[dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
    at org.apache.kafka.common.serialization.ExtendedSerializer$Wrapper.serialize(ExtendedSerializer.java:65) ~[kafka-clients-1.0.0.jar:na]
    at org.apache.kafka.common.serialization.ExtendedSerializer$Wrapper.serialize(ExtendedSerializer.java:55) ~[kafka-clients-1.0.0.jar:na]
    at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:783) ~[kafka-clients-1.0.0.jar:na]
    at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:760) ~[kafka-clients-1.0.0.jar:na]
    at org.springframework.kafka.core.DefaultKafkaProducerFactory$CloseSafeProducer.send(DefaultKafkaProducerFactory.java:260) ~[spring-kafka-2.1.1.RELEASE.jar:2.1.1.RELEASE]
    at org.springframework.kafka.core.KafkaTemplate.doSend(KafkaTemplate.java:316) ~[spring-kafka-2.1.1.RELEASE.jar:2.1.1.RELEASE]
    at org.springframework.kafka.core.KafkaTemplate.send(KafkaTemplate.java:166) ~[spring-kafka-2.1.1.RELEASE.jar:2.1.1.RELEASE]
    at org.springframework.kafka.core.KafkaTemplate.sendDefault(KafkaTemplate.java:145) ~[spring-kafka-2.1.1.RELEASE.jar:2.1.1.RELEASE]
    at org.dcache.pool.classic.PoolV4$NotifyBillingOnRemoveListener.stateChanged(PoolV4.java:668) ~[dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
    at org.dcache.pool.repository.v5.StateChangeListeners.lambda$stateChanged$0(StateChangeListeners.java:65) ~[dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_111]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_111]
    at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_111]

Modification:

set Subject.ROOT for RemoveFileinfoMessage and  StorageInfoMessage

Target: master
Require-book: no
Require-notes: no
Patch: https://rb.dcache.org/r/11120/
Acted-by: Paul