### PR TITLE
dcap: fix permission propagation with DCAP

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -1512,7 +1512,11 @@ public class DCapDoorInterpreterV3
         public boolean fileAttributesNotAvailable() throws CacheException
         {
             String path = _message.getPnfsPath();
-            FileAttributes attributes = FileAttributes.ofFileType(DIR);
+            FileAttributes attributes = FileAttributes.of()
+                    .mode(getMode(0700))
+                    .fileType(DIR)
+                    .build();
+
             int uid = getUid();
             if (uid != UNDEFINED) {
                 attributes.setOwner(uid);
@@ -1524,7 +1528,7 @@ public class DCapDoorInterpreterV3
 
             if (_vargs.hasOption("acl")) {
                 String acl = _vargs.getOption("acl");
-                attributes.setAcl(ACLParser.parseLinuxAcl(RsType.FILE, acl));
+                attributes.setAcl(ACLParser.parseLinuxAcl(RsType.DIR, acl));
             }
 
             _pnfs.createPnfsDirectory(path, attributes);
@@ -1833,7 +1837,13 @@ public class DCapDoorInterpreterV3
             _log.debug("Creating file. parent = new File(path).getParent()  -> parent = {}", parent);
             _log.info("Creating file {}", path);
 
-            FileAttributes attributes = FileAttributes.of().uid(getUid()).gid(getGid()).fileType(REGULAR).build();
+            FileAttributes attributes = FileAttributes.of()
+                    .uid(getUid())
+                    .gid(getGid())
+                    .fileType(REGULAR)
+                    .mode(getMode(0600))
+                    .build();
+
             if (_vargs.hasOption("acl")) {
                 String acl = _vargs.getOption("acl");
                 attributes.setAcl(ACLParser.parseLinuxAcl(RsType.FILE, acl));


### PR DESCRIPTION
Motivation:
when using dcap URL to create a file or a directory, then door should
respect client provided file mode.

Modification:
update dcap door to use client provided file mode. If not provided, then
0700 and 0600 is used for directories and files.

Result:
files and directories created with dcap get desired file permissions.

Acked-by: Jürgen Starek
Acked-by: Paul Millar
Target: master, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: yes
(cherry picked from commit 553056da1e0f2662c982a6d199b48d24dfd94a35)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>