### PR TITLE
pool: avoid log-and-throw anti-pattern

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.pool.classic;
 
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,9 +92,9 @@ public abstract class AbstractMoverProtocolTransferService
         } catch (ClassNotFoundException e) {
             throw new CacheException(27, "Protocol " + info + " is not supported", e);
         } catch (Exception e) {
+            Throwables.throwIfUnchecked(e);
             String error = "Could not create MoverProtocol mover for " + info
                     + ": " + Exceptions.messageOrClassName(e);
-            LOGGER.error(error, e);
             throw new CacheException(27, error, e);
         }
     }


### PR DESCRIPTION
Motivation:

If the pool is unable to create a mover, it logs the information with a
stack-trace and throws an exception.  There are two problems here.
First, this is the log-and-throw anti-pattern, which risks logging the
same problem multiple times.  Second, the code logs a stack-trace even
when the problem is not a bug.

Modification:

Update the code so that any RuntimeException is simply re-thrown.

Any other exception is wrapped in a CacheException, with a reasonable
error message.

Result:

The pool no longer logs configuration or deployment problems that
prevent the pool from creating a mover as if that problem was a bug.

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11687/
Acked-by: Tigran Mkrtchyan