### PR TITLE
nfs: checksum types dot command

### DIFF
--- a/docs/TheBook/src/main/markdown/rf-dot-commands.md
+++ b/docs/TheBook/src/main/markdown/rf-dot-commands.md
@@ -32,6 +32,25 @@ There are no guarantees concerning future availability of the file; in particula
 
 ***
 
+## GET CHECKSUM TYPES
+
+Get the valid / recognized checksum types for dCache.
+
+### USAGE:
+
+    cat ".(checksums)()"
+
+##### RETURNS:
+
+A new-line delimited list of checksum type names.
+
+##### EXAMPLE:
+
+    $ cat ".(checksums)()"
+    ADLER32
+    MD5
+    MD4
+
 ## GET CHECKSUM(S)
 
 Get checksum types and checksums for a given file.
@@ -42,7 +61,7 @@ Get checksum types and checksums for a given file.
 
 ##### RETURNS:
 
-A comma-delimited list of `type:value` pairs for all checksums stored in the database.  The valid stored checksum types are `ADLER32`, `MD4` and `MD5`.
+A comma-delimited list of `type:value` pairs for all checksums stored in the database.
 
 ##### EXAMPLE:
 

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInodeType.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInodeType.java
@@ -30,7 +30,8 @@ public enum FsInodeType {
     CONST(9),    // the content of the inode is a free form information
     PLOC(10),    // the content of the inode is the value of requested attributes
     PCRC(11),    // the content of the inode is a name-value list of checksum types and checksums
-    SURI(12);    // read, write or update/overwrite location info for type TAPE
+    SURI(12),    // read, write or update/overwrite location info for type TAPE
+    CKSTYP(13);  // the available checksum types
 
     private final int _id;
 

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_CKSTYP.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_CKSTYP.java
@@ -1,0 +1,100 @@
+/*
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program (see the file COPYING.LIB for more
+ * details); if not, write to the Free Software Foundation, Inc.,
+ * 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.dcache.chimera;
+
+import org.dcache.chimera.posix.Stat;
+import org.dcache.util.ChecksumType;
+
+/**
+ *   cat ".(checksums)()" returns the available checksum types.
+ */
+public class FsInode_CKSTYP extends FsInode {
+
+    private final String checksums;
+
+    public FsInode_CKSTYP(FileSystemProvider fs, long ino) {
+        super(fs, ino, FsInodeType.CKSTYP);
+        checksums = getChecksums();
+    }
+
+    @Override
+    public boolean exists() {
+        return true;
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return false;
+    }
+
+    @Override
+    public boolean isLink() {
+        return false;
+    }
+
+    @Override
+    public int read(long pos, byte[] data, int offset, int len) {
+        if (pos > checksums.length()) {
+            return 0;
+        }
+
+        byte[] tmp = checksums.getBytes();
+
+        int copyLen = Math.min(len, tmp.length - (int) pos);
+        System.arraycopy(tmp, 0, data, 0, copyLen);
+        return copyLen;
+    }
+
+    @Override
+    public void setStat(Stat predefinedStat) {
+        // nop
+    }
+
+    /*
+     *  Fake stat to make this behave like a file
+     *  (cf. FsInode_CONST).
+     */
+    @Override
+    public Stat stat() throws ChimeraFsException {
+        Stat ret = new Stat(super.stat());
+        ret.setNlink(1);
+        ret.setMode(0444 | UnixPermission.S_IFREG);
+        ret.setATime(System.currentTimeMillis());
+        ret.setMTime(ret.getATime());
+        ret.setCTime(ret.getATime());
+        ret.setUid(0);
+        ret.setGid(0);
+        ret.setSize(checksums.length());
+        return ret;
+    }
+
+    @Override
+    public int write(long pos, byte[] data, int offset, int len) {
+        return -1;
+    }
+
+    private String getChecksums() {
+        StringBuilder sb = new StringBuilder();
+        ChecksumType[] list = ChecksumType.values();
+
+        for (ChecksumType type : list) {
+            sb.append(type.getName()).append("\n");
+        }
+
+        return sb.toString();
+    }
+}

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -848,6 +848,10 @@ public class JdbcFs implements FileSystemProvider {
                 return new FsInode_SURI(this, inode.ino());
             }
 
+            if (name.equals(".(checksums)()")) {
+                return new FsInode_CKSTYP(this, parent.ino());
+            }
+
             if (name.equals(".(tags)()")) {
                 return new FsInode_TAGS(this, parent.ino());
             }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
@@ -44,6 +44,7 @@ import org.dcache.chimera.FileNotFoundHimeraFsException;
 import org.dcache.chimera.FileSystemProvider;
 import org.dcache.chimera.FsInode;
 import org.dcache.chimera.FsInodeType;
+import org.dcache.chimera.FsInode_CKSTYP;
 import org.dcache.chimera.FsInode_CONST;
 import org.dcache.chimera.FsInode_ID;
 import org.dcache.chimera.FsInode_NAMEOF;
@@ -84,18 +85,18 @@ import org.dcache.nfs.v4.xdr.utf8str_mixed;
 import org.dcache.nfs.v4.xdr.verifier4;
 import org.dcache.nfs.vfs.AclCheckable;
 import org.dcache.nfs.vfs.DirectoryEntry;
-import org.dcache.nfs.vfs.FsStat;
 import org.dcache.nfs.vfs.DirectoryStream;
+import org.dcache.nfs.vfs.FsStat;
 import org.dcache.nfs.vfs.Inode;
 import org.dcache.nfs.vfs.Stat;
 import org.dcache.nfs.vfs.VirtualFileSystem;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.dcache.chimera.FileSystemProvider.StatCacheOption.NO_STAT;
 import static org.dcache.chimera.FileSystemProvider.StatCacheOption.STAT;
 import static org.dcache.nfs.v4.xdr.nfs4_prot.ACCESS4_EXTEND;
 import static org.dcache.nfs.v4.xdr.nfs4_prot.ACCESS4_MODIFY;
 import static org.dcache.nfs.v4.xdr.nfs4_prot.ACE4_INHERIT_ONLY_ACE;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Interface to a virtual file system.
@@ -676,6 +677,10 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
 
             case SURI:
                 inode = new FsInode_SURI(fs, ino);
+                break;
+
+            case CKSTYP:
+                inode = new FsInode_CKSTYP(fs, ino);
                 break;
 
             default:


### PR DESCRIPTION
Motivation:

Support ability to get valid checksum types via NFS.

Modification:

Add an FsInode class similar to CONST which
returns the valid types.

Result:

Requirement satisfied.

Target: master
Requires-book: yes
Requires-notes: yes
Acked-by: Paul
Acked-by: Dmitry
Patch: https://rb.dcache.org/r/11922/