### PR TITLE
webdav: work-around Milton racy API for creating collections

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
@@ -97,6 +97,8 @@ public class DcacheStandardFilter implements Filter
              */
             response.setStatus(Response.Status.SC_TEMPORARY_REDIRECT);
             response.setLocationHeader(e.getUrl());
+        } catch (MethodNotAllowedException e) {
+            responseHandler.respondMethodNotAllowed(e.getResource(), response, request);
         } catch (WebDavException e) {
             log.warn("Internal server error: {}", e.toString());
             responseHandler.respondServerError(request, response, e.getMessage());

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/MethodNotAllowedException.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/MethodNotAllowedException.java
@@ -1,0 +1,31 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.webdav;
+
+import io.milton.resource.Resource;
+
+/**
+ * Return 405 Method Not Allowed to client.
+ */
+public class MethodNotAllowedException extends WebDavException
+{
+    public MethodNotAllowedException(String message, Throwable cause, Resource resource)
+    {
+        super(message, cause, resource);
+    }
+}


### PR DESCRIPTION
Motivation:

When processing a PUT request, milton checks whether parent paths exist
and creates them if not.  Unfortunately, this process is racy:
concurrent PUTs that target the same missing directory risk concurrent
createCollection method calls with the same target.  If this happens all
but one createCollection call will fail, resulting in the corresponding
PUT requests failing.

The problem is described here:

    https://github.com/miltonio/milton2/issues/114

Modification:

Add a work-around where dCache pretends the createCollection call is
successful, allowing the PUT request to succeed.

Result:

Fix a problem where all but one requests fail, if multiple concurrent
PUT requests have directories in the path that do not already exist.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11480/
Acked-by: Olufemi Adeyemi