### PR TITLE
dcache: wrap billing data source with AlarmEnabledDataSource

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/services/billing/cells/billing.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/billing/cells/billing.xml
@@ -54,22 +54,28 @@
 
   <!-- Set of beans instantiated if database is enabled -->
   <beans profile="db-true">
-      <bean id="data-source" class="com.zaxxer.hikari.HikariDataSource"
-            destroy-method="close">
+    <bean id="data-source" class="org.dcache.db.AlarmEnabledDataSource" destroy-method="close">
+      <description>Database connection pool</description>
+      <constructor-arg value="${billing.db.url}"/>
+      <constructor-arg value="BillingCell"/>
+      <constructor-arg>
+        <bean class="com.zaxxer.hikari.HikariDataSource">
           <constructor-arg>
-              <bean class="com.zaxxer.hikari.HikariConfig">
-                  <property name="jdbcUrl" value="${billing.db.url}"/>
-                  <property name="username" value="${billing.db.user}"/>
-                  <property name="password" value="#{ T(diskCacheV111.util.Pgpass).getPassword('${billing.db.password.file}', '${billing.db.url}', '${billing.db.user}', '${billing.db.password}') }"/>
-                  <property name="autoCommit" value="true"/>
-                  <property name="transactionIsolation" value="TRANSACTION_READ_COMMITTED"/>
-                  <property name="minimumIdle" value="${billing.db.connections.idle}"/>
-                  <property name="maximumPoolSize" value="${billing.db.connections.max}"/>
-              </bean>
+            <bean class="com.zaxxer.hikari.HikariConfig">
+              <property name="jdbcUrl" value="${billing.db.url}"/>
+              <property name="username" value="${billing.db.user}"/>
+              <property name="password" value="#{ T(diskCacheV111.util.Pgpass).getPassword('${billing.db.password.file}', '${billing.db.url}', '${billing.db.user}', '${billing.db.password}') }"/>
+              <property name="autoCommit" value="true"/>
+              <property name="transactionIsolation" value="TRANSACTION_READ_COMMITTED"/>
+              <property name="minimumIdle" value="${billing.db.connections.idle}"/>
+              <property name="maximumPoolSize" value="${billing.db.connections.max}"/>
+            </bean>
           </constructor-arg>
-      </bean>
+        </bean>
+      </constructor-arg>
+    </bean>
 
-      <bean id="pmf" class="org.datanucleus.api.jdo.JDOPersistenceManagerFactory"
+    <bean id="pmf" class="org.datanucleus.api.jdo.JDOPersistenceManagerFactory"
             depends-on="liquibase" destroy-method="close">
           <description>Database persistence manager</description>
           <constructor-arg>


### PR DESCRIPTION
Motivation:

The AlarmEnabledDataSource class wraps a delegate data source
(such as Hikari) in order to be able to catch fatal connection
errors and report them as alarms.

This wrapper is utilized in the spring configuration for
pnfsmanager, cleaner, srmmanager, spacemanager, transfermanager,
nfsv4, and resilience, but is missing from billing.

Modification:

Wrap the Hikari billing data source similarly to the others.

Result:

When there is database connection loss for billing it will
be reported.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Require-notes: yes
Require-book: no
Acked-by: Dmitry