### PR TITLE
libs: use nfs4j-0.17.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -742,7 +742,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.17.8</version>
+            <version>0.17.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
Highlights:

   * improve performance for file system locks

performance enhancement release:
Changelog for nfs4j-0.17.8..nfs4j-0.17.9
    * [a7107007] [maven-release-plugin] prepare for next development iteration
    * [4e588c62] nlm: improve concurrency of simple lock manager
    * [46a67cd1] nlm: use ConcurrentHashMap to store the locks
    * [cb6bcb0e] [maven-release-plugin] prepare release nfs4j-0.17.9

Acked-by: Paul Millar
Target: master, 5.0, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit b36842c8000c3348966819a428d1586fac6f6b81)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>