### PR TITLE
gplazma voms plugin: add trust anchor refresh paramater

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/TimeUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/TimeUtils.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -570,4 +571,11 @@ public class TimeUtils
         sb.append(')');
         return sb;
     }
+
+    public static long getMillis(Properties properties, String key)
+    {
+        return TimeUnit.valueOf(properties.getProperty(key + ".unit")).toMillis(
+                Long.parseLong(properties.getProperty(key)));
+    }
+
 }

--- a/modules/gplazma2-htpasswd/src/main/java/org/dcache/gplazma/htpasswd/HtpasswdPlugin.java
+++ b/modules/gplazma2-htpasswd/src/main/java/org/dcache/gplazma/htpasswd/HtpasswdPlugin.java
@@ -28,6 +28,7 @@ import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.getFirst;
 import static java.util.stream.Collectors.*;
 import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
+import static org.dcache.util.TimeUtils.getMillis;
 
 public class HtpasswdPlugin implements GPlazmaAuthenticationPlugin
 {
@@ -108,11 +109,5 @@ public class HtpasswdPlugin implements GPlazmaAuthenticationPlugin
             }
             return lines;
         }
-    }
-
-    private static long getMillis(Properties properties, String key)
-    {
-        return TimeUnit.valueOf(properties.getProperty(key + ".unit")).toMillis(
-                Long.parseLong(properties.getProperty(key)));
     }
 }

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -215,6 +215,12 @@ gplazma.vomsdir.dir=${dcache.authn.vomsdir}
 #  ---- Path to the directory containing trusted CA certificates
 gplazma.vomsdir.ca=${dcache.authn.capath}
 
+#  ---- VOMS validator refresh interval
+gplazma.vomsdir.refresh-interval = 4
+
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
+gplazma.vomsdir.refresh-interval.unit = HOURS
+
 #  ---- Path to the grid-vorolemap file
 gplazma.vorolemap.file=${dcache.paths.grid-security}/grid-vorolemap
 


### PR DESCRIPTION
Motivation

Since update to newer BC and voms-java-api libraries
sites report VOMS certificate validation errors like so:

[[canlError]:CAnL certificate validation error: Signature of a CRL corresponding to this certificates CA is invalid, [invalidAcCert]:LSC validation failed: AA certificate chain embedded in the VOMS AC failed certificate validation!, [aaCertNotFound]:AC signature verification failure: no valid VOMS server credential found.]

Modification

It has been noticed that gPlazma restart or mere touch of
gplazma.conf alleviates the issue (temporarily).
Based on the above - add trust anchor directory refresh to
certificate validation procedure. Default is 4 hours.

Result

Hopefully issue is fixed (being tested by a couple of sites)

Target: trunk
Request: 4.2, 5.0, 3.2
Acked-by: paul.millar@desy.de
Patch: https://rb.dcache.org/r/11488/
Release-notes: yes
Ticket: 9554