### PR TITLE
libs: use zookeeper-3.4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.12</version>
+                <version>3.4.13</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.jmx</groupId>


### PR DESCRIPTION
Motivation:
minor version update with many bugfixes.
See: https://zookeeper.apache.org/doc/r3.4.13/releasenotes.html

Result:
up-to-date dependency

Acked-by: Paul Millar
Target: master, 4.2
Require-book: no
Require-notes: no
(cherry picked from commit 52be70e5a0915c4f560ec54b0b83188e813eb069)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>