### PR TITLE
resilience: add ability to log resilience activity (incoming)

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/PoolInfoChangeHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/PoolInfoChangeHandler.java
@@ -95,6 +95,8 @@ import org.dcache.resilience.util.MapInitializer;
 public final class PoolInfoChangeHandler implements CellMessageReceiver {
     private static final Logger LOGGER = LoggerFactory.getLogger(
                     PoolInfoChangeHandler.class);
+    private static final Logger ACTIVITY_LOGGER =
+                    LoggerFactory.getLogger("org.dcache.resilience-log");
 
     private static final String SYNC_ALARM =
                     "Last pool monitor refresh was at %s, elapsed time is "
@@ -125,6 +127,10 @@ public final class PoolInfoChangeHandler implements CellMessageReceiver {
     }
 
     public void messageArrived(SerializablePoolMonitor monitor) {
+        ACTIVITY_LOGGER.info("Received pool monitor update; enabled {}, "
+                                             + "initialized {}",
+                             enabled, initializer.isInitialized());
+
         if (!enabled) {
             return;
         }

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/ResilienceMessageHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/ResilienceMessageHandler.java
@@ -91,6 +91,8 @@ import org.dcache.vehicles.CorruptFileMessage;
 public final class ResilienceMessageHandler implements CellMessageReceiver {
     private static final Logger LOGGER = LoggerFactory.getLogger(
                     ResilienceMessageHandler.class);
+    private static final Logger ACTIVITY_LOGGER =
+                    LoggerFactory.getLogger("org.dcache.resilience-log");
 
     private MessageGuard         messageGuard;
     private FileOperationHandler fileOperationHandler;
@@ -124,6 +126,8 @@ public final class ResilienceMessageHandler implements CellMessageReceiver {
     }
 
     public void messageArrived(CorruptFileMessage message) {
+        ACTIVITY_LOGGER.info("Received notice that file {} on pool {} is corrupt.",
+                             message.getPnfsId(), message.getPool());
         if (messageGuard.getStatus("CorruptFileMessage", message)
                         == Status.DISABLED) {
             return;
@@ -132,6 +136,8 @@ public final class ResilienceMessageHandler implements CellMessageReceiver {
     }
 
     public void messageArrived(PnfsAddCacheLocationMessage message) {
+        ACTIVITY_LOGGER.info("Received notice that pool {} received file {}.",
+                             message.getPoolName(), message.getPnfsId());
         if (messageGuard.getStatus("PnfsAddCacheLocationMessage", message)
                         != Status.EXTERNAL) {
             return;
@@ -140,6 +146,8 @@ public final class ResilienceMessageHandler implements CellMessageReceiver {
     }
 
     public void messageArrived(PnfsClearCacheLocationMessage message) {
+        ACTIVITY_LOGGER.info("Received notice that pool {} cleared file {}.",
+                             message.getPoolName(), message.getPnfsId());
         if (messageGuard.getStatus("PnfsClearCacheLocationMessage", message)
                         != Status.EXTERNAL) {
             return;
@@ -148,10 +156,16 @@ public final class ResilienceMessageHandler implements CellMessageReceiver {
     }
 
     public void messageArrived(PoolMigrationCopyFinishedMessage message) {
+        ACTIVITY_LOGGER.info("Received notice that transfer {} of file "
+                                             + "{} from {} has finished.",
+                             message.getUUID(), message.getPnfsId(), message.getPool());
         fileOperationHandler.handleMigrationCopyFinished(message);
     }
 
     public void messageArrived(CellMessage message, PoolMgrSelectReadPoolMsg reply) {
+        ACTIVITY_LOGGER.info("Received notice that file {} has been staged to pool {}",
+                             reply.getPool(),
+                             reply.getPnfsId());
         if (messageGuard.getStatus("PoolMgrSelectReadPoolMsg", message)
                         == Status.DISABLED) {
             return;


### PR DESCRIPTION
Motivation:

Providing an activity log, where resilience records its interactions
with other dCache components, may prove useful in understanding
behaviour.

Modification:

Log any cell message received by resilience.

Result:

It is now possible to record resilience activity (on the receiving
end), which may prove useful.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.0
Request: 4.2
Acked-by: Paul