### PR TITLE
xrootd: strip off query part from kXR_mv source

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -393,8 +393,25 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
         _log.info("Trying to rename {} to {}", req.getSourcePath(), req.getTargetPath());
 
         try {
+            /*
+             * We have observed kXR_mv requests with a source path like:
+             *
+             *     //foo/my-file?xrd.gsiusrpxy=/opt/domatests/x509up&xrd.wantprot=gsi,unix
+             *
+             * It currently isn't clear whether this is valid.  The xrootd
+             * protocol documentation does not document it as valid:
+             *
+	     *     https://github.com/xrootd/xrootd/issues/850
+             *
+             * However, the SLAC xrootd server accepts such requests and
+	     * strips off the query part.  Since xrootd clients exist that
+	     * expect this behaviour, we do the same (at least for now).
+             */
+            String srcWithQuery = req.getSourcePath();
+            int queryIndex = srcWithQuery.indexOf('?');
+            String src = queryIndex == -1 ? srcWithQuery : srcWithQuery.substring(0, queryIndex);
             _door.moveFile(
-                    createFullPath(req.getSourcePath()),
+                    createFullPath(src),
                     createFullPath(req.getTargetPath()),
                     req.getSubject(),
                     _authz);


### PR DESCRIPTION
Motivation:

We see kXR_mv requests where the source path contains a query/opaque
string.  The SLAC xrootd supports this, and strips off the query part,
despite this not being documented in the xrootd protocol.

Modification:

Add support for stripping off any query part from the source.

Result:

dCache allows xrootd clients to specify a query/opaque string in a
kXR_mv request's source path.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11292/
Acked-by: Tigran Mkrtchyan