### PR TITLE
dcache: add configuration for the Kafka producer timeout

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DcapDoorSettings.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DcapDoorSettings.java
@@ -88,8 +88,11 @@ public class DcapDoorSettings
     @Option(name = "bootstrap-server-kafka")
     protected String kafkaBootstrapServer;
 
-    @Option(name = "max-block-ms-kafka")
-    protected String kafkaMaxBlockMs;
+    @Option(name = "kafka-max-block", required = true)
+    protected long kafkaMaxBlock;
+
+    @Option(name = "kafka-max-block-units", required = true)
+    protected TimeUnit kafkaMaxBlockUnits;
 
     @Option(name = "retries-kafka")
     protected String kafkaRetries;
@@ -249,7 +252,7 @@ public class DcapDoorSettings
      * @retrun a timeframe during which producer will block sending messages, by default set to 60000
      */
     public String getKafkaMaxBlockMs() {
-        return kafkaMaxBlockMs;
+        return String.valueOf(TimeUnit.MILLISECONDS.convert(kafkaMaxBlock, kafkaMaxBlockUnits));
     }
 
     /**

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpDoorSettings.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpDoorSettings.java
@@ -53,8 +53,11 @@ public class FtpDoorSettings
     @Option(name = "bootstrap-server-kafka")
     protected String kafkaBootstrapServer;
 
-    @Option(name = "max-block-ms-kafka")
-    protected String kafkaMaxBlockMs;
+    @Option(name = "kafka-max-block", required = true)
+    protected long kafkaMaxBlock;
+
+    @Option(name = "kafka-max-block-units", required = true)
+    protected TimeUnit kafkaMaxBlockUnits;
 
     @Option(name = "retries-kafka")
     protected String kafkaRetries;
@@ -367,7 +370,7 @@ public class FtpDoorSettings
      * @retrun a timeframe during which producer will block when calling send()
      */
     public String getKafkaMaxBlockMs() {
-        return kafkaMaxBlockMs;
+        return String.valueOf(TimeUnit.MILLISECONDS.convert(kafkaMaxBlock, kafkaMaxBlockUnits));
     }
 
     /**

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpDoorSettings.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpDoorSettings.java
@@ -53,10 +53,12 @@ public class FtpDoorSettings
     @Option(name = "bootstrap-server-kafka")
     protected String kafkaBootstrapServer;
 
-    @Option(name = "kafka-max-block", required = true)
+    @Option(name = "kafka-max-block",
+            defaultValue = "1")
     protected long kafkaMaxBlock;
 
-    @Option(name = "kafka-max-block-units", required = true)
+    @Option(name = "kafka-max-block-units",
+            defaultValue = "SECONDS")
     protected TimeUnit kafkaMaxBlockUnits;
 
     @Option(name = "retries-kafka")

--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -240,9 +240,8 @@
                             <entry key="key.serializer" value="org.apache.kafka.common.serialization.StringSerializer" />
                             <entry key="value.serializer" value="org.dcache.notification.DoorRequestMessageSerializer" />
                             <entry key="client.id" value="${nfs.cell.name}@${dcache.domain.name}" />
-                            <!-- TODO  values for max.block.ms and retries are important for Non Blocking (Async) callback.-->
-                            <!-- maximum time producer.send() will block by default set to 60000. Could be changed latter. -->
-                            <entry key="max.block.ms" value="0" />
+                            <entry key="max.block.ms"
+                                   value="#{ T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(${nfs.kafka.maximum-block}, '${nfs.kafka.maximum-block.unit}')}" />
                             <!-- The maximum number of times to retry a call before failing it.-->
                             <entry key="retries" value="0" />
                         </map>

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -617,9 +617,8 @@
                             <entry key="key.serializer" value="org.apache.kafka.common.serialization.StringSerializer" />
                             <entry key="value.serializer" value="org.dcache.notification.DoorRequestMessageSerializer" />
                             <entry key="client.id" value="${webdav.cell.name}@${dcache.domain.name}" />
-                            <!-- TODO  values for max.block.ms and retries are important for Non Blocking (Async) callback.-->
-                            <!-- maximum time producer.send() will block by default set to 60000. Could be changed latter. -->
-                            <entry key="max.block.ms" value="0" />
+                            <entry key="max.block.ms"
+                                   value="#{ T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(${webdav.kafka.maximum-block}, '${webdav.kafka.maximum-block.unit}')}" />
                             <!-- The maximum number of times to retry a call before failing it.-->
                             <entry key="retries" value="0" />
                         </map>

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -197,9 +197,8 @@
               <entry key="key.serializer" value="org.apache.kafka.common.serialization.StringSerializer"/>
               <entry key="value.serializer" value="org.dcache.notification.DoorRequestMessageSerializer"/>
               <entry key="client.id" value="${xrootd.cell.name}@${dcache.domain.name}" />
-              <!-- TODO  values for max.block.ms and retries are important for Non Blocking (Async) callback.-->
-              <!-- maximum time producer.send() will block by default set to 60000. Could be changed latter. -->
-              <entry key="max.block.ms" value="0" />
+              <entry key="max.block.ms"
+                     value="#{ T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(${xrootd.kafka.maximum-block}, '${xrootd.kafka.maximum-block.unit}')}" />
               <!-- The maximum number of times to retry a call before failing it.-->
               <entry key="retries" value="0" />
             </map>

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -566,9 +566,8 @@
                            <entry key="key.serializer" value="org.apache.kafka.common.serialization.StringSerializer"/>
                            <entry key="value.serializer" value="org.dcache.notification.RemoveFileInfoMessageSerializer"/>
                            <entry key="client.id" value="${pool.cell.name}@${dcache.domain.name}-remove"/>
-                           <!-- TODO  values for max.block.ms and retries are important for Non Blocking (Async) callback.-->
-                           <!-- maximum time producer.send() will block by default set to 60000. Could be changed latter. -->
-                           <entry key="max.block.ms" value="0" />
+                           <entry key="max.block.ms"
+				  value="#{ T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(${pool.kafka.maximum-block}, '${pool.kafka.maximum-block.unit}')}" />
                            <!-- The maximum number of times to retry a call before failing it.-->
                            <entry key="retries" value="0" />
                        </map>
@@ -591,9 +590,8 @@
                             <entry key="key.serializer" value="org.apache.kafka.common.serialization.StringSerializer"/>
                             <entry key="value.serializer" value="org.dcache.notification.StorageInfoMessageSerializer"/>
                             <entry key="client.id" value="${pool.cell.name}@${dcache.domain.name}-hsm"/>
-                            <!-- TODO  values for max.block.ms and retries are important for Non Blocking (Async) callback.-->
-                            <!-- maximum time producer.send() will block by default set to 60000. Could be changed latter. -->
-                            <entry key="max.block.ms" value="0" />
+                           <entry key="max.block.ms"
+				  value="#{ T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(${pool.kafka.maximum-block}, '${pool.kafka.maximum-block.unit}')}" />
                             <!-- The maximum number of times to retry a call before failing it.-->
                             <entry key="retries" value="0" />
                         </map>
@@ -616,9 +614,8 @@
                             <entry key="key.serializer" value="org.apache.kafka.common.serialization.StringSerializer"/>
                             <entry key="value.serializer" value="org.dcache.notification.BillingMessageSerializer"/>
                             <entry key="client.id" value="${pool.cell.name}@${dcache.domain.name}-transfer"/>
-                            <!-- TODO  values for max.block.ms and retries are important for Non Blocking (Async) callback.-->
-                            <!-- maximum time producer.send() will block by default set to 60000. Could be changed latter. -->
-                            <entry key="max.block.ms" value="0" />
+                           <entry key="max.block.ms"
+				  value="#{ T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(${pool.kafka.maximum-block}, '${pool.kafka.maximum-block.unit}')}" />
                             <!-- The maximum number of times to retry a call before failing it.-->
                             <entry key="retries" value="0" />
                         </map>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1170,6 +1170,21 @@ dcache.oidc.hostnames =
 # host1:port1,host2:port2,....
 dcache.kafka.bootstrap-servers = localhost:9092
 
+#  Maximum time dCache will spend trying to send an event to the Kafka
+#  service.  If dCache is unable to send the event to Kafka within
+#  this time limit, the an error is logged and the event is dropped.
+#
+#  This value is referred to as 'max.block.ms' within Kafka
+#  documentation.
+#
+#  If the value is set too low then events will be lost under normal
+#  operational conditions.  If the value is set too high then there
+#  will be a high impact on dCache should the Kafka service be
+#  unavailable.
+#
+dcache.kafka.maximum-block = 1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
+dcache.kafka.maximum-block.unit = SECONDS
 
 #  -----------------------------------------------------------------------
 #  ---- Unused properties

--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -207,6 +207,10 @@ dcap.net.allowed-subnets=${dcache.net.allowed-subnets}
 #  ---- Kafka service enabled
 #
 (one-of?true|false|${dcache.enable.kafka})dcacp.enable.kafka = ${dcache.enable.kafka}
+dcap.kafka.maximum-block = ${dcache.kafka.maximum-block}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
+dcap.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
+
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 dcap.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -353,6 +353,9 @@ ftp.net.allowed-subnets=${dcache.net.allowed-subnets}
 #  ---- Kafka service enabled
 #
 (one-of?true|false|${dcache.enable.kafka})ftp.enable.kafka = ${dcache.enable.kafka}
+ftp.kafka.maximum-block = ${dcache.kafka.maximum-block}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
+ftp.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 ftp.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -243,6 +243,9 @@ nfs.cell.max-messages-queued = 1000
 #  ---- Kafka service enabled
 #
 (one-of?true|false|${dcache.enable.kafka})nfs.enable.kafka = ${dcache.enable.kafka}
+nfs.kafka.maximum-block = ${dcache.kafka.maximum-block}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
+nfs.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 nfs.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -537,6 +537,9 @@ pool.backend.ceph.pool-name = ${pool.name}
 #  ---- Kafka service enabled
 #
 (one-of?true|false|${dcache.enable.kafka})pool.enable.kafka = ${dcache.enable.kafka}
+pool.kafka.maximum-block = ${dcache.kafka.maximum-block}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
+pool.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 pool.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -706,6 +706,9 @@ webdav.allowed.client.origins =
 #  ---- Kafka service enabled
 #
 (one-of?true|false|${dcache.enable.kafka})webdav.enable.kafka = ${dcache.enable.kafka}
+webdav.kafka.maximum-block = ${dcache.kafka.maximum-block}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
+webdav.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 webdav.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -114,7 +114,8 @@ create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
              -billing=\"${dcap.service.billing}\" \
              -kafka=\"${dcacp.enable.kafka}\" \
              -bootstrap-server-kafka=\"${dcap.kafka.bootstrap-servers}\" \
-             -max-block-ms-kafka=600\
+             -kafka-max-block=${dcap.kafka.maximum-block}\
+             -kafka-max-block-units=${dcap.kafka.maximum-block.unit}\
              -retries-kafka=0 \
              -stageConfigurationFilePath=\"${dcap.authz.staging}\" \
              -io-queue=${dcap.mover.queue} \

--- a/skel/share/services/ftp.batch
+++ b/skel/share/services/ftp.batch
@@ -89,7 +89,8 @@ create dmg.cells.services.login.LoginManager ${ftp.cell.name} \
    -billing=\"${ftp.service.billing}\" \
    -kafka=\"${ftp.enable.kafka}\" \
    -bootstrap-server-kafka=\"${ftp.kafka.bootstrap-servers}\" \
-   -max-block-ms-kafka=600\
+   -kafka-max-block=${ftp.kafka.maximum-block}\
+   -kafka-max-block-units=${ftp.kafka.maximum-block.unit}\
    -retries-kafka=0 \
    -pnfsManager=\"${ftp.service.pnfsmanager}\" \
    -pnfsTimeout=${ftp.service.pnfsmanager.timeout} \


### PR DESCRIPTION
Motivation:

The kafka producer library has a property that controls how long it
spends when attempting to send an event.  If it takes too long, the
event is discarded and an error is logged.

Currently, the pool, and the xrootd, nfs and webdav doors hardcode this
timeout value to 0.  The dcap and ftp doors also have hard-code values,
albeit with a non-zero value.

For at least pools, this value is too small, as I have observed events
being discarded on an otherwise unloaded system, and unloaded kafka
instance.

Modification:

Introduce a configuration properties to control the Kafka timeout.  The
default is set to some (hopefully) reasonable default value.

Update all producers to use this configuration property.

Result:

The timeout used by dCache when attempting to send a Kafka event is now
adjustable via the configuration properties dcache.kafka.maximum-block
and dcache.kafka.maximum-block.unit.

The default timeout for pools, and the xrootd, nfs and webdav doors is
now non-zero.  This should fix the problem of kafka events being lost
under normal operational conditions.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/11177/
Acked-by: Marina Sahakyan