### PR TITLE
ftp: avoid NPE on HA-Proxy probes

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
@@ -236,7 +236,9 @@ public class NettyLineBasedDoor
     @Override
     public void stopped()
     {
-        interpreter.messagingClosed();
+        if (interpreter != null) {
+            interpreter.messagingClosed();
+        }
 
         channel.close().syncUninterruptibly();
 


### PR DESCRIPTION
Motivation:

An HA-Proxy instance, if deployed, can probe endpoints to discover if
they are still alive.

The FTP door has an optimisation that detects such probes and does not
create the FTP command interpreter, since the FTP client (the HA-Proxy
instance) is calling on behalf of itself, and will not issue any FTP
requests.

Commit 388e6d2b6ac introduced a regression where such probes result in
the NullPointerException:

    java.lang.NullPointerException: null
        at diskCacheV111.doors.NettyLineBasedDoor.stopped(NettyLineBasedDoor.java:246)
        at dmg.cells.nucleus.CellAdapter.postRemoval(CellAdapter.java:765)
        at dmg.cells.nucleus.CellNucleus.shutdown(CellNucleus.java:1016)
        at dmg.cells.nucleus.CellGlue.lambda$doKill$6(CellGlue.java:451)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)

Modification:

Check whether the interpreter was created before informing it will
receive no further cell messages.

Result:

A regression is fixed for FTP doors that are proxied by an HA-Proxy
instance.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11810/
Acked-by: Vincent Garonne