### PR TITLE
webdav: fix name of root

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResource.java
@@ -77,7 +77,7 @@ public class DcacheResource
     @Override
     public String getName()
     {
-        return _path.name();
+        return _path.isRoot() ? null : _path.name();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

WebDAV door logs warnings like:

Your resource factory returned a resource with a different name to that requested!!! Requested: null returned: / - resource factory: class io.milton.http.json.JsonResourceFactory

Modification:

Fix the name of the root directory.  Milton is expecting 'null', we
currently return "/".

Result:

No more logging of this error message.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Acked-by: Olufemi Adeyemi
Patch: https://rb.dcache.org/r/11479/