### PR TITLE
resilience: fix remove count when replica is precious

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/handlers/FileOperationHandler.java
@@ -1129,6 +1129,7 @@ public class FileOperationHandler implements CellMessageSender {
                     Set<String> removable = verifier.areRemovable(sticky,
                                                                   verified);
                     target = locationSelector.selectRemoveTarget(operation,
+                                                                 sticky,
                                                                  removable,
                                                                  tags);
                 }

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/LocationSelector.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/LocationSelector.java
@@ -129,6 +129,7 @@ public final class LocationSelector {
     }
 
     public String selectRemoveTarget(FileOperation operation,
+                                     Collection<String> sticky,
                                      Collection<String> locations,
                                      Collection<String> tags)
                     throws LocationSelectionException {
@@ -136,7 +137,7 @@ public final class LocationSelector {
                      operation.getPnfsId(),
                      locations,
                      tags);
-        if (locations.size() == 1) {
+        if (sticky.size() == 1) {
             String message = String.format("Remove replica was selected, but "
                                             + "the principal pool %s is the "
                                             + "only location; this is a bug.",


### PR DESCRIPTION
Motivation:

Currently, if there are two replicas, one of which is precious,
and some change is triggered which reduces the required count
for the file to 1, the removal operation will fail (see below).

This is because the remove method is counting the wrong set of
files (removable, instead of sticky) to determine how many
replicas there actually are.

Modification:

Change the method to look at sticky files.

Result:

Correct behavior (see below).

Target: master
Request: 5.2
Patch: https://rb.dcache.org/r/11933/
Requires-notes: yes
Requires-book: no
Acked-by: Dmitry