### PR TITLE
transfermanager: fix missing path

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -229,6 +229,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                 message = new PnfsGetFileAttributes(pnfsId, attributes);
                 message.setSubject(transferRequest.getSubject());
                 message.setRestriction(transferRequest.getRestriction());
+                message.setPnfsPath(pnfsPath);
                 setState(WAITING_FOR_CREATED_FILE_INFO_STATE);
             }
         } else {
@@ -240,6 +241,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             message.setSubject(transferRequest.getSubject());
             message.setRestriction(transferRequest.getRestriction());
             message.setAccessMask(EnumSet.of(AccessMask.READ_DATA));
+            message.setPnfsPath(pnfsPath);
             setState(WAITING_FOR_PNFS_INFO_STATE);
         }
         manager.persist(this);


### PR DESCRIPTION
Motivation:

WebDAV-initated third-party transfers that pull data from the third
party server create the new file within the door.  The transfermanager
then queries PnfsMangaer for information about this newly created file.
It currently fails to include the file's path in this query, resulting
in the following logged entries like:

18 Oct 2018 14:28:15 (PnfsManager) [door:webdav-secure-grid@dCacheDomain:AAV4f+vOA0A RemoteTransferManager PnfsGetFileAttributes 000044C5E0D4339F44958FCC253FF4C4A263] Restriction check by-passed due to missing path; please report this to <support@dCache.org>

Modification:

Include the file's path in the PnfsManager query.

Result:

The "restriction check by-passed" warning for each WebDAV-initiated
third-party transfer is fixed.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11261/
Acked-by: Albert Rossi