### PR TITLE
ftp: store calculated checksum using root privileges

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -2970,7 +2970,15 @@ public abstract class AbstractFtpDoorV1
                     }
                     setTransfer(null);
                 }
-                _pnfs.setFileAttributes(absPath, FileAttributes.ofChecksum(checksum));
+
+                /* The client may be downloading a file that it does not have
+                 * permission to add a new checksum value, nevertheless we want
+                 * to avoid recalculating the checksum if this file is
+                 * downloaded again.  Therefore, we add the freshly
+                 * calculated checksum value as user ROOT with no restrictions.
+                 */
+                new PnfsHandler(_pnfs, Subjects.ROOT, Restrictions.none())
+                        .setFileAttributes(absPath, FileAttributes.ofChecksum(checksum));
             }
 
             reply("213 " + checksum.getValue());


### PR DESCRIPTION
Motivation:

The CKSM command allows the client to request a checksum value of a file
using the specified algorithm.

In particular, Globus transfer service will use this to discover the MD5
checksum of source files, for which dCache may only know an ADLER32
checksum value.

If the client requests the checksum be calculated using an algorithm for
which dCache does not already have the value, then the door will
calculate the checksum value.  To avoid repeating this process, the door
will update the file in the namespace, recording the new checksum value.

Currently, the namespace is modified using the logged in user's
identity.  If the user is not allowed to modify the file then the
attempt to modify the file will fail, and so fail the CKSM command.

Modification:

Update the namespace as the root user.

Result:

The client can request the checksum value of a file not owned by that
user and where dCache does not already know the checksum value.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11591
Acked-by: Tigran Mkrtchyan