### PR TITLE
dcache-xrootd: implement support for security level and signed hashes

### DIFF
--- a/docs/TheBook/src/main/markdown/config-xrootd.md
+++ b/docs/TheBook/src/main/markdown/config-xrootd.md
@@ -323,8 +323,8 @@ to be mapped on the source server end.
 Signed hash verification support
 ---------------------------------------------
 
- The embedded third-party client will honor signed hash verification if the
- source server indicates it must be observed.
+The embedded third-party client will honor signed hash verification if the
+source server indicates it must be observed.
 
 Starting with dCache 5.0, the dCache door/server will also provide the option
 to enable signed hash verification.

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/AbstractXrootdRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/AbstractXrootdRequestHandler.java
@@ -31,16 +31,24 @@ import org.dcache.xrootd.protocol.messages.ProtocolResponse;
 import org.dcache.xrootd.protocol.messages.SetRequest;
 import org.dcache.xrootd.protocol.messages.SetResponse;
 import org.dcache.xrootd.protocol.messages.XrootdResponse;
+import org.dcache.xrootd.security.SigningPolicy;
 
 public class AbstractXrootdRequestHandler extends XrootdRequestHandler
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractXrootdRequestHandler.class);
 
+    protected SigningPolicy signingPolicy;
+
+    public void setSigningPolicy(SigningPolicy signingPolicy)
+    {
+        this.signingPolicy = signingPolicy;
+    }
+
     @Override
     protected XrootdResponse<ProtocolRequest> doOnProtocolRequest(ChannelHandlerContext ctx, ProtocolRequest msg)
             throws XrootdException
     {
-        return new ProtocolResponse(msg, XrootdProtocol.DATA_SERVER);
+        return new ProtocolResponse(msg, XrootdProtocol.DATA_SERVER, signingPolicy);
     }
 
     @Override

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -86,6 +86,12 @@
     <description>Administrative interface to manage connections</description>
   </bean>
 
+  <bean id="signing-policy"
+        class="org.dcache.xrootd.security.SigningPolicy">
+      <constructor-arg name="secLvl" value="${xrootd.security.level}"/>
+      <constructor-arg name="force" value="${xrootd.security.force-signing}"/>
+  </bean>
+
   <bean id="server" class="org.dcache.xrootd.door.NettyXrootdServer"
         init-method="start" destroy-method="stop">
     <description>Netty based Xrootd service</description>
@@ -109,6 +115,7 @@
         </bean>
     </property>
     <property name="expectedProxyProtocol" value="${xrootd.enable.proxy-protocol}"/>
+    <property name="signingPolicy" ref="signing-policy"/>
   </bean>
 
   <bean id="pnfs" class="diskCacheV111.util.PnfsHandler">

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -350,6 +350,12 @@
 
   </bean>
 
+  <bean id="signing-policy"
+        class="org.dcache.xrootd.security.SigningPolicy">
+    <constructor-arg name="secLvl" value="${pool.mover.xrootd.security.level}"/>
+    <constructor-arg name="force" value="${pool.mover.xrootd.security.force-signing}"/>
+  </bean>
+
   <bean id="xrootd-transfer-service" class="org.dcache.xrootd.pool.XrootdTransferService"
           depends-on="rep">
       <description>Xrootd transfer service</description>
@@ -389,6 +395,7 @@
           </bean>
       </property>
       <property name="thirdPartyShutdownExecutor" ref="workerThreadPool"/>
+    <property name="signingPolicy" ref="signing-policy"/>
   </bean>
 
   <bean id="http-transfer-service-parent" class="org.dcache.http.HttpTransferService"

--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -83,6 +83,10 @@
         <artifactId>xrootd4j-gsi</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.dcache</groupId>
+      <artifactId>xrootd4j-unix</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.dcache</groupId>
         <artifactId>xrootd4j-authz-plugin-alice</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.11.v20180605</version.jetty>
-        <version.xrootd4j>3.3.4</version.xrootd4j>
+        <version.xrootd4j>3.4.0</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
         <version.dcache-view>1.5.3</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
@@ -681,6 +681,11 @@
             <dependency>
                 <groupId>org.dcache</groupId>
                 <artifactId>xrootd4j-gsi</artifactId>
+                <version>${version.xrootd4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.dcache</groupId>
+                <artifactId>xrootd4j-unix</artifactId>
                 <version>${version.xrootd4j}</version>
             </dependency>
             <dependency>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1283,6 +1283,62 @@ dcache.inotify-generation.backlog.per-door = 1000
 dcache.inotify-generation.message-batch-size = 100
 
 #  -----------------------------------------------------------------------
+#       Xrootd: support for verifying signed hashes (by server/door)
+#  -----------------------------------------------------------------------
+#
+#  Determines which requests must be preceded by signed hash verification.
+#
+#  When signed hash verification is enforced, a signed hash of the message
+#  contents is sent before the actual message; usually the hash is then encrypted
+#  using a secret key established by the protocol between the two parties.
+#  Sending and verifying a hash this way protects against man-in-the-middle
+#  attacks.
+#
+#  The higher the security level, the more types of messages require signed
+#  hash verification; the most stringent level (pedantic) requires all messages
+#  sent after authentication is established to be signed.  The levels
+#  are somewhat arbitrary and the mappings to the message types may be found
+#  in the XrootD protocol documentation.  Default is verification disabled.
+#
+#  Possible levels:
+#
+#       kXR_secNone         = 0 (signed hash verification disabled)
+#       kXR_secCompatible   = 1;
+#       kXR_secStandard     = 2;
+#       kXR_secIntense      = 3;
+#       kXR_secPedantic     = 4;
+#
+dcache.xrootd.security.level=0
+
+#
+#  Force signed hash verification even if the protocol does not support encryption.
+#
+#  According to XrootD specification, this flag pertains only to authenticated
+#  (e.g., gsi or unix) connections.  The standard XrootD servers will not
+#  send signed hashes on unauthenticated connections even with this flag set
+#  to true.
+#
+#  Since pools do not currently require gsi, to enforce hash signing (without
+#  encryption) on the pool communication, a protocol of some sort must be used;
+#  The unix protocol is (for XrootD) something of a placemarker protocol
+#  where the username is the only authentication data.  Its only purpose seems
+#  to be to distinguish between "authenticated" and "unauthenticated" (i.e.,
+#  anonymous) connections.  Unix authentication uses no encryption
+#  algorithm.
+#
+#  If security level is > 0 and this flag is set to true in dCache,
+#  dCache also tells the client to use unix authentication.  That ensures that
+#  signed hashes will also be sent.  Without this flag, the pool connection
+#  remains unauthenticated.
+#
+#  In the dCache-XrootD universe, it does not make much sense to
+#  require a security level > 0 without also setting this flag to true,
+#  since the majority of requests sent after the initial authentication to
+#  the door are redirected to the pool.
+#
+dcache.xrootd.security.force-signing=false
+
+#  -----------------------------------------------------------------------
 #  ---- Unused properties
 #  -----------------------------------------------------------------------
 (obsolete)dcache.broker.client.port = Location manager now uses ZooKeeper

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -343,6 +343,14 @@ pool.mover.xrootd.plugins=
 #        gsi   - request to the source server from dcache will
 #                use a key-exchange process to identify the end-user.
 #
+#        unix  - request to the source server from dcache will
+#                use unix authentication.
+#
+#                NOTE: third-party copying between dCache instances or doors
+#                requires this plugin on destination pools in addition to
+#                any other auth plugins, if hash signing is enforced on
+#                the pools (see pool.xrootd.security.force-signing).
+#
 pool.mover.xrootd.tpc-authn-plugins=
 
 #  ---- Xrootd mover-idle timeout
@@ -375,6 +383,13 @@ pool.mover.xrootd.port.max = ${dcache.net.lan.port.max}
 pool.mover.xrootd.query-config!version = dCache ${dcache.version}
 pool.mover.xrootd.query-config!sitename = ${dcache.description}
 pool.mover.xrootd.query-config!role = none
+
+#
+#  Signed hash verification ----- see dcache.properties
+#
+pool.mover.xrootd.security.level=${dcache.xrootd.security.level}
+pool.mover.xrootd.security.force-signing=${dcache.xrootd.security.force-signing}
+
 
 
 #  ---- Thread pool size for http disk IO threads

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -222,6 +222,11 @@ xrootd.query-config!version = dCache ${dcache.version}
 xrootd.query-config!sitename = ${dcache.description}
 xrootd.query-config!role = none
 
+#  Signed hash verification ----- see dcache.properties
+#
+xrootd.security.level=${dcache.xrootd.security.level}
+xrootd.security.force-signing=${dcache.xrootd.security.force-signing}
+
 #  ----- Per-application io-queues
 #
 #   xrootd protocol allows clients to identify the name of their


### PR DESCRIPTION
Motivation:

Add server-side signed hash verification support.

Fourth of four patches.

Modification:

Add fields for signed hash configuration, and
inject the values.  These are passed into the
appropriate xrootd4j handlers.

The pool login response now returns unix as
the protocol when the security level and flags
indicate signed hashes should be used.

Result:

Full sigver support for xrootd transfers,
both two- and three-party.

Target: master
Request: 5.0
Requires-book: yes
Requires-notes: yes
Acked-by: Dmitry