### PR TITLE
dcache-frontend,dcache-history: revisit NPE fix

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/pool/PoolDataRequestProcessor.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/pool/PoolDataRequestProcessor.java
@@ -112,6 +112,13 @@ public final class PoolDataRequestProcessor
     protected PoolInfoWrapper process(String key,
                                       PoolDataRequestMessage message,
                                       long sent) {
+        Serializable errorObject = message.getErrorObject();
+        if (errorObject != null) {
+            LOGGER.warn("Problem with retrieval of pool data for {}: {}.",
+                        key, errorObject.toString());
+            return null;
+        }
+
         PoolData poolData = message.getData();
 
         CellData cellData = poolData == null ? null : poolData.getCellData();

--- a/modules/dcache-history/src/main/java/org/dcache/services/history/pools/PoolHistoriesRequestProcessor.java
+++ b/modules/dcache-history/src/main/java/org/dcache/services/history/pools/PoolHistoriesRequestProcessor.java
@@ -197,6 +197,14 @@ public final class PoolHistoriesRequestProcessor extends
     protected PoolInfoWrapper process(String key,
                                       PoolLiveDataForHistoriesMessage data,
                                       long sent) {
+        Serializable errorObject = data.getErrorObject();
+
+        if (errorObject != null) {
+            LOGGER.warn("Problem with retrieval of live pool data for {}: {}.",
+                        key, errorObject.toString());
+            return null;
+        }
+
         PoolInfoWrapper info = service.getWrapper(key);
 
         if (info == null) {

--- a/modules/dcache/src/main/java/org/dcache/util/collector/RequestFutureProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/util/collector/RequestFutureProcessor.java
@@ -191,7 +191,9 @@ public abstract class RequestFutureProcessor<T extends Serializable, D> {
 
             if (received != null) {
                 T toStore = process(key, received, wrapper.getSent());
-                next.put(key, toStore);
+                if (toStore != null) {
+                    next.put(key, toStore);
+                }
             }
 
             remove(key);


### PR DESCRIPTION
Motivation:

In commit 80c726088374599af23e70e3d2bdb48856ad7c23
an attempt was made to avoid accessing parts of a JSON object
which are absent because of an exception thrown on the pool
(the discovered case for this was an array indexing exception
when the counting histogram was initialized).

That fix, however, was imperfect, and the occurrence of
the exception was still resulting in a subsequent NPE.

Modification:

This patch entirely eliminates the JSON pool entry from
the map/cache in an all-or-nothing manner.  That is,
if any exception has been returned in the message,
we consider the entire object invalid.

Result:

Safer code.

Target: master
Request: 4.2
Acked-by: Tigran