### PR TITLE
dcache-xrootd: add checksum cgi handling to door query

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -31,6 +31,7 @@ import java.nio.channels.ClosedChannelException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
@@ -84,6 +85,7 @@ import org.dcache.xrootd.protocol.messages.StatxResponse;
 import org.dcache.xrootd.protocol.messages.XrootdResponse;
 import org.dcache.xrootd.tpc.XrootdTpcInfo;
 import org.dcache.xrootd.tpc.XrootdTpcInfo.Status;
+import org.dcache.xrootd.util.ChecksumInfo;
 import org.dcache.xrootd.util.FileStatus;
 import org.dcache.xrootd.util.OpaqueStringParser;
 import org.dcache.xrootd.util.ParseException;
@@ -791,18 +793,36 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
 
         case kXR_Qcksum:
             try {
-                Set<Checksum> checksums = _door.getChecksums(createFullPath(msg.getArgs()),
+                ChecksumInfo info = new ChecksumInfo(msg.getArgs());
+                Set<Checksum> checksums = _door.getChecksums(createFullPath(info.getPath()),
                                                              msg.getSubject(),
                                                              _authz);
                 if (!checksums.isEmpty()) {
-                    Checksum checksum = Checksums.preferrredOrder().min(checksums);
+                    Optional<String> type = info.getType();
+                    Optional<Checksum> result;
+
+                    if (type.isPresent()) {
+                        result = checksums.stream()
+                                          .filter((c) -> type.get()
+                                                             .equalsIgnoreCase(c.getType()
+                                                                                .getName()))
+                                          .findFirst();
+                    } else {
+                        result = Optional.of(Checksums.preferrredOrder().min(checksums));
+                    }
+
                     /**
                      * xrdcp expects lower case names for checksum algorithms
                      * https://github.com/xrootd/xrootd/issues/459
                      * TODO: remove toLowerCase() call when above issue is addressed
                      */
-                    return new QueryResponse(msg,
-                                             checksum.getType().getName().toLowerCase() + " " + checksum.getValue());
+                    if (result.isPresent()) {
+                        Checksum checksum = result.get();
+                        return new QueryResponse(msg,checksum.getType().getName()
+                                                             .toLowerCase()
+                                                             + " "
+                                                             + checksum.getValue());
+                    }
                 }
             } catch (FileNotFoundCacheException e) {
                 throw new XrootdException(kXR_NotFound, e.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>3.5.2</version.xrootd4j>
+        <version.xrootd4j>3.5.3</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.5.4</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Motivation:

The xrdcp 4.9 clients already implement protocol 4.0, and
thus may pass to the door a path with a query part specifying
the type of checksum to return.  This currently makes
the door fail on the checksum request with a "no such
file or directory" error because the path is not
parsed.

Modification:

Use ChecksumInfo to parse and handle the request.

Result:

Door should not fail from this form of the checksum
request.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Acked-by: Tigran
Acked-by: Lea