### PR TITLE
pool: grow file prior FTP upload

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
@@ -47,6 +47,7 @@ import org.dcache.ftp.data.ModeS;
 import org.dcache.ftp.data.ModeX;
 import org.dcache.ftp.data.Multiplexer;
 import org.dcache.ftp.data.Role;
+import org.dcache.namespace.FileAttribute;
 import org.dcache.pool.repository.FileStore;
 import org.dcache.pool.repository.FileRepositoryChannel;
 import org.dcache.pool.repository.RepositoryChannel;
@@ -469,6 +470,10 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
                 throw new IllegalArgumentException(err);
             }
             mode.setPartialRetrieveParameters(offset, size);
+        } else {
+            if (fileAttributes.isDefined(FileAttribute.SIZE)) {
+                fileChannel.truncate(fileAttributes.getSize());
+            }
         }
 
         try {


### PR DESCRIPTION
Motivation:
when FTP STOR requests sent to the dcache pool and file's length is
know, then we should pre-allocate file's size to let back-end store to
optimize block allocation. This is especially important for high latency
systems, like CEPH.

Modification:
Grow file on backend storage if size is known.

Result:
Performance boost for ceph pool.

Acked-by: Paul Millar
Target: master, 5.0, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 17f01abd5e179c33a0206768b5458c99e5f28585)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>