### PR TITLE
transfermanager: include pool name in error for 'mover ls' failures

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -839,7 +839,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             public void onFailure(Throwable e)
             {
                 reply.fail(message, CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
-                        "failed to query pool: " + e.getMessage());
+                        "failed to query pool " + pool.getName() + ": " + e.getMessage());
             }
         }, MoreExecutors.directExecutor());
 


### PR DESCRIPTION
Motivation:

WebDAV door will log errors like:

    Failed to fetch information for progress marker: failed to query pool: (0) Job not found : Job-1

Further investigation is hampered by not knowing which pool sent this
error.

Modification:

Update error message to include the pool's name.

Result:

Error messages where the TransferManager is unable to discover the
current status of the pool mover now include the pool's name.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/11809/
Acked-by: Vincent Garonne