### PR TITLE
dcache-xrootd: add missing query support for tpc on pools

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -707,6 +707,8 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                      */
                     s.append(XrootdProtocol.PROTOCOL_VERSION);
                     break;
+                case "tpcdlg":
+                    //TODO NOT YET SUPPORTED
                 default:
                     s.append(_queryConfig.getOrDefault(name, name));
                     break;

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -674,6 +674,15 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                 case "version":
                     s.append("dCache ").append(Version.of(XrootdPoolRequestHandler.class).getVersion());
                     break;
+                 case "tpc":
+                     /**
+                      * Indicate support for third-party copy by responding
+                      * with the protocol version.
+                      */
+                     s.append(XrootdProtocol.PROTOCOL_VERSION);
+                     break;
+                case "tpcdlg":
+                    //TODO NOT YET SUPPORTED
                 default:
                     s.append(_queryConfig.getOrDefault(name, name));
                     break;


### PR DESCRIPTION
Motivation:

The 'tpc' query is issued to the destination server to
confirm that tpc is supported.  Prior to version 4.9,
this query was only issued to the door, not to the
endpoint to which the transfer is redirected.  With
the new client, it is repeated on the pool and thus
needs to be supported there as well.

Modification:

Add the propert kXR_query kXR_config response.

Result:

We now work with the 4.9.x client (falling back
to no delegation).

Needs to be backported for future interoperability.

Target: master
Request: 4.2
Acked-by: Paul