### PR TITLE
pool: ensure initialisation thread has correct CDC information

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/cells/ThreadCreator.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/ThreadCreator.java
@@ -1,0 +1,29 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.cells;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * A class that implements ThreadCreator wishes to create new threads.
+ */
+public interface ThreadCreator
+{
+    /** Accept a ThreadFactory instance with which to create threads. */
+    void setThreadFactory(ThreadFactory factory);
+}

--- a/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
@@ -989,6 +989,10 @@ public class UniversalSpringCell
             ((CellMessageSender) bean).setCellEndpoint(this);
         }
 
+        if (bean instanceof ThreadCreator) {
+            ((ThreadCreator) bean).setThreadFactory(getNucleus());
+        }
+
         return bean;
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -103,6 +104,7 @@ import org.dcache.alarms.PredefinedAlarm;
 import org.dcache.auth.Subjects;
 import org.dcache.cells.CellStub;
 import org.dcache.cells.MessageReply;
+import org.dcache.cells.ThreadCreator;
 import org.dcache.pool.FaultEvent;
 import org.dcache.pool.FaultListener;
 import org.dcache.pool.PoolDataBeanProvider;
@@ -139,7 +141,7 @@ import static org.dcache.namespace.FileAttribute.CHECKSUM;
 public class PoolV4
     extends AbstractCellComponent
     implements FaultListener, CellCommandListener, CellMessageReceiver, CellSetupProvider, CellLifeCycleAware, CellInfoProvider,
-                PoolDataBeanProvider<PoolDataDetails>
+                PoolDataBeanProvider<PoolDataDetails>, ThreadCreator
 {
     private static final int DUP_REQ_NONE = 0;
     private static final int DUP_REQ_IGNORE = 1;
@@ -219,6 +221,8 @@ public class PoolV4
     private boolean _enableHsmFlag;
 
     private Consumer<RemoveFileInfoMessage> _kafkaSender = (s) -> {};
+
+    private ThreadFactory _threadFactory;
 
 
     protected void assertNotRunning(String error)
@@ -462,6 +466,12 @@ public class PoolV4
         _enableHsmFlag = enable;
     }
 
+    @Override
+    public void setThreadFactory(ThreadFactory factory)
+    {
+        _threadFactory = factory;
+    }
+
     public void init()
     {
         assertNotRunning("Cannot initialize several times");
@@ -487,9 +497,7 @@ public class PoolV4
     {
         disablePool(PoolV2Mode.DISABLED_STRICT, 1, "Awaiting initialization");
         _pingThread.start();
-        new Thread() {
-            @Override
-            public void run() {
+        _threadFactory.newThread(() -> {
                 int mode;
                 try {
                     _repository.init();
@@ -521,8 +529,7 @@ public class PoolV4
                 }
 
                 LOGGER.info("Repository finished");
-            }
-        }.start();
+            }).start();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Commit 499c3570448 updated the pool so that the startup is handled by a
separate thread.  As this thread is not created by the CellNucleus, it
is missing information about to which cell it belongs.  A consequence of
this is log messages are not attributed to the pool's cell name and do
not show up in the pool's pinboard.

Modification:

Allow spring beans to discover the cell's ThreadFactory, as provided by
the cell nucleus.

Update pool to discover the ThreadFactory and use this when creating the
initialisation thread.

Result:

Pool start-up logging is now recorded against the corresponding pool
cell name.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/11775/
Acked-by: Tigran Mkrtchyan
Acked-by: Marina Sahakyan
Acked-by: Lea Morschel