### PR TITLE
dcache: Creating multiple KafkaProducer instances results in 'Too man…

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -2459,6 +2459,17 @@ public class DCapDoorInterpreterV3
     }
 
     public void close() {
+
+
+        /*The producer consists of a pool of buffer space that holds records that haven't yet been
+          transmitted to the server as well as a background I/O thread
+          that is responsible for turning these records into requests and transmitting them to the cluster.
+          Failure to close the producer after use will leak these resources. Hence we need to  close Kafka Producer
+         */
+        if (_settings.isKafkaEnabled()) {
+            _kafkaProducer.close();
+        }
+
         for(SessionHandler sh: _sessions.values()) {
             try {
                 sh.removeUs();

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1731,6 +1731,15 @@ public abstract class AbstractFtpDoorV1
     @Override
     public void shutdown()
     {
+        /*The producer consists of a pool of buffer space that holds records that haven't yet been
+          transmitted to the server as well as a background I/O thread
+          that is responsible for turning these records into requests and transmitting them to the cluster.
+          Failure to close the producer after use will leak these resources. Hence we need to  and close Kafka Producer
+         */
+        if (_settings.isKafkaEnabled()) {
+            _kafkaProducer.close();
+        }
+
         /* In case of failure, we may have a transfer hanging around.
          */
         Transfer transfer = getTransfer();

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -205,7 +205,6 @@
           </constructor-arg>
         </bean>
       </constructor-arg>
-      <constructor-arg name="autoFlush" value="false"/>
       <property name="defaultTopic" value="billing"/>
       <property name="producerListener" ref="listener"/>
     </bean>

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -574,7 +574,6 @@
                    </constructor-arg>
                </bean>
            </constructor-arg>
-           <constructor-arg name="autoFlush" value="false" />
            <property name="defaultTopic" value="billing"/>
            <property name="producerListener" ref="listener"/>
        </bean>
@@ -598,7 +597,6 @@
                     </constructor-arg>
                 </bean>
             </constructor-arg>
-            <constructor-arg name="autoFlush" value="false" />
             <property name="defaultTopic" value="billing"/>
             <property name="producerListener" ref="listener"/>
         </bean>


### PR DESCRIPTION
…y open files'

Motivation

    For dcap and ftp dorrs for each transfer was created new Kafka producer.

    As a result first Server was shutdown with the following IO exception

    java.io.IOException: Too many open files
    at sun.nio.ch.ServerSocketChannelImpl.accept0(Native Method)
    at
    sun.nio.ch.ServerSocketChannelImpl.accept(ServerSocketChannelImpl.java:422)
    at
    sun.nio.ch.ServerSocketChannelImpl.accept(ServerSocketChannelImpl.java:250)
    at kafka.network.Acceptor.accept(SocketServer.scala:452)
    at kafka.network.Acceptor.run(SocketServer.scala:395)
    at java.lang.Thread.run(Thread.java:748)

    The reason is that  it reaches its  limit for  open files for the server.
     The default setting of 1024 for the maximum number of open files on most Unix-like systems is insufficient.

    Second issue was that the for each new producer new connnection was oppened which resulted in  gradual
    increase in CPU load and in that event the doors were shutdown

    Modifications

            Kafka Producers are now flushed and closed when destroy or close methods are called.

    for xrootd, webdav, nfs and pool  autoFlush configuration is added to flush producer after send.

    Target: master
    Request: 4.2
    Require-notes: yes
    Require-book: no
    Patch: https://rb.dcache.org/r/11194/
    Acked-by: Tigran, Paul