### PR TITLE
dcache-xrootd: compute VOMs CA refresh interval using unit

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/security/ProxyDelegationStore.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/security/ProxyDelegationStore.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Required;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.dcache.gsi.KeyPairCache;
 import org.dcache.gsi.X509Delegation;
@@ -43,18 +44,21 @@ public class ProxyDelegationStore
     VOMSACValidator             vomsValidator;
     KeyPairCache                keyPairCache;
 
-    private String vomsDir;
-    private String caCertificatePath;
-    private long   trustAnchorRefreshInterval;
+    private String   vomsDir;
+    private String   caCertificatePath;
+    private long     trustAnchorRefreshInterval;
+    private TimeUnit trustAnchorRefreshIntervalUnit;
 
     public void initialize()
     {
+        long refresh = trustAnchorRefreshIntervalUnit
+                        .toMillis(trustAnchorRefreshInterval);
         VOMSTrustStore vomsTrustStore
                         = VOMSTrustStores.newTrustStore(asList(vomsDir));
         X509CertChainValidatorExt certChainValidator
                         = new CertificateValidatorBuilder()
                         .lazyAnchorsLoading(false)
-                        .trustAnchorsUpdateInterval(trustAnchorRefreshInterval)
+                        .trustAnchorsUpdateInterval(refresh)
                         .trustAnchorsDir(caCertificatePath)
                         .build();
         vomsValidator = VOMSValidators.newValidator(vomsTrustStore,
@@ -82,6 +86,12 @@ public class ProxyDelegationStore
     public void setTrustAnchorRefreshInterval(long trustAnchorRefreshInterval)
     {
         this.trustAnchorRefreshInterval = trustAnchorRefreshInterval;
+    }
+
+    @Required
+    public void setTrustAnchorRefreshIntervalUnit(TimeUnit trustAnchorRefreshIntervalUnit)
+    {
+        this.trustAnchorRefreshIntervalUnit = trustAnchorRefreshIntervalUnit;
     }
 
     public void shutdown()

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -138,6 +138,7 @@
         init-method="initialize" destroy-method="shutdown">
     <property name="caCertificatePath" value="${xrootd.gsi.ca.path}"/>
     <property name="trustAnchorRefreshInterval" value="${xrootd.gsi.ca.refresh}"/>
+    <property name="trustAnchorRefreshIntervalUnit" value="${xrootd.gsi.ca.refresh.unit}"/>
     <property name="vomsDir" value="${xrootd.gsi.vomsdir.dir}"/>
     <property name="keyPairCache">
       <bean class="org.dcache.gsi.KeyPairCache">


### PR DESCRIPTION
Motivation:

Neglected to transform the numerical value to larger units (SECONDS),
causing the voms validator to reload the CA certs every 60 millis,
thus spiking the CPU for the door.

Modification:

Inject the forgotten unit and recompute.

Result:

What it should have been from the outset.

Target: master
Request: 5.2
Requires-notes: no
Requires-book: no
Acked-by: Dmitry
Acked-by: Paul
Acked-by: Lea