### PR TITLE
pool: update error messages to make them distinct

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
@@ -44,6 +44,7 @@ import org.dcache.pool.movers.MoverProtocolMover;
 import org.dcache.pool.repository.ReplicaDescriptor;
 import org.dcache.pool.repository.RepositoryChannel;
 import org.dcache.util.CDCExecutorServiceDecorator;
+import org.dcache.util.Exceptions;
 
 public abstract class AbstractMoverProtocolTransferService
         extends AbstractCellComponent
@@ -79,12 +80,20 @@ public abstract class AbstractMoverProtocolTransferService
             MoverProtocol moverProtocol = createMoverProtocol(info);
             return new MoverProtocolMover(handle, message, pathToDoor, this, moverProtocol, _checksumModule);
         } catch (InvocationTargetException e) {
-            throw new CacheException(27, "Could not create mover for " + info, e.getTargetException());
+            Throwable cause = e.getTargetException();
+            String causeError = cause instanceof Exception
+                    ? Exceptions.messageOrClassName((Exception)cause)
+                    : cause.toString();
+            String error = "Construction of MoverProtocol mover for " + info
+                    + " failed: " + causeError;
+            throw new CacheException(27, error, cause);
         } catch (ClassNotFoundException e) {
             throw new CacheException(27, "Protocol " + info + " is not supported", e);
         } catch (Exception e) {
-            LOGGER.error("Invalid mover for " + info + ": " + e.toString(), e);
-            throw new CacheException(27, "Could not create mover for " + info, e);
+            String error = "Could not create MoverProtocol mover for " + info
+                    + ": " + Exceptions.messageOrClassName(e);
+            LOGGER.error(error, e);
+            throw new CacheException(27, error, e);
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteGsiftpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteGsiftpTransferService.java
@@ -141,7 +141,7 @@ public class RemoteGsiftpTransferService extends AbstractMoverProtocolTransferSe
         if (info instanceof RemoteGsiftpTransferProtocolInfo) {
             moverProtocol = new RemoteGsiftpTransferProtocol(getCellEndpoint(), portRange, bannedCiphers, getContextFactory());
         } else {
-            throw new CacheException(27, "Could not create mover for " + info);
+            throw new CacheException(27, "Could not create third-party GSIFTP mover for " + info);
         }
         return moverProtocol;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteHttpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteHttpTransferService.java
@@ -127,7 +127,7 @@ public class RemoteHttpTransferService extends AbstractMoverProtocolTransferServ
         } else if (info instanceof RemoteHttpDataTransferProtocolInfo) {
             moverProtocol = new RemoteHttpDataTransferProtocol(getCellEndpoint());
         } else {
-            throw new CacheException(27, "Could not create mover for " + info);
+            throw new CacheException(27, "Could not create third-party HTTP mover for " + info);
         }
         return moverProtocol;
     }


### PR DESCRIPTION
Motivation:

The phrase "Could not create mover" has been copied several times.  This
makes it impossible to distinguish what exactly has failed.

Modification:

Update the message to make each instance more specific.  In places,
include the underlying error in the response.

Result:

Update error messages (previously "Could not create mover") to provide
more information about why the mover could not be created.

Target: master
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11526
Acked-by: Albert Rossi