### PR TITLE
ftp: add ability to log client-aborted transfers

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/LineIndentingPrintWriter.java
+++ b/modules/common/src/main/java/org/dcache/util/LineIndentingPrintWriter.java
@@ -1,0 +1,126 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2018 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+import java.io.PrintWriter;
+import java.io.Writer;
+
+/**
+ * An implementation of PrintWriter that indents each line by some prefix.  Any
+ * empty lines are left empty; i.e., there is no indent.
+ */
+public class LineIndentingPrintWriter extends PrintWriter
+{
+    private final String prefix;
+    private boolean isLineStart = true;
+
+    public LineIndentingPrintWriter(Writer inner, String prefix)
+    {
+        super(inner);
+        this.prefix = prefix;
+    }
+
+    @Override
+    public void println()
+    {
+        super.println();
+        isLineStart = true;
+    }
+
+    @Override
+    public void write(int c)
+    {
+        if (c == '\n') {
+            isLineStart = true;
+        } else {
+            if (isLineStart) {
+                isLineStart = false;
+                super.write(prefix);
+            }
+        }
+        super.write(c);
+    }
+
+    @Override
+    public void write(char cbuf[], int off, int len)
+    {
+        int curr = off;
+        int index = indexOf(cbuf, '\n', curr);
+        while (index != -1 && index <= off+len) {
+            if (isLineStart) {
+                isLineStart = false;
+                super.write(prefix, 0, prefix.length());
+            }
+            int count = 1 + index - curr; // +1 to include '\n'
+            super.write(cbuf, curr, count);
+            curr = index+1;
+            index = indexOf(cbuf, '\n', curr);
+            isLineStart = true;
+        }
+
+        if (curr < off+len) {
+            if (isLineStart) {
+                isLineStart = false;
+                super.write(prefix, 0, prefix.length());
+            }
+            super.write(cbuf, curr, off+len-curr);
+        }
+    }
+
+    private int indexOf(char buf[], char c, int off)
+    {
+        for (int i = off; i < buf.length; i++) {
+            if (buf [i] == c) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public void write(String str)
+    {
+        write(str, 0, str.length());
+    }
+
+    @Override
+    public void write(String str, int off, int len)
+    {
+        int curr = off;
+        int index = str.indexOf('\n', curr);
+        while (index != -1 && index <= off+len) {
+            if (isLineStart) {
+                isLineStart = false;
+                super.write(prefix, 0, prefix.length());
+            }
+            int count = 1 + index - curr; // +1 to include '\n'
+            super.write(str, curr, count);
+            curr = index+1;
+            index = str.indexOf('\n', curr);
+            isLineStart = true;
+        }
+
+        if (curr < off+len) {
+            if (isLineStart) {
+                isLineStart = false;
+                super.write(prefix, 0, prefix.length());
+            }
+            super.write(str, curr, off+len-curr);
+        }
+    }
+}

--- a/modules/common/src/main/java/org/dcache/util/TimeUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/TimeUtils.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
@@ -432,6 +433,12 @@ public class TimeUtils
         return appendRelativeTimestamp(new StringBuilder(), when, current);
     }
 
+    public static CharSequence relativeTimestamp(Instant when)
+    {
+        return appendRelativeTimestamp(new StringBuilder(), when.toEpochMilli(),
+                System.currentTimeMillis(), TimeUnitFormat.SHORT);
+    }
+
     /**
      * Append a description of some point in time using some reference point.
      * The appended text is {@code <timestamp> <space> <open-parenth> <integer>
@@ -445,6 +452,12 @@ public class TimeUtils
     public static StringBuilder appendRelativeTimestamp(StringBuilder sb,
             long when, long current)
     {
+        return appendRelativeTimestamp(sb, when, current, TimeUnitFormat.LONG);
+    }
+
+    public static StringBuilder appendRelativeTimestamp(StringBuilder sb,
+            long when, long current, TimeUnitFormat format)
+    {
         checkArgument(when > 0);
         checkArgument(current > 0);
 
@@ -453,7 +466,7 @@ public class TimeUtils
 
         long diff = Math.abs(when - current);
         sb.append(" (");
-        appendDuration(sb, diff, MILLISECONDS, TimeUnitFormat.LONG);
+        appendDuration(sb, diff, MILLISECONDS, format);
         sb.append(' ');
         sb.append(when < current ? "ago" : "in the future");
         sb.append(')');

--- a/modules/common/src/test/java/org/dcache/util/LineIndentingPrintWriterTest.java
+++ b/modules/common/src/test/java/org/dcache/util/LineIndentingPrintWriterTest.java
@@ -1,0 +1,176 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2018 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringWriter;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class LineIndentingPrintWriterTest
+{
+    LineIndentingPrintWriter pw;
+    StringWriter sw;
+
+    @Before
+    public void setup()
+    {
+        sw = new StringWriter();
+        pw = new LineIndentingPrintWriter(sw, "    ");
+    }
+
+    @Test
+    public void shouldIndentWriteString()
+    {
+        pw.write("hello");
+
+        assertThat(sw.toString(), is(equalTo("    hello")));
+    }
+
+    @Test
+    public void shouldIndentWriteWriteString()
+    {
+        pw.write("hello");
+        pw.write(", world");
+
+        assertThat(sw.toString(), is(equalTo("    hello, world")));
+    }
+
+    @Test
+    public void shouldIndentEmbeddedLine()
+    {
+        pw.write("hello\nworld");
+
+        assertThat(sw.toString(), is(equalTo("    hello\n    world")));
+    }
+
+    @Test
+    public void shouldNotIndentEmptyLine()
+    {
+        pw.write("hello\nworld\n");
+
+        assertThat(sw.toString(), is(equalTo("    hello\n    world\n")));
+    }
+
+    @Test
+    public void shouldIndentSubsequentLine()
+    {
+        pw.write("hello\nworld\n");
+        pw.write("There");
+
+        assertThat(sw.toString(), is(equalTo("    hello\n    world\n    There")));
+    }
+
+    @Test
+    public void shouldIndentCharacter()
+    {
+        pw.write('a');
+
+        assertThat(sw.toString(), is(equalTo("    a")));
+    }
+
+    @Test
+    public void shouldAcceptNewlineCharacter()
+    {
+        pw.write('a');
+        pw.write('\n');
+
+        assertThat(sw.toString(), is(equalTo("    a\n")));
+    }
+
+    @Test
+    public void shouldIndentLineAfterNewlineCharacter()
+    {
+        pw.write('a');
+        pw.write('\n');
+        pw.write('b');
+
+        assertThat(sw.toString(), is(equalTo("    a\n    b")));
+    }
+
+    @Test
+    public void shouldSuppressEmptyLineIndent()
+    {
+        pw.write('\n');
+        pw.write('b');
+
+        assertThat(sw.toString(), is(equalTo("\n    b")));
+    }
+
+    @Test
+    public void shouldIndentPartialCharArray()
+    {
+        pw.write("abcd".toCharArray(), 1, 2);
+
+        assertThat(sw.toString(), is(equalTo("    bc")));
+    }
+
+    @Test
+    public void shouldNotIndentPartialCharArrayWithFinalNewline()
+    {
+        pw.write("abcd\nef".toCharArray(), 1, 4);
+
+        assertThat(sw.toString(), is(equalTo("    bcd\n")));
+    }
+
+    @Test
+    public void shouldRememberEmbeddedNewlineWithinPartialCharArray()
+    {
+        pw.write("abcd\nef".toCharArray(), 1, 4);
+        pw.write("test");
+
+        assertThat(sw.toString(), is(equalTo("    bcd\n    test")));
+    }
+
+    @Test
+    public void shouldIndentEmbeddedNewlineWithinPartialCharArray()
+    {
+        pw.write("abcd\nef".toCharArray(), 1, 5);
+
+        assertThat(sw.toString(), is(equalTo("    bcd\n    e")));
+    }
+
+    @Test
+    public void shouldIndentPartialString()
+    {
+        pw.write("world", 1, 2);
+
+        assertThat(sw.toString(), is(equalTo("    or")));
+    }
+
+    @Test
+    public void shouldRememberEmbeddedNewlineWithinPartialString()
+    {
+        pw.write("abcd\nef", 1, 4);
+        pw.write("test");
+
+        assertThat(sw.toString(), is(equalTo("    bcd\n    test")));
+    }
+
+    @Test
+    public void shouldIndentEmbeddedNewlineWithinPartialString()
+    {
+        pw.write("abcd\nef", 1, 5);
+
+        assertThat(sw.toString(), is(equalTo("    bcd\n    e")));
+    }
+}

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -113,6 +113,7 @@ import java.security.Principal;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -215,8 +216,11 @@ import org.dcache.util.CDCExecutorDecorator;
 import org.dcache.util.Checksum;
 import org.dcache.util.ChecksumType;
 import org.dcache.util.Glob;
+import org.dcache.util.LineIndentingPrintWriter;
 import org.dcache.util.NetLoggerBuilder;
 import org.dcache.util.PortRange;
+import org.dcache.util.TimeUtils;
+import org.dcache.util.TimeUtils.TimeUnitFormat;
 import org.dcache.util.Transfer;
 import org.dcache.util.TransferRetryPolicy;
 import org.dcache.util.list.DirectoryEntry;
@@ -238,6 +242,8 @@ import static org.dcache.namespace.FileType.LINK;
 import static org.dcache.util.ByteUnit.MiB;
 import static org.dcache.util.Exceptions.genericCheck;
 import static org.dcache.util.NetLoggerBuilder.Level.INFO;
+import static org.dcache.util.Strings.describe;
+import static org.dcache.util.Strings.describeSize;
 
 @Inherited
 @Retention(RUNTIME)
@@ -258,7 +264,10 @@ enum AnonymousPermission
     ALLOW_ANONYMOUS_USER, FORBID_ANONYMOUS_USER
 }
 
-/** Cancelling a transfer by notification. */
+/**
+ * Cancelling a transfer by some other dCache component.
+ * @see ClientAbortException
+ */
 class CancelledUploadException extends Exception
 {
 }
@@ -300,6 +309,21 @@ class FTPCommandException extends Exception
     }
 }
 
+/**
+ * An FTPCommandException that indicates some request is failing due to the
+ * client's behaviour after making the request.  This is distinct from requests
+ * that fail for dCache-internal reasons, bad syntax, etc.  An example where
+ * ClientAbortException may be used is aborting a transfer due to the client
+ * tearing down the control channel.
+ */
+class ClientAbortException extends FTPCommandException
+{
+    public ClientAbortException(int code, String reply)
+    {
+        super(code, reply);
+    }
+}
+
 public abstract class AbstractFtpDoorV1
         implements LineBasedInterpreter, CellMessageReceiver, CellCommandListener,
         CellInfoProvider, CellMessageSender, CellIdentityAware
@@ -326,6 +350,8 @@ public abstract class AbstractFtpDoorV1
     protected Executor _executor;
     private IdentityResolverFactory _identityResolverFactory;
     private IdentityResolver _identityResolver;
+    private boolean _logAbortedTransfers;
+    private String _clientInfo;
 
     /**
      * Simple class to allow easy accumulation of space usage.
@@ -901,7 +927,9 @@ public abstract class AbstractFtpDoorV1
         private final ProtocolFamily _protocolFamily;
         private final int _version;
         private final CommandRequest _request = AbstractFtpDoorV1.this._currentRequest;
+        private final Instant whenCreated = Instant.now();
 
+        private java.util.Optional<Instant> whenMoverStarted = java.util.Optional.empty();
         private long _offset;
         private long _size;
 
@@ -1183,6 +1211,7 @@ public abstract class AbstractFtpDoorV1
 
             setStatus("Mover " + getPool() + "/" + getMoverId() + ": " +
                       (isWrite() ? "Receiving" : "Sending"));
+            whenMoverStarted = java.util.Optional.of(Instant.now());
 
             reply(_request, "150 Opening BINARY data connection for " + _path);
 
@@ -1252,6 +1281,19 @@ public abstract class AbstractFtpDoorV1
         @Override
         protected synchronized void onFailure(Throwable t)
         {
+            if (_logAbortedTransfers && t instanceof ClientAbortException) {
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new LineIndentingPrintWriter(sw, "    ");
+                pw.println("Control channel: remote " + describe(_remoteSocketAddress) + "; local " + describe(_localSocketAddress));
+                if (_clientInfo != null) {
+                    pw.println("Client info: " + _clientInfo);
+                }
+                getInfo(pw);
+                String info = sw.toString();
+                _log.warn("Client aborted transfer, details follow:\n{}",
+                        info.substring(0, info.length()-1)); // remove trailing '\n'
+            }
+
             if (_perfMarkerTask != null) {
                 _perfMarkerTask.stop();
             }
@@ -1318,18 +1360,52 @@ public abstract class AbstractFtpDoorV1
 
         public void getInfo(PrintWriter pw)
         {
-            pw.println( "  Data channel  : " + _mode + "; mode " + _xferMode + "; " + _parallel + " streams");
-            PerfMarkerTask perfMarkerTask = _perfMarkerTask;
+            pw.println("Transaction: " + getTransaction());
+            pw.println("Transfer command: " + _request);
+            pw.println("Transfer direction: " + (isWrite() ? "UPLOAD" : "DOWNLOAD"));
+            pw.println("Transfer started: " + TimeUtils.relativeTimestamp(whenCreated));
+            pw.println("Mover started: " + whenMoverStarted.map(TimeUtils::relativeTimestamp).orElse("not started"));
+            String dataChannel = _mode + "; mode " + _xferMode + "; ";
+            if (_mode == Mode.ACTIVE) {
+                // _parallel only has an effect if the pool is active and is not using a proxy.
+                dataChannel = dataChannel + _parallel + " stream" + (_parallel == 1 ? "" : "s") + "; connecting to";
+            } else {
+                dataChannel = dataChannel + "expecting connections from";
+            }
+            pw.println("Data channel: " + dataChannel + " " + describe(_client));
+            String pool = getPool();
+            if (pool != null) {
+                pw.println("Pool: " + pool);
+            }
+            Integer moverId = getMoverId();
+            if (moverId != null) {
+                pw.println("Mover ID: " + moverId);
+            }
+            String status = getStatus();
+            if (status != null) {
+                pw.println("Transfer status: " + status);
+            }
+            pw.println("Protocol version: " + _version);
+            if (_mode == Mode.PASSIVE) {
+                pw.println("IP family: " + _protocolFamily);
+                if (_delayedPassive != DelayedPassiveReply.NONE) {
+                    pw.println("Delayed passive: " + _delayedPassive);
+                }
+            }
+
             FileAttributes fileAttributes = getFileAttributes();
             if (fileAttributes.isDefined(SIZE)) {
-                pw.println("     File size  : " + fileAttributes.getSize());
+                pw.println("File size: " + describeSize(fileAttributes.getSize()));
             }
             if (!isWrite() && _size > -1 && _offset > -1) {
-                pw.println("  File segment  : " + _offset + '-' + (_offset + _size));
+                pw.println("File segment: " + _offset + '-' + (_offset + _size));
             }
-            if (perfMarkerTask != null) {
-                pw.println("   Transferred  : " + perfMarkerTask.getBytesTransferred());
+
+            if (_perfMarkerTask != null) {
+                pw.println("Performance markers:");
+                _perfMarkerTask.getInfo(new LineIndentingPrintWriter(pw, "    "));
             }
+
             ProxyAdapter adapter = _adapter;
             if (adapter != null) {
                 pw.println("         Proxy  : " + adapter);
@@ -1456,6 +1532,8 @@ public abstract class AbstractFtpDoorV1
         if (_settings.getPerformanceMarkerPeriod() > 0) {
             _performanceMarkerPeriod = _settings.getPerformanceMarkerPeriodUnit().toMillis(_settings.getPerformanceMarkerPeriod());
         }
+
+        _logAbortedTransfers = _settings.logAbortedTransfers();
 
         _clientDataAddress =
             new InetSocketAddress(_remoteSocketAddress.getAddress(), DEFAULT_DATA_PORT);
@@ -1637,7 +1715,7 @@ public abstract class AbstractFtpDoorV1
          */
         Transfer transfer = getTransfer();
         if (transfer instanceof FtpTransfer) {
-            ((FtpTransfer)transfer).abort(451, "Aborting transfer due to session termination");
+            ((FtpTransfer)transfer).abort(new ClientAbortException(451, "Aborting transfer due to session termination"));
         }
 
         closePassiveModeServerSocket();
@@ -1685,6 +1763,10 @@ public abstract class AbstractFtpDoorV1
         String user = getUser();
         if (user != null) {
             pw.println("          User  : " + user);
+        }
+        pw.println("Control channel : remote " + describe(_remoteSocketAddress) + "; local " + describe(_localSocketAddress));
+        if (_clientInfo != null) {
+            pw.println("   Client info  : " + _clientInfo);
         }
         pw.println("    Local Host  : " + _internalInetAddress);
         pw.println("  Last Command  : " + _lastCommand);
@@ -3030,6 +3112,8 @@ public abstract class AbstractFtpDoorV1
     public void doClientinfo(String description)
     {
         LOGGER.debug("client-info: {}", description);
+        _clientInfo = description;
+
         Map<String,String> items = splitToMap(description);
 
         // If items.get("appname") is "globusonline-fxp" then client is the
@@ -3976,7 +4060,7 @@ public abstract class AbstractFtpDoorV1
 
         Transfer transfer = getTransfer();
         if (transfer instanceof FtpTransfer) {
-            ((FtpTransfer)transfer).abort(426, "Transfer aborted");
+            ((FtpTransfer)transfer).abort(new ClientAbortException(426, "Transfer aborted"));
         }
         closeDataSocket();
         reply("226 Abort successful");
@@ -4012,6 +4096,13 @@ public abstract class AbstractFtpDoorV1
         private final CommandRequest _request;
         private final CDC _cdc;
         private boolean _stopped;
+        private int _markerSendCount;
+        private java.util.Optional<Instant> _lastMarkerSent = java.util.Optional.empty();
+        private int _querySendCount;
+        private int _queryFailCount;
+        private String _lastQueryErrorMessage;
+        private java.util.Optional<Instant> _lastQueryError = java.util.Optional.empty();
+        private java.util.Optional<Instant> _lastQuerySent = java.util.Optional.empty();
 
         public PerfMarkerTask(CommandRequest request, CellAddressCore pool, int moverId, long timeout)
         {
@@ -4066,7 +4157,15 @@ public abstract class AbstractFtpDoorV1
         {
             if (!_stopped) {
                 reply(_request, _perfMarkersBlock.markers(0).getReply());
+                _lastMarkerSent = java.util.Optional.of(Instant.now());
+                _markerSendCount++;
             }
+        }
+
+        private void recordQueryError(String message)
+        {
+            _lastQueryErrorMessage = message;
+            _lastQueryError = java.util.Optional.of(Instant.now());
         }
 
         protected synchronized void setProgressInfo(long bytes, long timeStamp)
@@ -4086,12 +4185,16 @@ public abstract class AbstractFtpDoorV1
             try (CDC ignored = _cdc.restore()) {
                 CellMessage msg = new CellMessage(_pool, "mover ls -binary " + _moverId);
                 _cellEndpoint.sendMessage(msg, this, _executor, _timeout);
+                _lastQuerySent = java.util.Optional.of(Instant.now());
+                _querySendCount++;
             }
         }
 
         @Override
         public synchronized void exceptionArrived(CellMessage request, Exception exception)
         {
+            _queryFailCount++;
+            recordQueryError("Received exception: " + exception);
             if (exception instanceof NoRouteToCellException) {
                 /* Seems we lost connectivity to the pool. This is
                  * not fatal, but we send a new marker to the
@@ -4108,6 +4211,8 @@ public abstract class AbstractFtpDoorV1
         public synchronized void answerTimedOut(CellMessage request)
         {
             sendMarker();
+            _queryFailCount++;
+            recordQueryError("Answer timed out");
         }
 
         @Override
@@ -4127,29 +4232,63 @@ public abstract class AbstractFtpDoorV1
                     sendMarker();
                 } else if (status.equals("K") || status.equals("R")) {
                     // "Killed" or "Removed" job
+                    _queryFailCount++;
+                    recordQueryError("Mover has status " + status);
                 } else if (status.equals("W") || status.equals("QUEUED")) {
                     sendMarker();
                 } else {
                     LOGGER.error("Performance marker engine received unexcepted status from mover: {}",
                             status);
+                    _queryFailCount++;
+                    recordQueryError("Mover has unknown status " + status);
                 }
             } else if (msg instanceof Exception) {
                 LOGGER.warn("Performance marker engine: {}",
                         ((Exception) msg).getMessage());
+                _queryFailCount++;
+                recordQueryError("Pool responded exceptionally: " + msg);
             } else if (msg instanceof String) {
                 /* Typically this is just an error message saying the
                  * mover is gone.
                  */
                 LOGGER.info("Performance marker engine: {}", msg);
+                _queryFailCount++;
+                recordQueryError("Pool responded with message \"" + msg + "\"");
             } else {
                 LOGGER.error("Performance marker engine: {}",
                         msg.getClass().getName());
+                _queryFailCount++;
+                recordQueryError("Unexpected pool responded: " + msg);
             }
         }
 
         public long getBytesTransferred()
         {
             return _perfMarkersBlock.getBytesTransferred();
+        }
+
+        public void getInfo(PrintWriter pw)
+        {
+            pw.println("Status: " + (_stopped ? "stopped" : "active"));
+            CharSequence period = TimeUtils.duration(_performanceMarkerPeriod, TimeUnit.MILLISECONDS, TimeUnitFormat.SHORT);
+            pw.println("Period: " + _performanceMarkerPeriod + " ms (" + period + ")");
+            pw.println("Mover status queries:");
+            pw.println("    Sent: " + _querySendCount);
+            if (_querySendCount > 0) {
+                pw.println("    Last sent: " + describe(_lastQuerySent));
+            }
+            if (_queryFailCount > 0) {
+                pw.println("    Failures: " + _queryFailCount);
+                pw.println("    Last failure: " + describe(_lastQueryError)
+                        + " " + _lastQueryErrorMessage);
+            }
+            pw.println("Markers sent to client:");
+            pw.println("    Sent: " + _markerSendCount);
+            if (_markerSendCount > 0) {
+                pw.println("    Last sent: " + describe(_lastMarkerSent));
+            }
+            pw.println("Latest marker information:");
+            _perfMarkersBlock.getInfo(new LineIndentingPrintWriter(pw, "    "));
         }
     }
 

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpDoorSettings.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpDoorSettings.java
@@ -189,6 +189,11 @@ public class FtpDoorSettings
             description = "Root path")
     protected String root;
 
+    @Option(name = "log-aborted-transfers",
+            description = "If enabled, the state of a transfer is logged when the client aborts.",
+            defaultValue = "false")
+    protected boolean logAbortedTransfers;
+
     public PortRange getPortRange()
     {
         return portRange;
@@ -202,6 +207,11 @@ public class FtpDoorSettings
     public boolean isReadOnly()
     {
         return readOnly;
+    }
+
+    public boolean logAbortedTransfers()
+    {
+        return logAbortedTransfers;
     }
 
     public int getMaxRetries()

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GFtpPerfMarkersBlock.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GFtpPerfMarkersBlock.java
@@ -68,6 +68,10 @@ COPYRIGHT STATUS:
 
 package org.dcache.ftp.door;
 
+import java.io.PrintWriter;
+
+import org.dcache.util.LineIndentingPrintWriter;
+
 /**
  * <p>Title: GFtpPerfMarkersBlock</p>
  * <p>Description: Block of GridFtp Performance Markers</p>
@@ -159,5 +163,20 @@ public class GFtpPerfMarkersBlock {
             sum += marker.getstripeBytesTransferred();
         }
         return sum;
+    }
+
+    public void getInfo(PrintWriter pw)
+    {
+        if (getLength() == 1) {
+            markers[0].getInfo(pw);
+        } else {
+            pw.println("Total transferred: " + getBytesTransferred() + " bytes");
+            if (markers != null) {
+                for (GFtpPerfMarker marker : markers) {
+                    pw.println("Stripe: " + marker.getStripeIndex());
+                    marker.getInfo(new LineIndentingPrintWriter(pw, "    "));
+                }
+            }
+        }
     }
 }

--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -26,6 +26,7 @@ dcache.default-retention-policy=REPLICA
 frontend.static!dcache-view.endpoints.webdav = https://localhost:2881/
 webdav.allowed.client.origins = http://localhost:3880, https://localhost:3881
 
+ftp.enable.log-aborted-transfers = true
 
 hsqldb.path=${system-test.home}/var/db
 

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -74,6 +74,20 @@ ftp.authz.staging=${dcache.authz.staging}
 (one-of?true|false)ftp.authz.readonly.gsi=false
 (one-of?true|false)ftp.authz.readonly.kerberos=false
 
+#  ---- Log aborted transfers
+#
+#  Under normal circumstances, when a file transfer is requested, the
+#  requesting client will wait until that transfer completes (either
+#  successfully or otherwise).  The client may abort the transfer,
+#  which may indicate that the client believes there is some problem
+#  with the transfer (e.g., a lack of progress).
+#
+#  If this option is enabled and a client aborts a transfer then
+#  dCache will log internal status of that transfer, which may yield a
+#  clue on what triggered the problem.
+#
+(one-of?true|false)ftp.enable.log-aborted-transfers = false
+
 #  ---- Root path of FTP door
 #
 #   Specifies the root directory exposed through the FTP door.

--- a/skel/share/services/ftp.batch
+++ b/skel/share/services/ftp.batch
@@ -57,6 +57,7 @@ check ftp.net.listen
 check ftp.net.internal
 check ftp.mover.queue
 check ftp.root
+check -strong ftp.enable.log-aborted-transfers
 
 exec file:${dcache.paths.share}/cells/stage.fragment ftp doors
 
@@ -122,4 +123,5 @@ create dmg.cells.services.login.LoginManager ${ftp.cell.name} \
    -key-cache-lifetime=\"${ftp.authn.gsi.delegation.cache.lifetime}\" \
    -key-cache-lifetime-unit=\"${ftp.authn.gsi.delegation.cache.lifetime.unit}\" \
    -netmask=\"${ftp.net.allowed-subnets}\" \
+   -log-aborted-transfers=${ftp.enable.log-aborted-transfers} \
    "


### PR DESCRIPTION
Motivation:

We are observing many complaints of aborted transfers.  Unfortunately,
dCache provides insufficient information to allow detailed post-mortem
analysis of why the transfer failed.

Modification:

Add a subclass of FTPException to identify when the client has aborted a
transfer.  This allows us to distinguish between transfers that fail for
some other reason (e.g., permission denied, insufficient capacity).

Add the 'ftp.enable.log-aborted-transfers' dCache configuration option
to control whether client-aborted transfers are logged.

Note that this patch disables this logging by default.  This is to
facilitate back-porting to supported branches; however, I am inclined to
enable this logging by default on master as such transfer cancellations
are almost always a cause for concern and, by logging this information,
a post-mortem may be able to deduce whether dCache (or the other party)
is to blame.

Support in AbstractFTPDoor to log the current status of the transfer,
triggered by the client aborting the transfer.  This includes collecting
some additional (potentially useful) information.

Some ancillary changes to support production of readable output.

Result:

dCache now has the ability to log the current status of a transfer at
the point the client decided to abort an FTP transfer.  This should
support a post mortem investigation on why a transfer was cancelled.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/11124/
Acked-by: Tigran Mkrtchyan