### PR TITLE
info: display the timestamps when metrics were collected

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/base/StateValue.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/base/StateValue.java
@@ -20,6 +20,7 @@ public abstract class StateValue implements StateComponent
     private static final int _granularity = 500;
     private static final int _millisecondsInSecond = 1000;
 
+    private final Date _creationTime = new Date();
     private final Date _expiryTime;
     private final boolean _isEphemeral;
 
@@ -179,5 +180,10 @@ public abstract class StateValue implements StateComponent
     public Date getEarliestChildExpiryDate()
     {
         return null; // we never have children.
+    }
+
+    public Date getCreationTime()
+    {
+        return _creationTime;
     }
 }

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/serialisation/XmlSerialiser.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/serialisation/XmlSerialiser.java
@@ -2,6 +2,7 @@ package org.dcache.services.info.serialisation;
 
 import org.springframework.beans.factory.annotation.Required;
 
+import java.util.Date;
 import java.util.Map;
 
 import org.dcache.services.info.base.BooleanStateValue;
@@ -136,28 +137,32 @@ public class XmlSerialiser extends SubtreeVisitor implements StateSerialiser
     public void visitInteger(StatePath path, IntegerStateValue value)
     {
         emitLastBeginElement(false);
-        addElement(buildMetricElement(path.getLastElement(), value.getTypeName(), value.toString()));
+        addElement(buildMetricElement(path.getLastElement(), value.getTypeName(),
+                value.toString(), value.getCreationTime()));
     }
 
     @Override
     public void visitString(StatePath path, StringStateValue value)
     {
         emitLastBeginElement(false);
-        addElement(buildMetricElement(path.getLastElement(), value.getTypeName(), xmlTextMarkup(value.toString())));
+        addElement(buildMetricElement(path.getLastElement(), value.getTypeName(),
+                xmlTextMarkup(value.toString()), value.getCreationTime()));
     }
 
     @Override
     public void visitBoolean(StatePath path, BooleanStateValue value)
     {
         emitLastBeginElement(false);
-        addElement(buildMetricElement(path.getLastElement(), value.getTypeName(), value.toString()));
+        addElement(buildMetricElement(path.getLastElement(), value.getTypeName(),
+                value.toString(), value.getCreationTime()));
     }
 
     @Override
     public void visitFloatingPoint(StatePath path, FloatingPointStateValue value)
     {
         emitLastBeginElement(false);
-        addElement(buildMetricElement(path.getLastElement(), value.getTypeName(), value.toString()));
+        addElement(buildMetricElement(path.getLastElement(), value.getTypeName(),
+                value.toString(), value.getCreationTime()));
     }
 
     /**
@@ -277,13 +282,17 @@ public class XmlSerialiser extends SubtreeVisitor implements StateSerialiser
      * @param name the name of the metric
      * @param type the type of the metric
      * @param value the value
+     * @parma created when the metric was created
      */
-    private String buildMetricElement(String name, String type, String value)
+    private String buildMetricElement(String name, String type, String value,
+            Date created)
     {
         StringBuilder sb = new StringBuilder();
-        Attribute attr[] = new Attribute[2];
-        attr[0] = new Attribute("name", name);
-        attr[1] = new Attribute("type", type);
+        Attribute attr[] = {
+            new Attribute("name", name),
+            new Attribute("type", type),
+            new Attribute("last-updated", String.valueOf(created.getTime()/1000))
+        };
 
         sb.append(beginElement("metric", attr, false));
         sb.append(value);


### PR DESCRIPTION
Motivation:

The Storage Resource record format wishes to know when information was
collected.  Since the info service collects data and caches the result,
the value may be some point in the past.

Modification:

Update info service to record when a metric was added (i.e., the value
was last refreshed).

Update the XML serialiser to expose this value as the 'last-updated'
attribute.  The value is UNIX time: seconds since 1970-01-01.

Result:

Components that use info may learn how stale is the stored data.

Target: master
Request: 4.2
Request: 4.1
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/11211/