### PR TITLE
ftp: fix MLSC command for non-small directories

### DIFF
--- a/modules/common-security/src/main/java/org/dcache/dss/DssContext.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/DssContext.java
@@ -44,6 +44,14 @@ public interface DssContext
     byte[] wrap(byte[] data, int offset, int len) throws IOException;
 
     /**
+     * Maximum number of bytes (of application data) that may be send to a
+     * single invocation of {@link #wrap}.  This represents a limitation due
+     * to the encrypted token having a maximum size.  Returns Long.MAX_VALUE
+     * if no such limit.
+     */
+    long maxApplicationSize();
+
+    /**
      * Unwraps a token received from a peer.
      */
     byte[] unwrap(byte[] token) throws IOException;

--- a/modules/common-security/src/main/java/org/dcache/dss/GssDssContext.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/GssDssContext.java
@@ -105,6 +105,16 @@ public abstract class GssDssContext implements DssContext
         }
     }
 
+
+    @Override
+    public long maxApplicationSize()
+    {
+        // REVISIT: currently, we do not place any limits on how long an
+        // encrypted token may be.
+        return Long.MAX_VALUE;
+    }
+
+
     @Override
     public Subject getSubject()
     {

--- a/modules/common-security/src/main/java/org/dcache/dss/SslEngineDssContext.java
+++ b/modules/common-security/src/main/java/org/dcache/dss/SslEngineDssContext.java
@@ -142,6 +142,12 @@ public class SslEngineDssContext implements DssContext
         }
     }
 
+    @Override
+    public long maxApplicationSize()
+    {
+        return engine.getSession().getApplicationBufferSize();
+    }
+
     private boolean unwrap() throws IOException
     {
         while (true) {

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
@@ -2,6 +2,8 @@ package org.dcache.ftp.door;
 
 import com.google.common.base.Strings;
 
+import com.google.common.base.Splitter;
+
 import org.dcache.dss.DssContext;
 import org.dcache.dss.DssContextFactory;
 
@@ -17,6 +19,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import diskCacheV111.util.CacheException;
@@ -86,15 +89,42 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1
     @Override
     protected void secure_reply(CommandRequest request, String answer, String code)
     {
-        byte[] data = (answer + "\r\n").getBytes(UTF8);
+        byte[] allData = (answer + "\r\n").getBytes(UTF8);
+
         try {
-            data = context.wrap(data, 0, data.length);
+            /*
+             * If the response exceeds 16.5 KiB then the encrypted output no
+             * longer fits in a single TLS token and must be split into multiple
+             * partial responses.  At the current time, the only place where
+             * this can happen is the MLSC command for directories with more
+             * than ~80 entries; the exact number depends on the file names.
+             *
+             * Only Globus (globus.org) uses the MLSC command and its client has
+             * the peculiarity that the TLS record must match a complete number
+             * of directory entries.  The Globus server code sends a TLS record
+             * for each directory item when generating an MLSC response.
+             */
+            if (allData.length <= context.maxApplicationSize()) {
+                wrapAndSend(code, ' ', allData);
+            } else {
+                List<String> lines = Splitter.on("\r\n").splitToList(answer);
+                for (int i = 0; i < lines.size(); i++) {
+                    boolean isLastLine = i == lines.size()-1;
+                    byte[] lineData = (lines.get(i) + "\r\n").getBytes(UTF8);
+                    wrapAndSend(code, isLastLine ? ' ' : '-', lineData);
+                }
+            }
         } catch (IOException e) {
             LOGGER.error("Failed to encrypt reply '{}': {}", answer, e.toString());
             reply(request.getOriginalRequest(), "500 Reply encryption error: " + e);
-            return;
         }
-        println(code + " " + Base64.getEncoder().encodeToString(data));
+    }
+
+    private void wrapAndSend(String code, char separator, byte[] applicationData)
+            throws IOException
+    {
+        byte[] wrapped = context.wrap(applicationData, 0, applicationData.length);
+        println(code + separator + Base64.getEncoder().encodeToString(wrapped));
     }
 
     @Help("AUTH <SP> <arg> - Initiate secure context negotiation.")


### PR DESCRIPTION
Motivation:

Globus (globus.org) is unable to list directories with more than ~80
directory items.

Globus uses the MLSC command, which sends the MLSD output over the
control channel.  Currently, dCache generates the complete output and
sends it in one go, assuming it will fit in a single TLS record.
Once the MLSC output exceeds the maximum "application" data size, dCache
sends and incomplete response and the directory listing no longer works.

Modification:

Check to see if the response is too big for a TLS record.

It too big, split the response into smaller chunks that Globus can
parse.  It seems to require that the TLS record contains only whole
MLSC output lines.

Result:

Globus is now able to list directories with > 100 directories.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11518/
Acked-by: Tigran Mkrtchyan