### PR TITLE
webdav/frontend: disabling basic authn should not disable macaroons

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
@@ -262,15 +262,16 @@ public class AuthenticationHandler extends HandlerWrapper {
 
 
     private void addAuthCredentialsToSubject(HttpServletRequest request, Subject subject) {
-        if (!_isBasicAuthenticationEnabled) {
-            return;
-        }
 
         Optional<AuthInfo> optional = parseAuthenticationHeader(request);
         if (optional.isPresent()) {
             AuthInfo info = optional.get();
             switch (info.getScheme()) {
                 case HttpServletRequest.BASIC_AUTH:
+                    if (!_isBasicAuthenticationEnabled) {
+                        return;
+                    }
+
                     try {
                         byte[] bytes = Base64.getDecoder().decode(info.getData().getBytes(StandardCharsets.US_ASCII));
                         String credential = new String(bytes, StandardCharsets.UTF_8);


### PR DESCRIPTION
Motivation:

The 'webdav.authn.basic' and 'frontend.authn.basic' properties control
whether basic authentication is supported.  A site that configures one
of these properties to 'false' prevents users from supplying username +
password.

This configuration properties also has the undocumented (and undesired)
side-effect of disabling support for macaroons if present through the
Authorization HTTP request header, through the 'bearer' authz scheme.

Modification:

Move the *.authn.basic check so it only affects BASIC authentication.

Result:

Fix 'webdav.authn.basic' and 'frontend.authn.basic' so that setting
these configuration properties to 'false' no longer blocks macaroons
from being accepted in the HTTP Authorization header.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11541/
Acked-by: Dmitry Litvintsev