### PR TITLE
pool-ceph: Failure when initiating a macaroon authz HTTP PUSH, authn with X.509/macaroon to target.

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ceph/CephRepositoryChannel.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ceph/CephRepositoryChannel.java
@@ -157,8 +157,10 @@ public class CephRepositoryChannel implements RepositoryChannel {
 
     @Override
     public synchronized void close() throws IOException {
-        rbdImage.close();
-        rbdImage = null;
+        if (rbdImage != null) {
+            rbdImage.close();
+            rbdImage = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Client:
```
Initiating a macaroon authz HTTP PUSH, authn with X.509 to target: FAILED:  Bug detected (please report): null
...
Initiating a macaroon authz HTTP PUSH, authz with macaroon to target: FAILED:  Bug detected (please report): null
```

server:
```
...[door:WebDAV-https-cosgrove@cosgroveDomain:AAWEFNFoipg RemoteTransferManager PoolDeliverFile 000072AD46DA1C25408498C24F76659B5666] Transfer failed due to a bug
java.lang.NullPointerException: null
	at org.dcache.pool.repository.ceph.CephRepositoryChannel.close(CephRepositoryChannel.java:160) ~[dcache-core-5.0.7.jar:5.0.7]
	at org.dcache.pool.statistics.IoStatisticsChannel.close(IoStatisticsChannel.java:344) ~[dcache-core-5.0.7.jar:5.0.7]
	at org.dcache.pool.classic.AbstractMoverProtocolTransferService$MoverTask.run(AbstractMoverProtocolTransferService.java:156) ~[dcache-core-5.0.7.jar:5.0.7]
	at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149) ~[dcache-core-5.0.7.jar:5.0.7]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:834) ~[na:na]
```

Modification:

Do not close the image if the image is not opened to mitigate the issue.

Note: More investigation might be needed to understand why it happens with these
particular workflows.

Result:

Be able to see smoke signals from Ceph or Ceph smoking or ..

Target: master
Require-notes: yes
Require-book: yes
Request: 5.0
Patch: https://rb.dcache.org/r/11611/
Acked-by: Paul Millar
Committed: 83c8b1bcd6
Pull-request: https://github.com/dCache/dcache/pull/xxxx