### PR TITLE
dcache-frontend: undefined suid parameter on transfers should be NULL…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
@@ -159,7 +159,7 @@ public final class TransferResources {
             return service.get(token,
                                offset,
                                limit,
-                               String.valueOf(suid),
+                               suid == null ? null : String.valueOf(suid),
                                state,
                                door,
                                domain,


### PR DESCRIPTION
… not "null"

Motivation:

In checking as to whether a transfer should be visible,
the subject uid is used.  This is set to NULL (and is
checked for null) if either the visible to all flag
is true or the user has admin role provileges.

However, this null value is erroneously being passed
to the service layer using String.valueOf(suid), which
converts NULL to the string "null".

Modification:

Fix it.

Result:

Transfers should not inappropriately be filtered out.

Target: master
Request: 5.0
Request: 4.2
Bug: #4554
Acked-by:  Paul