### PR TITLE
dcache: release dcache-view version 1.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.jetty>9.4.11.v20180605</version.jetty>
         <version.xrootd4j>3.3.0</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.4.3</version.dcache-view>
+        <version.dcache-view>1.4.5</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.4.3 to v1.4.5

[d7e572b](dCache/dcache-view@d7e572b) dcache-view (user-profile): fix gravatar request
[d7e572b](dCache/dcache-view@70d8546) dcache-view (namespace,authentication): fix file download
[d612162](dCache/dcache-view@d612162) dcache-view (authentication): minor fixes in the oic-login-form page
[912173e](dCache/dcache-view@912173e) dcache-view: improve handling of mover kill
[942446c](dCache/dcache-view@942446c) dcache-view (authentication): fix openid connect redirect handling

Request: 4.2
Request: 4.1
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11140/

(cherry picked from commit 779b458844c9f58ff75b4432dfad9727c7cbac27)