### PR TITLE
pool: fix the xrootd version number on pool transfer service

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -475,7 +475,7 @@
       <property name="factories">
         <map>
             <entry key="NFS4-4" value-ref="nfs-transfer-service" />
-            <entry key="Xrootd-2" value-ref="xrootd-transfer-service"/>
+            <entry key="Xrootd-4" value-ref="xrootd-transfer-service"/>
             <entry key="Http-1" value-ref="http-transfer-service"/>
             <entry key="RemoteHttpDataTransfer-1" value-ref="remote-http-transfer-service"/>
             <entry key="RemoteHttpsDataTransfer-1" value-ref="remote-http-transfer-service"/>


### PR DESCRIPTION
Motivation:

changed the protocol version numbers of xrootd but neglected
to change the mapping.  This produces a ClassNotFoundException
on the pool when trying to start the mover and returns
```
[ERROR] Server responded with an error: [3012] Failed to open file (Protocol Xrootd-4.0:131.225.69.21:38374 is not supported [27])
```
to the client.

Modification:

Change to Xrootd-4.

Result:

It now works.

Target: master
Request: 6.0
Request: 5.2
Requires-book: no
Requires-notes: yes
Patch: https://rb.dcache.org/r/12009
Acked-by:  Paul
Acked-by:  Dmitry