### PR TITLE
dcache-xrootd: remove mv request hack

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -638,28 +638,10 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
         _log.info("Trying to rename {} to {}", req.getSourcePath(), req.getTargetPath());
 
         try {
-            /*
-             * We have observed kXR_mv requests with a source path like:
-             *
-             *     //foo/my-file?xrd.gsiusrpxy=/opt/domatests/x509up&xrd.wantprot=gsi,unix
-             *
-             * It currently isn't clear whether this is valid.  The xrootd
-             * protocol documentation does not document it as valid:
-             *
-	     *     https://github.com/xrootd/xrootd/issues/850
-             *
-             * However, the SLAC xrootd server accepts such requests and
-	     * strips off the query part.  Since xrootd clients exist that
-	     * expect this behaviour, we do the same (at least for now).
-             */
-            String srcWithQuery = req.getSourcePath();
-            int queryIndex = srcWithQuery.indexOf('?');
-            String src = queryIndex == -1 ? srcWithQuery : srcWithQuery.substring(0, queryIndex);
-            _door.moveFile(
-                    createFullPath(src),
-                    createFullPath(req.getTargetPath()),
-                    req.getSubject(),
-                    _authz);
+            _door.moveFile(createFullPath(req.getSourcePath()),
+                           createFullPath(req.getTargetPath()),
+                           req.getSubject(),
+                           _authz);
             return withOk(req);
         } catch (TimeoutCacheException e) {
             throw new XrootdException(kXR_ServerError, "Internal timeout");


### PR DESCRIPTION
Motivation:

Xrootd4j previously was not supporting a query part
(opaque data) on the source path.  A hack was
included in the dCache door to fix this until
the problem was solved.

The issue has been addressed in xrootd4j.

Modification:

Remove the parsing code in the door.

Result:

Mv with query on either source or target succeeds.
Changes invisible to user.

Target: master
Request: 5.0
Request: 4.2
Depends-on: 11422
Acked-by: Tigran