### PR TITLE
Include information on creating ban.conf

### DIFF
--- a/docs/TheBook/src/main/markdown/install.md
+++ b/docs/TheBook/src/main/markdown/install.md
@@ -655,6 +655,12 @@ username:tester uid:1000 gid:1000,true
 username:admin uid:0 gid:0,true
 ```
 
+Additionally we create an empty banfile to make sure the ban file plugin works:
+
+```console-root
+touch /etc/dcache/ban.conf
+```
+
 Finally, we need to provide some session data for this user, which is
 stored in the `authzdb` plugin configuration. For backwards
 compatibility, this plugin's default configuration location is the


### PR DESCRIPTION
`ban.conf` was missing when I followed the steps of this introduction. FYI, this is the error in the log that I encountered and that put me on the right path. Adding ban.conf solved this. Great instructions and helpful error message, by the way! 👍 

```
Caused by: java.io.FileNotFoundException: /etc/dcache/ban.conf (No such file or directory)
        at java.io.FileInputStream.open0(Native Method)
        at java.io.FileInputStream.open(FileInputStream.java:195)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at scala.io.Source$.fromFile(Source.scala:91)
        at scala.io.Source$.fromFile(Source.scala:76)
        at scala.io.Source$.fromFile(Source.scala:54)
        at org.dcache.gplazma.plugins.BanFilePlugin.fromSource(BanFilePlugin.scala:35)
        ... 29 common frames omitted
12 Sep 2019 10:49:11 (gPlazma) [WebDAV-dcache-server Login] Login attempt failed; detailed explanation follows:
LOGIN FAIL
 |    in: Origin[::1]
 |        PasswordCredential[user=tester]
 |
 +--AUTH OK
 |   |
 |   +--htpasswd SUFFICIENT:FAIL (tester is unknown) => OK
 |
 +--MAP OK
 |   |
 |   +--multimap SUFFICIENT:FAIL (no mappable principals) => OK
 |
 +--ACCOUNT FAIL
 |   |
 |   +--banfile REQUISITE:FAIL (null) => FAIL (ends the phase)
 |
 +--(SESSION) skipped
 |
 +--(VALIDATION) skipped
```