### PR TITLE
dcache: use getAddress for uniform client IPs in Transfer info

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -691,7 +691,9 @@ public class Transfer implements Comparable<Transfer>
                                _pool == null? "<unknown>" : _pool.getName(),
                                _status,
                                _startedAt,
-                               _clientAddresses.get(0).getHostString());
+                               _clientAddresses.get(0)
+                                               .getAddress()
+                                               .getHostAddress());
     }
 
     /**


### PR DESCRIPTION
Motivation:

Currently, the IoDoorEntry created by the Transfer class
uses host string on the InetSocketAddress class to populate
the remote host / client field.  Depending on the protocol,
this appears as either a host name or an IP address.

It is preferable that this info be uniformly IP address.

Modfication:

Use getAddress() instead.

Result:

See attached.

Gridftp (and other protocols) show IP currently, whereas
Xrootd shows name.  After patch, all IPs.

Target: master
Request: 4.2
Acked-by: Tigran