### PR TITLE
info/space-manager: monitor number of files in reservation

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/SrmSpaceDetailsMsgHandler.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/SrmSpaceDetailsMsgHandler.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.OptionalLong;
 
 import diskCacheV111.services.space.Space;
 import diskCacheV111.services.space.message.GetSpaceTokensMessage;
@@ -84,6 +85,15 @@ public class SrmSpaceDetailsMsgHandler implements MessageHandler
             addLinkgroup(update, thisSpacePath, String.valueOf(space.getLinkGroupId()), String.valueOf(space.getId()), metricLifetime);
 
             addVoInfo(update, thisSpacePath.newChild("authorisation"), space.getVoGroup(), space.getVoRole(), metricLifetime);
+
+            OptionalLong fileCount = space.getNumberofFiles();
+            StatePath fileCountPath = thisSpacePath.newChild("file-count");
+            if (fileCount.isPresent()) {
+                update.appendUpdate(fileCountPath,
+                        new IntegerStateValue(fileCount.getAsLong(), metricLifetime));
+            } else {
+                update.purgeUnder(fileCountPath);
+            }
         }
 
         _sum.enqueueUpdate(update);

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/srm/SrmSpaceDetailsDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/srm/SrmSpaceDetailsDga.java
@@ -56,7 +56,7 @@ public class SrmSpaceDetailsDga extends SkelPeriodicActivity
 
         LOGGER.trace("Sending space token details request message");
 
-        _sender.sendMessage(_metricLifetime, _spacemanager, new GetSpaceTokensMessage());
+        _sender.sendMessage(_metricLifetime, _spacemanager, new GetSpaceTokensMessage(true));
     }
 
     @Override

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/services/space/Space.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/services/space/Space.java
@@ -2,6 +2,7 @@ package diskCacheV111.services.space;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.OptionalLong;
 
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.RetentionPolicy;
@@ -21,6 +22,7 @@ public class Space implements Serializable {
     private Long expirationTime;
     private String description;
     private SpaceState state;
+    private Long numberOfFiles;
 
     public Space(
             long id,
@@ -120,6 +122,7 @@ public class Space implements Serializable {
         sb.append("state:").append(state).append(' ');
         sb.append("used:").append(usedSizeInBytes).append(' ');
         sb.append("allocated:").append(allocatedSpaceInBytes).append(' ');
+        sb.append("files:").append(numberOfFiles);
         return sb.toString();
     }
 
@@ -174,5 +177,15 @@ public class Space implements Serializable {
     public void setExpirationTime(Long expirationTime)
     {
         this.expirationTime = expirationTime;
+    }
+
+    public void setNumberOfFiles(long count)
+    {
+        numberOfFiles = count;
+    }
+
+    public OptionalLong getNumberofFiles()
+    {
+        return numberOfFiles == null ? OptionalLong.empty() : OptionalLong.of(numberOfFiles);
     }
 }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/services/space/message/GetSpaceTokensMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/services/space/message/GetSpaceTokensMessage.java
@@ -11,9 +11,17 @@ public class GetSpaceTokensMessage extends Message {
 	private static final long serialVersionUID = -419540669938740860L;
 
 	private Collection<Space> list = Collections.emptySet();
+	private final boolean isFileCountRequested;
 
 	public GetSpaceTokensMessage() {
 		setReplyRequired(true);
+		isFileCountRequested = false;
+	}
+
+	public GetSpaceTokensMessage(boolean isFileCountRequested)
+        {
+		setReplyRequired(true);
+		this.isFileCountRequested = isFileCountRequested;
 	}
 
 	public Collection<Space> getSpaceTokenSet() {
@@ -24,4 +32,7 @@ public class GetSpaceTokensMessage extends Message {
 		this.list = list;
 	}
 
+	public boolean isFileCountRequested() {
+		return isFileCountRequested;
+	}
 }


### PR DESCRIPTION
Motivation:

WLCG now wants to know how many files are stored in a space reservation.

Modification:

Update space manager to support an updated message that queries space
metadata and optionally also the number of files stored in each
reservation.

Update info to present this information in serialised output.

Result:

info clients (such as info-provider and storage-report) are now informed
of the number of files stored in a space reservation.

Target: master
Request: 4.2
Request: 4.1
Require-notes: yes
Require-book: no