### PR TITLE
chimera: support origin tag discovery

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FileSystemProvider.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FileSystemProvider.java
@@ -289,6 +289,16 @@ public interface FileSystemProvider extends Closeable {
 
     void setTagMode(FsInode_TAG tagInode, String name, int mode) throws ChimeraFsException;
 
+    /**
+     * Find a list of origin tags that have the supplied name.  Origin tags are
+     * those tags explicitly created in the namespace.  Tags that are inherited
+     * automatically are not origin tags and are not include in the response.
+     * @param tagName The name of the origin tag.
+     * @return a list of origin tags
+     * @throws ChimeraFsException if there is any problem
+     */
+    List<OriginTag> findTags(String tagName) throws ChimeraFsException;
+
     int getFsId();
 
     void setStorageInfo(FsInode inode,

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -1229,6 +1229,13 @@ public class JdbcFs implements FileSystemProvider {
         });
     }
 
+    @Override
+    public List<OriginTag> findTags(String tagName) throws ChimeraFsException {
+        return inTransaction(status -> _sqlDriver.findTags(tagName));
+    }
+
+
+
     ///////////////////////////////////////////////////////////////
     //
     // Id and Co.

--- a/modules/chimera/src/main/java/org/dcache/chimera/OriginTag.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/OriginTag.java
@@ -1,0 +1,42 @@
+/*
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program (see the file COPYING.LIB for more
+ * details); if not, write to the Free Software Foundation, Inc.,
+ * 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.dcache.chimera;
+
+/**
+ * Information about an origin tag.
+ */
+public class OriginTag
+{
+    private final String path;
+    private final byte[] value;
+
+    public OriginTag(String path, byte[] value)
+    {
+        this.path = path;
+        this.value = value;
+    }
+
+    public String getPath()
+    {
+        return path;
+    }
+
+    public byte[] getValue()
+    {
+        return value;
+    }
+}

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -55,6 +56,7 @@ import org.dcache.chimera.FsFactory;
 import org.dcache.chimera.FsInode;
 import org.dcache.chimera.HimeraDirectoryEntry;
 import org.dcache.chimera.NotDirChimeraException;
+import org.dcache.chimera.OriginTag;
 import org.dcache.chimera.UnixPermission;
 import org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor;
 import org.dcache.chimera.namespace.ChimeraStorageInfoExtractable;
@@ -604,6 +606,40 @@ public class Shell extends ShellApplication
             }
             fs.remove(inode);
             return null;
+        }
+    }
+
+    @Command(name = "findtags", hint = "find origin tags in the filesystem",
+            description = "Search chimera for all origin tags with the given"
+                    + " tag name.  An origin tag is one that is created"
+                    + " explicitly, with a specific value.  Tags that are"
+                    + " inherited, and so created automatically, are not"
+                    + " included in the output.\n"
+                    + "\n"
+                    + "The output consists of the directory path in which the"
+                    + " tag is defined followed by the value of the tag.")
+    public class FindTagsCommand implements Callable<Serializable>
+    {
+        @Argument(index = 0)
+        String name;
+
+        @Override
+        public Serializable call() throws ChimeraFsException
+        {
+            List<OriginTag> tags = fs.findTags(name);
+
+            StringBuilder sb = new StringBuilder();
+            for (OriginTag tag : tags) {
+                if (sb.length() != 0) {
+                    sb.append('\n');
+                }
+                sb.append(tag.getPath()).append('\n');
+                String tagValue = new String(tag.getValue(), StandardCharsets.UTF_8);
+                for (String line : tagValue.split("\\r?\\n")) {
+                    sb.append("    ").append(line).append('\n');
+                }
+            }
+            return sb.toString();
         }
     }
 


### PR DESCRIPTION
Motivation:

WLCG wishes to know to which path(s) a space reservation has been
mapped.  In particular, the storage descriptor JSON format has an
optional (but desired) field for providing this information.

In dCache, the mapped path corresponds to origin WriteToken tags.

Therefore, as a first step, this patch adds the ability to search for
origin tags in the chimera shell.  By itself, this provides potentially
useful information for admins.

Modification:

Chimera is updated to support searching for origin tags of a given name.

A new chimera shell command is added that exposes this new
functionality.

Result:

Chimera shell is now able to find origin tags of a given name.

Target: master
Request: 4.2 ?
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/11295/
Acked-by: Albert Rossi
Acked-by: Tigran Mkrtchyan