### PR TITLE
xrootd: upgrade to xrootd4j v3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.11.v20180605</version.jetty>
-        <version.xrootd4j>3.4.0</version.xrootd4j>
+        <version.xrootd4j>3.4.1</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
         <version.dcache-view>1.5.3</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Motivation:

Keep supporting pre-4.9 TPC clients until delegation is ready.

Modification:

Update xrootd4j library to v3.4.1.  Change-log:

    2ebc7c1ea8d7071c91fb700068d1a2f4b1130e45 [maven-release-plugin] prepare release v3.4.1
    b664aa13951f3d77de188e32db400a8d83dc146f Merge pull request #34 from alrossi/fix/3.4/support-4.9-client
    4e4ef7c09258d2b688f41db222d2eeaf0d86a536 xrootd4j: do not reject 4.9 client
    ea7b0b9eba691a2724f9497cc369e2293402df04 [maven-release-plugin] prepare for next development iteration

Result:

Upgrade xrootd4j to v3.4.1 to fix regression in supporting TPC pre-4.9
clients.

Target: master
Request: 5.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11604/
Acked-by: Tigran Mkrtchyan