### PR TITLE
resilience: don't compare Integer objects by refference

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/StorageUnitConstraints.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/StorageUnitConstraints.java
@@ -62,6 +62,7 @@ package org.dcache.resilience.data;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -92,7 +93,7 @@ public final class StorageUnitConstraints extends ResilienceMarker {
     }
 
     public boolean equals(StorageUnitConstraints constraints) {
-        return constraints != null && this.required == constraints.required
+        return constraints != null && Objects.equals(this.required, constraints.required)
                         && this.oneCopyPer.equals(constraints.oneCopyPer);
     }
 


### PR DESCRIPTION
Motivation:
Though Integer objects are often unboxed for arithmetic operations, a
direct equality check of two instances with '==' operator checks only
for instance reference level equality. As boxing uses Integer#valueOf,
for values below 127 such check can accidentally work.

Modification:
Use Objects#equals to check equality by value and handle  possible 'null'
value cases.

Result:
fix equality check of replica count.

Acked-by: Paul Millar
Acked-by: Albert Rossi
Target: master, 6.0, 5.2, 5.1, 5.0, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 053dd1fd0ae21eb55a3e20fd5b8898f17498b25d)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>