### PR TITLE
dcache: fix RepositorySubsystem unit test NPE

### DIFF
--- a/modules/dcache/src/test/java/org/dcache/tests/repository/RepositorySubsystemTest.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/repository/RepositorySubsystemTest.java
@@ -206,6 +206,7 @@ public class RepositorySubsystemTest
         repository.setSpaceSweeperPolicy(sweeper);
         repository.setMaxDiskSpace(new DiskSpace(repoSize));
         repository.addFaultListener(event -> System.err.println(event.getMessage() + ": " + event.getCause()));
+        repository.setScanThreads(1);
     }
 
     @Before


### PR DESCRIPTION
Motivation:

master@da929a09b6cf63e87071cb42c565b56f66b071d8
(#11928) introduced a new Spring-injected
field into the Repository, 'scanThreads'.  This
field needs to be configured in the unit test initialization
or the equality check will produce an NPE.

Modification:

Set the value to 1.

Result:

No NPE.

Target: master
Request: 5.2
Requires-notes: no
Requires-book: no
Acked-by: Olufemi
Patch: https://rb.dcache.org/r/11930/