### PR TITLE
common: fix formatting of error message in Checksum

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/Checksum.java
+++ b/modules/common/src/main/java/org/dcache/util/Checksum.java
@@ -62,7 +62,7 @@ public class Checksum  implements Serializable
                 "checksum value \"%s\" contains non-hexadecimal digits", value);
 
         checkArgument(this.value.length() == type.getNibbles(),
-            "%s requires %d hexadecimal digits but \"%s\" has %d",
+            "%s requires %s hexadecimal digits but \"%s\" has %s",
             type.getName(), type.getNibbles(), value, this.value.length());
     }
 


### PR DESCRIPTION
Motivation:

GUAVA uses ad hoc formatting which does not accept '%d'.
The Checksum class outputs an error message which is
formatted using the Java '%d' for numerics.

Modification:

Change the '%d' to '%s'.

Result:

Proper error output (see the Testing).

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Acked-by: Paul
Patch: https://rb.dcache.org/r/11920/