### PR TITLE
dcache/frontend: release dcache-view version 1.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.6.0</version.wicket>
         <version.xrootd4j>3.2.5</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.4.6</version.dcache-view>
+        <version.dcache-view>1.4.7</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.4.6 to v1.4.7

[08064cc](dCache/dcache-view@08064cc) dcache-view (context-menu): fix incorrectly positioned context-menu
[b5dad7b](dCache/dcache-view@b5dad7b) dcache-view (upload): fix issue 113
[18cd9ca](dCache/dcache-view@18cd9ca) dcache-view (user-profile): make gravatar optional
[835be71](dCache/dcache-view@835be71) dcache-view (build): fix and update the build system
[a5785d2](dCache/dcache-view@a5785d2) dcache-view (upload): fix dcache issue 3011

Release Note:

Normally, we don't add new major features to patch version but since all the new major
features here have been in the pipeline over along period and we don't want to delay
releasing these new features.

We appreciate it when you report issues - so we've got some couple of them fixed. Worth
mentioning is that some of your feature requests made it through this release, so update
to this version as soon as possible.

What’s New
==========

- User image internal workings is now slightly different in this version. Gravatar request
    is now make optional and how the images are stored are now more efficient to reduce the
    number of request made.

Bug Fixes
=========

- When file upload failed, sometimes the reason is not shown. Now, we added a button
    you can clicked to get possible causes of such errors and what you can do to fix
    them.
- We noticed some weird behaviour when right clicking on a file; the context menu
    is illogically positioned. So we've tweak some part of the code and this seem
    to working logically now.

Request: 4.1
Require-notes: yes
Acked-by: Tigran Mkrtchyan

Reviewed at https://rb.dcache.org/r/11484/