### PR TITLE
srm: include TLS/SSL port in 'dcache ports' command

### DIFF
--- a/skel/share/defaults/srm.properties
+++ b/skel/share/defaults/srm.properties
@@ -265,7 +265,7 @@ srm.ping-extra-info!backend_version = ${dcache.version}
 #
 #   Document which TCP ports are opened
 #
-(immutable)srm.net.ports.tcp=${srm.net.port}
+(immutable)srm.net.ports.tcp=${srm.net.port} ${srm.net.ssl-port}
 
 
 


### PR DESCRIPTION
Motivation:

The 'dcache ports' command shows on which ports dCache is listening.
Currently, the srm service does not list the port on which it listens
for TLS connections.

Modification:

Add the srm TLS port to the list of ports.

Result:

The 'dcache ports' command now includes the srm's TLS/SSL interface

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Fixes: #4512
Patch: https://rb.dcache.org/r/11489/
Acked-by: Vincent Garonne