### PR TITLE
dcache, frontend: release dcache-view version 1.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.xrootd4j>3.3.5</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.5.4</version.dcache-view>
+        <version.dcache-view>1.5.5</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.5.4 to v1.5.5

[869afb3](dCache/dcache-view@869afb3) dcache-view (route): ensure route change reflect in url
[10c2fac](dCache/dcache-view@10c2fac) dcache-view (authentication): prevent browser login pop-up
[cd02135](dCache/dcache-view@cd02135) dcache-view (webdav): re-request webdav door information

Target: master
Request: 5.2
Request: 5.1
Request: 4.2
Require-notes: yes
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11872/

(cherry picked from commit f7222ae2cb4d229a5f7299789fccc313b1f1cddd)