### PR TITLE
pom: use nfs4j-0.17.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -742,7 +742,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.17.8</version>
+            <version>0.17.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
Zero code change bugfix - compiled with java8 to avoid

java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer

as java9 have introduced ByteBuffer#limit, which is used instead of
Buffer#limit when compiled with java9+.

Changelog for nfs4j-0.17.8..nfs4j-0.17.9
* [a7107007] [maven-release-plugin] prepare for next development iteration
* [4e588c62] nlm: improve concurrency of simple lock manager
* [46a67cd1] nlm: use ConcurrentHashMap to store the locks
* [cb6bcb0e] [maven-release-plugin] prepare release nfs4j-0.17.9

Acked-by: Jürgen Starek
Target: master, 5.0, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 563094fb8264e2b0e00a21cfd7bfd42b54b807f5)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>