### PR TITLE
chimera-shell: fix class cast of extractor in constructor

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
@@ -58,7 +58,6 @@ import org.dcache.chimera.HimeraDirectoryEntry;
 import org.dcache.chimera.NotDirChimeraException;
 import org.dcache.chimera.OriginTag;
 import org.dcache.chimera.UnixPermission;
-import org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor;
 import org.dcache.chimera.namespace.ChimeraStorageInfoExtractable;
 import org.dcache.chimera.namespace.ExtendedInode;
 import org.dcache.chimera.posix.Stat;
@@ -107,12 +106,11 @@ public class Shell extends ShellApplication
         pwd = fs.path2inode(path);
 
 
-        Class<? extends ChimeraOsmStorageInfoExtractor> storageInfoExtractor =
-                Class.forName(extractor).asSubclass(ChimeraOsmStorageInfoExtractor.class);
+        Class<? extends ChimeraStorageInfoExtractable> storageInfoExtractor =
+                Class.forName(extractor).asSubclass(ChimeraStorageInfoExtractable.class);
         Constructor<? extends ChimeraStorageInfoExtractable> constructor = storageInfoExtractor.getConstructor(AccessLatency.class, RetentionPolicy.class);
 
-        this.extractor = (ChimeraStorageInfoExtractable) constructor.newInstance(
-                AccessLatency.getAccessLatency(accessLatency),
+        this.extractor = constructor.newInstance(AccessLatency.getAccessLatency(accessLatency),
                 RetentionPolicy.getRetentionPolicy(retentionPolicy));
     }
 


### PR DESCRIPTION
See https://github.com/dCache/dcache/issues/4751

When constructing the shell, the current constructor casts the storage info extractor
subtype to ChimeraOsmStorageInfoExtractor.

However, some extractors, like those for enstore, subclass
ChimerahsmStorageInfoExtractor directly.

This produces a ClassCastException.

Modification:

Change the cast to the parent type.

Result:

Successful login to shell.

Target: master
Bug: #4751
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Requires-notes: yes
Requires-book: no
Acked-by: Tigran
Acked-by: Paul