### PR TITLE
dcache: update kafka-client lib version to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -859,7 +859,7 @@
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                 </exclusions>
-                <version>1.0.0</version>
+                <version>2.1.0</version>
             </dependency>
             <dependency>
                 <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
Motivation

There has been a report that not all billing messages where sent via Kafka Producer.

20 Sep 2018 10:08:11 (dcache-desy16-03)
[door:GFTP-dcache-door-desy03-AAV2SQYIB6g@dcache-door-desy03_gridftpDomain
GFTP-dcache-door-desy03-AAV2SQYIB6g PoolAcceptFile
0000AF0446E33D66400D9542FE707D39E114] Unable to send message to topic
billing on  partition null, with key null and value
MoverInfoMessage{dataTransferred=100709673, connectionTime=1067,
protocolInfo=GFtp-2.0 131.169.192.120 41166, fileCreated=true,
initiator='door:GFTP-dcache-door-desy03-AAV2SQYIB6g@dcache-door-desy03_gridftpDomain:1537430889929000',
isP2p=false,
transferPath='/upload/5/bca4838f-5f55-40d5-9ec1-64a7adedb1b2/mdst_000102_prod00005684_task00031229.root',
readBw='2.2962093995963E9', writeBw='4.552821234775509E8',
readIdle='PT1.076601496S', readActive='PT0.031741423S',
writeIdle='PT0.851732864S', writeActive='PT0.254562479S'}
InfoMessage{cellType='pool', messageType='transfer',
cellAddress=dcache-desy16-03@dcache-desy16-03Domain, timeQueued=0,
resultCode=0, message='', timestamp=1537430891063, transaction='null',
transactionID=4045, subject=Subject:
         Principal: /C=JP/O=KEK/OU=CRC/CN=Robot: BelleDIRAC Production -
UEDA Ikuo
         Principal: UidPrincipal[23202]
         Principal: GroupNamePrincipal[belle2]
         Principal: Origin[109.127.250.81]
         Principal: EmailAddressPrincipal[email='ueda@post.kek.jp]
         Principal: GidPrincipal[5296,primary]
         Principal: GroupNamePrincipal[b2prod,primary]
         Principal: UserNamePrincipal[b2prod]
         Principal: EntityDefinitionPrincipal[Robot]
         Principal: FQANPrincipal[/belle]
         Principal: LoAPrincipal[IGTF-AP:Classic]
         Principal: FQANPrincipal[/belle/Role=production,primary]
} : Failed to update metadata after 0 ms

The reason for this could be several issues: slow network, serevre is not available and etc.

According to kafka documentation a failed message could be resent if number of retries is greater than 0 and the error is Retriable (for example Timeout Exception).

Nonetheless, setting retry greater than ) results in duplication of messages, therefore  Idempotent Producer (Exactly Once Semantics) must be used.

The new version of kafka-client contains ENABLE_IDEMPOTENCE_CONFIG used to enable an Idempotent Producer.

Target: master
Request: 5.0
Request: 4.2
Requires-notes: no
Requires-book: no
Acked-by: Tigran, Paul
Patch: https://rb.dcache.org/r/11348/