### PR TITLE
ftp: avoid kafka bug, make shutdown more robust

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1734,33 +1734,36 @@ public abstract class AbstractFtpDoorV1
     @Override
     public void shutdown()
     {
-        /*The producer consists of a pool of buffer space that holds records that haven't yet been
-          transmitted to the server as well as a background I/O thread
-          that is responsible for turning these records into requests and transmitting them to the cluster.
-          Failure to close the producer after use will leak these resources. Hence we need to  and close Kafka Producer
-         */
-        //TODO _sendToKafka checks if the shutdown() method has been called and whether the producer has been closed or not.
-        // currently  there is no method isClosed() in kafka API
-        if (_sendToKafka) {
-            _sendToKafka = false;
-            _kafkaProducer.close();
-        }
+        try {
+            /* In case of failure, we may have a transfer hanging around.
+             */
+            Transfer transfer = getTransfer();
+            if (transfer instanceof FtpTransfer) {
+                ((FtpTransfer)transfer).abort(new ClientAbortException(451, "Aborting transfer due to session termination"));
+            }
 
-        /* In case of failure, we may have a transfer hanging around.
-         */
-        Transfer transfer = getTransfer();
-        if (transfer instanceof FtpTransfer) {
-            ((FtpTransfer)transfer).abort(new ClientAbortException(451, "Aborting transfer due to session termination"));
-        }
+            /*The producer consists of a pool of buffer space that holds records that haven't yet been
+              transmitted to the server as well as a background I/O thread
+              that is responsible for turning these records into requests and transmitting them to the cluster.
+              Failure to close the producer after use will leak these resources. Hence we need to  and close Kafka Producer
+             */
+            //TODO _sendToKafka checks if the shutdown() method has been called and whether the producer has been closed or not.
+            // currently  there is no method isClosed() in kafka API
+            if (_sendToKafka) {
+                _sendToKafka = false;
+                _kafkaProducer.close();
+            }
 
-        _clientConnectionHandler.close();
-        _sessionAllPassive = false; // REVISIT see RFC 2428 Section 4.
+        } finally {
+            _clientConnectionHandler.close();
+            _sessionAllPassive = false; // REVISIT see RFC 2428 Section 4.
 
-        if (ACCESS_LOGGER.isInfoEnabled()) {
-            NetLoggerBuilder log = new NetLoggerBuilder(INFO, "org.dcache.ftp.disconnect").omitNullValues();
-            log.add("host.remote", _remoteSocketAddress);
-            log.add("session", CDC.getSession());
-            log.toLogger(ACCESS_LOGGER);
+            if (ACCESS_LOGGER.isInfoEnabled()) {
+                NetLoggerBuilder log = new NetLoggerBuilder(INFO, "org.dcache.ftp.disconnect").omitNullValues();
+                log.add("host.remote", _remoteSocketAddress);
+                log.add("session", CDC.getSession());
+                log.toLogger(ACCESS_LOGGER);
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

We observe leaking server sockets if a client aborts a proxied transfers
with kafka enabled.

Modification:

Stop the kafka producer after the transfer is aborted.

Use try-finally construct to ensure essential shutdown activity is not
stopped by a bug in less essential activity.

Result:

No further server sockets leaked when a proxy is being used, kafka
notification is enabled, and the client aborts the transfer.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11339/
Acked-by: Tigran Mkrtchyan