### PR TITLE
ftp: make performance marker task robust.

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -4183,10 +4183,14 @@ public abstract class AbstractFtpDoorV1
         public synchronized void run()
         {
             try (CDC ignored = _cdc.restore()) {
-                CellMessage msg = new CellMessage(_pool, "mover ls -binary " + _moverId);
-                _cellEndpoint.sendMessage(msg, this, _executor, _timeout);
-                _lastQuerySent = java.util.Optional.of(Instant.now());
-                _querySendCount++;
+                try {
+                    CellMessage msg = new CellMessage(_pool, "mover ls -binary " + _moverId);
+                    _cellEndpoint.sendMessage(msg, this, _executor, _timeout);
+                    _lastQuerySent = java.util.Optional.of(Instant.now());
+                    _querySendCount++;
+                } catch (RuntimeException e) {
+                    LOGGER.error("Bug detected, please report this to <support@dcache.org>", e);
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:

The performance markers that dCache sends back to the client are driven
by a single Timer object that is shared between all door instances.

If the thread providing this Timer service dies (e.g., a
RuntimeException is thrown) then all tasks subsequently submitted to the
Timer will fail with IllegalStateException: Timer already cancelled.

Modification:

Protect against RuntimeException, so that the Timer thread does not die.

Result:

Sending performance markers (and, more generally, any MODE E uploads)
is more robust against bugs.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no