### PR TITLE
webdav/frontend: add switch to reject macaroons sent unencrypted

### DIFF
--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -405,6 +405,8 @@
                     <property name="readOnly" value="${frontend.authz.readonly}"/>
                     <property name="enableBasicAuthentication" value="${frontend.authn.basic}"/>
                     <property name="realm" value="${frontend.authn.realm}"/>
+                    <property name="acceptBearerTokenUnencrypted"
+                              value="${frontend.macaroons.accept-over-unencrypted-channel}"/>
                 </bean>
             </list>
         </property>

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -347,6 +347,8 @@
         <property name="enableBasicAuthentication" value="${webdav.authn.basic}"/>
         <property name="enableSpnegoAuthentication" value="${webdav.authn.spnego}"/>
         <property name="realm" value="${webdav.authn.realm}"/>
+        <property name="acceptBearerTokenUnencrypted"
+                  value="${webdav.macaroons.accept-over-unencrypted-channel}"/>
     </bean>
 
     <bean id="lb" class="dmg.cells.services.login.LoginBrokerPublisher">

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1127,6 +1127,25 @@ dcache.macaroons.default-lifetime = 1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
 dcache.macaroons.default-lifetime.unit = DAYS
 
+#  Whether to accept macaroons over an unencrypted channel.
+#
+#  Macaroons are bearer tokens: anyone who steals a macaroon can use
+#  it.  Therefore, it is important to keep the macaroon secret.
+#  Sending a macaroon over an unencrypted channel introduces the risk
+#  that someone steals the token.  dCache cannot prevent a client from
+#  sending a macaroon unencrypted; however, it can fail all such
+#  requests.
+#
+#  With very careful evaluation by someone well versed in computer
+#  security trade-offs, there may be some very specific, limited
+#  circumstances where the associated risk of enabling unencrypted
+#  macaroon is acceptable.
+#
+#  In the vast majority of cases, dCache should NOT accept macaroons
+#  over an unencrypted channel.
+#
+(one-of?true|false)dcache.macaroons.accept-over-unencrypted-channel = true
+
 
 
 #  -----------------------------------------------------------------------

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -563,6 +563,8 @@ frontend.enable.macaroons = ${dcache.enable.macaroons}
 frontend.macaroons.expired-removal-period = ${dcache.macaroons.expired-removal-period}
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.macaroons.expired-removal-period.unit})\
 frontend.macaroons.expired-removal-period.unit = ${dcache.macaroons.expired-removal-period.unit}
+(one-of?true|false|${dcache.macaroons.accept-over-unencrypted-channel})\
+frontend.macaroons.accept-over-unencrypted-channel = ${dcache.macaroons.accept-over-unencrypted-channel}
 
 frontend.version.swagger-ui = @version.swagger-ui@
 

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -88,7 +88,8 @@ webdav.macaroons.max-lifetime.unit = ${dcache.macaroons.max-lifetime.unit}
 webdav.macaroons.default-lifetime = ${dcache.macaroons.default-lifetime}
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.macaroons.default-lifetime.unit})\
 webdav.macaroons.default-lifetime.unit = ${dcache.macaroons.default-lifetime.unit}
-
+(one-of?true|false|${dcache.macaroons.accept-over-unencrypted-channel})\
+webdav.macaroons.accept-over-unencrypted-channel = ${dcache.macaroons.accept-over-unencrypted-channel}
 
 #  ---- Mover queue
 #

--- a/skel/share/services/frontend.batch
+++ b/skel/share/services/frontend.batch
@@ -84,6 +84,8 @@ check frontend.static!dcache-view.oidc-authz-endpoint-list
 
 check frontend.authn.ciphers
 
+check -strong frontend.macaroons.accept-over-unencrypted-channel
+
 onerror continue
 test -f ${frontend.authn.keystore}
 set env have_keystore ${rc}

--- a/skel/share/services/webdav.batch
+++ b/skel/share/services/webdav.batch
@@ -76,6 +76,8 @@ check -strong webdav.limits.queue-length
 check -strong webdav.limits.graceful-shutdown
 check -strong webdav.limits.graceful-shutdown.unit
 
+check -strong webdav.macaroons.accept-over-unencrypted-channel
+
 check webdav.net.internal
 check webdav.mover.queue
 check webdav.authn.ciphers


### PR DESCRIPTION
Motivation:

Bearer tokens are susceptible to being stolen.  To prevent this, it is
normally required that such tokens are only ever sent over an encrypted
channel.

dCache cannot enforce this behaviour, as it is the clients decision what
it sends over the network.  However, we can deliberately "break" such
clients, to act as a strong indicator that something is wrong.

Modification:

Update AuthenticationHandler to reject any macaroon sent over an
unencrypted channel.

Note: the default is set to not enforce this behaviour, as we want to
back-port this patch.  There should be a follow-up patch (targeting just
'master') where the default value is updated.

Result:

Sites may configure dCache to reject any macaroons send over an
unencrypted channel.  This is following security recommendations.  The
default behaviour is to continue accepting macaroons sent over an
unencrypted channel to avoid breaking existing deployment.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/11522/
Acked-by: Tigran Mkrtchyan