### PR TITLE
libs: update jetty version to 9.4.12.v20180830

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.aspectj>1.8.10</version.aspectj>
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
-        <version.jetty>9.4.11.v20180605</version.jetty>
+        <version.jetty>9.4.12.v20180830</version.jetty>
         <version.xrootd4j>3.3.4</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
         <version.dcache-view>1.5.3</version.dcache-view>


### PR DESCRIPTION
CVE-2018-12545

Acked-by: Paul Millar
Target: master, 5.0, 4.2
Requires-book: no
Requires-notes: yes
(cherry picked from commit eddda93d9ed32f9ccbb5b15d127aae14ff6c31ef)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>