### PR TITLE
webdav: fix proxied partial (vector-read) GET requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <target.version>1.8</target.version>
 
         <version.slf4j>1.7.25</version.slf4j>
-        <version.milton>2.7.2.0</version.milton>
+        <version.milton>2.7.3.0-dcache-1</version.milton>
         <version.spring>4.3.8.RELEASE</version.spring>
         <!-- Remember to sync aspectj version in dcache.properties -->
         <version.aspectj>1.8.10</version.aspectj>


### PR DESCRIPTION
Motivation:

When HTTP transfers are proxied, the support for HTTP Range request is
handled by the milton library.  This is currently broken: resulting in
an 500 response.

Modification:

There are two parts to this fix:

First, upgrading to Milton v2.7.3.0 fixes the 500 response and the door
will return the correct response if the request contains a Range header
with a single byte-range.

Second, the output for multiple range requests is fixed within Milton.
This fix has already been accepted upstream, but to avoid waiting on
upstream release schedule and to minimise the risk when back-porting, a
dCache-specific release of 2.7.3.0 has been made (2.7.3.0-dcache-1).

Result:

Partial (or vector-read) GET requests now work with proxied transfers.

Target: master
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Ticket: https://rt.dcache.org/Ticket/Display.html?id=8343
Ticket: https://rt.dcache.org/Ticket/Display.html?id=9528
Patch: https://rb.dcache.org/r/11435/
Acked-by: Tigran Mkrtchyan