### PR TITLE
pool: fix reordering of removable replicas on access

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ReplicaStoreCache.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ReplicaStoreCache.java
@@ -254,7 +254,10 @@ public class ReplicaStoreCache
         public void setLastAccessTime(long time) throws CacheException
         {
             try {
+                CacheEntry currentEntry = new CacheEntryImpl(_record);
                 _record.setLastAccessTime(time);
+                CacheEntry updatedEntry = new CacheEntryImpl(_record);
+                _stateChangeListener.accessTimeChanged(new EntryChangeEvent(currentEntry, updatedEntry));
             } catch (IllegalArgumentException e) {
                 throw e;
             } catch (RuntimeException | DiskErrorCacheException e) {


### PR DESCRIPTION
Motivation:

Commit 9830f2d introduced a regression where accessing a file failed to
reorder the replicas subject to garbage collection.

Modification:

Ensure pool components are aware when the access time of a replica
changes.

Result:

Accessing a cache-only replica not only updates the last access time,
but also adjusts the LRU ordering.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.1
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11746
Acked-by: Dmitry Litvintsev