### PR TITLE
DO NOT MERGE Revert "libs: upgrade to bouncycastle 1.54,  CANL to 2.5.0 and voms-a…

### DIFF
--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/X509Plugin.java
@@ -7,6 +7,7 @@ import eu.emi.security.authn.x509.proxy.ProxyUtils;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.DERObjectIdentifier;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.PolicyInformation;
@@ -131,7 +132,7 @@ public class X509Plugin implements GPlazmaAuthenticationPlugin
         listPolicies(eec).stream()
                 .map(PolicyInformation::getInstance)
                 .map(PolicyInformation::getPolicyIdentifier)
-                .map(ASN1ObjectIdentifier::getId)
+                .map(DERObjectIdentifier::getId)
                 .map(X509Plugin::asPrincipal)
                 .filter(Objects::nonNull)
                 .forEach(principals::add);

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dcache</groupId>
@@ -103,8 +104,7 @@
                1.43     bcprov-jdk16    JDK v1.6; used by JGlobus-1.8.x
          -->
         <bouncycastle.bcprov>bcprov-jdk15on</bouncycastle.bcprov>
-        <bouncycastle.bcpkix>bcpkix-jdk15on</bouncycastle.bcpkix>
-        <bouncycastle.version>1.54</bouncycastle.version>
+        <bouncycastle.version>1.50</bouncycastle.version>
         <datanucleus-core.version>4.1.8</datanucleus-core.version>
         <datanucleus.plugin.version>4.0.2</datanucleus.plugin.version>
         <hazelcast.version>3.9.3</hazelcast.version>
@@ -239,12 +239,12 @@
             <dependency>
                 <groupId>eu.eu-emi.security</groupId>
                 <artifactId>canl</artifactId>
-                <version>2.5.0</version>
+                <version>2.1.2</version>
             </dependency>
             <dependency>
                 <groupId>org.italiangrid</groupId>
                 <artifactId>voms-api-java</artifactId>
-                <version>3.3.0</version>
+                <version>3.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.glite.authz</groupId>
@@ -693,12 +693,6 @@
                 <groupId>org.dcache</groupId>
                 <artifactId>dcache-view</artifactId>
                 <version>${version.dcache-view}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>${bouncycastle.bcpkix}</artifactId>
-                <version>${bouncycastle.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
DO NOT MERGE

…pi-java to 3.3.0"

This reverts commit eafbd5c1b11d3525787c80136d8dc81b52f44427.

It looks like this commit causes a problem for some VOMS servers:

14 Jan 2019 16:40:13 (gPlazma) [sfY:20:srm2:ls SRM-dcache-dot3 Login AUTH voms] Validation failure 1IY4 for DN "CN=Samuel Louis Bein,CN=739893,CN=sbein,OU=Users,OU=Organic Units,DC=cern,DC=ch": [[canlError]:CAnL certificate validation error: Signature of a CRL corresponding to this certificates CA is invalid, [invalidAcCert]:LSC validation failed: AA certificate chain embedded in the VOMS AC failed certificate validation!, [aaCertNotFound]:AC signature verification failure: no valid VOMS server credential found.]