### PR TITLE
macaroons: fix logged id

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonProcessor.java
@@ -7,11 +7,13 @@ import com.github.nitram509.jmacaroons.MacaroonsVerifier;
 import com.github.nitram509.jmacaroons.NotDeSerializableException;
 import com.google.common.base.Throwables;
 import com.google.common.hash.Hashing;
+import com.google.common.io.BaseEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Arrays;
@@ -116,6 +118,10 @@ public class MacaroonProcessor
 
         Macaroon macaroon = MacaroonsBuilder.deserialize(serialisedMacaroon);
 
+        // Use the first 6 bytes of signature as an ID for this macaroon
+        byte[] rawId = BaseEncoding.base16().lowerCase().decode(macaroon.signature.substring(0, 12));
+        String macaroonId = new String(Base64.getEncoder().encode(rawId), StandardCharsets.US_ASCII);
+
         MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
 
         ClientIPCaveatVerifier clientIPVerifier = new ClientIPCaveatVerifier(clientAddress);
@@ -137,7 +143,7 @@ public class MacaroonProcessor
         }
 
         MacaroonContext context = contextExtractor.getContext();
-        context.setId(macaroon.identifier);
+        context.setId(macaroonId);
         return context;
     }
 


### PR DESCRIPTION
Motivation:

Currently, the logged identity for a macaroon is the macaroon 'identity'
field.

The macaroon 'identity' field is a non-cryptographically protected field
that is used by dCache to identify the corresponding secret.  That is
fine, as modifying the value results in an invalid macaroon.

However, using the macaroon 'identity' field as the logged value means
that all macaroons issued against the same secret will have the same
identity.  It is anticipated that (in general) many macaroons will share
the same secret, therefore, this is a poor way to identify the macaroon.

Modification:

Use (part of) the macaroon signature to identify the macaroon.
Identical macaroons will have the same signature; however, non-identical
macaroons with the same secret will have (very likely) different
signatures.

Result:

Problem is fixed where different macaroons with the same secret are
logged with the same identifier.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11251/
Acked-by: Tigran Mkrtchyan