### PR TITLE
webdav: fail COPY early if file is currently being uploaded

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -78,8 +78,7 @@ import org.dcache.webdav.transfer.CopyFilter.CredentialSource;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.dcache.namespace.FileAttribute.PNFSID;
-import static org.dcache.namespace.FileAttribute.TYPE;
+import static org.dcache.namespace.FileAttribute.*;
 import static org.dcache.util.ByteUnit.MiB;
 import static org.dcache.webdav.transfer.CopyFilter.CredentialSource.*;
 
@@ -376,10 +375,14 @@ public class RemoteTransferHandler implements CellMessageReceiver
                 case PUSH:
                     try {
                         FileAttributes attributes = _pnfs.getFileAttributes(_path.toString(),
-                                EnumSet.of(PNFSID, TYPE), READ_ACCESS_MASK, false);
+                                EnumSet.of(PNFSID, SIZE, TYPE), READ_ACCESS_MASK, false);
 
                         if (attributes.getFileType() != FileType.REGULAR) {
                             throw new ErrorResponseException(Response.Status.SC_BAD_REQUEST, "Not a file");
+                        }
+
+                        if (!attributes.isDefined(SIZE)) {
+                            throw new ErrorResponseException(Response.Status.SC_CONFLICT, "File upload in progress");
                         }
 
                         return attributes.getPnfsId();


### PR DESCRIPTION
Motivation:

Sites have reported errors like:

    java.lang.IllegalArgumentException: Required attributes are missing.
            at com.google.common.base.Preconditions.checkArgument(Preconditions.java:135) ~[guava-24.1-jre.jar:na]
            at diskCacheV111.vehicles.PoolMgrSelectReadPoolMsg.<init>(PoolMgrSelectReadPoolMsg.java:78) ~[dcache-core-5.1.0-SNAPSHOT.jar:5.1.0-SNAPSHOT]
            at diskCacheV111.vehicles.PoolMgrSelectReadPoolMsg.<init>(PoolMgrSelectReadPoolMsg.java:63) ~[dcache-core-5.1.0-SNAPSHOT.jar:5.1.0-SNAPSHOT]
            at diskCacheV111.services.TransferManagerHandler.selectPool(TransferManagerHandler.java:421) ~[dcache-core-5.1.0-SNAPSHOT.jar:5.1.0-SNAPSHOT]
            at diskCacheV111.services.TransferManagerHandler.storageInfoArrived(TransferManagerHandler.java:415) ~[dcache-core-5.1.0-SNAPSHOT.jar:5.1.0-SNAPSHOT]
            at diskCacheV111.services.TransferManagerHandler.success(TransferManagerHandler.java:250) ~[dcache-core-5.1.0-SNAPSHOT.jar:5.1.0-SNAPSHOT]
            at org.dcache.cells.AbstractMessageCallback.success(AbstractMessageCallback.java:32) ~[dcache-core-5.1.0-SNAPSHOT.jar:5.1.0-SNAPSHOT]
            at org.dcache.cells.CellStub.lambda$addCallback$0(CellStub.java:516) ~[dcache-core-5.1.0-SNAPSHOT.jar:5.1.0-SNAPSHOT]
            at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149) ~[dcache-core-5.1.0-SNAPSHOT.jar:5.1.0-SNAPSHOT]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_191]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_191]
            at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_191]

These are (likely) due to a client attempting to issue COPY request for
a file that is still being uploaded.

Modification:

Return a clear error (409 status code) to client if this happens.

Result:

Attempts by a client to copy a file that has not fully been uploaded now
results in a clear error response.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11545/
Acked-by: Dmitry Litvintsev