### PR TITLE
common: fix histogram metadata merge

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/histograms/HistogramMetadata.java
+++ b/modules/common/src/main/java/org/dcache/util/histograms/HistogramMetadata.java
@@ -188,7 +188,7 @@ public final class HistogramMetadata implements Serializable {
 
         if (metadata.minValue != null) {
             minValue = minValue == null ? metadata.minValue :
-                            FastMath.max(minValue, metadata.minValue);
+                            FastMath.min(minValue, metadata.minValue);
         }
 
         return this;


### PR DESCRIPTION
Fixes simple bug in histogram.

Metadata merge uses max when it should use min.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Acked-by: Dmitry