### PR TITLE
core: avoid sending bad macaroons to gplazma

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/auth/UnionLoginStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/UnionLoginStrategy.java
@@ -19,13 +19,21 @@ import diskCacheV111.util.PermissionDeniedCacheException;
 import org.dcache.auth.attributes.Restrictions;
 
 /**
- * LoginStrategy which forms the union of allowed logins of several
- * access strategies. Login will be granted by the first of a list of
- * LoginStrategies which grants login. If no LoginStrategy grants
- * login then the behaviour depends on whether the user supplied any credentials.
- * If no credentials were presented then the login attempt is treated as
- * anonymous and the correct level of access is granted.  If credentials were
- * presented then fallback to anonymous only if that is allowed.
+ * LoginStrategy which consults a list of several access strategies when
+ * authenticating a user.  The first strategy in the list is consulted.  If that
+ * strategy successfully authenticates the user then there is no further action
+ * and the LoginReply is used.  If that strategy understands the supplied
+ * credentials and rejects the login then no further strategies are consulted.
+ * If the strategy does not understand the supplied credential then the the next
+ * strategy is tried.  Once no further strategies are to be tried and the user
+ * has not been logged in successfully then.
+ * <p>
+ * If none of the consulted strategies has granted login then the behaviour
+ * depends on whether the user supplied any credentials.  If no credentials were
+ * presented then the login attempt is treated as anonymous and the correct
+ * level of access is granted.  If credentials were presented then it is
+ * configurable whether the user is treated as the anonymous user, or the login
+ * failure is propagated.
  */
 public class UnionLoginStrategy implements LoginStrategy
 {
@@ -86,33 +94,31 @@ public class UnionLoginStrategy implements LoginStrategy
                 || !subject.getPublicCredentials().isEmpty()
                 || !subject.getPrincipals().stream().allMatch(Origin.class::isInstance);
 
-        for (LoginStrategy strategy: _loginStrategies) {
-            _log.debug( "Attempting login strategy: {}", strategy.getClass().getName());
+        PermissionDeniedCacheException loginFailure = null;
+        try {
+            for (LoginStrategy strategy: _loginStrategies) {
+                _log.debug( "Attempting login strategy: {}", strategy.getClass().getName());
 
-            try {
-                LoginReply login = strategy.login(subject);
-                _log.debug( "Login strategy returned {}", login.getSubject());
-                if (!Subjects.isNobody(login.getSubject())) {
-                    return login;
+                try {
+                    LoginReply login = strategy.login(subject);
+                    _log.debug( "Login strategy returned {}", login.getSubject());
+                    if (!Subjects.isNobody(login.getSubject())) {
+                        return login;
+                    }
+                } catch (IllegalArgumentException e) {
+                    /* LoginStrategies throw IllegalArgumentException when
+                     * provided with a Subject they cannot handle.
+                     */
+                    _log.debug("Login failed with IllegalArgumentException for {}: {}", subject,
+                            e.getMessage());
                 }
-            } catch (IllegalArgumentException e) {
-                /* LoginStrategies throw IllegalArgumentException when
-                 * provided with a Subject they cannot handle.
-                 */
-                _log.debug("Login failed with IllegalArgumentException for {}: {}", subject,
-                        e.getMessage());
-            } catch (PermissionDeniedCacheException e) {
-                /* As we form the union of all allowed logins of all
-                 * strategies, we ignore the failure and try the next
-                 * strategy.
-                 */
-                _log.debug("Permission denied for {}: {}", subject,
-                        e.getMessage());
             }
+        } catch (PermissionDeniedCacheException e) {
+            loginFailure = e;
         }
 
         if (areCredentialsSupplied && !_shouldFallback) {
-            throw new PermissionDeniedCacheException("Access denied");
+            throw loginFailure != null ? loginFailure : new PermissionDeniedCacheException("Access denied");
         }
 
         _log.debug( "Strategies failed, trying for anonymous access");
@@ -136,7 +142,7 @@ public class UnionLoginStrategy implements LoginStrategy
 
         default:
             _log.debug( "Login failed");
-            throw new PermissionDeniedCacheException("Access denied");
+            throw loginFailure != null ? loginFailure : new PermissionDeniedCacheException("Access denied");
         }
         return reply;
     }


### PR DESCRIPTION
Motivation:

Macaroons are bearer tokens issued by dCache: a macaroon issued by
dCache is only acceptable by the dCache instance that issued it.

UnionLoginStrategy, when used to combine multiple strategies, is
currently used only to combine the MacaroonLoginStrategy with the
RemoteLoginStrategy (i.e., gPlazma).

Currently, UnionLoginStrategy stops iterating through the list of
configured LoginStrategy objects only if the login was successful and
yielded a non-NOBODY identity.  This means that UnionLoginStrategy will
send a dCache-issued macaroon that is invalid (e.g., has expired) to
gPlazma.

As macaroons may be unique with each request, any caching (e.g., within
the door, to prevent overloading gPlazma) may be ineffective and
(potentially) all invalid macaroons are sent to gPlazma.

OpenID-Connect (OIDC) access-tokens are also bearer tokens.  OIDC access
tokens are opaque: there's no way to determine whether a bearer token is
an OIDC access token.  (An OP could issue a macaroon as an OIDC access
token, but currently no OP does this.)

This means that, if gPlazma has the OpenID-Connect (OIDC) plugin
configured, then (potentially) all invalid macaroons are sent to all
OPs.

Some OPs may implement counter-measures for such request spamming, such
as rate-limiting requests if requests are received too often.  This can
result in login requests to gPlazma timing out.

Modification:

Update UnionLoginStrategy so that any LoginStrategy that both
understands the credentials and rejects it terminates the login attempt.

Update MacaroonLoginStrategy so that unknown macaroons are treated as an
unknown credential instead of failing the login.

Result:

An invalid macaroon login no longer spams gPlazma and (consequently) OPs.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11245/
Acked-by: Tigran Mkrtchyan