### PR TITLE
webdav+transfermanagers: support TPC pull with targeted macaroons

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/transferManager/TransferManagerMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/transferManager/TransferManagerMessage.java
@@ -1,4 +1,6 @@
 package diskCacheV111.vehicles.transferManager;
+
+import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.Message;
 
 import org.dcache.auth.attributes.Restriction;
@@ -30,6 +32,7 @@ public abstract class TransferManagerMessage extends Message {
     private boolean spaceReservationStrict;
     private Long credentialId;
     private Restriction restriction;
+    private PnfsId pnfsId;
 
     public TransferManagerMessage(
             String pnfsPath,
@@ -65,6 +68,21 @@ public abstract class TransferManagerMessage extends Message {
     public Restriction getRestriction()
     {
         return restriction == null ? Restrictions.none() : restriction;
+    }
+
+    public void setPnfsId(PnfsId id)
+    {
+        pnfsId = id;
+    }
+
+    /**
+     * The ID of the local file.  May be null to indicate the
+     * TransferManagerHandler is responsible for creating the target file
+     * for pull requests.
+     */
+    public PnfsId getPnfsId()
+    {
+        return pnfsId;
     }
 
     /** Getter for property store.

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
@@ -40,8 +40,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.AccessController;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -50,22 +48,15 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import diskCacheV111.util.CacheException;
-import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
-import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
 
-import org.dcache.acl.enums.AccessMask;
 import org.dcache.auth.BearerTokenCredential;
 import org.dcache.auth.OidcSubjectPrincipal;
 import org.dcache.auth.OpenIdClientSecret;
 import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.cells.CellStub;
-import org.dcache.namespace.FileAttribute;
-import org.dcache.namespace.FileType;
-import org.dcache.vehicles.FileAttributes;
 import org.dcache.http.AuthenticationHandler;
 import org.dcache.http.PathMapper;
 import org.dcache.webdav.transfer.RemoteTransferHandler.Direction;
@@ -73,8 +64,6 @@ import org.dcache.webdav.transfer.RemoteTransferHandler.TransferType;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.dcache.namespace.FileAttribute.PNFSID;
-import static org.dcache.namespace.FileAttribute.TYPE;
 
 /**
  * The CopyFilter adds support for initiating third-party copies via
@@ -112,13 +101,6 @@ public class CopyFilter implements Filter
     private static final String QUERY_KEY_ASKED_TO_DELEGATE = "asked-to-delegate";
     private static final String REQUEST_HEADER_CREDENTIAL = "Credential";
     private static final String REQUEST_HEADER_VERIFICATION = "RequireChecksumVerification";
-
-    private static final Set<AccessMask> READ_ACCESS_MASK =
-            EnumSet.of(AccessMask.READ_DATA);
-    private static final Set<AccessMask> WRITE_ACCESS_MASK =
-            EnumSet.of(AccessMask.WRITE_DATA);
-    private static final Set<AccessMask> CREATE_ACCESS_MASK =
-            EnumSet.of(AccessMask.ADD_FILE);
 
     private ImmutableMap<String,String> _clientIds;
     private ImmutableMap<String,String> _clientSecrets;
@@ -171,7 +153,6 @@ public class CopyFilter implements Filter
         }
     }
 
-    private PnfsHandler _pnfs;
     private CredentialServiceClient _credentialService;
     private PathMapper _pathMapper;
     private RemoteTransferHandler _remoteTransfers;
@@ -180,12 +161,6 @@ public class CopyFilter implements Filter
     public void setPathMapper(PathMapper mapper)
     {
         _pathMapper = mapper;
-    }
-
-    @Required
-    public void setPnfsStub(CellStub stub)
-    {
-        _pnfs = new PnfsHandler(stub);
     }
 
     @Required
@@ -365,7 +340,9 @@ public class CopyFilter implements Filter
 
         FsPath path = _pathMapper.asDcachePath(ServletRequest.getRequest(),
                 request.getAbsolutePath(), m -> new ErrorResponseException(Status.SC_FORBIDDEN, m));
-        checkPath(path, direction);
+
+        // Always check any client-supplied Overwrite header, to throw an error if the value is malformed.
+        boolean overwriteAllowed = clientAllowsOverwrite();
 
         CredentialSource source = getCredentialSource(request, type);
         Object credential = fetchCredential(source);
@@ -380,7 +357,8 @@ public class CopyFilter implements Filter
         } else {
             _remoteTransfers.acceptRequest(response.getOutputStream(),
                     request.getHeaders(), getSubject(), getRestriction(), path,
-                    remote, credential, direction, isVerificationRequired());
+                    remote, credential, direction, isVerificationRequired(),
+                    overwriteAllowed);
         }
     }
 
@@ -544,64 +522,6 @@ public class CopyFilter implements Filter
         }
 
         return true;
-    }
-
-    /**
-     * Check whether the path is allowed for this transfer.
-     */
-    private void checkPath(FsPath path, Direction direction) throws ErrorResponseException
-    {
-        PnfsHandler pnfs = new PnfsHandler(_pnfs, getSubject(), getRestriction());
-
-        // Always check any client-supplied Overwrite header.
-        boolean overwriteAllowed = clientAllowsOverwrite();
-
-        Set<AccessMask> mask = direction == Direction.PUSH ? READ_ACCESS_MASK : WRITE_ACCESS_MASK;
-        FileAttributes attributes;
-        try {
-            try {
-                attributes = pnfs.getFileAttributes(path.toString(),
-                        EnumSet.of(PNFSID, TYPE), mask, false);
-
-                if (attributes.getFileType() != FileType.REGULAR) {
-                    throw new ErrorResponseException(Status.SC_BAD_REQUEST, "Not a file");
-                }
-
-                if (direction == Direction.PULL) {
-                    if (!overwriteAllowed) {
-                        throw new ErrorResponseException(Status.SC_PRECONDITION_FAILED,
-                                "File already exists");
-                    }
-
-                    // REVISIT: ideally, the transfermanager would handle
-                    // deleting existing entry.
-                    try {
-                        pnfs.deletePnfsEntry(attributes.getPnfsId(), path.toString(),
-                                EnumSet.of(FileType.REGULAR),
-                                EnumSet.noneOf(FileAttribute.class));
-                    } catch (FileNotFoundCacheException ignored) {
-                        // Ignore this: someone else deleted the file, which
-                        // suggests we might be unlucky pulling the data.
-                    }
-                }
-            } catch (FileNotFoundCacheException e) {
-                if (direction == Direction.PUSH) {
-                    throw new ErrorResponseException(Status.SC_NOT_FOUND, "no such file");
-                } else {
-                    pnfs.getFileAttributes(path.parent().toString(), Collections.emptySet(),
-                                           CREATE_ACCESS_MASK, false);
-                }
-            }
-        } catch (PermissionDeniedCacheException e) {
-            _log.debug("Permission denied: {}", e.getMessage());
-            throw new ErrorResponseException(Status.SC_UNAUTHORIZED,
-                    "Permission denied");
-        } catch (CacheException e) {
-            _log.error("failed query file {} for copy request: {}", path,
-                    e.getMessage());
-            throw new ErrorResponseException(Status.SC_INTERNAL_SERVER_ERROR,
-                    "Internal problem with server");
-        }
     }
 
     private Subject getSubject()

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -123,6 +123,7 @@
   <bean id="remote-transfer-handler" class="org.dcache.webdav.transfer.RemoteTransferHandler">
       <description>Coordinate transfers</description>
 
+      <property name="pnfsStub" ref="pnfs-stub"/>
       <property name="transferManagerStub" ref="transfer-manager-stub"/>
       <property name="performanceMarkerPeroid"
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
@@ -144,7 +145,6 @@
       <description>Handles requests for 3rd-party copies</description>
 
       <property name="credentialServiceClient" ref="credential-service-client"/>
-      <property name="pnfsStub" ref="pnfs-stub"/>
       <property name="remoteTransferHandler" ref="remote-transfer-handler"/>
       <property name="pathMapper" ref="path-mapper"/>
       <property name="oidClientIds" ref="oidc-client-ids"/>

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -87,6 +87,8 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
     public static final int INITIAL_STATE = 0;
     public static final int WAITING_FOR_PNFS_INFO_STATE = 1;
     public static final int RECEIVED_PNFS_INFO_STATE = 2;
+    public static final int WAITING_FOR_CREATED_FILE_INFO_STATE = 3;
+    public static final int RECEIVED_CREATED_FILE_INFO_STATE = 4;
     public static final int WAITING_FOR_PNFS_ENTRY_CREATION_INFO_STATE = 5;
     public static final int RECEIVED_PNFS_ENTRY_CREATION_INFO_STATE = 6;
     public static final int WAITING_FOR_POOL_INFO_STATE = 7;
@@ -108,6 +110,8 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             .put(INITIAL_STATE, "initialising")
             .put(WAITING_FOR_PNFS_INFO_STATE, "querying file metadata")
             .put(RECEIVED_PNFS_INFO_STATE, "recieved file metadata")
+            .put(WAITING_FOR_CREATED_FILE_INFO_STATE, "querying created file metadata")
+            .put(RECEIVED_CREATED_FILE_INFO_STATE, "received created file metadata")
             .put(WAITING_FOR_PNFS_ENTRY_CREATION_INFO_STATE, "creating namespace entry")
             .put(RECEIVED_PNFS_ENTRY_CREATION_INFO_STATE, "namespace entry created")
             .put(WAITING_FOR_POOL_INFO_STATE, "selecting pool")
@@ -191,6 +195,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                 new ChainedPermissionHandler(
                 new ACLPermissionHandler(),
                 new PosixPermissionHandler());
+        pnfsId = transferRequest.getPnfsId();
     }
 
     public static String describeState(int state)
@@ -211,15 +216,28 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         parentDir = pnfsPath.substring(0, last_slash_pos);
         PnfsMessage message;
         if (store) {
-            message = new PnfsCreateEntryMessage(pnfsPath, FileAttributes.ofFileType(FileType.REGULAR));
-            message.setSubject(transferRequest.getSubject());
-            message.setRestriction(transferRequest.getRestriction());
-            setState(WAITING_FOR_PNFS_ENTRY_CREATION_INFO_STATE);
+            if (pnfsId == null) {
+                message = new PnfsCreateEntryMessage(pnfsPath, FileAttributes.ofFileType(FileType.REGULAR));
+                message.setSubject(transferRequest.getSubject());
+                message.setRestriction(transferRequest.getRestriction());
+                setState(WAITING_FOR_PNFS_ENTRY_CREATION_INFO_STATE);
+            } else {
+                info.setPnfsId(pnfsId);
+                pnfsIdString = pnfsId.toString();
+                EnumSet<FileAttribute> attributes = EnumSet.noneOf(FileAttribute.class);
+                attributes.addAll(permissionHandler.getRequiredAttributes());
+                attributes.addAll(PoolMgrSelectReadPoolMsg.getRequiredAttributes());
+                message = new PnfsGetFileAttributes(pnfsId, attributes);
+                message.setSubject(transferRequest.getSubject());
+                message.setRestriction(transferRequest.getRestriction());
+                setState(WAITING_FOR_CREATED_FILE_INFO_STATE);
+            }
         } else {
             EnumSet<FileAttribute> attributes = EnumSet.noneOf(FileAttribute.class);
             attributes.addAll(permissionHandler.getRequiredAttributes());
             attributes.addAll(PoolMgrSelectReadPoolMsg.getRequiredAttributes());
-            message = new PnfsGetFileAttributes(pnfsPath, attributes);
+            message = pnfsId == null ? new PnfsGetFileAttributes(pnfsPath, attributes)
+                    : new PnfsGetFileAttributes(pnfsId, attributes);
             message.setSubject(transferRequest.getSubject());
             message.setRestriction(transferRequest.getRestriction());
             message.setAccessMask(EnumSet.of(AccessMask.READ_DATA));
@@ -248,6 +266,10 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                 if (state == WAITING_FOR_PNFS_INFO_STATE) {
                     setState(RECEIVED_PNFS_INFO_STATE);
                     storageInfoArrived(attributesMessage);
+                    return;
+                } else if (state == WAITING_FOR_CREATED_FILE_INFO_STATE) {
+                    state = RECEIVED_CREATED_FILE_INFO_STATE;
+                    getFileAttributesArrived(attributesMessage);
                     return;
                 }
                 log.error(this.toString() + " got unexpected PnfsGetStorageInfoMessage "
@@ -306,6 +328,10 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             sendErrorReply(rc, "Failed to create namespace entry: " + error);
             break;
 
+        case WAITING_FOR_CREATED_FILE_INFO_STATE:
+            sendErrorReply(rc, "Failed to lookup created namespace entry: " + error);
+            break;
+
         case WAITING_FIRST_POOL_REPLY_STATE:
             // FIXME: in the case of an attempted read (pool pushing the file
             //        to some remote site), we can ask PoolManager for another
@@ -360,6 +386,19 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         info.setStorageInfo(create.getFileAttributes().getStorageInfo());
         if (create.getFileAttributes().isDefined(STORAGEINFO) && create.getFileAttributes().getStorageInfo().getKey("path") != null) {
             info.setBillingPath(create.getFileAttributes().getStorageInfo().getKey("path"));
+        }
+
+        selectPool();
+    }
+
+    public void getFileAttributesArrived(PnfsGetFileAttributes msg)
+    {
+        manager.persist(this);
+
+        fileAttributes = msg.getFileAttributes();
+        info.setStorageInfo(msg.getFileAttributes().getStorageInfo());
+        if (msg.getFileAttributes().isDefined(STORAGEINFO) && msg.getFileAttributes().getStorageInfo().getKey("path") != null) {
+            info.setBillingPath(msg.getFileAttributes().getStorageInfo().getKey("path"));
         }
 
         selectPool();


### PR DESCRIPTION
Motivation:

Fix support for WebDAV Third-Party-Copy (TPC) pull requests that are
authorised with a macaroon only valid for writing a specific file.

Modification:

Currently the transfermanager is responsible for creating the file for a
pull-request.

It is desirable that the WebDAV door checks whether the user can
transfer a file, as this allows the door to return an HTTP error rather
than returning 200 OK and an error as the final update in the streaming
response.  Therefore the WebDAV door checks if the user is allowed to
read/write (for push/pull transfers, resp.) the local file before
creating the request with transfermanager.

For non-macaroon authorised transfers, the granularity of file creation
is directories.  For macaroons, the granularity is per file.  Therefore
the existing infrastructure does not permit checking whether a user is
allowed to create an individual file.

To resolve this problem, responsibility for creating the file (for
WebDAV-triggered pull requests) is moved from the transfermanager to the
WebDAV door.  The transfermanager is still responsible for creating the
file for srmCopy pull requests.

Result:

It is possible to transfer a file using a targeted macaroon.

NOTE: both the webdav door and transfermanagers must be updated before
the fix is effective.

Target: master
Require-notes: yes
Require-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9468
Patch: https://rb.dcache.org/r/11180/
Acked-by: Tigran Mkrtchyan