### PR TITLE
webdav: fail TPC request early on unknown hostname

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -473,6 +473,11 @@ public class RemoteTransferHandler implements CellMessageReceiver
             InetSocketAddress address = new InetSocketAddress(_destination.getHost(),
                     URIs.portWithDefault(_destination));
 
+            if (address.isUnresolved()) {
+                String target = _direction == Direction.PULL ? "source" : "destination";
+                throw new ErrorResponseException(Response.Status.SC_BAD_REQUEST, "Unknown " + target + " hostname");
+            }
+
             switch (_type) {
             case GSIFTP:
                 return new RemoteGsiftpTransferProtocolInfo("RemoteGsiftpTransfer",


### PR DESCRIPTION
Motivation:

The client can write any hostname as the third-party-copy source or
destination URL.  If the host is unknown then the request is accepted
and poolmanager will (eventually) fail the request.

It is more efficient and provides better feedback if such bad requests
are failed as quickly as possible.

Modification:

Check within WebDAV door if the hostname was resolved.  If not, fail the
request.

Result:

Fail fast on HTTP third-party-transfers where the hostname is unknown.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11289/
Acked-by: Tigran Mkrtchyan