### PR TITLE
libs: update aspectj to java11 friendly version 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <version.milton>2.7.3.0-dcache-1</version.milton>
         <version.spring>4.3.8.RELEASE</version.spring>
         <!-- Remember to sync aspectj version in dcache.properties -->
-        <version.aspectj>1.8.10</version.aspectj>
+        <version.aspectj>1.9.2</version.aspectj>
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -194,7 +194,7 @@ dcache.log.resilience.max-history=30
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath=${dcache.java.oom.file} \
     -XX:+UseCompressedOops \
-    -javaagent:${dcache.paths.classes}/aspectjweaver-1.8.10.jar \
+    -javaagent:${dcache.paths.classes}/aspectjweaver-1.9.2.jar \
     ${dcache.java.options.common} \
     ${dcache.java.options.extra}
 


### PR DESCRIPTION
Motivation:
The old version of aspectj makes java11 quite unhappy:

WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor (file:/usr/share/dcache/classes/aspectjweaver-1.8.10.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of org.aspectj.weaver.loadtime.ClassLoaderWeavingAdaptor
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

Modification:
update pom to use aspectj-1.9.2.

Result:
java-11 can be used at build and runtime.

Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit c63b52bf76a7acbe038c81ca6dfd562e412c1180)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>