### PR TITLE
dcap: fix premature close of kafka sender:

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -70,6 +70,7 @@ import dmg.cells.nucleus.CellAddressCore;
 import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellInfoProvider;
+import dmg.cells.nucleus.CellLifeCycleAware;
 import dmg.cells.nucleus.CellMessage;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.CellPath;
@@ -102,7 +103,7 @@ import static org.dcache.namespace.FileType.DIR;
 import static org.dcache.namespace.FileType.REGULAR;
 
 public class DCapDoorInterpreterV3
-        implements KeepAliveListener, CellMessageReceiver, CellInfoProvider, CellCommandListener
+        implements KeepAliveListener, CellMessageReceiver, CellInfoProvider, CellCommandListener, CellLifeCycleAware
 {
 
     private static final int UNDEFINED = -1;
@@ -2470,16 +2471,6 @@ public class DCapDoorInterpreterV3
 
     public void close() {
 
-
-        /*The producer consists of a pool of buffer space that holds records that haven't yet been
-          transmitted to the server as well as a background I/O thread
-          that is responsible for turning these records into requests and transmitting them to the cluster.
-          Failure to close the producer after use will leak these resources. Hence we need to  close Kafka Producer
-         */
-        if (_settings.isKafkaEnabled()) {
-            _kafkaProducer.close();
-        }
-
         for(SessionHandler sh: _sessions.values()) {
             try {
                 sh.removeUs();
@@ -2489,6 +2480,19 @@ public class DCapDoorInterpreterV3
                  */
                 _log.error("failed to removed session: " + sh, e);
             }
+        }
+    }
+
+    @Override
+    public void beforeStop() {
+
+        /*The producer consists of a pool of buffer space that holds records that haven't yet been
+          transmitted to the server as well as a background I/O thread
+          that is responsible for turning these records into requests and transmitting them to the cluster.
+          Failure to close the producer after use will leak these resources. Hence we need to  close Kafka Producer
+         */
+        if (_settings.isKafkaEnabled()) {
+            _kafkaProducer.close();
         }
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
@@ -53,6 +53,7 @@ import diskCacheV111.services.space.Space;
 import dmg.cells.nucleus.CDC;
 import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellInfoProvider;
+import dmg.cells.nucleus.CellLifeCycleAware;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.util.CommandExitException;
@@ -76,7 +77,7 @@ import static org.dcache.util.ByteUnit.KiB;
  * and accept Strings. These are passed on to an interpreter for processing.
  */
 public class NettyLineBasedDoor
-    extends AbstractCell implements ChannelInboundHandler
+    extends AbstractCell implements ChannelInboundHandler, CellLifeCycleAware
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(NettyLineBasedDoor.class);
 
@@ -119,6 +120,8 @@ public class NettyLineBasedDoor
      * Line oriented protocol interpreter.
      */
     private LineBasedInterpreter interpreter;
+
+    private Optional<CellLifeCycleAware> lifeCycleAwareInterpreter = Optional.empty();
 
     /**
      * Cell logging context under which protocol lines are interpreted.
@@ -219,6 +222,9 @@ public class NettyLineBasedDoor
         }
         if (interpreter instanceof CellMessageReceiver) {
             addMessageListener((CellMessageReceiver) interpreter);
+        }
+        if (interpreter instanceof CellLifeCycleAware) {
+            lifeCycleAwareInterpreter = Optional.of((CellLifeCycleAware)interpreter);
         }
         start().get(); // Blocking to prevent that we process any commands before the cell is alive
     }
@@ -429,5 +435,35 @@ public class NettyLineBasedDoor
                 }
             }
         }
+    }
+
+    @Override
+    public void afterStart()
+    {
+        lifeCycleAwareInterpreter.ifPresent(i -> i.afterSetup());
+    }
+
+    @Override
+    public void beforeStop()
+    {
+        lifeCycleAwareInterpreter.ifPresent(i -> i.beforeStop());
+    }
+
+    @Override
+    public void beforeSetup()
+    {
+        lifeCycleAwareInterpreter.ifPresent(i -> i.beforeSetup());
+    }
+
+    @Override
+    public void afterSetup()
+    {
+        lifeCycleAwareInterpreter.ifPresent(i -> i.afterSetup());
+    }
+
+    @Override
+    public void setupChanged(int version)
+    {
+        lifeCycleAwareInterpreter.ifPresent(i -> i.setupChanged(version));
     }
 }


### PR DESCRIPTION
Motivation:

Issue #4831 reported a stack-trace:

    08 May 2019 15:37:37 (DCap00-fndca4a-AAWIZk3V24A) [door:DCap00-fndca4a-AAWIZk3V24A@dcap00-fndca4aDomain PnfsManager PnfsGetFileAttributes] Uncaught exception in thread DCap00-fndca4a-io-2
org.apache.kafka.common.KafkaException: Producer closed while send in progress
           at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:864) ~[kafka-clients-2.1.0.jar:na]
           at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:841) ~[kafka-clients-2.1.0.jar:na]
           at diskCacheV111.doors.DCapDoorInterpreterV3.sendAsynctoKafka(DCapDoorInterpreterV3.java:2553) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3.postToBilling(DCapDoorInterpreterV3.java:2546) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3.access$1500(DCapDoorInterpreterV3.java:104) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3$SessionHandler.sendReply(DCapDoorInterpreterV3.java:875) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3$SessionHandler.sendReply(DCapDoorInterpreterV3.java:856) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3$PnfsSessionHandler.fileAttributesNotAvailable(DCapDoorInterpreterV3.java:1141) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3$PnfsSessionHandler.pnfsGetFileAttributesArrived(DCapDoorInterpreterV3.java:1105) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3.messageArrived(DCapDoorInterpreterV3.java:2527) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_181]
           at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_181]
           at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_181]
           at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_181]
           at org.dcache.cells.CellMessageDispatcher$LongReceiver.deliver(CellMessageDispatcher.java:304) ~[dcache-core-4.2.32-FNAL.jar:4.2.32-FNAL]
           at org.dcache.cells.CellMessageDispatcher.call(CellMessageDispatcher.java:201) ~[dcache-core-4.2.32-FNAL.jar:4.2.32-FNAL]
           at org.dcache.cells.AbstractCell.messageArrived(AbstractCell.java:331) ~[dcache-core-4.2.32-FNAL.jar:4.2.32-FNAL]
           at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:890) ~[cells-4.2.32-FNAL.jar:4.2.32-FNAL]
           at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1211) ~[cells-4.2.32-FNAL.jar:4.2.32-FNAL]
           at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) [dcache-common-4.2.32-FNAL.jar:4.2.32-FNAL]
           at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_181]
           at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_181]
           at java.lang.Thread.run(Thread.java:748) [na:1.8.0_181]
    Caused by: org.apache.kafka.common.KafkaException: Requested metadata update after close
           at org.apache.kafka.clients.Metadata.awaitUpdate(Metadata.java:200) ~[kafka-clients-2.1.0.jar:na]
           at org.apache.kafka.clients.producer.KafkaProducer.waitOnMetadata(KafkaProducer.java:981) ~[kafka-clients-2.1.0.jar:na]
           at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:861) ~[kafka-clients-2.1.0.jar:na]
           ... 22 common frames omitted

This is caused by the dcap client disconnecting before the transfer is
complete.

Modification:

Update NettyLineBasedDoor to support interpreters that wish to know
about cell lifecycle events.

Close kafka after we are sure no further messages will be received
(i.e., the beforeStop lifecycle event)

Result:

No more stack-traces from dcap door when the client closes connection
before request is processed.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.1
Request: 5.0
Request: 4.2
Closes: #4831
Patch: https://rb.dcache.org/r/11733/
Acked-by: Tigran Mkrtchyan
Acked-by: Dmitry Litvintsev