### PR TITLE
srmmanager/webdav: consider VOMS AC validity of delegated credential

### DIFF
--- a/modules/common-security/pom.xml
+++ b/modules/common-security/pom.xml
@@ -35,5 +35,9 @@
             <groupId>eu.eu-emi.security</groupId>
             <artifactId>canl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.italiangrid</groupId>
+            <artifactId>voms-api-java</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/common-security/src/main/java/org/dcache/security/util/X509Credentials.java
+++ b/modules/common-security/src/main/java/org/dcache/security/util/X509Credentials.java
@@ -1,0 +1,110 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2018 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.security.util;
+
+import eu.emi.security.authn.x509.X509Credential;
+import eu.emi.security.authn.x509.proxy.ProxyChainInfo;
+import org.bouncycastle.asn1.x509.AttributeCertificate;
+import org.italiangrid.voms.VOMSAttribute;
+import org.italiangrid.voms.VOMSError;
+import org.italiangrid.voms.asn1.VOMSACUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ *  Utility methods for X509Credential objects.
+ */
+public class X509Credentials
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(X509Credentials.class);
+
+    private static final AttributeCertificate[] EMPTY_ARRAY = {};
+
+    private X509Credentials()
+    {
+        // Prevent instantiation
+    }
+
+    /**
+     * Calculate when this credential will expire.  If the credential contains
+     * AttributeCertificates then this is taken into account.
+     * @param credential the credential to examine
+     * @return when this credential will expire
+     */
+    public static Optional<Instant> calculateExpiry(X509Credential credential)
+    {
+        Optional<Instant> expiry = Stream.of(credential.getCertificateChain())
+                        .map(X509Certificate::getNotAfter)
+                        .min(Date::compareTo)
+                        .map(Date::toInstant);
+
+        Map<String,Instant> expiryPerVo = new HashMap<>();
+        try {
+            ProxyChainInfo info = new ProxyChainInfo(credential.getCertificateChain());
+            for (AttributeCertificate[] acForCertificateOrNull : info.getAttributeCertificateExtensions()) {
+                AttributeCertificate[] acForCertificate = acForCertificateOrNull == null ? EMPTY_ARRAY : acForCertificateOrNull;
+                for (AttributeCertificate ac : acForCertificate) {
+                    try {
+                        VOMSAttribute attribute = VOMSACUtils.deserializeVOMSAttributes(ac);
+                        Instant acExpires = attribute.getNotAfter().toInstant();
+
+                        /* It is allowed for an X.509 chain to have multiple
+                         * ACs from the same VOMS server.  For example, if the
+                         * X.509 chain is valid for one week, but the VOMS
+                         * server issues ACs that are valid for one day then
+                         * the AC may be renewed by contacting the VOMS server
+                         * shortly before the AC certificate expires, requesting
+                         * a new AC and creating a new proxy credential with
+                         * this new AC.
+                         *
+                         * Therefore, we consider all ACs for the same VO as
+                         * equivalent and take the AC expiry that is furthest in
+                         * the future.
+                         */
+                        String vo = attribute.getVO();
+                        expiryPerVo.merge(vo, acExpires, (a,b) -> a.isAfter(b) ? a : b);
+                    } catch (VOMSError e) {
+                        LOGGER.warn("Badly formatted VOMS AC: {}", e.toString());
+                    }
+                }
+            }
+        } catch (IOException | CertificateException e) {
+            LOGGER.warn("Unable to parse AC: {}", e.toString());
+        }
+
+        // Since we cannot know which VO is important if the credential
+        // contains multiple, consider the ACs expired if any VO has expired.
+        Optional<Instant> acExpiry = expiryPerVo.values().stream().sorted().findFirst();
+
+        if (!expiry.isPresent() || (acExpiry.isPresent() && acExpiry.get().isBefore(expiry.get()))) {
+            expiry = acExpiry;
+        }
+
+        return expiry;
+    }
+}

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
@@ -23,14 +23,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.io.IOException;
-import java.security.cert.X509Certificate;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import org.dcache.auth.FQAN;
 import org.dcache.delegation.gridsite2.DelegationException;
+import org.dcache.security.util.X509Credentials;
 import org.dcache.srm.request.RequestCredential;
 import org.dcache.srm.request.RequestCredentialStorage;
 import org.dcache.util.Exceptions;
@@ -147,9 +146,8 @@ public class SrmCredentialStore implements CredentialStore
 
     private static Date expiryDateFor(X509Credential credential)
     {
-        return Stream.of(credential.getCertificateChain())
-                .map(X509Certificate::getNotAfter)
-                .min(Date::compareTo)
+        return X509Credentials.calculateExpiry(credential)
+                .map(Date::from)
                 .orElseThrow(() -> new IllegalArgumentException("Certificate chain is empty."));
     }
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/RequestCredential.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/RequestCredential.java
@@ -70,18 +70,17 @@ import com.google.common.collect.MapMaker;
 import eu.emi.security.authn.x509.X509Credential;
 import org.springframework.dao.DataAccessException;
 
-import java.security.cert.X509Certificate;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Stream;
 
 import org.dcache.srm.SRMInvalidRequestException;
 import org.dcache.srm.scheduler.JobIdGeneratorFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.dcache.security.util.X509Credentials.calculateExpiry;
 
 public class RequestCredential
 {
@@ -213,11 +212,7 @@ public class RequestCredential
 
     private static long expiryDateFor(X509Credential credential)
     {
-        return Stream.of(credential.getCertificateChain())
-                        .map(X509Certificate::getNotAfter)
-                        .min(Date::compareTo)
-                        .map(Date::getTime)
-                        .orElse(0L);
+        return calculateExpiry(credential).map(Instant::toEpochMilli).orElse(0L);
     }
 
     private void updateCredential(X509Credential credential)


### PR DESCRIPTION
Motivation:

Currently, dCache only considers the X.509 proxy certificate chain when
calculating a delegated credential's lifetime.  It is possible that a
client delegates a credential where the VOMS AC expires before the X.509
proxies.  If this happens, then dCache will attempt HTTP TPC with an
AC-expired credential.

Modification:

Move proxy lifetime calculation to a utility class.

Include AC lifetime in the credential lifetime calculation.

Result:

A delegated credential with VOMS AC that expires before the X.509 is not
used beyond the AC expiry time.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11300/
Acked-by: Albert Rossi