### PR TITLE
dcache: add path to transfer information

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -10,6 +10,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.security.auth.Subject;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -28,9 +30,6 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import javax.security.auth.Subject;
-
 import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.poolManager.PoolSelectionUnit.DirectionType;
@@ -1779,6 +1778,7 @@ public class DCapDoorInterpreterV3
 
             return new IoDoorEntry(_sessionId,
                                    pnfsid,
+                                   _message.getPnfsPath(),
                                    _subject,
                                    _pool == null? "<unknown>" : _pool.getName(),
                                    _status,

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/transfers/TransferCollectionUtils.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/transfers/TransferCollectionUtils.java
@@ -180,6 +180,7 @@ public final class TransferCollectionUtils {
 
         info.setProcess(door.getProcess());
         info.setPnfsId(Objects.toString(session.getPnfsId(), ""));
+        info.setPath(session.getPath());
         info.setPool(Objects.toString(session.getPool(), ""));
         info.setReplyHost(Objects.toString(session.getReplyHost(), ""));
         info.setSessionStatus(Objects.toString(session.getStatus(), ""));

--- a/modules/dcache-frontend/src/test/java/org/dcache/restful/util/admin/SnapshotDataAccessTest.java
+++ b/modules/dcache-frontend/src/test/java/org/dcache/restful/util/admin/SnapshotDataAccessTest.java
@@ -127,6 +127,8 @@ public final class SnapshotDataAccessTest {
                 transferInfo.setPnfsId(
                                 getString(jsonTransfer.get("pnfsId"),
                                           null));
+                transferInfo.setPath(getString(jsonTransfer.get("path"),
+                                          null));
                 transferInfo.setPool(
                                 getString(jsonTransfer.get("pool"), null));
                 transferInfo.setReplyHost(

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoDoorEntry.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoDoorEntry.java
@@ -1,11 +1,11 @@
 package diskCacheV111.vehicles;
 
-import java.io.IOException;
-import java.io.Serializable;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.security.auth.Subject;
+
+import java.io.IOException;
+import java.io.Serializable;
 
 import diskCacheV111.util.PnfsId;
 
@@ -22,15 +22,17 @@ public class IoDoorEntry implements Serializable
     private final long _waitingSince;
     private final String _replyHost;
     private final Subject _subject;
+    private final String _path;
 
     private static final long serialVersionUID = 7283617314269359997L;
 
-    public IoDoorEntry(long serialId, PnfsId pnfsId, Subject subject,
-                       String pool, String status,
+    public IoDoorEntry(long serialId, PnfsId pnfsId, String path,
+                       Subject subject, String pool, String status,
                        long waitingSince, String replyHost)
     {
         _serialId = serialId;
         _pnfsId = pnfsId;
+        _path = path;
         _subject = subject;
         _pool = pool;
         _status = status;
@@ -41,6 +43,12 @@ public class IoDoorEntry implements Serializable
     public long getSerialId()
     {
         return _serialId;
+    }
+
+    @Nullable
+    public String getPath()
+    {
+        return _path;
     }
 
     @Nullable

--- a/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
@@ -59,12 +59,12 @@ documents or software obtained from this server.
  */
 package diskCacheV111.util;
 
+import javax.security.auth.Subject;
+
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-
-import javax.security.auth.Subject;
 
 import org.dcache.util.InvalidatableItem;
 import org.dcache.util.TimeUtils.DurationParser;
@@ -82,7 +82,7 @@ public class TransferInfo implements Comparable<TransferInfo>, InvalidatableItem
     private static final String FORMAT    = "(%s %s %s)(prot %s)"
                     + "(uid %s gid %s vomsgrp %s)"
                     + "(proc %s)(%s)(pool %s)(client %s)"
-                    + "(%s)(state %s)(elapsed %s)(transferred %s)(speed %s)\n";
+                    + "(%s)(state %s)(elapsed %s)(transferred %s)(speed %s)(path %s)\n";
 
     protected static String getTimeString(long time, boolean display) {
         if (!display) {
@@ -114,19 +114,20 @@ public class TransferInfo implements Comparable<TransferInfo>, InvalidatableItem
     protected String protocol      = "<unknown>";
     protected String process       = "<unknown>";
     protected String pnfsId        = "";
-    protected String pool          = "";
-    protected String replyHost     = "";
-    protected String sessionStatus = "";
-    protected long waitingSince;
-    protected MoverState moverStatus = MoverState.NOTFOUND;
-    protected Long     transferTime;
-    protected Long     bytesTransferred;
-    protected Long     moverId;
-    protected Long     moverSubmit;
-    protected Long     moverStart;
-    protected Subject  subject;
-    protected UserInfo userInfo;
-    protected boolean  valid = true;
+    protected String path          = "";
+    protected String     pool          = "";
+    protected String     replyHost     = "";
+    protected String     sessionStatus = "";
+    protected long       waitingSince;
+    protected MoverState moverStatus   = MoverState.NOTFOUND;
+    protected Long       transferTime;
+    protected Long       bytesTransferred;
+    protected Long       moverId;
+    protected Long       moverSubmit;
+    protected Long       moverStart;
+    protected Subject    subject;
+    protected UserInfo   userInfo;
+    protected boolean    valid         = true;
 
     @Override
     public int compareTo(TransferInfo o) {
@@ -192,6 +193,10 @@ public class TransferInfo implements Comparable<TransferInfo>, InvalidatableItem
 
     public Long getMoverSubmit() {
         return moverSubmit;
+    }
+
+    public String getPath() {
+        return path;
     }
 
     public String getPnfsId() {
@@ -310,6 +315,10 @@ public class TransferInfo implements Comparable<TransferInfo>, InvalidatableItem
         this.moverSubmit = moverSubmit;
     }
 
+    public void setPath(String path) {
+        this.path = path;
+    }
+
     public void setPnfsId(String pnfsId) {
         this.pnfsId = pnfsId;
     }
@@ -388,7 +397,8 @@ public class TransferInfo implements Comparable<TransferInfo>, InvalidatableItem
                              state,
                              getTimeWaiting(),
                              size,
-                             speed);
+                             speed,
+                             path);
     }
 
     protected String timeRunning(long now, boolean display) {

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -1,6 +1,5 @@
 package org.dcache.util;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Longs;
@@ -79,9 +78,10 @@ import org.dcache.poolmanager.PoolManagerStub;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.PnfsGetFileAttributes;
 
-import static java.util.Objects.requireNonNull;
-import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.*;
+import static java.util.Objects.requireNonNull;
 import static org.dcache.namespace.FileAttribute.*;
 import static org.dcache.namespace.FileType.REGULAR;
 import static org.dcache.util.MathUtils.addWithInfinity;
@@ -686,6 +686,7 @@ public class Transfer implements Comparable<Transfer>
     {
         return new IoDoorEntry(_id,
                                getPnfsId(),
+                               getTransferPath(),
                                _subject,
                                _pool == null? "<unknown>" : _pool.getName(),
                                _status,


### PR DESCRIPTION
Motivation:

To facilitate delivery of monitoring information without multiple
querying, the path may be included as part of the transfer information.

Modification:

Add path to IoDoorEntry, and provide the parameter in the Transfer
as well as Dcap interpreter.

Add path field to TransferInfo and set it where necessary.

Modify string formatting of TransferInfo (path appended to end).

Result:

Transfer information conveys path.

Target: master
Request: 4.2
Acked-by:  Vincent