### PR TITLE
libs: update nfs4j to version 0.17.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -742,7 +742,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.17.6</version>
+            <version>0.17.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
Motivation:

minor bugfix version to handle NPE on set attribute

Changelog for nfs4j-0.17.6..nfs4j-0.17.7
    * [a266ccde] [maven-release-plugin] prepare for next development iteration
    * [500e3e0d] nfs4: ensure that SETATTR4res always has attribute bitmap
    * [00276b1b] nfs4: do not initialize attrsset in OperationSETATTR
    * [9ee6578d] [maven-release-plugin] prepare release nfs4j-0.17.7

Acked-by: Paul Millar
Target: master, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit bdd96052fb98a3bb3b2350f21493f3854bb383b6)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>