### PR TITLE
dcache-xrootd: refine error handling

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/CacheExceptionMapper.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/CacheExceptionMapper.java
@@ -1,0 +1,98 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2014 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.xrootd;
+
+import diskCacheV111.util.CacheException;
+
+import org.dcache.xrootd.core.XrootdException;
+
+import static diskCacheV111.util.CacheException.*;
+import static org.dcache.xrootd.protocol.XrootdProtocol.*;
+
+/**
+ *  Centralized place for translating CacheExceptions into XrootdExceptions
+ */
+public class CacheExceptionMapper
+{
+    public static XrootdException xrootdException(CacheException e)
+    {
+        return xrootdException(e.getRc(), e.getMessage());
+    }
+
+    public static XrootdException xrootdException(int error, String message)
+    {
+        return new XrootdException(xrootdErrorCode(error), message);
+    }
+
+    public static int xrootdErrorCode(int rc)
+    {
+        switch(rc) {
+            case FILE_NOT_FOUND:
+                return kXR_NotFound;
+
+            case NOT_DIR:
+            case NOT_FILE:
+                return kXR_NotFile;
+
+            case FILE_IS_NEW:
+            case LOCKED:
+                return kXR_FileLocked;
+
+            case PERMISSION_DENIED:
+                return kXR_NotAuthorized;
+
+            case FILE_CORRUPTED:
+                return kXR_ChkSumErr;
+
+            case FILE_NOT_IN_REPOSITORY:
+            case FILE_NOT_ONLINE:
+            case FILE_EXISTS:
+            case FILE_PRECIOUS:
+            case FILE_NOT_STORED:
+            case FILESIZE_UNKNOWN:
+            case FILE_IN_CACHE:
+            case HSM_DELAY_ERROR:
+            case NOT_IN_TRASH:
+            case OUT_OF_DATE:
+                return kXR_FSError;
+
+            case INVALID_ARGS:
+            case ATTRIBUTE_FORMAT_ERROR:
+                return kXR_ArgInvalid;
+
+            case ERROR_IO_DISK:
+                return kXR_IOError;
+
+            case TIMEOUT:
+            case POOL_DISABLED:
+            case NO_POOL_CONFIGURED:
+            case NO_POOL_ONLINE:
+            case MOVER_NOT_FOUND:
+            case SERVICE_UNAVAILABLE:
+            case RESOURCE:
+            case THIRD_PARTY_TRANSFER_FAILED:
+            case UNEXPECTED_SYSTEM_EXCEPTION:
+            case PANIC:
+            default:
+                return kXR_ServerError;
+        }
+    }
+
+    private CacheExceptionMapper()
+    {} // static class
+}

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -397,8 +397,7 @@ public class XrootdDoor
             createUploadTransfer(InetSocketAddress client, FsPath path,
                     String ioQueue, UUID uuid, InetSocketAddress local,
                     Subject subject, Restriction restriction, boolean createDir,
-                    boolean overwrite, Long size, FsPath uploadPath)
-            throws CacheException, InterruptedException {
+                    boolean overwrite, Long size, FsPath uploadPath) {
 
         XrootdTransfer transfer
                 = new XrootdTransfer(_pnfs, subject, restriction, uploadPath) {

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -90,6 +90,8 @@ import org.dcache.xrootd.util.FileStatus;
 import org.dcache.xrootd.util.OpaqueStringParser;
 import org.dcache.xrootd.util.ParseException;
 
+import static org.dcache.xrootd.CacheExceptionMapper.xrootdErrorCode;
+import static org.dcache.xrootd.CacheExceptionMapper.xrootdException;
 import static org.dcache.xrootd.protocol.XrootdProtocol.*;
 
 /**
@@ -330,19 +332,19 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                     req, InetAddresses.toUriString(address.getAddress()),
                     address.getPort(), opaqueString, "");
         } catch (FileNotFoundCacheException e) {
-            return withError(req, kXR_NotFound, "No such file");
+            return withError(req, xrootdErrorCode(e.getRc()), "No such file");
         } catch (FileExistsCacheException e) {
             return withError(req, kXR_NotAuthorized, "File already exists");
         } catch (TimeoutCacheException e) {
-            return withError(req, kXR_ServerError, "Internal timeout");
+            return withError(req, xrootdErrorCode(e.getRc()), "Internal timeout");
         } catch (PermissionDeniedCacheException e) {
-            return withError(req, kXR_NotAuthorized, e.getMessage());
+            return withError(req, xrootdErrorCode(e.getRc()), e.getMessage());
         } catch (FileIsNewCacheException e) {
-            return withError(req, kXR_FileLocked, "File is locked by upload");
+            return withError(req, xrootdErrorCode(e.getRc()), "File is locked by upload");
         } catch (NotFileCacheException e) {
-            return withError(req, kXR_NotFile, "Not a file");
+            return withError(req, xrootdErrorCode(e.getRc()), "Not a file");
         } catch (CacheException e) {
-            return withError(req, kXR_ServerError,
+            return withError(req, xrootdErrorCode(e.getRc()),
                              String.format("Failed to open file (%s [%d])",
                                            e.getMessage(), e.getRc()));
         } catch (InterruptedException e) {
@@ -576,7 +578,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
         if (_door.removeTpcPlaceholder(fd)) {
             return withOk(msg);
         } else {
-            return withError(msg, kXR_InvalidRequest,
+            return withError(msg, kXR_FileNotOpen,
                              "Invalid file handle " + fd
                                              + " for tpc source close.");
         }
@@ -592,13 +594,13 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
             return new StatResponse(req, _door.getFileStatus(createFullPath(path), req.getSubject(), _authz,
                                                              client.getAddress().getHostAddress()));
         } catch (FileNotFoundCacheException e) {
-            throw new XrootdException(kXR_NotFound, "No such file");
+            throw xrootdException(e.getRc(), "No such file");
         } catch (TimeoutCacheException e) {
-            throw new XrootdException(kXR_ServerError, "Internal timeout");
+            throw xrootdException(e.getRc(), "Internal timeout");
         } catch (PermissionDeniedCacheException e) {
-            throw new XrootdException(kXR_NotAuthorized, e.getMessage());
+            throw xrootdException(e);
         } catch (CacheException e) {
-            throw new XrootdException(kXR_ServerError,
+            throw xrootdException(e.getRc(),
                                       String.format("Failed to open file (%s [%d])",
                                                     e.getMessage(), e.getRc()));
         }
@@ -618,11 +620,11 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
             }
             return new StatxResponse(req, _door.getMultipleFileStatuses(paths, req.getSubject(), _authz));
         } catch (TimeoutCacheException e) {
-            throw new XrootdException(kXR_ServerError, "Internal timeout");
+            throw xrootdException(e.getRc(), "Internal timeout");
         } catch (PermissionDeniedCacheException e) {
-            throw new XrootdException(kXR_NotAuthorized, e.getMessage());
+            throw xrootdException(e);
         } catch (CacheException e) {
-            throw new XrootdException(kXR_ServerError,
+            throw xrootdException(e.getRc(),
                                       String.format("Failed to open file (%s [%d])",
                                                     e.getMessage(), e.getRc()));
         }
@@ -643,13 +645,13 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
             _door.deleteFile(createFullPath(req.getPath()), req.getSubject(), _authz);
             return withOk(req);
         } catch (TimeoutCacheException e) {
-            throw new XrootdException(kXR_ServerError, "Internal timeout");
+            throw xrootdException(e.getRc(), "Internal timeout");
         } catch (PermissionDeniedCacheException e) {
-            throw new XrootdException(kXR_NotAuthorized, e.getMessage());
+            throw xrootdException(e);
         } catch (FileNotFoundCacheException e) {
-            throw new XrootdException(kXR_NotFound, "No such file");
+            throw xrootdException(e.getRc(), "No such file");
         } catch (CacheException e) {
-            throw new XrootdException(kXR_ServerError,
+            throw xrootdException(e.getRc(),
                                       String.format("Failed to delete file (%s [%d])",
                                                     e.getMessage(), e.getRc()));
         }
@@ -669,13 +671,11 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
             _door.deleteDirectory(createFullPath(req.getPath()), req.getSubject(), _authz);
             return withOk(req);
         } catch (TimeoutCacheException e) {
-            throw new XrootdException(kXR_ServerError, "Internal timeout");
-        } catch (PermissionDeniedCacheException e) {
-            throw new XrootdException(kXR_NotAuthorized, e.getMessage());
-        } catch (FileNotFoundCacheException e) {
-            throw new XrootdException(kXR_NotFound, e.getMessage());
+            throw xrootdException(e.getRc(), "Internal timeout");
+        } catch (PermissionDeniedCacheException | FileNotFoundCacheException e) {
+            throw xrootdException(e);
         } catch (CacheException e) {
-            throw new XrootdException(kXR_ServerError,
+            throw xrootdException(e.getRc(),
                                       String.format("Failed to delete directory " +
                                                     "(%s [%d]).",
                                                     e.getMessage(), e.getRc()));
@@ -699,13 +699,12 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                                   _authz);
             return withOk(req);
         } catch (TimeoutCacheException e) {
-            throw new XrootdException(kXR_ServerError, "Internal timeout");
-        } catch (PermissionDeniedCacheException e) {
-            throw new XrootdException(kXR_NotAuthorized, e.getMessage());
-        } catch (FileNotFoundCacheException | FileExistsCacheException e) {
-            throw new XrootdException(kXR_FSError, e.getMessage());
+            throw xrootdException(e.getRc(), "Internal timeout");
+        } catch (PermissionDeniedCacheException |FileNotFoundCacheException
+                        | FileExistsCacheException e) {
+            throw xrootdException(e);
         } catch (CacheException e) {
-            throw new XrootdException(kXR_ServerError,
+            throw xrootdException(e.getRc(),
                                       String.format("Failed to create directory " +
                                                             "(%s [%d]).",
                                                     e.getMessage(), e.getRc()));
@@ -735,19 +734,19 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                            _authz);
             return withOk(req);
         } catch (TimeoutCacheException e) {
-            throw new XrootdException(kXR_ServerError, "Internal timeout");
+            throw xrootdException(e.getRc(), "Internal timeout");
         } catch (PermissionDeniedCacheException e) {
-            throw new XrootdException(kXR_NotAuthorized, e.getMessage());
+            throw xrootdException(e);
         } catch (FileNotFoundCacheException e) {
-            throw new XrootdException(kXR_NotFound,
+            throw xrootdException(e.getRc(),
                                       String.format("Source file does not exist (%s) ",
                                                     e.getMessage()));
         } catch (FileExistsCacheException e) {
-            throw new XrootdException(kXR_FSError,
+            throw xrootdException(e.getRc(),
                                       String.format("Will not overwrite existing file " +
                                                     "(%s).", e.getMessage()));
         } catch (CacheException e) {
-            throw new XrootdException(kXR_ServerError,
+            throw xrootdException(e.getRc(),
                                       String.format("Failed to move file " +
                                                     "(%s [%d]).",
                                                     e.getMessage(), e.getRc()));
@@ -824,12 +823,8 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                                                              + checksum.getValue());
                     }
                 }
-            } catch (FileNotFoundCacheException e) {
-                throw new XrootdException(kXR_NotFound, e.getMessage());
-            } catch (PermissionDeniedCacheException e) {
-                throw new XrootdException(kXR_NotAuthorized, e.getMessage());
             } catch (CacheException e) {
-                throw new XrootdException(kXR_ServerError, e.getMessage());
+                throw xrootdException(e);
             }
             throw new XrootdException(kXR_Unsupported, "No checksum available for this file.");
 
@@ -866,7 +861,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
             }
             return null;
         } catch (PermissionDeniedCacheException e) {
-            throw new XrootdException(kXR_NotAuthorized, e.getMessage());
+            throw xrootdException(e);
         }
     }
 
@@ -1011,33 +1006,28 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
         @Override
         public void failure(int rc, Object error)
         {
+            String errorMessage;
+
             switch (rc) {
-            case CacheException.TIMEOUT:
-                respond(_context,
-                        withError(_request,
-                                  kXR_ServerError,
-                                  "Timeout when trying to list directory: " +
-                                  error.toString()));
-                break;
-            case CacheException.PERMISSION_DENIED:
-                respond(_context,
-                        withError(_request,
-                                  kXR_NotAuthorized,
-                                  "Permission to list that directory denied: " +
-                                  error.toString()));
-                break;
-            case CacheException.FILE_NOT_FOUND:
-                respond(_context,
-                        withError(_request, kXR_NotFound, "Path not found"));
-                break;
-            default:
-                respond(_context,
-                        withError(_request,
-                                  kXR_ServerError,
-                                  "Error when processing list response: " +
-                                  error.toString()));
-                break;
+                case CacheException.TIMEOUT:
+                    errorMessage = "Timeout when trying to list directory: "
+                                    + error.toString();
+                    break;
+                case CacheException.PERMISSION_DENIED:
+                    errorMessage = "Permission to list that directory denied: "
+                                    + error.toString();
+                    break;
+                case CacheException.FILE_NOT_FOUND:
+                    errorMessage = "Path not found: ";
+                    break;
+                default:
+                    errorMessage = "Error when processing list response: "
+                                    + error.toString();
+                    break;
             }
+
+            respond(_context,
+                    withError(_request, xrootdErrorCode(rc), errorMessage));
         }
 
         /**
@@ -1101,7 +1091,10 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
         public void success(PnfsListDirectoryMessage message)
         {
             message.getEntries().stream().forEach(
-                    e -> _response.add(e.getName(), _door.getFileStatus(_request.getSubject(), _authz, _dirPath.child(e.getName()), _client, e.getFileAttributes())));
+                    e -> _response.add(e.getName(), _door.getFileStatus(_request.getSubject(),
+                                                                        _authz,
+                                                                        _dirPath.child(e.getName()),
+                                                                        _client, e.getFileAttributes())));
             if (message.isFinal()) {
                 respond(_context, _response.buildFinal());
             } else {

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/security/GSIProxyDelegationClient.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/security/GSIProxyDelegationClient.java
@@ -47,6 +47,8 @@ import org.dcache.xrootd.util.ProxyRequest;
 
 import static com.google.common.collect.Iterables.getFirst;
 import static java.util.Arrays.asList;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_IOError;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_NotAuthorized;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
 
 /**
@@ -99,7 +101,7 @@ public class GSIProxyDelegationClient extends X509ProxyDelegationClient
 
         if (delegation == null) {
             throw new XrootdException(kXR_ServerError,
-                                      "internal error from during finalize proxy;"
+                                      "internal error during finalize proxy;"
                                                       + "cannot find delegation for: "
                                                       + id);
         }
@@ -111,8 +113,8 @@ public class GSIProxyDelegationClient extends X509ProxyDelegationClient
             return new SerializableX509Credential(credential.getCertificateChain(),
                                                   credential.getKey());
         } catch (GeneralSecurityException e) {
-            throw new XrootdException(kXR_ServerError,
-                                      "internal error from during finalize proxy;"
+            throw new XrootdException(kXR_NotAuthorized,
+                                      "error during finalize proxy;"
                                                       + "accept certificate failed for: "
                                                       + id);
         }
@@ -143,8 +145,13 @@ public class GSIProxyDelegationClient extends X509ProxyDelegationClient
             return new ProxyRequest(certChain,
                                     delegation.getId(),
                                     delegation.getPemRequest());
-        } catch (IOException | GeneralSecurityException e) {
-            throw new XrootdException(kXR_ServerError,
+        } catch (IOException e) {
+            throw new XrootdException(kXR_IOError,
+                                      "could not create new Proxy Request (CSR) for "
+                                                      + subject + ": "
+                                                      + e.getMessage());
+        } catch (GeneralSecurityException e) {
+            throw new XrootdException(kXR_NotAuthorized,
                                       "could not create new Proxy Request (CSR) for "
                                                       + subject + ": "
                                                       + e.getMessage());

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -91,6 +91,7 @@ import org.dcache.xrootd.util.ByteBuffersProvider;
 import org.dcache.xrootd.util.FileStatus;
 import org.dcache.xrootd.util.ParseException;
 
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ArgInvalid;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_IOError;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ok;
@@ -271,7 +272,7 @@ public final class TpcWriteDescriptor extends WriteDescriptor
                 }
             }, response.getWsec(), TimeUnit.SECONDS);
         } catch (ParseException e) {
-            throw new XrootdException(kXR_ServerError, e.getMessage());
+            throw new XrootdException(kXR_ArgInvalid, e.getMessage());
         }
     }
 

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptorHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptorHandler.java
@@ -69,7 +69,7 @@ import org.dcache.util.Checksum;
 import org.dcache.util.ChecksumType;
 import org.dcache.xrootd.tpc.protocol.messages.InboundChecksumResponse;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_error;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ChkSumErr;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ok;
 
 /**
@@ -124,7 +124,7 @@ public final class TpcWriteDescriptorHandler extends TpcSourceReadHandler
                                      streamId,
                                      sourceValue,
                                      dCacheValue);
-        handleTransferTerminated(kXR_error, error, ctx);
+        handleTransferTerminated(kXR_ChkSumErr, error, ctx);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>3.5.3</version.xrootd4j>
+        <version.xrootd4j>3.5.4</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.5.5</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Motivation:

See remarks to #11957.

Modification:

Create a CacheException error code to XrootdException error code
mapper and replace the ad hoc construction of exceptions with
calls to it for the sake of consistency.

Make several adjustments to the type of xrootd error associated with
internal exceptions.

Result:

More meaningful (or at least consistent) error responses
to the client.

Target: master
Patch: https://rb.dcache.org/r/11958/
Requires-book: no
Requires-notes: no
Acked-by: Dmitry
Acked-by: Lea