### PR TITLE
dcache-frontend: fix QoS pin semantics

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/qos/QosManagement.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/qos/QosManagement.java
@@ -45,6 +45,7 @@ public class QosManagement {
     public static final String DISK_TAPE = "disk+tape";
     public static final String VOLATILE = "volatile";
     public static final String UNAVAILABLE = "unavailable";
+    public static final String QOS_PIN_REQUEST_ID = "qos";
 
     @Inject
     @Named("geographic-placement")

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCountPinsMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCountPinsMessage.java
@@ -9,28 +9,31 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 
 public class PinManagerCountPinsMessage extends Message {
-
-
     private static final long serialVersionUID = 7314454233774958888L;
     private final PnfsId _pnfsId;
+    private final String _requestId;
 
     private int count;
 
-
     public PinManagerCountPinsMessage(PnfsId pnfsId) {
         _pnfsId = checkNotNull(pnfsId);
+        _requestId = null;
     }
 
+    public PinManagerCountPinsMessage(PnfsId pnfsId, String requestId) {
+        _pnfsId = checkNotNull(pnfsId);
+        _requestId = requestId;
+    }
 
     public int getCount() {
         return count;
     }
 
+    public String getRequestId() { return _requestId; }
 
     public void setCount(int count) {
         this.count = count;
     }
-
 
     public PnfsId getPnfsId() {
         return _pnfsId;

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/QueryRequestProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/QueryRequestProcessor.java
@@ -1,11 +1,12 @@
 package org.dcache.pinmanager;
 
-
-import dmg.cells.nucleus.CellMessageReceiver;
-
 import org.springframework.beans.factory.annotation.Required;
 
 import diskCacheV111.util.CacheException;
+
+import dmg.cells.nucleus.CellMessageReceiver;
+
+import org.dcache.pinmanager.PinDao.PinCriterion;
 
 import static org.dcache.pinmanager.model.Pin.State.UNPINNING;
 
@@ -27,10 +28,14 @@ public class QueryRequestProcessor
 
     public PinManagerCountPinsMessage
     messageArrived(PinManagerCountPinsMessage message)
-            throws CacheException {
-        message.setCount(_dao.count(_dao.where().pnfsId(message.getPnfsId()).stateIsNot(UNPINNING)));
+            throws CacheException
+    {
+        PinCriterion criterion = _dao.where().pnfsId(message.getPnfsId());
+        String requestId = message.getRequestId();
+        if (requestId != null) {
+            criterion.requestId(message.getRequestId());
+        }
+        message.setCount(_dao.count(criterion.stateIsNot(UNPINNING)));
         return message;
     }
-
-
 }


### PR DESCRIPTION
Motivation:

In determining the QoS state of a file, the
frontend services (FileResource, QoSManagement)
count the pins on that file.  This is incorrect,
leading to a number of related issues
when trying to apply transitions.

The correct behavior should be for it to look
only for a pin with the QoS requestId.

Modification:

"isPinned" actually should mean "forQoS",
and the methods and variables have been
so renamed.  A requestId field has been
added to the message and is taken into
account by the PinManager processor.
The QoS query always includes this value.

Some refactoring was done in
the interest of code re-use.

Result:

Correct behavior.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/12016/
Requires-book: no
Requires-notes: yes
Acked-by: Dmitry