### PR TITLE
dcache: Adjust Date formating of Timestamp value for `date` key for  …

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/notification/BillingMessageSerializer.java
+++ b/modules/dcache/src/main/java/org/dcache/notification/BillingMessageSerializer.java
@@ -5,7 +5,10 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.net.InetSocketAddress;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import diskCacheV111.vehicles.IpProtocolInfo;
@@ -21,7 +24,8 @@ public class BillingMessageSerializer implements Serializer<MoverInfoMessage> {
         JSONObject o = new JSONObject();
         o.put("version", "1.0");
         o.put("msgType", data.getMessageType());
-        o.put("date", new Date(data.getTimestamp()));
+        o.put("date", DateTimeFormatter.ISO_OFFSET_DATE_TIME
+                .format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(data.getTimestamp()), ZoneId.systemDefault())));
         o.put("queuingTime", data.getTimeQueued());
         o.put("cellName", data.getCellAddress().getCellName());
         o.put("cellType", data.getCellType());

--- a/modules/dcache/src/main/java/org/dcache/notification/DoorRequestMessageSerializer.java
+++ b/modules/dcache/src/main/java/org/dcache/notification/DoorRequestMessageSerializer.java
@@ -4,7 +4,10 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import diskCacheV111.vehicles.DoorRequestInfoMessage;
@@ -19,7 +22,8 @@ public class DoorRequestMessageSerializer implements Serializer<DoorRequestInfoM
         JSONObject o = new JSONObject();
         o.put("VERSION", "1.0");
         o.put("msgType", data.getMessageType());
-        o.put("date", new Date(data.getTimestamp()));
+        o.put("date", DateTimeFormatter.ISO_OFFSET_DATE_TIME
+                .format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(data.getTimestamp()), ZoneId.systemDefault())));
         o.put("queuingTime", data.getTimeQueued());
         o.put("cellName", data.getCellAddress().getCellName());
         o.put("cellType", data.getCellType());

--- a/modules/dcache/src/main/java/org/dcache/notification/RemoveFileInfoMessageSerializer.java
+++ b/modules/dcache/src/main/java/org/dcache/notification/RemoveFileInfoMessageSerializer.java
@@ -21,6 +21,10 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
 
@@ -37,7 +41,8 @@ public class RemoveFileInfoMessageSerializer implements Serializer<RemoveFileInf
         JSONObject o = new JSONObject();
         o.put("version", "1.0");
         o.put("msgType", data.getMessageType());
-        o.put("date", new Date(data.getTimestamp()));
+        o.put("date", DateTimeFormatter.ISO_OFFSET_DATE_TIME
+                .format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(data.getTimestamp()), ZoneId.systemDefault())));
         o.put("queuingTime", data.getTimeQueued());
         o.put("transaction", data.getTransaction());
         o.put("cellName", data.getCellAddress().getCellName());

--- a/modules/dcache/src/main/java/org/dcache/notification/StorageInfoMessageSerializer.java
+++ b/modules/dcache/src/main/java/org/dcache/notification/StorageInfoMessageSerializer.java
@@ -18,6 +18,7 @@
 package org.dcache.notification;
 
 import org.apache.kafka.common.serialization.Serializer;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.time.Instant;

--- a/modules/dcache/src/main/java/org/dcache/notification/StorageInfoMessageSerializer.java
+++ b/modules/dcache/src/main/java/org/dcache/notification/StorageInfoMessageSerializer.java
@@ -18,11 +18,14 @@
 package org.dcache.notification;
 
 import org.apache.kafka.common.serialization.Serializer;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
+
 import diskCacheV111.vehicles.StorageInfoMessage;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -35,7 +38,8 @@ public class StorageInfoMessageSerializer implements Serializer<StorageInfoMessa
         JSONObject o = new JSONObject();
         o.put("version", "1.0");
         o.put("msgType", data.getMessageType());
-        o.put("date", new Date(data.getTimestamp()));
+        o.put("date", DateTimeFormatter.ISO_OFFSET_DATE_TIME
+                .format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(data.getTimestamp()), ZoneId.systemDefault())));
         o.put("queuingTime", data.getTimeQueued());
         o.put("transaction", data.getTransaction());
         o.put("cellName", data.getCellAddress().getCellName());


### PR DESCRIPTION
…kafka producer

Motivation:

	Previous format "date":"Mon Oct 01 13:49:00 CEST 2018" was not easy to parse.

Modification & Result:

New format, `date":"2018-10-0113:50:30.008+02:00` is easier to parse.

Target: master
Requires-notes: no
Patch: https://rb.dcache.org/r/11220/
Acked-by: Tigran Mkrtchyan