### PR TITLE
transfermanager: abort transfer if there is a bug

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -231,6 +231,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
     @Override
     public void success(Message message)
     {
+        try {
             if (message instanceof PnfsCreateEntryMessage) {
                 PnfsCreateEntryMessage create_msg =
                         (PnfsCreateEntryMessage) message;
@@ -289,7 +290,11 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                     sendErrorReply();
                 }
             }
-        manager.persist(this);
+            manager.persist(this);
+        } catch (RuntimeException e) {
+            log.error("Bug detected in transfermanager, please report this to <support@dCache.org>", e);
+            failure(1, "Bug detected: " + e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Transfermanager contains a bug that is triggered if a client attempts to
copy a file that is still being uploaded.

However, the more serious problem is that, if transfermanager encounters
such a bug, the transfer is left in a limbo state and not terminated.

Modification:

Catch runtime exception, log the stack-trace and fail the transfer.

Result:

A bug in transfermanager now terminates a transfer, rather than leaving
it in a limbo state.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/11544/
Acked-by: Dmitry Litvintsev