### PR TITLE
webdav: include CDC in scheduled activity

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -96,10 +96,16 @@
   </bean>
 
 
-  <bean id="scheduled-thread-pool" class="java.util.concurrent.Executors"
-        factory-method="newScheduledThreadPool" destroy-method="shutdown">
+  <bean id="scheduled-thread-pool"
+        class="org.dcache.util.CDCScheduledExecutorServiceDecorator"
+        destroy-method="shutdown">
       <description>Thread pool for scheduled activities</description>
-      <constructor-arg value="2"/>
+      <constructor-arg>
+          <bean class="java.util.concurrent.Executors"
+                factory-method="newScheduledThreadPool">
+              <constructor-arg value="2"/>
+          </bean>
+      </constructor-arg>
   </bean>
 
   <bean id="cache-login-strategy" class="org.dcache.auth.CachingLoginStrategy">


### PR DESCRIPTION
Motivation:

The WebDAV door currently does not include CDC information when
executing periodic tasks.  This prevents log messages from being
identified as being from the WebDAV service, and results such messages
being absent from the cell's pinboard.

Modification:

Include CDC wrapper to ensure the CDC is set correctly.

Result:

Periodic activity associated with the WebDAV door is now logged with the
door's cell name.  Such messages will also appear in the door's
pinboard.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/11779/
Acked-by: Tigran Mkrtchyan