### PR TITLE
pool: don't update atime on flush

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -102,6 +102,7 @@ import org.dcache.pool.repository.IllegalTransitionException;
 import org.dcache.pool.repository.ReplicaDescriptor;
 import org.dcache.pool.repository.ReplicaState;
 import org.dcache.pool.repository.Repository;
+import org.dcache.pool.repository.Repository.OpenFlags;
 import org.dcache.pool.repository.StateChangeEvent;
 import org.dcache.pool.repository.StateChangeListener;
 import org.dcache.pool.repository.StickyChangeEvent;
@@ -821,7 +822,7 @@ public class NearlineStorageHandler
         {
             super(nearlineStorage);
             infoMsg = new StorageInfoMessage(cellAddress, pnfsId, false);
-            descriptor = repository.openEntry(pnfsId, NO_FLAGS);
+            descriptor = repository.openEntry(pnfsId, EnumSet.of(OpenFlags.NOATIME));
             String path = descriptor.getFileAttributes().getStorageInfo().getKey("path");
             if (path != null) {
                 infoMsg.setBillingPath(path);


### PR DESCRIPTION
Motivation:

The onFlush checksum option calculates the checksum before the file is
flushed to tape.  To do this, it must access that file's data.

Currently, that access results in the file's atime being update, despite
this access not involving a client.

Modification:

Instruct the access not to trigger an atime update.

Result:

The checksum policy onFlush no longer triggers an update a file's atime.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11504/
Acked-by: Tigran Mkrtchyan