### PR TITLE
nfs: handle chimera exception on remove of a missing file

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/AccessLogAwareOperationFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/AccessLogAwareOperationFactory.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2017 - 2018 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -28,11 +28,13 @@ import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.dcache.chimera.FileNotFoundHimeraFsException;
 import org.dcache.chimera.FileSystemProvider;
 import org.dcache.chimera.FsInode;
 import org.dcache.chimera.JdbcFs;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.nfsstat;
+import org.dcache.nfs.status.NoEntException;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
 import org.dcache.nfs.v4.CompoundContext;
 import org.dcache.nfs.v4.MDSOperationFactory;
@@ -326,6 +328,9 @@ public class AccessLogAwareOperationFactory extends MDSOperationFactory {
             } catch (ChimeraNFSException e) {
                 status = e.getStatus();
                 throw e;
+            } catch (FileNotFoundHimeraFsException e) {
+                status = nfsstat.NFSERR_NOENT;
+                throw new NoEntException("not found: " + name, e);
             } finally {
                 nl.add("nfs.status", nfsstat.toString(status));
                 nl.log();


### PR DESCRIPTION
Motivation:
when removing a missing file, AccessLogAwareOperationFactory will
produce a stack trace:

org.dcache.chimera.FileNotFoundHimeraFsException: path [RM2a] does not exist
	at org.dcache.chimera.JdbcFs.inodeOf(JdbcFs.java:930) ~[chimera-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.chimera.nfsv41.door.AccessLogAwareOperationFactory$OpRemove.process(AccessLogAwareOperationFactory.java:323) ~[dcache-nfs-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.chimera.nfsv41.door.proxy.ProxyIoMdsOpFactory$1.lambda$process$0(ProxyIoMdsOpFactory.java:53) ~[dcache-nfs-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at java.security.AccessController.doPrivileged(Native Method) ~[na:1.8.0_111]
	at javax.security.auth.Subject.doAs(Subject.java:360) ~[na:1.8.0_111]
	at org.dcache.chimera.nfsv41.door.proxy.ProxyIoMdsOpFactory$1.process(ProxyIoMdsOpFactory.java:47) ~[dcache-nfs-4.1.0-SNAPSHOT.jar:4.1.0-SNAPSHOT]
	at org.dcache.nfs.v4.NFSServerV41.NFSPROC4_COMPOUND_4(NFSServerV41.java:204) ~[nfs4j-core-0.16.0.jar:0.16.0]
	at org.dcache.nfs.v4.xdr.nfs4_prot_NFS4_PROGRAM_ServerStub.dispatchOncRpcCall(nfs4_prot_NFS4_PROGRAM_ServerStub.java:48) [nfs4j-core-0.16.0.jar:0.16.0]
	at org.dcache.xdr.RpcDispatcher$1.run(RpcDispatcher.java:110) [oncrpc4j-core-2.7.0.jar:na]
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:591) [grizzly-framework-2.3.24.jar:2.3.24]
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:571) [grizzly-framework-2.3.24.jar:2.3.24]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_111]

Modification:
convert FileNotFoundHimeraFsException into NoEntException

Result:
no stack trace.

Acked-by: Paul Millar
Target: master, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit d1baecfe291a4e68b4b2b8dd74edaaca90acd331)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>