### PR TITLE
nfs: increase request retry delay when selecting/starting  pool or mover

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -183,10 +183,10 @@ public class NFSv41Door extends AbstractCellComponent implements
     private static final long NFS_REQUEST_BLOCKING = TimeUnit.SECONDS.toMillis(3);
 
     /**
-     * Given that the timeout is pretty short, the retry period has to
-     * be rather small too.
+     * A time diration that Transfer class will wait before retrying a request to
+     * a pool or pool manager.
      */
-    private static final long NFS_RETRY_PERIOD = 500; // In millis
+    private static final long NFS_RETRY_PERIOD = TimeUnit.SECONDS.toMillis(10);
 
     /**
      * How long stage request can hang around. As the tape system can be broken,


### PR DESCRIPTION
Motivation:
Transfer class is may get an error when selecting a pool or starting a mover.
WIn case of a transient error, transfer class will re-try the request,
for example, when pools are not online yet. However, with a tight retry
loop we nay run into StackOverflowError as retry logic builds a chain of
ListanableFutures (https://github.com/dCache/dcache/issues/4392).
Moreover, the situation causing the retry very likely is not fixed yet
if we retry soon.

Modification:
increase the request retry delay to (a) reduce likelihood to StackOverflowError
and (b) give system a chance to recover from the error.

Result:
no StackOverflowError exception observed on affected system.

Acked-by: Albert Rossi
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit 6c37e7a2943b5a53ff828515f72cf27e7bbdfa90)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>