### PR TITLE
alarms: add pool dead alarm

### DIFF
--- a/modules/common/src/main/java/org/dcache/alarms/PredefinedAlarm.java
+++ b/modules/common/src/main/java/org/dcache/alarms/PredefinedAlarm.java
@@ -74,6 +74,7 @@ public enum PredefinedAlarm implements Alarm {
    HSM_SCRIPT_FAILURE,
    POOL_DOWN,
    POOL_DISABLED,
+   POOL_DEAD,
    POOL_SIZE,
    POOL_FREE_SPACE,
    BROKEN_FILE,

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -558,16 +558,19 @@ public class PoolV4
     {
         Throwable cause = event.getCause();
         String poolState;
+        PredefinedAlarm alarm;
         switch (event.getAction()) {
         case READONLY:
             poolState = "Pool read-only: ";
             disablePool(PoolV2Mode.DISABLED_RDONLY,
                             99, poolState + event.getMessage());
+            alarm = null;
             break;
 
         case DISABLED:
             poolState = "Pool disabled: ";
             disablePool(PoolV2Mode.DISABLED_STRICT, 99, poolState + event.getMessage());
+            alarm = PredefinedAlarm.POOL_DISABLED;
             break;
 
         default:
@@ -575,20 +578,21 @@ public class PoolV4
             disablePool(PoolV2Mode.DISABLED_STRICT
                             | PoolV2Mode.DISABLED_DEAD,
                             666, poolState + event.getMessage());
+            alarm = PredefinedAlarm.POOL_DEAD;
             break;
         }
 
-        String message = "Fault occurred in " + event.getSource() + ": "
-                        + event.getMessage() +". " + poolState;
-
-        if (cause != null) {
-            LOGGER.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.POOL_DISABLED,
-                                                      _poolName),
-                         "{}: {}", message, cause.toString());
-        } else {
-            LOGGER.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.POOL_DISABLED,
-                                                      _poolName),
-                         message);
+        if (alarm != null) {
+            if (cause != null) {
+                LOGGER.error(AlarmMarkerFactory.getMarker(alarm, _poolName),
+                             "Fault occurred in {}: {}. {}, cause: {}",
+                             event.getSource(), event.getMessage(), poolState,
+                             cause.toString());
+            } else {
+                LOGGER.error(AlarmMarkerFactory.getMarker(alarm, _poolName),
+                             "Fault occurred in {}: {}. {}",
+                             event.getSource(), event.getMessage(), poolState);
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

The granularity for pool alarms currently does not
distinguish between disabled and dead.  That distinction,
however, is useful in order to set different priority
levels and as a consequence only send an alarm
email for the latter.

Modification:

Add POOL_DEAD predefined alarm, and alter the FaultEvent listener
code accordingly.

Result:

Pool errors involving a fatal repository fault, for
instance, can be sent as an email alarm without
having to send all pool disabled alarms.

This is something we need at Fermi.  I would argue
this is actually a bug, not a new feature, so
I am requesting a backport to 4.2 (and beyond).

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-book: no
Requires-notes: yes
Acked-by: Tigran