### PR TITLE
pool: fix pool's runtime configured size regression (b70b0d9)

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReplicaRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReplicaRepository.java
@@ -942,7 +942,7 @@ public class ReplicaRepository
             info.setFileSystemRatioFreeToTotal(((double) fsFree) / fsTotal);
             info.setFileSystemMaxSpace(fsFree + used);
             info.setStaticallyConfiguredMax(_staticMaxSize.longValue());
-            info.setRuntimeConfiguredMax(_runtimeMaxSize.longValue());
+            info.setRuntimeConfiguredMax(getConfiguredMaxSize().longValue());
         } finally {
             _stateLock.readLock().unlock();
         }


### PR DESCRIPTION
Motivation:
When pools size is only specified in layout file, then it runtime
configured size (the one which can be changed during runtime) is
initially equal to that value. However, the reported value doesn't
respect that and directly accesses undefined value. As a result, 8EB
reported (Long.MAX).

Modification:
instead of direct value access use ReplicaRepository#getConfiguredMaxSize()
which falls back to static configured value from layout file.

Result:
Pools with size configured in layout file only report correct runtime
size.

Ticket: #9516
Acked-by:
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit f5ba0103ea1b6b91b22e6c17b203fa9913ec5251)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>