### PR TITLE
pinmanager: add logging info

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManager.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManager.java
@@ -181,6 +181,7 @@ public class PinManager
         @Override
         public void isLeader()
         {
+            _log.info("Assuming leader role. Scheduling Expiration and Unpin tasks.");
             expirationFuture = executor.scheduleWithFixedDelay(
                     new FireAndForgetTask(expirationTask),
                     INITIAL_EXPIRATION_DELAY,
@@ -196,6 +197,7 @@ public class PinManager
         @Override
         public void notLeader()
         {
+            _log.info("Not assuming leader role. Probably there is another PinManager that already is entitled to the leader role.");
             expirationFuture.cancel(false);
             unpinFuture.cancel(true);
         }

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManager.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManager.java
@@ -197,7 +197,7 @@ public class PinManager
         @Override
         public void notLeader()
         {
-            _log.info("Not assuming leader role. Probably there is another PinManager that already is entitled to the leader role.");
+            _log.info("Dropping leader role. Cancelling Expiration and Unpin tasks.");
             expirationFuture.cancel(false);
             unpinFuture.cancel(true);
         }


### PR DESCRIPTION
In issue #4825 we've seen that it may be helpful to understand whether a pinmanager assumes the leader role. I hope with these two lines, it can be understood from the logs whether that happens. In case the messages are incorrect or inaccurate, please feel free to correct them.