### PR TITLE
resilience: add ability to log resilience activity

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
@@ -61,6 +61,8 @@ package org.dcache.resilience.data;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -122,6 +124,9 @@ import org.dcache.vehicles.resilience.ForceSystemStickyBitMessage;
  *      to be unsynchronized.</p>
  */
 public final class FileOperation {
+    private static final Logger ACTIVITY_LOGGER =
+            LoggerFactory.getLogger("org.dcache.resilience-log");
+
     /*
      * Stored state. Instead of using enum, to leave less of a memory footprint.
      * As above.
@@ -250,6 +255,7 @@ public final class FileOperation {
 
         String pool = poolInfoMap.getPool(getNullForNil(source));
 
+        ACTIVITY_LOGGER.info("Setting system sticky for {} on {}", pnfsId, pool);
         pools.send(new CellPath(pool),
                    new ForceSystemStickyBitMessage(pool, pnfsId));
     }

--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -12,6 +12,7 @@ dcache.net.wan.port.min=23000
 dcache.net.wan.port.max=25000
 dcache.paths.grid-security=${system-test.home}/etc/grid-security
 dcache.log.level.events=debug
+dcache.log.level.resilience=info
 dcache.authn.crl-mode=IF_VALID
 dcache.authn.hostcert.refresh=5
 dcache.authn.hostcert.refresh.unit=SECONDS

--- a/skel/etc/logback.xml
+++ b/skel/etc/logback.xml
@@ -297,7 +297,7 @@
     <threshold>
       <appender>resilience</appender>
       <logger>org.dcache.resilience-log</logger>
-      <level>error</level>
+      <level>${dcache.log.level.resilience}</level>
     </threshold>
 
   </turboFilter>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -72,6 +72,7 @@
 (not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.events=off
 (not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.access=info
 (not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.zookeeper=info
+(not-for-services,one-of?off|error|warn|info|debug|trace|all)dcache.log.level.resilience=error
 
 # How many days to keep access logs
 dcache.log.access.max-history=30


### PR DESCRIPTION
Motivation:

Providing an activity log, where resilience records its interactions
with other dCache components, may prove useful in understanding
behaviour.

Modification:

Log any cell message sent by resilience.

Make the log-level of the .resilience log file configurable, in the same
fashion other log files are configurable.  The default is not modified,
so (by default) this patch enables no additional logging.

Update system-test to record resilience activity.

Result:

It is now possible to record resilience activity, which may prove
useful.

Target: master
Requires-notes: yes
Requires-book: yes
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0