### PR TITLE
pool: fix lookup for canonical hostname for IPv6 addresses

### DIFF
--- a/modules/dcache/src/test/java/org/dcache/http/HttpsTransferServiceTest.java
+++ b/modules/dcache/src/test/java/org/dcache/http/HttpsTransferServiceTest.java
@@ -1,0 +1,49 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.http;
+
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class HttpsTransferServiceTest
+{
+    @Test
+    public void shouldReturnIPv4AddressAsIPv4Address()
+    {
+        URI url = URI.create("https://192.168.1.1:8443/path/to/file");
+
+        String host = HttpsTransferService.getHost(url);
+
+        assertThat(host, is(equalTo("192.168.1.1")));
+    }
+
+    @Test
+    public void shouldReturnIPv6AddressWithoutBrackets()
+    {
+        URI url = URI.create("https://[2001:638:700:20d6::1:3a]:8443/path/to/file");
+
+        String host = HttpsTransferService.getHost(url);
+
+        assertThat(host, is(equalTo("2001:638:700:20d6::1:3a")));
+    }
+}


### PR DESCRIPTION
Motivation:

Secure/authenticated HTTP transfers require the server to present an
X.509 certificate, which identifies the server by it's DNS FQDN.
Therefore it is important that the pool returns a URL that uses the DNS
FQDN to identify itself.

An earlier patch attempted to enforce this, but did not fix the problem
for IPv6 addresses.

Modification:

Update code to understand IPv6 addresses as IP addresses.

Include diagnostic messages to record if the DNS canonical name lookup
fails.

Result:

Secure HTTP transfers work over IPv6.  Problems are easier to diagnose.

Target: master
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Ticket: https://rt.dcache.org/Ticket/Display.html?id=9606
Patch: https://rb.dcache.org/r/11524/
Acked-by: Albert Rossi