### PR TITLE
dcache: release dcache-view version 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.11.v20180605</version.jetty>
         <version.xrootd4j>3.3.3</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.5.0</version.dcache-view>
+        <version.dcache-view>1.5.1</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.5.0 to v1.5.1

[381d1d2](dCache/dcache-view@381d1d2) dcache-view (namespace): upgrade file-icon element to v0.0.5
[c9e436b](dCache/dcache-view@c9e436b) dcache-view (gulp-tasks): ensure copy-pdfjs task successful execution
[19e86e3](dCache/dcache-view@19e86e3) dcache-view (context-menu): add get webdav url to context menu
[1246c38](dCache/dcache-view@1246c38) dcache-view (app-shell): create findViewFile function and adjust context-menu

Target: master
Request: 4.2
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11371/

(cherry picked from commit dd2bf55dd2b4cf54f0664aa2024e30c427b430fa)