### PR TITLE
pool: avoid using the same error message in multiple places

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/P2PClient.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/P2PClient.java
@@ -190,8 +190,7 @@ public class P2PClient
                  * around.
                  */
                 if (t == null) {
-                    cancelCompanions(pnfsId,
-                                     "Replica already exists");
+                    cancelCompanions(pnfsId, "Replicated by another transfer");
                 }
             } catch (InterruptedException e) {
                 // Ignored, typically happens at cell shutdown
@@ -226,8 +225,9 @@ public class P2PClient
         if (_pnfs == null) {
             throw new IllegalStateException("PNFS stub not initialized");
         }
-        if (_repository.getState(fileAttributes.getPnfsId()) != ReplicaState.NEW) {
-            throw new IllegalStateException("Replica already exists");
+        ReplicaState state = _repository.getState(fileAttributes.getPnfsId());
+        if (state != ReplicaState.NEW) {
+            throw new IllegalStateException("Replica exists with state: " + state);
         }
 
         Callback cb = new Callback(callback);


### PR DESCRIPTION
Motivation:

The error message 'Replica already exists' is used in three different
places, making it hard to know what exactly went wrong if that message
is logged.

Modification:

Update two of the three error messages so the message is clearer.  The
replica's state is also logged at that may be useful information.

Result:

Pool errors due to pool-to-pool replication problems (previously
reported as "Replica already exists") now use distinct messages.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11532/
Acked-by: Tigran Mkrtchyan