### PR TITLE
libs: upgrade to bouncycastle 1.54,  CANL to 2.5.0 and voms-api-java …

### DIFF
--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
@@ -7,7 +7,6 @@ import eu.emi.security.authn.x509.proxy.ProxyUtils;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DERObjectIdentifier;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.PolicyInformation;
@@ -132,7 +131,7 @@ public class X509Plugin implements GPlazmaAuthenticationPlugin
         listPolicies(eec).stream()
                 .map(PolicyInformation::getInstance)
                 .map(PolicyInformation::getPolicyIdentifier)
-                .map(DERObjectIdentifier::getId)
+                .map(ASN1ObjectIdentifier::getId)
                 .map(X509Plugin::asPrincipal)
                 .filter(Objects::nonNull)
                 .forEach(principals::add);

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dcache</groupId>
@@ -104,7 +103,8 @@
                1.43     bcprov-jdk16    JDK v1.6; used by JGlobus-1.8.x
          -->
         <bouncycastle.bcprov>bcprov-jdk15on</bouncycastle.bcprov>
-        <bouncycastle.version>1.50</bouncycastle.version>
+        <bouncycastle.bcpkix>bcpkix-jdk15on</bouncycastle.bcpkix>
+        <bouncycastle.version>1.54</bouncycastle.version>
         <datanucleus-core.version>4.1.8</datanucleus-core.version>
         <datanucleus.plugin.version>4.0.2</datanucleus.plugin.version>
         <hazelcast.version>3.9.3</hazelcast.version>
@@ -239,12 +239,12 @@
             <dependency>
                 <groupId>eu.eu-emi.security</groupId>
                 <artifactId>canl</artifactId>
-                <version>2.1.2</version>
+                <version>2.5.0</version>
             </dependency>
             <dependency>
                 <groupId>org.italiangrid</groupId>
                 <artifactId>voms-api-java</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.glite.authz</groupId>
@@ -693,6 +693,12 @@
                 <groupId>org.dcache</groupId>
                 <artifactId>dcache-view</artifactId>
                 <version>${version.dcache-view}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>${bouncycastle.bcpkix}</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
…to 3.3.0

Motivation:

Attempt to use custom build bouncycastle 1.50 that contains a fix to provide
JSSE compatibility failed on some instalaltions due to JAR not being signed.

Modification:

Checked that newer version of bouncycastle 1.54 provided necessary functionality.
Upgrade to bouncycastle 1.54 and other dependent libraries

Result:

Observed xrdcp works w/o fail.

Patch: https://rb.dcache.org/r/11281/
Acked-by: Paul Millar, Albert Rossi
Require-notes: no

Target: trunk
Request: 4.2