### PR TITLE
dcache-resilience: fix indexing on retry errors command

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/OperationHistory.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/OperationHistory.java
@@ -136,7 +136,7 @@ public class OperationHistory {
                             .map((s) ->
                                  {
                                     String pnfsid = s.substring(s.indexOf("(") + 1);
-                                    return pnfsid.substring(pnfsid.indexOf(" "));
+                                    return pnfsid.substring(0, pnfsid.indexOf(" "));
                                  })
                             .collect(toList());
             errors.clear();


### PR DESCRIPTION
Motivation:

Faulty parsing of the error string on the 'retry errors'
command results in operation failure, with message
"IllegalArgumentException: Illegal pnfsid string length."

Modification:

Fix the substring indexing.

Result:

Command works.

Target: master
Request: 5.0
Requires-book: no
Requires-notes: yes
Acked-by: Olufemi