### PR TITLE
dcache-frontend: add path filter to transfers

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
@@ -69,7 +69,6 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
@@ -77,7 +76,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import diskCacheV111.util.CacheException;
@@ -142,6 +140,8 @@ public final class TransferResources {
                                                    @QueryParam("gid") String gid,
                                                    @ApiParam("Select transfers initiated by a member of this vomsgroup.")
                                                    @QueryParam("vomsgroup") String vomsgroup,
+                                                   @ApiParam("Select transfers involving this path.")
+                                                   @QueryParam("path") String path,
                                                    @ApiParam("Select transfers involving this pnfsid.")
                                                    @QueryParam("pnfsid") String pnfsid,
                                                    @ApiParam("Select transfers involving this pool.")
@@ -168,12 +168,11 @@ public final class TransferResources {
                                uid,
                                gid,
                                vomsgroup,
+                               path,
                                pnfsid,
                                pool,
                                client,
                                sort);
-        } catch (NoSuchElementException e) {
-            throw new ForbiddenException("User subject must contain uid to access transfers.");
         } catch (CacheException e) {
             throw new InternalServerErrorException(e);
         }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoService.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoService.java
@@ -117,6 +117,7 @@ public interface TransferInfoService {
                                    String uid,
                                    String gid,
                                    String vomsgroup,
+                                   String path,
                                    String pnfsid,
                                    String pool,
                                    String client,

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/transfers/TransferInfoServiceImpl.java
@@ -166,6 +166,13 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                                         + "default is all.")
         Integer[] proc = {};
 
+        @Option(name = "path",
+                        separator = ",",
+                        usage = "List only transfers matching this "
+                                        + "comma-delimited set of paths; "
+                                        + "default is all.")
+        String[] path = {};
+
         @Option(name = "pnfsId",
                         separator = ",",
                         usage = "List only transfers matching this "
@@ -234,6 +241,7 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
             filter.setGid(Arrays.asList(gid));
             filter.setVomsGroup(Arrays.asList(vomsGroup));
             filter.setHost(Arrays.asList(host));
+            filter.setPath(Arrays.asList(path));
             filter.setPnfsId(Arrays.asList(pnfsId));
             filter.setPool(Arrays.asList(pool));
             filter.setProc(Arrays.asList(proc));
@@ -249,6 +257,7 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                             = get(null,
                                   0,
                                   limit,
+                                  null,
                                   null,
                                   null,
                                   null,
@@ -316,6 +325,9 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                 case "vomsgroup":
                     comparator = Comparator.comparing(TransferInfo::getVomsGroup);
                     break;
+                case "path":
+                    comparator = Comparator.comparing(TransferInfo::getPath);
+                    break;
                 case "pnfsid":
                     comparator = Comparator.comparing(TransferInfo::getPnfsId);
                     break;
@@ -352,7 +364,8 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                                                      String state, String door,
                                                      String domain, String protocol,
                                                      String uid, String gid,
-                                                     String vomsgroup, String pnfsid,
+                                                     String vomsgroup,
+                                                     String path, String pnfsid,
                                                      String pool, String client) {
         Predicate<TransferInfo> matchesSubject =
                         (info) -> subjectUid == null
@@ -380,6 +393,9 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
         Predicate<TransferInfo> matchesVomsGroup =
                         (info) -> vomsgroup == null || Strings.nullToEmpty(info.getVomsGroup())
                                                           .contains(vomsgroup);
+        Predicate<TransferInfo> matchesPath =
+                        (info) -> path == null || Strings.nullToEmpty(info.getPath())
+                                                           .contains(path);
         Predicate<TransferInfo> matchesPnfsid =
                         (info) -> pnfsid == null || Strings.nullToEmpty(info.getPnfsId())
                                                           .contains(pnfsid);
@@ -393,7 +409,8 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
         return matchesSubject.and(matchesState).and(matchesDoor)
                              .and(matchesDomain).and(matchesProtocol)
                              .and(matchesUid).and(matchesGid).and(matchesVomsGroup)
-                             .and(matchesPnfsid).and(matchesPool).and(matchesClient);
+                             .and(matchesPath).and(matchesPnfsid)
+                             .and(matchesPool).and(matchesClient);
     }
 
     /**
@@ -425,6 +442,7 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
                                           String uid,
                                           String gid,
                                           String vomsgroup,
+                                          String path,
                                           String pnfsid,
                                           String pool,
                                           String client,
@@ -432,7 +450,7 @@ public class TransferInfoServiceImpl extends CellDataCollectingService<Map<Strin
         Predicate<TransferInfo> filter = getFilter(suid,
                                                    state, door, domain, protocol,
                                                    uid, gid, vomsgroup,
-                                                   pnfsid, pool, client);
+                                                   path, pnfsid, pool, client);
         if (Strings.isNullOrEmpty(sort)) {
             sort = "door,waiting";
         }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/transfers/TransferFilter.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/transfers/TransferFilter.java
@@ -78,6 +78,7 @@ public final class TransferFilter {
     private Pattern  door;
     private Pattern  domain;
     private Pattern  prot;
+    private Pattern  path;
     private Pattern  pnfsId;
     private Pattern  pool;
     private Pattern  host;
@@ -105,6 +106,10 @@ public final class TransferFilter {
         }
 
         if (!matches(prot, transferInfo.getProtocol())) {
+            return false;
+        }
+
+        if (!matches(path, transferInfo.getPath())) {
             return false;
         }
 
@@ -213,6 +218,10 @@ public final class TransferFilter {
 
     public void setHost(List<String> host) {
         this.host = compile(host);
+    }
+
+    public void setPath(List<String> path) {
+        this.path = compile(path);
     }
 
     public void setPnfsId(List<String> pnfsId) {


### PR DESCRIPTION
Motivation:

We would now like to provide backend filtering and sorting
capabilities on this attribute.

Modification:

Add the filter to the transfers API and implement it
analogously with the other string filters.  Also
add 'path' to the sort fields.

Result:

Filter box and multisort on file paths now possible.
Note: this patch also removes the catch block for NoSuchElementException
from the resource GET method.

Target: master
Request: 4.2
Acked-by: Dmitry