### PR TITLE
restful: Return not Found/404 for non existing pool.

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
@@ -77,22 +77,24 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.DefaultValue;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.NoSuchElementException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -178,12 +180,21 @@ public final class PoolInfoResources {
 
     @GET
     @ApiOperation("Get information about a specific pool (name, group membership, links).")
+    @ApiResponses({
+                @ApiResponse(code = 404, message = "Not Found"),
+                @ApiResponse(code = 500, message = "Internal Server Error"),
+            })
     @Path("/{pool}")
     @Produces(MediaType.APPLICATION_JSON)
     public Pool getPool(@ApiParam(value = "The pool to be described.",
                                 required = true)
                         @PathParam("pool") String pool) {
-        return new Pool(pool, poolMonitor.getPoolSelectionUnit());
+        try {
+            return new Pool(pool, poolMonitor.getPoolSelectionUnit());
+        }
+        catch (NoSuchElementException e) {
+             throw new NotFoundException(e);
+        }
     }
 
 


### PR DESCRIPTION
Motivation:

```
$ dcache-admin pools  getPool --pool doesnotexists
2018-11-15 12:28:02,027 - dcacheclient.client - ERROR - response.status_code: 500
2018-11-15 12:28:02,028 - dcacheclient.client - ERROR - response.text: {"errors":[{"message":"Internal error: java.util.NoSuchElementException: aerty","status":"500"}]}
```

Modification:

```
$ dcache-admin pools  getPool --pool doesnotexists
2018-11-15 14:35:44,927 - dcacheclient.client - ERROR - response.status_code: 404
2018-11-15 14:35:44,928 - dcacheclient.client - ERROR - response.text: {"errors":[{"message":"Not Found","status":"404"}]}

```

Target: master
Require-notes: no
Require-book: no
Request: 4.2
Patch: https://rb.dcache.org/r/11370/
Acked-by: Albert Rossi
Committed: eb662a97df
Pull-request: https://github.com/dCache/dcache/pull/xxx