### PR TITLE
webdav: adjust minimum validity after requesting delegation

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
@@ -471,6 +471,7 @@ public class CopyFilter implements Filter
         switch (source) {
         case GRIDSITE:
             try {
+                HttpServletRequest request = ServletRequest.getRequest();
                 // Use the X.509 identity from TLS, even if that wasn't used to
                 // establish the user's identity.  This allows the local activity of
                 // the COPY (i.e., the ability to read a file, or create a new file)
@@ -478,15 +479,23 @@ public class CopyFilter implements Filter
                 // delegated X.509 credential when authenticating for the
                 // third-party copy, based on the client credential presented when
                 // establishing the TLS connection.
-                Subject x509Subject = AuthenticationHandler.getX509Identity(ServletRequest.getRequest());
+                Subject x509Subject = AuthenticationHandler.getX509Identity(request);
                 String dn = x509Subject == null ? null : Subjects.getDn(x509Subject);
                 if (dn == null) {
                     throw new ErrorResponseException(Response.Status.SC_UNAUTHORIZED,
                             "user must present valid X.509 certificate");
                 }
                 String fqan = Objects.toString(Subjects.getPrimaryFqan(x509Subject), null);
+
+                /* If delegation has been requested and declined then
+                 * potentially use the existing delegated credential.  We don't
+                 * want to artifically fail requests that might otherwise
+                 * succeed.
+                 */
+                int minLifetimeInMinutes = hasClientAlreadyBeenRedirected(request)
+                        ? 2 : 20;
                 return _credentialService.getDelegatedCredential(dn, fqan,
-                        20, MINUTES);
+                        minLifetimeInMinutes, MINUTES);
             } catch (PermissionDeniedCacheException e) {
                 throw new ErrorResponseException(Status.SC_UNAUTHORIZED,
                         "Presented X.509 certificate not valid");


### PR DESCRIPTION
Motivation:

When the WebDAV door is considering an HTTP third-party-copy request
that uses grid-site delegation, there is a minimum 20 minute validity
that any existing delegated credential must satisfy.  If this is not
satisfied then dCache will request a fresh delegated credential.

Currently, if the client fails to delegate a fresh certificate then the
subsequent COPY request will be rejected.

This is too harsh, as the COPY request could succeed if there is an
unexpired delegated credential.

Modification:

Adjust the minimum validity after requesting a fresh credential is
deligated.

Results:

dCache will attempt an HTTP third-party-copy that should use an X.509
credential that is already delegated, is still valid and has less than
20 minutes, and where the client declined to delegate a fresh credential
when prompted.

Requires-notes: yes
Requires-book: no
Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11299/
Acked-by: Tigran Mkrtchyan