### PR TITLE
DO NOT MERGE pool: instrument ftp mover to show partial transfers

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/data/BlockLog.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/data/BlockLog.java
@@ -1,8 +1,14 @@
 package org.dcache.ftp.data;
 
+import java.io.PrintWriter;
 import java.text.MessageFormat;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.dcache.util.Strings.humanReadableSize;
 
 /**
  * A log of transferred blocks. Adjacent blocks are merged, so for a
@@ -196,5 +202,25 @@ public class BlockLog
     {
         _limit = limit;
         notifyAll();
+    }
+
+    private Function<Map.Entry<Long,Long>,String> asHumanReadable()
+    {
+        if (_blocks.size() <= 1) {
+            return e -> humanReadableSize(e.getKey()) + "--" + humanReadableSize(e.getValue());
+        } else {
+            return e -> humanReadableSize(e.getKey()) + "--" + humanReadableSize(e.getValue())
+                        + " (" + humanReadableSize(e.getValue() - e.getKey()) + ")";
+        }
+    }
+
+    public synchronized void getInfo(PrintWriter pw)
+    {
+        pw.println("Transferred blocks: " + _blocks.entrySet().stream()
+                .map(e -> e.getKey() + "--" + e.getValue())
+                .collect(Collectors.joining(", ")));
+        pw.println("Transferred blocks: " + _blocks.entrySet().stream()
+                .map(asHumanReadable())
+                .collect(Collectors.joining(", ")));
     }
 }

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GFtpPerfMarker.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GFtpPerfMarker.java
@@ -240,10 +240,7 @@ public class GFtpPerfMarker {
         pw.println("Last updated: " + describe(lastUpdated()));
         SummaryStatistics bandwidth = getBandwidthStatistics();
         if (bandwidth.getN() > 0) {
-            pw.println("Bandwidth:"
-                    + " min. " + describeBandwidth(bandwidth.getMin())
-                    + ", mean " + describeBandwidthMean(bandwidth)
-                    + ", max. " + describeBandwidth(bandwidth.getMax()));
+            pw.println("Bandwidth: " + describeBandwidth(bandwidth));
         }
         Optional<Instant> stall = stalledSince();
         if (stall.isPresent()) {

--- a/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.BindException;
 import java.net.ConnectException;
 import java.net.InetAddress;
@@ -18,7 +20,9 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.FileSystems;
+import java.time.Instant;
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -46,16 +50,20 @@ import org.dcache.ftp.data.Role;
 import org.dcache.pool.repository.FileStore;
 import org.dcache.pool.repository.FileRepositoryChannel;
 import org.dcache.pool.repository.RepositoryChannel;
+import org.dcache.pool.statistics.IoStatisticsChannel;
 import org.dcache.util.Args;
 import org.dcache.util.Checksum;
 import org.dcache.util.ChecksumType;
+import org.dcache.util.LineIndentingPrintWriter;
 import org.dcache.util.NetworkUtils;
 import org.dcache.util.PortRange;
+import org.dcache.util.TimeUtils;
 import org.dcache.vehicles.FileAttributes;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static org.dcache.util.ByteUnit.*;
+import static org.dcache.util.Strings.*;
 
 /**
  * FTP mover. Supports both mover protocols GFtp/1 and GFtp/2.
@@ -141,6 +149,12 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
     protected final PortRange _portRange;
 
     /**
+     * Whether this mover instance should log statistics if the transfer is
+     * incomplete.
+     */
+    private final boolean _logAbortedTransfer;
+
+    /**
      * The chunk size used when transferring files.
      *
      * Large blocks will reduce the overhead. However, it case of
@@ -163,6 +177,8 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
      */
     protected boolean      _inProgress;
 
+    private Mode _mode;
+
     public GFtpProtocol_2_nio(CellEndpoint cell)
     {
         _cell = cell;
@@ -173,6 +189,9 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         } else {
             _portRange = new PortRange(0);
         }
+
+        String logAbortedTransfers = System.getProperty("org.dcache.ftp.log-aborted-transfers");
+        _logAbortedTransfer = Boolean.valueOf(logAbortedTransfers);
     }
 
     /**
@@ -216,7 +235,6 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         _role             = role;
         _bytesTransferred = 0;
         _blockLog         = new BlockLog();
-        _fileChannel      = fileChannel;
         _status           = "None";
 
         /* Startup the transfer. The transfer is performed on a single
@@ -272,7 +290,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
 
         /* Check that we receive the whole file.
          */
-        if (!_blockLog.isComplete()) {
+        if (_role == Role.Receiver && !(_blockLog.isComplete() && mode.hasCompletedSuccessfully())) {
             throw new CacheException(44, "Incomplete file detected");
         }
     }
@@ -322,6 +340,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         long   size        = gftpProtocolInfo.getSize();
         boolean passive    = gftpProtocolInfo.getPassive() && _allowPassivePool;
         ProtocolFamily protocolFamily = gftpProtocolInfo.getProtocolFamily();
+        _fileChannel = fileChannel;
 
         _log.debug("version={}, role={}, mode={}, host={} buffer={}, passive={}, parallelism={}",
                   version, role, gftpProtocolInfo.getMode(),
@@ -344,6 +363,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         _lastTransferred  = _transferStarted;
 
         Mode mode = createMode(gftpProtocolInfo.getMode(), role, fileChannel);
+        _mode = mode;
         mode.setBufferSize(bufferSize);
 
         /* For GFtp/2, the FTP door expects a
@@ -454,6 +474,14 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         try {
             transfer(fileChannel, role, mode);
         } finally {
+            if (_logAbortedTransfer && (!_blockLog.isComplete() || !mode.hasCompletedSuccessfully() || _bytesTransferred < mode.getSize())) {
+                StringWriter sw = new StringWriter();
+                getInfo(new LineIndentingPrintWriter(sw, "    "));
+                String info = sw.toString();
+                _log.warn("Incomplete transfer; details follow:\n{}",
+                        info.substring(0, info.length()-1)); // Strip final '\n'
+            }
+
             /* Log some useful information about the transfer. This
              * will be send back to the door by the pool cell.
              */
@@ -461,9 +489,40 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
             gftpProtocolInfo.setTransferTime(getTransferTime());
             if (passive) {
                 gftpProtocolInfo.setSocketAddress(
-                        Iterables.getFirst(mode.getRemoteAddresses(), gftpProtocolInfo.getSocketAddress()));
+                        Iterables.getFirst(_mode.getRemoteAddresses(), gftpProtocolInfo.getSocketAddress()));
             }
         }
+    }
+
+    public void getInfo(PrintWriter pw)
+    {
+        pw.println("Direction: " + (_role == Role.Receiver ? "UPLOAD" : "DOWNLOAD"));
+        pw.println("Mode: " + _mode.name());
+        _mode.getInfo(new LineIndentingPrintWriter(pw, "    "));
+        if (_role == Role.Sender) {
+            try {
+                long fileSize = _fileChannel.size();
+                pw.println("File size: " + describeSize(fileSize));
+                String percent = toThreeSigFig(100 * _bytesTransferred / (double)fileSize, 1000);
+                pw.println("Transferred: " + describeSize(_bytesTransferred) + " (" + percent + "% of file)");
+            } catch (IOException e) {
+                pw.println("Transferred: " + describeSize(_bytesTransferred));
+            }
+        } else {
+            pw.println("Transferred: " + describeSize(_bytesTransferred));
+        }
+        Optional<Instant> started = _transferStarted == 0
+                ? Optional.empty()
+                : Optional.of(Instant.ofEpochMilli(_transferStarted));
+        pw.println("Mover started: " + describe(started));
+        Optional<Instant> lastTransferred = _lastTransferred == _transferStarted
+                ? Optional.empty()
+                : Optional.of(Instant.ofEpochMilli(_lastTransferred));
+        pw.println("Last " + (_role == Role.Receiver ? "received" : "sent")
+                + " data: " + describe(lastTransferred));
+        _fileChannel.optionallyAs(IoStatisticsChannel.class)
+                .ifPresent(c -> c.getInfo(pw));
+        _blockLog.getInfo(pw);
     }
 
     /** Part of the MoverProtocol interface. */

--- a/modules/dcache/src/main/java/org/dcache/pool/statistics/DirectedIoStatistics.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/statistics/DirectedIoStatistics.java
@@ -17,7 +17,12 @@
  */
 package org.dcache.pool.statistics;
 
+import java.io.PrintWriter;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.dcache.util.TimeUtils.describe;
 
 
 /**
@@ -29,19 +34,26 @@ public class DirectedIoStatistics
     private final SnapshotStatistics _statistics;
     private final Duration _idle;
     private final Duration _active;
+    private final Instant _firstAccess;
+    private final Instant _latestAccess;
 
     public DirectedIoStatistics()
     {
         _idle = Duration.ZERO;
         _active = Duration.ZERO;
+        _firstAccess = null;
+        _latestAccess = null;
         _statistics = new SnapshotStatistics();
     }
 
     public DirectedIoStatistics(Duration idle, Duration active,
+            Instant firstAccess, Instant latestAccess,
             LiveStatistics statistics)
     {
         _idle = idle;
         _active = active;
+        _firstAccess = firstAccess;
+        _latestAccess = latestAccess;
         _statistics = statistics.snapshot();
     }
 
@@ -68,5 +80,14 @@ public class DirectedIoStatistics
     public Duration active()
     {
         return _active;
+    }
+
+    public void getInfo(PrintWriter pw)
+    {
+        pw.println("First request: " + org.dcache.util.Strings.describe(Optional.ofNullable(_firstAccess)));
+        pw.println("Latest request: " + org.dcache.util.Strings.describe(Optional.ofNullable(_latestAccess)));
+        pw.println("Active: " + describe(_active).orElse("never active"));
+        pw.println("Idle: " + describe(_idle).orElse("never idle"));
+        _statistics.getInfo(pw);
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/statistics/SnapshotStatistics.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/statistics/SnapshotStatistics.java
@@ -20,6 +20,14 @@ package org.dcache.pool.statistics;
 import org.apache.commons.math3.stat.descriptive.StatisticalSummary;
 import org.apache.commons.math3.stat.descriptive.StatisticalSummaryValues;
 
+import java.io.PrintWriter;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.dcache.util.Strings.describeBandwidth;
+import static org.dcache.util.Strings.describeInteger;
+import static org.dcache.util.Strings.describeSize;
+import static org.dcache.util.TimeUtils.describeDuration;
+
 /**
  * Provides a snapshot of the information maintained within LiveStatistics.
  * This class makes use of Apache Commons Math StatisticalSummary class to hold
@@ -103,5 +111,24 @@ public class SnapshotStatistics
     public StatisticalSummary IOTime()
     {
         return _duration;
+    }
+
+    public void getInfo(PrintWriter pw)
+    {
+        if (_instantaneousBandwidth.getN() > 0) {
+            pw.println("Instantaneous bandwidth: " + describeBandwidth(_instantaneousBandwidth));
+        }
+        if (_duration.getN() > 0) {
+            pw.println("IO wait time: " + describeDuration(_duration, NANOSECONDS));
+        }
+        if (_requestedBytes.getN() > 0) {
+            pw.println("IO requested size: " + describeSize(_requestedBytes));
+        }
+        if (_transferredBytes.getN() > 0) {
+            pw.println("IO transferred size: " + describeSize(_transferredBytes));
+        }
+        if (_concurrency.getN() > 0) {
+            pw.println("Concurrency: " + describeInteger(_concurrency));
+        }
     }
 }

--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -27,6 +27,7 @@ frontend.static!dcache-view.endpoints.webdav = https://localhost:2881/
 webdav.allowed.client.origins = http://localhost:3880, https://localhost:3881
 
 ftp.enable.log-aborted-transfers = true
+pool.mover.ftp.enable.log-aborted-transfers = true
 
 hsqldb.path=${system-test.home}/var/db
 

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -181,6 +181,7 @@ dcache.log.resilience.max-history=30
     -Dsun.net.inetaddr.ttl=${dcache.net.inetaddr.lifetime} \
     -Dorg.globus.tcp.port.range=${dcache.net.wan.port.min},${dcache.net.wan.port.max} \
     -Dorg.dcache.dcap.port=${pool.mover.dcap.port} \
+    -Dorg.dcache.ftp.log-aborted-transfers=${pool.mover.ftp.enable.log-aborted-transfers} \
     -Dorg.dcache.net.tcp.portrange=${dcache.net.lan.port.min}:${dcache.net.lan.port.max} \
     -Djava.security.krb5.realm=${dcache.authn.kerberos.realm} \
     -Djava.security.krb5.kdc=${dcache.authn.kerberos.key-distribution-center-list} \

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -245,6 +245,29 @@ pool.mover.dcap.port = 0
 #
 (one-of?true|false)pool.mover.ftp.mmap = false
 
+
+#  ----- Whether to log incomplete transfers
+#
+#   The following property controls whether the FTP mover will log
+#   statistics about transfers aborted by the client.  This mover is
+#   responsible for direct uploads and downloads, and for third-party
+#   transfers initiated with the FTP protocol.
+#
+#   It is not always possible for the pool to detect incomplete
+#   transfers; for example, if the transfer uses mode S and dCache
+#   accepts data then the pool cannot know if that transfer is
+#   incomplete.  The pool can detect incomplete transfers if dCache is
+#   supplying data, or if the transfer uses mode E.
+#
+#   An incomplete transfer may be due to the pool detecting a problem
+#   (e.g., unable to connect to the target TCP port) or from the
+#   client detecting some problem (e.g., insufficient progress).
+#   Logging the statistics when that transfer is aborted may yield
+#   information that helps diagnose such problems.
+#
+(one-of?true|false)pool.mover.ftp.enable.log-aborted-transfers = false
+
+
 #  ----- Distance between transfer and checksum computation in FTP mover
 #
 #   When the checksum is computed on the fly, the FTP mover performs

--- a/skel/share/services/pool.batch
+++ b/skel/share/services/pool.batch
@@ -47,6 +47,7 @@ check -strong pool.mover.http.port.min
 check -strong pool.mover.http.port.max
 check -strong pool.mover.ftp.port.min
 check -strong pool.mover.ftp.port.max
+check -strong pool.mover.ftp.enable.log-aborted-transfers
 check -strong pool.mover.nfs.rpcsec_gss
 check -strong pool.service.pool.timeout
 check -strong pool.service.pool.timeout.unit


### PR DESCRIPTION
DO NOT MERGE
Motivation:

We have reports of partial FTP transfers where the cause is not unknown.
In particular, with third-party GridFTP transfers where the client (FTS)
aborts the transfer.  We currently have insufficient information to
determine why this is happening.

Modification:

Update pool to detect partial transfers using the Mode.  The pool
currently only knows of incomplete transfers if there is a hole in the
uploaded content; however, the data travelling over MODE E allows the
pool to discover any partial upload.

Update pool ftp mover to log additional information if it detects that
the transfer was partial.

Result:

dCache pool now logs considerable information about failed FTP
transfers.  This may be useful in the diagnosis of such errors.

Target: master
Require-notes: yes
Require-book: yes
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2