### PR TITLE
dcache-xrootd: add missing kafka property

### DIFF
--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -256,3 +256,8 @@ xrootd.query-config!role = none
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 xrootd.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}
+
+xrootd.kafka.maximum-block=${dcache.kafka.maximum-block}
+
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka-maximum-block.unit})\
+xrootd.kafka.maximum-block.unit=${dcache.kafka-maximum-block.unit}


### PR DESCRIPTION
Missing xrootd.kafka.maximum-block stops spring loading when
kafka is activated.

04 Oct 2018 20:05:02 (System) [] Caused by: java.lang.IllegalArgumentException: Could not resolve placeholder 'xrootd.kafka.maximum-block' in value "#{ T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(${xrootd.kafka.maximum-block}, '${xrootd.kafka.maximum-block.unit}')}"

Add missing block and unit properties.

Target: master
Request: 4.2
Acked-by: Tigran