### PR TITLE
frontend: ensure client is disconnected when shutting down channel

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/events/Channel.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/events/Channel.java
@@ -168,15 +168,17 @@ public class Channel extends CloseableWithTasks
 
         onClose(() -> {
                     subscriptionsByIdentity.values().forEach(Subscription::close);
-                    if (sink != null && !sink.isClosed()) {
-                        sink.close();
-                        sink = null;
-                        sse = null;
-                    }
-                    ringBuffer.clear();
-                    if (closeFuture != null) {
-                        closeFuture.cancel(false); // do not interrupt ourself
-                        closeFuture = null;
+                    synchronized (Channel.this) {
+                        if (sink != null && !sink.isClosed()) {
+                            sink.close();
+                            sink = null;
+                            sse = null;
+                        }
+                        ringBuffer.clear();
+                        if (closeFuture != null) {
+                            closeFuture.cancel(false); // do not interrupt ourself
+                            closeFuture = null;
+                        }
                     }
                 });
 


### PR DESCRIPTION
Motivation:

The destroy sequence for a channel failed to obtain the Channel
monitor.  This could result in concurrent changes to the Channel's
state and incomplete Channel shutdown.

Modification:

Update shutdown code so that it obtains the Channel monitor

Result:

The shutdown sequence of a channel is more robust.

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11690/diff/1#index_header
Acked-by: Tigran Mkrtchyan