### PR TITLE
core: provide better feedback and logging if a macaroon is rejected

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
@@ -125,7 +125,7 @@ public class AuthenticationHandler extends HandlerWrapper {
                 LOG.warn("{} for path {} and user {}", e.getMessage(), request.getPathInfo(),
                         NetLoggerBuilder.describeSubject(subject));
                 response.sendError((Subjects.isNobody(subject)) ? HttpServletResponse.SC_UNAUTHORIZED :
-                        HttpServletResponse.SC_FORBIDDEN);
+                        HttpServletResponse.SC_FORBIDDEN, e.getMessage());
                 baseRequest.setHandled(true);
             } catch (CacheException e) {
                 LOG.error("Internal server error: {}", e);


### PR DESCRIPTION
Motivation:

Since a macaroon credential is something a user may modify autonomously,
it is useful to report back to the user why a macaroon was rejected.

Similarly, it is useful for the admin if an explanation is logged
describing why a macaroon was rejected.

Modification:

Update HTTP 401 response to login failures so that it includes a custom
message as the status-line reason/explanation phrase.

*Note* that gPlazma login failure messages are already redacted in
Gplazma2LoginStrategy.  This is to prevent leaking information about
which accounts exist in dCache.  Therefore, this patch only exposes
information from non-gPlazma login failures, which is currently limited
to macaroons.

Result:

HTTP requests that are made with an invalid macaroon have a 401 HTTP
response with the status-line explanation phrase that describes why the
macaroon is invalid.

The access log file also logs why a macaroon was rejected.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11246/
Acked-by: Tigran Mkrtchyan