### PR TITLE
xrootd: add support for kXR_stat on open files

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -74,6 +74,7 @@ import org.dcache.xrootd.protocol.messages.RedirectResponse;
 import org.dcache.xrootd.protocol.messages.RmDirRequest;
 import org.dcache.xrootd.protocol.messages.RmRequest;
 import org.dcache.xrootd.protocol.messages.StatRequest;
+import org.dcache.xrootd.protocol.messages.StatResponse;
 import org.dcache.xrootd.protocol.messages.StatxRequest;
 import org.dcache.xrootd.protocol.messages.SyncRequest;
 import org.dcache.xrootd.protocol.messages.WriteRequest;
@@ -363,20 +364,39 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
      */
     @Override
     protected XrootdResponse<StatRequest> doOnStat(ChannelHandlerContext ctx, StatRequest msg)
-        throws XrootdException
+            throws XrootdException
     {
-        int fd = msg.getFhandle();
+        switch (msg.getTarget()) {
+        case PATH:
+            _log.trace("Request to stat {}; redirecting to door.", msg);
+            return redirectToDoor(ctx, msg);
 
-        if (isValidFileDescriptor(fd)) {
+        case FHANDLE:
+            int fd = msg.getFhandle();
+
+            if (!isValidFileDescriptor(fd)) {
+                _log.warn("Could not find a file descriptor for handle {}", fd);
+                throw new XrootdException(kXR_FileNotOpen,
+                                          "The file handle does not refer to an open " +
+                                          "file.");
+            }
+
             FileDescriptor descriptor = _descriptors.get(fd);
             if (descriptor instanceof TpcWriteDescriptor) {
                 _log.trace("Request to stat {} is for third-party transfer.", msg);
                 return ((TpcWriteDescriptor)descriptor).handleStat(msg);
+            } else {
+                try {
+                    _log.trace("Request to stat open file fhandle={}", fd);
+                    return new StatResponse(msg, stat(descriptor.getChannel()));
+                } catch (IOException e) {
+                    throw new XrootdException(kXR_IOError, e.getMessage());
+                }
             }
-        }
 
-        _log.trace("Request to stat {}; redirecting to door.", msg);
-        return redirectToDoor(ctx, msg);
+        default:
+            throw new XrootdException(kXR_ServerError, "Unexpected stat target");
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Occationally, the xrootd client requires `kXR_stat` on an open file
handle to succeed.  It is not documented in the protocol specificiation
whether this is a reasonable expectation; but, given this is easy to
implement, it makes sense to support it.

Modification:

Update the pool to return information about the file if the `kXR_stat`
request targets an open file handle.  Requests that target a path
continue to be redirected back to the door.

Result:

The xrootd client is happer; in particular, the `--zip` option now
works.

NOTE this patch depends on xrootd4j >= 3.3.2 or >= 3.2.3.

Target: master
Request: 4.2
Requires-notes: yes
Requires-book: no
Closes: #4258
Patch: https://rb.dcache.org/r/11239/
Acked-by: Tigran Mkrtchyan
Acked-by: Albert Rossi