### PR TITLE
pool: fix pool space accounting on failed restores

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1159,10 +1159,21 @@ public class NearlineStorageHandler
             }
         }
 
+        /**
+         * Deallocate space. Used only when handling stage failure.
+         */
+        private synchronized void deallocateSpace()
+        {
+            if (allocationFuture != null && !allocationFuture.cancel(false)) {
+                allocator.free(getFileAttributes().getSize());
+            }
+        }
+
         private void done(Throwable cause)
         {
             PnfsId pnfsId = getFileAttributes().getPnfsId();
             if (cause != null) {
+                deallocateSpace();
                 if (cause instanceof InterruptedException || cause instanceof CancellationException) {
                     cause = new TimeoutCacheException("Stage was cancelled.", cause);
                 }


### PR DESCRIPTION
Motivation:

Pool repository leaks used space (non-removable) when restores fail.

Modification:

Deallocate repository space on restore failures.

Result:

No used space leak.

Issue: https://github.com/dCache/dcache/issues/4482
Ticket : https://rt.dcache.org/Ticket/Display.html?id=9576

RB: https://rb.dcache.org/r/11423/
Acked-by: Paul Millar

Target: trunk
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2

Require-book: no
Require-notes: yes