### PR TITLE
nfs: include CDC in scheduled activity

### DIFF
--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -51,11 +51,15 @@
     </bean>
 
     <bean id="scheduled-thread-pool"
-        class="java.util.concurrent.Executors"
-        factory-method="newScheduledThreadPool"
-        destroy-method="shutdown">
+          class="org.dcache.util.CDCScheduledExecutorServiceDecorator"
+          destroy-method="shutdown">
         <description>Thread pool for scheduled activities</description>
-        <constructor-arg value="1"/>
+        <constructor-arg>
+            <bean class="java.util.concurrent.Executors"
+                  factory-method="newScheduledThreadPool">
+                <constructor-arg value="1"/>
+            </bean>
+        </constructor-arg>
     </bean>
 
     <bean id="dataSource" class="org.dcache.db.AlarmEnabledDataSource" destroy-method="close">


### PR DESCRIPTION
Motivation:

The NFS door currently does not include CDC information when executing
periodic tasks.  This prevents log messages from being identified as
being from the NFS service, and results such messages being absent from
the cell's pinboard.

Modification:

Include CDC wrapper to ensure the CDC is set correctly.

Result:

Periodic activity associated with the NFS door is now logged with the
door's cell name.  Such messages will also appear in the door's
pinboard.

Target: master
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11777/
Acked-by: Tigran Mkrtchyan
Request: 5.1
Request: 5.0
Request: 4.2