### PR TITLE
httpd: add path to context/transfers.json

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -181,6 +181,7 @@ public class TransferObserverV1
             }
             process = transfer.door().getProcess();
             pnfsId = Objects.toString(transfer.session().getPnfsId(), "");
+            path = transfer.session().getPath();
             pool = Objects.toString(transfer.session().getPool(), "");
             replyHost = Objects.toString(transfer.session().getReplyHost(), "");
             sessionStatus = Objects.toString(transfer.session().getStatus(), "");


### PR DESCRIPTION
Motivation:

but the patch neglected to add the field to the transfers.json
produced by the transfer observer in the old httpd demon.

Modification:

Add the missing info.

Result:

The call "http://host:2288/context/transfers.json" now also includes the path.

Target: master
Request: 4.2
Bug: #4297
Acked-by: Dmitry