### PR TITLE
webdav/frontend: make anonymous fallback on bad login optional

### DIFF
--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -574,6 +574,8 @@
                     </bean>
                 </list>
             </property>
+            <property name="fallbackToAnonymous"
+                      value="${webdav.enable.authn.anonymous-fallback-on-failed-login}"/>
             <property name="anonymousAccess" value="${frontend.authz.anonymous-operations}"/>
         </bean>
     </beans>
@@ -588,6 +590,8 @@
                     </bean>
                 </list>
             </property>
+            <property name="fallbackToAnonymous"
+                      value="${webdav.enable.authn.anonymous-fallback-on-failed-login}"/>
             <property name="anonymousAccess" value="${frontend.authz.anonymous-operations}"/>
         </bean>
     </beans>

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -535,6 +535,8 @@
                     </bean>
                 </list>
             </property>
+            <property name="fallbackToAnonymous"
+                      value="${webdav.enable.authn.anonymous-fallback-on-failed-login}"/>
             <property name="anonymousAccess" value="${webdav.authz.anonymous-operations}"/>
         </bean>
     </beans>
@@ -561,6 +563,8 @@
                     </bean>
                 </list>
             </property>
+            <property name="fallbackToAnonymous"
+                      value="${webdav.enable.authn.anonymous-fallback-on-failed-login}"/>
             <property name="anonymousAccess" value="${webdav.authz.anonymous-operations}"/>
         </bean>
     </beans>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -894,6 +894,25 @@ dcache.authn.ocsp-mode=IGNORE
 #
 (any-of?DISABLE_EC|DISABLE_RC4)dcache.authn.ciphers = DISABLE_RC4
 
+
+#  --- Anonymous fall-back for failed logins
+#
+#   The doors that use HTTP (webdav and restful) have a feature where
+#   a user that supplies authentication material (X.509,
+#   username+password, OpenID-Connect access-token, macaroon, ...) but
+#   that material fails to log in the user (unknown user, bad
+#   password, expired token) is treated as if the client provided no
+#   authentication material; i.e., they are the anonymous user.
+#
+#   With the following property enabled, any operation where the user
+#   fails to log in will succeed if the anonymous user is allowed that
+#   operation, otherwise a 401 HTTP status code is returned.
+#
+#   With this option disabled, any operation where the user fails to
+#   log in will always fail with a 401 HTTP status code.
+#
+(one-of?true|false)dcache.enable.authn.anonymous-fallback-on-failed-login = true
+
 #  ---- Whether to overwrite existing files on upload
 #
 #   The following property affects FTP doors, WebDAV doors and the SRM.

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -387,6 +387,8 @@ frontend.custom-response-header!Server = dCache/${dcache.version}
 #  See dcache.authn.ciphers for details.
 frontend.authn.ciphers = ${dcache.authn.ciphers}
 
+frontend.enable.authn.anonymous-fallback-on-failed-login = ${dcache.enable.authn.anonymous-fallback-on-failed-login}
+
 # Set Http authentication realm
 frontend.authn.realm = ${dcache.description}
 

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -595,6 +595,8 @@ webdav.templates.html=file:${dcache.paths.share}/webdav/templates/html.stg
 #  See dcache.authn.ciphers for details.
 webdav.authn.ciphers = ${dcache.authn.ciphers}
 
+webdav.enable.authn.anonymous-fallback-on-failed-login = ${dcache.enable.authn.anonymous-fallback-on-failed-login}
+
 # Set Http Webdav authentication realm
 webdav.authn.realm = ${dcache.description}
 


### PR DESCRIPTION
Motivation:

dCache has a hard-coded "feature" where a user providing bad
authentication (e.g., wrong password, expired OIDC access-token or
macaroon) is treated as the anonymous user.

This has proved counter-intuitive, as wrong/expired credentials often
appear to succeed for some operations (e.g., directory listing), while
failing others (upload/download).  Also, interpreting the response to
the frontend user introspection endpoint is more complicated, as the
ANONYMOUS status could be either no credentials presented or bad
credentials presented.

An alternative (and more common) approach is for bad/expired credentials
to always fail the request, providing the user/client with immediate
feedback.  A client that wishes to attempt the operation as the
anonymous user may resubmit the request without providing any
credentials (i.e., anonymously).

Modification:

Add a configuration option to fail-fast on bad client credentials.

Result:

Provide a configuration property to control how WebDAV and frontend
behave if the client supplies bad credentials.  The default value does
not result in any change in behaviour.

Target: master
Request: 4.2
Requires notes: yes
Requires book: no
Acked-by: Tigran Mkrtchyan
Patch: https://rb.dcache.org/r/11203/