### PR TITLE
systemtest: remove ancient replica pools

### DIFF
--- a/packages/system-test/src/main/skel/var/config/poolmanager.conf
+++ b/packages/system-test/src/main/skel/var/config/poolmanager.conf
@@ -56,9 +56,6 @@ psu addto ugroup resilient-store test:resilient@osm
 #
 psu create pool pool_write
 psu create pool pool_read
-psu create pool pool_r1
-psu create pool pool_r2
-psu create pool pool_r3
 psu create pool pool_sm
 psu create pool pool_res1
 psu create pool pool_res2


### PR DESCRIPTION
Motivation:

Pools pool_r{1,2,3} were added to test replica manager.  With
the introduction of resilience and the removal of replica manager, these
pools were no longer part of systemtest.  However, the pools were
mistakenly not removed from the poolmanager.conf file, leaving
them as phantom pools: onces that poolmanager knows about, but
that are never part of the dCachec cluster.

Their presence in dCache pool causes resilience to believe that
something has changed when it receives new pool information.

Modification:

Remove pool_r{1,2,3} from poolmanager.conf

Result:

More sane poolmanager.conf configuration.

Target: master
Request: 5.0
Request: 4.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/11617/
Acked-by: Jürgen Starek