### PR TITLE
libs: update apache.commons:commons-compress to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -747,7 +747,7 @@
             <dependency>
               <groupId>org.apache.commons</groupId>
               <artifactId>commons-compress</artifactId>
-              <version>1.18</version>
+              <version>1.19</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
CVE-2019-12402

Acked-by: Olufemi Adeyemi
Acked-by: Lea Morschel
Target: master, 6.0, 5.2, 5.1, 5.0, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 594cd1e45af0c79af52c8984c77e995ca6dcbb17)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>