### PR TITLE
pom: use jacoco with java11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1106,7 +1106,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.7.201606060606</version>
+                    <version>0.8.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Motivation:
deploy and test with java11 runtime environment.

Modification:
use jacoco 0.8.3.201811190732 with java11 support

Result:
code coverage is possible with java11 runtime

Acked-by: Paul Millar
Target: master, 4.2
Require-book: no
Require-notes: no
(cherry picked from commit 1623ebebdcda9b5db2802000a0521294e969f167)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>