### PR TITLE
core: revert custom bouncycastle version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,13 +104,7 @@
                1.43     bcprov-jdk16    JDK v1.6; used by JGlobus-1.8.x
          -->
         <bouncycastle.bcprov>bcprov-jdk15on</bouncycastle.bcprov>
-	<!--
-	   Use a private BC 1.50 release that provides for
-	   JSSE compatible handling of key agreement secret
-           generation. This support is available in BC starting
-	   version 1.54
-	-->
-        <bouncycastle.version>dcache-1.50</bouncycastle.version>
+        <bouncycastle.version>1.50</bouncycastle.version>
         <datanucleus-core.version>4.1.8</datanucleus-core.version>
         <datanucleus.plugin.version>4.0.2</datanucleus.plugin.version>
         <hazelcast.version>3.9.3</hazelcast.version>


### PR DESCRIPTION
Motivation:

The custom bouncycastle JCE provider was found to fail on one of our
production instances.  The result was an inability to log into the admin
interface.

Modification:

Revert back to the standard bouncycastle version.

Result:

Admins should be able to use the admin interface again.

Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11282/
Acked-by: Tigran Mkrtchyan