### PR TITLE
frontend: avoid race on cancelling channel garbage-collect task

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/events/Channel.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/events/Channel.java
@@ -290,10 +290,9 @@ public class Channel extends CloseableWithTasks
         }
 
         if (closeFuture != null) {
-            if (closeFuture.isDone()) {
+            if (!closeFuture.cancel(false)) {
                 throw new NotFoundException("Channel is closed"); // This shouldn't really happen.
             }
-            closeFuture.cancel(true);
             closeFuture = null;
         }
 


### PR DESCRIPTION
Motivation:

Channels self-delete if left unused for long enough.  When a client
connects, this timer is cancelled.  There are two problems with
the current approach.

First, it allows interrupting the delete task.  This could lead
to the channel being in an inconsistent, half-deleted state.

Second, there is a race condition: the cancel happens after
checking whether the task has completed.

Modification:

Avoid interrupting the delete task and use the cancel method's
return value to determine whether the channel is still open.

Result:

Less chance for a channel to be in an inconsistent state.

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11691/
Acked-by: Tigran MKrtchyan