### PR TITLE
webdav: fix NPE when Kafka notified file deletion

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/notification/DoorRequestMessageSerializer.java
+++ b/modules/dcache/src/main/java/org/dcache/notification/DoorRequestMessageSerializer.java
@@ -11,6 +11,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import diskCacheV111.vehicles.DoorRequestInfoMessage;
+import diskCacheV111.vehicles.StorageInfo;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -49,7 +50,10 @@ public class DoorRequestMessageSerializer implements Serializer<DoorRequestInfoM
         o.put("pnfsid", data.getPnfsId());
         o.put("billingPath", data.getBillingPath());
         o.put("fileSize", data.getFileSize());
-        o.put("storageInfo", data.getStorageInfo().getStorageClass() + "@" + data.getStorageInfo().getHsm());
+        StorageInfo info = data.getStorageInfo();
+        if (info != null) {
+            o.put("storageInfo", info.getStorageClass() + "@" + info.getHsm());
+        }
         return o.toString().getBytes(UTF_8);
 
     }


### PR DESCRIPTION
Motivation:

A recent patch (commit 7a9ac72b11aþ) triggered the following NPE:

    15 Feb 2019 17:37:10 (WebDAV-https-astoria) [door:WebDAV-https-astoria@astoriaDomain:AAWB8WLr8sg] Internal server error
    java.lang.NullPointerException: null
        at org.dcache.notification.DoorRequestMessageSerializer.serialize(DoorRequestMessageSerializer.java:52) ~[dcache-core-5.0.4.jar:5.0.4]
        at org.dcache.notification.DoorRequestMessageSerializer.serialize(DoorRequestMessageSerializer.java:17) ~[dcache-core-5.0.4.jar:5.0.4]
        at org.apache.kafka.common.serialization.Serializer.serialize(Serializer.java:60) ~[kafka-clients-2.1.0.jar:na]
        at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:879) ~[kafka-clients-2.1.0.jar:na]
        at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:841) ~[kafka-clients-2.1.0.jar:na]
        at org.springframework.kafka.core.DefaultKafkaProducerFactory$CloseSafeProducer.send(DefaultKafkaProducerFactory.java:260) ~[spring-kafka-2.1.1.RELEASE.jar:2.1.1.RELEASE]
        at org.springframework.kafka.core.KafkaTemplate.doSend(KafkaTemplate.java:316) ~[spring-kafka-2.1.1.RELEASE.jar:2.1.1.RELEASE]
        at org.springframework.kafka.core.KafkaTemplate.send(KafkaTemplate.java:166) ~[spring-kafka-2.1.1.RELEASE.jar:2.1.1.RELEASE]
        at org.springframework.kafka.core.KafkaTemplate.sendDefault(KafkaTemplate.java:145) ~[spring-kafka-2.1.1.RELEASE.jar:2.1.1.RELEASE]
        at org.dcache.webdav.DcacheResourceFactory.sendRemoveInfoToBilling(DcacheResourceFactory.java:1065) ~[dcache-webdav-5.0.4.jar:5.0.4]
        at org.dcache.webdav.DcacheResourceFactory.deleteFile(DcacheResourceFactory.java:1050) ~[dcache-webdav-5.0.4.jar:5.0.4]
        at org.dcache.webdav.DcacheFileResource.delete(DcacheFileResource.java:192) ~[dcache-webdav-5.0.4.jar:5.0.4]
        at io.milton.http.DeleteHelperImpl.delete(DeleteHelperImpl.java:126) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at io.milton.http.http11.DeleteHandler.processExistingResource(DeleteHandler.java:98) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at io.milton.http.ResourceHandlerHelper.processResource(ResourceHandlerHelper.java:196) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at io.milton.http.ResourceHandlerHelper.processResource(ResourceHandlerHelper.java:131) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at io.milton.http.http11.DeleteHandler.processResource(DeleteHandler.java:83) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at io.milton.http.ResourceHandlerHelper.process(ResourceHandlerHelper.java:127) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at org.dcache.webdav.DcacheResourceHandlerHelper.process(DcacheResourceHandlerHelper.java:70) ~[dcache-webdav-5.0.4.jar:5.0.4]
        at io.milton.http.http11.DeleteHandler.process(DeleteHandler.java:72) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at org.dcache.webdav.DcacheStandardFilter.process(DcacheStandardFilter.java:54) ~[dcache-webdav-5.0.4.jar:5.0.4]
        at io.milton.http.FilterChain.process(FilterChain.java:46) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at org.dcache.webdav.transfer.CopyFilter.process(CopyFilter.java:300) ~[dcache-webdav-5.0.4.jar:5.0.4]
        at io.milton.http.FilterChain.process(FilterChain.java:46) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at io.milton.http.HttpManager.process(HttpManager.java:158) ~[milton-server-ce-2.7.3.0-dcache-1.jar:na]
        at org.dcache.webdav.MiltonHandler.handle(MiltonHandler.java:141) ~[dcache-webdav-5.0.4.jar:5.0.4]
        at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:61) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.dcache.http.AuthenticationHandler.access$101(AuthenticationHandler.java:63) ~[dcache-core-5.0.4.jar:5.0.4]
        at org.dcache.http.AuthenticationHandler.lambda$handle$0(AuthenticationHandler.java:162) ~[dcache-core-5.0.4.jar:5.0.4]
        at java.base/java.security.AccessController.doPrivileged(Native Method) ~[na:na]
        at java.base/javax.security.auth.Subject.doAs(Subject.java:361) ~[na:na]
        at org.dcache.http.AuthenticationHandler.handle(AuthenticationHandler.java:160) ~[dcache-core-5.0.4.jar:5.0.4]
        at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:61) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.dcache.webdav.LoggingHandler.handle(LoggingHandler.java:43) ~[dcache-webdav-5.0.4.jar:5.0.4]
        at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:61) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.rewrite.handler.RewriteHandler.handle(RewriteHandler.java:335) ~[jetty-rewrite-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.server.Server.handle(Server.java:531) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260) ~[jetty-server-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281) ~[jetty-io-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102) ~[jetty-io-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:291) ~[jetty-io-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.io.ssl.SslConnection$3.succeeded(SslConnection.java:151) ~[jetty-io-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102) ~[jetty-io-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118) ~[jetty-io-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333) ~[jetty-util-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310) ~[jetty-util-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168) ~[jetty-util-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126) ~[jetty-util-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366) ~[jetty-util-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:762) ~[jetty-util-9.4.11.v20180605.jar:9.4.11.v20180605]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:680) ~[jetty-util-9.4.11.v20180605.jar:9.4.11.v20180605]
        at java.base/java.lang.Thread.run(Thread.java:834) ~[na:na]

This problem triggered by deleting a file through WebDAV with Kafka
notification enabled.

Modification:

Avoid adding the storage class ("storageInfo") to the JSON object if this
information is unknown.

Result:

No more NPE when sending Kafka notification of a file being deleted
through the WebDAV door.

Target: master
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11564/
Acked-by: Tigran Mkrtchyan