### PR TITLE
resilience: update state on pool operations when restarted from admin…

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/admin/ResilienceCommands.java
@@ -1064,6 +1064,7 @@ public final class ResilienceCommands implements CellCommandListener {
                     new Thread(() -> {
                         poolOperationMap.loadPools();
                         poolOperationMap.initialize();
+                        poolOperationMap.updateInitialized();
                     }).start();
                     return "Consumer initialization and pool reload started.";
                 case SHUTDOWN:

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
@@ -563,6 +563,13 @@ public class PoolOperationMap extends RunnableModule {
         watchdog.running = on;
     }
 
+    public void updateInitialized() {
+        poolInfoMap.getResilientPools().stream()
+                   .filter(poolInfoMap::isInitialized)
+                   .map(poolInfoMap::getPoolState)
+                   .forEach(this::update);
+    }
+
     /**
      * <p>Called upon receipt of a pool status update (generated via
      *      comparison of PoolMonitor data).</p>

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/MapInitializer.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/MapInitializer.java
@@ -192,14 +192,11 @@ public final class MapInitializer implements Runnable {
         poolInfoChangeHandler.startWatchdog();
 
         /*
-         *  Do this after initialization.  There first PoolMonitor message
+         *  Do this after initialization.  The first PoolMonitor message
          *  may already have pools whose states are known.
          */
         LOGGER.info("Updating initialized pools.");
-        poolInfoMap.getResilientPools().stream()
-                   .filter(poolInfoMap::isInitialized)
-                   .map(poolInfoMap::getPoolState)
-                   .forEach(poolOperationMap::update);
+        poolOperationMap.updateInitialized();
 
         /*
          *  Do this after initialization.  It may take a while


### PR DESCRIPTION
… command

Motivation:

The admin command 'pool ctrl'  provides for 'start' and 'shutdown'
options which stop the processing of all pool operations.

The 'start' option, however, neglects to update the state info
on the pool operations when they are readded to the map and
the map initialized.  This means that, barring state change
updates from the PoolMonitor, these pools will appear
perpetually uninitialized and will block any operation from
running.

Modification:

Take the update code out of the MapInitializer and add it
to the PoolOperationMap, where it is called both by the
MapInitializer and the admin command.

Result:

Pool operations can successfully be restarted from the
command line after they have been shutdown, without
restarting resilience.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Requires-notes: yes
Requires-book: no
Acked-by: Tigran