### PR TITLE
webdav: 401 for unauthenticated requests; message in status line

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/macaroons/MacaroonRequestHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/macaroons/MacaroonRequestHandler.java
@@ -75,8 +75,7 @@ import org.dcache.http.PathMapper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.emptyToNull;
 import static java.lang.Boolean.TRUE;
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static javax.servlet.http.HttpServletResponse.*;
 import static org.dcache.macaroons.CaveatType.BEFORE;
 import static org.dcache.macaroons.InvalidCaveatException.checkCaveat;
 
@@ -184,10 +183,7 @@ public class MacaroonRequestHandler extends AbstractHandler implements CellIdent
                     w.println(json.toString(JSON_RESPONSE_INDENTATION));
                 }
             } catch (ErrorResponseException e) {
-                response.setStatus(e.getStatus());
-                try (PrintWriter w = response.getWriter()) {
-                    w.println(e.getMessage());
-                }
+                response.sendError(e.getStatus(), e.getMessage());
             } catch (RuntimeException e) {
                 LOG.error("Bug detected", e);
                 response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -307,8 +303,10 @@ public class MacaroonRequestHandler extends AbstractHandler implements CellIdent
 
     private String buildMacaroon(String target, Request request) throws ErrorResponseException
     {
-        checkValidRequest(request.isSecure(), "Not secure transport.");
-        checkValidRequest(!Subjects.isNobody(getSubject()), "User not authenticated.");
+        checkValidRequest(request.isSecure(), "Not secure transport");
+        if (Subjects.isNobody(getSubject())) {
+            throw new ErrorResponseException(SC_UNAUTHORIZED, "Authentication required");
+        }
 
         MacaroonContext context = buildContext(target, request);
 


### PR DESCRIPTION
Motivation:

dCache rejects any unauthenticated client requesting a macaroon.  It
currently does this by responding with a 400 (Bad Request) status code.

A more correct status code is 401 (Unauthorized) as this suggests to the
client that repeating the request while authenticated may succeed.  In
particular, it is a common pattern for a client to attempt a request
unauthenticated and use the 'WWW-Authenticate' response header to learn
what methods of authentication the server supports.

The 400 response dCache currently returns breaks such clients.

Additionally, the error message was returned as the response entity,
rather than as part of the status line.

Modification:

Update interface to return 401 on unauthenticated requests.

Return the message as part of the status line.

Result:

dCache works better with standard clients when requesting macaroons.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11515/
Acked-by: Dmitry Litvintsev
Acked-by: Tigran Mkrtchyan