### PR TITLE
srm: gridsite fix querying validity of delegated credential

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/SrmCredentialStore.java
@@ -56,8 +56,7 @@ public class SrmCredentialStore implements CredentialStore
     @Override
     public X509Credential get(DelegationIdentity id) throws DelegationException
     {
-        RequestCredential credential =
-                _store.getRequestCredential(nameFromId(id), null);
+        RequestCredential credential = _store.getRequestCredential(nameFromId(id));
         assertThat(credential != null, "no stored credential", id);
         return credential.getDelegatedCredential();
     }
@@ -103,8 +102,7 @@ public class SrmCredentialStore implements CredentialStore
     @Override
     public Calendar getExpiry(DelegationIdentity id) throws DelegationException
     {
-        RequestCredential credential =
-                _store.getRequestCredential(nameFromId(id), null);
+        RequestCredential credential = _store.getRequestCredential(nameFromId(id));
 
         assertThat(credential != null, "no credential", id);
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/HashtableRequestCredentialStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/HashtableRequestCredentialStorage.java
@@ -157,6 +157,12 @@ public class HashtableRequestCredentialStorage
     }
 
     @Override
+    public RequestCredential getRequestCredential(String name)
+    {
+        return Iterables.find(store.values(), c -> c.getCredentialName().equals(name), null);
+    }
+
+    @Override
     public boolean hasRequestCredential(String name, String role)
     {
         return getRequestCredential(name, role) != null;

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/RequestCredentialStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/RequestCredentialStorage.java
@@ -94,6 +94,14 @@ public interface RequestCredentialStorage {
     RequestCredential getRequestCredential(String name, String role);
 
     /**
+     * Return the credential with the longest remaining lifetime that
+     * matches the given name.  The returned credential may have any primary
+     * FQAN or have no primary FQAN at all.  If there is no match then null is
+     * returned.
+     */
+    RequestCredential getRequestCredential(String name);
+
+    /**
      * Search for the credential with the longest remaining lifetime that matches
      * the name and role Globs.  If role is null then only a credential with
      * no primary FQAN is returned.  If role is specified then only a credential

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseRequestCredentialStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseRequestCredentialStorage.java
@@ -228,6 +228,15 @@ public class DatabaseRequestCredentialStorage implements RequestCredentialStorag
       }
    }
 
+    public static final String SELECT_BY_NAME_ONLY = "SELECT * FROM " + requestCredentialTableName +
+        " WHERE credentialname=? ORDER BY credentialexpiration DESC";
+
+    @Override
+    public RequestCredential getRequestCredential(String credentialName)
+            throws DataAccessException {
+        return getRequestCredentialByCondition(SELECT_BY_NAME_ONLY, credentialName);
+    }
+
     private static final String UPDATE = "UPDATE " +requestCredentialTableName +
        " SET creationtime=?, credentialname=?, role=?, " +
        " numberofusers=?, delegatedcredentials=?, credentialexpiration=? where id=? ";


### PR DESCRIPTION
Motivation:

The gridsite endpoint allows clients to delegate a credential.  It also
allows clients to manage delegated credentials.

There is a bug where a delegated credential with a primary FQAN (from a
VOMS server that dCache trusts) is not found when the client queries its
expiry time, but it is found when the client subsequently attempts to
delegate a credential.

This inconsitent behaviour prevents some gridsite clients, such as
davix, from delegating.

Modification:

Update RequestCredentialStore interface to support querying for a
credential with given name, ignoring any FQAN.  The credential with the
longest remaining validity is returned, irrespective of whether or not
that credential has a primary FQAN or the value of that primary FQAN.

Result:

Clients that use the gridsite protocol, such as davix, can now delegate
their credential.

Target: master
Require-notes: yes
Require-book: no
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11327/
Acked-by: Dmitry Litvintsev