### PR TITLE
libs: use nfs4j-0.17.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -742,7 +742,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.17.10</version>
+            <version>0.17.11</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.dcache.common</groupId>


### PR DESCRIPTION
bugfix release. The highlights:

 - fix of export table evaluation order

Changelog for nfs4j-0.17.10..nfs4j-0.17.11
    * [a6e3d801] [maven-release-plugin] prepare for next development iteration
    * [cea96d55] nfs: fix export entry ordering
    * [6a21c53c] [maven-release-plugin] prepare release nfs4j-0.17.11

Target: master, 5.0
Require-book: no
Require-notes: yes