### PR TITLE
libs: use postgres-jdbc 42.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.1.4</version>
+                <version>42.2.5</version>
             </dependency>
             <dependency>
                 <groupId>io.milton</groupId>


### PR DESCRIPTION
better integration with postgres 10, better support for java11

Acked-by: Paul Millar
Target: master, 4.2 (eventually)
Require-book: no
Require-notes: no
(cherry picked from commit 3b97acc1b6ab2f48553893777c8c5e3be68f5977)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>