### PR TITLE
dcache-frontend: fix array out of bounds exception in cell info service

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/cells/CellInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/cells/CellInfoServiceImpl.java
@@ -64,6 +64,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
+import dmg.cells.nucleus.CellAddressCore;
 import dmg.cells.nucleus.CellInfo;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.util.command.Command;
@@ -133,10 +134,10 @@ public class CellInfoServiceImpl extends
     public CellData getCellData(String address) {
         CellData cached = cache.read(address);
         if (cached == null) {
+            CellAddressCore core = new CellAddressCore(address);
             cached = new CellData();
-            String[] key = address.split("@");
-            cached.setCellName(key[0]);
-            cached.setDomainName(key[1]);
+            cached.setCellName(core.getCellName());
+            cached.setDomainName(core.getCellDomainName());
             cached.setState(4); // "Unknown"
         }
         return cached;


### PR DESCRIPTION
Motivation:

See GitHub #4242

NOTE:  technically, the full domain name is needed to get live information,
since the cell's key to the cached value is the fully-qualified domain name.

Modification:

Check for length of split array of input.

Result:

Do not generate exception when input is of type -X GET https://srm.ndgf.org:3880/api/v1/cells/topo (i.e., no domain specified).
The information returned on such a cell, however, will be incomplete.

Target: master
Request: 4.2
Request: 4.1
Bug: #4242
Acked-by: Dmitry
Acked-by: Paul