### PR TITLE
chimera: fix postgres 95 optimization regression

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
@@ -23,6 +23,7 @@ import org.springframework.dao.DuplicateKeyException;
 import javax.sql.DataSource;
 
 import java.sql.Timestamp;
+import org.dcache.chimera.posix.Stat;
 
 import org.dcache.chimera.store.InodeStorageInformation;
 
@@ -48,6 +49,50 @@ public class PgSQL95FsSqlDriver extends PgSQLFsSqlDriver {
         _log.info("Running PostgreSQL >= 9.5 specific Driver");
     }
 
+        @Override
+    protected FsInode createInodeInParent(FsInode parent, String name, String id, int owner, int group, int mode, int type,
+                                          int nlink, long size) {
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+
+        Long inumber =
+                _jdbc.query("SELECT f_create_inode_95(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                            cs -> {
+                                cs.setLong(1, parent.ino());
+                                cs.setString(2, name);
+                                cs.setString(3, id);
+                                cs.setInt(4, type);
+                                cs.setInt(5, mode & UnixPermission.S_PERMS);
+                                cs.setInt(6, nlink);
+                                cs.setInt(7, owner);
+                                cs.setInt(8, group);
+                                cs.setLong(9, size);
+                                cs.setInt(10, FileState.CREATED.getValue());
+                                cs.setTimestamp(11, now);
+                            },
+                            rs -> rs.next() ? rs.getLong(1) : null);
+        if (inumber == null || inumber == 0L) {
+            throw new DuplicateKeyException("Entry already exists");
+        }
+
+        Stat stat = new Stat();
+        stat.setIno(inumber);
+        stat.setId(id);
+        stat.setCrTime(now.getTime());
+        stat.setGeneration(0);
+        stat.setSize(size);
+        stat.setATime(now.getTime());
+        stat.setCTime(now.getTime());
+        stat.setMTime(now.getTime());
+        stat.setUid(owner);
+        stat.setGid(group);
+        stat.setMode(mode & UnixPermission.S_PERMS | type);
+        stat.setNlink(nlink);
+        stat.setDev(17);
+        stat.setRdev(13);
+        stat.setState(FileState.CREATED);
+
+        return new FsInode(parent.getFs(), inumber, FsInodeType.INODE, 0, stat);
+    }
 
     @Override
     void createEntryInParent(FsInode parent, String name, FsInode inode) {

--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.15.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-2.15.xml
@@ -109,6 +109,32 @@
         </rollback>
     </changeSet>
 
+    <changeSet id="7.1" author="tigran" dbms="postgresql">
+        <comment>Update f_create_inode stored procedure to return inumber for postgres 9.5+</comment>
+        <createProcedure>
+            CREATE OR REPLACE FUNCTION f_create_inode_95(parent bigint, name varchar, id varchar, type integer, mode integer, nlink integer, uid integer, gid int, size bigint, io integer, now timestamp) RETURNS bigint AS $$
+            DECLARE
+                newid bigint;
+                ignored bigint;
+            BEGIN
+                INSERT INTO t_inodes VALUES (id,type,mode,nlink,uid,gid,size,io,now,now,now,now,0) RETURNING inumber INTO newid;
+                INSERT INTO t_dirs VALUES (parent, newid, name) ON CONFLICT ON CONSTRAINT t_dirs_pkey DO NOTHING RETURNING ichild INTO ignored;
+                IF foo IS NULL
+                THEN
+                    RETURN NULL;
+                ELSE
+                    UPDATE t_inodes SET inlink=inlink+1,imtime=now,ictime=now,igeneration=igeneration+1 WHERE inumber = parent;
+                    RETURN newid;
+                END IF;
+            END;
+            $$ LANGUAGE plpgsql;
+        </createProcedure>
+
+        <rollback >
+            <dropProcedure procedureName="f_create_inode_95"/>
+        </rollback>
+    </changeSet>
+
     <changeSet id="8" author="behrmann">
         <comment>Rewrite t_tags to use inumber as foreign key</comment>
 


### PR DESCRIPTION
Motivation:
Chimera relies on DB to enforce consistency. Unfortunately PostgreSQL logs
primary key violation as fatal error in the log files. With PostgreSQL 95
there is way to avoid sych entries in the log file. Unfortunately in dcache
2.15 we have introduced a stored procedure file inode creation which
have lost that optimization. As a result, postgres logs full of

'duplicate key value violates'

messages

Modification:
Update postgres 95+ driver to use an alternative stored procedure to avoid
such error messages.

Result:
No 'duplicate key value violates'  in postgres log files.

Acked-by: Paul Millar
Target: master, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit a9abaa78636f21f3262de03576a983470d3c9f24)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>