### PR TITLE
core: fix pool selection in killAll command of TransferManager

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -183,7 +183,7 @@ public abstract class TransferManager extends AbstractCellComponent
                 Matcher m = p.matcher(String.valueOf(id));
                 if (m.matches()) {
                     log.debug("pattern: \"{}\" matches id=\"{}\"", args.argv(0), id);
-                    if (pool != null && pool.equals(handler.getPool())) {
+                    if (pool != null && pool.equals(handler.getPool().getName())) {
                         handlersToKill.add(handler);
                     } else if (pool == null) {
                         handlersToKill.add(handler);


### PR DESCRIPTION
Acked-by: Paul Millar
Acked-by: Lea Morschel
Target: master, 5.1, 5.0, 4.2
Require-book: no
Require-notes: no
(cherry picked from commit 9a85d76cce3f5c77346cca9fe330c48d7ea57590)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>