### PR TITLE
webdav: fix path-to-caveat for macaroon minting endpoint

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/macaroons/MacaroonRequestHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/macaroons/MacaroonRequestHandler.java
@@ -283,6 +283,10 @@ public class MacaroonRequestHandler extends AbstractHandler implements CellIdent
         context.setUsername(Subjects.getUserName(subject));
         context.setRoot(_pathMapper.effectiveRoot(userRoot, m -> new ErrorResponseException(SC_BAD_REQUEST, m)));
 
+        if (!target.equals("/") && !context.getPath().isPresent()) {
+            context.setPath(_pathMapper.asDcachePath(request, target));
+        }
+
         return context;
     }
 


### PR DESCRIPTION
Motivation:

A macaroon request is an HTTP POST request that targets a specific path.
If that path is not root ("/") then the HTTP path is used to build a
"path" caveat.

Commit 99c726e3 inadvertently broke this feature, resulting in certain
dCache users requesting a path-limited macaroon being returned a
macaroon without any "path" caveat.

Modification:

If the HTTP POST request contains a non-root path then, after processing
this request in the context of that user's restrictions, verify that a
path caveat is requested.  If not (because the user has no path
restriction) then add the path caveat request.

Result:

Users without any path restriction in dCache are able to request a
path-limited macaroon by specifying a non-root path in the HTTP POST
request.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11573/
Acked-by: Tigran Mkrtchyan