### PR TITLE
ftp: avoid NullPointerException if adapter is not connected

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/SocketAdapter.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/SocketAdapter.java
@@ -759,27 +759,31 @@ public class SocketAdapter implements Runnable, ProxyAdapter
         pw.println("    Listening on:");
         pw.println("        Client: " + _clientConnectionHandler.getLocalAddress());
         pw.println("        Pool: " + _poolConnectionHandler.getLocalAddress());
-        pw.println("    Proxy status:");
-        ProxyPrinter proxy = new ProxyPrinter();
-        Socket out = _output.socket();
-        boolean isFirstRow = true;
-        for (Redirector redirector : _redirectors) {
-            if (isFirstRow) {
-                if (_clientToPool) {
-                    proxy.pool(out);
-                } else {
-                    proxy.client(out);
+        if (_output == null) {
+            pw.println("    Proxy status: not connected");
+        } else {
+            pw.println("    Proxy status:");
+            ProxyPrinter proxy = new ProxyPrinter();
+            Socket out = _output.socket();
+            boolean isFirstRow = true;
+            for (Redirector redirector : _redirectors) {
+                if (isFirstRow) {
+                    if (_clientToPool) {
+                        proxy.pool(out);
+                    } else {
+                        proxy.client(out);
+                    }
+                    isFirstRow = false;
                 }
-                isFirstRow = false;
+                Socket in = redirector._input.socket();
+                if (_clientToPool) {
+                    proxy.client(in);
+                } else {
+                    proxy.pool(in);
+                }
+                proxy.add();
             }
-            Socket in = redirector._input.socket();
-            if (_clientToPool) {
-                proxy.client(in);
-            } else {
-                proxy.pool(in);
-            }
-            proxy.add();
+            pw.println(indentLines("        ", proxy.toString()));
         }
-        pw.println(indentLines("        ", proxy.toString()));
     }
 }


### PR DESCRIPTION
Motivation:

Observed following stack-trace on 4.2:

    java.lang.NullPointerException: null
            at org.dcache.ftp.proxy.SocketAdapter.getInfo(SocketAdapter.java:764) ~\[dcache-ftp-4.2.13.jar:4.2.13\]
            at org.dcache.ftp.door.AbstractFtpDoorV1$FtpTransfer.getInfo(AbstractFtpDoorV1.java:1429) ~\[dcache-ftp-4.2.13.jar:4.2.13\]
            at org.dcache.ftp.door.AbstractFtpDoorV1$FtpTransfer.onFailure(AbstractFtpDoorV1.java:1312) ~\[dcache-ftp-4.2.13.jar:4.2.13\]
            at org.dcache.util.AsynchronousRedirectedTransfer$Monitor.doAbort(AsynchronousRedirectedTransfer.java:190) ~\[dcache-core-4.2.13.jar:4.2.13\]
            at org.dcache.util.AsynchronousRedirectedTransfer$Monitor.access$400(AsynchronousRedirectedTransfer.java:117) ~\[dcache-core-4.2.13.jar:4.2.13\]
            at org.dcache.util.AsynchronousRedirectedTransfer.lambda$abort$1(AsynchronousRedirectedTransfer.java:77) ~\[dcache-core-4.2.13.jar:4.2.13\]
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~\[na:1.8.0_181\]
            at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~\[na:1.8.0_181\]
            at org.dcache.util.CDCExecutorDecorator$WrappedRunnable.run(CDCExecutorDecorator.java:62) ~\[dcache-core-4.2.13.jar:4.2.13\]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~\[na:1.8.0_181\]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~\[na:1.8.0_181\]
            at java.lang.Thread.run(Thread.java:748) ~\[na:1.8.0_181\]

Modification:

Check whether client is connected before generating proxy TCP connection
status output.

Result:

A NullPointerException is thrown if an FTP proxy is needed for the FTP
data channels but the client did not connect, but disconnects from the
control channel, aborting the transfer.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-book: no
Requires-notes: yes
Patch: https://rb.dcache.org/r/11312/
Acked-by: Tigran Mkrtchyan