### PR TITLE
sweeper: use in-memory map instead of repository for histogram data

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
@@ -291,7 +291,8 @@ public class SpaceSweeper2
     }
 
     @Override
-    public SweeperData getDataObject() throws InterruptedException {
+    public SweeperData getDataObject()
+    {
         SweeperData info = new SweeperData();
         info.setLabel("Space Sweeper v2");
 
@@ -304,30 +305,26 @@ public class SpaceSweeper2
         }
 
         List<Double> fileLifetime = new ArrayList<>();
-        Long now = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
 
         for (PnfsId id : list) {
-            try {
-                CacheEntry entry = _repository.getEntry(id);
-                Long lastAccess = entry.getLastAccessTime();
-                Long lvalue = now - lastAccess;
-                if (lvalue < 0L) {
-                    now = System.currentTimeMillis();
-                    lvalue = now -lastAccess;
-                    if (lvalue < 0L) {
-                        _log.warn("repository last access time for {}"
-                                                  + " is later than current "
-                                                  + "system time - now {}, "
-                                                  + "last access {}",
-                                  id, now, lastAccess);
-                    }
-                }
-                fileLifetime.add(lvalue.doubleValue());
-            } catch (FileNotInCacheException e) {
-                // Ignored
-            } catch (CacheException e) {
-                // Continue trying
+            Long lastAccess = _queue.timeStamps.get(id);
+            if (lastAccess == null) {
+                continue;
             }
+            long lvalue = now - lastAccess;
+            if (lvalue < 0L) {
+                now = System.currentTimeMillis();
+                lvalue = now - lastAccess;
+                if (lvalue < 0L) {
+                    _log.warn("repository last access time for {}"
+                                              + " is later than current "
+                                              + "system time - now {}, "
+                                              + "last access {}",
+                              id, now, lastAccess);
+                }
+            }
+            fileLifetime.add((double)lvalue);
         }
 
         CountingHistogram histogram = SweeperData.createLastAccessHistogram();


### PR DESCRIPTION
Motivation:

Responds to RT 9750 Strange CPU usage on dCache pool (urgent)

The getDataObject() method on the sweeper collects file
lifetimes for the histogram data; it is currently periodically
accessed by both the frontend and history services.
When the number of cached files is of several orders of magnitude,
iterating through the repository for their lifetimes becomes
CPU intensive.

Modification:

Use the in-memory stored lifetimes and avoid calls to the
repository.  (Unlike with ``sweeper ls``, no other metadata
for individual files is required by this method.)

Result:

Should reduce CPU consumption.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/11984/
Bug: https://rt.dcache.org/Ticket/Display.html?id=9750
Acked-by: Paul