### PR TITLE
webdav: fix resource name for door root

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResource.java
@@ -77,7 +77,7 @@ public class DcacheResource
     @Override
     public String getName()
     {
-        return _path.isRoot() ? null : _path.name();
+        return _factory.isDoorRoot(_path) ? null : _path.name();
     }
 
     @Override

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -569,6 +569,11 @@ public class DcacheResourceFactory
         return _internalAddress.getHostAddress();
     }
 
+    public boolean isDoorRoot(FsPath path)
+    {
+        return _pathMapper.isDoorRoot(ServletRequest.getRequest(), path);
+    }
+
     @Override
     public void getInfo(PrintWriter pw)
     {

--- a/modules/dcache/src/main/java/org/dcache/http/PathMapper.java
+++ b/modules/dcache/src/main/java/org/dcache/http/PathMapper.java
@@ -114,6 +114,15 @@ public class PathMapper implements CellInfoProvider
     }
 
     /**
+     * Calculate whether the dCache path corresponds to the root path in
+     * the requested URL.
+     */
+    public boolean isDoorRoot(HttpServletRequest request, FsPath path)
+    {
+        return path.equals(effectiveRoot(request, RuntimeException::new));
+    }
+
+    /**
      * Calculate the path that a client would request that would correspond to
      * the supplied dCache path.  This method is the inverse of the
      * {@link #asDcachePath} method.  It is expected that the caller has already


### PR DESCRIPTION
Motivation:

Further reports of the following error:

    Your resource factory returned a resource with a different name to that requested!!!
    Requested: null returned: atlas - resource f[...]

An earlier patch (a42022b) attempted to address this problem but was
incomplete.

Modification:

Consider the user's and door's root when deciding the name of a
resource.

Result:

The error message "Your resource factory returned a resource with a
different name to that requested!!!" error message should no longer
appear.

Target: master
Requires-notes: yes
Requires-book: yes
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Ticket: https://rt.dcache.org/Ticket/Display.html?id=9650
Patch: https://rb.dcache.org/r/11595/
Acked-by: Tigran Mkrtchyan