### PR TITLE
dcap batch : fix handling of dcap.kafka.topic variable

### DIFF
--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -114,7 +114,7 @@ create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
              -billing=\"${dcap.service.billing}\" \
              -kafka=\"${dcacp.enable.kafka}\" \
              -bootstrap-server-kafka=\"${dcap.kafka.bootstrap-servers}\" \
-	     -kafka-topic=\"{dcap.kafka.topic}\" \
+	     -kafka-topic=\"${dcap.kafka.topic}\" \
              -kafka-max-block=${dcap.kafka.maximum-block}\
              -kafka-max-block-units=${dcap.kafka.maximum-block.unit}\
              -retries-kafka=0 \


### PR DESCRIPTION
Patch 806de4076b3 neglected to add a $ in front of variable name.
This patch fixes this typo

RB : https://rb.dcache.org/r/11731/

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Require-book: no
Require-notes: no