### PR TITLE
macaroons: include macaroon id in error message

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/macaroons/InvalidMacaroonException.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/InvalidMacaroonException.java
@@ -27,10 +27,10 @@ public class InvalidMacaroonException extends Exception
     /**
      * A utility method similar to Guava check* methods.
      */
-    public static void checkMacaroon(boolean isOK, String message)
+    public static void checkMacaroon(boolean isOK, String message, Object... arguments)
             throws InvalidMacaroonException
     {
-        genericCheck(isOK, InvalidMacaroonException::new, message);
+        genericCheck(isOK, InvalidMacaroonException::new, message, arguments);
     }
 
     public InvalidMacaroonException(String message) {

--- a/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonProcessor.java
@@ -131,10 +131,10 @@ public class MacaroonProcessor
         verifier.satisfyGeneral(contextExtractor);
 
         byte[] secret = _secretHandler.findSecret(macaroon.identifier);
-        checkMacaroon(secret != null, "Unable to find corresponding secret");
+        checkMacaroon(secret != null, "Unable to find secret for macaroon [%s]", macaroonId);
 
         if (!verifier.isValid(secret)) {
-            StringBuilder error = new StringBuilder("Invalid macaroon");
+            StringBuilder error = new StringBuilder("Invalid macaroon [").append(macaroonId).append(']');
 
             Strings.combine(clientIPVerifier.getError(), " and ", contextExtractor.getError())
                     .ifPresent(msg -> error.append(": ").append(msg));


### PR DESCRIPTION
Motivation:

The macaroon's identifier is included in the Subject, if the macaroon is
valid.

If the macaroon is rejected then the macaroon id is currently not
included in the error message. This makes it hard to trace which
macaroon has been rejected, when it was requested, with which caveats,
etc.

Modification:

Update the message describing why a macaroon was rejected so it also
includes the macaroon's ID.

Result:

It is now possible to identify which macaroon is rejected, and so
investigate further why this is happening.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11254/
Acked-by: Tigran Mkrtchyan