### PR TITLE
libs: update to commons-compress-1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -784,7 +784,7 @@
             <dependency>
               <groupId>org.apache.commons</groupId>
               <artifactId>commons-compress</artifactId>
-              <version>1.13</version>
+              <version>1.18</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Motivation:
https://nvd.nist.gov/vuln/detail/CVE-2018-11771

Result:
up-to-date dependency

Acked-by: Paul Millar
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit e75563978019d82c81c68dad82e3b20ebb096a69)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>