### PR TITLE
scitoken: fix remote reading of JSON with UTF-8 CharSet

### DIFF
--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/HttpJsonNode.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/HttpJsonNode.java
@@ -170,6 +170,7 @@ public class HttpJsonNode extends PreparationJsonNode
                 case "us-ascii":
                     charset = StandardCharsets.US_ASCII;
                     break;
+                case "utf-8":
                 case "utf8":
                     charset = StandardCharsets.UTF_8;
                     break;


### PR DESCRIPTION
Motivation:

dCache fails to discover SciToken/OAuth JSON documents if the
OAuth server advertises the charset as "utf-8".

Modification:

Include "utf-8" as a valid alias for "utf8".

Result:

dCache can now work with OPs that use "utf-8" charset.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11911/
Acked-by: Lea Morschel