### PR TITLE
nfs: do not filter device's IP addresses based on site locality

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -563,16 +563,17 @@ public class NFSv41Door extends AbstractCellComponent implements
         }
 
         // limit addresses returned to client to the same 'type' as clients own address
+        // NOTICE: according to rfc1918 we allow access to private networks from public ip address
+        // Site must take care that private IP space is not visible to site external clients.
         InetAddress clientAddress = context.getRemoteSocketAddress().getAddress();
         InetSocketAddress[] usableAddresses = Stream.of(ds.getDeviceAddr())
                 .filter(a -> !a.getAddress().isLoopbackAddress() || clientAddress.isLoopbackAddress())
                 .filter(a -> !a.getAddress().isLinkLocalAddress() || clientAddress.isLinkLocalAddress())
-                .filter(a -> !a.getAddress().isSiteLocalAddress() || clientAddress.isSiteLocalAddress())
                 // due to bug in linux kernel we need to filter out IPv6 addresses if client connected
                 // with IPv4.
                 // REVISIT: remove this workaround as soon as RHEL 7.5 is released.
                 .filter(a -> clientAddress.getAddress().length >= a.getAddress().getAddress().length)
-                .toArray(size -> new InetSocketAddress[size]);
+                .toArray(InetSocketAddress[]::new);
 
         return layoutDriver.getDeviceAddress(usableAddresses);
     }


### PR DESCRIPTION
Motivation:
The NFS door assumes that routable IP address, like 130.199.49.35,  in general can't
access private subnet, like 10.1.1.1. This assumption is not always true for all sites
and ends up with non functional pNFS deployment.

Modification:
do not filter device's IP addresses if they don't match on site locality

Result:
normal pNFS IO operations even if the client and the pool have different
site locality for their IP addresses.

Reported-by: "Hironori Ito" <hito@rcf.rhic.bnl.gov>
Acked-by: Paul Millar
Target: master, 5.0, 4.2
Ticket: #9532
Require-book: no
Require-notes: yes
(cherry picked from commit 606c8236b731906c89d8321006a3abbb6aeade05)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>