### PR TITLE
ftp: fix MLSC command for non-small directories

### DIFF
--- a/modules/common-security/src/main/java/org/dcache/dss/DssContext.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/DssContext.java
@@ -44,6 +44,14 @@ public interface DssContext
     byte[] wrap(byte[] data, int offset, int len) throws IOException;
 
     /**
+     * Maximum number of bytes (of application data) that may be send to a
+     * single invocation of {@link #wrap}.  This represents a limitation due
+     * to the encrypted token having a maximum size.  Returns Long.MAX_VALUE
+     * if no such limit.
+     */
+    long maxApplicationSize();
+
+    /**
      * Unwraps a token received from a peer.
      */
     byte[] unwrap(byte[] token) throws IOException;

--- a/modules/common-security/src/main/java/org/dcache/dss/GssDssContext.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/GssDssContext.java
@@ -105,6 +105,16 @@ public abstract class GssDssContext implements DssContext
         }
     }
 
+
+    @Override
+    public long maxApplicationSize()
+    {
+        // REVISIT: currently, we do not place any limits on how long an
+        // encrypted token may be.
+        return Long.MAX_VALUE;
+    }
+
+
     @Override
     public Subject getSubject()
     {

--- a/modules/common-security/src/main/java/org/dcache/dss/SslEngineDssContext.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/SslEngineDssContext.java
@@ -142,6 +142,12 @@ public class SslEngineDssContext implements DssContext
         }
     }
 
+    @Override
+    public long maxApplicationSize()
+    {
+        return engine.getSession().getApplicationBufferSize();
+    }
+
     private boolean unwrap() throws IOException
     {
         while (true) {


### PR DESCRIPTION
Motivation:

Globus (globus.org) is unable to list directories with more than ~80
directory items.

Globus uses the MLSC command, which sends the MLSD output over the
control channel.  Currently, dCache generates the complete output and
sends it in one go, assuming it will fit in a single TLS record.
Once the MLSC output exceeds the maximum "application" data size, dCache
sends and incomplete response and the directory listing no longer works.

Modification:

Check to see if the response is too big for a TLS record.

It too big, split the response into smaller chunks that Globus can
parse.  It seems to require that the TLS record contains only whole
MLSC output lines.

Result:

Globus is now able to list directories with > 100 directories.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11518/
Acked-by: Tigran Mkrtchyan