### PR TITLE
httpd: escape status field in HttpPoolMgrEngineV3

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/HttpPoolMgrEngineV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/HttpPoolMgrEngineV3.java
@@ -1,5 +1,7 @@
 package diskCacheV111.poolManager;
 
+import com.google.common.escape.Escaper;
+import com.google.common.html.HtmlEscapers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,6 +111,8 @@ public class HttpPoolMgrEngineV3 implements
     private Map<String, Object> _context;
 
     private CellEndpoint _endpoint;
+
+    private final Escaper htmlEscaper = HtmlEscapers.htmlEscaper();
 
     public HttpPoolMgrEngineV3(String[] argsString)
     {
@@ -973,7 +977,8 @@ public class HttpPoolMgrEngineV3 implements
         String  pool = info.getPool();
         pool = (pool == null) || (pool.isEmpty() || pool.equals("<unknown>")) ? "N.N." : pool;
         String status = info.getStatus();
-        status = (status == null) || (status.isEmpty()) ? "&nbsp;" : status;
+        status = (status == null) || (status.isEmpty()) ? "&nbsp;" : htmlEscaper.escape(status);
+
         if (error) {
             html.beginRow("error", "error odd");
         } else {


### PR DESCRIPTION
Motivation:

See GitHub #5071 Bug.

Modfication:

Use com.google.common.html.HtmlEscapers

Result:

Should resolve the bug.

Target: master
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11948/
Bug: #5071
Acked-by: Tigran
Acked-by: Lea