### PR TITLE
webdav: improve logging of TPC requests

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -39,6 +39,7 @@ import java.security.cert.X509Certificate;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import diskCacheV111.services.TransferManagerHandler;
@@ -216,7 +217,11 @@ public class RemoteTransferHandler implements CellMessageReceiver
         return _performanceMarkerPeriod;
     }
 
-    public void acceptRequest(OutputStream out, Map<String,String> requestHeaders,
+    /**
+     * Start a transfer and block until that transfer is complete.
+     * @return a description of the error, if there was a problem.
+     */
+    public Optional<String> acceptRequest(OutputStream out, Map<String,String> requestHeaders,
             Subject subject, Restriction restriction, FsPath path, URI remote,
             Object credential, Direction direction, boolean verification,
             boolean overwriteAllowed)
@@ -248,6 +253,8 @@ public class RemoteTransferHandler implements CellMessageReceiver
                 _transfers.remove(id);
             }
         }
+
+        return Optional.ofNullable(transfer._problem);
     }
 
     private ImmutableMap<String,String> buildTransferHeaders(Map<String,String> requestHeaders)


### PR DESCRIPTION
Motivation:

When investigating problems with HTTP TPC transfers, various useful
pieces of information are missing:

    what actually went wrong (as reported back to the client),

    which credential source was used,

    whether checksum verificiation was required,

    the source or destination URL.

Additionally, both TPC successful and failured operations are currently
logged at INFO level.  This is in contrast with other access log
entries, where failing operations are logged at either WARN or ERROR
level.

Modification:

Record information about the COPY request in various attributes.

Update the access log file so these attributes are recorded, if present.

Update the log level so TPC failures are logged at WARN level.

Result:

The admin has more logged information in the webdav access log file with
which to diagnose third-party-copy problems.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11266/
Acked-by: Albert Rossi