### PR TITLE
resilience: adjust synchronization of file operation removal from map

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
@@ -409,12 +409,9 @@ public final class FileOperation {
                         retried, exception == null ? "" : new ExceptionMessage(exception));
     }
 
-    void abortOperation() {
-        synchronized( this) {
-            updateState(ABORTED);
-            opCount = 0;
-        }
-
+    synchronized void abortOperation() {
+        updateState(ABORTED);
+        opCount = 0;
         lastUpdate = System.currentTimeMillis();
         source = NIL;
         target = NIL;
@@ -450,15 +447,13 @@ public final class FileOperation {
         tried.add(target);
     }
 
-    boolean cancelCurrent() {
-        synchronized( this) {
-            if (isInTerminalState()) {
-                return false;
-            }
-
-            updateState(CANCELED);
-            --opCount;
+    synchronized boolean cancelCurrent() {
+        if (isInTerminalState()) {
+            return false;
         }
+
+        updateState(CANCELED);
+        --opCount;
 
         lastUpdate = System.currentTimeMillis();
         if (task != null) {
@@ -496,10 +491,8 @@ public final class FileOperation {
         ++retried;
     }
 
-    void resetOperation() {
-        synchronized (this) {
-            updateState(WAITING);
-        }
+    synchronized void resetOperation() {
+        updateState(WAITING);
         task = null;
         exception = null;
         lastUpdate = System.currentTimeMillis();
@@ -550,7 +543,7 @@ public final class FileOperation {
     }
 
     @VisibleForTesting
-    void setState(String state) {
+    synchronized void setState(String state) {
         switch (state) {
             case "WAITING":     updateState(WAITING);   break;
             case "RUNNING":     updateState(RUNNING);   break;
@@ -576,7 +569,7 @@ public final class FileOperation {
      *    queued, we simply overwrite the appropriate fields on
      *    this one.</p>
      */
-    void updateOperation(FileOperation operation) {
+    synchronized void updateOperation(FileOperation operation) {
         if (operation.storageUnit != NIL) {
             storageUnit = operation.storageUnit;
         }
@@ -595,34 +588,30 @@ public final class FileOperation {
         opCount += operation.opCount;
     }
 
-    boolean updateOperation(CacheException error) {
-        synchronized (this) {
-            if (isInTerminalState()) {
-                return false;
-            }
+    synchronized boolean updateOperation(CacheException error) {
+        if (isInTerminalState()) {
+            return false;
+        }
 
-            if (error != null) {
-                exception = error;
-                updateState(FAILED);
-            } else {
-                updateState(DONE);
-                --opCount;
-                retried = 0;
-            }
+        if (error != null) {
+            exception = error;
+            updateState(FAILED);
+        } else {
+            updateState(DONE);
+            --opCount;
+            retried = 0;
         }
 
         lastUpdate = System.currentTimeMillis();
         return true;
     }
 
-    boolean voidOperation() {
-        synchronized(this) {
-            if (isInTerminalState()) {
-                return false;
-            }
-            updateState(VOID);
-            opCount = 0;
+    synchronized boolean voidOperation() {
+        if (isInTerminalState()) {
+            return false;
         }
+        updateState(DONE);
+        opCount = 0;
         retried = 0;
         source = NIL;
         target = NIL;


### PR DESCRIPTION
Motivation:

The FileOperation encapsulates the state for a single pnfsid
in need of replication or replica adjustment.  The following
points of contention on it are possible:

1. presence or absence in the FileOpMap index:

"incoming" threadchecks (sync on incoming)
"processor" thread accesses (via FileOpHandler); removes

2. operation count:

"incoming" thread sets;
"processor" threadsets, gets;
"task" threadsets;

3. operation state:

"processor" threadsets, gets;
"task" threadsets

From the above, it can be seen that count and state need to
be protected by synchronization (on the object).  For the
presence or absence in the index, it appeared to be
enough to make the initial check and put operation
atomic via synchronization on the incoming queue.

However, the removal from the index is also susceptible
to a race where the incoming thread could potentially
update an object which the processor has already
decided to remove from the index.

Modification:

Make the check for opCount and removal from index
symmetrically atomic to the check and put by synchronizing
on the incoming map.

Also, the internal synchronization
protecting opCount and state has been lifted out to
the entire method where before the synchronized block did not include
the setting of other fields on the update. (This change is not
crucial but it makes the code cleaner and more consistent.)

Result:

The risk of updating a stale operation (instead of creating
a new one when it is too late to update the previous) is
removed, and with it the possibility that an operation
could run too few times.

Target: master
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Acked-by: Tigran