### PR TITLE
dcache, frontend: release dcache-view version 1.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.xrootd4j>3.3.5</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.5.3</version.dcache-view>
+        <version.dcache-view>1.5.4</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.5.3 to v1.5.4

[547717e](dCache/dcache-view@547717e) dcache-view (frontend and webdav): encode file path which are part of url
[8c089ac](dCache/dcache-view@8c089ac) dcache-view: increase display time of the notification message
[c78f346](dCache/dcache-view@c78f346) dcache-view (rename): fix rename issue
[c8f3d78](dCache/dcache-view@c8f3d78) dcache-view (download): show useful error message
[d504488](dCache/dcache-view@d504488) dcache-view (webdav): improve webdav door selection
[6b3eaaa](dCache/dcache-view@6b3eaaa) dcache-view (admim): fix issue with authentication for admin page
[88c7554](dCache/dcache-view@88c7554) dcache-view: fix label for time in mover listing
[207100a](dCache/dcache-view@207100a) dcache-view: fix sorting on numerical fields converted to format with byte size suffixes
[70c4e6d](dCache/dcache-view@70c4e6d) dcache-view (npm-package): upgrade bower to the latest version

Target: master
Request: 5.2
Request: 5.1
Request: 4.2
Require-notes: yes
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11821/

(cherry picked from commit 8916f6b259b4964ef9a5c89fe2196a01690acc3f)