### PR TITLE
transfermanager: do not retry starting mover if transfer is not suppo…

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/util/CacheException.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/util/CacheException.java
@@ -9,6 +9,9 @@ public class CacheException extends Exception
 {
     private static final long serialVersionUID = 3219663683702355240L;
 
+    /** Requested transfer is not possible on this pool. */
+    public static final int CANNOT_CREATE_MOVER = 27;
+
     /** Requested operation is disabled in pool. */
     public static final int POOL_DISABLED = 104;
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -326,13 +326,10 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             case CacheException.OUT_OF_DATE:
             case CacheException.POOL_DISABLED:
             case CacheException.FILE_NOT_IN_REPOSITORY:
-                if (numberOfPoolSelectionRetries++ < MAXIMUM_POOL_SELECTION_ATTEMPTS) {
-                    log.debug("Pool {} reported rc={}; retrying pool selection",
-                            pool.getAddress(), rc);
-                    selectPool();
-                } else {
-                    sendErrorReply(rc, "Too many attempts to select pool: " + error);
-                }
+            case CacheException.CANNOT_CREATE_MOVER:
+                log.debug("Pool {} reported rc={}; retrying pool selection",
+                        pool.getAddress(), rc);
+                retryPoolSelection(rc, error);
                 break;
 
             case CacheException.TIMEOUT:
@@ -363,15 +360,9 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                                 }
                             });
                 } else {
-                    if (numberOfPoolSelectionRetries++ < MAXIMUM_POOL_SELECTION_ATTEMPTS) {
-                        log.debug("Too many attempts to start mover on pool {}, retrying pool selection",
-                                pool.getAddress(), rc);
-                        numberOfMoverStartRetries = 0;
-                        selectPool();
-                    } else {
-                        sendErrorReply(rc, "Too many attempts to start mover on pool "
-                                + pool.getAddress() + ": " + error);
-                    }
+                    log.debug("Too many attempts to start mover on pool {},"
+                            + " retrying pool selection", pool.getAddress());
+                    retryPoolSelection(rc, error);
                 }
                 break;
             }
@@ -406,6 +397,17 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             sendErrorReply(rc, "Failed in state " + state + ": " + error +
                     " [" + rc + "]");
             break;
+        }
+    }
+
+    private void retryPoolSelection(int rc, Object error)
+    {
+        if (numberOfPoolSelectionRetries++ < MAXIMUM_POOL_SELECTION_ATTEMPTS) {
+            numberOfMoverStartRetries = 0;
+            selectPool();
+        } else {
+            sendErrorReply(rc, "Too many attempts to select pool; last pool "
+                    + pool.getAddress() + " failed with " + error);
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
@@ -88,14 +88,17 @@ public abstract class AbstractMoverProtocolTransferService
                     : cause.toString();
             String error = "Construction of MoverProtocol mover for " + info
                     + " failed: " + causeError;
-            throw new CacheException(27, error, cause);
+            throw new CacheException(CacheException.CANNOT_CREATE_MOVER, error,
+                    cause);
         } catch (ClassNotFoundException e) {
-            throw new CacheException(27, "Protocol " + info + " is not supported", e);
+            throw new CacheException(CacheException.CANNOT_CREATE_MOVER,
+                    "Protocol " + info + " is not supported", e);
         } catch (Exception e) {
             Throwables.throwIfUnchecked(e);
             String error = "Could not create MoverProtocol mover for " + info
                     + ": " + Exceptions.messageOrClassName(e);
-            throw new CacheException(27, error, e);
+            throw new CacheException(CacheException.CANNOT_CREATE_MOVER, error,
+                    e);
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteGsiftpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteGsiftpTransferService.java
@@ -141,7 +141,8 @@ public class RemoteGsiftpTransferService extends AbstractMoverProtocolTransferSe
         if (info instanceof RemoteGsiftpTransferProtocolInfo) {
             moverProtocol = new RemoteGsiftpTransferProtocol(getCellEndpoint(), portRange, bannedCiphers, getContextFactory());
         } else {
-            throw new CacheException(27, "Could not create third-party GSIFTP mover for " + info);
+            throw new CacheException(CacheException.CANNOT_CREATE_MOVER,
+                    "Could not create third-party GSIFTP mover for " + info);
         }
         return moverProtocol;
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteHttpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteHttpTransferService.java
@@ -130,7 +130,8 @@ public class RemoteHttpTransferService extends AbstractMoverProtocolTransferServ
         } else if (info instanceof RemoteHttpDataTransferProtocolInfo) {
             moverProtocol = new RemoteHttpDataTransferProtocol(getCellEndpoint());
         } else {
-            throw new CacheException(27, "Could not create third-party HTTP mover for " + info);
+            throw new CacheException(CacheException.CANNOT_CREATE_MOVER,
+                    "Could not create third-party HTTP mover for " + info);
         }
         return moverProtocol;
     }


### PR DESCRIPTION
…rted

Motivation:

By default, the transfermanager will retry starting the mover ten times
before giving up on the pool.  If we know that a pool doesn't support
this transfer type (for whatever reason), then this makes no sense.

Modification:

Assign a constant for the CacheException rc corresponding to a pool
being unable to start a mover.

Alter transfermanager's behaviour so that it immediately retries pool
selection if the selected pool does not support this transfer type.

Result:

A pool that does not support a particular transfer is not immediately
retried.

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11689/
Acked-by: Tigran Mkrtchyan