### PR TITLE
restful: Rename operations to have unique operationId.

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/EventResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/EventResources.java
@@ -474,7 +474,7 @@ public class EventResources
                 @ApiResponse(code = 404, message = "No such channel"),
             })
     @Path("/channels/{id}")
-    public void delete(@NotNull @PathParam("id") String id) throws IOException
+    public void deleteChannel(@NotNull @PathParam("id") String id) throws IOException
     {
         channelForId(id).close();
     }
@@ -595,7 +595,7 @@ public class EventResources
                 @ApiResponse(code = 404, message = "Not Found"),
             })
     @Path("/channels/{channel_id}/subscriptions/{type}/{subscription_id}")
-    public void delete(@NotNull @PathParam("channel_id") String channelId,
+    public void deleteSubscription(@NotNull @PathParam("channel_id") String channelId,
             @NotNull @PathParam("type") String eventType,
             @NotNull @PathParam("subscription_id") String subscriptionId) throws IOException
     {

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/cells/CellInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/cells/CellInfoResources.java
@@ -113,7 +113,7 @@ public final class CellInfoResources {
             })
     @Path("/{address}")
     @Produces(MediaType.APPLICATION_JSON)
-    public CellData getCellData(
+    public CellData getCell(
                     @ApiParam(value="The cell to query", example="cell@domain")
                     @PathParam("address") String address)throws CacheException {
         return service.getCellData(address);
@@ -127,7 +127,7 @@ public final class CellInfoResources {
                 @ApiResponse(code = 403, message = "Cell info service only accessible to admin users."),
             })
     @Produces(MediaType.APPLICATION_JSON)
-    public CellData[] getCellData()throws CacheException {
+    public CellData[] getCells()throws CacheException {
         return Arrays.stream(service.getAddresses())
                      .map(service::getCellData)
                      .collect(Collectors.toList())


### PR DESCRIPTION
Motivation:

Some functions have the same name and thus the same generated OperationId in
the swagger.json file for the same resource:

Resource cells: getCellData
Resource events: delete

The python clients generated from the swagger file are then incorrect.

Modification:

getCellData -> getCells
getCellData -> getCell
delete -> deleteChannel
delete -> deleteSubscription

Result:

No function name/operationIds clashes for the swagger generated clients.

Target: master
Require-notes: yes
Require-book: yes
Request: 4.2
Patch: https://rb.dcache.org/r/11346/
Acked-by: Paul Millar
Committed: b319876458
Pull-request: https://github.com/dCache/dcache/pull/xxxx