### PR TITLE
systemtest: fix OpenSSL DN format change

### DIFF
--- a/packages/system-test/src/main/bin/credentials
+++ b/packages/system-test/src/main/bin/credentials
@@ -397,7 +397,10 @@ EOF
     cp $CA_CERT $TARGET_TRUST_STORE/$hash_new.0
 
     cat > $TARGET_TRUST_STORE/$hash_new.signing_policy <<EOF
-access_id_CA    X509    '$(openssl x509 -in $CA_CERT -noout -subject | sed 's/subject= //')'
+access_id_CA    X509    '$(openssl x509 -in $CA_CERT -noout -subject -nameopt compat | sed 's:subject= *\+/\?:/:;s:, :/:g')'
+
+
+
 pos_rights      globus  CA:sign
 cond_subjects   globus  '"/DC=org/DC=dCache/*"'
 EOF

--- a/packages/system-test/src/main/bin/populate
+++ b/packages/system-test/src/main/bin/populate
@@ -19,7 +19,21 @@ lib="$(getProperty dcache.paths.share.lib)"
 cd @TARGET@/dcache
 
 dn() { # $1 - path to X.509 certificate
-    openssl x509 -in "$1" -subject -noout -nameopt compat | sed 's:subject= *\+:/:;s:, :/:g'
+
+    # OpenSSL used to print the subject DN like
+    #
+    #     subject=/C=DE/O=GermanGrid/OU=DESY/CN=Alexander Paul Millar
+    #
+    # They changed the format to
+    #
+    #     subject=C = DE, O = GermanGrid, OU = DESY, CN = Alexander Paul Millar
+    #
+    # Initially without any backwards compatibility. The following
+    # accepts either format and produces output like:
+    #
+    #     /C=DE/O=GermanGrid/OU=DESY/CN=Alexander Paul Millar
+    #
+    openssl x509 -in "$1" -subject -noout -nameopt compat | sed 's:subject= *\+/\?:/:;s:, :/:g'
 }
 
 if [ ! -f etc/dcache.kpwd ]; then
@@ -188,4 +202,3 @@ for path in etc/grid-security/certificates/*; do
     compare $path ~/.globus/certificates/$file
     compare $path /etc/grid-security/certificates/$file
 done
-


### PR DESCRIPTION
Motivation:

OpenSSL changed the format in which it prints DNs from

     subject=/C=DE/O=GermanGrid/OU=DESY/CN=Alexander Paul Millar

to

     subject=C = DE, O = GermanGrid, OU = DESY, CN = Alexander Paul Millar

System test uses OpenSSL to generate DNs from certificates in a few
places. Changes already introduced to handle this format change were
broken (for OpenSSL that prints DN using slashes) and not applied
everywhere.

Modification:

Avoid an initial double slash if OpenSSL prints DN in compat format.

Update credential generation so that the signing policy file is
generated with the correct DN.

Result:

No user- and admin visible changes.

Systemtest works with newer OpenSSL instances.

Target: master
Requires-notes: no
Requires-book: no
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11551/
Acked-by: Tigran Mkrtchyan