### PR TITLE
pool (sweeper): catch negative file lifetime value

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
@@ -19,12 +19,14 @@ import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileNotInCacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.StorageInfos;
+
 import dmg.cells.nucleus.CellCommandListener;
 import dmg.util.Formats;
 import dmg.util.command.Argument;
 import dmg.util.command.Command;
 import dmg.util.command.DelayedCommand;
 import dmg.util.command.Option;
+
 import org.dcache.namespace.FileAttribute;
 import org.dcache.pool.PoolDataBeanProvider;
 import org.dcache.pool.classic.json.SweeperData;
@@ -308,7 +310,15 @@ public class SpaceSweeper2
         for (PnfsId id : list) {
             try {
                 CacheEntry entry = _repository.getEntry(id);
-                Long lvalue = now - entry.getLastAccessTime();
+                Long lastAccess = entry.getLastAccessTime();
+                Long lvalue = now - lastAccess;
+                if (lvalue < 0L) {
+                    throw new RuntimeException("repository last access time for "
+                                                + id + " is later than current "
+                                                + "system time! - now "
+                                                + now + ", last access "
+                                                + lastAccess + "; this is a bug.");
+                }
                 fileLifetime.add(lvalue.doubleValue());
             } catch (FileNotInCacheException e) {
                 // Ignored


### PR DESCRIPTION
Motivation:

GitHub issue #4867 indicates a problem we
recently discovered at FNAL after restarting
pools after commits 9830f2d and d2472e4.

The error is hard to diagnose without some
code modification.

Modification:

Check for potential negative values for
file lifetime, and throw a RuntimeException
if this occurs.

Result:

More of a chance we will be able to understand
what is happening in a case like GH 4867.

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Acked-by: Paul