### PR TITLE
frontend: include CDC in scheduled activity

### DIFF
--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -138,10 +138,15 @@
       <property name="topic" value="${frontend.loginbroker.request-topic}"/>
   </bean>
 
-  <bean id="scheduling-service" class="java.util.concurrent.ScheduledThreadPoolExecutor"
-          destroy-method="shutdownNow">
-        <description>Used to execute periodic data collection (admin services)</description>
-        <constructor-arg value="5"/>
+  <bean id="scheduling-service"
+        class="org.dcache.util.CDCScheduledExecutorServiceDecorator"
+        destroy-method="shutdownNow">
+      <description>Used to execute periodic data collection (admin services)</description>
+      <constructor-arg>
+          <bean class="java.util.concurrent.ScheduledThreadPoolExecutor">
+              <constructor-arg value="5"/>
+          </bean>
+      </constructor-arg>
   </bean>
 
   <bean id="transfer-collector" class="org.dcache.restful.util.transfers.TransferCollector">


### PR DESCRIPTION
Motivation:

The frontend door currently does not include CDC information when
executing periodic tasks.  This prevents log messages from being
identified as being from the frontend service, and results such messages
being absent from the cell's pinboard.

Modification:

Include CDC wrapper to ensure the CDC is set correctly.

Result:

Periodic activity associated with the frontend door is now logged with the
door's cell name.  Such messages will also appear in the door's
pinboard.

Target: master
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11780/
Acked-by: Tigran Mkrtchyan
Request: 5.1
Request: 5.0
Request: 4.2