### PR TITLE
alarms: add pool name to POOL_DEAD alarm

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -586,13 +586,13 @@ public class PoolV4
         if (alarm != null) {
             if (cause != null) {
                 LOGGER.error(AlarmMarkerFactory.getMarker(alarm, _poolName),
-                             "Fault occurred in {}: {}. {}, cause: {}",
-                             event.getSource(), event.getMessage(), poolState,
+                             "Pool: {}, fault occurred in {}: {}. {}, cause: {}",
+                             _poolName, event.getSource(), event.getMessage(), poolState,
                              cause.toString());
             } else {
                 LOGGER.error(AlarmMarkerFactory.getMarker(alarm, _poolName),
-                             "Fault occurred in {}: {}. {}",
-                             event.getSource(), event.getMessage(), poolState);
+                             "Pool: {}, fault occurred in {}: {}. {}",
+                             _poolName, event.getSource(), event.getMessage(), poolState);
             }
         }
     }


### PR DESCRIPTION
Motivation:

Alarm does not include pool name.

Modification:

Add it to the message.

Result:

Pool name tracked with alarm.

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Acked-by: Paul