### PR TITLE
gplazma-role: add observer role

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/attributes/LoginAttributes.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/LoginAttributes.java
@@ -28,7 +28,9 @@ import diskCacheV111.util.FsPath;
 public class LoginAttributes
 {
     public static final String ADMIN_ROLE_NAME = "admin";
+    public static final String OBSERVER_ROLE_NAME = "observer";
     private static final Role ADMIN_ROLE = new Role(ADMIN_ROLE_NAME);
+    private static final Role OBSERVER_ROLE = new Role(OBSERVER_ROLE_NAME);
 
     private LoginAttributes()
     {
@@ -43,7 +45,7 @@ public class LoginAttributes
     {
         FsPath root = FsPath.ROOT;
         for (LoginAttribute attribute : attributes) {
-            if (attribute.equals(ADMIN_ROLE)) {
+            if (attribute.equals(ADMIN_ROLE) || attribute.equals(OBSERVER_ROLE)) {
                 return FsPath.ROOT;
             }
             if (attribute instanceof RootDirectory) {
@@ -58,12 +60,19 @@ public class LoginAttributes
         return ADMIN_ROLE;
     }
 
+    public static Role observerRole()
+    {
+        return OBSERVER_ROLE;
+    }
+
     public static boolean hasAdminRole(Collection<LoginAttribute> attributes)
     {
-        return attributes.stream()
-                .filter(Role.class::isInstance)
-                .map(Role.class::cast)
-                .anyMatch(r -> r.equals(ADMIN_ROLE));
+        return attributes.stream().anyMatch(ADMIN_ROLE::equals);
+    }
+
+    public static boolean hasObserverRole(Collection<LoginAttribute> attributes)
+    {
+        return attributes.stream().anyMatch(OBSERVER_ROLE::equals);
     }
 
     public static Stream<String> assertedRoles(Collection<LoginAttribute> attributes)

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -363,10 +363,15 @@ gplazma.oidc.hostnames = ${dcache.oidc.hostnames}
 #     session required roles
 #   Make sure it is above any "session sufficient" lines.
 #
-#   The following property describes the gid of a group a user must be
-#   a member of before they are authorized to obtain admin role.
+#   The following properties describe the gid of a group a user must be
+#   a member of before they are authorized to obtain the admin role
+#   or the observer role.  The latter is essentially equivalent to
+#   read-only admin access.
 #
-gplazma.roles.admin-gid = 0
+#   Leaving either blank means the role is undefined.
+#
+gplazma.roles.admin-gid= 0
+gplazma.roles.observer-gid =
 
 #
 #


### PR DESCRIPTION
Motivation:

A weaker role than "admin" is useful for according
read-only access to system or file information.

Modification:

This patch simply adds the role; subsequent patches
will implement the distinction between admin and observer
in the frontend and dcache-view.

Note that

(a) It was easier just to hard-code this definition the way
    admin is hardcoded; otherwise the properties definition
    becomes clumsy (we would need something richer, like JSON).
(b) As far as user root, observer is equivalent to admin.
(c) While it is true that observer is a subset of admin
    privileges, the implementation treats the roles as
    distinct.  That is, if a user is accorded admin privileges,
    she does not automatically get observer privileges
    (IOW, the user must explicitly be given both gids
    to get both roles), unless both roles map to the
    same GID.  This implementation decision,
    however, is open to discussion.

Junit tests have been added.

Result:

A new role, "observer", is defined and available.

Target: master
Request: 4.2
Acked-by: Paul