### PR TITLE
srm: do not log a stack-trace on expected Exception errors

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/PinCompanion.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/PinCompanion.java
@@ -100,6 +100,7 @@ import org.dcache.srm.SRMException;
 import org.dcache.srm.SRMFileUnvailableException;
 import org.dcache.srm.SRMInternalErrorException;
 import org.dcache.srm.SRMInvalidPathException;
+import org.dcache.util.Exceptions;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.PnfsGetFileAttributes;
 
@@ -141,7 +142,10 @@ public class PinCompanion extends AbstractFuture<AbstractStorageElement.Pin>
         @Override
         public void failure(int rc, Object error)
         {
-            fail(rc, error);
+            String message = error instanceof Exception
+                    ? Exceptions.messageOrClassName((Exception)error)
+                    : String.valueOf(error);
+            fail(rc, message);
         }
     }
 
@@ -302,7 +306,7 @@ public class PinCompanion extends AbstractFuture<AbstractStorageElement.Pin>
         _state = new PinnedState();
     }
 
-    private void fail(int rc, Object error)
+    private void fail(int rc, String error)
     {
         switch (rc) {
         case FILE_NOT_FOUND:
@@ -311,12 +315,12 @@ public class PinCompanion extends AbstractFuture<AbstractStorageElement.Pin>
 
         case FILE_NOT_IN_REPOSITORY:
             _log.warn("Pinning failed for {} ({})", _path, error);
-            setException(new SRMFileUnvailableException(error.toString()));
+            setException(new SRMFileUnvailableException(error));
             break;
 
         case PERMISSION_DENIED:
             _log.warn("Pinning failed for {} ({})", _path, error);
-            setException(new SRMAuthorizationException(error.toString()));
+            setException(new SRMAuthorizationException(error));
             break;
 
         case TIMEOUT:

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/SrmReleaseSpaceCompanion.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/SrmReleaseSpaceCompanion.java
@@ -83,6 +83,7 @@ import dmg.cells.nucleus.CellPath;
 import org.dcache.cells.AbstractMessageCallback;
 import org.dcache.cells.CellStub;
 import org.dcache.srm.SrmReleaseSpaceCallback;
+import org.dcache.util.Exceptions;
 
 public final class SrmReleaseSpaceCompanion
         extends AbstractMessageCallback<Release>
@@ -105,8 +106,11 @@ public final class SrmReleaseSpaceCompanion
             SpaceException se = (SpaceException) error;
             callback.failed(se.getMessage());
         } else {
-            LOGGER.error("Space Release Failed rc: {} error: {}", rc, error);
-            callback.failed("Failed to release space: " + error);
+            String message = error instanceof Exception
+                    ? Exceptions.messageOrClassName((Exception)error)
+                    : String.valueOf(error);
+            LOGGER.error("Space Release Failed rc: {} error: {}", rc, message);
+            callback.failed("Failed to release space: " + message);
         }
     }
 

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/UnpinCompanion.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/UnpinCompanion.java
@@ -82,6 +82,7 @@ import org.dcache.cells.CellStub;
 import org.dcache.pinmanager.PinManagerUnpinMessage;
 import org.dcache.srm.SRMException;
 import org.dcache.srm.SRMInternalErrorException;
+import org.dcache.util.Exceptions;
 
 import static diskCacheV111.util.CacheException.TIMEOUT;
 
@@ -116,9 +117,12 @@ public class UnpinCompanion
             break;
 
         default:
-            _log.error("Unpinning failed for {} [rc={},msg={}]", pnfsId, rc, error);
+            String message = error instanceof Exception
+                    ? Exceptions.messageOrClassName((Exception)error)
+                    : String.valueOf(error);
+            _log.error("Unpinning failed for {} [rc={},msg={}]", pnfsId, rc, message);
             String reason =
-                String.format("Failed to unpin file [rc=%d,msg=%s]", rc, error);
+                String.format("Failed to unpin file [rc=%d,msg=%s]", rc, message);
             future.setException(new SRMException(reason));
             break;
         }


### PR DESCRIPTION
Motivation:

A site has reported log entries like:

    11 Feb 2019 15:15:31 (SrmManager) [Mo8:87120605:srm2:bringOnline:-1965405430:-1965405382 Mo8:87120605:srm2:bringOnline SRM-srm] Pinning failed for /pnfs/grid.sara.nl/data/atlas/atlasdatatape/data16_13TeV/RAW/other/data16_13TeV.00301932.physics_CosmicCalo.merge.RAW/data16_13TeV.00301932.physics_CosmicCalo.merge.RAW._lb0153._SFO-ALL._0001.1 [rc=10011,msg={}].
    org.springframework.dao.CannotSerializeTransactionException: PreparedStatementCallback; SQL [UPDATE pins SET state = ?,request_id = ? WHERE id = ?]; ERROR: could not serialize access due to concurrent update; nested exception is org.postgresql.util.PSQLException: ERROR: could not serialize access due to concurrent update
            at org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator.doTranslate(SQLErrorCodeSQLExceptionTranslator.java:267) ~[spring-jdbc-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:73) ~[spring-jdbc-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:649) ~[spring-jdbc-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:870) ~[spring-jdbc-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:931) ~[spring-jdbc-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:941) ~[spring-jdbc-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.dcache.pinmanager.JdbcDao.update(JdbcDao.java:125) ~[dcache-core-3.2.41.jar:3.2.41]
            at org.dcache.pinmanager.PinDao.update(PinDao.java:74) ~[dcache-core-3.2.41.jar:3.2.41]
            at org.dcache.pinmanager.PinRequestProcessor.createTask_aroundBody0(PinRequestProcessor.java:554) ~[dcache-core-3.2.41.jar:3.2.41]
            at org.dcache.pinmanager.PinRequestProcessor$AjcClosure1.run(PinRequestProcessor.java:1) ~[dcache-core-3.2.41.jar:3.2.41]
            at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96cproceed(AbstractTransactionAspect.aj:66) ~[spring-aspects-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.transaction.aspectj.AbstractTransactionAspect$AbstractTransactionAspect$1.proceedWithInvocation(AbstractTransactionAspect.aj:72) ~[spring-aspects-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:282) ~[spring-tx-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96c(AbstractTransactionAspect.aj:70) ~[spring-aspects-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.dcache.pinmanager.PinRequestProcessor.createTask(PinRequestProcessor.java:539) ~[dcache-core-3.2.41.jar:3.2.41]
            at org.dcache.pinmanager.PinRequestProcessor.messageArrived(PinRequestProcessor.java:199) ~[dcache-core-3.2.41.jar:3.2.41]
            at sun.reflect.GeneratedMethodAccessor254.invoke(Unknown Source) ~[na:na]
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_191]
            at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_191]
            at org.dcache.cells.CellMessageDispatcher$ShortReceiver.deliver(CellMessageDispatcher.java:289) ~[dcache-core-3.2.41.jar:3.2.41]
            at org.dcache.cells.CellMessageDispatcher.call(CellMessageDispatcher.java:202) ~[dcache-core-3.2.41.jar:3.2.41]
            at org.dcache.cells.AbstractCell.messageArrived(AbstractCell.java:331) ~[dcache-core-3.2.41.jar:3.2.41]
            at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:890) ~[cells-3.2.41.jar:3.2.41]
            at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1218) ~[cells-3.2.41.jar:3.2.41]
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) ~[dcache-common-3.2.41.jar:3.2.41]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_191]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_191]
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$4(CellNucleus.java:754) ~[cells-3.2.41.jar:3.2.41]
            at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_191]
    Caused by: org.postgresql.util.PSQLException: ERROR: could not serialize access due to concurrent update
            at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2455) ~[postgresql-9.4.1212.jar:9.4.1212]
            at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2155) ~[postgresql-9.4.1212.jar:9.4.1212]
            at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:288) ~[postgresql-9.4.1212.jar:9.4.1212]
            at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:430) ~[postgresql-9.4.1212.jar:9.4.1212]
            at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:356) ~[postgresql-9.4.1212.jar:9.4.1212]
            at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:168) ~[postgresql-9.4.1212.jar:9.4.1212]
            at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:135) ~[postgresql-9.4.1212.jar:9.4.1212]
            at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61) ~[HikariCP-2.6.0.jar:na]
            at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java) ~[HikariCP-2.6.0.jar:na]
            at org.springframework.jdbc.core.JdbcTemplate$2.doInPreparedStatement(JdbcTemplate.java:877) ~[spring-jdbc-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.jdbc.core.JdbcTemplate$2.doInPreparedStatement(JdbcTemplate.java:870) ~[spring-jdbc-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:633) ~[spring-jdbc-4.3.8.RELEASE.jar:4.3.8.RELEASE]
            ... 26 common frames omitted

The intention was to log a simple message when a SQL transaction fails
due to (expected) concurrent updates.

Modification:

More careful conversion of an error Object into a String.  Similar
problems elsewhere in dCache SRM plugin are also updated.

Result:

No more stack-traces from concurrent updates in pin-manager and similar
(expected) failures.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11543/
Acked-by: Dmitry Litvintsev