### PR TITLE
dcache, frontend: release dcache-view version 1.4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.wicket>7.6.0</version.wicket>
         <version.xrootd4j>3.2.5</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.4.7</version.dcache-view>
+        <version.dcache-view>1.4.8</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.4.7 to v1.4.8

[46c2660](dCache/dcache-view@46c2660) dcache-view: fix billing plot title error
[1b9178a](dCache/dcache-view@1b9178a) dcache-view (gulpfile): add missing webcomponents.js polyfills
[2badb9d](dCache/dcache-view@2badb9d) dcache-view (npm-package): add bower to list of dependencies

Release Note:

- If you're having troubles using firefox and/or safari to browse
    dcache-view, this is now resolve and fix. Thank you for reporting
    the issue.

Request: 4.1
Require-notes: yes
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11521/