### PR TITLE
webdav: allow transfers as user with role 'admin'

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -87,6 +87,7 @@ import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.CellPath;
 import dmg.cells.services.login.LoginManagerChildrenInfo;
 
+import org.dcache.auth.Origin;
 import org.dcache.auth.SubjectWrapper;
 import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.LoginAttribute;
@@ -1214,7 +1215,25 @@ public class DcacheResourceFactory
 
     private Subject roleAwareSubject()
     {
-        return isAdmin() ? Subjects.ROOT : getSubject();
+        Subject subject = getSubject();
+
+        if (isAdmin()) {
+            Origin origin = Subjects.getOrigin(subject);
+
+            if (origin == null) {
+                return Subjects.ROOT;
+            } else {
+                Subject adminSubject = new Subject(false,
+                        Subjects.ROOT.getPrincipals(),
+                        Subjects.ROOT.getPublicCredentials(),
+                        Subjects.ROOT.getPrivateCredentials());
+                adminSubject.getPrincipals().add(origin);
+                adminSubject.setReadOnly();
+                return adminSubject;
+            }
+        } else {
+            return subject;
+        }
     }
 
     private Restriction roleAwareRestriction()


### PR DESCRIPTION
Motivation:

Attempting to transfer a file with role 'admin' leads to the following
error:

    \[door:WebDAV-S-Olufemis-MacBook-Pro@dCacheDomain:AAWJ21hIIxg\] Internal server error
    java.lang.NullPointerException: null
            at org.dcache.webdav.DcacheResourceFactory.initializeTransfer(DcacheResourceFactory.java:1339)
            at org.dcache.webdav.DcacheResourceFactory.access$400(DcacheResourceFactory.java:140)
            at org.dcache.webdav.DcacheResourceFactory$HttpTransfer.<init>(DcacheResourceFactory.java:1470)
            at org.dcache.webdav.DcacheResourceFactory$ReadTransfer.<init>(DcacheResourceFactory.java:1544)
            at org.dcache.webdav.DcacheResourceFactory.beginRead(DcacheResourceFactory.java:1135)
            at org.dcache.webdav.DcacheResourceFactory.readFile(DcacheResourceFactory.java:837)
            at org.dcache.webdav.DcacheFileResource.sendContent(DcacheFileResource.java:118)
            at io.milton.http.entity.GetableResourceEntity.write(GetableResourceEntity.java:71)

Modification:

Ensure that the admin Subject includes the Origin principal if the
origin is known.

Result:

A NullPointerException is fixed that is triggered when attempting to
transfer a file as a user asserting their admin role.

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Closes: #4878
Patch: https://rb.dcache.org/r/11753/
Acked-by: Olufemi Adeyemi