### PR TITLE
pool: avoid IllegalStateException in 'csm check *' command

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
@@ -27,6 +27,7 @@ import diskCacheV111.util.PnfsId;
 
 import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellLifeCycleAware;
+import dmg.util.CommandException;
 import dmg.util.command.Argument;
 import dmg.util.command.Command;
 
@@ -40,6 +41,7 @@ import org.dcache.util.Checksum;
 import org.dcache.util.Exceptions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static dmg.util.CommandException.checkCommand;
 import static org.dcache.util.Exceptions.messageOrClassName;
 
 public class ChecksumScanner
@@ -592,13 +594,16 @@ public class ChecksumScanner
         String pnfsID;
 
         @Override
-        public String call() throws
-                CacheException, InterruptedException,
-                IOException, NoSuchAlgorithmException
+        public String call() throws CommandException, CacheException,
+                InterruptedException, IOException, NoSuchAlgorithmException
         {
             if (pnfsID.equals("*")) {
+                checkCommand(!_fullScan.isActive(),
+                        "Existing full scan is still active: %s", _fullScan);
                 _fullScan.start();
             } else {
+                checkCommand(!_singleScan.isActive(),
+                        "Existing single scan is still active: %s", _singleScan);
                 _singleScan.go(new PnfsId(pnfsID));
             }
             return "Started ...; check 'csm status' for status";


### PR DESCRIPTION
Motivation:

Attempting to start a full checksum while a full checksum is still
underway results in the code throwing an IllegalStateException, which is
logged as a stack-trace and reported back to the admin as a bug.

Modification:

First check whether the full scan is still running.  If it is, return a
reasonable error message.

The single-scan suffers from a similar problem, and is updated as well.

Result:

Attempting to start a full checksum scan (with 'csm check *') while an
existing scan is still running is no longer reported as a bug.

Target: master
Request: 5.1
Request: 5.0
Request: 4.2
Request: 4.1
Request: 4.0
Request: 3.2
Requires-notes: yes
Requires-book: no
Closes: #4927
Patch: https://rb.dcache.org/r/11784/
Acked-by: Olufemi Adeyemi
Acked-by: Lea Morschel