### PR TITLE
nfs: make timeout of pnfshandler configurable

### DIFF
--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -112,13 +112,16 @@
         </constructor-arg>
     </bean>
 
+    <bean id="pnfs-stub"  class="org.dcache.cells.CellStub">
+        <description>PNFS manager communication stub</description>
+        <property name="destination" value="${nfs.service.pnfsmanager}"/>
+        <property name="timeout" value="${nfs.service.pnfsmanager.timeout}"/>
+        <property name="timeoutUnit" value="${nfs.service.pnfsmanager.timeout.unit}"/>
+    </bean>
+
     <bean id="pnfs" class="diskCacheV111.util.PnfsHandler">
         <description>PNFS manager client module</description>
-        <constructor-arg>
-            <bean class="dmg.cells.nucleus.CellPath">
-                <constructor-arg value="${nfs.service.pnfsmanager}"/>
-            </bean>
-        </constructor-arg>
+        <constructor-arg ref="pnfs-stub"/>
     </bean>
 
     <bean id="login-stub" class="org.dcache.cells.CellStub">

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -128,6 +128,9 @@ nfs.service.gplazma.timeout = 3000
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)nfs.service.gplazma.timeout.unit=MILLISECONDS
 
 nfs.service.pnfsmanager=${dcache.service.pnfsmanager}
+nfs.service.pnfsmanager.timeout = 500
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)nfs.service.pnfsmanager.timeout.unit=MILLISECONDS
+
 nfs.service.billing=${dcache.topic.billing}
 
 #


### PR DESCRIPTION
Motivation:
if for whatever reason a request to PnfsManager get lost nfs door will
retry the request after specified timeout. This is especially desired in
HA deployments, where a second PnfsManager can hadle request if first
one is lost. However, the default timeout of pnfs handler is 30min which
makes nfs operation to stack in such situations.

Modification:
introduce two new properties:

nfs.service.pnfsmanager.timeout
nfs.service.pnfsmanager.timeout.unit

with default value of 500 ms, which is x200 of typical requesr to
PnfsManager.

Result:
nfs door quicker recovers from situations, when a PnfsManager is not
available.

Acked-by: Paul Millar
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: no
(cherry picked from commit 2e81036724319a26011a493288c04117d0b8bb5f)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>