### PR TITLE
core: avoid stacktrace on arbitrary CacheException

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
@@ -128,7 +128,7 @@ public class AuthenticationHandler extends HandlerWrapper {
                         HttpServletResponse.SC_FORBIDDEN);
                 baseRequest.setHandled(true);
             } catch (CacheException e) {
-                LOG.error("Internal server error: {}", e);
+                LOG.error("Internal server error: {}", e.getMessage());
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 baseRequest.setHandled(true);
             }


### PR DESCRIPTION
Motivation:

We log unexpected CacheException with a stack-trace, yet this is not a
bug.

Modification:

Update log to record the message without the stack-trace

Result:

Fewer stack-traces.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/11243/
Acked-by: Tigran Mkrtchyan