### PR TITLE
dcache-xrootd: use debug level instead of trace

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -948,7 +948,7 @@ public class XrootdDoor
 
     public void messageArrived(XrootdDoorAdressInfoMessage msg)
     {
-        _log.trace("Received redirect msg from mover");
+        _log.debug("Received redirect msg from mover");
         XrootdTransfer transfer = _transfers.get(msg.getXrootdFileHandle());
         if (transfer != null) {
             transfer.redirect(msg.getSocketAddress());

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -244,7 +244,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                                         new XrootdSigverDecoder(signingPolicy,
                                                                 null));
             ctx.pipeline().remove("decoder");
-            _log.trace("swapped decoder for sigverDecoder.");
+            _log.debug("swapped decoder for sigverDecoder.");
         } else {
             sec = "";
         }
@@ -309,7 +309,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                                     file.getProtocolInfo().getFlags()
                                         .contains(XrootdProtocolInfo.Flags.POSC);
                     if (opaqueMap.containsKey("tpc.src")) {
-                        _log.trace("Request to open {} is as third-party destination.", msg);
+                        _log.debug("Request to open {} is as third-party destination.", msg);
                         descriptor = new TpcWriteDescriptor(file, posc, ctx,
                                                             _server,
                                                             opaqueMap.get("org.dcache.xrootd.client"),
@@ -390,7 +390,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
     {
         switch (msg.getTarget()) {
         case PATH:
-            _log.trace("Request to stat {}; redirecting to door.", msg);
+            _log.debug("Request to stat {}; redirecting to door.", msg);
             return redirectToDoor(ctx, msg);
 
         case FHANDLE:
@@ -405,11 +405,11 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
 
             FileDescriptor descriptor = _descriptors.get(fd);
             if (descriptor instanceof TpcWriteDescriptor) {
-                _log.trace("Request to stat {} is for third-party transfer.", msg);
+                _log.debug("Request to stat {} is for third-party transfer.", msg);
                 return ((TpcWriteDescriptor)descriptor).handleStat(msg);
             } else {
                 try {
-                    _log.trace("Request to stat open file fhandle={}", fd);
+                    _log.debug("Request to stat open file fhandle={}", fd);
                     return new StatResponse(msg, stat(descriptor.getChannel()));
                 } catch (IOException e) {
                     throw new XrootdException(kXR_IOError, e.getMessage());

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -164,7 +164,7 @@ public final class TpcWriteDescriptor extends WriteDescriptor
     public synchronized void fireDelayedSync(int result, String error)
     {
         int errno = client.getErrno();
-        LOGGER.trace("fireDelayedSync (result {}), (error {}), (serverError {}); "
+        LOGGER.debug("fireDelayedSync (result {}), (error {}), (serverError {}); "
                                      + "syncRequest {}, isFirstSync {}",
                      result, error, client.getError(), syncRequest, isFirstSync);
         transferStatus = result;
@@ -290,7 +290,7 @@ public final class TpcWriteDescriptor extends WriteDescriptor
                                        client.getError());
         }
 
-        LOGGER.trace("Request to sync ({}) is for third-party write.",
+        LOGGER.debug("Request to sync ({}) is for third-party write.",
                      syncRequest);
 
         if (isFirstSync) {
@@ -298,7 +298,7 @@ public final class TpcWriteDescriptor extends WriteDescriptor
              * The tpc should be started now,
              * and OK returned to the caller.
              */
-            LOGGER.trace("fireDelayedSync starting TPC client.");
+            LOGGER.debug("fireDelayedSync starting TPC client.");
 
             /*
              * Start the client connection.

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptorHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptorHandler.java
@@ -105,7 +105,7 @@ public final class TpcWriteDescriptorHandler extends TpcSourceReadHandler
             if (checksum.getType() == type) {
                 dCacheValue = checksum.getValue();
                 if (sourceValue != null && sourceValue.equals(dCacheValue)) {
-                    LOGGER.trace("Checksum query for {} on {}, "
+                    LOGGER.debug("Checksum query for {} on {}, "
                                                  + "channel {}, stream {}, succeeded.",
                                  info.getLfn(),
                                  info.getSrc(),


### PR DESCRIPTION
Motivation:

We intend to add full byte-by-byte dumps of authentication
messages to the xrootd4j library.  This will be done at the
TRACE level.

Hence it makes more sense to allow for a full debug-level
output which simply excludes that last level of detail.

Modification:

Change logging at trace level to debug level (this is
reasonable in all discovered cases).

Result:

Ability to have debugging without the final byte dumps
cluttering the output.

Requesting backport because we will be requesting a
backport for the next patch (delegation).

Target: master
Request: 5.0
Acked-by: Tigran