### PR TITLE
webdav: add allow header to OPTION method request

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
@@ -72,6 +72,7 @@ public class CrossOriginResourceSharingHandler extends AbstractHandler
             }
         }
         if ("OPTIONS".equals(request.getMethod())) {
+            response.setHeader("Allow", "GET, PUT, POST, DELETE");
             response.setHeader("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE");
             response.setHeader("Access-Control-Allow-Headers",
                     "Authorization, Content-Type, Suppress-WWW-Authenticate");


### PR DESCRIPTION
Motivation:

Recently, we refactor and restructure the part of webdav door
for OPTION method request (see https://rb.dcache.org/r/11883/).
Although, the patch conform with the standard behaviour/spec,
the ATLAS CERN people relied on the allow header that was there
before.

Modification:

Add allow header to list of response headers for OPTION method
request.

Result:

Backward compatibly for OPTION method request is now supported.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel

Reviewed at https://rb.dcache.org/r/11939/

(cherry picked from commit 3dca2b59a2486cd717daaeade94368ed388e8aea)