### PR TITLE
ftp: add kafka to push messages

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -78,6 +78,8 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.net.InetAddresses;
 import com.google.common.primitives.Ints;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -867,6 +869,9 @@ public abstract class AbstractFtpDoorV1
     protected TransferRetryPolicy _readRetryPolicy;
     protected TransferRetryPolicy _writeRetryPolicy;
 
+    protected KafkaProducer _kafkaProducer;
+
+
     /** Tape Protection */
     protected CheckStagePermission _checkStagePermission;
 
@@ -977,6 +982,13 @@ public abstract class AbstractFtpDoorV1
             setPoolManagerStub(_poolManagerStub);
             setPoolStub(AbstractFtpDoorV1.this._poolStub);
             setBillingStub(_billingStub);
+
+            if(_settings.isKafkaEnabled()){
+                setKafkaSender(m -> {
+                    _kafkaProducer.send(new ProducerRecord<String, DoorRequestInfoMessage>("billing", m));
+                });
+            }
+
             setAllocation(_allo);
             setIoQueue(_settings.getIoQueueName());
 
@@ -1465,6 +1477,13 @@ public abstract class AbstractFtpDoorV1
                 : InetAddress.getByName(_settings.getInternalAddress());
 
         _billingStub = _settings.createBillingStub(_cellEndpoint);
+
+        if (_settings.isKafkaEnabled()) {
+            _kafkaProducer = _settings.createKafkaProducer(_settings.getKafkaBootstrapServer(),
+                                                           _settings.getInternalAddress(),
+                                                           _settings.getKafkaMaxBlockMs(),
+                                                           _settings.getKafkaRetries());
+        }
         _poolManagerStub = _settings.createPoolManagerStub(_cellEndpoint, _cellAddress, _poolManagerHandler);
         _poolStub = _settings.createPoolStub(_cellEndpoint);
         _gPlazmaStub = _settings.createGplazmaStub(_cellEndpoint);
@@ -4373,7 +4392,17 @@ public abstract class AbstractFtpDoorV1
         infoRemove.setClient(_clientDataAddress.getAddress().getHostAddress());
 
         _billingStub.notify(infoRemove);
-     }
+
+        if(_settings.isKafkaEnabled()){
+            _kafkaProducer.send(new ProducerRecord<String, DoorRequestInfoMessage>("billing", infoRemove), (rm, e) -> {
+                if (e != null) {
+                    LOGGER.error("Unable to send message to topic {} on  partition {}: {}",
+                            rm.topic(), rm.partition(), e.getMessage());
+                }
+            });
+        }
+
+    }
 
     /** A short format which only includes the file name. */
     static class ShortListPrinter implements DirectoryListPrinter

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -334,3 +334,11 @@ ftp.net.allowed-subnets=${dcache.net.allowed-subnets}
 (forbidden)ftp.authz.upload-directory=See gplazma.authz.upload-directory
 (obsolete)ftp.cell.export = See ftp.cell.consume
 (obsolete)ftp.transaction-log = Use the access log instead
+
+
+#  ---- Kafka service enabled
+#
+(one-of?true|false|${dcache.enable.kafka})ftp.enable.kafka = ${dcache.enable.kafka}
+
+# A list of host/port pairs (brokers) host1:port1,host2:port2,....
+ftp.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}

--- a/skel/share/services/ftp.batch
+++ b/skel/share/services/ftp.batch
@@ -86,6 +86,10 @@ create dmg.cells.services.login.LoginManager ${ftp.cell.name} \
    -brokerPort=${ftp.loginbroker.port} \
    -gplazma=\"${ftp.service.gplazma}\" \
    -billing=\"${ftp.service.billing}\" \
+   -kafka=\"${ftp.enable.kafka}\" \
+   -bootstrap-server-kafka=\"${ftp.kafka.bootstrap-servers}\" \
+   -max-block-ms-kafka=600\
+   -retries-kafka=0 \
    -pnfsManager=\"${ftp.service.pnfsmanager}\" \
    -pnfsTimeout=${ftp.service.pnfsmanager.timeout} \
    -pnfsTimeoutUnit=${ftp.service.pnfsmanager.timeout.unit} \


### PR DESCRIPTION
Motivation

This patch similar to  https://rb.dcache.org/r/10691/  adds possibility to send transfer events from dCache to Kafka.

Modification

ftp.batch:
    add optional switch to enable KafkaProducer
    all necessary properties for Producer (number of retries, bootstrap-servers)

ftp properties:

(one-of?true|false|${dcache.enable.kafka})ftp.enable.kafka =  ${dcache.enable.kafka}
ftp.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}

FtPDoorSettings:
    optional properties used while creating KafkaProducer

AbstractFtpDoorV1:
asynchronious send method sendAsynctoKafka is added.

Target: master
Require-book: no
Require-notes: no
Patch: https://rb.dcache.org/r/11073/
Acted-by: Tigran Mkrtchyan