### PR TITLE
webdav: fix cross origin resources sharing issue

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
@@ -1,0 +1,85 @@
+package org.dcache.webdav;
+
+import com.google.common.collect.ImmutableList;
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class CrossOriginResourceSharingHandler extends AbstractHandler
+{
+    private static final ImmutableList<String> ALLOWED_ORIGIN_PROTOCOL = ImmutableList.of("http", "https");
+    private List<String> _allowedClientOrigins = Collections.emptyList();
+
+    public void setAllowedClientOrigins(String origins)
+    {
+        if (origins.isEmpty()) {
+            _allowedClientOrigins = Collections.emptyList();
+        } else {
+            List<String> originList = Arrays.stream(origins.split(","))
+                    .map(String::trim)
+                    .collect(Collectors.toList());
+            originList.forEach(CrossOriginResourceSharingHandler::checkOrigin);
+            _allowedClientOrigins = originList;
+        }
+    }
+
+    private static void checkOrigin(String s)
+    {
+        try {
+            URI uri = new URI(s);
+
+            checkArgument(ALLOWED_ORIGIN_PROTOCOL.contains(uri.toURL().getProtocol()),
+                    "Invalid URL: The URL: %s contain unsupported protocol. Use either http or https.", s);
+            checkArgument(!uri.getHost().isEmpty(), "Invalid URL: the host name is not provided in %s:", s);
+            checkArgument(uri.getUserInfo() == null,
+                    "The URL: %s is invalid. User information is not allowed to be part of the URL.", s);
+            checkArgument(uri.toURL().getPath().isEmpty(),
+                    "The URL: %s is invalid. Remove the \"path\" part of the URL.", s);
+            checkArgument(uri.toURL().getQuery() == null,
+                    "The URL: %s is invalid. Remove the query-path part of the URL.", s);
+            checkArgument(uri.toURL().getRef() == null,
+                    "URL: %s is invalid. Reason: no reference or fragment allowed in the URL.", s);
+            checkArgument(!uri.isOpaque(), "URL: %s is invalid. Check the scheme part of the URL", s);
+        } catch (MalformedURLException | URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public void handle(String target, Request baseRequest,
+                       HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
+    {
+        String clientOrigin = request.getHeader("origin");
+        if (_allowedClientOrigins.contains(clientOrigin)) {
+            response.setHeader("Access-Control-Allow-Origin", clientOrigin);
+            if (_allowedClientOrigins.size() > 1) {
+                response.setHeader("Vary", "Origin");
+            }
+        }
+        if ("OPTIONS".equals(request.getMethod())) {
+            response.setHeader("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE");
+            response.setHeader("Access-Control-Allow-Headers",
+                    "Authorization, Content-Type, Suppress-WWW-Authenticate");
+            response.setHeader("Access-Control-Allow-Credentials", "true");
+            response.setStatus(HttpServletResponse.SC_OK);
+            Request base_request = (request instanceof Request) ?
+                    (Request)request: HttpConnection.getCurrentConnection().getHttpChannel().getRequest();
+            base_request.setHandled(true);
+        }
+    }
+}

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/MiltonHandler.java
@@ -20,16 +20,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.AccessController;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import dmg.cells.nucleus.CDC;
 import dmg.cells.nucleus.CellAddressCore;
@@ -37,8 +29,6 @@ import dmg.cells.nucleus.CellIdentityAware;
 
 import org.dcache.auth.Subjects;
 import org.dcache.util.Transfer;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * A Jetty handler that wraps a Milton HttpManager. Makes it possible
@@ -52,46 +42,10 @@ public class MiltonHandler
 
     private HttpManager _httpManager;
     private CellAddressCore _myAddress;
-    private List<String> _allowedClientOrigins;
 
     public void setHttpManager(HttpManager httpManager)
     {
         _httpManager = httpManager;
-    }
-
-    public void setAllowedClientOrigins(String origins)
-    {
-        if (origins.isEmpty()) {
-            _allowedClientOrigins = Collections.emptyList();
-        } else {
-            List<String> originList = Arrays.stream(origins.split(","))
-                    .map(String::trim)
-                    .collect(Collectors.toList());
-            originList.forEach(MiltonHandler::checkOrigin);
-            _allowedClientOrigins = originList;
-        }
-    }
-
-    private static void checkOrigin(String s)
-    {
-        try {
-            URI uri = new URI(s);
-
-            checkArgument(ALLOWED_ORIGIN_PROTOCOL.contains(uri.toURL().getProtocol()), "Invalid URL: The URL: %s " +
-                    "contain unsupported protocol. Use either http or https.", s);
-            checkArgument(!uri.getHost().isEmpty(), "Invalid URL: the host name is not provided in %s:", s);
-            checkArgument(uri.getUserInfo() == null, "The URL: %s is invalid. User information is not allowed " +
-                    "to be part of the URL.", s);
-            checkArgument(uri.toURL().getPath().isEmpty(), "The URL: %s is invalid. Remove the \"path\" part of the " +
-                    "URL.", s);
-            checkArgument(uri.toURL().getQuery() == null, "The URL: %s is invalid. Remove the query-path part of " +
-                    "the URL.", s);
-            checkArgument(uri.toURL().getRef() == null, "URL: %s is invalid. Reason: no reference or fragment " +
-                    "allowed in the URL.", s);
-            checkArgument(!uri.isOpaque(), "URL: %s is invalid. Check the scheme part of the URL", s);
-        } catch (MalformedURLException | URISyntaxException e) {
-            throw new IllegalArgumentException(e);
-        }
     }
 
     @Override
@@ -109,24 +63,9 @@ public class MiltonHandler
             Transfer.initSession(false, false);
             ServletContext context = ContextHandler.getCurrentContext();
 
-            String clientOrigin = request.getHeader("origin");
-            if (_allowedClientOrigins.contains(clientOrigin)) {
-                response.setHeader("Access-Control-Allow-Origin", clientOrigin);
-                if (_allowedClientOrigins.size() > 1) {
-                    response.setHeader("Vary", "Origin");
-                }
-            }
-
-            switch (request.getMethod()) {
-            case "USERINFO":
+            if ("USERINFO".equals(request.getMethod())) {
                 response.sendError(501, "Not implemented");
-                break;
-            case "OPTIONS":
-                response.setHeader("Access-Control-Allow-Methods", "PUT, POST, DELETE");
-                response.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, Suppress-WWW-Authenticate");
-                response.setHeader("Access-Control-Allow-Credentials", "true");
-                // fall through, to allow Milton to add more details.
-            default:
+            } else {
                 Subject subject = Subject.getSubject(AccessController.getContext());
                 ServletRequest req = new DcacheServletRequest(request, context);
                 ServletResponse resp = new DcacheServletResponse(response);

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -263,6 +263,9 @@
       <description>List of handlers for HTTP requests</description>
       <property name="handlers">
           <list>
+              <bean class="org.dcache.webdav.CrossOriginResourceSharingHandler">
+                  <property name="allowedClientOrigins" value="${webdav.allowed.client.origins}"/>
+              </bean>
               <bean class="org.eclipse.jetty.server.handler.ContextHandler">
                   <property name="contextPath" value="${webdav.static-content.location}"/>
                   <property name="handler">
@@ -524,7 +527,6 @@
 
                     <bean class="org.dcache.webdav.MiltonHandler">
                         <property name="httpManager" ref="http-manager"/>
-                        <property name="allowedClientOrigins" value="${webdav.allowed.client.origins}"/>
                     </bean>
                     <bean class="org.eclipse.jetty.server.handler.DefaultHandler"/>
                 </list>
@@ -555,7 +557,6 @@
                 <list>
                     <bean class="org.dcache.webdav.MiltonHandler">
                         <property name="httpManager" ref="http-manager"/>
-                        <property name="allowedClientOrigins" value="${webdav.allowed.client.origins}"/>
                     </bean>
                     <bean class="org.eclipse.jetty.server.handler.DefaultHandler"/>
                 </list>


### PR DESCRIPTION
Motivation:

If a client like dcache-view needs to read from or write
to dcache through the webdav door, the browser will first
send a preflight request by the OPTION method and then if
the dcache-view origin is allowed, the main request will
be send.

Since the OPTION method does not include an Authentication
header, hence, if a dcache site does not allow anonymous
operation, this will result in a 401 Unauthorised response
from dcache. Although Milton handler included the CORS
implementation but 401 Unauthorised is caught before the
request reached the Milton handler.

Modification:

- Create a filter and handler for CORS request. This
    handler will be the first on list to handle OPTION
    method request.
- Factor out the CORS implementation inside the Milton
    handler and use the filter to achieved exactly the
    same thing.

Result:

CORS is now properly handle.

Release Note:

Fix CORS for WebDAV doors that do not allow anonymous
access; in particular, to support dCacheView uploading
and downloading files with such authentication-required
WebDAV doors.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires notes: yes
Requires book: no
Acked-by: Paul Millar
Fixes: https://github.com/dCache/dcache/issues/4986

Reviewed at https://rb.dcache.org/r/11883/

(cherry picked from commit 385b77fac2a2732f1db87075e2e32765a13d2d57)