### PR TITLE
dcache-dcap: add uid/gid to transfer info for plain/anonymous dcap

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -10,6 +10,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.security.auth.Subject;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -23,14 +25,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import javax.security.auth.Subject;
-
 import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.poolManager.PoolSelectionUnit.DirectionType;
@@ -81,11 +81,14 @@ import dmg.util.KeepAliveListener;
 import org.dcache.acl.enums.AccessMask;
 import org.dcache.acl.enums.RsType;
 import org.dcache.acl.parser.ACLParser;
+import org.dcache.auth.GidPrincipal;
 import org.dcache.auth.LoginNamePrincipal;
 import org.dcache.auth.LoginReply;
 import org.dcache.auth.LoginStrategy;
 import org.dcache.auth.Origin;
 import org.dcache.auth.Subjects;
+import org.dcache.auth.UidPrincipal;
+import org.dcache.auth.attributes.LoginAttributes;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.auth.attributes.Restrictions;
 import org.dcache.cells.CellStub;
@@ -1777,10 +1780,20 @@ public class DCapDoorInterpreterV3
             PnfsId pnfsid =
                     _fileAttributes != null ? _fileAttributes.getPnfsId() : null;
 
+            try {
+                Subjects.getUid(_subject);
+            } catch (NoSuchElementException e) {
+                _subject.getPrincipals().add(new UidPrincipal(_uid));
+            }
+
+            if (Subjects.getGids(_subject).length == 0) {
+                _subject.getPrincipals().add(new GidPrincipal(_gid, true));
+            }
+
             return new IoDoorEntry(_sessionId,
                                    pnfsid,
                                    _subject,
-                                   _pool == null? "<unknown>" : _pool.getName(),
+                                   _pool == null ? "<unknown>" : _pool.getName(),
                                    _status,
                                    _statusSince,
                                    _clientSocketAddress.getAddress().getHostAddress());


### PR DESCRIPTION
Motivation:

For plain dcap, the session subject received from login does not
contain uid or gid principals, but it is this subject which, via
IoDoorEntry, is conveyed to the transfer info.  These transfers
should nevertheless still be identifiable as to their initiator.

Modification:

If the subject used to construct IoDoorEntry does not contain
uid or gid principals, add them based on the uid and gid passed
during the "hello" command.

Result:

DCAP writes and reads no longer lack the uid/gid attributes.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Acked-by: Dmitry