### PR TITLE
pool: P2P failures trigger stack-trace

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
@@ -62,6 +62,7 @@ import org.dcache.pool.repository.ReplicaDescriptor;
 import org.dcache.pool.repository.Repository;
 import org.dcache.pool.repository.StickyRecord;
 import org.dcache.util.Checksum;
+import org.dcache.util.Exceptions;
 import org.dcache.util.FireAndForgetTask;
 import org.dcache.util.Version;
 import org.dcache.vehicles.FileAttributes;
@@ -568,11 +569,15 @@ class Companion
         }
 
         if (_error != null) {
-            if (_error instanceof RuntimeException || _error instanceof Error) {
-                _log.error(String.format("P2P for %s failed: %s", _pnfsId, _error),
-                           (Throwable) _error);
+            if (_error instanceof Error) {
+                _log.error("P2P for {} failed due to a serious problem in the JVM.",
+                        _pnfsId, _error);
+                throw (Error)_error; // We should not attempt to recover from this!
+            } else if (_error instanceof RuntimeException) {
+                _log.error("P2P for {} failed due to a bug.  Please report"
+                        + " this to <support@dCache.org>", _pnfsId, _error);
             } else {
-                _log.error(String.format("P2P for %s failed: %s", _pnfsId, _error));
+                _log.error("P2P for {} failed: {}", _pnfsId, _error.toString());
             }
         } else {
             _log.info(String.format("P2P for %s completed", _pnfsId));


### PR DESCRIPTION
Motivation:

A p2p transfer can fail in a number of ways; for example, if the file
was deleted during the P2P transfer.  These failures trigger a
stack-trace, even though there is no bug in dCache.

The RuntimeException/Error handling is also broken.

The Error is "swallowed".

Modification:

Do not log a stack-trace for any checked exception.

Do not include a bogus '{}' in the Error / RuntimeException template.

Include a request to report bugs to us, for RuntimeException.

Ensure that any Error is propagated after it is logged.

Result:

dCache pools no longer log a stack-trace for non-bug P2P failures.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Ticket: http://rt.dcache.org/Ticket/Display.html?id=9518
Patch: https://rb.dcache.org/r/11265/
Acked-by: Tigran Mkrtchyan