### PR TITLE
alarms: fix persistence.xml configuration

### DIFF
--- a/modules/dcache/src/main/resources/META-INF/persistence.xml
+++ b/modules/dcache/src/main/resources/META-INF/persistence.xml
@@ -7,6 +7,10 @@
 
     <persistence-unit name="AlarmsXML">
       <mapping-file>org/dcache/alarms/dao/package.jdo</mapping-file>
+        <properties>
+            <property name="datanucleus.detachAllOnCommit" value="false"/>
+            <property name="javax.jdo.option.RetainValues" value="true"/>
+        </properties>
     </persistence-unit>
 
     <persistence-unit name="AlarmsRDBMS">


### PR DESCRIPTION
Motivation:

Evidently the default value of the retainValues
property changed somewhere between original implementation of
alarms and the latest update to version 4.0+.

This value needs to be true so that we can reference
the values of the object after the transaction.

Currently, we are not setting the property for the
XML plugin.

Modification:

Explicitly set it to true as we do for RDBMS.

Result:

NPE no longer appears, and the referenced object
is guaranteed to have its original field values
(created by conversion from the logging event).

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Bug: #4461
Acked-by: Paul