### PR TITLE
poolmanager: fix NPE on unknown host

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -669,10 +669,13 @@ public class RequestContainerV5
         ProtocolInfo protocolInfo = request.getProtocolInfo() ;
         EnumSet<RequestState> allowedStates = request.getAllowedStates();
 
-        String  hostName    =
-               protocolInfo instanceof IpProtocolInfo ?
-               ((IpProtocolInfo)protocolInfo).getSocketAddress().getAddress().getHostAddress() :
-               "NoSuchHost" ;
+        String hostName;
+        if (protocolInfo instanceof IpProtocolInfo) {
+            InetSocketAddress target = ((IpProtocolInfo)protocolInfo).getSocketAddress();
+            hostName = target.isUnresolved() ? target.getHostString() : target.getAddress().getHostAddress();
+        } else {
+            hostName = "NoSuchHost";
+        }
 
         String netName      = _selectionUnit.getNetIdentifier(hostName);
         String protocolNameFromInfo = protocolInfo.getProtocol()+"/"+protocolInfo.getMajorVersion() ;


### PR DESCRIPTION
Motivation:

When selecting a pool, the door supplies the identity of the remote host
that will participate in the transfer.  If the client supplies this
information as a hostname that could not be resolved to an IP address
then poolmanager will fail the request with a NPE, like:

    24 Oct 2018 23:57:10 (PoolManager) [door:webdav-secure-grid@dCacheDomain:AAV5AJFr/oA RemoteTransferManager PoolMgrSelectReadPool 00004F9DFFC25F6A4C4591B501137B83D422] Uncaught exception in thread PoolM
anager-0
    java.lang.NullPointerException: null
            at diskCacheV111.poolManager.RequestContainerV5.messageArrived(RequestContainerV5.java:674) ~[dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at sun.reflect.GeneratedMethodAccessor472.invoke(Unknown Source) ~[na:na]
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_181]
            at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_181]
            at org.dcache.cells.CellMessageDispatcher$LongReceiver.deliver(CellMessageDispatcher.java:304) ~[dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.cells.CellMessageDispatcher.call(CellMessageDispatcher.java:201) ~[dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.cells.AbstractCell.messageArrived(AbstractCell.java:331) ~[dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:890) ~[cells-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1211) ~[cells-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) [dcache-common-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_181]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_181]
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$4(CellNucleus.java:747) [cells-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_181]

Modification:

Update code to use the hostname if the IP address is not known.  This
will trigger an attempt to resolve the hostname

Result:

Supplying poolmanager with an unresolved hostname as the target will
trigger a DNS lookup.  If that lookup fails then the pool selection will
fail with an UnknownHostException.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11288/
Acked-by: Marina Sahakyan