### PR TITLE
ftp/webdav: fix bypass of restrictions

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -2928,7 +2928,7 @@ public abstract class AbstractFtpDoorV1
             }
             ChecksumType type = ChecksumType.getChecksumType(algo);
             FileAttributes attributes =
-                _pnfs.getFileAttributes(absPath, EnumSet.of(PNFSID, CHECKSUM));
+                _pnfs.getFileAttributes(absPath, EnumSet.of(CHECKSUM));
             Checksum checksum = attributes.getChecksums().stream()
                     .filter(c -> c.getType() == type)
                     .findFirst()
@@ -2960,7 +2960,7 @@ public abstract class AbstractFtpDoorV1
                     }
                     setTransfer(null);
                 }
-                _pnfs.setFileAttributes(attributes.getPnfsId(), FileAttributes.ofChecksum(checksum));
+                _pnfs.setFileAttributes(absPath, FileAttributes.ofChecksum(checksum));
             }
 
             reply("213 " + checksum.getValue());
@@ -3016,14 +3016,14 @@ public abstract class AbstractFtpDoorV1
             // Assume octal regardless of string
             int newperms = Integer.parseInt(permstring, 8);
 
+            FsPath absPath = absolutePath(path);
             attributes =
-                _pnfs.getFileAttributes(absolutePath(path), EnumSet.of(PNFSID, TYPE));
+                _pnfs.getFileAttributes(absPath, EnumSet.of(TYPE));
 
             checkFTPCommand(attributes.getFileType() != FileType.LINK,
                     502, "chmod of symbolic links is not yet supported.");
 
-            _pnfs.setFileAttributes(attributes.getPnfsId(),
-                    FileAttributes.ofMode(newperms));
+            _pnfs.setFileAttributes(absPath, FileAttributes.ofMode(newperms));
 
             reply("250 OK");
         } catch (NumberFormatException ex) {
@@ -3068,12 +3068,13 @@ public abstract class AbstractFtpDoorV1
 
         FileAttributes attributes;
         try {
-            attributes = _pnfs.getFileAttributes(absolutePath(path), EnumSet.of(PNFSID, TYPE));
+            FsPath absPath = absolutePath(path);
+            attributes = _pnfs.getFileAttributes(absPath, EnumSet.of(TYPE));
 
             checkFTPCommand(attributes.getFileType() != FileType.LINK,
                     504, "chgrp of symbolic links is not yet supported.");
 
-            _pnfs.setFileAttributes(attributes.getPnfsId(), FileAttributes.ofGid(gid));
+            _pnfs.setFileAttributes(absPath, FileAttributes.ofGid(gid));
 
             reply("250 OK");
         } catch (PermissionDeniedCacheException e) {

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -930,7 +930,8 @@ public class Transfer implements Comparable<Transfer>
 
         try {
             setStatus("PnfsManager: Setting checksum");
-            _pnfs.setChecksum(getPnfsId(), checksum);
+            FileAttributes attr = FileAttributes.ofChecksum(checksum);
+            _pnfs.setFileAttributes(_path, attr);
             synchronized (this) {
                 _fileAttributes.getChecksums().add(checksum);
             }


### PR DESCRIPTION
Motivation:

Restrictions are the mechanism for enforcing macaroon (and other) path
related limitations. This requires doors to send the path of a file.
Not all doors do this, resulting in the following warning:

    (PnfsManager) [door:... GFTP-... PnfsSetFileAttributes 00...F60] Restriction check by-passed due to missing path; please report this to <support@dCache.org>

The problem is present if the client specifies a checksum value with
either an FTP or WebDAV upload.

Modification:

Update WebDAV and FTP doors to always use the file's path.

Result:

No more warnings about restrictions being by-passed if the client
specifies a checksum value when uploading via FTP or WebDAV.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Ticket: https://rt.dcache.org/Ticket/Display.html?id=9565
Patch: https://rb.dcache.org/r/11416/
Acked-by: Albert Rossi