### PR TITLE
dcache-history,dcache-frontend: check for serialized error when handl…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/pool/PoolDataRequestProcessor.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/pool/PoolDataRequestProcessor.java
@@ -61,9 +61,13 @@ package org.dcache.restful.util.pool;
 
 import org.springframework.beans.factory.annotation.Required;
 
+import java.io.Serializable;
+
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.TimeoutCacheException;
+
 import dmg.cells.nucleus.NoRouteToCellException;
+
 import org.dcache.cells.json.CellData;
 import org.dcache.pool.json.PoolData;
 import org.dcache.pool.json.PoolInfoWrapper;
@@ -123,11 +127,19 @@ public final class PoolDataRequestProcessor
         PoolInfoWrapper info = new PoolInfoWrapper();
         info.setKey(key);
 
+        Serializable errorObject = message.getErrorObject();
+
         /*
          *  NB:  the counts histogram is already part of the sweeper
          *  data object (data.getSweeperData().getLastAccessHistogram()).
          */
         info.setInfo(poolData);
+
+        if (errorObject != null) {
+            LOGGER.warn("Problem with retrieval of pool data for {}: {}.",
+                        key, errorObject.toString());
+            return info;
+        }
 
         try {
             handler.addHistoricalData(info);

--- a/modules/dcache-history/src/main/java/org/dcache/services/history/pools/PoolHistoriesRequestProcessor.java
+++ b/modules/dcache-history/src/main/java/org/dcache/services/history/pools/PoolHistoriesRequestProcessor.java
@@ -69,6 +69,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -205,6 +206,18 @@ public final class PoolHistoriesRequestProcessor extends
         }
 
         long timestamp = System.currentTimeMillis();
+
+        Serializable errorObject = data.getErrorObject();
+
+        if (errorObject != null) {
+            LOGGER.warn("Problem with retrieval of live pool data for {}: {}.",
+                        key, errorObject.toString());
+            PoolData poolData = new PoolData();
+            PoolDataDetails details = new PoolDataDetails();
+            poolData.setDetailsData(details);
+            info.setInfo(poolData);
+            return info;
+        }
 
         PoolCostData poolCostData = data.getPoolCostData();
 

--- a/modules/dcache/src/main/java/org/dcache/pool/PoolDataBeanProvider.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/PoolDataBeanProvider.java
@@ -72,5 +72,5 @@ public interface PoolDataBeanProvider<T extends Serializable> {
      * @return the populated bean to be composed into a
      * {@link PoolData} object.
      */
-    T getDataObject();
+    T getDataObject() throws InterruptedException;
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
@@ -289,7 +289,7 @@ public class SpaceSweeper2
     }
 
     @Override
-    public SweeperData getDataObject() {
+    public SweeperData getDataObject() throws InterruptedException {
         SweeperData info = new SweeperData();
         info.setLabel("Space Sweeper v2");
 
@@ -312,9 +312,6 @@ public class SpaceSweeper2
                 fileLifetime.add(lvalue.doubleValue());
             } catch (FileNotInCacheException e) {
                 // Ignored
-            } catch (InterruptedException e) {
-                // should exit
-                return null;
             } catch (CacheException e) {
                 // Continue trying
             }


### PR DESCRIPTION
…ing pool data request messages

Motivation:

In RB #11334 we called attention to the fact that pool request processing
on the pool returns the actual exception ... even if a runtime exception ...
embedded in the message.   When this happens, the configuration of the
data can be incomplete and NPEs are possible if the receiver tries
to access them.

Modification:

Check for these embedded exceptions and exit the processing for that
data when they are found.  This occurs in the collection threads
on the pool history service and the pool info service of the frontend.

We have also modified the null return in the Sweeper data method
by adding throws InterruptedException to the provider interface getData()
signature.

Also added uncaughtExceptionHandling logic to those pool methods.

Result:

Reduced risk of NPEs in the receivers.

Target: master
Request: 4.2
Acked-by: Paul