### PR TITLE
webdav: obtain FQAN from X.509 credential for gridsite

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.security.AccessController;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.security.cert.CertificateException;
@@ -70,6 +71,8 @@ public class AuthenticationHandler extends HandlerWrapper {
             "org.dcache.restriction";
     public static final String DCACHE_LOGIN_ATTRIBUTES =
             "org.dcache.login";
+    private static final String AUTH_HANDLER_ATTRIBUTE = "org.dcache.authentication-handler";
+    private static final String X509_SUBJECT_ATTRIBUTE = "org.dcache.x509-subject";
     public static final String BEARER_TOKEN_QUERY_KEY = "authz";
 
     private static final InetAddress UNKNOWN_ADDRESS = InetAddresses.forString("0.0.0.0");
@@ -84,6 +87,50 @@ public class AuthenticationHandler extends HandlerWrapper {
 
     public static Set<LoginAttribute> getLoginAttributes(HttpServletRequest request) {
         return (Set<LoginAttribute>) request.getAttribute(DCACHE_LOGIN_ATTRIBUTES);
+    }
+
+    /**
+     * Provide the identity of the user, based solely on their X.509 certificate
+     * (if supplied).  If the user was already authenticated based on their
+     * X.509 certificate then this method simply returned that existing Subject,
+     * otherwise the X.509 certificate chain is authenticated and that result
+     * returned.
+     * @param request the HTTP request to process
+     * @throws PermissionDeniedCacheException if the user could not be logged in
+     * @throws CacheException some other problem with the X.509-based login
+     * @throws IllegalArgumentException X.509 authentication is not supported
+     * @return a Subject based on the users X.509 certificate or null if the
+     * user provided no X.509 certificate
+     */
+    public static Subject getX509Identity(HttpServletRequest request)
+            throws CacheException
+    {
+        Subject dCacheUser = Subject.getSubject(AccessController.getContext());
+        if (dCacheUser != null && Subjects.getDn(dCacheUser) != null) {
+            return dCacheUser;
+        }
+
+        if (!(request.getAttribute(X509_CERTIFICATE_ATTRIBUTE) instanceof X509Certificate[])) {
+            return null;
+        }
+
+        Object existingX509Subject = request.getAttribute(X509_SUBJECT_ATTRIBUTE);
+        if (existingX509Subject instanceof Subject) {
+            return (Subject)existingX509Subject;
+        }
+
+        AuthenticationHandler handler = (AuthenticationHandler)request.getAttribute(AUTH_HANDLER_ATTRIBUTE);
+        Subject x509Subject = handler.x509Login(request);
+        request.setAttribute(X509_SUBJECT_ATTRIBUTE, x509Subject);
+        return x509Subject;
+    }
+
+    private Subject x509Login(HttpServletRequest request) throws CacheException
+    {
+        Subject suppliedIdentity = new Subject();
+        addX509ChainToSubject(request, suppliedIdentity);
+        addOriginToSubject(request, suppliedIdentity);
+        return _loginStrategy.login(suppliedIdentity).getSubject();
     }
 
     @Override
@@ -106,6 +153,7 @@ public class AuthenticationHandler extends HandlerWrapper {
                 request.setAttribute(DCACHE_SUBJECT_ATTRIBUTE, subject);
                 request.setAttribute(DCACHE_RESTRICTION_ATTRIBUTE, restriction);
                 request.setAttribute(DCACHE_LOGIN_ATTRIBUTES, login.getLoginAttributes());
+                request.setAttribute(AUTH_HANDLER_ATTRIBUTE, this);
 
                 /* Process the request as the authenticated user.*/
                 Exception problem = Subject.doAs(subject, (PrivilegedAction<Exception>) () -> {


### PR DESCRIPTION
Motivation:

A previous commit (5b0a1e05) was motivated to support clients that
supply two credentials for third-party copy: a credential that is used
to authorise reading/writing in dCache (a macaroon) and another
credential that identifies which delegated X.509 credential to use when
authenticating with the remote server (X.509 via TLS).

Unfortunately, that patch was incomplete, as it failed to obtain the
primary FQAN from the TLS-supplied X.509 credential but continued to
take this from the macaroon-based authenticated dCache user.  Since the
macaroon-based identity does not include any FQANs, the primary FQAN is
always null.

As the delegated credential store requires both the DN and primary FQAN
to match, any delegated credential with a primary FQAN was not available
for gridsite-based TPC.  Such requests always failed.

Modification:

Instead of reimplementing the FQAN extraction within the door, webdav
now sends the X.509 credential off to be authenticated.  Care is taken
to ensure this is done only when necessary.

Result:

X.509-with-FQAN authenticated third-party transfers with macaroons now
work.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11260/
Acked-by: Tigran Mkrtchyan