### PR TITLE
systemtest: remove reference to access-log plugin

### DIFF
--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -137,7 +137,7 @@ xrootd.authz.write-paths=/
 [dCacheDomain/xrootd]
 xrootd.cell.name=Xrootd-gsi-${host.name}
 xrootd.net.port=1095
-xrootd.plugins=gplazma:gsi,access-log
+xrootd.plugins=gplazma:gsi
 xrootd.authz.write-paths=/
 
 [dCacheDomain/frontend]


### PR DESCRIPTION
Motivation:

Since commit 2c6c4a15f, the access-log plugin must not be included in
the netty pipeline.  However, an xrootd door in systemtest was
overlooked.

Modification:

Remove the access-log from system test

Result:

There is no user or admin visible effect.

Systemtest GSI xrootd door no longer complains about the access log
plugin being instantiated twice.

Target: master
Request: 5.0
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/11550/
Acked-by: Albert Rossi