### PR TITLE
pool: update log status using exception class name if no message

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -253,7 +253,7 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
                     setTransferStatus(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, "Bug detected (please report): " + e.getMessage());
                 } catch (Exception e) {
                     LOGGER.error("Transfer failed: {}", e.toString());
-                    setTransferStatus(CacheException.DEFAULT_ERROR_CODE, "General problem: " + e.getMessage());
+                    setTransferStatus(CacheException.DEFAULT_ERROR_CODE, "General problem: " + Exceptions.messageOrClassName(e));
                 } catch (Throwable e) {
                     LOGGER.error("Transfer failed:", e);
                     Thread thread = Thread.currentThread();


### PR DESCRIPTION
Motivation:

Observed transfers failing with the pool billing entries like:

    10.26 18:17:54 [pool:pool1:transfer] [0000C98B40F7B826472088734F87324A126D,540759567] [/VOs/dteam/tpc-test/https/domatest/file11_1bdc76ec-70c8-421c-a026-9573c9c77455] test:default@osm 540759567 2519512 true {RemoteHttpsDataTransfer-1.1:https://dpmhead-rc.cern.ch:443/dpm/cern.ch/home/dteam/domatests/https/domatest/file11_1bdc76ec-70c8-421c-a026-9573c9c77455} [door:RemoteTransferManager@dCacheDomain:1540566461077-536] {666:"General problem: null"}

Modification:

Use utility method to record the exception class name if the exception
has no message.

Result:

For some failed transfers, the pool billing record now contains more
information about what went wrong.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11303/
Acked-by: Olufemi Adeyemi