### PR TITLE
pom.xml:  update xrootd4j dependency to 3.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.11.v20180605</version.jetty>
         <version.wicket>7.6.0</version.wicket>
-        <version.xrootd4j>3.2.2</version.xrootd4j>
+        <version.xrootd4j>3.2.3</version.xrootd4j>
         <version.jersey>2.24</version.jersey>
         <version.dcache-view>1.3.3</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Backports stacktrace fix

see https://github.com/dCache/xrootd4j/issues/4
    https://rb.dcache.org/r/11047/

Request: 4.1
Request: 4.0
Request: 3.2