### PR TITLE
poolmanager: fix staging files from tape

### DIFF
--- a/modules/dcache-vehicles/src/main/java/org/dcache/poolmanager/SelectedPool.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/poolmanager/SelectedPool.java
@@ -19,6 +19,8 @@
 
 package org.dcache.poolmanager;
 
+import java.io.Serializable;
+
 import dmg.cells.nucleus.CellAddressCore;
 
 import org.dcache.pool.assumption.Assumption;
@@ -32,8 +34,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Encapsulates information about the pool and the assumptions under which
  * the pool was selected.
  */
-public class SelectedPool
+public class SelectedPool implements Serializable
 {
+    private static final long serialVersionUID = 1L;
+
     private final PoolInfo info;
 
     private final Assumption assumption;


### PR DESCRIPTION
Motivation:

dCache currently cannot stage files from tape.

Commit 887d8d5738c switched the staging context to use SelectedPool.
However, since SelectedPool is not Serializable, it is impossible for
poolmanager to reply to the door if the request requires staging a file.

Modification:

Make SelectedPool Serializable.

Result:

It is possible to stage files in dCache.

Target: master
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11122/
Acked-by: Albert Rossi
Acked-by: Dmitry Litvintsev