### PR TITLE
dcache-frontend: remove admin restrictions on GET and filter transfer…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/alarms/AlarmsResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/alarms/AlarmsResources.java
@@ -120,7 +120,7 @@ public final class AlarmsResources {
     private AlarmsInfoService service;
 
 
-    @ApiOperation(value = "General information about alarms service. Requires admin role.",
+    @ApiOperation(value = "General information about alarms service.",
             hidden = true)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -131,10 +131,9 @@ public final class AlarmsResources {
 
 
     @GET
-    @ApiOperation("Provides a filtered list of log entries. Requires admin role.")
+    @ApiOperation("Provides a filtered list of log entries.")
     @ApiResponses({
                 @ApiResponse(code = 400, message = "Bad request"),
-                @ApiResponse(code = 403, message = "Alarm service only accessible to admin users."),
                 @ApiResponse(code = 500, message = "Internal Server Error"),
             })
     @Path("logentries") // collection of all LogEntry.
@@ -163,11 +162,6 @@ public final class AlarmsResources {
                                     @QueryParam("info") String info,
                                     @ApiParam("A comma-seperated list of fields to sort log entries.")
                                     @QueryParam("sort") String sort) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Alarm service only accessible to admin users.");
-        }
-
         try {
             return this.service.get(offset,
                                     limit,
@@ -268,7 +262,7 @@ public final class AlarmsResources {
 
 
     @GET
-    @ApiOperation(value = "Request for a single log entry. Requires admin role.", hidden = true)
+    @ApiOperation(value = "Request for a single log entry.", hidden = true)
     @Path("/logentries/{key}")
     @Produces(MediaType.APPLICATION_JSON)
     public LogEntry getLogEntry(@ApiParam("The log entry to provide.")
@@ -350,36 +344,20 @@ public final class AlarmsResources {
 
 
     @GET
-    @ApiOperation("Request the current mapping of all alarm types to priorities. Requires admin role.")
-    @ApiResponses({
-                @ApiResponse(code = 403, message = "Alarm service only accessible to admin users.")
-            })
+    @ApiOperation("Request the current mapping of all alarm types to priorities.")
     @Path("/priorities")
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, String> getPriorities() {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Alarm service only accessible to admin users.");
-        }
-
         return service.getMap();
     }
 
 
     @GET
-    @ApiOperation("Request the current mapping of an alarm type to its priority. Requires admin role.")
-    @ApiResponses({
-                @ApiResponse(code = 403, message = "Alarm service only accessible to admin users.")
-            })
+    @ApiOperation("Request the current mapping of an alarm type to its priority.")
     @Path("/priorities/{type}")
     @Produces(MediaType.APPLICATION_JSON)
     public String getPriority(@ApiParam("The alarm type.")
                               @PathParam("type") String type) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Alarm service only accessible to admin users.");
-        }
-
         return service.getMap().get(type);
     }
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/billing/BillingResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/billing/BillingResources.java
@@ -72,7 +72,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
@@ -100,7 +99,6 @@ import org.dcache.restful.providers.billing.DoorTransferRecord;
 import org.dcache.restful.providers.billing.HSMTransferRecord;
 import org.dcache.restful.providers.billing.P2PTransferRecord;
 import org.dcache.restful.services.billing.BillingInfoService;
-import org.dcache.restful.util.HttpServletRequests;
 import org.dcache.util.histograms.Histogram;
 
 import static org.dcache.restful.providers.PagedList.TOTAL_COUNT_HEADER;
@@ -112,9 +110,6 @@ import static org.dcache.restful.providers.PagedList.TOTAL_COUNT_HEADER;
 @Api(value = "billing", authorizations = {@Authorization("basicAuth")})
 @Path("/billing")
 public class BillingResources {
-    @Context
-    private HttpServletRequest request;
-
     @Inject
     private BillingInfoService service;
 
@@ -123,8 +118,7 @@ public class BillingResources {
 
 
     @GET
-    @ApiOperation("Provides a list of read transfers for a specific PNFS-ID.  "
-            + "Requires admin role.")
+    @ApiOperation("Provides a list of read transfers for a specific PNFS-ID.")
     @ApiResponses({
                 @ApiResponse(code = 400, message = "Bad request"),
                 @ApiResponse(code = 403, message = "Billing records are only available to admin users."),
@@ -154,11 +148,6 @@ public class BillingResources {
                                              @DefaultValue("date")
                                              @QueryParam("sort") String sort) {
         try {
-            if (!HttpServletRequests.isAdmin(request)) {
-                throw new ForbiddenException("Billing records are only available "
-                                                             + "to admin users.");
-            }
-
             limit = limit == null ? Integer.MAX_VALUE: limit;
 
             PagedList<DoorTransferRecord> result = service.getReads(pnfsid,
@@ -183,8 +172,7 @@ public class BillingResources {
 
 
     @GET
-    @ApiOperation("Provides a list of write transfers for a specific PNFS-ID.  "
-            + "Requires admin role.")
+    @ApiOperation("Provides a list of write transfers for a specific PNFS-ID.")
     @ApiResponses({
                 @ApiResponse(code = 400, message = "Bad request"),
                 @ApiResponse(code = 403, message = "Billing records are only available to admin users."),
@@ -214,11 +202,6 @@ public class BillingResources {
                                               @DefaultValue("date")
                                               @QueryParam("sort") String sort) {
         try {
-            if (!HttpServletRequests.isAdmin(request)) {
-                throw new ForbiddenException("Billing records are only available "
-                                                             + "to admin users.");
-            }
-
             limit = limit == null ? Integer.MAX_VALUE: limit;
 
             PagedList<DoorTransferRecord> result = service.getWrites(pnfsid,
@@ -244,7 +227,7 @@ public class BillingResources {
 
     @GET
     @ApiOperation("Provides a list of pool-to-pool transfers for a specific "
-            + "PNFS-ID.  Requires admin role.")
+            + "PNFS-ID.")
     @ApiResponses({
                 @ApiResponse(code = 400, message = "Bad request"),
                 @ApiResponse(code = 403, message = "Billing records are only available to admin users."),
@@ -274,11 +257,6 @@ public class BillingResources {
                                            @DefaultValue("date")
                                            @QueryParam("sort") String sort) {
         try {
-            if (!HttpServletRequests.isAdmin(request)) {
-                throw new ForbiddenException("Billing records are only available "
-                                                             + "to admin users.");
-            }
-
             limit = limit == null ? Integer.MAX_VALUE: limit;
 
             PagedList<P2PTransferRecord> result = service.getP2ps(pnfsid,
@@ -303,8 +281,7 @@ public class BillingResources {
 
 
     @GET
-    @ApiOperation("Provides a list of tape writes for a specific PNFS-ID.  "
-            + "Requires admin role.")
+    @ApiOperation("Provides a list of tape writes for a specific PNFS-ID.")
     @ApiResponses({
                 @ApiResponse(code = 400, message = "Bad request"),
                 @ApiResponse(code = 403, message = "Billing records are only available to admin users."),
@@ -330,11 +307,6 @@ public class BillingResources {
                                              @DefaultValue("date")
                                              @QueryParam("sort") String sort) {
         try {
-            if (!HttpServletRequests.isAdmin(request)) {
-                throw new ForbiddenException("Billing records are only available "
-                                                             + "to admin users.");
-            }
-
             limit = limit == null ? Integer.MAX_VALUE: limit;
 
             PagedList<HSMTransferRecord> result = service.getStores(pnfsid,
@@ -357,8 +329,7 @@ public class BillingResources {
 
 
     @GET
-    @ApiOperation("Provide a list of tape reads for a specific PNFS-ID.  "
-            + "Requires admin role.")
+    @ApiOperation("Provide a list of tape reads for a specific PNFS-ID.")
     @ApiResponses({
                 @ApiResponse(code = 400, message = "Bad request"),
                 @ApiResponse(code = 403, message = "Billing records are only available to admin users."),
@@ -384,11 +355,6 @@ public class BillingResources {
                                                @DefaultValue("date")
                                                @QueryParam("sort") String sort) {
         try {
-            if (!HttpServletRequests.isAdmin(request)) {
-                throw new ForbiddenException("Billing records are only available "
-                                                             + "to admin users.");
-            }
-
             limit = limit == null ? Integer.MAX_VALUE: limit;
 
             PagedList<HSMTransferRecord> result = service.getRestores(pnfsid,
@@ -411,8 +377,7 @@ public class BillingResources {
 
 
     @GET
-    @ApiOperation("Provide the full \"grid\" of time series data in one pass. "
-                    + "Data is sorted lexicographically by key.")
+    @ApiOperation("Provide the full \"grid\" of time series data in one pass.")
     @ApiResponses({
                 @ApiResponse(code = 500, message = "Internal Server Error"),
             })

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/cells/CellInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/cells/CellInfoResources.java
@@ -68,13 +68,10 @@ import io.swagger.annotations.Authorization;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import java.util.Arrays;
@@ -85,7 +82,6 @@ import diskCacheV111.util.CacheException;
 
 import org.dcache.cells.json.CellData;
 import org.dcache.restful.services.cells.CellInfoService;
-import org.dcache.restful.util.HttpServletRequests;
 
 /**
  * RESTful API to the {@link CellInfoService} service.
@@ -94,34 +90,24 @@ import org.dcache.restful.util.HttpServletRequests;
 @Api(value = "cells", authorizations = {@Authorization("basicAuth")})
 @Path("/cells")
 public final class CellInfoResources {
-
-    @Context
-    private HttpServletRequest request;
-
     @Inject
     private CellInfoService service;
 
 
     @GET
-    @ApiOperation("Get a list of current addresses for well-known cells.  "
-            + "Requires admin role.")
+    @ApiOperation("Get a list of current addresses for well-known cells.")
     @ApiResponses({
                 @ApiResponse(code = 403, message = "Cell info service only accessible to admin users."),
             })
     @Path("/addresses")
     @Produces(MediaType.APPLICATION_JSON)
     public String[] getAddresses() throws CacheException {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Cell info service only accessible to admin users.");
-        }
         return service.getAddresses();
     }
 
 
     @GET
-    @ApiOperation("Provide information about a specific cell.  Requires admin "
-            + "role.")
+    @ApiOperation("Provide information about a specific cell.")
     @ApiResponses({
                 @ApiResponse(code = 403, message = "Cell info service only accessible to admin users."),
             })
@@ -130,27 +116,18 @@ public final class CellInfoResources {
     public CellData getCellData(
                     @ApiParam(value="The cell to query", example="cell@domain")
                     @PathParam("address") String address)throws CacheException {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Cell info service only accessible to admin users.");
-        }
         return service.getCellData(address);
     }
 
 
     @GET
-    @ApiOperation("Provide information about all cells.  Requires admin role. "
+    @ApiOperation("Provide information about all cells. "
                     + "Results sorted lexicographically by cell name.")
     @ApiResponses({
                 @ApiResponse(code = 403, message = "Cell info service only accessible to admin users."),
             })
     @Produces(MediaType.APPLICATION_JSON)
     public CellData[] getCellData()throws CacheException {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Cell info service only accessible to admin users.");
-        }
-
         return Arrays.stream(service.getAddresses())
                      .map(service::getCellData)
                      .collect(Collectors.toList())

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolGroupInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolGroupInfoResources.java
@@ -62,19 +62,14 @@ package org.dcache.restful.resources.pool;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import java.util.Comparator;
@@ -88,7 +83,6 @@ import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.restful.providers.pool.PoolGroupInfo;
 import org.dcache.restful.providers.selection.PoolGroup;
 import org.dcache.restful.services.pool.PoolInfoService;
-import org.dcache.restful.util.HttpServletRequests;
 
 /**
  * <p>RESTful API to the {@link PoolInfoService} service.</p>
@@ -99,9 +93,6 @@ import org.dcache.restful.util.HttpServletRequests;
 @Api(value = "poolmanager", authorizations = {@Authorization("basicAuth")})
 @Path("/poolgroups")
 public final class PoolGroupInfoResources {
-    @Context
-    private HttpServletRequest request;
-
     @Inject
     private PoolInfoService service;
 
@@ -109,18 +100,10 @@ public final class PoolGroupInfoResources {
     private PoolMonitor poolMonitor;
 
     @GET
-    @ApiOperation("Get a list of poolgroups.  Requires admin role."
+    @ApiOperation("Get a list of poolgroups."
                     + " Results sorted lexicographically by group name.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool group info only accessible to admin users."),
-    })
     @Produces(MediaType.APPLICATION_JSON)
     public List<PoolGroup> getPoolGroups() {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Pool group info only accessible to admin users.");
-        }
-
         PoolSelectionUnit psu = poolMonitor.getPoolSelectionUnit();
 
         return psu.getPoolGroups().values()
@@ -133,18 +116,10 @@ public final class PoolGroupInfoResources {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation("Get information about a poolgroup.  Requires admin role.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool group info only accessible to admin users."),
-    })
+    @ApiOperation("Get information about a poolgroup.")
     @Path("/{group}")
     public PoolGroup getPoolGroup(@ApiParam("The poolgroup to be described.")
                                   @PathParam("group") String group) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Pool group info only accessible to admin users.");
-        }
-
         return new PoolGroup(group, poolMonitor.getPoolSelectionUnit());
     }
 
@@ -165,20 +140,11 @@ public final class PoolGroupInfoResources {
 
 
     @GET
-    @ApiOperation("Get usage metadata about a specific poolgroup.  Requires "
-            + "admin role.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool group info only accessible to admin users."),
-    })
+    @ApiOperation("Get usage metadata about a specific poolgroup.")
     @Path("/{group}/usage")
     @Produces(MediaType.APPLICATION_JSON)
     public PoolGroupInfo getGroupUsage(@ApiParam("The poolgroup to be described.")
                                        @PathParam("group") String group) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Pool group info only accessible to admin users.");
-        }
-
         PoolGroupInfo info = new PoolGroupInfo();
 
         service.getGroupCellInfos(group, info);
@@ -188,20 +154,11 @@ public final class PoolGroupInfoResources {
 
 
     @GET
-    @ApiOperation("Get pool activity information about pools of a specific poolgroup.  "
-            + "Requires admin role.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool group info only accessible to admin users."),
-    })
+    @ApiOperation("Get pool activity information about pools of a specific poolgroup.")
     @Path("/{group}/queues")
     @Produces(MediaType.APPLICATION_JSON)
     public PoolGroupInfo getQueueInfo(@ApiParam("The poolgroup to be described.")
                                       @PathParam("group") String group) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Pool group info only accessible to admin users.");
-        }
-
         PoolGroupInfo info = new PoolGroupInfo();
 
         service.getGroupQueueInfos(group, info);
@@ -211,20 +168,11 @@ public final class PoolGroupInfoResources {
 
 
     @GET
-    @ApiOperation("Get space information about pools of a specific poolgroup.  Requires "
-            + "admin role.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool group info only accessible to admin users."),
-    })
+    @ApiOperation("Get space information about pools of a specific poolgroup.")
     @Path("/{group}/space")
     @Produces(MediaType.APPLICATION_JSON)
     public PoolGroupInfo getSpaceInfo(@ApiParam("The poolgroup to be described.")
                                       @PathParam("group") String group) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Pool group info only accessible to admin users.");
-        }
-
         PoolGroupInfo info = new PoolGroupInfo();
 
         service.getGroupSpaceInfos(group, info);
@@ -234,8 +182,7 @@ public final class PoolGroupInfoResources {
 
 
     @GET
-    @ApiOperation("Get aggregated pool activity histogram information from pools in a specific poolgroup.  "
-            + "Requires admin role.")
+    @ApiOperation("Get aggregated pool activity histogram information from pools in a specific poolgroup.")
     @Path("/{group}/histograms/queues")
     @Produces(MediaType.APPLICATION_JSON)
     public PoolGroupInfo getQueueHistograms(@ApiParam("The poolgroup to be described.")
@@ -249,11 +196,7 @@ public final class PoolGroupInfoResources {
 
 
     @GET
-    @ApiOperation("Get aggregated file statistics histogram information from pools in a specific poolgroup.  Requires "
-            + "admin role.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool group info only accessible to admin users."),
-    })
+    @ApiOperation("Get aggregated file statistics histogram information from pools in a specific poolgroup.")
     @Path("/{group}/histograms/files")
     @Produces(MediaType.APPLICATION_JSON)
     public PoolGroupInfo getFilesHistograms(@ApiParam("The poolgroup to be described.")

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
@@ -160,17 +160,9 @@ public final class PoolInfoResources {
 
     @GET
     @ApiOperation("Get information about all pools (name, group membership, links).  "
-                    + "Requires admin role.  Results sorted lexicographically by pool name.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool info only accessible to admin users."),
-    })
+                    + "Results sorted lexicographically by pool name.")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Pool> getPools() throws CacheException {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Pool info only accessible to admin users.");
-        }
-
         PoolSelectionUnit psu = poolMonitor.getPoolSelectionUnit();
 
         return psu.getPools().values()
@@ -182,41 +174,23 @@ public final class PoolInfoResources {
 
 
     @GET
-    @ApiOperation("Get information about a specific pool (name, group membership, links). "
-                    + "Requires admin role.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool info only accessible to admin users."),
-    })
+    @ApiOperation("Get information about a specific pool (name, group membership, links).")
     @Path("/{pool}")
     @Produces(MediaType.APPLICATION_JSON)
     public Pool getPool(@ApiParam(value = "The pool to be described.",
                                 required = true)
                         @PathParam("pool") String pool) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Pool info only accessible to admin users.");
-        }
-
         return new Pool(pool, poolMonitor.getPoolSelectionUnit());
     }
 
 
     @GET
-    @ApiOperation("Get information about a specific pool (configuration, state, usage).  "
-                    + "Requires admin role.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool info only accessible to admin users."),
-    })
+    @ApiOperation("Get information about a specific pool (configuration, state, usage).")
     @Path("/{pool}/usage")
     @Produces(MediaType.APPLICATION_JSON)
     public PoolInfo getPoolUsage(@ApiParam(value = "The pool to be described.",
                                          required = true)
                                  @PathParam("pool") String pool) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Pool info only accessible to admin users.");
-        }
-
         PoolInfo info = new PoolInfo();
 
         service.getDiagnosticInfo(pool, info);
@@ -227,10 +201,7 @@ public final class PoolInfoResources {
 
     @GET
     @ApiOperation("Get information about a specific PNFS-ID usage within a "
-            + "specific pool.  Requires admin role.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Pool info only accessible to admin users."),
-    })
+            + "specific pool.")
     @Path("/{pool}/{pnfsid}")
     @Produces(MediaType.APPLICATION_JSON)
     public PoolInfo getRepositoryInfoForFile(@ApiParam(value = "The pool to be described.",
@@ -239,11 +210,6 @@ public final class PoolInfoResources {
                                              @ApiParam(value = "The PNFS-ID of the file to be described.",
                                                      required = true)
                                              @PathParam("pnfsid") PnfsId pnfsid) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Repository info for file only accessible to admin users.");
-        }
-
         PoolInfo info = new PoolInfo();
 
         service.getCacheInfo(pool, pnfsid, info);
@@ -283,16 +249,13 @@ public final class PoolInfoResources {
 
 
     @GET
-    @ApiOperation(value = "Get mover information for a specific pool.  Requires admin role.",
+    @ApiOperation(value = "Get mover information for a specific pool.",
             responseHeaders = {
                 @ResponseHeader(name = "X-Total-Count", description = "Total "
                         + "number of potential responses.  This may be greater "
                         + "than the number of response if offset or limit are "
                         + "specified")
             })
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Mover info only accessible to admin users."),
-    })
     @Path("/{pool}/movers")
     @Produces(MediaType.APPLICATION_JSON)
     public List<MoverData> getMovers(@ApiParam("The pool to be described.")
@@ -321,11 +284,6 @@ public final class PoolInfoResources {
                                      @ApiParam("How returned items should be sorted.")
                                      @DefaultValue("door,startTime")
                                      @QueryParam("sort") String sort) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Mover info only accessible to admin users.");
-        }
-
         limit = limit == null ? Integer.MAX_VALUE : limit;
 
         String[] type = typeList == null ? new String[0]:
@@ -374,11 +332,9 @@ public final class PoolInfoResources {
 
 
     @GET
-    @ApiOperation("Get nearline activity information for a specific pool.  "
-                    + "Requires admin role.")
+    @ApiOperation("Get nearline activity information for a specific pool.")
     @ApiResponses({
         @ApiResponse(code = 400, message = "unrecognized queue type"),
-        @ApiResponse(code = 403, message = "Flush info only accessible to admin users."),
         @ApiResponse(code = 500, message = "Internal Server Error"),
     })
     @Path("/{pool}/nearline/queues")
@@ -402,11 +358,6 @@ public final class PoolInfoResources {
                                                 @ApiParam("How the returned values should be sorted.")
                                                 @DefaultValue("class,created")
                                                 @QueryParam("sort") String sort) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Flush info only accessible to admin users.");
-        }
-
         limit = limit == null ? Integer.MAX_VALUE : limit;
 
         List<NearlineData> list = new ArrayList<>();

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/LinkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/LinkResources.java
@@ -61,18 +61,13 @@ package org.dcache.restful.resources.selection;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import java.util.Comparator;
@@ -86,7 +81,6 @@ import diskCacheV111.poolManager.PoolSelectionUnit.SelectionLinkGroup;
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.restful.providers.selection.Link;
 import org.dcache.restful.providers.selection.LinkGroup;
-import org.dcache.restful.util.HttpServletRequests;
 
 /**
  * <p>RESTful API to the {@link org.dcache.poolmanager.PoolMonitor}, in
@@ -98,26 +92,15 @@ import org.dcache.restful.util.HttpServletRequests;
 @Api(value = "poolmanager", authorizations = {@Authorization("basicAuth")})
 @Path("/links")
 public final class LinkResources {
-    @Context
-    private HttpServletRequest request;
-
     @Inject
     private PoolMonitor poolMonitor;
 
 
     @GET
-    @ApiOperation("Get information about all links.  Requires admin role."
+    @ApiOperation("Get information about all links."
                     + " Results sorted lexicographically by link name.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Link info only accessible to admin users."),
-    })
     @Produces(MediaType.APPLICATION_JSON)
     public List<Link> getLinks() {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Link info only accessible to admin users.");
-        }
-
         return poolMonitor.getPoolSelectionUnit().getLinks().values()
                           .stream()
                           .sorted(Comparator.comparing(SelectionLink::getName))
@@ -126,19 +109,11 @@ public final class LinkResources {
     }
 
     @GET
-    @ApiOperation("Get information about all linkgroups.  Requires admin role."
+    @ApiOperation("Get information about all linkgroups."
                     + " Results sorted lexicographically by link group name.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Link group info only accessible to admin users."),
-    })
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/groups")
     public List<LinkGroup> getLinkGroups() {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Link group info only accessible to admin users.");
-        }
-
         PoolSelectionUnit psu = poolMonitor.getPoolSelectionUnit();
 
         return psu.getLinkGroups().values()

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/PartitionResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/PartitionResources.java
@@ -61,18 +61,13 @@ package org.dcache.restful.resources.selection;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import java.util.Comparator;
@@ -82,7 +77,6 @@ import java.util.stream.Collectors;
 
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.restful.providers.selection.Partition;
-import org.dcache.restful.util.HttpServletRequests;
 
 /**
  * <p>RESTful API to the {@link org.dcache.poolmanager.PoolMonitor}, in
@@ -94,26 +88,15 @@ import org.dcache.restful.util.HttpServletRequests;
 @Api(value = "poolmanager", authorizations = {@Authorization("basicAuth")})
 @Path("/partitions")
 public final class PartitionResources {
-    @Context
-    private HttpServletRequest request;
-
     @Inject
     private PoolMonitor poolMonitor;
 
 
     @GET
-    @ApiOperation("Get information about all partitions.  Requires admin role."
+    @ApiOperation("Get information about all partitions."
                     + " Results sorted lexicographically by partition name.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Partition info only accessible to admin users."),
-    })
     @Produces(MediaType.APPLICATION_JSON)
     public List<Partition> getPartitions() {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Partition info only accessible to admin users.");
-        }
-
         return poolMonitor.getPartitionManager().getPartitions().entrySet()
                           .stream()
                           .sorted(Comparator.comparing(Entry::getKey))

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/PoolPreferenceResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/PoolPreferenceResources.java
@@ -73,7 +73,6 @@ import javax.inject.Named;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
@@ -93,7 +92,6 @@ import dmg.cells.nucleus.NoRouteToCellException;
 import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.restful.providers.selection.PreferenceResult;
-import org.dcache.restful.util.HttpServletRequests;
 
 /**
  * <p>RESTful API to the {@link diskCacheV111.poolManager.PoolManagerV5}, in
@@ -105,9 +103,6 @@ import org.dcache.restful.util.HttpServletRequests;
 @Api(value = "poolmanager", authorizations = {@Authorization("basicAuth")})
 @Path("/pool-preferences")
 public final class PoolPreferenceResources {
-    @Context
-    private HttpServletRequest request;
-
     @Inject
     private PoolMonitor poolMonitor;
 
@@ -119,7 +114,6 @@ public final class PoolPreferenceResources {
     @ApiOperation("Describe the pools selected by a particular request.")
     @ApiResponses({
         @ApiResponse(code = 400, message = "Bad Request"),
-        @ApiResponse(code = 403, message = "Pool preference info only accessible to admin users."),
         @ApiResponse(code = 500, message = "Internal Server Error"),
     })
     @Produces(MediaType.APPLICATION_JSON)
@@ -142,11 +136,6 @@ public final class PoolPreferenceResources {
                                         @ApiParam("The linkgroup unit, or 'none' for a request outside of a linkgroup.")
                                         @DefaultValue("none")
                                         @QueryParam("linkGroup") String linkGroup) {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Pool preference info only accessible to admin users.");
-        }
-
         try {
             String command = "psux match " + type + " " + store + " "
                             + dcache + " " + net  + " " + protocol

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/UnitResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/UnitResources.java
@@ -61,14 +61,11 @@ package org.dcache.restful.resources.selection;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -86,7 +83,6 @@ import diskCacheV111.poolManager.PoolSelectionUnit.SelectionUnitGroup;
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.restful.providers.selection.Unit;
 import org.dcache.restful.providers.selection.UnitGroup;
-import org.dcache.restful.util.HttpServletRequests;
 
 /**
  * <p>RESTful API to the {@link org.dcache.poolmanager.PoolMonitor}, in
@@ -98,25 +94,14 @@ import org.dcache.restful.util.HttpServletRequests;
 @Api(value = "poolmanager", authorizations = {@Authorization("basicAuth")})
 @Path("/units")
 public final class UnitResources {
-    @Context
-    private HttpServletRequest request;
-
     @Inject
     private PoolMonitor poolMonitor;
 
     @GET
-    @ApiOperation("List all units.  Requires admin role."
+    @ApiOperation("List all units."
                     + " Results sorted lexicographically by unit name.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Unit info only accessible to admin users."),
-    })
     @Produces(MediaType.APPLICATION_JSON)
     public List<Unit> getUnits() {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Unit info only accessible to admin users.");
-        }
-
         return poolMonitor.getPoolSelectionUnit().getSelectionUnits().values()
                           .stream()
                           .sorted(Comparator.comparing(SelectionUnit::getName))
@@ -126,19 +111,11 @@ public final class UnitResources {
 
 
     @GET
-    @ApiOperation("List all unitgroups.  Requires admin role."
+    @ApiOperation("List all unitgroups."
                     + " Results sorted lexicographically by unit group name.")
-    @ApiResponses({
-        @ApiResponse(code = 403, message = "Unit info only accessible to admin users."),
-    })
     @Path("/groups")
     @Produces(MediaType.APPLICATION_JSON)
     public List<UnitGroup> getUnitGroups() {
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(
-                            "Unit group info only accessible to admin users.");
-        }
-
         PoolSelectionUnit psu = poolMonitor.getPoolSelectionUnit();
 
         return poolMonitor.getPoolSelectionUnit().getUnitGroups().values()

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/space/SpaceManagerResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/space/SpaceManagerResources.java
@@ -69,15 +69,12 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import java.util.Comparator;
@@ -101,7 +98,6 @@ import dmg.cells.nucleus.NoRouteToCellException;
 import org.dcache.cells.CellStub;
 import org.dcache.restful.providers.space.LinkGroupInfo;
 import org.dcache.restful.providers.space.SpaceToken;
-import org.dcache.restful.util.HttpServletRequests;
 
 /**
  * <p>RESTful API to the SpaceManager.</p>
@@ -114,9 +110,6 @@ import org.dcache.restful.util.HttpServletRequests;
 public final class SpaceManagerResources {
     private final static String FORBIDDEN = "Spacemanager info only accessible to "
                                                 + "admin users.";
-    @Context
-    private HttpServletRequest request;
-
     @Inject
     @Named("spacemanager-stub")
     private CellStub spacemanagerStub;
@@ -124,11 +117,10 @@ public final class SpaceManagerResources {
     private boolean spaceReservationEnabled;
 
     @GET
-    @ApiOperation("Get information about link groups.  Requires admin role."
+    @ApiOperation("Get information about link groups."
                     + " Results sorted lexicographically by link group name.")
     @ApiResponses({
         @ApiResponse(code = 400, message = "Bad Request Error"),
-        @ApiResponse(code = 403, message = "Link group info only accessible to admin users."),
         @ApiResponse(code = 404, message = "DCache not configured for space management."),
         @ApiResponse(code = 500, message = "Internal Server Error")
     })
@@ -156,10 +148,6 @@ public final class SpaceManagerResources {
                                       @QueryParam("minAvailableSpace") Long minAvailableSpace) {
         if (!spaceReservationEnabled) {
             throw new NotFoundException();
-        }
-
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(FORBIDDEN);
         }
 
         Predicate<LinkGroup> filter = getLinkGroupFilter(name,
@@ -190,9 +178,8 @@ public final class SpaceManagerResources {
 
     @GET
     @ApiOperation("Get information about space tokens.  "
-                    + "Requires admin role.  Results sorted by token id.")
+                    + "Results sorted by token id.")
     @ApiResponses({
-        @ApiResponse(code = 403, message = "Space token info only accessible to admin users."),
         @ApiResponse(code = 404, message = "DCache not configured for space management."),
         @ApiResponse(code = 500, message = "Internal Server Error")
     })
@@ -218,10 +205,6 @@ public final class SpaceManagerResources {
                                               @QueryParam("minFreeSpace") Long minFreeSpace) {
         if (!spaceReservationEnabled) {
             throw new NotFoundException();
-        }
-
-        if (!HttpServletRequests.isAdmin(request)) {
-            throw new ForbiddenException(FORBIDDEN);
         }
 
         Predicate<Space> filter = getSpaceFilter(id,

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoService.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoService.java
@@ -90,6 +90,7 @@ public interface TransferInfoService {
      *                  without a token (refresh).
      * @param offset    Return transfers beginning at this index.
      * @param limit     Return at most this number of items.
+     * @param suid      Return transfers only belonging to this user (null returns all).
      * @param state     Filter on state.
      * @param door      Filter on door.
      * @param domain    Filter on domain.
@@ -108,6 +109,7 @@ public interface TransferInfoService {
     SnapshotList<TransferInfo> get(UUID token,
                                    Integer offset,
                                    Integer limit,
+                                   String suid,
                                    String state,
                                    String door,
                                    String domain,

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoServiceImpl.java
@@ -259,6 +259,7 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                                   null,
                                   null,
                                   null,
+                                  null,
                                   null);
             List<TransferInfo> snapshot = result.getItems();
 
@@ -347,11 +348,17 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
         };
     }
 
-    private static Predicate<TransferInfo> getFilter(String state, String door,
+    private static Predicate<TransferInfo> getFilter(String subjectUid,
+                                                     String state, String door,
                                                      String domain, String protocol,
                                                      String uid, String gid,
                                                      String vomsgroup, String pnfsid,
                                                      String pool, String client) {
+        Predicate<TransferInfo> matchesSubject =
+                        (info) -> subjectUid == null
+                                        || Strings.emptyToNull(info.getUid()) == null  // allow all users to see anonymous transfers
+                                        || info.getUid().equals(subjectUid);
+
         Predicate<TransferInfo> matchesState =
                         (info) -> state == null || Strings.nullToEmpty(info.getMoverStatus())
                                                           .contains(state);
@@ -383,9 +390,10 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                         (info) -> client == null || Strings.nullToEmpty(info.getReplyHost())
                                                           .contains(client);
 
-        return matchesState.and(matchesDoor).and(matchesDomain).and(matchesProtocol)
-                           .and(matchesUid).and(matchesGid).and(matchesVomsGroup)
-                           .and(matchesPnfsid).and(matchesPool).and(matchesClient);
+        return matchesSubject.and(matchesState).and(matchesDoor)
+                             .and(matchesDomain).and(matchesProtocol)
+                             .and(matchesUid).and(matchesGid).and(matchesVomsGroup)
+                             .and(matchesPnfsid).and(matchesPool).and(matchesClient);
     }
 
     /**
@@ -409,6 +417,7 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
     public SnapshotList<TransferInfo> get(UUID token,
                                           Integer offset,
                                           Integer limit,
+                                          String suid,
                                           String state,
                                           String door,
                                           String domain,
@@ -420,7 +429,8 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                                           String pool,
                                           String client,
                                           String sort) throws CacheException {
-        Predicate<TransferInfo> filter = getFilter(state, door, domain, protocol,
+        Predicate<TransferInfo> filter = getFilter(suid,
+                                                   state, door, domain, protocol,
                                                    uid, gid, vomsgroup,
                                                    pnfsid, pool, client);
         if (Strings.isNullOrEmpty(sort)) {


### PR DESCRIPTION
…s on uid if not admin

Motivation:

Currently all monitoring information is only available to admin role users.
This is a change from the previous webadmin interface, where most information
(except alarms and space token definition) was available to all users.
This probably is too restrictive and may disrupt some user patterns.

Modification:

This patch alters the RESTful API and implementation; a subsequent one
will modify dcache-view.

All GET methods are now open to all users.  Only POST, PATCH, PUT and DELETE
are limited where implemented.

As for active transfers, if the user is admin, all transfers are returned;
otherwise, only those matching the user's uid.  Transfers without uid
defined are visible to everyone.

Result:

Access semantics which are more compatible with previous usage.

Target: master
Request: 4.2
Acked-by: Paul