### PR TITLE
xrootd: fix broken configuration property

### DIFF
--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -259,5 +259,5 @@ xrootd.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}
 
 xrootd.kafka.maximum-block=${dcache.kafka.maximum-block}
 
-(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka-maximum-block.unit})\
-xrootd.kafka.maximum-block.unit=${dcache.kafka-maximum-block.unit}
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
+xrootd.kafka.maximum-block.unit=${dcache.kafka.maximum-block.unit}


### PR DESCRIPTION
Motivation:

A previous patch, committed on master as 6e90136c12f, introduced xrootd
properties to control the behaviour of the xrootd door when sending
kafka events.  This patch was broken as there was a typo in the default
value.  The result was dCache does not start with a kafka enabled xrootd
door.

Modification:

Fix typo in default value

Result:

dCache now starts with a kafka enabled xrootd door.

Target: master
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11283/
Acked-by: Tigran Mkrtchyan