### PR TITLE
dcache, frontend: release dcache-view version 1.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.11.v20180605</version.jetty>
         <version.xrootd4j>3.3.4</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.5.2</version.dcache-view>
+        <version.dcache-view>1.5.3</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.5.2 to v1.5.3

[1a829d9](dCache/dcache-view@1a829d9) dcache-view: fix billing plot title error
[135cd1b](dCache/dcache-view@135cd1b) dcache-view (gulpfile): add missing webcomponents.js polyfills
[304ef73](dCache/dcache-view@304ef73) dcache-view (npm-package): add bower to list of dependencies

Release Note:

- If you're having troubles using firefox and/or safari to browse
    dcache-view, this is now resolve and fix. Thank you for reporting
    the issue.

Target: master
Request: 5.0
Request: 4.2
Require-notes: yes
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11520/

(cherry picked from commit b2d7393ba3e084fa049bb7d5f6a8f15a15c45889)