### PR TITLE
ftp: avoid NullPointerException after passive upload

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -3696,6 +3696,7 @@ public abstract class AbstractFtpDoorV1
         case PASSIVE:
             replyDelayedPassive(_delayedPassive, (InetSocketAddress) _passiveModeServerSocket.getLocalAddress());
             reply("150 Ready to accept ASCII mode data connection");
+            _passiveModeServerSocket.configureBlocking(true);
             _dataSocket = _passiveModeServerSocket.accept().socket();
             break;
         case ACTIVE:

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/SocketAdapter.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/SocketAdapter.java
@@ -559,6 +559,7 @@ public class SocketAdapter implements Runnable, ProxyAdapter
              */
             LOGGER.debug("Accepting output connection on {}",
                          outputSock.socket().getLocalSocketAddress());
+            outputSock.configureBlocking(true);
             SocketChannel output = outputSock.accept();
             sockets.add(output);
             if (_bufferSize > 0) {


### PR DESCRIPTION
Motivation:

We have had reports that downloading a file after uploading a file
within the same session fails.  The error is a NullPointerException
like:

    Uncaught exception in thread SocketAdapter-/193.48.99.18:30396
    java.lang.NullPointerException: null
        at org.dcache.ftp.proxy.SocketAdapter.run(SocketAdapter.java:692) ~[dcache-ftp-3.2.40.jar:3.2.40]
        at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_191]

This stack-trace is actually the result of the clean-up code
encountering a null value stored as a to-be-closed socket, there is
another NullPointerException that this hides.

The problem stems from the proxy (SocketAdapter) configuring the
data-receiving server socket to be non-blocking, but requires the
data-sending server socket to be blocking without configuring this.

For a passive upload, the data-receiving server socket is the
client-facing server socket, whereas for the passive download the
client-facing server socket is data-sending.

The upload will succeed, since the required blocking behaviour is the
default.  However, a subsequent download will fail, as the server socket
will be non-blocking.  The `accept` call will return immediately with
`null` value, so triggering the NullPointerException.

Modification:

Ensure that the server socket is configured to be blocking whenever the
FTP door requires the `accept` call to block.

The same problem exists in the door, which requires the socket to be
non-blocking for directory listing operations without configuring it.

Result:

Fix a NullPointerException where a client attempts to download a file or
list a directory (LIST, NLST or MLSD) after uploading a file if the door
is passive and transfers are proxied.

Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Closes: #4830
Patch: https://rb.dcache.org/r/11748/
Acked-by: Albert Rossi