### PR TITLE
ftp: better address selection for cross-family passive proxied transfers

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -119,6 +119,7 @@ import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
@@ -2501,7 +2502,7 @@ public abstract class AbstractFtpDoorV1
      * This method exists to allow a mock of this class to isolate itself
      * from the testing machine's network configuration.
      */
-    protected Iterable<InterfaceAddress> getLocalAddressInterfaces()
+    protected Collection<InterfaceAddress> getLocalAddressInterfaces()
             throws SocketException
     {
         return NetworkInterface.getByInetAddress(_localSocketAddress.getAddress())


### PR DESCRIPTION
Motivation:

If the ftp client requests a proxied passive transfer with a different
IP family from the control channel (i.e., the client connects using IPv6
and requests an IPv4 data channel, or vice versa) the ftp server must
select which IP address it should return to the client.

As pointed out by Francesco Prelz (thanks\!), the door currently selects
the first address from the same interface that has the desired IP
family.  However, this may not be accessible by the client.

Modification:

Update the cross-family address selection to select the address with the
small scope that is greater than or equal to the control channel's
scope.

NB. similar functionality exists in NetworkUtils class; however, this
cannot be used currently as the NetworkUtils class currently doesn't
support unit-testing.

Result:

Proxied passive transfers where the data channel should use a different
IP family from the control channel and where the targeted network
interface has multiple such addresses will avoid addresses to which the
client (very likely) cannot connect.

Target: master
Request: 4.2
Request: 4.1
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11206/
Acked-by: Tigran Mkrtchyan