### PR TITLE
vehicles: fix serialization regression  in  FileCorruptedCacheException

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/util/FileCorruptedCacheException.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/util/FileCorruptedCacheException.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2007-2013 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2007-2018 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -34,27 +34,27 @@ public class FileCorruptedCacheException extends CacheException
 {
     private static final long serialVersionUID = 6022529795888425409L;
 
-    private final Optional<Set<Checksum>> _expectedChecksums;
-    private final Optional<Set<Checksum>> _actualChecksums;
-    private final Optional<Long> _expectedSize;
-    private final Optional<Long> _actualSize;
+    private final Set<Checksum> _expectedChecksums;
+    private final Set<Checksum> _actualChecksums;
+    private final Long _expectedSize;
+    private final Long _actualSize;
 
     public FileCorruptedCacheException(String message)
     {
         super(FILE_CORRUPTED, message);
-        _expectedChecksums = Optional.empty();
-        _actualChecksums = Optional.empty();
-        _expectedSize = Optional.empty();
-        _actualSize = Optional.empty();
+        _expectedChecksums = null;
+        _actualChecksums = null;
+        _expectedSize = null;
+        _actualSize = null;
     }
 
     public FileCorruptedCacheException(String message, Throwable cause)
     {
         super(FILE_CORRUPTED, message, cause);
-        _expectedChecksums = Optional.empty();
-        _actualChecksums = Optional.empty();
-        _expectedSize = Optional.empty();
-        _actualSize = Optional.empty();
+        _expectedChecksums = null;
+        _actualChecksums = null;
+        _expectedSize = null;
+        _actualSize = null;
     }
 
     public FileCorruptedCacheException(Checksum expectedChecksum, Checksum actualChecksum)
@@ -65,38 +65,38 @@ public class FileCorruptedCacheException extends CacheException
     public FileCorruptedCacheException(Set<Checksum> expectedChecksums, Set<Checksum> actualChecksums)
     {
         super(FILE_CORRUPTED, "Checksum mismatch (expected=" + expectedChecksums + ", actual=" + actualChecksums + ')');
-        _expectedChecksums = Optional.of(expectedChecksums);
-        _actualChecksums = Optional.of(actualChecksums);
-        _expectedSize = Optional.empty();
-        _actualSize = Optional.empty();
+        _expectedChecksums = expectedChecksums;
+        _actualChecksums = actualChecksums;
+        _expectedSize = null;
+        _actualSize = null;
     }
 
     public FileCorruptedCacheException(long expectedSize, long actualSize)
     {
         super(FILE_CORRUPTED, "File size mismatch (expected=" + expectedSize + ", actual=" + actualSize + ')');
-        _expectedChecksums = Optional.empty();
-        _actualChecksums = Optional.empty();
-        _expectedSize = Optional.of(expectedSize);
-        _actualSize = Optional.of(actualSize);
+        _expectedChecksums = null;
+        _actualChecksums = null;
+        _expectedSize = expectedSize;
+        _actualSize = actualSize;
     }
 
     public Optional<Set<Checksum>> getExpectedChecksums()
     {
-        return _expectedChecksums;
+        return Optional.ofNullable(_expectedChecksums);
     }
 
     public Optional<Set<Checksum>> getActualChecksums()
     {
-        return _actualChecksums;
+        return Optional.ofNullable(_actualChecksums);
     }
 
     public Optional<Long> getExpectedSize()
     {
-        return _expectedSize;
+        return Optional.ofNullable(_expectedSize);
     }
 
     public Optional<Long> getActualSize()
     {
-        return _actualSize;
+        return Optional.ofNullable(_actualSize);
     }
 }


### PR DESCRIPTION
Motivation:
Commit dea4beb have converted usage of guava's Optional to jdk native Optional.
However, jdk Optional is not implementing serializable interface and, as
a result, NotSerializableException is thrown when FileCorruptedCacheException
is sent from one cell to an other:

dmg.cells.nucleus.SerializationException: Failed to serialize object because the object is not serializable (this is usually a bug)
        at dmg.cells.nucleus.CellMessage.encode(CellMessage.java:211) ~[cells-4.2.7.jar:4.2.7]
        at dmg.cells.nucleus.CellMessage.encode(CellMessage.java:187) ~[cells-4.2.7.jar:4.2.7]
        at dmg.cells.nucleus.CellGlue.sendMessage(CellGlue.java:466) ~[cells-4.2.7.jar:4.2.7]
        at dmg.cells.nucleus.CellNucleus.sendMessage(CellNucleus.java:408) ~[cells-4.2.7.jar:4.2.7]
        at dmg.cells.nucleus.CellAdapter.sendMessage(CellAdapter.java:445) ~[cells-4.2.7.jar:4.2.7]
        at dmg.cells.nucleus.AbstractCellComponent.sendMessage(AbstractCellComponent.java:41) ~[cells-4.2.7.jar:4.2.7]
        at diskCacheV111.namespace.PnfsManagerV3.postProcessMessage(PnfsManagerV3.java:1754) ~[dcache-core-4.2.7.jar:4.2.7]
        at diskCacheV111.namespace.PnfsManagerV3.processPnfsMessage(PnfsManagerV3.java:1698) ~[dcache-core-4.2.7.jar:4.2.7]
        at diskCacheV111.namespace.PnfsManagerV3$ProcessThread.run(PnfsManagerV3.java:1591) ~[dcache-core-4.2.7.jar:4.2.7]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_161]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_161]
        at java.lang.Thread.run(Thread.java:748) [na:1.8.0_161]
Caused by: java.io.NotSerializableException: java.util.Optional
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184) ~[na:1.8.0_161]
        at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548) ~[na:1.8.0_161]
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509) ~[na:1.8.0_161]
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432) ~[na:1.8.0_161]
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178) ~[na:1.8.0_161]
        at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548) ~[na:1.8.0_161]
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509) ~[na:1.8.0_161]
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432) ~[na:1.8.0_161]
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178) ~[na:1.8.0_161]
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348) ~[na:1.8.0_161]
        at dmg.cells.nucleus.CellMessage.encode(CellMessage.java:206) ~[cells-4.2.7.jar:4.2.7]
        ... 11 common frames omitted

Modification:
Update FileCorruptedCacheException to store value fields, possible nulls and
convert them to Optional only in getters.

Result:
No NotSerializableException.

NOTICE: this change breaks compatibility with existing code. However, as
messages can't be serialized anyway we break already broken compatibility.

Acked-by: Albert Rossi
Target: master, 4.2, 4.1, 4.0
Require-book: no
Require-notes: yes
(cherry picked from commit 6c679438427ad02a0d14650df6fe7e47f04c4e4f)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>