### PR TITLE
systemd: Add `/etc/security/limits.d/92-dcache.conf` in the dcache systemd unit and generator.

### DIFF
--- a/skel/lib/systemd/system-generators/dcache-generator
+++ b/skel/lib/systemd/system-generators/dcache-generator
@@ -38,6 +38,8 @@ for domain in $(getProperty dcache.domains); do
 	Environment="CLASSPATH=$CLASSPATH" "LD_LIBRARY_PATH=$JAVA_LIBRARY_PATH"
 	$( [ -z "$USER" ] || echo "User=$USER" )
 	ExecStart=${JAVA} ${JAVA_OPTIONS} "-Ddcache.home=$HOME" "-Ddcache.paths.defaults=${DCACHE_DEFAULTS}" org.dcache.boot.BootLoader start ${domain}
+	LimitNOFILE=65535
+	LimitNPROC=infinity
 
 	[Install]
 	WantedBy=default.target

--- a/skel/lib/systemd/system/dcache.service
+++ b/skel/lib/systemd/system/dcache.service
@@ -9,6 +9,8 @@ Type=oneshot
 ExecStart=/bin/true
 ExecReload=/bin/true
 RemainAfterExit=on
+LimitNOFILE=65535
+LimitNPROC=infinity
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Motivation:

Systemd does not inherite the system-wide limits and completely ignores /etc/security/limits.d/92-dcache.conf.

Modification:

Add the limits:

    LimitNOFILE=65535
    LimitNPROC=infinity

in the corresponding  dcache systemd unit and generator.

Result:

The limits successfully loaded and enabled as expected.

Acked-by:
Target: master, 4.2, 4.1, 4.0, 3.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/11172/
Committed: master@abcf632048
Pull-request: https://github.com/dCache/dcache/pull/xxxx

Signed-off-by: Vincent Garonne vgaronne@gmail.com