### PR TITLE
resilience: fix NPE if file unlinked when resilience processes a brok…

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
@@ -13,6 +13,7 @@ import java.util.StringTokenizer;
 
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.vehicles.EnstoreStorageInfo;
 import diskCacheV111.vehicles.StorageInfo;
@@ -86,6 +87,9 @@ public class ChimeraEnstoreStorageInfoExtractor extends ChimeraHsmStorageInfoExt
         ExtendedInode dirInode;
         if (!inode.isDirectory()) {
             dirInode = inode.getParent();
+            if (dirInode == null) {
+                throw new FileNotFoundCacheException("file unlinked");
+            }
         }
         else {
             dirInode = inode;

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraOsmStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraOsmStorageInfoExtractor.java
@@ -9,6 +9,7 @@ import java.util.StringTokenizer;
 
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.vehicles.OSMStorageInfo;
 import diskCacheV111.vehicles.StorageInfo;
@@ -73,6 +74,9 @@ public class ChimeraOsmStorageInfoExtractor extends ChimeraHsmStorageInfoExtract
         ExtendedInode dirInode;
         if (!inode.isDirectory()) {
             dirInode = inode.getParent();
+            if (dirInode == null) {
+                throw new FileNotFoundCacheException("file unlinked");
+            }
         }
         else {
             dirInode = inode;


### PR DESCRIPTION
…en file

Motivation:

Observed following stack-trace:

    27 Nov 2018 11:43:29 (Resilience) [pool_write CorruptFile] Uncaught exception in thread pool-271-thread-1
    java.lang.NullPointerException: null
            at org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor.getDirStorageInfo(ChimeraOsmStorageInfoExtractor.java:82) ~[dcache-chimera-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor.getFileStorageInfo(ChimeraOsmStorageInfoExtractor.java:44) ~[dcache-chimera-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.chimera.namespace.ChimeraHsmStorageInfoExtractor.getStorageInfo(ChimeraHsmStorageInfoExtractor.java:162) ~[dcache-chimera-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.getFileAttributes(ChimeraNameSpaceProvider.java:965) ~[dcache-chimera-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.getFileAttributes(ChimeraNameSpaceProvider.java:992) ~[dcache-chimera-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.resilience.db.LocalNamespaceAccess.getRequiredAttributes(LocalNamespaceAccess.java:164) ~[dcache-resilience-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.resilience.data.FileUpdate.getAttributes(FileUpdate.java:113) ~[dcache-resilience-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.resilience.handlers.FileOperationHandler.handleBrokenFileLocation(FileOperationHandler.java:188) ~[dcache-resilience-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.resilience.util.BrokenFileTask.call(BrokenFileTask.java:84) ~[dcache-resilience-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.resilience.util.ErrorAwareTask.lambda$createFireAndForgetTask$1(ErrorAwareTask.java:93) ~[dcache-resilience-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:31) ~[dcache-common-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149) [dcache-core-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_181]
            at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_181]
            at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_181]
            at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [na:1.8.0_181]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_181]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_181]
            at java.lang.Thread.run(Thread.java:748) [na:1.8.0_181]

Modification:

Handle the case when requesting file attributes of a file that has
already been unlinked from the namespace: both in
ChimeraOsmStorageInfoExtractor and in ChimeraEnstoreStorageInfoExtractor

Result:

A very rare race-condition is fixed where a failed upload results in
resilience recording a stack-trace.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11397/
Acked-by: Tigran Mkrtchyan
Acked-by: Albert Rossi
Acked-by: Dmitry Litvintsev