### PR TITLE
admin : add direct command execution capability

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/DirectCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/DirectCommand.java
@@ -1,0 +1,225 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.services.ssh2;
+
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.ExitCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.List;
+
+import diskCacheV111.admin.UserAdminShell;
+
+import dmg.cells.nucleus.CellEndpoint;
+import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.cells.nucleus.SerializationException;
+import dmg.util.CommandAclException;
+import dmg.util.CommandEvaluationException;
+import dmg.util.CommandException;
+import dmg.util.CommandExitException;
+import dmg.util.CommandPanicException;
+import dmg.util.CommandSyntaxException;
+
+import org.dcache.cells.CellStub;
+import org.dcache.util.list.ListDirectoryHandler;
+import org.dcache.util.Strings;
+
+/**
+ * Implementation of Command interface that allows
+ * direct command execution in admin server. Executes
+ * list of commands:
+ *    ssh -p PORT user@example.org "command1;command2;command3"
+ *
+ * @author litvinse
+ */
+public class DirectCommand implements Command, Runnable
+{
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(DirectCommand.class);
+
+    private ExitCallback exitCallback;
+    private PrintWriter errorWriter;
+    private PrintWriter outWriter;
+    private final UserAdminShell shell;
+    private List<String> commands;
+    private Thread shellThread;
+
+    DirectCommand(List<String> commands,
+                  CellEndpoint endpoint,
+                  CellStub poolManager,
+                  CellStub pnfsManager,
+                  CellStub acm,
+                  String prompt,
+                  ListDirectoryHandler list)
+    {
+        this.commands = commands;
+        shell = new UserAdminShell(prompt);
+        shell.setCellEndpoint(endpoint);
+        shell.setPnfsManager(pnfsManager);
+        shell.setPoolManager(poolManager);
+        shell.setAcm(acm);
+        shell.setListHandler(list);
+    }
+
+    @Override
+    public void destroy() {
+        shellThread.interrupt();
+    }
+
+    @Override
+    public void setErrorStream(OutputStream err) {
+        errorWriter = new PrintWriter(err);
+    }
+
+    @Override
+    public void setExitCallback(ExitCallback callback) {
+        this.exitCallback = callback;
+    }
+
+    @Override
+    public void setInputStream(InputStream in) {
+        //  we don't use the input stream
+    }
+
+    @Override
+    public void setOutputStream(OutputStream out) {
+        outWriter = new PrintWriter(out);
+    }
+
+    @Override
+    public void start(Environment env)  {
+        shell.setUser(env.getEnv().get(Environment.ENV_USER));
+        shellThread = new Thread(this);
+        shellThread.start();
+    }
+
+    @Override
+    public void run() {
+        try {
+            executeCommands();
+        } catch (RuntimeException e) {
+            LOGGER.error(e.toString());
+        } finally {
+            exitCallback.onExit(0);
+        }
+    }
+
+    private void executeCommands() {
+        for (String command : commands) {
+            Object error = null;
+            try {
+                Object result = shell.executeCommand(command);
+                String s = Strings.toString(result);
+                if (!s.isEmpty()) {
+                    outWriter.println(s);
+                }
+                outWriter.flush();
+            } catch (IllegalArgumentException e) {
+                error = e.toString();
+            } catch (SerializationException e) {
+                error = "There is a bug here, please report to support@dcache.org";
+                LOGGER.error("This must be a bug, please report to support@dcache.org.", e);
+            } catch (CommandSyntaxException e) {
+                error = e;
+            } catch (CommandEvaluationException | CommandAclException e) {
+                error = e.getMessage();
+            } catch (CommandExitException e) {
+                break;
+            } catch (CommandPanicException e) {
+                error = String.format("Command '%s' triggered a bug (%s);"
+                        + "the service log file contains additional information. Please "
+                        + "contact support@dcache.org.", command, e.getTargetException());
+            } catch (CommandException e) {
+                error = e.getMessage();
+            } catch (NoRouteToCellException e) {
+                error = "Cell name does not exist or cell is not started: "
+                        + e.getMessage();
+                LOGGER.warn("Command cannot be executed in the cell, cell is gone {}",
+                        e.getMessage());
+            } catch (RuntimeException e) {
+                error = String.format("Command '%s' triggered a bug (%s); please"
+                        + " locate this message in the log file of the admin service and"
+                        + " send an email to support@dcache.org with this line and the"
+                        + " following stack-trace", command, e);
+                LOGGER.error((String) error, e);
+            } catch (Exception e) {
+                error = e.getMessage();
+                if (error == null) {
+                    error = e.getClass().getSimpleName() + ": (null)";
+                }
+            }
+
+            if (error != null) {
+                if (error instanceof CommandSyntaxException) {
+                    CommandSyntaxException e = (CommandSyntaxException) error;
+                    errorWriter.append("Syntax error: ").println(e.getMessage());
+                } else {
+                    errorWriter.println(error);
+                }
+                errorWriter.flush();
+            }
+        }
+    }
+}

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/DirectCommandFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/DirectCommandFactory.java
@@ -1,0 +1,141 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.services.ssh2;
+
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.CommandFactory;
+import org.springframework.beans.factory.annotation.Required;
+
+import java.util.Arrays;
+
+import dmg.cells.nucleus.CellEndpoint;
+import dmg.cells.nucleus.CellMessageSender;
+
+import org.dcache.cells.CellStub;
+import org.dcache.util.list.ListDirectoryHandler;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Implementation of Command Factory interface that enables
+ * direct command execution in dCache admin server. Commands
+ * are semicolon (;) separated:
+ *   ssh -p PORT user@example.org "command1;command2;command3"
+ *
+ * @author litvinse
+ */
+public class DirectCommandFactory implements CommandFactory, CellMessageSender
+{
+    private static String COMMAND_SEPARATOR = ";";
+    private CellEndpoint endpoint;
+    private CellStub pnfsManager;
+    private CellStub poolManager;
+    private CellStub acm;
+    private String prompt;
+    private ListDirectoryHandler list;
+
+    @Required
+    public void setPnfsManager(CellStub stub)
+    {
+        this.pnfsManager = stub;
+    }
+
+    @Required
+    public void setPoolManager(CellStub stub)
+    {
+        this.poolManager = stub;
+    }
+
+    @Required
+    public void setAcm(CellStub stub)
+    {
+        this.acm = stub;
+    }
+
+    @Required
+    public void setPrompt(String prompt)
+    {
+        this.prompt = prompt;
+    }
+
+    @Required
+    public void setListHandler(ListDirectoryHandler list)
+    {
+        this.list = list;
+    }
+
+    public void setCellEndpoint(CellEndpoint endpoint)
+    {
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public Command createCommand(String command) {
+        checkArgument(command != null, "No command");
+        return new DirectCommand(Arrays.asList(command.split(COMMAND_SEPARATOR)),
+                endpoint,
+                poolManager,
+                pnfsManager,
+                acm,
+                prompt,
+                list);
+    }
+}
+

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -13,6 +13,7 @@ import org.apache.sshd.common.session.Session;
 import org.apache.sshd.common.session.SessionListener;
 import org.apache.sshd.common.util.security.SecurityUtils;
 import org.apache.sshd.server.Command;
+import org.apache.sshd.server.CommandFactory;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.gss.GSSAuthenticator;
 import org.apache.sshd.server.auth.password.PasswordAuthenticator;
@@ -152,9 +153,13 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
     }
 
     @Required
-    public void setShellFactory(Factory<Command> shellCommand)
-    {
+    public void setShellFactory(Factory<Command> shellCommand) {
         _server.setShellFactory(shellCommand);
+    }
+
+    @Required
+    public void setCommandFactory(CommandFactory commandFactory) {
+        _server.setCommandFactory(commandFactory);
     }
 
     @Required

--- a/modules/dcache/src/main/resources/org/dcache/services/ssh2/ssh2Admin.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/ssh2/ssh2Admin.xml
@@ -83,6 +83,22 @@
         </property>
     </bean>
 
+    <bean id="command-factory" class="org.dcache.services.ssh2.DirectCommandFactory">
+        <property name="pnfsManager" ref="pnfsmanager"/>
+        <property name="poolManager" ref="poolmanager"/>
+        <property name="acm" ref="acm"/>
+        <property name="prompt" value="${admin.prompt}"/>
+        <property name="listHandler">
+            <bean class="org.dcache.util.list.ListDirectoryHandler">
+                <constructor-arg>
+                    <bean class="diskCacheV111.util.PnfsHandler">
+                        <constructor-arg ref="pnfsmanager"/>
+                    </bean>
+                </constructor-arg>
+            </bean>
+        </property>
+    </bean>
+
     <bean id="legacy-factory" class="org.dcache.services.ssh2.LegacySubsystemFactory">
         <property name="historyFile" value="${admin.paths.history}"/>
         <property name="historySize" value="${admin.history.size}"/>
@@ -109,6 +125,7 @@
         <property name="loginStrategy"      ref="login-strategy"/>
         <property name="adminGroupId"       value="${admin.authz.gid}"/>
         <property name="shellFactory"       ref="shell-factory"/>
+        <property name="commandFactory"     ref="command-factory"/>
         <property name="subsystemFactories">
             <list>
                 <ref bean="pcells-factory"/>


### PR DESCRIPTION
Motivation

dCache admin shell lacks direct command execution capability, that is,
the following invocation fails:

	ssh -p <port> user@example.com "<command>"

Modification:

Add support for direct command execution by implementing CommandFactory
interface provided by mina-sshd library.

Result:

Direct command execution works with support for semicolon (;)
 separated list of commands like so:

	ssh -p <port> user@example.com "command1; command2; command3"

Target: master
Ticket: https://rt.dcache.org/Ticket/Display.html?id=9418
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/11517/
Acked-by: Paul Millar <paul.millar@desy.de>
Require-book: yes
Require-notes: yes