### PR TITLE
Fixed typo in PoolSelectionUnit Method

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/UnitGroup.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/selection/UnitGroup.java
@@ -85,7 +85,7 @@ public final class UnitGroup extends SelectionTypeWithLinks {
 
     public UnitGroup(SelectionUnitGroup group, PoolSelectionUnit psu) {
         super(group.getName(), psu);
-        units = group.getMemeberUnits()
+        units = group.getMemberUnits()
                      .stream()
                      .sorted(Comparator.comparing(SelectionUnit::getName))
                      .map(SelectionUnit::getName)

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/StorageUnitInfoExtractor.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/StorageUnitInfoExtractor.java
@@ -105,7 +105,7 @@ public final class StorageUnitInfoExtractor {
         psu.getLinksPointingToPoolGroup(name).stream()
                         .map(SelectionLink::getUnitGroupsTargetedBy)
                         .flatMap(Collection::stream)
-                        .map(SelectionUnitGroup::getMemeberUnits)
+                        .map(SelectionUnitGroup::getMemberUnits)
                         .flatMap(Collection::stream)
                         .filter(StorageUnit.class::isInstance)
                         .map(StorageUnit.class::cast)

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnit.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnit.java
@@ -195,7 +195,7 @@ public interface PoolSelectionUnit  {
     }
 
     interface SelectionUnitGroup extends SelectionEntity {
-        Collection<SelectionUnit> getMemeberUnits();
+        Collection<SelectionUnit> getMemberUnits();
         Collection<SelectionLink> getLinksPointingTo();
     }
    SelectionPool getPool(String poolName) ;

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/UGroup.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/UGroup.java
@@ -28,7 +28,7 @@ class UGroup implements Serializable, SelectionUnitGroup {
     }
 
     @Override
-    public Collection<SelectionUnit> getMemeberUnits() {
+    public Collection<SelectionUnit> getMemberUnits() {
         return new ArrayList<>(_unitList.values());
     }
 


### PR DESCRIPTION
`getMemberUnits()` was called `getMemeberUnits`. 
Method was used in 
* `dcache-frontend/src/main/java/org/dcache/restful/providers/selection/UnitGroup.java`
* `dcache-resilience/src/main/java/org/dcache/resilience/util/StorageUnitInfoExtractor.java`
* `poolManager/PoolSelectionUnit.java`
* `poolManager/UGroup.java`