### PR TITLE
ldap: search user by uidNumber attribute if only UidPrincipal is prov…

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/StrategyIdMapper.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/StrategyIdMapper.java
@@ -37,6 +37,7 @@ import org.dcache.auth.UserNamePrincipal;
 import org.dcache.nfs.v4.NfsIdMapping;
 import org.dcache.oncrpc4j.rpc.RpcLoginService;
 import org.dcache.oncrpc4j.rpc.RpcTransport;
+import org.dcache.utils.SubjectHolder;
 
 public class StrategyIdMapper implements NfsIdMapping, RpcLoginService {
 
@@ -186,6 +187,16 @@ public class StrategyIdMapper implements NfsIdMapping, RpcLoginService {
             LOGGER.debug("Failed to login for : {} : {}", gssc, e.toString());
         }
         return Subjects.NOBODY;
+    }
+
+    public Subject login(Subject in) {
+
+        try {
+            return _remoteLoginStrategy.login(in).getSubject();
+        } catch (CacheException e) {
+            LOGGER.debug("Failed to login for : {} : {}", new SubjectHolder(in),  e.toString());
+        }
+        return in;
     }
 
     /**

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoMdsOpFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoMdsOpFactory.java
@@ -1,10 +1,19 @@
 package org.dcache.chimera.nfsv41.door.proxy;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
 import java.io.IOException;
+import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import javax.security.auth.Subject;
 import org.dcache.auth.Origin;
+import org.dcache.auth.Subjects;
+import org.dcache.auth.UidPrincipal;
+import org.dcache.chimera.nfsv41.door.StrategyIdMapper;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.v4.AbstractNFSv4Operation;
 import org.dcache.nfs.v4.CompoundContext;
@@ -13,6 +22,7 @@ import org.dcache.nfs.v4.xdr.nfs_argop4;
 import org.dcache.nfs.v4.xdr.nfs_opnum4;
 import org.dcache.nfs.v4.xdr.nfs_resop4;
 import org.dcache.oncrpc4j.rpc.OncRpcException;
+import org.dcache.oncrpc4j.rpc.RpcAuthType;
 
 /**
  * NFS operation factory which uses Proxy IO adapter for read requests
@@ -22,9 +32,31 @@ public class ProxyIoMdsOpFactory implements NFSv4OperationFactory {
     private final ProxyIoFactory _proxyIoFactory;
     private final NFSv4OperationFactory _inner;
 
-    public ProxyIoMdsOpFactory(ProxyIoFactory proxyIoFactory, NFSv4OperationFactory inner) {
+    private final Optional<LoadingCache<Principal, Subject>> _subjectCache;
+
+    public ProxyIoMdsOpFactory(ProxyIoFactory proxyIoFactory,
+            NFSv4OperationFactory inner,
+            Optional<StrategyIdMapper> subjectMapper) {
         _proxyIoFactory = proxyIoFactory;
         _inner = inner;
+
+        if (subjectMapper.isPresent()) {
+            CacheLoader<Principal, Subject> loader = new CacheLoader<Principal, Subject>() {
+                @Override
+                public Subject load(Principal key) throws Exception {
+                    Subject in = new Subject();
+                    in.getPrincipals().add(key);
+                    return subjectMapper.get().login(in);
+                }
+            };
+
+            _subjectCache = Optional.of(CacheBuilder.newBuilder()
+                    .maximumSize(2048)
+                    .expireAfterWrite(10, TimeUnit.MINUTES)
+                    .build(loader));
+        } else {
+            _subjectCache = Optional.empty();
+        }
     }
 
     @Override
@@ -47,7 +79,19 @@ public class ProxyIoMdsOpFactory implements NFSv4OperationFactory {
                 Optional<IOException> optionalException = Subject.doAs(context.getSubject(), (PrivilegedAction<Optional<IOException>>) () -> {
                     try {
                         Subject subject = context.getSubject();
+
                         if (!subject.isReadOnly()) {
+
+                            if (_subjectCache.isPresent() && context.getRpcCall().getCredential().type() == RpcAuthType.UNIX) {
+                                long[] gids = Subjects.getGids(subject);
+                                if (gids.length >= 16) {
+                                    long uid = Subjects.getUid(subject);
+                                    UidPrincipal uidPrincipal = new UidPrincipal(uid);
+                                    subject = _subjectCache.get().getUnchecked(uidPrincipal);
+                                    context.getSubject().getPrincipals().addAll(subject.getPrincipals());
+                                }
+                            }
+
                             context.getSubject().getPrincipals().add(new Origin(context.getRemoteSocketAddress().getAddress()));
                         }
                         operation.process(context, result);

--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -196,6 +196,7 @@
         <property name="loginBrokerPublisher" ref="lb"/>
         <property name="vfsCacheConfig" ref="cache-config"/>
         <property name="accessLogMode" value="${nfs.enable.access-log}" />
+        <property name="manageGroups" value="${nfs.idmap.manage-gids}" />
     </bean>
 
     <bean id="pool-manager-handler" class="org.dcache.poolmanager.PoolManagerHandlerSubscriber">

--- a/modules/gplazma2-ldap/src/test/java/org/dcache/gplazma/plugins/LdapTest.java
+++ b/modules/gplazma2-ldap/src/test/java/org/dcache/gplazma/plugins/LdapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Deutsches Elektronen-Synchroton,
+ * Copyright (c) 2017 - 2018 Deutsches Elektronen-Synchroton,
  * Member of the Helmholtz Association, (DESY), HAMBURG, GERMANY
  *
  * This library is free software; you can redistribute it and/or modify
@@ -44,10 +44,8 @@ import org.dcache.auth.attributes.RootDirectory;
 import org.dcache.gplazma.AuthenticationException;
 import org.dcache.gplazma.NoSuchPrincipalException;
 import org.dcache.ldap4testing.EmbeddedServer;
-import org.dcache.util.PrincipalSetMaker;
 
 import static org.dcache.gplazma.plugins.Ldap.*;
-import static org.dcache.util.PrincipalSetMaker.aSetOfPrincipals;
 import static org.junit.Assert.*;
 import static org.hamcrest.Matchers.*;
 
@@ -93,6 +91,7 @@ public class LdapTest {
         properties.put(LDAP_USER_HOME, "/home/%uid%");
         properties.put(LDAP_USER_ROOT, "/");
         properties.put(LDAP_GROUP_MEMBER, "uniqueMember");
+        properties.put(LDAP_TRY_UID_MAPPING, "true");
 
         properties.put(LDAP_AUTH, "simple");
         properties.put(LDAP_BINDDN, "uid=kermit,ou=people,o=dcache,c=org");
@@ -104,6 +103,19 @@ public class LdapTest {
     @Test
     public void shouldReturnMatchingUidGid() throws AuthenticationException {
         Set<Principal> principals = Sets.newHashSet(KERMIT_PRINCIPAL);
+
+        plugin.map(principals);
+
+        assertThat("unexpected number of returned principals", principals, hasSize(4));
+        assertThat("expected USERNAME not found", principals, hasItem(KERMIT_PRINCIPAL));
+        assertThat("expected UID not found", principals, hasItem(KERMIT_UID_PRINCIPAL));
+        assertThat("expected GID not found", principals, hasItem(KERMIT_PRIMARY_GID_PRINCIPAL));
+        assertThat("expected GID not found", principals, hasItem(ACTOR_GID_PRINCIPAL));
+    }
+
+    @Test
+    public void shouldReturnMatchingUidGidByUid() throws AuthenticationException {
+        Set<Principal> principals = Sets.newHashSet(KERMIT_UID_PRINCIPAL);
 
         plugin.map(principals);
 

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -323,6 +323,10 @@ gplazma.ldap.userfilter = (uid=%s)
 gplazma.ldap.home-dir = %homeDirectory%
 gplazma.ldap.root-dir = /
 
+# Allow the ldap plugin to use the user's (numerical) uid to identify the user
+# if no username is known. If enabled, the plugin uses the `uidNumber` attribute
+# in LDAP to establish the username for such login attempts.
+(one-of?true|false)gplazma.ldap.try-uid-mapping = false
 
 # ---- BanFile plugin
 #

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -59,6 +59,11 @@ nfs.idmap.cache.timeout.unit = SECONDS
 # and for setups without mapping service like NIS or LDAP.
 (one-of?true|false)nfs.idmap.legacy = true
 
+# If client uses AUTH_SYS and number of sub-groups is more than fifteen (15)
+# then nfs door will query gplazma to discover additional user groups.
+#
+(one-of?true|false)nfs.idmap.manage-gids = false
+
 #  ---- Mover queue
 #
 #   The mover queue on the pool to which this request will be


### PR DESCRIPTION
…ided

Motivation:
In a situation where users numeric id is already known, but other attributes
still required, plugin can query LDAP server by uidNumber attribute, if
configured.

Modification:
added property (default: false)

gplazma.ldap.try-uid-mapping=true|false

to allow search by uidNumber field. Updated plugin to ensure that user
name is added when missing.

Result:
ldap plugin can be used for user mapping even if only users numeric id
is known.

Acked-by: Paul Millar
Target: master, 4.2
Require-book: yes
Require-notes: yes
(cherry picked from commit 196c5af6ce71132df8f8fec5d4d912193f905c81)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>