### PR TITLE
 pool: grow file prior HTTP TPC

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -265,6 +265,11 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
             if (entity == null) {
                 throw new ClientProtocolException("Response contains no content");
             }
+
+            long length = entity.getContentLength();
+            if (length > 0) {
+                _channel.truncate(length);
+            }
             entity.writeTo(Channels.newOutputStream(_channel));
         } catch (SocketTimeoutException e) {
             String message = "socket timeout (received "


### PR DESCRIPTION
Motivation:
when HTTP TPC client receives the "Content-Length" header from a server,
then we should pre-allocate file's size to let back-end store to
optimize block allocation. This is especially important for high latency
systems, like CEPH.

Modification:
Grow file on backend storage if size is known.

Result:
Performance boost for ceph pool.

Acked-by: Dmitry Litvintsev
Acked-by: Paul Millar
Target: master, 5.0, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 18a79e77684d24bf4647c98a752d0a7b27d1bc69)
Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de