### PR TITLE
nfs4: only block pool selection on the first attempt

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1012,7 +1012,8 @@ public class NFSv41Door extends AbstractCellComponent implements
                 throw  error;
             }
 
-            if (_redirectFuture == null) {
+            boolean isFirstAttempt = _redirectFuture == null;
+            if (isFirstAttempt) {
 
                 readNameSpaceEntry(_ioMode == layoutiomode4.LAYOUTIOMODE4_RW);
 
@@ -1066,12 +1067,12 @@ public class NFSv41Door extends AbstractCellComponent implements
             }
 
             /*
-             * If we wait for offline file, then there is no need to block.
-             * The async reply will update _redirectFuture when it's timed out or
-             * ready.
+             * If already have triggered selection process, then there are no
+             * reasons to block. The async reply will update _redirectFuture when
+             * it's timed out or ready.
              */
-            if (!isWrite() && !getOnlineFilesOnly() && !_redirectFuture.isDone()) {
-                throw new LayoutTryLaterException("Wating for file to become online.");
+            if (!isFirstAttempt && !_redirectFuture.isDone()) {
+                throw new LayoutTryLaterException("Waiting for pool to become ready.");
             }
 
             try {


### PR DESCRIPTION
Motivation:
When door performs an async pool selection, then there are no reasons to
block on ListenableFuture#get as we can check the readiness status by
calling ListenableFuture#isDone. However, we should block when request
is performed the very first time to handle busy system and slow
networks.

Modification:
fail fast with LayoutTryLaterException selection process is not done. Do
not distinct between read and write requests, as write can wait for a
pool to become online.

Result:
client is not blocked if door knows that the request is not processed yet.

Acked-by: Paul Millar
Target: master, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 851cc59dc9c8f81328a142378b3fb7e690f25a6d)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>