### PR TITLE
frontend: make geographic placement configurable

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/qos/QoSMetadata.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/qos/QoSMetadata.java
@@ -1,11 +1,13 @@
 package org.dcache.restful.qos;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.util.List;
 
 @ApiModel(description = "Attributes of a specific Quality of Service, based on CDMI specification.")
+@JsonInclude(JsonInclude.Include.NON_EMPTY) // avoid sending empty cdmi_geographic_placement_provided
 public class QoSMetadata {
 
     @ApiModelProperty("Number of copies of each file.")

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/qos/QosManagement.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/qos/QosManagement.java
@@ -10,6 +10,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.stereotype.Component;
 
+import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
@@ -44,8 +46,9 @@ public class QosManagement {
     public static final String VOLATILE = "volatile";
     public static final String UNAVAILABLE = "unavailable";
 
-    public static List<String> cdmi_geographic_placement_provided = Arrays.asList("DE");
-
+    @Inject
+    @Named("geographic-placement")
+    private List<String> geographicPlacement;
 
     @GET
     @ApiOperation("List the available quality of services for a specific object "
@@ -129,25 +132,25 @@ public class QosManagement {
             // Set data and metadata for "DISK" QoS
             if (DISK.equals(qosValue)) {
 
-                QoSMetadata qoSMetadata = new QoSMetadata("1", cdmi_geographic_placement_provided, "100");
+                QoSMetadata qoSMetadata = new QoSMetadata("1", geographicPlacement, "100");
                 setBackendCapability(backendCapability, DISK, Arrays.asList(TAPE, DISK_TAPE), qoSMetadata);
             }
             // Set data and metadata for "TAPE" QoS
             else if (TAPE.equals(qosValue)) {
 
-                QoSMetadata qoSMetadata = new QoSMetadata("1", cdmi_geographic_placement_provided, "600000");
+                QoSMetadata qoSMetadata = new QoSMetadata("1", geographicPlacement, "600000");
                 setBackendCapability(backendCapability, TAPE, Arrays.asList(DISK_TAPE), qoSMetadata);
 
             }
             // Set data and metadata for "Disk & TAPE" QoS
             else if (DISK_TAPE.equals(qosValue)) {
 
-                QoSMetadata qoSMetadata = new QoSMetadata("2", cdmi_geographic_placement_provided, "100");
+                QoSMetadata qoSMetadata = new QoSMetadata("2", geographicPlacement, "100");
                 setBackendCapability(backendCapability, DISK_TAPE, Arrays.asList(TAPE), qoSMetadata);
 
             }
             else if (VOLATILE.equals(qosValue)) {
-                QoSMetadata qoSMetadata = new QoSMetadata("0", cdmi_geographic_placement_provided, "100");
+                QoSMetadata qoSMetadata = new QoSMetadata("0", geographicPlacement, "100");
                 setBackendCapability(backendCapability, VOLATILE, Arrays.asList(DISK), qoSMetadata);
             }
             // The QoS is not known or supported.
@@ -201,22 +204,22 @@ public class QosManagement {
             // Set data and metadata for "DISK" QoS
             if (DISK.equals(qosValue)) {
 
-                QoSMetadata qoSMetadata = new QoSMetadata("1", cdmi_geographic_placement_provided, "100");
+                QoSMetadata qoSMetadata = new QoSMetadata("1", geographicPlacement, "100");
                 setBackendCapability(backendCapability, DISK, Arrays.asList(TAPE), qoSMetadata);
             }
             // Set data and metadata for "TAPE" QoS
             else if (TAPE.equals(qosValue)) {
 
-                QoSMetadata qoSMetadata = new QoSMetadata("1", cdmi_geographic_placement_provided, "600000");
+                QoSMetadata qoSMetadata = new QoSMetadata("1", geographicPlacement, "600000");
                 setBackendCapability(backendCapability, TAPE, Arrays.asList(DISK), qoSMetadata);
             }
             // Set data and metadata for "Disk & TAPE" QoS
             else if (DISK_TAPE.equals(qosValue)) {
-                QoSMetadata qoSMetadata = new QoSMetadata("2", cdmi_geographic_placement_provided, "100");
+                QoSMetadata qoSMetadata = new QoSMetadata("2", geographicPlacement, "100");
                 setBackendCapability(backendCapability, DISK_TAPE, Collections.emptyList(), qoSMetadata);
             }
             else if (VOLATILE.equals(qosValue)) {
-                QoSMetadata qoSMetadata = new QoSMetadata("0", cdmi_geographic_placement_provided, "100");
+                QoSMetadata qoSMetadata = new QoSMetadata("0", geographicPlacement, "100");
                 setBackendCapability(backendCapability, VOLATILE, Collections.emptyList(), qoSMetadata);
             }
             // The QoS is not known or supported.

--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -123,6 +123,12 @@
     </property>
   </bean>
 
+  <bean id="geographic-placement" class="com.google.common.collect.ImmutableList"
+	factory-method="copyOf">
+    <description>ISO-3166 identifiers where data may be stored.</description>
+    <constructor-arg value="#{ T(com.google.common.base.Splitter).on(',').trimResults().omitEmptyStrings().splitToList('${frontend.geographic-placement}') }"/>
+  </bean>
+
   <bean id="event-registrar" class="org.dcache.restful.events.Registrar">
     <description>Registrar for clients</description>
     <property name="maximumChannelsPerUser"

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -416,6 +416,13 @@ frontend.service.gplazma.cache.timeout.unit = MINUTES
 # Used by the billing service for periodic collection
 frontend.service.billing.collection.timeout = 1
 
+# Geographic placement
+#
+# A comma-separated list of ISO-3166 alpha-2 codes that identify where
+# data may be located.
+#
+frontend.geographic-placement =
+
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
 frontend.service.billing.collection.timeout.unit = MINUTES
 
@@ -574,4 +581,3 @@ frontend.version.swagger-ui = @version.swagger-ui@
 (obsolete)frontend.dcache-view.oidc-provider-name-list = Use frontend.static!dcache-view.oidc-provider-name-list instead
 (obsolete)frontend.dcache-view.oidc-client-id-list = Use frontend.static!dcache-view.oidc-client-id-list instead
 (obsolete)frontend.dcache-view.oidc-authz-endpoint-list = Use frontend.static!dcache-view.oidc-authz-endpoint-list instead
-


### PR DESCRIPTION
Motivation:

Currently dCache frontend hard-codes the geographic placement as Germany
("DE").  This is bad, as we have dCache instances running at various
locations throughout the world; therefore, this property should reflect
where data is actually stored.

Modification:

Add a configuration property that controls the value(s) returned as the
geographic placement.

Result:

Admins may now configure frontend to specify in which country (or
countries) data may be stored.  This information is visible through
dCacheView.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Reuqest: 4.2
Requires-notes: yes
Requires-book: no
Closes: #5048
Patch: https://rb.dcache.org/r/11921/
Acked-by: Albert Rossi
Acked-by: Olufemi Adeyemi