### PR TITLE
webdav: return 405 status code for PUT requests targeting collections

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
@@ -46,10 +46,10 @@ import diskCacheV111.util.FileExistsCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.MissingResourceCacheException;
+import diskCacheV111.util.NotFileCacheException;
 import diskCacheV111.util.PermissionDeniedCacheException;
 
 import org.dcache.vehicles.FileAttributes;
-
 
 import static io.milton.property.PropertySource.PropertyAccessibility.READ_ONLY;
 
@@ -154,6 +154,8 @@ public class DcacheDirectoryResource
             throw WebDavExceptions.permissionDenied(this);
         } catch (FileExistsCacheException e) {
             throw new ConflictException(this);
+        } catch (NotFileCacheException e) { // Attempt to replace directory with file
+            throw new MethodNotAllowedException("Resource exists as collection", e, null);
         } catch (MissingResourceCacheException e) {
             if (FULL_POOL_MESSAGE.contains(e.getMessage())) {
                 throw new InsufficientStorageException(e.getMessage(), e, this);

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
@@ -99,6 +99,8 @@ public class DcacheStandardFilter implements Filter
             response.setLocationHeader(e.getUrl());
         } catch (MethodNotAllowedException e) {
             responseHandler.respondMethodNotAllowed(e.getResource(), response, request);
+            // Work-around: milton doesn't allow non-standard text, so we update the value here.
+            ServletResponse.getResponse().setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED, e.getMessage());
         } catch (WebDavException e) {
             log.warn("Internal server error: {}", e.toString());
             responseHandler.respondServerError(request, response, e.getMessage());


### PR DESCRIPTION
Motivation:

A client may issue a PUT request that targets an existing collection
resource; i.e., attempt to write a file as a path that is a directory.
This is not supported.

Currently dCache returns an "500 Internal Error", suggesting something
went wrong within dCache, whereas the problem is actually the client
made an invalid request.  Therefore a 4xx status code is appropriate.

RFC 4918 says in 9.7.2. "PUT for Collections":

   This specification does not define the behavior of the PUT method for
   existing collections.  A PUT request to an existing collection MAY be
   treated as an error (405 Method Not Allowed).

Modification:

Update status code for response where the client attempts to PUT a file
targeting an existing collection: a 405 status code is generate.

The existing work-around (for custom status explanations) is also
applied to 405 status codes, allowing the client to receive the custom
message within the response status line.

Result:

A PUT request that targets an existing collection resource (a directory)
will continue to fail, but the HTTP client will receive the expected
status code (405) instead of 500 Internal Error.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11860/
Acked-by: Vincent Garonne