### PR TITLE
gplazma: JAAS plugin logs a stack-trace on misconfiguration

### DIFF
--- a/modules/gplazma2-jaas/src/main/java/org/dcache/gplazma/plugins/JaasPlugin.java
+++ b/modules/gplazma2-jaas/src/main/java/org/dcache/gplazma/plugins/JaasPlugin.java
@@ -1,5 +1,8 @@
 package org.dcache.gplazma.plugins;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
@@ -20,6 +23,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.getFirst;
 import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
+import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
  * A {@link GPlazmaAuthenticationPlugin} implementation which verifies
@@ -30,6 +34,7 @@ import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
  */
 public class JaasPlugin implements GPlazmaAuthenticationPlugin
 {
+    private static final Logger LOG = LoggerFactory.getLogger(JaasPlugin.class);
     private static final String NAME = "gplazma.jaas.name";
 
     private final String _name;
@@ -59,6 +64,9 @@ public class JaasPlugin implements GPlazmaAuthenticationPlugin
             loginContext.login();
             identifiedPrincipals.addAll(loginContext.getSubject().getPrincipals());
             tryToLogout(loginContext);
+        } catch (SecurityException e) {
+            LOG.error("Plugin not authorised to use JAAS: {}", messageOrClassName(e));
+            throw new AuthenticationException("Not authorised to use JAAS");
         } catch (LoginException e) {
             throw new AuthenticationException(e.getMessage(), e);
         }


### PR DESCRIPTION
Motivation:

Observed the following in gPlazma log file:

    07 Feb 2019 13:53:09 (gPlazma) [WebDAV-dcache-door-doma01 Login AUTH jaas] Bug in plugin:
    java.lang.SecurityException: java.io.IOException: Configuration Error:
            Line 1: expected [{], found [null]
            at sun.security.provider.ConfigFile$Spi.<init>(ConfigFile.java:137) ~[na:1.8.0_191]
            at sun.security.provider.ConfigFile.<init>(ConfigFile.java:102) ~[na:1.8.0_191]
            at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_191]
            at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_191]
            at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_191]
            at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_191]
            at java.lang.Class.newInstance(Class.java:442) ~[na:1.8.0_191]
            at javax.security.auth.login.Configuration$2.run(Configuration.java:255) ~[na:1.8.0_191]
            at javax.security.auth.login.Configuration$2.run(Configuration.java:247) ~[na:1.8.0_191]
            at java.security.AccessController.doPrivileged(Native Method) ~[na:1.8.0_191]
            at javax.security.auth.login.Configuration.getConfiguration(Configuration.java:246) ~[na:1.8.0_191]
            at javax.security.auth.login.LoginContext$1.run(LoginContext.java:245) ~[na:1.8.0_191]
            at javax.security.auth.login.LoginContext$1.run(LoginContext.java:243) ~[na:1.8.0_191]
            at java.security.AccessController.doPrivileged(Native Method) ~[na:1.8.0_191]
            at javax.security.auth.login.LoginContext.init(LoginContext.java:243) ~[na:1.8.0_191]
            at javax.security.auth.login.LoginContext.<init>(LoginContext.java:417) ~[na:1.8.0_191]
            at org.dcache.gplazma.plugins.JaasPlugin.authenticate(JaasPlugin.java:56) ~[gplazma2-jaas-5.0.2.jar:5.0.2]
            at org.dcache.gplazma.plugins.GPlazmaAuthenticationPlugin.authenticate(GPlazmaAuthenticationPlugin.java:49) ~[gplazma2-5.0.2.jar:5.0.2]
            at org.dcache.gplazma.strategies.DefaultAuthenticationStrategy.lambda$authenticate$0(DefaultAuthenticationStrategy.java:67) [gplazma2-5.0.2.jar:5.0.2]
            at org.dcache.gplazma.strategies.PAMStyleStrategy.callPlugins(PAMStyleStrategy.java:98) ~[gplazma2-5.0.2.jar:5.0.2]
            at org.dcache.gplazma.strategies.DefaultAuthenticationStrategy.authenticate(DefaultAuthenticationStrategy.java:57) [gplazma2-5.0.2.jar:5.0.2]
            at org.dcache.gplazma.GPlazma$Setup.doAuthPhase(GPlazma.java:557) [gplazma2-5.0.2.jar:5.0.2]
            at org.dcache.gplazma.GPlazma.login(GPlazma.java:268) [gplazma2-5.0.2.jar:5.0.2]
            at org.dcache.gplazma.GPlazma.login(GPlazma.java:227) [gplazma2-5.0.2.jar:5.0.2]
            at org.dcache.auth.Gplazma2LoginStrategy.login(Gplazma2LoginStrategy.java:156) [dcache-gplazma-5.0.2.jar:5.0.2]
            at org.dcache.services.login.MessageHandler.messageArrived(MessageHandler.java:69) [dcache-core-5.0.2.jar:5.0.2]
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_191]
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_191]
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_191]
            at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_191]
            at org.dcache.cells.CellMessageDispatcher$LongReceiver.deliver(CellMessageDispatcher.java:304) [dcache-core-5.0.2.jar:5.0.2]
            at org.dcache.cells.CellMessageDispatcher.call(CellMessageDispatcher.java:201) [dcache-core-5.0.2.jar:5.0.2]
            at org.dcache.cells.AbstractCell.messageArrived(AbstractCell.java:331) [dcache-core-5.0.2.jar:5.0.2]
            at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:891) [cells-5.0.2.jar:5.0.2]
            at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1211) [cells-5.0.2.jar:5.0.2]
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) [dcache-common-5.0.2.jar:5.0.2]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_191]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_191]
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$4(CellNucleus.java:747) [cells-5.0.2.jar:5.0.2]
            at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_191]
    Caused by: java.io.IOException: Configuration Error:
            Line 1: expected [{], found [null]
            at sun.security.provider.ConfigFile$Spi.ioException(ConfigFile.java:666) ~[na:1.8.0_191]
            at sun.security.provider.ConfigFile$Spi.match(ConfigFile.java:579) ~[na:1.8.0_191]
            at sun.security.provider.ConfigFile$Spi.parseLoginEntry(ConfigFile.java:445) ~[na:1.8.0_191]
            at sun.security.provider.ConfigFile$Spi.readConfig(ConfigFile.java:427) ~[na:1.8.0_191]
            at sun.security.provider.ConfigFile$Spi.init(ConfigFile.java:329) ~[na:1.8.0_191]
            at sun.security.provider.ConfigFile$Spi.init(ConfigFile.java:271) ~[na:1.8.0_191]
            at sun.security.provider.ConfigFile$Spi.<init>(ConfigFile.java:135) ~[na:1.8.0_191]
            ... 39 common frames omitted

Note that, as SecurityException is a RuntimeException, dCache considers
it a bug.

Modification:

Catch the SecurityException, log it, and throw a non-RuntimeException.

Result:

The JAAS gplazma plugin no longer logs a stacktrace on bad configuration.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11534/
Acked-by: Tigran Mkrtchyan