### PR TITLE
pool: report correct replica creation time to sweeper

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
@@ -52,6 +52,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
 
     private final PnfsId _pnfsId;
     private final AbstractBerkeleyDBReplicaStore _repository;
+    private final long _creationTime;
 
     /**
      * Sticky records held by the file.
@@ -59,8 +60,6 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
     private ImmutableList<StickyRecord> _sticky;
 
     private ReplicaState _state;
-
-    private long _creationTime = System.currentTimeMillis();
 
     private long _lastAccess;
 
@@ -74,6 +73,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
         _pnfsId = pnfsId;
         _state = NEW;
         _sticky = ImmutableList.of();
+        _creationTime =   System.currentTimeMillis();
         _lastAccess = _creationTime;
     }
 
@@ -85,6 +85,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
         _state = state;
         setStickyRecords(sticky);
         _lastAccess = attributes.lastModifiedTime().toMillis();
+        _creationTime = attributes.creationTime().toMillis();
         _size = attributes.size();
     }
 
@@ -118,11 +119,6 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
     public synchronized int getLinkCount()
     {
         return _linkCount;
-    }
-
-    public synchronized void setCreationTime(long time)
-    {
-        _creationTime = time;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Sweeper ls command shows two timestamps - replica creation time and
last access time. Replica creation time is incorrect - it shows either
replica creation time or pool start up time (whicever is more recent).

Modification:

Set creation time properly when repository loads.

Result:

Correct replica creation time displayed by sweeper ls

	Patch: https://rb.dcache.org/r/11538/
	Target: master
	Request: 5.0
	Request: 4.2

	Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
	Require-book: no
	Require-notes: yes