### PR TITLE
pinmanager: avoid NPE if no argument given for 'bulk ls' command

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCLI.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCLI.java
@@ -326,7 +326,7 @@ public class PinManagerCLI
         @Override
         public String call()
         {
-            if (id == 0) {
+            if (id == null) {
                 StringBuilder sb = new StringBuilder();
                 for (Map.Entry<Integer,BulkJob> entry: _jobs.entrySet()) {
                     int id = entry.getKey();


### PR DESCRIPTION
Motivation:

The 'bulk ls' command is broken if the optional argument is omitted,
with a NPE being thrown:

    24 May 2019 10:28:41 (PinManager) \[admin\] Command failed due to a bug, please contact support@dcache.org.
    dmg.util.CommandPanicException: (1) Command failed: java.lang.NullPointerException
            at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:156)
            at dmg.cells.nucleus.CellAdapter.executeCommand(CellAdapter.java:239)
            at org.dcache.cells.UniversalSpringCell.executeCommand(UniversalSpringCell.java:195)
            at dmg.cells.nucleus.CellAdapter$1.doExecute(CellAdapter.java:105)
            at org.dcache.util.cli.CommandInterpreter.command(CommandInterpreter.java:129)
            at dmg.cells.nucleus.CellAdapter$1.command(CellAdapter.java:122)
            at dmg.cells.nucleus.CellAdapter.command(CellAdapter.java:224)
            at dmg.cells.nucleus.CellAdapter.executeLocalCommand(CellAdapter.java:916)
            at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:856)
            at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1211)
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$4(CellNucleus.java:747)
            at java.lang.Thread.run(Thread.java:748)
    Caused by: java.lang.NullPointerException: null
            at org.dcache.pinmanager.PinManagerCLI$BulkListCommand.call(PinManagerCLI.java:329)
            at org.dcache.pinmanager.PinManagerCLI$BulkListCommand.call(PinManagerCLI.java:318)
            at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:145)
    ... 14 common frames omitted

Modification:

Correct typo where '0' was used instead of 'null'.

Result:

A bug is fixed where PinManager 'bulk ls' admin command yielded a
NullPointerException if the optional argument was omitted.

Target: master
Closes: #4876
Closes: #3998
Requires-notes: yes
Requires-book: no
Request: 5.1
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Patch: https://rb.dcache.org/r/11754/
Acked-by: Tigran Mkrtchyan