### PR TITLE
pnfsmanager: do not emit IN_ATTRIB event on atime updates

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/namespace/MonitoringNameSpaceProvider.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/MonitoringNameSpaceProvider.java
@@ -50,6 +50,7 @@ import org.dcache.util.Glob;
 import org.dcache.vehicles.FileAttributes;
 
 import static java.util.Objects.requireNonNull;
+import static org.dcache.namespace.FileAttribute.ACCESS_TIME;
 
 
 /**
@@ -63,6 +64,8 @@ public class MonitoringNameSpaceProvider extends ForwardingNameSpaceProvider
     private static final EnumSet<FileAttribute> PNFSID = EnumSet.of(FileAttribute.PNFSID);
     private static final EnumSet<FileAttribute> FILETYPE = EnumSet.of(FileAttribute.TYPE);
     private static final EnumSet<FileAttribute> PNFSID_FILETYPE = EnumSet.of(FileAttribute.PNFSID, FileAttribute.TYPE);
+    private static final EnumSet<FileAttribute> SIGNIFICANT_UPDATES =
+            EnumSet.complementOf(EnumSet.of(FileAttribute.ACCESS_TIME));
 
     private NameSpaceProvider delegate;
     private EventReceiver eventReceiver;
@@ -151,10 +154,12 @@ public class MonitoringNameSpaceProvider extends ForwardingNameSpaceProvider
         FileAttributes returnAttr = super.setFileAttributes(subject, target, attr,
                 union(fetch,FILETYPE));
 
-        FileType type = returnAttr.getFileType();
+        if (!attr.isUndefined(SIGNIFICANT_UPDATES)) {
+            FileType type = returnAttr.getFileType();
 
-        eventReceiver.notifySelfEvent(EventType.IN_ATTRIB, target, type);
-        notifyParents(target, EventType.IN_ATTRIB, type);
+            eventReceiver.notifySelfEvent(EventType.IN_ATTRIB, target, type);
+            notifyParents(target, EventType.IN_ATTRIB, type);
+        }
 
         return returnAttr;
     }


### PR DESCRIPTION
Motivation:

A pool will attempt to update a file's atime whenever a client opens a
file.  PnfsManager may choose to accept or ignore this request, based on
the 'pnfsmanager.atime-gap' configuration property.

Amongst other checks, MonitoringNameSpaceProvider will react to any
changes to a file's attributes by issuing an IN_ATTRIB.  This includes
any request from a pool to update the file's atime (and nothing else)
that is accepted by PnfsManager.

In other words, opening an existing file for reading will trigger an
IN_ATTRIB if the atime changes.

This behaviour is different from the Linux kernel, where the IN_ATTRIB
event is never generated when a file is opened for reading.

Modification:

Declare a set of "interesting" file attributes.  If any of these file
attributes are updated then an IN_ATTRIB event is generated.  If none of
these are present then no IN_ATTRIB event is generated.  This set is
defined to be all file attributes exception ACCESS_TIME.

Result:

dCache no longer emits an IN_ATTRIB event if opening an existing file in
dCache updates that file's atime.

This change brings dCache's inotify implementation closer to that of the
Linux kernel.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11503/
Acked-by: Tigran Mkrtchyan