### PR TITLE
chimera: fix ABBA db deadlock when mkdir and rmdir run concurrently

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -313,18 +313,14 @@ public class FsSqlDriver {
         // A directory contains two pseudo entries for '.' and '..'
         decNlink(inode, 2);
 
+        // ensure that t_inodes and t_tags_inodes updated in the same order as
+        // in mkdir
+        decNlink(parent);
         removeTag(inode);
 
         if (!removeInodeIfUnlinked(inode)) {
             throw new DirNotEmptyHimeraFsException("directory is not empty");
         }
-
-        /* During bulk deletion of files in the same directory,
-         * updating the parent inode is often a contention point. The
-         * link count on the parent is updated last to reduce the time
-         * in which the directory inode is locked by the database.
-         */
-        decNlink(parent);
 
         return true;
     }

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -579,6 +579,8 @@ public class JdbcFs implements FileSystemProvider {
                     perm = mode;
                 }
 
+                // ensure that t_inodes and t_tags_inodes update in the same order as
+                // in removeDir
                 FsInode inode = _sqlDriver.mkdir(parent, name, owner, gid, perm);
                 _sqlDriver.copyTags(parent, inode);
                 _sqlDriver.copyAcl(parent, inode, RsType.DIR, EnumSet.of(INHERIT_ONLY_ACE),


### PR DESCRIPTION
Motivation:
when in a single directory mkdir and rmdir happen concurrently then
t_inodes and t_tags_inodes tables are updated in two (2) competing
transactions. As tables accessed in a different order, then we run
into ABBA deadlock:

2019-10-10 06:27:23 CEST [8126] [nfs4-door(50554)]: [5-1] ERROR:  deadlock detected
2019-10-10 06:27:23 CEST [8126] [nfs4-door(50554)]: [6-1] DETAIL:  Process 8126 waits for ShareLock on transaction 685251509; blocked by process 1034.
        Process 1034 waits for ShareLock on transaction 685251510; blocked by process 8126.
        Process 8126: UPDATE t_tags_inodes SET inlink = inlink + 1 WHERE itagid=$1
        Process 1034: UPDATE t_inodes SET inlink=inlink -$1,imtime=$2,ictime=$3,igeneration=igeneration+1 WHERE inumber=$4

Modification:
ensure that mkdir and rmdir access t_inodes and t_tags_inodes in the same order.

Result:
no deadlock

Acked-by: Marina Sahakyan
Acked-by: Lea Morschel
Target: master, 6.0, 5.2, 5.1, 4.2
Requires-book: no
Requires-notes: yes
(cherry picked from commit f4674723f88485f1f7bd74fb235ea10d22fc7677)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>