### PR TITLE
nfs: fix NPE on "show transfers" command

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -930,7 +930,9 @@ public class NFSv41Door extends AbstractCellComponent implements
             description = "Show active transfers excluding proxy-io.")
     public class ShowTransfersCmd implements Callable<String> {
 
-        @Option(name = "pool", usage = "An optional pool for filtering. Glob pattern matching is supported.")
+        @Option(name = "pool", usage = "An optional pool for filtering."
+                + "  Specifying an empty string selects only transfers where no"
+                + " pool has been selected. Glob pattern matching is supported.")
         Glob pool;
 
         @Option(name = "client", usage = "An optional client for filtering. Glob pattern matching is supported.")
@@ -944,7 +946,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
             return _ioMessages.values()
                     .stream()
-                    .filter(d -> pool == null ? true : pool.matches(d.getPool().getName()))
+                    .filter(d -> pool == null ? true : pool.matches(d.getPool() == null ? "" : d.getPool().getName()))
                     .filter(d -> client == null ? true : client.matches(d.getClient().toString()))
                     .filter(d -> pnfsid == null ? true : pnfsid.matches(d.getPnfsId().toString()))
                     .map(Object::toString)


### PR DESCRIPTION
Motivation:

Report of the following stack-trace:

    dmg.util.CommandPanicException: (1) Command failed: java.lang.NullPointerException
            at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:156) ~[common-cli-4.2.30.jar:4.2.30]
            at dmg.cells.nucleus.CellAdapter.executeCommand(CellAdapter.java:238) ~[cells-4.2.30.jar:4.2.30]
            at org.dcache.cells.UniversalSpringCell.executeCommand(UniversalSpringCell.java:195) ~[dcache-core-4.2.30.jar:4.2.30]
            at dmg.cells.nucleus.CellAdapter$1.doExecute(CellAdapter.java:104) ~[cells-4.2.30.jar:4.2.30]
            at org.dcache.util.cli.CommandInterpreter.command(CommandInterpreter.java:129) ~[common-cli-4.2.30.jar:4.2.30]
            at dmg.cells.nucleus.CellAdapter$1.command(CellAdapter.java:121) ~[cells-4.2.30.jar:4.2.30]
            at dmg.cells.nucleus.CellAdapter.command(CellAdapter.java:223) ~[cells-4.2.30.jar:4.2.30]
            at dmg.cells.nucleus.CellAdapter.executeLocalCommand(CellAdapter.java:915) ~[cells-4.2.30.jar:4.2.30]
            at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:855) ~[cells-4.2.30.jar:4.2.30]
            at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1211) [cells-4.2.30.jar:4.2.30]
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251) [dcache-common-4.2.30.jar:4.2.30]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_181]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_181]
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$4(CellNucleus.java:747) [cells-4.2.30.jar:4.2.30]
            at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_181]
    Caused by: java.lang.NullPointerException: null
            at org.dcache.chimera.nfsv41.door.NFSv41Door$ShowTransfersCmd.lambda$call$0(NFSv41Door.java:909) ~[dcache-nfs-4.2.30.jar:4.2.30]
            at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174) ~[na:1.8.0_181]
            at java.util.concurrent.ConcurrentHashMap$ValueSpliterator.forEachRemaining(ConcurrentHashMap.java:3566) ~[na:1.8.0_181]
            at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[na:1.8.0_181]
            at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[na:1.8.0_181]
            at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[na:1.8.0_181]
            at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:1.8.0_181]
            at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) ~[na:1.8.0_181]
            at org.dcache.chimera.nfsv41.door.NFSv41Door$ShowTransfersCmd.call(NFSv41Door.java:913) ~[dcache-nfs-4.2.30.jar:4.2.30]
            at org.dcache.chimera.nfsv41.door.NFSv41Door$ShowTransfersCmd.call(NFSv41Door.java:891) ~[dcache-nfs-4.2.30.jar:4.2.30]
            at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:145) ~[common-cli-4.2.30.jar:4.2.30]
            ... 14 common frames omitted

Modification:

Update code so it does not assume getPool() returns non-null value.

The pool option may now be used to select transfers without a pool by
specifying the empty string.

Result:

The NFS door's "show transfers" command now works when specifying a pool
selection (the 'pool' command option) and there are transfers that do
not yet have a selected pool.  Specifying an empty string as the 'pool'
option's value ("show transfers -pool=") selects only transfers that do
not yet have a pool.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/11901/
Acked-by: Tigran Mkrtchyan