### PR TITLE
dcache-resilience (stable branches): fix race condition on replica state

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -75,6 +75,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import diskCacheV111.util.CacheException;
@@ -82,6 +83,7 @@ import diskCacheV111.util.PnfsId;
 import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.util.SpreadAndWait;
 import diskCacheV111.vehicles.PoolCheckFileMessage;
+import diskCacheV111.vehicles.PoolFileCheckable;
 
 import dmg.cells.nucleus.CellPath;
 
@@ -135,6 +137,9 @@ public class FileOperationHandler {
     private static final ImmutableList<StickyRecord> ONLINE_STICKY_RECORD
                     = ImmutableList.of(
                     new StickyRecord("system", StickyRecord.NON_EXPIRING));
+
+    private static final Predicate<PoolFileCheckable> REPLICA_EXISTS
+                    = (p) -> p.getHave() || p.getWaiting();
 
     private static final RateLimiter LIMITER = RateLimiter.create(0.001);
 
@@ -821,7 +826,7 @@ public class FileOperationHandler {
 
         return controller.getReplies().values()
                          .stream()
-                         .filter(PoolCheckFileMessage::getHave)
+                         .filter(REPLICA_EXISTS)
                          .map(PoolCheckFileMessage::getPoolName)
                          .collect(Collectors.toSet());
     }


### PR DESCRIPTION
Motivation:

A race condition on AddCacheLocation can cause resilience
to consider the replica verification for the source pool
failed if the replica has not changed state from FROM_CLIENT
to CACHED or PRECIOUS by the time resilience checks.

Modification:

Allow the 'waiting' state (on the PoolFileCheckable message)
to qualify as verified.

Result:

No 'inaccessible file errors' for a newly written file.

Target: 5.1
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Acked-by: Tigran