### PR TITLE
gplazma: support large gid values for roles

### DIFF
--- a/modules/gplazma2-roles/src/main/java/org/dcache/gplazma/roles/RolesPlugin.java
+++ b/modules/gplazma2-roles/src/main/java/org/dcache/gplazma/roles/RolesPlugin.java
@@ -101,11 +101,11 @@ public class RolesPlugin implements GPlazmaSessionPlugin
                   .map(GidPrincipal.class::cast)
                   .map(GidPrincipal::getGid)
                   .forEach((gid) -> {
-                      if (adminGid != null && gid == adminGid) {
+                      if (adminGid != null && gid == adminGid.longValue()) {
                           roles.add(LoginAttributes.adminRole());
                       }
 
-                      if (observerGid != null && gid == observerGid) {
+                      if (observerGid != null && gid == observerGid.longValue()) {
                           roles.add(LoginAttributes.observerRole());
                       }
                   });


### PR DESCRIPTION
Motivation:

Setting the gid associated with a value to a relatively large non-zero
value stops roles plugin from working.

Modification:

Ensure comparison is made on long primatives not against Long objects.

Result:

Large numerical value gids may be used to define roles.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11264/
Acked-by: Dmitry Litvintsev
Acked-by: Albert Rossi
Closes: #4296