### PR TITLE
pom.xml: update xrootd4j dependency to 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.11.v20180605</version.jetty>
-        <version.xrootd4j>3.3.3</version.xrootd4j>
+        <version.xrootd4j>3.3.4</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
         <version.dcache-view>1.5.2</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Changes from 3.3.3:

b662c04 pom: bump copyright year to 2019
72dba0f xrootd4j-gsi: change the protocol version to int
a0966a6 xrootd4j: add ERROR status to tpc info
040f8e1 xrootd4j: prevent NPE when constructing error response
d0d7126 xrootd4j: append zero-padding when TlsPremaster truncates it (on encrypt)
8d27048 xrootd4j: fix path handling in move request
9950063 xrootd4j: correctly handle multiple authn protocols as indicated by server
0879c69 xrootd4j: restructure client pipeline error handling
8772d58 xrootd4j-gsi: fix condition for proxy path
e236cca xrootd4j-gsi: handle correctly IO/Security exceptions on credential loading
cea7e79 xrootd4j: distinguish correctly between kXR_wait and kXR_waitresp
039a41d xrootd4j: do not catch Exception in request handler error routine

Target: master
Request: 5.0
Request: 4.2
Requires-book: no
Requires-notes: no
Acked-by: Paul