### PR TITLE
dcache-xrootd: respond to tpc query correctly*

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -758,10 +758,11 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                      * Indicate support for third-party copy by responding
                      * with the protocol version.
                      */
-                    s.append(XrootdProtocol.PROTOCOL_VERSION);
+                    s.append(XrootdProtocol.TPC_VERSION);
                     break;
                 case "tpcdlg":
-                    //TODO NOT YET SUPPORTED
+                    s.append("gsi");
+                    break;
                 default:
                     s.append(_queryConfig.getOrDefault(name, name));
                     break;

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -702,15 +702,16 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                 case "version":
                     s.append("dCache ").append(Version.of(XrootdPoolRequestHandler.class).getVersion());
                     break;
-                 case "tpc":
-                     /**
-                      * Indicate support for third-party copy by responding
-                      * with the protocol version.
-                      */
-                     s.append(XrootdProtocol.PROTOCOL_VERSION);
-                     break;
+                case "tpc":
+                    /**
+                     * Indicate support for third-party copy by responding
+                     * with the protocol version.
+                     */
+                    s.append(XrootdProtocol.TPC_VERSION);
+                    break;
                 case "tpcdlg":
-                    //TODO NOT YET SUPPORTED
+                    s.append("gsi");
+                    break;
                 default:
                     s.append(_queryConfig.getOrDefault(name, name));
                     break;

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>3.5.1</version.xrootd4j>
+        <version.xrootd4j>3.5.2</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.5.4</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Motivation:

Neglected to implement query which indicates delegation support.

Modification:

Return "gsi" in response to 'tpcdlg'.  Also, return 1 (the
TPC protocol version) for the tpc query.

Depends on xrootd4j 3.5.2 (added version definition). #11823

Result:

Correct behavior in responding to client.

Target: master
Request:  5.2
Acked-by: Paul