### PR TITLE
xrootd: fix access logging when xrootd door is configured with HAproxy

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/ProxyAccessLogHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/ProxyAccessLogHandler.java
@@ -19,6 +19,7 @@
 package org.dcache.xrootd.plugins;
 
 import com.google.common.net.HostAndPort;
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.haproxy.HAProxyCommand;
@@ -72,7 +73,7 @@ public class ProxyAccessLogHandler extends AccessLogHandler
                     log.add("socket.remote", remoteAddress);
                     log.add("socket.local", localAddress);
                     log.toLogger(logger);
-                    ctx.channel().pipeline().replace(this, null, handler);
+                    replaceWith(ctx, handler);
                 } else if (!Objects.equals(destinationAddress, localAddress.getAddress().getHostAddress())) {
                     /* The above check is a workaround for what looks like a bug in HAProxy - health checks
                      * should generate a LOCAL command, but it appears they do actually use PROXY.
@@ -86,11 +87,16 @@ public class ProxyAccessLogHandler extends AccessLogHandler
                             HostAndPort.fromParts(destinationAddress, proxyMessage.destinationPort()));
                     log.add("socket.local", localAddress);
                     log.toLogger(logger);
-                    ctx.channel().pipeline().replace(this, null, handler);
+                    replaceWith(ctx, handler);
                 }
             }
         }
         super.channelRead(ctx, msg);
+    }
+
+    protected void replaceWith(ChannelHandlerContext ctx, ChannelHandler handler)
+    {
+        ctx.channel().pipeline().replace(this, null, handler);
     }
 
     @Override

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/ProxyAccessLogHandlerFactory.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/ProxyAccessLogHandlerFactory.java
@@ -19,12 +19,22 @@
 package org.dcache.xrootd.plugins;
 
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
 
 import org.dcache.util.ChannelCdcSessionHandlerWrapper;
 
 public class ProxyAccessLogHandlerFactory extends AccessLogHandlerFactory
 {
-    private final ChannelHandler proxyAccessLogHandler = new ChannelCdcSessionHandlerWrapper(new ProxyAccessLogHandler(accessLogger, handler));
+    private final ChannelHandler proxyAccessLogHandler = new ChannelCdcSessionHandlerWrapper(
+                new ProxyAccessLogHandler(accessLogger, handler) {
+                    @Override
+                    protected void replaceWith(ChannelHandlerContext ctx, ChannelHandler handler)
+                    {
+                        ctx.pipeline().replace(ProxyAccessLogHandlerFactory.this.proxyAccessLogHandler,
+                                null, handler);
+                    }
+                }
+            );
 
     @Override
     public ChannelHandler createHandler()


### PR DESCRIPTION
Motivation:

Commit 5ecd79a82ad inadvertently broke access log support for HAproxy.

Modification:

Be sure to remove the wrapped ChannelHandler from the pipeline.

Result:

HAproxy logging for xrootd works as expected.

Target: master
Request: 5.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11549/
Acked-by: Albert Rossi
Acked-by: Vincent Garonne