### PR TITLE
transfermanager: avoid NPE on shutdown

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -380,6 +380,9 @@ public abstract class TransferManager extends AbstractCellComponent
 
     public void removeActiveTransfer(long id) {
         TransferManagerHandler handler = _activeTransfers.remove(id);
+        if (handler == null) {
+            return;
+        }
         if (doDbLogging()) {
             PersistenceManager pm = _pmf.getPersistenceManager();
             try {


### PR DESCRIPTION
Motivation:

Observed the following stack-trace.

    10 Apr 2019 23:00:44 (RemoteTransferManager) [door:WebDAV-S-sprocket@dCacheDomain:AAWGM1neT8g WebDAV-S-sprocket RemoteTransferManager] Uncaught exception in thread pool-223-thread-1
    java.lang.NullPointerException: null
            at diskCacheV111.services.TransferManagerHandlerBackup.<init>(TransferManagerHandlerBackup.java:33)
            at diskCacheV111.services.TransferManager.removeActiveTransfer(TransferManager.java:387)
            at diskCacheV111.services.TransferManagerHandler.sendErrorReply(TransferManagerHandler.java:639)
            at diskCacheV111.services.TransferManagerHandler.sendErrorReply(TransferManagerHandler.java:579)
            at diskCacheV111.services.TransferManagerHandler.failure(TransferManagerHandler.java:344)
            at org.dcache.cells.AbstractMessageCallback.noroute(AbstractMessageCallback.java:38)
            at org.dcache.cells.CellStub.lambda$addCallback$0(CellStub.java:526)
            at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
            at java.lang.Thread.run(Thread.java:748)

Modification:

Avoid any database operations if the id is not longer known.

Result:

Fix a NullPointerException if transfer was cancelled.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.1
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11686/
Acked-by: Tigran Mkrtchyan