### PR TITLE
pool: HTTP TPC rework exception logging

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -20,6 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.channels.Channels;
 import java.nio.file.OpenOption;
@@ -43,6 +45,7 @@ import org.dcache.pool.repository.RepositoryChannel;
 import org.dcache.util.Checksum;
 import org.dcache.util.ChecksumType;
 import org.dcache.util.Checksums;
+import org.dcache.util.Exceptions;
 import org.dcache.util.Version;
 import org.dcache.vehicles.FileAttributes;
 
@@ -53,7 +56,9 @@ import static org.dcache.util.ByteUnit.MiB;
 import static org.dcache.util.Exceptions.genericCheck;
 import static org.dcache.util.TimeUtils.describeDuration;
 import static diskCacheV111.util.ThirdPartyTransferFailedCacheException.checkThirdPartyTransferSuccessful;
+import static dmg.util.Exceptions.getMessageWithCauses;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * This class implements transfers of data between a pool and some remote
@@ -254,6 +259,14 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                 throw new ClientProtocolException("Response contains no content");
             }
             entity.writeTo(Channels.newOutputStream(_channel));
+        } catch (SocketTimeoutException e) {
+            String message = "socket timeout (received "
+                    + _channel.getBytesTransferred() + " bytes; "
+                    + e.bytesTransferred + " pending)";
+            if (e.getMessage() != null) {
+                message += ": " + e.getMessage();
+            }
+            throw new ThirdPartyTransferFailedCacheException(message, e);
         } catch (IOException e) {
             throw new ThirdPartyTransferFailedCacheException(e.toString(), e);
         } catch (InterruptedException e) {
@@ -370,10 +383,13 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                             "server rejected PUT: " + status.getStatusCode() +
                             " " + status.getReasonPhrase());
                 }
-            } catch (IOException e) {
-                _log.error("problem connecting: {}", e.toString());
+            } catch (ConnectException e) {
                 throw new ThirdPartyTransferFailedCacheException("failed to " +
-                        "connect to server: " + e.toString(), e);
+                        "connect to server: " + messageOrClassName(e), e);
+            } catch (ClientProtocolException e) {
+                throw new ThirdPartyTransferFailedCacheException("HTTP protocol failure: " + getMessageWithCauses(e), e);
+            } catch (IOException e) {
+                throw new ThirdPartyTransferFailedCacheException("problem sending data: " + messageOrClassName(e), e);
             }
         }
 


### PR DESCRIPTION
Motivation:

Various error messages are sub-optimal.  In particular,
SocketTimeoutException and ClientProtocolException provide insufficient
information.

Modification:

Remove log-and-throw anti-pattern.

Adjust exception handling to improve error messages.

Result:

Hopefully more detailed information to allow diagnostics should an HTTP
third-party-transfer fail.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: yes