### PR TITLE
nfs: fix missing CDC initialization

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -568,7 +568,7 @@ public class NFSv41Door extends AbstractCellComponent implements
         LayoutDriver layoutDriver = getLayoutDriver(layoutType);
 
         NFS4Client client = null;
-        try {
+        try(CDC ignored = CDC.reset(getCellName(), getCellDomainName())) {
 
             FsInode inode = _chimeraVfs.inodeFromBytes(nfsInode.getFileId());
             PnfsId pnfsId = new PnfsId(inode.getId());
@@ -678,10 +678,6 @@ public class NFSv41Door extends AbstractCellComponent implements
             throw asNfsException(e, LayoutTryLaterException.class);
         } catch (InterruptedException e) {
             throw new LayoutTryLaterException(e.getMessage(), e);
-        } finally {
-            CDC.clearMessageContext();
-            NDC.pop();
-            NDC.pop();
         }
 
     }


### PR DESCRIPTION
Motivation:
NFs door's debug context missing domain and cell information

Modification:
Ensure that debug context is initialized when door interacts with
dcache.

Result:
more accurate logging.

Acked-by: Paul Millar
Acked-by: Marina Sahakyan
Target: master, 5.0, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 8c54546107acb618f1e2e88f750f065ade15bf0d)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>