### PR TITLE
srm: Remove JVM memory limits

### DIFF
--- a/modules/srm-client/src/main/lib/srm
+++ b/modules/srm-client/src/main/lib/srm
@@ -77,7 +77,7 @@ if [ "$SRM_CONFIG" = "NONE" ]; then
 fi
 
 if [ -z "$SRM_JAVA_OPTIONS" ]; then
-    SRM_JAVA_OPTIONS="-Xms64m -Xmx178m -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    SRM_JAVA_OPTIONS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
 fi
 
 


### PR DESCRIPTION
Motivation:

A new user community requires the srm tools to be able to handle
very large file listings. During preliminary tests, OutOfMemory
errors from the srmls tool were observed.

Modification:

The $SRMDIR/lib/srm script contained hard memory limits for srm
(and srmls is just a wrapper for srm) of Xms=64m and Xmx=178m.
Those limits were removed.

Result:

srm can now support operations on very large file lists
without running out of memory.

Target: master
Requires-notes: yes
Requires-book: no
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/11924/
Acked-by: Albert Rossi