### PR TITLE
scripts: Avoid findbugs memory errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1141,6 +1141,10 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>3.0.4</version>
+                    <configuration>
+                      <fork>true</fork>
+                      <jvmArgs>-Xmx2g</jvmArgs>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.datanucleus</groupId>


### PR DESCRIPTION
Motivation:

Maven's findbugs plugin is run extensively on our automated build system.
It has a step that enumerates the entire source tree's changes
using `git blame`. That step often dies due to lack of memory in
the automated builds.

Modification:

Changed the project's pom.xml to have the findbugs process run in
its own JVM with plenty of memory.

Result:

During testing, memory issues disappeared.
This should lead to quicker turnaround on the Jenkins agents and
more reliable releasing processes.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: no
Require-book: no
Patch: https://rb.dcache.org/r/11210/
Acked-by: Paul Millar