### PR TITLE
doors: initialize IdentityResolverFactory after dependency injection

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoorFactory.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoorFactory.java
@@ -59,7 +59,7 @@ public class NettyLineBasedDoorFactory extends AbstractService implements LoginC
     private final String parentCellName;
     private final Args args;
     private final NettyLineBasedInterpreterFactory factory;
-    private final IdentityResolverFactory idResolverFactory;
+    private IdentityResolverFactory idResolverFactory;
     private ExecutorService executor;
     private PoolManagerHandlerSubscriber poolManagerHandler;
     private NioEventLoopGroup socketGroup;
@@ -106,9 +106,6 @@ public class NettyLineBasedDoorFactory extends AbstractService implements LoginC
         this.args = args;
 
         new OptionParser(args).inject(this);
-
-        LoginStrategy loginStrategy = new RemoteLoginStrategy(new CellStub(parentEndpoint, gPlazma, 30000));
-        idResolverFactory = new IdentityResolverFactory(loginStrategy);
     }
 
     @Override
@@ -150,6 +147,9 @@ public class NettyLineBasedDoorFactory extends AbstractService implements LoginC
         CellStub spaceManager = new CellStub(parentEndpoint, spaceManagerPath, 30_000);
         spaceDescriptionCache = ReservationCaches.buildOwnerDescriptionLookupCache(spaceManager, executor);
         spaceLookupCache = ReservationCaches.buildSpaceLookupCache(spaceManager, executor);
+
+        LoginStrategy loginStrategy = new RemoteLoginStrategy(new CellStub(parentEndpoint, gPlazma, 30_000));
+        idResolverFactory = new IdentityResolverFactory(loginStrategy);
 
         poolManagerHandler = new PoolManagerHandlerSubscriber();
         poolManagerHandler.setPoolManager(new CellStub(parentEndpoint, poolManager, poolManagerTimeout, poolManagerTimeoutUnit));


### PR DESCRIPTION
Motivation:
as IdentityResolverFactory uses pointer to gPlazma we should initialize
it after all dependencies are injected.

Modification:
move IdentityResolverFactory instantiation into
NettyLineBasedDoorFactory#doStart

Result:
fixes IdentityResolverFactory with gPlazma in NettyLineBasedDoorFactory

Acked-by: Paul Millar
Target: master, 6.0, 5.2
Require-book: no
Require-notes: no
(cherry picked from commit e79b9f923b77ad3e72ad133f486856cc8cd6878b)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>