### PR TITLE
dcache: add configuration for the Kafka producer timeout

### DIFF
--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -232,9 +232,8 @@
                             <entry key="key.serializer" value="org.apache.kafka.common.serialization.StringSerializer" />
                             <entry key="value.serializer" value="org.dcache.notification.DoorRequestMessageSerializer" />
                             <entry key="client.id" value="${nfs.cell.name}@${dcache.domain.name}" />
-                            <!-- TODO  values for max.block.ms and retries are important for Non Blocking (Async) callback.-->
-                            <!-- maximum time producer.send() will block by default set to 60000. Could be changed latter. -->
-                            <entry key="max.block.ms" value="0" />
+                            <entry key="max.block.ms"
+                                   value="#{ T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(${nfs.kafka.maximum-block}, '${nfs.kafka.maximum-block.unit}')}" />
                             <!-- The maximum number of times to retry a call before failing it.-->
                             <entry key="retries" value="0" />
                         </map>

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -551,9 +551,8 @@
                             <entry key="key.serializer" value="org.apache.kafka.common.serialization.StringSerializer" />
                             <entry key="value.serializer" value="org.dcache.notification.BillingMessageSerializer" />
                             <entry key="client.id" value="${pool.cell.name}@${dcache.domain.name}" />
-                            <!-- TODO  values for max.block.ms and retries are important for Non Blocking (Async) callback.-->
-                            <!-- maximum time producer.send() will block by default set to 60000. Could be changed latter. -->
-                            <entry key="max.block.ms" value="0" />
+                            <entry key="max.block.ms"
+				  value="#{ T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(${pool.kafka.maximum-block}, '${pool.kafka.maximum-block.unit}')}" />
                             <!-- The maximum number of times to retry a call before failing it.-->
                             <entry key="retries" value="0" />
                         </map>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1169,6 +1169,21 @@ dcache.oidc.hostnames =
 # host1:port1,host2:port2,....
 dcache.kafka.bootstrap-servers = localhost:9092
 
+#  Maximum time dCache will spend trying to send an event to the Kafka
+#  service.  If dCache is unable to send the event to Kafka within
+#  this time limit, the an error is logged and the event is dropped.
+#
+#  This value is referred to as 'max.block.ms' within Kafka
+#  documentation.
+#
+#  If the value is set too low then events will be lost under normal
+#  operational conditions.  If the value is set too high then there
+#  will be a high impact on dCache should the Kafka service be
+#  unavailable.
+#
+dcache.kafka.maximum-block = 1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
+dcache.kafka.maximum-block.unit = SECONDS
 
 #  -----------------------------------------------------------------------
 #  ---- Unused properties

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -234,6 +234,9 @@ nfs.cell.max-messages-queued = 1000
 #  ---- Kafka service enabled
 #
 (one-of?true|false|${dcache.enable.kafka})nfs.enable.kafka = ${dcache.enable.kafka}
+nfs.kafka.maximum-block = ${dcache.kafka.maximum-block}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
+nfs.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 nfs.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -516,6 +516,9 @@ pool.backend.ceph.pool-name = ${pool.name}
 #  ---- Kafka service enabled
 #
 (one-of?true|false|${dcache.enable.kafka})pool.enable.kafka = ${dcache.enable.kafka}
+pool.kafka.maximum-block = ${dcache.kafka.maximum-block}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
+pool.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 pool.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}


### PR DESCRIPTION
Motivation:

The kafka producer library has a property that controls how long it
spends when attempting to send an event.  If it takes too long, the
event is discarded and an error is logged.

Currently, the pool, and the xrootd, nfs and webdav doors hardcode this
timeout value to 0.  The dcap and ftp doors also have hard-code values,
albeit with a non-zero value.

For at least pools, this value is too small, as I have observed events
being discarded on an otherwise unloaded system, and unloaded kafka
instance.

Modification:

Introduce a configuration properties to control the Kafka timeout.  The
default is set to some (hopefully) reasonable default value.

Update all producers to use this configuration property.

Result:

The timeout used by dCache when attempting to send a Kafka event is now
adjustable via the configuration properties dcache.kafka.maximum-block
and dcache.kafka.maximum-block.unit.

The default timeout for pools, and the xrootd, nfs and webdav doors is
now non-zero.  This should fix the problem of kafka events being lost
under normal operational conditions.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/11177/
Acked-by: Marina Sahakyan