### PR TITLE
dcache-xrootd: update protocol version numbers

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -101,6 +101,7 @@ import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.PnfsListDirectoryMessage;
 import org.dcache.vehicles.XrootdDoorAdressInfoMessage;
 import org.dcache.vehicles.XrootdProtocolInfo;
+import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.dcache.xrootd.tpc.XrootdTpcInfo;
 import org.dcache.xrootd.tpc.XrootdTpcInfoCleanerTask;
 import org.dcache.xrootd.util.FileStatus;
@@ -124,12 +125,10 @@ public class XrootdDoor
                CellCommandListener, CellInfoProvider
 {
     public static final String XROOTD_PROTOCOL_STRING = "Xrootd";
-    public static final int XROOTD_PROTOCOL_MAJOR_VERSION = 2;
-    public static final int XROOTD_PROTOCOL_MINOR_VERSION = 7;
     public static final String XROOTD_PROTOCOL_VERSION =
         String.format("%d.%d",
-                      XROOTD_PROTOCOL_MAJOR_VERSION,
-                      XROOTD_PROTOCOL_MINOR_VERSION);
+                      XrootdProtocol.PROTOCOL_VERSION_MAJOR,
+                      XrootdProtocol.PROTOCOL_VERSION_MINOR);
 
     private static final String TPC_PLACEMENT = "tpc-placement";
 

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -349,8 +349,8 @@ public class XrootdDoor
     public void getInfo(PrintWriter pw)
     {
         pw.println(String.format("Protocol Version %d.%d",
-                                 XROOTD_PROTOCOL_MAJOR_VERSION,
-                                 XROOTD_PROTOCOL_MINOR_VERSION));
+                                 XrootdProtocol.PROTOCOL_VERSION_MAJOR,
+                                 XrootdProtocol.PROTOCOL_VERSION_MINOR));
     }
 
     private void uploadDone(Subject subject, Restriction restriction,

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
@@ -15,6 +15,7 @@ import dmg.cells.nucleus.CellPath;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.util.RedirectedTransfer;
 import org.dcache.vehicles.XrootdProtocolInfo;
+import org.dcache.xrootd.protocol.XrootdProtocol;
 
 public class XrootdTransfer extends RedirectedTransfer<InetSocketAddress>
 {
@@ -67,8 +68,8 @@ public class XrootdTransfer extends RedirectedTransfer<InetSocketAddress>
     {
         InetSocketAddress client = getClientAddress();
         return new XrootdProtocolInfo(XrootdDoor.XROOTD_PROTOCOL_STRING,
-                                      XrootdDoor.XROOTD_PROTOCOL_MAJOR_VERSION,
-                                      XrootdDoor.XROOTD_PROTOCOL_MINOR_VERSION,
+                                      XrootdProtocol.PROTOCOL_VERSION_MAJOR,
+                                      XrootdProtocol.PROTOCOL_VERSION_MINOR,
                                       client,
                                       new CellPath(getCellName(), getDomainName()),
                                       getPnfsId(),


### PR DESCRIPTION
Motivation:

The dCache xrootd door maintains a separate pair of constants
defining protocol version.  These should reflect the version
of the library being used.

Modification:

Eliminate them and use the library version numbers.

Result:

Consistent with library and automatically updated when
the library is.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Patch: https://rb.dcache.org/r/11981
Acked-by: Vincent
Acked-by: Lea
Requires-book: no
Requires-notes: yes