### PR TITLE
dcap/pinmanager: stage request for unknown location results in NPE

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -1184,9 +1184,14 @@ public class DCapDoorInterpreterV3
                     return;
                 }
 
+                InetSocketAddress addr = new InetSocketAddress(_destination, 0);
+                if (addr.isUnresolved()) {
+                    _log.info("prestage request with unknown location: {}",
+                            _destination);
+                }
+
                 DCapProtocolInfo protocolInfo =
-                    new DCapProtocolInfo("DCap", 3, 0,
-                        new InetSocketAddress(_destination, 0));
+                        new DCapProtocolInfo("DCap", 3, 0, addr);
                 PinManagerPinMessage message =
                     new PinManagerPinMessage(_fileAttributes, protocolInfo,
                                              null, 0);

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
@@ -7,6 +7,10 @@ import com.google.common.collect.Ordering;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -310,10 +314,15 @@ public class PoolMonitorV5
             throw new PermissionDeniedCacheException("File is online, but not in read-allowed pool");
         }
 
-        private String getHostName() {
-            return (_protocolInfo instanceof IpProtocolInfo)
-            ? ((IpProtocolInfo) _protocolInfo).getSocketAddress().getAddress().getHostAddress()
-            : null;
+        @Nullable
+        private String getHostName()
+        {
+            if (_protocolInfo instanceof IpProtocolInfo) {
+                InetSocketAddress socketAddress = ((IpProtocolInfo) _protocolInfo).getSocketAddress();
+                InetAddress addr = socketAddress.getAddress();
+                return addr == null ? null : addr.getHostAddress();
+            }
+            return null;
         }
 
         private String getProtocol() {


### PR DESCRIPTION
Motivation:

Site has reported seeing problems with pin-manager:

    07 May 2019 16:46:55 (PinManager) [door:DCap-storage01-AAWITUnHIwA@dcap-storage01Domain DCap-storage01-AAWITUnHIwA PinManagerPin] Uncaught exception in thread PinManager-671562 java.lang.NullPointerException: null
            at diskCacheV111.poolManager.PoolMonitorV5$PnfsFileLocation.getHostName(PoolMonitorV5.java:309) ~[dcache-core-3.2.40.jar:3.2.40]
            at diskCacheV111.poolManager.PoolMonitorV5$PnfsFileLocation.selectPinPool(PoolMonitorV5.java:430) ~[dcache-core-3.2.40.jar:3.2.40]
            at org.dcache.pinmanager.PinRequestProcessor.selectReadPool(PinRequestProcessor.java:329) ~[dcache-core-3.2.40.jar:3.2.40]
            at org.dcache.pinmanager.PinRequestProcessor.messageArrived(PinRequestProcessor.java:204) ~[dcache-core-3.2.40.jar:3.2.40]
            at sun.reflect.GeneratedMethodAccessor233.invoke(Unknown Source) ~[na:na]
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_131]
            at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_131]
            at org.dcache.cells.CellMessageDispatcher$ShortReceiver.deliver(CellMessageDispatcher.java:289) ~[dcache-core-3.2.40.jar:3.2.40]
            at org.dcache.cells.CellMessageDispatcher.call(CellMessageDispatcher.java:202) ~[dcache-core-3.2.40.jar:3.2.40]
            at org.dcache.cells.AbstractCell.messageArrived(AbstractCell.java:331) ~[dcache-core-3.2.40.jar:3.2.40]
            at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:890) ~[cells-3.2.40.jar:3.2.40]
            at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1218) ~[cells-3.2.40.jar:3.2.40]
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) [dcache-common-3.2.40.jar:3.2.40]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_131]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_131]
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$4(CellNucleus.java:754) [cells-3.2.40.jar:3.2.40]
            at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_131]

Modification:

Log (at info level) if the client supplies a location that cannot be
resolved.

Update PoolMonitorV5 to be robust if a stage request is from some
unresolved client location.

Result:

Using dccp to stage a file should work even if the location is unknown.

Target: master
Requires-notes: yes
Requires-book: no
Target: 5.1
Target: 5.0
Target: 4.2
Target: 4.1
Target: 4.0
Target: 3.2
Ticket: https://rt.dcache.org/Ticket/Display.html?id=9689
Patch: https://rb.dcache.org/r/11732/
Acked-by: Tigran Mkrtchyan