### PR TITLE
pools: make the xrootd tpc response timeout less aggressive

### DIFF
--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -372,10 +372,9 @@ pool.mover.xrootd.timeout.connect = 300
 #  ---- Xrootd tpc server response timeout
 #
 #   Timeout that the third-party client will wait for a response from a server
-#   before raising a timeout exception.  The
-#   aggressive default mirrors that of the xrootd server standard implementation.
+#   before raising a timeout exception.
 #
-pool.mover.xrootd.tpc-server-response-timeout = 2
+pool.mover.xrootd.tpc-server-response-timeout = 30
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)pool.mover.xrootd.tpc-server-response-timeout.unit = SECONDS
 
 #  ---- Xrootd mover port range


### PR DESCRIPTION
Motivation:

The current setting of 2 seconds is much too aggressive and fragile.
Once can under not extraordinary conditions trigger it unnecessarily.

Modification:

Set it to something more reasonable (30 seconds).

Result:

Much less likelihood of unnecessary failures.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Acked-by: Dmitry
Acked-by: Paul