### PR TITLE
nfs: support ability to set file checksum(s) via dot command

### DIFF
--- a/docs/TheBook/src/main/markdown/rf-dot-commands.md
+++ b/docs/TheBook/src/main/markdown/rf-dot-commands.md
@@ -68,7 +68,46 @@ A comma-delimited list of `type:value` pairs for all checksums stored in the dat
     $ cat ".(get)(test_file-Thu_Oct_23_10:39:37_CDT_2014-109)(checksums)"
     $ ADLER32:66300001
 
-***
+## SET CHECKSUM
+
+Set a checksum value for a file.   An ordinary user can only set one
+checksum (type, value) pair, and cannot overwrite existing values.  A ROOT
+user is allowed to set multiple types (successively) and also to overwrite
+values for any type.
+
+### USAGE:
+
+    touch ".(fset)(<filename>)(checksum)(<type>)(<value>)"
+
+##### EXAMPLES:
+
+    [arossi@otfrid volatile]$ touch testfile
+
+    [arossi@otfrid volatile]$ cat ".(get)(testfile)(checksum)"
+
+    [arossi@otfrid volatile]$ touch ".(fset)(testfile)(checksum)(ADLER32)(ffffffff)"
+
+    [arossi@otfrid volatile]$ cat ".(get)(testfile)(checksum)"
+    ADLER32:ffffffff
+
+    [arossi@otfrid volatile]$ touch ".(fset)(testfile)(checksum)(ADLER32)(fffffff0)"
+    touch: setting times of ‘.(fset)(testfile)(checksum)(ADLER32)(fffffff0)’: Operation not permitted
+
+    [arossi@otfrid volatile]$ ksu
+    Authenticated arossi@FNAL.GOV
+    Account root: authorization for arossi@FNAL.GOV successful
+    Changing uid to root (0)
+
+    [root@otfrid volatile]# touch ".(fset)(testfile)(checksum)(ADLER32)(fffffff0)"
+
+    [root@otfrid volatile]# cat ".(get)(testfile)(checksum)"
+    ADLER32:fffffff0
+
+    [root@otfrid volatile]# touch ".(fset)(testfile)(checksum)(MD5)(12341234123412345678567856785678)"
+
+    [root@otfrid volatile]# cat ".(get)(testfile)(checksum)"
+    ADLER32:fffffff0, MD5:12341234123412345678567856785678
+
 
 #### PIN/STAGE
 

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PCRC.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PCRC.java
@@ -28,33 +28,29 @@ import org.dcache.util.Checksum;
  * @author arossi
  */
 public class FsInode_PCRC extends FsInode_PGET {
-    private String _checksum;
 
     public FsInode_PCRC(FileSystemProvider fs, long ino) {
         super(fs, ino, FsInodeType.PCRC);
     }
 
     protected String value() throws ChimeraFsException {
-        if (_checksum == null) {
-            Set<Checksum> results = _fs.getInodeChecksums(this);
-            StringBuilder sb = new StringBuilder();
+        Set<Checksum> results = _fs.getInodeChecksums(this);
+        StringBuilder sb = new StringBuilder();
 
-            Iterator<Checksum> it = results.iterator();
-            if (it.hasNext()) {
-                Checksum result = it.next();
-                sb.append(result.getType()).append(':').append(
-                                result.getValue());
-            }
-
-            while (it.hasNext()) {
-                Checksum result = it.next();
-                sb.append(", ").append(result.getType()).append(':').append(
-                                result.getValue());
-            }
-
-            sb.append(NEWLINE);
-            _checksum = sb.toString();
+        Iterator<Checksum> it = results.iterator();
+        if (it.hasNext()) {
+            Checksum result = it.next();
+            sb.append(result.getType()).append(':').append(
+                            result.getValue());
         }
-        return _checksum;
+
+        while (it.hasNext()) {
+            Checksum result = it.next();
+            sb.append(", ").append(result.getType()).append(':').append(
+                            result.getValue());
+        }
+
+        sb.append(NEWLINE);
+        return sb.toString();
     }
 }

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PSET.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsInode_PSET.java
@@ -19,16 +19,20 @@ package org.dcache.chimera;
 import com.google.common.base.Charsets;
 
 import java.util.Arrays;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.dcache.chimera.posix.Stat;
+import org.dcache.util.Checksum;
+import org.dcache.util.ChecksumType;
 
 public class FsInode_PSET extends FsInode {
-    private static final String SIZE = "size";
-    private static final String IO = "io";
-    private static final String ONLN = "bringonline";
-    private static final String STG = "stage";
-    private static final String PIN = "pin";
+    private static final String SIZE   = "size";
+    private static final String IO     = "io";
+    private static final String ONLN   = "bringonline";
+    private static final String STG    = "stage";
+    private static final String PIN    = "pin";
+    private static final String CKS    = "checksum";
 
     private final String[] _args;
 
@@ -42,41 +46,43 @@ public class FsInode_PSET extends FsInode {
         return false;
     }
 
+    public boolean isChecksum() { return CKS.equals(_args[0]); }
+
     @Override
     public int read(long pos, byte[] data, int offset, int len) {
         return -1;
     }
 
     @Override
-    public void setStat(Stat newStat) {
-	try {
-	    if (newStat.isDefined(Stat.StatAttributes.MTIME)) {
-		switch (_args[0]) {
-		    case SIZE:
-			Stat s = new Stat();
-			try {
-			    s.setSize(Long.parseLong(_args[1]));
-			} catch (NumberFormatException ignored) {
-			    // Bad values ignored
-			}
-			s.setMTime(newStat.getMTime());
-			_fs.setInodeAttributes(this, 0, s);
-			break;
-		    case IO:
-			_fs.setInodeIo(this, _args[1].equals("on"));
-			break;
-		    case ONLN:
-		    case STG:
-		    case PIN:
-			handlePinRequest();
-			break;
-		    default:
-			break;
-		}
-
-	    }
-	} catch (ChimeraFsException ignored) {
-	}
+    public void setStat(Stat newStat) throws ChimeraFsException
+    {
+        if (newStat.isDefined(Stat.StatAttributes.MTIME)) {
+            switch (_args[0]) {
+                case SIZE:
+                    Stat s = new Stat();
+                    try {
+                        s.setSize(Long.parseLong(_args[1]));
+                    } catch (NumberFormatException ignored) {
+                        // Bad values ignored
+                    }
+                    s.setMTime(newStat.getMTime());
+                    _fs.setInodeAttributes(this, 0, s);
+                    break;
+                case IO:
+                    _fs.setInodeIo(this, _args[1].equals("on"));
+                    break;
+                case ONLN:
+                case STG:
+                case PIN:
+                    handlePinRequest();
+                    break;
+                case CKS:
+                    handleSetChecksum();
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 
     @Override
@@ -146,6 +152,39 @@ public class FsInode_PSET extends FsInode {
             _fs.unpin(new FsInode(_fs, ino()));
         } else {
             _fs.pin(new FsInode(_fs, ino()), lifetime);
+        }
+    }
+
+    /*
+     *  This method allows overwrite only with ROOT access.
+     *  It also allows a non-ROOT user to set only one checksum
+     *  (type, value) pair.
+     */
+    private void handleSetChecksum() throws ChimeraFsException {
+        if (_args.length != 3) {
+            throw new InvalidArgumentChimeraException("incorrect number of arguments.");
+        }
+
+        Set<Checksum> checksums = _fs.getInodeChecksums(this);
+        ChecksumType type = ChecksumType.getChecksumType(_args[1]);
+
+        try {
+            /*
+             * The filesystem implementation does not allow
+             * overwrite using the 'setInodeChecksum' method, so
+             * an explicit deletion is required.
+             */
+            if (checksums.stream().anyMatch(c -> type.equals(c.getType()))) {
+                _fs.removeInodeChecksum(this, type.getType());
+            }
+
+            Checksum cks = new Checksum(type, _args[2]);
+            _fs.setInodeChecksum(this, type.getType(), cks.getValue());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidArgumentChimeraException("Invalid checksum: "
+                                                                      + _args[2]
+                                                                      + "; "
+                                                                      + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Motivation:

Some admin scripts (such as client to enstore) will need this
ability in the near future.

Modification:

Add the operation type to PSET.  Support overwrite and multiple
sets only if user is ROOT.

Result:

Requirement satisfied.

Target: master
Requires-book: yes
Requires-notes: yes
Patch: https://rb.dcache.org/r/11923
Acked-by: Tigran