### PR TITLE
ftp: make shutdown more robust

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1712,21 +1712,23 @@ public abstract class AbstractFtpDoorV1
     @Override
     public void shutdown()
     {
-        /* In case of failure, we may have a transfer hanging around.
-         */
-        Transfer transfer = getTransfer();
-        if (transfer instanceof FtpTransfer) {
-            ((FtpTransfer)transfer).abort(new ClientAbortException(451, "Aborting transfer due to session termination"));
-        }
+        try {
+            /* In case of failure, we may have a transfer hanging around.
+             */
+            Transfer transfer = getTransfer();
+            if (transfer instanceof FtpTransfer) {
+                ((FtpTransfer)transfer).abort(new ClientAbortException(451, "Aborting transfer due to session termination"));
+            }
+        } finally {
+            _clientConnectionHandler.close();
+            _sessionAllPassive = false; // REVISIT see RFC 2428 Section 4.
 
-        _clientConnectionHandler.close();
-        _sessionAllPassive = false; // REVISIT see RFC 2428 Section 4.
-
-        if (ACCESS_LOGGER.isInfoEnabled()) {
-            NetLoggerBuilder log = new NetLoggerBuilder(INFO, "org.dcache.ftp.disconnect").omitNullValues();
-            log.add("host.remote", _remoteSocketAddress);
-            log.add("session", CDC.getSession());
-            log.toLogger(ACCESS_LOGGER);
+            if (ACCESS_LOGGER.isInfoEnabled()) {
+                NetLoggerBuilder log = new NetLoggerBuilder(INFO, "org.dcache.ftp.disconnect").omitNullValues();
+                log.add("host.remote", _remoteSocketAddress);
+                log.add("session", CDC.getSession());
+                log.toLogger(ACCESS_LOGGER);
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

We have observed leaked server sockets if, when aborting a proxied
transfer after a client disconnects, there is a runtime exception during
the clean process.  These are manifest as sockets left in the LISTENING
state.

Modification:

Use try-finally construct to ensure essential shutdown activity is not
stopped by a bug in less essential activity.

Result:

Better protection against leaking proxy/data TCP sockets if client
aborts a proxied transfer.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11339/
Acked-by: Tigran Mkrtchyan