### PR TITLE
dcap: fix premature close of kafka sender

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -2474,17 +2474,6 @@ public class DCapDoorInterpreterV3
     }
 
     public void close() {
-
-
-        /*The producer consists of a pool of buffer space that holds records that haven't yet been
-          transmitted to the server as well as a background I/O thread
-          that is responsible for turning these records into requests and transmitting them to the cluster.
-          Failure to close the producer after use will leak these resources. Hence we need to  close Kafka Producer
-         */
-        if (_settings.isKafkaEnabled()) {
-            _kafkaProducer.close();
-        }
-
         for(SessionHandler sh: _sessions.values()) {
             try {
                 sh.removeUs();
@@ -2494,6 +2483,18 @@ public class DCapDoorInterpreterV3
                  */
                 _log.error("failed to removed session: " + sh, e);
             }
+        }
+    }
+
+    protected void shutdownKafka() {
+        /*The producer consists of a pool of buffer space that holds records that haven't yet been
+          transmitted to the server as well as a background I/O thread
+          that is responsible for turning these records into requests and transmitting them to the cluster.
+          Failure to close the producer after use will leak these resources. Hence we need to  close Kafka Producer
+         */
+        if (_settings.isKafkaEnabled()) {
+            _log.debug("Shutting down kafka");
+            _kafkaProducer.close();
         }
     }
 

--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DcapLineBasedInterpreterAdapter.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DcapLineBasedInterpreterAdapter.java
@@ -106,6 +106,12 @@ public class DcapLineBasedInterpreterAdapter
     }
 
     @Override
+    public void messagingClosed()
+    {
+        shutdownKafka();
+    }
+
+    @Override
     public void getInfo(PrintWriter pw)
     {
         pw.println("         User  : " + Subjects.getDisplayName(subject));

--- a/modules/dcache/src/main/java/diskCacheV111/doors/LineBasedDoor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/LineBasedDoor.java
@@ -210,6 +210,8 @@ public class LineBasedDoor
     @Override
     public void stopped()
     {
+        interpreter.messagingClosed();
+
         /* Closing the input stream will cause the FTP command
          * processing thread to shut down. In case the shutdown was
          * initiated by the FTP client, this will already have

--- a/modules/dcache/src/main/java/diskCacheV111/doors/LineBasedInterpreter.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/LineBasedInterpreter.java
@@ -44,7 +44,19 @@ public interface LineBasedInterpreter
     void execute(String cmd) throws CommandExitException;
 
     /**
-     * Signals that the connection with the client is being terminated.
+     * Signals that the connection with the client is being terminated.  The
+     * implementation is still able to send and receive cell messages.
      */
     void shutdown();
+
+    /**
+     * Signals that this cell will receive no further cell messages.  Sending
+     * cell messages is also no longer supported.  The network connection to
+     * the client has not yet been closed, but the client might not accept any
+     * more data.
+     */
+    default void messagingClosed()
+    {
+        // do nothing.
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
@@ -236,6 +236,8 @@ public class NettyLineBasedDoor
     @Override
     public void stopped()
     {
+        interpreter.messagingClosed();
+
         channel.close().syncUninterruptibly();
 
         super.stopped();


### PR DESCRIPTION
Motivation:

Issue #4831 reported a stack-trace:

    08 May 2019 15:37:37 (DCap00-fndca4a-AAWIZk3V24A) \[door:DCap00-fndca4a-AAWIZk3V24A@dcap00-fndca4aDomain PnfsManager PnfsGetFileAttributes\] Uncaught exception in thread DCap00-fndca4a-io-2
    org.apache.kafka.common.KafkaException: Producer closed while send in progress
           at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:864) ~[kafka-clients-2.1.0.jar:na]
           at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:841) ~[kafka-clients-2.1.0.jar:na]
           at diskCacheV111.doors.DCapDoorInterpreterV3.sendAsynctoKafka(DCapDoorInterpreterV3.java:2553) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3.postToBilling(DCapDoorInterpreterV3.java:2546) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3.access$1500(DCapDoorInterpreterV3.java:104) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3$SessionHandler.sendReply(DCapDoorInterpreterV3.java:875) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3$SessionHandler.sendReply(DCapDoorInterpreterV3.java:856) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3$PnfsSessionHandler.fileAttributesNotAvailable(DCapDoorInterpreterV3.java:1141) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3$PnfsSessionHandler.pnfsGetFileAttributesArrived(DCapDoorInterpreterV3.java:1105) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at diskCacheV111.doors.DCapDoorInterpreterV3.messageArrived(DCapDoorInterpreterV3.java:2527) ~[dcache-dcap-4.2.32-FNAL.jar:4.2.32-FNAL]
           at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_181]
           at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_181]
           at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_181]
           at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_181]
           at org.dcache.cells.CellMessageDispatcher$LongReceiver.deliver(CellMessageDispatcher.java:304) ~[dcache-core-4.2.32-FNAL.jar:4.2.32-FNAL]
           at org.dcache.cells.CellMessageDispatcher.call(CellMessageDispatcher.java:201) ~[dcache-core-4.2.32-FNAL.jar:4.2.32-FNAL]
           at org.dcache.cells.AbstractCell.messageArrived(AbstractCell.java:331) ~[dcache-core-4.2.32-FNAL.jar:4.2.32-FNAL]
           at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:890) ~[cells-4.2.32-FNAL.jar:4.2.32-FNAL]
           at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1211) ~[cells-4.2.32-FNAL.jar:4.2.32-FNAL]
           at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) [dcache-common-4.2.32-FNAL.jar:4.2.32-FNAL]
           at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_181]
           at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_181]
           at java.lang.Thread.run(Thread.java:748) [na:1.8.0_181]
    Caused by: org.apache.kafka.common.KafkaException: Requested metadata update after close
           at org.apache.kafka.clients.Metadata.awaitUpdate(Metadata.java:200) ~[kafka-clients-2.1.0.jar:na]
           at org.apache.kafka.clients.producer.KafkaProducer.waitOnMetadata(KafkaProducer.java:981) ~[kafka-clients-2.1.0.jar:na]
           at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:861) ~[kafka-clients-2.1.0.jar:na]
           ... 22 common frames omitted

This is caused by the dcap client disconnecting before the transfer is
complete.

Modification:

Update NettyLineBasedDoor to support interpreters that wish to know
about cell lifecycle events.

Close kafka after we are sure no further messages will be received
(i.e., the beforeStop lifecycle event)

Result:

No more stack-traces from dcap door when the client closes connection
before request is processed.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.1
Request: 5.0
Request: 4.2
Closes: #4831
Ticket: https://rt.dcache.org/Ticket/Display.html?id=9700
Patch: https://rb.dcache.org/r/11735/
Acked-by: Lea Morschel