### PR TITLE
common: fix random data generation in TimeseriesHistogram unit test

### DIFF
--- a/modules/common/src/test/java/org/dcache/util/histograms/TimeseriesHistogramTest.java
+++ b/modules/common/src/test/java/org/dcache/util/histograms/TimeseriesHistogramTest.java
@@ -60,7 +60,6 @@ documents or software obtained from this server.
 package org.dcache.util.histograms;
 
 import com.google.gson.GsonBuilder;
-import org.apache.commons.math3.util.FastMath;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -73,7 +72,6 @@ import org.dcache.util.histograms.TimeFrame.Type;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.dcache.util.ByteUnit.GiB;
-import static org.dcache.util.ByteUnit.KiB;
 import static org.junit.Assert.assertTrue;
 
 public final class TimeseriesHistogramTest extends HistogramModelTest {
@@ -247,7 +245,7 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
     private void assertThatUpdateAveragesLastValue() {
         Double[][] values = values();
         double lastValue = values[values.length - 1][1];
-        double newValue = lastValue * 3;
+        double newValue = lastValue + 1.0;
         double average = (lastValue + newValue) / 2;
         timeseriesHistogram.average(newValue, now);
         values = values();
@@ -260,7 +258,7 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
     private void assertThatUpdateReplacesLastValue() {
         Double[][] values = values();
         double lastValue = values[values.length - 1][1];
-        double newValue = lastValue * 3;
+        double newValue = lastValue + 1.0;
         timeseriesHistogram.replace(newValue, now);
         values = values();
         assertTrue("value was not replaced",
@@ -303,7 +301,7 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
     private void assertThatUpdateSumsLastValue() {
         Double[][] values = values();
         double lastValue = values[values.length - 1][1];
-        double newValue = lastValue * 3;
+        double newValue = lastValue + 1.0;
         timeseriesHistogram.add(newValue, now);
         values = values();
         assertTrue("value was not replaced",
@@ -324,25 +322,18 @@ public final class TimeseriesHistogramTest extends HistogramModelTest {
 
     private List<Double> getQueueCountsFor(int units) {
         List<Double> queue = new ArrayList<>();
-        int radix = 1000;
-
         for (int i = 0; i < units; ++i) {
-            long count = FastMath.abs(RANDOM.nextLong()) % radix;
-            queue.add((double) count);
+            queue.add(0.0);
         }
-
         return queue;
     }
 
     private List<Double> getRawBytesFor(int units) {
         List<Double> bytes = new ArrayList<>();
-        long radix = KiB.toBytes(1L);
-
+        double size = GiB.toBytes(1.0);
         for (int i = 0; i < units; ++i) {
-            long size = GiB.toBytes(FastMath.abs(RANDOM.nextLong()) % radix);
-            bytes.add((double) size);
+            bytes.add(size);
         }
-
         return bytes;
     }
 


### PR DESCRIPTION
Motivation:

Occasionally encountering error like:

Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.204 sec - in org.dcache.tests.util.GlobTest

Results :

Failed tests:
TimeseriesHistogramTest.updateOnTimeseriesHistogramShouldReplaceLastValue:181->assertThatUpdateReplacesLastValue:266 value was not replaced

Tests run: 864, Failures: 1, Errors: 0, Skipped: 0
[INFO] dCache common ...................................... FAILURE [ 16.650 s]

Modification:

As the failure seems to be because the new value is the same as the old,
change current method of generating a new value from old, which involves
multiplication by 3 if a random value, to checking using a fixed value
and adding 1 (apparently, the random number generated
occasionally is 0.0, in which case multiplication by 3 does not generate
a distinguishable new value).

Result:

All unit tests still pass.  Whether this fixes the sporadic error or not
remains to be seen.  Change invisible to users.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-book:  no
Requires-notes: no
Acked-by: Paul