### PR TITLE
door: fix issue 4551 (wrong storage)

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/notification/DoorRequestMessageSerializer.java
+++ b/modules/dcache/src/main/java/org/dcache/notification/DoorRequestMessageSerializer.java
@@ -49,7 +49,7 @@ public class DoorRequestMessageSerializer implements Serializer<DoorRequestInfoM
         o.put("pnfsid", data.getPnfsId());
         o.put("billingPath", data.getBillingPath());
         o.put("fileSize", data.getFileSize());
-        o.put("storageInfo", data.getStorageInfo());
+        o.put("storageInfo", data.getStorageInfo().getStorageClass() + "@" + data.getStorageInfo().getHsm());
         return o.toString().getBytes(UTF_8);
 
     }


### PR DESCRIPTION
Motivation

The door request uses storageInfo#toString when constructs record for kafka:

{
    "storageInfo": "size=2003667968;new=true;stored=false;sClass=desy:linac-test;cClass=-;hsm=osm;accessLatency=NEARLINE;retentionPolicy=REPLICA;uid=406;path=/;gid=406;StoreName=desy;flag-c=1:6ddf5686;store=desy;group=linac-test;bfid=<Unknown>;",
}

while it should provide the same information as pool record:

{
    "storageInfo": "atlas:atlasdatadisk@osm",
}

Modification

DoorRequestMessageSerializer is modified to sent the correct data

Target: master
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11516/
Acked-by: Paul