### PR TITLE
xrootd: remove spurious stack-trace

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -296,7 +296,6 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                     req, InetAddresses.toUriString(address.getAddress()),
                     address.getPort(), opaqueString, "");
         } catch (FileNotFoundCacheException e) {
-            e.printStackTrace();  // FIXME REMOVE
             return withError(req, kXR_NotFound, "No such file");
         } catch (FileExistsCacheException e) {
             return withError(req, kXR_NotAuthorized, "File already exists");


### PR DESCRIPTION
Motivation:

A recent patch added a stack-trace, likely mistakenly as a hang-over
from previous debugging work.  The code results in a stack-trace being
logged during legitimate client-driven failure modes, and not from a
dCache bug.

Modification:

Remove erroneous stack-trace logging.

Result:

dCache no longer logs a stack-trace when a client requests a file be
created, the parent directory does not exist, and the kXR_mkpath option
is omitted.

Target: master
Request: 4.2
Requires-notes: yes
Requires-book: no
Closes: #4259
Patch: https://rb.dcache.org/r/11236/
Acked-by: Albert Rossi