### PR TITLE
pool: fix CDC for repository listener notification

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/StateChangeListeners.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/StateChangeListeners.java
@@ -12,6 +12,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import dmg.cells.nucleus.CDC;
+
 import org.dcache.pool.repository.EntryChangeEvent;
 import org.dcache.pool.repository.StateChangeEvent;
 import org.dcache.pool.repository.StateChangeListener;
@@ -58,20 +60,23 @@ class StateChangeListeners
 
     public void stateChanged(final StateChangeEvent event)
     {
+        CDC callingContext = new CDC();
         try {
             _executor.execute(() -> {
-                for (StateChangeListener listener: _listeners) {
-                    try {
-                        listener.stateChanged(event);
-                    } catch (RuntimeException e) {
-                        /* State change notifications are
-                         * important for proper functioning of the
-                         * pool and we cannot risk a problem in an
-                         * event handler causing other event
-                         * handlers not to be called. We therefore
-                         * catch, log and ignore these problems.
-                         */
-                        _log.error("Unexpected failure during state change notification", e);
+                try (CDC oldContext = callingContext.restore()) {
+                    for (StateChangeListener listener: _listeners) {
+                        try {
+                            listener.stateChanged(event);
+                        } catch (RuntimeException e) {
+                            /* State change notifications are
+                             * important for proper functioning of the
+                             * pool and we cannot risk a problem in an
+                             * event handler causing other event
+                             * handlers not to be called. We therefore
+                             * catch, log and ignore these problems.
+                             */
+                            _log.error("Unexpected failure during state change notification", e);
+                        }
                     }
                 }
             });
@@ -83,20 +88,23 @@ class StateChangeListeners
 
     public void accessTimeChanged(final EntryChangeEvent event)
     {
+        CDC callingContext = new CDC();
         try {
             _executor.execute(() -> {
-                for (StateChangeListener listener: _listeners) {
-                    try {
-                        listener.accessTimeChanged(event);
-                    } catch (RuntimeException e) {
-                        /* State change notifications are
-                         * important for proper functioning of the
-                         * pool and we cannot risk a problem in an
-                         * event handler causing other event
-                         * handlers not to be called. We therefore
-                         * catch, log and ignore these problems.
-                         */
-                        _log.error("Unexpected failure during state change notification", e);
+                try (CDC oldContext = callingContext.restore()) {
+                    for (StateChangeListener listener: _listeners) {
+                        try {
+                            listener.accessTimeChanged(event);
+                        } catch (RuntimeException e) {
+                            /* State change notifications are
+                             * important for proper functioning of the
+                             * pool and we cannot risk a problem in an
+                             * event handler causing other event
+                             * handlers not to be called. We therefore
+                             * catch, log and ignore these problems.
+                             */
+                            _log.error("Unexpected failure during state change notification", e);
+                        }
                     }
                 }
             });
@@ -108,20 +116,23 @@ class StateChangeListeners
 
     public void stickyChanged(final StickyChangeEvent event)
     {
+        CDC callingContext = new CDC();
         try {
             _executor.execute(() -> {
-                for (StateChangeListener listener: _listeners) {
-                    try {
-                        listener.stickyChanged(event);
-                    } catch (RuntimeException e) {
-                        /* State change notifications are
-                         * important for proper functioning of the
-                         * pool and we cannot risk a problem in an
-                         * event handler causing other event
-                         * handlers not to be called. We therefore
-                         * catch, log and ignore these problems.
-                         */
-                        _log.error("Unexpected failure during state change notification", e);
+                try (CDC oldContext = callingContext.restore()) {
+                    for (StateChangeListener listener: _listeners) {
+                        try {
+                            listener.stickyChanged(event);
+                        } catch (RuntimeException e) {
+                            /* State change notifications are
+                             * important for proper functioning of the
+                             * pool and we cannot risk a problem in an
+                             * event handler causing other event
+                             * handlers not to be called. We therefore
+                             * catch, log and ignore these problems.
+                             */
+                            _log.error("Unexpected failure during state change notification", e);
+                        }
                     }
                 }
             });


### PR DESCRIPTION
Motivation:

The repository supports the registration of listeners that
may learn of changes to replicas within the repository in a
decoupled fashion.

The CDC (logging context) for this notification is wrong, as the
notification happens on a separate, reused thread (from an executor) but
without establishing the correct context.  The result is any logging
will be recorded against arbitrary (and misleading) context, making
diagnosing problems much harder.

Modification:

Ensure the CDC is initialised correctly before calling the listeners,
using the caller's context.

Result:

Fix some logging on the pool where messages were recorded against an
arbitrary context (i.e., the bit in square brackets), resulting in
misleading information.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11589/
Acked-by: Tigran Mkrtchyan