### PR TITLE
chimera: update ctime on checksum set and remove

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -1475,6 +1475,7 @@ public class FsSqlDriver {
                          ps.setLong(4, inode.ino());
                          ps.setInt(5, type);
                      });
+        setInodeAttributes(inode, 0, new Stat());
     }
 
     /**
@@ -1506,6 +1507,7 @@ public class FsSqlDriver {
         } else {
             _jdbc.update("DELETE FROM t_inodes_checksum WHERE inumber=?", inode);
         }
+        setInodeAttributes(inode, 0, new Stat());
     }
 
     /**

--- a/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/BasicTest.java
@@ -704,6 +704,42 @@ public class BasicTest extends ChimeraTestCaseHelper {
         assertHasChecksum(new Checksum(ChecksumType.getChecksumType(1), sum), fileInode);
     }
 
+    @Test
+    public void testCtimeOnUpdateChecksum() throws Exception {
+        String sum = "abc";
+
+        FsInode base = _rootInode.mkdir("junit");
+        FsInode fileInode = base.create("testCreateFile", 0, 0, 0644);
+        Stat stat = fileInode.stat();
+        long before = stat.getCTime();
+        long genBefore = stat.getGeneration();
+        Thread.sleep(100);
+        _fs.setInodeChecksum(fileInode, 1, sum);
+        stat = fileInode.stat();
+        long after = stat.getCTime();
+        long genAfter = stat.getGeneration();
+        assertNotEquals("ctime was not updated", before, after);
+        assertNotEquals("generation was not updated", genBefore, genAfter);
+    }
+
+    @Test
+    public void testCtimeOnRemoveChecksum() throws Exception {
+        String sum = "abc";
+
+        FsInode base = _rootInode.mkdir("junit");
+        FsInode fileInode = base.create("testCreateFile", 0, 0, 0644);
+        Stat stat = fileInode.stat();
+        long before = stat.getCTime();
+        long genBefore = stat.getGeneration();
+        Thread.sleep(100);
+        _fs.removeInodeChecksum(fileInode, 1);
+        stat = fileInode.stat();
+        long after = stat.getCTime();
+        long genAfter = stat.getGeneration();
+        assertNotEquals("ctime was not updated", before, after);
+        assertNotEquals("generation was not updated", genBefore, genAfter);
+    }
+
     @Ignore("Functionality not yet written, but desired")
     @Test
     public void testUpdateChecksumDifferTypes() throws Exception {


### PR DESCRIPTION
Motivation:

In order to support checksum overwrite, ctime needs to
be updated on set and removal, otherwise ".(get)(file)(checksums)"
will continue to go to the Linux client cache for the current
value.

Modification:

Add a call to setInodeAttributes to each method in the driver.

Also added two small unit tests.

Result:

Ctime is updated on these calls.

Target: master
Request: 5.2
Requires-book: no
Requires-notes: no
Patch: https://rb.dcache.org/r/11931/
Acked-by: Tigran