### PR TITLE
dcache-frontend: add documentation concerning restores

### DIFF
--- a/docs/TheBook/src/main/markdown/config-frontend.md
+++ b/docs/TheBook/src/main/markdown/config-frontend.md
@@ -121,6 +121,40 @@ document; see, for instance,
 The same procedure applies when enabling the admin role in dCache-View.
 At the upper right hand corner of the dCache-View landing page,
 you will see the user icon.  Click on it and select "add another credential"
-Type in the user name and password, and check the box which says "assert all roles". 
+Type in the user name and password, and check the box which says "assert all roles".
 
 See the [dCache-View] documentation for further information.
+
+##### A Note on the RESTful API for tape restores
+
+The data retrieved via the REST path
+
+```
+/api/v1/restores ...
+```
+
+corresponds to the admin command
+
+```
+\sp rc ls
+```
+
+for all available pool managers.   This means that the restores listed in the
+output are those initiated by an actual protocol through a door.  The restore
+initiated by the pool command:
+
+
+```
+\s <pool> rh restore <pnfsid>
+```
+
+does not show up in this list because the pool manager knows nothing about it.
+
+In order to get all the restores (stages) on a given pool, the REST path
+
+```
+/api/v1/pools/{pool}/nearline/queues?type=stage
+```
+
+must be used.
+

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
@@ -102,8 +102,14 @@ public final class RestoreResources {
     private boolean unlimitedOperationVisibility;
 
     @GET
-    @ApiOperation("Obtain a (potentially partial) list of restore operations "
-            + "from some snapshot, along with a token that identifies the snapshot.")
+    @ApiOperation("Obtain a (potentially partial) list of restore operations"
+            + " from some snapshot, along with a token that identifies the snapshot.  Note:"
+                    + " the output to this request represents all the staging operations"
+                    + " triggered through the pool manager (via read requests through"
+                    + " the doors); cf the admin command '\\sp rc ls'.  Stage operations"
+                    + " initiated directly on a pool via 'rh restore <pnfsid>' do not"
+                    + " appear here.  To see a listing of all stages/restores on a given"
+                    + " pool, use the API for /pools/{pool}/nearline/queues?type=stage).")
     @ApiResponses({
                 @ApiResponse(code = 403, message = "Restores can only be accessed by admin users."),
                 @ApiResponse(code = 500, message = "Internal Server Error"),


### PR DESCRIPTION
Motivation:

It is currently unclear (at least it is not explicitly
documented) what the 'restores' API corresponds to.
In particular, users may get the impression that
the tape restores should also include requests
initiated using the pool command 'rh restore <pnfsid>'.

Modification:

Add statement at the end of the frontend section
of book explaining the difference between the
restores page and an API request for the stage
queue on a pool.

Do the same in SWAGGER documentation for the
restores API path.

Result:

Confusion hopefully mitigated.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Acked-by: Olufemi
Acked-by: Paul