### PR TITLE
sweeper: compute now after the values have been fetched

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
@@ -303,9 +303,8 @@ public class SpaceSweeper2
             info.setLruTimestamp(System.currentTimeMillis() - getLru());
         }
 
-        long now = System.currentTimeMillis();
-
         List<Double> fileLifetime = new ArrayList<>();
+        Long now = System.currentTimeMillis();
 
         for (PnfsId id : list) {
             try {
@@ -313,11 +312,15 @@ public class SpaceSweeper2
                 Long lastAccess = entry.getLastAccessTime();
                 Long lvalue = now - lastAccess;
                 if (lvalue < 0L) {
-                    throw new RuntimeException("repository last access time for "
-                                                + id + " is later than current "
-                                                + "system time! - now "
-                                                + now + ", last access "
-                                                + lastAccess + "; this is a bug.");
+                    now = System.currentTimeMillis();
+                    lvalue = now -lastAccess;
+                    if (lvalue < 0L) {
+                        _log.warn("repository last access time for {}"
+                                                  + " is later than current "
+                                                  + "system time - now {}, "
+                                                  + "last access {}",
+                                  id, now, lastAccess);
+                    }
                 }
                 fileLifetime.add(lvalue.doubleValue());
             } catch (FileNotInCacheException e) {


### PR DESCRIPTION
See commit 040c86b1d60944bf85aa4f7f83ecd9f334e8ee6d

Motivation:

04 Jun 2019 08:05:31 () [] Problem with retrieval of pool data for dmsdca19-1:
java.lang.RuntimeException: repository last access time for 0000A91499AE627F4ED0A250CD21A7540793
is later than current system time! - now 1559653531347, last access 1559653531374; this is a bug.

It would seem the flaw in the procedure rests in the mtime of the file being
updated after now has been computed.  This is suggested, in fact, by the
billing activity for the above example.

Modification:

Use system.currentTimeMillis() as the value recomputed just after
each file lifetime has been fetched.

Result:

The negative skew error should not occur (but we have left the
check in place just in case).

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Acked-by: Dmitry