### PR TITLE
scripts: set hsmcp and infoprovidercms executable

### DIFF
--- a/packages/fhs/src/main/deb/postinst
+++ b/packages/fhs/src/main/deb/postinst
@@ -42,6 +42,8 @@ Please fix this and reinstall this package." >&2
     chmod 700 /var/lib/dcache/statistics
 
     # allow somewhat more relaxed permissions elsewhere
+    chmod 755 /usr/share/dcache/lib/hsmcp.sh
+    chmod 755 /usr/share/dcache/lib/infoprovidercms.rb
     chmod 750 /var/lib/dcache/billing
     chmod 770 /var/lib/dcache/star
     chmod 755 /var/spool/dcache/star

--- a/packages/fhs/src/main/deb/postinst
+++ b/packages/fhs/src/main/deb/postinst
@@ -42,7 +42,7 @@ Please fix this and reinstall this package." >&2
     chmod 700 /var/lib/dcache/statistics
 
     # allow somewhat more relaxed permissions elsewhere
-    chmod 755 /usr/share/dcache/lib/hsmcp.sh
+    chmod 755 /usr/share/dcache/lib/hsmcp.rb
     chmod 755 /usr/share/dcache/lib/infoprovidercms.rb
     chmod 750 /var/lib/dcache/billing
     chmod 770 /var/lib/dcache/star

--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -107,7 +107,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/share/man/man8/dcache-billing-indexer.8
 /usr/share/man/man8/dcache.8
 
-%attr(755,root,root) /usr/share/dcache/lib/hsmcp.sh
+%attr(755,root,root) /usr/share/dcache/lib/hsmcp.rb
 %attr(755,root,root) /usr/share/dcache/lib/infoprovidercms.rb
 
 %attr(-,dcache,dcache) /var/log/dcache

--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -107,6 +107,9 @@ rm -rf $RPM_BUILD_ROOT
 /usr/share/man/man8/dcache-billing-indexer.8
 /usr/share/man/man8/dcache.8
 
+%attr(755,root,root) /usr/share/dcache/lib/hsmcp.sh
+%attr(755,root,root) /usr/share/dcache/lib/infoprovidercms.rb
+
 %attr(-,dcache,dcache) /var/log/dcache
 %attr(-,dcache,dcache) /var/lib/dcache/config
 %attr(700,dcache,dcache) /var/lib/dcache/alarms


### PR DESCRIPTION
Motivation:

Github ticket 3158 noted that the default HSM script is not set
as executable during the installation. Likewise, the
infoprovidercms.rb script also needs this set.

Other files in /usr/share/dcache/lib/ could also be set executable
by default. However, since most are templates that are meant to be
customized by admins, this patch only modifies these two files'
permissions.

Modification:

The RPM specfile and the DEB's postinst script were modified
so that the hsmcp.rb and infoprovidercms.rb scripts are installed
with 755 permissions.

Result:

Simple setups with tape connection work out-of-the-box.

Target: master
Require-notes: yes
Require-book: no
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2