### PR TITLE
frontend: fix broken directory qos reporting

### DIFF
--- a/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
+++ b/modules/dcache-restful-api/src/main/java/org/dcache/restful/qos/QosManagement.java
@@ -16,6 +16,7 @@ import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.core.MediaType;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -37,6 +38,7 @@ public class QosManagement {
     public static final String DISK = "disk";
     public static final String TAPE = "tape";
     public static final String DISK_TAPE = "disk+tape";
+    public static final String VOLATILE = "volatile";
     public static final String UNAVAILABLE = "unavailable";
 
     public static List<String> cdmi_geographic_placement_provided = Arrays.asList("DE");
@@ -66,21 +68,15 @@ public class QosManagement {
 
             // query the lis of available QoS for file objects
             if ("file".equals(qosValue)) {
-
-                JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE, DISK_TAPE));
+                JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE, DISK_TAPE, VOLATILE));
                 json.put("name", list);
-
             }
             // query the lis of available QoS for directory objects
             else if ("directory".equals(qosValue.trim())) {
-
-                JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE));
+                JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE, DISK_TAPE, VOLATILE));
                 json.put("name", list);
-
-
             } else {
                 throw new NotFoundException();
-
             }
 
             json.put("status", "200");
@@ -148,6 +144,10 @@ public class QosManagement {
                 setBackendCapability(backendCapability, DISK_TAPE, Arrays.asList(TAPE), qoSMetadata);
 
             }
+            else if (VOLATILE.equals(qosValue)) {
+                QoSMetadata qoSMetadata = new QoSMetadata("0", cdmi_geographic_placement_provided, "100");
+                setBackendCapability(backendCapability, VOLATILE, Arrays.asList(DISK), qoSMetadata);
+            }
             // The QoS is not known or supported.
             else {
                 throw new NotFoundException();
@@ -207,6 +207,15 @@ public class QosManagement {
 
                 QoSMetadata qoSMetadata = new QoSMetadata("1", cdmi_geographic_placement_provided, "600000");
                 setBackendCapability(backendCapability, TAPE, Arrays.asList(DISK), qoSMetadata);
+            }
+            // Set data and metadata for "Disk & TAPE" QoS
+            else if (DISK_TAPE.equals(qosValue)) {
+                QoSMetadata qoSMetadata = new QoSMetadata("2", cdmi_geographic_placement_provided, "100");
+                setBackendCapability(backendCapability, DISK_TAPE, Collections.emptyList(), qoSMetadata);
+            }
+            else if (VOLATILE.equals(qosValue)) {
+                QoSMetadata qoSMetadata = new QoSMetadata("0", cdmi_geographic_placement_provided, "100");
+                setBackendCapability(backendCapability, VOLATILE, Collections.emptyList(), qoSMetadata);
             }
             // The QoS is not known or supported.
             else {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/StickyRecord.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/StickyRecord.java
@@ -30,7 +30,7 @@ public class StickyRecord implements Serializable {
 		return isNonExpiring() || _expire > time;
 	}
 
-	private boolean isNonExpiring()
+	public boolean isNonExpiring()
 	{
 	    return _expire == NON_EXPIRING;
 	}


### PR DESCRIPTION
Motivation:

The frontend can report back to a client which QoS a file will recieve
when uploaded into a specific directory.  This calculation is wrong.

Modification:

Update the frontend to use the actual policy class that the pool
(likely) uses, when calculating the QoS of a directory.

(Unfortunately, there is insufficient information to determine exactly
with which policy a file will be written; therefore, the output may
deviate from reality if a new file is accepted by a volatile pool (one
that has lsf mode precious).  That said, this patch provides a much
better description.)

Update the hard-coded metadata to include the new file QoS (volatile)
and the new directory QoS (disk+tape and volatile).

Result:

Frontend now more accurately describes the QoS of directories; i.e., the
QoS that newly written files will recieve when written into this
directory, assuming none of the targeted pools are volatile.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11165
Acked-by: Albert Rossi

Conflicts:
	modules/dcache-restful-api/src/main/java/org/dcache/restful/util/namespace/NamespaceUtils.java