### PR TITLE
gplazma: consider bearer token when deciding whether to log failures

### DIFF
--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/GPlazma.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/GPlazma.java
@@ -1,8 +1,9 @@
 package org.dcache.gplazma;
 
-import com.google.common.collect.Iterables;
+import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
+import org.globus.gsi.gssapi.jaas.SimplePrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +12,7 @@ import javax.security.auth.Subject;
 import java.lang.reflect.Modifier;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -18,6 +20,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.dcache.auth.BearerTokenCredential;
 import org.dcache.auth.LoginNamePrincipal;
 import org.dcache.auth.Origin;
 import org.dcache.auth.PasswordCredential;
@@ -62,6 +65,7 @@ import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.Collections2.filter;
 import static com.google.common.collect.Iterables.*;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 public class GPlazma
 {
@@ -110,17 +114,21 @@ public class GPlazma
          * support this, principals may be added that contain
          * non-sensitive information contained in a private credential.
          */
-        private static void addPrincipalsForPrivateCredentials(
-                Set<Principal> principals, Set<Object> privateCredentials)
+        private static void addPrincipalsForPrivateCredentials(Set<Principal> principals,
+                Set<Object> privateCredentials)
         {
-            PasswordCredential password =
-                    getFirst(Iterables.filter(privateCredentials,
-                    PasswordCredential.class), null);
-
-            if(password != null) {
-                Principal loginName =
-                        new LoginNamePrincipal(password.getUsername());
-                principals.add(loginName);
+            for (Object credential : privateCredentials) {
+                if (credential instanceof PasswordCredential) {
+                    String username = ((PasswordCredential)credential).getUsername();
+                    Principal loginName = new LoginNamePrincipal(username);
+                    principals.add(loginName);
+                } else if (credential instanceof BearerTokenCredential) {
+                    String token = ((BearerTokenCredential)credential).getToken();
+                    byte[] hashBytes = Hashing.goodFastHash(128).hashBytes(token.getBytes(US_ASCII)).asBytes();
+                    String hash = Base64.getEncoder().encodeToString(hashBytes);
+                    Principal p = new SimplePrincipal(hash);
+                    principals.add(p);
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:

gPlazma logs the first failure attempt and not subsequent attempts.
Currently, when deciding whether to record a failed login attempt, a
login with no login credentials is equivalent to a login attempt with a
bearer token.

Since dCacheView first attempts a login without any credential.  This
will fail for clients that do not have an X.509 credential in their
browser (i.e., most clients).  This attempt is logged.  If there is a
subsequent login attempt with an OpenID-Connect access token that fails
then this is not logged.

Modification:

Update the failed-login-identity Subject to include a hash of the bearer
token.

Result:

Failed login attempts using OpenID-Connect, particularly from dCacheView
are now logged.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/11764/
Acked-by: Tigran Mkrtchyan