### PR TITLE
UnpinProcessor: fix assumed typo `{)`

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pinmanager/UnpinProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/UnpinProcessor.java
@@ -64,7 +64,7 @@ public class UnpinProcessor implements Runnable
             _logger.error("Database failure while unpinning: {}",
                           e.getMessage());
         } catch (RemoteConnectFailureException e) {
-            _logger.error("Remote connection failure while unpinning: {)", e.getMessage());
+            _logger.error("Remote connection failure while unpinning: {}", e.getMessage());
         } catch (RuntimeException e) {
             _logger.error("Unexpected failure while unpinning", e);
         } finally {


### PR DESCRIPTION
My Java is nowhere near fluent but this `{)` looks like a typo... I spotted it when trying to find out why we have loads of "unpinning" pins. If I'm mistaken please feel free to reject this pull request.