### PR TITLE
pom: use jetty 9.4.17.v20190418

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/jetty/CanlContextFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/util/jetty/CanlContextFactory.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2015 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2015 - 2019 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -53,7 +53,7 @@ import org.dcache.util.Callables;
  * Can optionally create GSIEngine wrappers for SSLEngine to support GSI delegation. Should be
  * combined with GsiRequestCustomizer to add the delegated credentials to the HttpServletRequest.
  */
-public class CanlContextFactory extends SslContextFactory
+public class CanlContextFactory extends SslContextFactory.Server
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CanlContextFactory.class);
 
@@ -213,7 +213,9 @@ public class CanlContextFactory extends SslContextFactory
      */
     private SslContextFactory createDelegate() throws Exception
     {
-        SslContextFactory factory = new SslContextFactory()
+        // use instance of SslContextFactory.Server as it allows non 'https' protocol schemas.
+        // See: https://github.com/eclipse/jetty.project/issues/3454
+        SslContextFactory factory = new SslContextFactory.Server()
         {
             private final PEMCredential serverCredential =
                     new PEMCredential(keyPath.toString(), certificatePath.toString(), null);

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.aspectj>1.8.10</version.aspectj>
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
-        <version.jetty>9.4.12.v20180830</version.jetty>
+        <version.jetty>9.4.17.v20190418</version.jetty>
         <version.wicket>7.6.0</version.wicket>
         <version.xrootd4j>3.2.5</version.xrootd4j>
         <version.jersey>2.24</version.jersey>


### PR DESCRIPTION
CVE-2019-10247

Acked-by: Albert Rossi
Target: master, 5.1, 5.0, 4.2, 4.1, 4.0, 3.2
Require-book: no
Require-notes: no
(cherry picked from commit 120f702739f1cdb9b97a8b259ec1806574c33180)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>