### PR TITLE
dcache-xrootd: honor read paths when listing directories

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -827,6 +827,11 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
 
             _log.info("Listing directory {}", listPath);
             FsPath fullListPath = createFullPath(listPath);
+
+            if (!_door.isReadAllowed(fullListPath)) {
+                throw new PermissionDeniedCacheException("Permission denied.");
+            }
+
             if (request.isDirectoryStat()) {
                 _door.listPath(fullListPath, request.getSubject(), _authz,
                                new StatListCallback(request, fullListPath, ctx),


### PR DESCRIPTION
Motivation:

RT ticket 9769 indicated a bug in xrootd directory listing.
When read paths are defined, the list command does not observe them.

Modification:

Add a check to make sure the initial path (or one of its descendants)
is a read path, if any are defined.

Result:

Correct behavior.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-book: no
Requires-notes: yes
Patch: https://rb.dcache.org/r/12015/
Bug: https://rt.dcache.org/Ticket/Display.html?id=9769
Acked-by: Dmitry