### PR TITLE
transfermanager: fail third-party copy if the file is still being upl…

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executor;
 
 import diskCacheV111.doors.FTPTransactionLog;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileIsNewCacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.DoorRequestInfoMessage;
 import diskCacheV111.vehicles.DoorTransferFinishedMessage;
@@ -237,6 +238,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             EnumSet<FileAttribute> attributes = EnumSet.noneOf(FileAttribute.class);
             attributes.addAll(permissionHandler.getRequiredAttributes());
             attributes.addAll(PoolMgrSelectReadPoolMsg.getRequiredAttributes());
+            attributes.add(SIZE); // to determine if file is currently being uploaded
             message = pnfsId == null ? new PnfsGetFileAttributes(pnfsPath, attributes)
                     : new PnfsGetFileAttributes(pnfsId, attributes);
             message.setSubject(transferRequest.getSubject());
@@ -408,6 +410,11 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void storageInfoArrived(PnfsGetFileAttributes msg)
     {
+        if (!msg.getFileAttributes().isDefined(SIZE)) {
+            sendErrorReply(CacheException.FILE_IS_NEW, new FileIsNewCacheException());
+            return;
+        }
+
         if (!store && tlog != null) {
             tlog.middle(msg.getFileAttributes().getSize());
         }


### PR DESCRIPTION
…oaded

Motivation:

A client may initiate a third-party copy that targets a file that is
still being uploaded.  These currently lead to a bug, where the SIZE
attribute is missing.

Modification:

Add a check to see whether the file is being uploaded.  Fail the request
if it is.

Result:

Third-party transfers fail if the client is requesting to copy a file
from dCache that has not fully been uploaded.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11546/
Acked-by: Dmitry Litvintsev