### PR TITLE
packaging: use private BC 1.50 release that provides JSSE compatible …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,13 @@
                1.43     bcprov-jdk16    JDK v1.6; used by JGlobus-1.8.x
          -->
         <bouncycastle.bcprov>bcprov-jdk15on</bouncycastle.bcprov>
-        <bouncycastle.version>1.50</bouncycastle.version>
+	<!--
+	   Use a private BC 1.50 release that provides for
+	   JSSE compatible handling of key agreement secret
+           generation. This support is available in BC starting
+	   version 1.54
+	-->
+        <bouncycastle.version>dcache-1.50</bouncycastle.version>
         <datanucleus-core.version>4.1.8</datanucleus-core.version>
         <datanucleus.plugin.version>4.0.2</datanucleus.plugin.version>
         <hazelcast.version>3.9.3</hazelcast.version>


### PR DESCRIPTION
…handling of key agreement secret generation.

Motivation:

After switch to bouncycastle 1.50 xrdcp against dCache XRootD
door fail in 0.5% of cases w/ 'pad block corrupted' due to
extra 0 padding added when generating secret key using DH algorithm.

Modification:

Provide a hook by using a special algorithm names "TlsPremasterSecret"
to force non-padded key geneartion function.

Result:

Together w/ patch to xrootd4j that utilizes "TlsPremasterSecret"
algorithm the 'pad block corrupted' error is gone.

    Target: trunk
    Request: 4.2

    Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>