### PR TITLE
srmclient: complete and tidy-up storageSystemInfo support

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMBringOnlineClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMBringOnlineClientV2.java
@@ -76,7 +76,6 @@ import org.apache.axis.types.URI;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.request.AccessLatency;
@@ -84,7 +83,6 @@ import org.dcache.srm.request.RetentionPolicy;
 import org.dcache.srm.util.RequestStatusTool;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ArrayOfString;
-import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
 import org.dcache.srm.v2_2.ArrayOfTGetFileRequest;
 import org.dcache.srm.v2_2.ISRM;
 import org.dcache.srm.v2_2.SrmAbortFilesRequest;
@@ -97,7 +95,6 @@ import org.dcache.srm.v2_2.TAccessLatency;
 import org.dcache.srm.v2_2.TAccessPattern;
 import org.dcache.srm.v2_2.TBringOnlineRequestFileStatus;
 import org.dcache.srm.v2_2.TConnectionType;
-import org.dcache.srm.v2_2.TExtraInfo;
 import org.dcache.srm.v2_2.TGetFileRequest;
 import org.dcache.srm.v2_2.TRetentionPolicy;
 import org.dcache.srm.v2_2.TRetentionPolicyInfo;
@@ -204,17 +201,7 @@ public class SRMBringOnlineClientV2 extends SRMClient implements Runnable {
                         arrayOfClientNetworks,
                         protocolArray));
             }
-            if (configuration.getExtraParameters().size()>0) {
-                TExtraInfo[] extraInfoArray = new TExtraInfo[configuration.getExtraParameters().size()];
-                int counter=0;
-                Map<String,String> extraParameters = configuration.getExtraParameters();
-                for (String key : extraParameters.keySet()) {
-                    String value = extraParameters.get(key);
-                    extraInfoArray[counter++] = new TExtraInfo(key, value);
-                }
-                ArrayOfTExtraInfo arrayOfExtraInfo = new ArrayOfTExtraInfo(extraInfoArray);
-                srmBringOnlineRequest.setStorageSystemInfo(arrayOfExtraInfo);
-            }
+            configuration.getStorageSystemInfo().ifPresent(srmBringOnlineRequest::setStorageSystemInfo);
             say("calling srmBringOnline");
             SrmBringOnlineResponse response = srmv2.srmBringOnline(srmBringOnlineRequest);
             say("received response");

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCheckPermissionClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCheckPermissionClientV2.java
@@ -75,8 +75,6 @@ package gov.fnal.srm.util;
 import eu.emi.security.authn.x509.X509Credential;
 import org.apache.axis.types.URI;
 
-import java.util.Date;
-
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ArrayOfTSURLPermissionReturn;
@@ -138,6 +136,7 @@ public class SRMCheckPermissionClientV2 extends SRMClient {
         surlarray.setUrlArray(uriarray);
         SrmCheckPermissionRequest req = new SrmCheckPermissionRequest();
         req.setArrayOfSURLs(surlarray);
+        configuration.getStorageSystemInfo().ifPresent(req::setStorageSystemInfo);
         SrmCheckPermissionResponse resp = isrm.srmCheckPermission(req);
         try {
             TReturnStatus rs   = resp.getReturnStatus();

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMCopyClientV2.java
@@ -104,11 +104,8 @@ import eu.emi.security.authn.x509.X509Credential;
 import org.apache.axis.types.URI;
 
 import java.io.IOException;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.stream.Stream;
 
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.request.AccessLatency;
@@ -118,7 +115,6 @@ import org.dcache.srm.request.RetentionPolicy;
 import org.dcache.srm.util.RequestStatusTool;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ArrayOfTCopyFileRequest;
-import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
 import org.dcache.srm.v2_2.ISRM;
 import org.dcache.srm.v2_2.SrmAbortFilesRequest;
 import org.dcache.srm.v2_2.SrmAbortFilesResponse;
@@ -130,7 +126,6 @@ import org.dcache.srm.v2_2.TAccessLatency;
 import org.dcache.srm.v2_2.TCopyFileRequest;
 import org.dcache.srm.v2_2.TCopyRequestFileStatus;
 import org.dcache.srm.v2_2.TDirOption;
-import org.dcache.srm.v2_2.TExtraInfo;
 import org.dcache.srm.v2_2.TRetentionPolicy;
 import org.dcache.srm.v2_2.TRetentionPolicyInfo;
 import org.dcache.srm.v2_2.TReturnStatus;
@@ -240,17 +235,7 @@ public class SRMCopyClientV2 extends SRMClient implements Runnable {
             if(configuration.getSpaceToken() != null) {
                 req.setTargetSpaceToken(configuration.getSpaceToken());
             }
-            if (configuration.getExtraParameters().size()>0) {
-                TExtraInfo[] extraInfoArray = new TExtraInfo[configuration.getExtraParameters().size()];
-                int counter=0;
-                Map<String,String> extraParameters = configuration.getExtraParameters();
-                for (String key : extraParameters.keySet()) {
-                    String value = extraParameters.get(key);
-                    extraInfoArray[counter++] = new TExtraInfo(key, value);
-                }
-                ArrayOfTExtraInfo arrayOfExtraInfo = new ArrayOfTExtraInfo(extraInfoArray);
-                req.setSourceStorageSystemInfo(arrayOfExtraInfo);
-            }
+            configuration.getStorageSystemInfo().ifPresent(req::setSourceStorageSystemInfo);
             SrmCopyResponse resp = srmv2.srmCopy(req);
             if ( resp == null ) {
                 throw new IOException(" null SrmCopyResponse");

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetClientV2.java
@@ -76,7 +76,6 @@ import org.apache.axis.types.URI;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.request.AccessLatency;
@@ -84,7 +83,6 @@ import org.dcache.srm.request.RetentionPolicy;
 import org.dcache.srm.util.RequestStatusTool;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ArrayOfString;
-import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
 import org.dcache.srm.v2_2.ArrayOfTGetFileRequest;
 import org.dcache.srm.v2_2.ISRM;
 import org.dcache.srm.v2_2.SrmAbortFilesRequest;
@@ -96,7 +94,6 @@ import org.dcache.srm.v2_2.SrmStatusOfGetRequestResponse;
 import org.dcache.srm.v2_2.TAccessLatency;
 import org.dcache.srm.v2_2.TAccessPattern;
 import org.dcache.srm.v2_2.TConnectionType;
-import org.dcache.srm.v2_2.TExtraInfo;
 import org.dcache.srm.v2_2.TGetFileRequest;
 import org.dcache.srm.v2_2.TGetRequestFileStatus;
 import org.dcache.srm.v2_2.TRetentionPolicy;
@@ -206,17 +203,7 @@ public class SRMGetClientV2 extends SRMClient implements Runnable {
                         arrayOfClientNetworks,
                         protocolArray));
             }
-            if (configuration.getExtraParameters().size()>0) {
-                TExtraInfo[] extraInfoArray = new TExtraInfo[configuration.getExtraParameters().size()];
-                int counter=0;
-                Map<String,String> extraParameters = configuration.getExtraParameters();
-                for (String key : extraParameters.keySet()) {
-                    String value = extraParameters.get(key);
-                    extraInfoArray[counter++] = new TExtraInfo(key, value);
-                }
-                ArrayOfTExtraInfo arrayOfExtraInfo = new ArrayOfTExtraInfo(extraInfoArray);
-                srmPrepareToGetRequest.setStorageSystemInfo(arrayOfExtraInfo);
-            }
+            configuration.getStorageSystemInfo().ifPresent(srmPrepareToGetRequest::setStorageSystemInfo);
             say("calling srmPrepareToGet");
 
             SrmPrepareToGetResponse response = srmv2.srmPrepareToGet(srmPrepareToGetRequest);

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetPermissionClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMGetPermissionClientV2.java
@@ -84,8 +84,6 @@ package gov.fnal.srm.util;
 import eu.emi.security.authn.x509.X509Credential;
 import org.apache.axis.types.URI;
 
-import java.util.Date;
-
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ArrayOfTGroupPermission;
@@ -153,6 +151,7 @@ public class SRMGetPermissionClientV2 extends SRMClient {
 
         SrmGetPermissionRequest req = new SrmGetPermissionRequest();
         req.setArrayOfSURLs(surlarray);
+        configuration.getStorageSystemInfo().ifPresent(req::setStorageSystemInfo);
         SrmGetPermissionResponse resp = isrm.srmGetPermission(req);
         TReturnStatus rs   = resp.getReturnStatus();
         ArrayOfTPermissionReturn permissions=resp.getArrayOfPermissionReturns();

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMLsClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMLsClientV2.java
@@ -164,6 +164,7 @@ public class SRMLsClientV2 extends SRMClient implements Runnable {
             req.setArrayOfSURLs(new ArrayOfAnyURI(turlia));
             hook = new Thread(this);
             Runtime.getRuntime().addShutdownHook(hook);
+            configuration.getStorageSystemInfo().ifPresent(req::setStorageSystemInfo);
             SrmLsResponse response = isrm.srmLs(req);
             if(response == null){
                 throw new Exception ("srm ls response is null!");

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMMkDirClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMMkDirClientV2.java
@@ -84,8 +84,6 @@ package gov.fnal.srm.util;
 import eu.emi.security.authn.x509.X509Credential;
 import org.apache.axis.types.URI;
 
-import java.util.Date;
-
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.v2_2.ISRM;
 import org.dcache.srm.v2_2.SrmMkdirRequest;
@@ -134,6 +132,7 @@ public class SRMMkDirClientV2 extends SRMClient {
         checkValid(cred);
         SrmMkdirRequest req = new SrmMkdirRequest();
         req.setSURL(new URI(surl_string));
+        configuration.getStorageSystemInfo().ifPresent(req::setStorageSystemInfo);
         SrmMkdirResponse resp = isrm.srmMkdir(req);
         TReturnStatus rs   = resp.getReturnStatus();
         if (rs.getStatusCode() != TStatusCode.SRM_SUCCESS) {

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMMvClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMMvClientV2.java
@@ -84,8 +84,6 @@ package gov.fnal.srm.util;
 import eu.emi.security.authn.x509.X509Credential;
 import org.apache.axis.types.URI;
 
-import java.util.Date;
-
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.v2_2.ISRM;
 import org.dcache.srm.v2_2.SrmMvRequest;
@@ -135,6 +133,7 @@ public class SRMMvClientV2 extends SRMClient {
         SrmMvRequest req = new SrmMvRequest();
         req.setFromSURL(new URI(surl_strings[0]));
         req.setToSURL(new URI(surl_strings[1]));
+        configuration.getStorageSystemInfo().ifPresent(req::setStorageSystemInfo);
         SrmMvResponse resp = isrm.srmMv(req);
         TReturnStatus rs   = resp.getReturnStatus();
         if (rs.getStatusCode() != TStatusCode.SRM_SUCCESS) {

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMPutClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMPutClientV2.java
@@ -78,7 +78,6 @@ import org.apache.axis.types.UnsignedLong;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.request.AccessLatency;
@@ -87,7 +86,6 @@ import org.dcache.srm.request.RetentionPolicy;
 import org.dcache.srm.util.RequestStatusTool;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ArrayOfString;
-import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
 import org.dcache.srm.v2_2.ArrayOfTPutFileRequest;
 import org.dcache.srm.v2_2.ISRM;
 import org.dcache.srm.v2_2.SrmAbortFilesRequest;
@@ -99,7 +97,6 @@ import org.dcache.srm.v2_2.SrmStatusOfPutRequestResponse;
 import org.dcache.srm.v2_2.TAccessLatency;
 import org.dcache.srm.v2_2.TAccessPattern;
 import org.dcache.srm.v2_2.TConnectionType;
-import org.dcache.srm.v2_2.TExtraInfo;
 import org.dcache.srm.v2_2.TOverwriteMode;
 import org.dcache.srm.v2_2.TPutFileRequest;
 import org.dcache.srm.v2_2.TPutRequestFileStatus;
@@ -243,17 +240,7 @@ public class SRMPutClientV2 extends SRMClient implements Runnable {
             if(configuration.getSpaceToken() != null) {
                 srmPrepareToPutRequest.setTargetSpaceToken(configuration.getSpaceToken());
             }
-            if (configuration.getExtraParameters().size()>0) {
-                TExtraInfo[] extraInfoArray = new TExtraInfo[configuration.getExtraParameters().size()];
-                int counter=0;
-                Map<String,String> extraParameters = configuration.getExtraParameters();
-                for (String key : extraParameters.keySet()) {
-                    String value = extraParameters.get(key);
-                    extraInfoArray[counter++] = new TExtraInfo(key, value);
-                }
-                ArrayOfTExtraInfo arrayOfExtraInfo = new ArrayOfTExtraInfo(extraInfoArray);
-                srmPrepareToPutRequest.setStorageSystemInfo(arrayOfExtraInfo);
-            }
+            configuration.getStorageSystemInfo().ifPresent(srmPrepareToPutRequest::setStorageSystemInfo);
             response = srmv2.srmPrepareToPut(srmPrepareToPutRequest);
             if(response == null) {
                 throw new IOException(" null response");

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReleaseSpaceClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReleaseSpaceClientV2.java
@@ -85,7 +85,6 @@ package gov.fnal.srm.util;
 import eu.emi.security.authn.x509.X509Credential;
 
 import java.io.IOException;
-import java.util.Date;
 
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.util.RequestStatusTool;
@@ -136,6 +135,7 @@ public class SRMReleaseSpaceClientV2 extends SRMClient  {
         try {
             request.setSpaceToken(configuration.getSpaceToken());
             request.setForceFileRelease(configuration.getForceFileRelease());
+            configuration.getStorageSystemInfo().ifPresent(request::setStorageSystemInfo);
             SrmReleaseSpaceResponse response = srmv2.srmReleaseSpace(request);
             if ( response == null ) {
                 throw new IOException(" null SrmReleaseSpace");

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReserveSpaceClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMReserveSpaceClientV2.java
@@ -86,14 +86,12 @@ import eu.emi.security.authn.x509.X509Credential;
 import org.apache.axis.types.UnsignedLong;
 
 import java.io.IOException;
-import java.util.Date;
 
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.request.AccessLatency;
 import org.dcache.srm.request.RetentionPolicy;
 import org.dcache.srm.util.RequestStatusTool;
 import org.dcache.srm.v2_2.ArrayOfString;
-import org.dcache.srm.v2_2.ArrayOfTExtraInfo;
 import org.dcache.srm.v2_2.ISRM;
 import org.dcache.srm.v2_2.SrmAbortRequestRequest;
 import org.dcache.srm.v2_2.SrmAbortRequestResponse;
@@ -104,7 +102,6 @@ import org.dcache.srm.v2_2.SrmStatusOfReserveSpaceRequestResponse;
 import org.dcache.srm.v2_2.TAccessLatency;
 import org.dcache.srm.v2_2.TAccessPattern;
 import org.dcache.srm.v2_2.TConnectionType;
-import org.dcache.srm.v2_2.TExtraInfo;
 import org.dcache.srm.v2_2.TRetentionPolicy;
 import org.dcache.srm.v2_2.TRetentionPolicyInfo;
 import org.dcache.srm.v2_2.TReturnStatus;
@@ -194,10 +191,7 @@ public class SRMReserveSpaceClientV2 extends SRMClient implements Runnable {
                 }
                 request.setTransferParameters(tp);
             }
-            if (configuration.getLinkgroup() != null) {
-                TExtraInfo linkgroupSelector = new TExtraInfo("linkgroup", configuration.getLinkgroup());
-                request.setStorageSystemInfo(new ArrayOfTExtraInfo(new TExtraInfo[]{linkgroupSelector}));
-            }
+            configuration.getStorageSystemInfo().ifPresent(request::setStorageSystemInfo);
             hook = new Thread(this);
             Runtime.getRuntime().addShutdownHook(hook);
 

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMRmClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMRmClientV2.java
@@ -84,8 +84,6 @@ package gov.fnal.srm.util;
 import eu.emi.security.authn.x509.X509Credential;
 import org.apache.axis.types.URI;
 
-import java.util.Date;
-
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.v2_2.ArrayOfAnyURI;
 import org.dcache.srm.v2_2.ISRM;
@@ -141,6 +139,7 @@ public class SRMRmClientV2 extends SRMClient {
             uris[i] = new URI(surl_strings[i]);
         }
         req.setArrayOfSURLs(new ArrayOfAnyURI(uris));
+        configuration.getStorageSystemInfo().ifPresent(req::setStorageSystemInfo);
         SrmRmResponse resp = isrm.srmRm(req);
         TReturnStatus rs   = resp.getReturnStatus();
         if (rs.getStatusCode() != TStatusCode.SRM_SUCCESS) {

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMRmdirClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMRmdirClientV2.java
@@ -84,8 +84,6 @@ package gov.fnal.srm.util;
 import eu.emi.security.authn.x509.X509Credential;
 import org.apache.axis.types.URI;
 
-import java.util.Date;
-
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.v2_2.ISRM;
 import org.dcache.srm.v2_2.SrmRmdirRequest;
@@ -141,6 +139,7 @@ public class SRMRmdirClientV2 extends SRMClient {
         }
         URI uri = new URI(surl_string);
         req.setSURL(uri);
+        configuration.getStorageSystemInfo().ifPresent(req::setStorageSystemInfo);
         SrmRmdirResponse resp = isrm.srmRmdir(req);
         TReturnStatus rs   = resp.getReturnStatus();
         if (rs.getStatusCode() != TStatusCode.SRM_SUCCESS) {

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMSetPermissionClientV2.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMSetPermissionClientV2.java
@@ -84,8 +84,6 @@ package gov.fnal.srm.util;
 import eu.emi.security.authn.x509.X509Credential;
 import org.apache.axis.types.URI;
 
-import java.util.Date;
-
 import org.dcache.srm.client.SRMClientV2;
 import org.dcache.srm.v2_2.ArrayOfTGroupPermission;
 import org.dcache.srm.v2_2.ISRM;
@@ -169,6 +167,7 @@ public class SRMSetPermissionClientV2 extends SRMClient {
             other = TPermissionMode.fromString(configuration.getSetOtherPermissionMode());
         }
         req.setOtherPermission(other);
+        configuration.getStorageSystemInfo().ifPresent(req::setStorageSystemInfo);
         SrmSetPermissionResponse resp = isrm.srmSetPermission(req);
         try {
             TReturnStatus rs   = resp.getReturnStatus();


### PR DESCRIPTION
Motivation:

The SRM client supports sending arbitrary key-value pairs in the
storageSystemInfo argument for srmBringOnline, srmCopy, srmPrepareToGet
srmPrepareToPut requests.

This support is incomplete, as storageSystemInfo may also be specified
in srmCheckPermissions, srmGetPermissions, srmLs, srmMkdir, srmMv,
srmReleaseSpace, srmReserveSpace, srmRm, srmRmdir and srmSetPermission
requests.

The SRM client supports making these requests, but not specifying
storageSystemInfo values.

In addition, the existing code to support storageSystemInfo is
needlessly bloated, uses confusing names, and violates the DRY
principle.

Modification:

Update code to avoid code duplication, simplying design.

Add support for storageSystemInfo for requests where that support was
missing.

Result:

The commands 'srm-check-permissions', 'srm-get-permissions', 'srmls',
'srmmkdir', 'srmmv', 'srm-release-space', 'srm-reserve-space', 'srmrm',
'srmrmdir' and 'srm-set-permissions' now support the '-extraInfo'
command-line option.

Target: master
Request: 6.0
Requires-notes: yes