### PR TITLE
dcache: release dcache-view version 1.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.6.0</version.wicket>
         <version.xrootd4j>3.2.5</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.4.5</version.dcache-view>
+        <version.dcache-view>1.4.6</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from 1.4.5 to v1.4.6

[28ac07b](dCache/dcache-view@28ac07b) dcache-view: alter the way multiple errors are handled
[f75365c](dCache/dcache-view@f75365c) dcache-view: fix reference to migration job in pool info dialog
[234c93a](dCache/dcache-view@234c93a) dcache-view (namespace): fix notification in dnd move op
[980f2bb](dCache/dcache-view@980f2bb) dcache-view (namespace): add width to rename element
[b8c307e](dCache/dcache-view@b8c307e) dcache-view: use on-tap instead of onclick in restores view
[781411f](dCache/dcache-view@781411f) dcache-view (namespace): fix style issue in list-row & list-row-header

Request: 4.1
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11353/