### PR TITLE
correct the properties for access-log

### DIFF
--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -323,6 +323,10 @@ pool.mover.xrootd.frame-size = 2097152
 #   and authorization plugins can be loaded as authn:<plugin> and
 #   authz:<plugin> respectively.
 #
+#   Placement of the access-log is significant, as other plugins may alter
+#   the request. To include login events in the access log, the access-log
+#   plugin must be placed before any other plugins.
+#
 pool.mover.xrootd.plugins=
 
 #  ---- Xrootd mover-idle timeout

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -169,7 +169,7 @@ xrootd.authz.write-paths =
 #
 #   Placement of the access-log is significant, as other plugins may alter
 #   the request. To include login events in the access log, the access-log
-#   plugin must be placed after the gplazma:* authentication plugin.
+#   plugin must be placed before any other plugins.
 #
 xrootd.plugins=gplazma:none,access-log,authz:none
 


### PR DESCRIPTION
access-log plugin should precede all others