### PR TITLE
dcap: fix  NullPointerException:

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -2543,7 +2543,7 @@ public class DCapDoorInterpreterV3
         _kafkaProducer.send(record, (rm, e) -> {
             if (e != null) {
                 _log.error("Unable to send message to topic {} on  partition {}: {}",
-                        rm.topic(), rm.partition(), e.getMessage());
+                        record.topic(), record.partition(), e.getMessage());
             }
         });
     }


### PR DESCRIPTION
Motivation

There was a bug in `DCapDoorInterpreterV3` which was causing NullPointerException.

The issue was that in sendAsynctoKafka methode RecordMetadata rm was null therefore `rm.topic(), rm.partition()` was resulting in NullPointerException.

Modification

rm  is changed to record

rm.topic(), rm.partition() -> record.topic(), record.partition()

Target: master
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11348/
Acked-by: Paul  Millar