### PR TITLE
poolmanager: do not squash request if state is not allowed

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -852,6 +852,18 @@ public class RequestContainerV5
         //
         public void addRequest( CellMessage message ){
 
+           PoolMgrSelectReadPoolMsg request =
+                (PoolMgrSelectReadPoolMsg)message.getMessageObject() ;
+
+            // fail-fast if state is not allowed
+            if (!request.getAllowedStates().contains(_state)) {
+                request.setFailed(CacheException.PERMISSION_DENIED, "Pool manager state not allowed");
+
+                message.revertDirection();
+                sendMessage(message);
+                return;
+            }
+
            _messages.add(message);
            _stagingDenied = false;
 
@@ -864,9 +876,6 @@ public class RequestContainerV5
            if (_poolSelector != null) {
                return;
            }
-
-           PoolMgrSelectReadPoolMsg request =
-                (PoolMgrSelectReadPoolMsg)message.getMessageObject() ;
 
            _linkGroup = request.getLinkGroup();
            _protocolInfo = request.getProtocolInfo();


### PR DESCRIPTION
Motivation:
when a select read pool request arrives pool manager then it will be
squashed with an existing request. However, if existing request is
blocked on p2p or stage the new request will be accepted, even if those
states are not allowed.

Modification:
Before squashing request with an existing one, check that states are
allowed.

Result:
Request, that is not allowed to stage will fail with permission deny
even if there is an other pending request.

Acked-by: Dmitry Litvintsev
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit 9488cf474b7c7cd19a830e35850c139cdf15f923)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>