### PR TITLE
scripts: avoid copy-n-paste error when calculating pool size

### DIFF
--- a/skel/share/lib/utils.sh
+++ b/skel/share/lib/utils.sh
@@ -285,7 +285,7 @@ stringToGiB() # in $1 = size, out $2 = size in GiB
             ;;
 
         *)
-            checkInt "${1%?}"
+            checkInt "$1"
             gib=$(($1/(1024*1024*1024)))
             ;;
     esac


### PR DESCRIPTION
Motivation:

The 'dcache pool ls' command shows information about pools, which
includes the size. If a pool size is defined without any suffix the last
digit is omitted when checking the value is an integer.  If the value is
a single digit then dCache (incorrectly) claims the value is not an
integer.

Modification:

Do not remove last digit when checking if the pool size is an integer.

Result:

The 'dcache pool ls' command provides correct output even if the pool is
defined with a single-digit number of bytes.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Closes: #4973
Patch: https://rb.dcache.org/r/11839/
Acked-by: Vincent Garonne