### PR TITLE
webdav: update access log to record macaroon request details

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/LoggingHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/LoggingHandler.java
@@ -1,8 +1,6 @@
 package org.dcache.webdav;
 
 import com.google.common.net.InetAddresses;
-import dmg.cells.nucleus.CDC;
-import org.dcache.util.NetLoggerBuilder;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -14,10 +12,16 @@ import javax.security.auth.Subject;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.cert.X509Certificate;
+
+import dmg.cells.nucleus.CDC;
+
+import org.dcache.util.NetLoggerBuilder;
+import org.dcache.webdav.macaroons.MacaroonRequestHandler;
 
 import static org.dcache.http.AuthenticationHandler.DCACHE_SUBJECT_ATTRIBUTE;
 import static org.dcache.webdav.DcacheResourceFactory.TRANSACTION_ATTRIBUTE;
@@ -45,8 +49,10 @@ public class LoggingHandler extends HandlerWrapper {
             log.add("transaction", getTransaction(request));
             log.add("request.method", request.getMethod());
             log.add("request.url", request.getRequestURL());
+            log.add("request.macaroon-request", MacaroonRequestHandler.getMacaroonRequest(request));
             log.add("response.code", statusCode);
             log.add("response.reason", getReason(response));
+            log.add("response.macaroon-id", MacaroonRequestHandler.getMacaroonId(request));
             log.add("location", response.getHeader("Location"));
             InetAddress addr = InetAddresses.forString(request.getRemoteAddr());
             log.add("socket.remote", new InetSocketAddress(addr, request.getRemotePort()));

--- a/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonProcessor.java
@@ -19,13 +19,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.EnumSet;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
-import diskCacheV111.util.FsPath;
-
-import org.dcache.auth.attributes.Activity;
 import org.dcache.util.Strings;
 
 import static org.dcache.macaroons.CaveatValues.*;
@@ -111,6 +105,18 @@ public class MacaroonProcessor
         return builder.getMacaroon().serialize();
     }
 
+    public static String idOfMacaroon(String macaroon)
+    {
+        return idOfMacaroon(MacaroonsBuilder.deserialize(macaroon));
+    }
+
+    private static String idOfMacaroon(Macaroon macaroon)
+    {
+        // Use the first 6 bytes of signature as an ID for this macaroon
+        byte[] rawId = BaseEncoding.base16().lowerCase().decode(macaroon.signature.substring(0, 12));
+        return new String(Base64.getEncoder().encode(rawId), StandardCharsets.US_ASCII);
+    }
+
     public MacaroonContext expandMacaroon(String serialisedMacaroon, InetAddress clientAddress)
             throws InvalidMacaroonException
     {
@@ -118,9 +124,7 @@ public class MacaroonProcessor
 
         Macaroon macaroon = MacaroonsBuilder.deserialize(serialisedMacaroon);
 
-        // Use the first 6 bytes of signature as an ID for this macaroon
-        byte[] rawId = BaseEncoding.base16().lowerCase().decode(macaroon.signature.substring(0, 12));
-        String macaroonId = new String(Base64.getEncoder().encode(rawId), StandardCharsets.US_ASCII);
+        String macaroonId = idOfMacaroon(macaroon);
 
         MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
 


### PR DESCRIPTION
Motivation:

A user may request a macaroon by making an HTTP POST request to the
WebDAV door.  Although the POST request is logged in the access log
file, some important details are missing: what kind of macaroon was
requested and the id of the resulting macaroon.

Without these details, it is impossible to investigate what is going
wrong with macaroon-supplied requests.

Modification:

Add macaroon details to Servlet attributes to record details of the
macaroon.

Update access logging to record these details.

Result:

The access log file now records what kind of macaroon was requested and
the id of the returned macaroon.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11253/
Acked-by: Tigran Mkrtchyan