### PR TITLE
ftp: java.lang.IllegalStateException: Cannot send after the producer …

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -898,7 +898,7 @@ public abstract class AbstractFtpDoorV1
     protected TransferRetryPolicy _writeRetryPolicy;
 
     protected KafkaProducer _kafkaProducer;
-
+    private volatile boolean _sendToKafka;
 
     /** Tape Protection */
     protected CheckStagePermission _checkStagePermission;
@@ -1013,7 +1013,7 @@ public abstract class AbstractFtpDoorV1
             setPoolStub(AbstractFtpDoorV1.this._poolStub);
             setBillingStub(_billingStub);
 
-            if(_settings.isKafkaEnabled()){
+            if (_sendToKafka) {
                 setKafkaSender(m -> {
                     _kafkaProducer.send(new ProducerRecord<String, DoorRequestInfoMessage>("billing", m));
                 });
@@ -1564,6 +1564,8 @@ public abstract class AbstractFtpDoorV1
                                                            _cellAddress.toString(),
                                                            _settings.getKafkaMaxBlockMs(),
                                                            _settings.getKafkaRetries());
+            _sendToKafka = _settings.isKafkaEnabled();
+
         }
         _poolManagerStub = _settings.createPoolManagerStub(_cellEndpoint, _cellAddress, _poolManagerHandler);
         _poolStub = _settings.createPoolStub(_cellEndpoint);
@@ -1737,7 +1739,10 @@ public abstract class AbstractFtpDoorV1
           that is responsible for turning these records into requests and transmitting them to the cluster.
           Failure to close the producer after use will leak these resources. Hence we need to  and close Kafka Producer
          */
-        if (_settings.isKafkaEnabled()) {
+        //TODO _sendToKafka checks if the shutdown() method has been called and whether the producer has been closed or not.
+        // currently  there is no method isClosed() in kafka API
+        if (_sendToKafka) {
+            _sendToKafka = false;
             _kafkaProducer.close();
         }
 
@@ -4544,7 +4549,7 @@ public abstract class AbstractFtpDoorV1
 
         _billingStub.notify(infoRemove);
 
-        if(_settings.isKafkaEnabled()){
+        if (_sendToKafka) {
             _kafkaProducer.send(new ProducerRecord<String, DoorRequestInfoMessage>("billing", infoRemove), (rm, e) -> {
                 if (e != null) {
                     LOGGER.error("Unable to send message to topic {} on  partition {}: {}",


### PR DESCRIPTION
…is closed.

Motivation:
10 Oct 2018 11:07:34 (FTP-srm-cosgrove-AAV33C7CoXg) [door:FTP-srm-cosgrove-AAV33C7CoXg@cosgroveDomain tarpool_002 DoorTransferFinished 00009D67503DECA14FEC9191A13467CC5BBC] Possible bug detected.
java.lang.IllegalStateException: Cannot send after the producer is closed.
    at org.apache.kafka.clients.producer.internals.RecordAccumulator.append(RecordAccumulator.java:198) ~[kafka-clients-1.0.0.jar:na]
    at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:806) ~[kafka-clients-1.0.0.jar:na]
    at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:760) ~[kafka-clients-1.0.0.jar:na]
    at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:648) ~[kafka-clients-1.0.0.jar:na]
    at org.dcache.ftp.door.AbstractFtpDoorV1$FtpTransfer.lambda$new$0(AbstractFtpDoorV1.java:1017) ~[dcache-ftp-4.2.12.jar:4.2.12]
    at org.dcache.util.Transfer.notifyBilling(Transfer.java:1217) ~[dcache-core-4.2.12.jar:4.2.12]
    at org.dcache.ftp.door.AbstractFtpDoorV1$FtpTransfer.onFinish(AbstractFtpDoorV1.java:1277) ~[dcache-ftp-4.2.12.jar:4.2.12]
    at org.dcache.util.AsynchronousRedirectedTransfer$Monitor.doFinish(AsynchronousRedirectedTransfer.java:178) [dcache-core-4.2.12.jar:4.2.12]
    at org.dcache.util.AsynchronousRedirectedTransfer$Monitor.finished(AsynchronousRedirectedTransfer.java:220) [dcache-core-4.2.12.jar:4.2.12]
    at org.dcache.util.AsynchronousRedirectedTransfer.lambda$finished$2(AsynchronousRedirectedTransfer.java:92) [dcache-core-4.2.12.jar:4.2.12]
    at org.dcache.util.CDCExecutorDecorator$WrappedRunnable.run(CDCExecutorDecorator.java:62) ~[dcache-core-4.2.12.jar:4.2.12]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_181]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_181]
    at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_181]
10 Oct 2018 11:07:34 (FTP-srm-cosgrove-AAV33C7CoXg) [door:FTP-srm-cosgrove-AAV33C7CoXg@cosgroveDomain tarpool_002 DoorTransferFinished 00009D67503DECA14FEC9191A13467CC5BBC] Transfer error: 451 Transient internal error

Target: master
Request: 4.2
Requires-notes: yes
Requires-book: no
Acked-by:  Paul