### PR TITLE
xrootd: fix `kill mover` command

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -1220,7 +1220,7 @@ public class XrootdDoor
         String pool = args.argv(0);
 
         for (Transfer transfer : _transfers.values()) {
-            if (transfer.getMoverId() == mover && transfer.getPool() != null && transfer.getPool().equals(pool)) {
+            if (transfer.getMoverId() == mover && transfer.getPool() != null && transfer.getPool().getName().equals(pool)) {
 
                 transfer.killMover(0, "killed by door 'kill mover' command");
                 return "Kill request to the mover " + mover + " has been submitted";


### PR DESCRIPTION
fix regression introduced in a11ec8d76b

Acked-by: Paul Millar
Acked-by: Lea Morschel
Target: master, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit a8cd5884a3023551f0d0ba712986bc411b9ebada)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>