### PR TITLE
libs: update to nfs4j-0.17.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -736,7 +736,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.17.3</version>
+            <version>0.17.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
minor bugfix update with highlights:

  - fix compatibility with standard rpcbind clients
  - fix allow regular users to change file's owner to the same value

Changelog for nfs4j-0.17.3..nfs4j-0.17.4
    * [5dfe071c] [maven-release-plugin] prepare for next development iteration
    * [dc80128a] libs: update to oncrpc-3.0.2
    * [1907dc23] pseudofs: ignore owner change to the same value
    * [fb1ddd4a] [maven-release-plugin] prepare release nfs4j-0.17.4

Acked-by: Paul Millar
Target: master, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 88022876e96bf76175bf61df37f3ee69773fc08a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>