### PR TITLE
pom.xml: update to xrootd4j dependency to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.11.v20180605</version.jetty>
-        <version.xrootd4j>3.3.0</version.xrootd4j>
+        <version.xrootd4j>3.3.1</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
         <version.dcache-view>1.4.5</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Contains fix for backward compatibility with older xrdcp clients
broken by xrootd4j #10949.

See also #11128

Target: master
Request: 4.2
Acked-by:  Vincent