### PR TITLE
dcache-xrootd: handle possible race condition in directory listing

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -882,7 +882,9 @@ public class XrootdDoor
         }
 
         public synchronized void cancelTimeout() {
-            _executionInstance.cancel(false);
+            if (_executionInstance != null) {
+                _executionInstance.cancel(false);
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

It seems that cancelTimeout in the directory listing procedure
can be called before the executable object has been assigned,
depending on how quickly the message returns and success is called.

Modification:

Just add a null check, as there is in resetTimeout method.

Result:

The failure reported below should not occur.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Bug:  RT 9566
Acked-by: Paul