### PR TITLE
xrootd: add support for kXR_stat on open files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.11.v20180605</version.jetty>
         <version.wicket>7.6.0</version.wicket>
-        <version.xrootd4j>3.2.4</version.xrootd4j>
+        <version.xrootd4j>3.2.5</version.xrootd4j>
         <version.jersey>2.24</version.jersey>
         <version.dcache-view>1.3.3</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Motivation:

Occationally, the xrootd client requires `kXR_stat` on an open file
handle to succeed.  It is not documented in the protocol specificiation
whether this is a reasonable expectation; but, given this is easy to
implement, it makes sense to support it.

Modification:

Update the pool to return information about the file if the `kXR_stat`
request targets an open file handle.  Requests that target a path
continue to be redirected back to the door.

Result:

The xrootd client is happer; in particular, the `--zip` option now
works.

Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Closes: #4258
Patch: https://rb.dcache.org/r/11285/
Acked-by: Tigran Mkrtchyan