### PR TITLE
kafka: add ability to specify Kafka topic name

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -2549,7 +2549,7 @@ public class DCapDoorInterpreterV3
 
     private void sendAsynctoKafka(DoorRequestInfoMessage info) {
 
-        ProducerRecord<String, DoorRequestInfoMessage> record = new ProducerRecord<String, DoorRequestInfoMessage>("billing", info);
+        ProducerRecord<String, DoorRequestInfoMessage> record = new ProducerRecord<String, DoorRequestInfoMessage>(_settings.getKafkaTopic(), info);
         _kafkaProducer.send(record, (rm, e) -> {
             if (e != null) {
                 _log.error("Unable to send message to topic {} on  partition {}: {}",

--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DcapDoorSettings.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DcapDoorSettings.java
@@ -88,6 +88,9 @@ public class DcapDoorSettings
     @Option(name = "bootstrap-server-kafka")
     protected String kafkaBootstrapServer;
 
+    @Option(name = "kafka-topic")
+    protected String kafkaTopic;
+
     @Option(name = "kafka-max-block", required = true)
     protected long kafkaMaxBlock;
 
@@ -243,6 +246,15 @@ public class DcapDoorSettings
      */
     public String getKafkaBootstrapServer() {
         return kafkaBootstrapServer;
+    }
+
+    /**
+     * Returns the name of kafka topic
+     *
+     * @return    kafka topic name
+     */
+    public String getKafkaTopic() {
+        return kafkaTopic;
     }
 
     /**

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -1015,7 +1015,7 @@ public abstract class AbstractFtpDoorV1
 
             if (_sendToKafka) {
                 setKafkaSender(m -> {
-                    _kafkaProducer.send(new ProducerRecord<String, DoorRequestInfoMessage>("billing", m));
+                   _kafkaProducer.send(new ProducerRecord<String, DoorRequestInfoMessage>(_settings.getKafkaTopic(), m));
                 });
             }
 

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpDoorSettings.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpDoorSettings.java
@@ -53,6 +53,9 @@ public class FtpDoorSettings
     @Option(name = "bootstrap-server-kafka")
     protected String kafkaBootstrapServer;
 
+    @Option(name = "kafka-topic")
+    protected String kafkaTopic;
+
     @Option(name = "kafka-max-block",
             defaultValue = "1")
     protected long kafkaMaxBlock;
@@ -363,6 +366,15 @@ public class FtpDoorSettings
      */
     public String getKafkaBootstrapServer() {
         return kafkaBootstrapServer;
+    }
+
+    /**
+     * Returns name of kafka topic
+     *
+     * @return    kafka topic name
+     */
+    public String getKafkaTopic() {
+        return kafkaTopic;
     }
 
     /**

--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -250,7 +250,7 @@
                 </bean>
             </constructor-arg>
             <constructor-arg name="autoFlush" value="false" />
-            <property name="defaultTopic" value="billing"/>
+            <property name="defaultTopic" value="${nfs.kafka.topic}"/>
             <property name="producerListener" ref="listener"/>
         </bean>
     </beans>

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -631,7 +631,7 @@
                     </constructor-arg>
                 </bean>
             </constructor-arg>
-            <property name="defaultTopic" value="billing"/>
+            <property name="defaultTopic" value="${webdav.kafka.topic}"/>
             <property name="producerListener" ref="listener"/>
 
         </bean>

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -205,7 +205,7 @@
           </constructor-arg>
         </bean>
       </constructor-arg>
-      <property name="defaultTopic" value="billing"/>
+      <property name="defaultTopic" value="${xrootd.kafka.topic}"/>
       <property name="producerListener" ref="listener"/>
     </bean>
   </beans>

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -574,7 +574,7 @@
                    </constructor-arg>
                </bean>
            </constructor-arg>
-           <property name="defaultTopic" value="billing"/>
+           <property name="defaultTopic" value="${pool.kafka.topic}"/>
            <property name="producerListener" ref="listener"/>
        </bean>
 
@@ -597,7 +597,7 @@
                     </constructor-arg>
                 </bean>
             </constructor-arg>
-            <property name="defaultTopic" value="billing"/>
+            <property name="defaultTopic" value="${pool.kafka.topic}"/>
             <property name="producerListener" ref="listener"/>
         </bean>
 
@@ -621,7 +621,7 @@
                 </bean>
             </constructor-arg>
             <constructor-arg name="autoFlush" value="false" />
-            <property name="defaultTopic" value="billing"/>
+            <property name="defaultTopic" value="${pool.kafka.topic}"/>
             <property name="producerListener" ref="listener"/>
         </bean>
     </beans>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1209,6 +1209,9 @@ dcache.oidc.hostnames =
 # host1:port1,host2:port2,....
 dcache.kafka.bootstrap-servers = localhost:9092
 
+# Kafka topic name
+dcache.kafka.topic = billing
+
 #  Maximum time dCache will spend trying to send an event to the Kafka
 #  service.  If dCache is unable to send the event to Kafka within
 #  this time limit, the an error is logged and the event is dropped.

--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -215,3 +215,5 @@ dcap.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 dcap.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}
 
+# Kafka topic name
+dcap.kafka.topic = ${dcache.kafka.topic}

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -359,3 +359,6 @@ ftp.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 ftp.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}
+
+# Kafka topic name
+ftp.kafka.topic = ${dcache.kafka.topic}

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -254,3 +254,6 @@ nfs.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 nfs.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}
+
+# Kafka topic name
+nfs.kafka.topic = ${dcache.kafka.topic}

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -571,6 +571,8 @@ pool.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 pool.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}
 
+# Kafka topic name
+pool.kafka.topic = ${dcache.kafka.topic}
 
 # Support for encrypted transfers.
 #
@@ -596,5 +598,3 @@ pool.mover.https.hostcert.key=${dcache.authn.hostcert.key}
 #   connections react to this property.
 #
 pool.mover.https.capath=${dcache.authn.capath}
-
-

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -715,3 +715,6 @@ webdav.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}
 
 # A list of host/port pairs (brokers) host1:port1,host2:port2,....
 webdav.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}
+
+# Kafka topic name
+webdav.kafka.topic = ${dcache.kafka.topic}

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -261,3 +261,6 @@ xrootd.kafka.maximum-block=${dcache.kafka.maximum-block}
 
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
 xrootd.kafka.maximum-block.unit=${dcache.kafka.maximum-block.unit}
+
+# Kafka topic name
+xrootd.kafka.topic = ${dcache.kafka.topic}

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -114,6 +114,7 @@ create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
              -billing=\"${dcap.service.billing}\" \
              -kafka=\"${dcacp.enable.kafka}\" \
              -bootstrap-server-kafka=\"${dcap.kafka.bootstrap-servers}\" \
+	     -kafka-topic=\"{dcap.kafka.topic}\" \
              -kafka-max-block=${dcap.kafka.maximum-block}\
              -kafka-max-block-units=${dcap.kafka.maximum-block.unit}\
              -retries-kafka=0 \

--- a/skel/share/services/ftp.batch
+++ b/skel/share/services/ftp.batch
@@ -89,6 +89,7 @@ create dmg.cells.services.login.LoginManager ${ftp.cell.name} \
    -billing=\"${ftp.service.billing}\" \
    -kafka=\"${ftp.enable.kafka}\" \
    -bootstrap-server-kafka=\"${ftp.kafka.bootstrap-servers}\" \
+   -kafka-topic=\"${ftp.kafka.topic}\" \
    -kafka-max-block=${ftp.kafka.maximum-block}\
    -kafka-max-block-units=${ftp.kafka.maximum-block.unit}\
    -retries-kafka=0 \


### PR DESCRIPTION
Motivation:

Kafka topic name has been hardcoded to "billing" in dCache code making
it difficult to work with external Kafka installations.

Modification:

Add environment variable

dcache.kafka.topic=billing

and

service.kafka.topic=${dcache.kafka.topic} where service=dcap,ftp,nfs,pool,webdav,xrootd
to be able to specify Kafka receiving topic name

Result:

Added ability to specify Kafka receiving topic name

	Target: master
	Request: 5.0
	Request: 4.2

	Require-book: yes
	Require-notes: yes

	Acked-by: Paul Millar <paul.millar@desy.de>
	Patch: https://rb.dcache.org/r/11610/
        Issue: https://github.com/dCache/dcache/issues/4722