### PR TITLE
util: decorate retry executor with CDC-aware wrapper

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -146,7 +146,9 @@ public class Transfer implements Comparable<Transfer>
     private static final ThreadFactory RETRY_THREAD_FACTORY =
             new ThreadFactoryBuilder().setDaemon(true).setNameFormat("transfer-retry-timer-%d").build();
     private static final ListeningScheduledExecutorService RETRY_EXECUTOR =
-            MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1, RETRY_THREAD_FACTORY));
+            MoreExecutors.listeningDecorator(
+                    new CDCScheduledExecutorServiceDecorator<>(Executors.newScheduledThreadPool(1, RETRY_THREAD_FACTORY))
+            );
 
     /**
      * Which activities poolmanager is allowed to do.


### PR DESCRIPTION
Motivation:
When a transfer re-tries an async request then a scheduler is used to simulate a
delay. As CDC is not propagated, then log messages loose some information:

31 Jul 2019 12:24:46 (NFS-dcache-lab007) [door:NFS-dcache-lab007@core-dcache-lab007:AAWO94jEMrg 0000DA89851974B04CF394024C2316BF6EEA /131.169.185.213:687] Pool unavailable
31 Jul 2019 12:24:56 (c-core-dcache-lab000-AAWO94Td6Dg-AAWO94TeD0g) [] Pool unavailable
31 Jul 2019 12:24:56 (NFS-dcache-lab007) [] Pool unavailable

Modification:
decorate scheduler used for retry with CDC-aware wrapper.

Result:
The CDC context is available in during retries

31 Jul 2019 12:38:58 (NFS-dcache-lab007) [door:NFS-dcache-lab007@core-dcache-lab007:AAWO97uNwSg 0000DA89851974B04CF394024C2316BF6EEA /131.169.185.213:693] Pool unavailable
31 Jul 2019 12:39:08 (NFS-dcache-lab007) [door:NFS-dcache-lab007@core-dcache-lab007:AAWO97uNwSg 0000DA89851974B04CF394024C2316BF6EEA /131.169.185.213:693] Pool unavailable
31 Jul 2019 12:39:08 (NFS-dcache-lab007) [door:NFS-dcache-lab007@core-dcache-lab007:AAWO97uNwSg 0000DA89851974B04CF394024C2316BF6EEA /131.169.185.213:693] Pool unavailable

Acked-by: Marina Sahakyan
Target: master, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit 1e778e7ad02f57c7b5b81a3815827c7b81b7fff7)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>