### PR TITLE
gplazma2-fermi plugin (vogroup plugin): allow for wildcard match of f…

### DIFF
--- a/modules/gplazma2-fermi/src/test/java/org/dcache/gplazma/plugins/VOGroupPluginTest.java
+++ b/modules/gplazma2-fermi/src/test/java/org/dcache/gplazma/plugins/VOGroupPluginTest.java
@@ -134,6 +134,21 @@ public class VOGroupPluginTest {
     }
 
     @Test
+    public void shouldFindTheWildcardMatch()
+                    throws Exception {
+        givenFQAN(anFqanWithUnameForWildCardMatch());
+        whenMapIsCalled();
+        assertThatPluginSucceeded();
+    }
+
+    @Test
+    public void shouldFailOnNoMatch()
+        throws Exception {
+        givenFQAN(anFqanThatShouldNotMacth());
+        whenMapIsCalled();
+        assertThatPluginFailed();
+    }
+    @Test
     public void shouldNotFailIfUserNamePresent() throws Exception {
         givenFQAN(anFqanWithUname());
         whenMapIsCalled();
@@ -172,6 +187,15 @@ public class VOGroupPluginTest {
     private String anFqanWithoutUname() {
         return "/fermilab/accelerator/Role=None";
     }
+
+    private String anFqanWithUnameForWildCardMatch() {
+        return "/fermilab/cdf/Role=Production";
+    }
+
+    private String anFqanThatShouldNotMacth() {
+        return "/fermilab/Role=production";
+    }
+
 
     private void assertThatGidPrincipalWasAdded() {
         Optional<GidPrincipal> gidPrincipal

--- a/modules/gplazma2-fermi/src/test/resources/org/dcache/gplazma/plugins/vo-group.json
+++ b/modules/gplazma2-fermi/src/test/resources/org/dcache/gplazma/plugins/vo-group.json
@@ -1,4 +1,9 @@
 [
+ {
+    "fqan": "/fermilab/*Role=Production",
+    "mapped_uname": "production",
+    "mapped_gid": "9767"
+  },
   {
     "fqan": "/GLOW/Role=None",
     "mapped_uname": "glow",


### PR DESCRIPTION
…qans

Motivation

During pre-production testing of Fermilab user registry system (FERRY) is has been
discovered that vo-group.json file extracted from FERRY contains not only valid
FQANs but also wildcard match patterns. These are usually used to account for
opportunistic users.

Modification

Code is modified to check exact match and then also check wildcard match
in case of failure to find exact match

Result

Plugin handles wildcards in fqan fields of vo-group.json file

Release Notes:

gplazma2-fermi voggroup plugin supports wilcard match on user fqan

RB: https://rb.dcache.org/r/11185/
Acked-by: Paul Millar <paul.millar@desy.de>

Target: trunk
Request: 4.2

Require-notes: yes
Require-book: no