### PR TITLE
srm: improve access logging of srmBringOnline requests.

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
@@ -1225,6 +1225,8 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
         {
             log.addSingleValue("request.surl", request.getArrayOfFileRequests(),
                     ArrayOfTGetFileRequest::getRequestArray, TGetFileRequest::getSourceSURL);
+            log.add("request.desiredLifeTime", request.getDesiredLifeTime());
+            log.add("request.desiredTotalRequestTime", request.getDesiredTotalRequestTime());
 
             logFileStatus(log, response.getArrayOfFileStatuses(),
                     ArrayOfTBringOnlineRequestFileStatus::getStatusArray,


### PR DESCRIPTION
Motivation:

Investigation into tape carousel has highlighted limitations in what
dCache logs.  In particular, information about the pin lifetime for
srmBringOnline is missing.

Modification:

Update access log file to record desired lifetimes in srmBringOnline as
"request.desiredLifeTime" and "request.desiredTotalRequestTime".

Result:

dCache SRM access logging contains information about client's desired
pin lifetime in srmBringOnline requests.

Target: master
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12002
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel