### PR TITLE
pool-repository: Improve metadata check speed on pool re-start.

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -149,6 +149,7 @@
               value="#{ '${pool.lfs}' == 'volatile' or '${pool.lfs}' == 'transient' }"/>
     <property name="maxDiskSpaceString" value="${pool.size}"/>
     <property name="replicaStore" ref="replica-store"/>
+    <property name="scanThreads" value="${pool.limits.scan-threads}"/>
   </bean>
 
   <bean id="repository-interpreter" class="org.dcache.pool.repository.RepositoryInterpreter">

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -119,6 +119,9 @@ pool.limits.worker-threads=5
 # e.g. name space operations or callouts into installed nearline storage providers.
 pool.limits.nearline-threads=30
 
+# Worker thread pool to scan and check metadata from the pool repository.
+pool.limits.scan-threads=1
+
 # Pool cell name. Currently this has to be the same as the pool name.
 pool.cell.name=${pool.name}
 


### PR DESCRIPTION
Motivation:

For large pools (> 1T, > 1M files), reading the repository and checking metadata can take
a long time when restarting dCache pools -- O (nbr. of entries). This leads to have
`smaller` pools which are more manageable in case of interventions (upgrade, reboot, etc).

Modification:
- Extend the replica repository class to scan the repository with a threads pool.
- Add the property: pool.limits.scan-threads(by default 1) to define the number of threads
dCache will use to scan the local replica repository of the pool.

Result:

For 706469 files, to check the metadata of each file in the repository it takes 3 minutes
with 1 threads(as today) and 34 seconds with 10 threads.

Acked-by: Albert Rossi
Target: master, 5.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/11928/
Committed: master@da929a09b6
Pull-request: https://github.com/dCache/dcache/pull/5055
Signed-off-by: Vincent Garonne vgaronne@gmail.com