### PR TITLE
pool: increase TPC socket timeout for GET requests

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -133,6 +133,13 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     private static final int SOCKET_TIMEOUT = (int) TimeUnit.MINUTES.toMillis(1);
 
     /**
+     * Maximum time to wait for next packet from remote server for GET requests.
+     * This needs to be longer as DPM can block on GET requests while calculating
+     * the checksum.
+     */
+    private static final int GET_SOCKET_TIMEOUT = (int) TimeUnit.MINUTES.toMillis(20);
+
+    /**
      * Expected maximum delay all post-processing files will experience,
      * in milliseconds.
      */
@@ -269,7 +276,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
         addHeadersToRequest(info, get);
         get.setConfig(RequestConfig.custom()
                               .setConnectTimeout(CONNECTION_TIMEOUT)
-                              .setSocketTimeout(SOCKET_TIMEOUT)
+                              .setSocketTimeout(GET_SOCKET_TIMEOUT)
                               .build());
 
         CloseableHttpResponse response = _client.execute(get);


### PR DESCRIPTION
Motivation:

DPM will block HTTP GET requests while calculation checksums.
Therefore the default one minute timeout may be too short.

Modification:

Add a GET-specific timeout that allows for longer delays.

Result:

HTTP TPC Transfers involving DPM become more reliable.

Target: master
Requires-notes: yes
Requires-book: no
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11301/
Acked-by: Tigran Mkrtchyan