### PR TITLE
transfermanager: include pool address in the mover start failure message

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -314,8 +314,9 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             //        pool.  For an attempted write (pool pulling the file)
             //        we must fail the transfer as we don't know if a mover
             //        was started.
-            sendErrorReply(CacheException.SELECTED_POOL_FAILED,
-                    "Failed while waiting for mover to start: " + error);
+            sendErrorReply(CacheException.SELECTED_POOL_FAILED, "Failed while"
+                    + " waiting for mover on " + pool.getAddress() + " to"
+                    + " start: "+ error);
             break;
 
         case WAITING_FOR_PNFS_CHECK_BEFORE_DELETE_STATE:


### PR DESCRIPTION
Motivation:

The transfermanager returns an error to the caller (e.g., WebDAV) if
there was a problem starting the mover.  This message does not include
any details describing on which pool this failure occured.  Without this
information, it is impossible to know which pool is rejecting the
transfer.

Modification:

Update message returned to the door so it include's the pool's address.

Result:

HTTP TPC failures in which the pool does not start the mover now include
the pool's address in the error message.  This allows admins to
investigate further.

Target: master
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11525/
Acked-by: Vincent Garonne