### PR TITLE
frontend: fix NPE if limit is not specified

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/billing/BillingInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/billing/BillingInfoServiceImpl.java
@@ -291,7 +291,7 @@ public class BillingInfoServiceImpl
                                                            clientPool,
                                                            serverPool,
                                                            client,
-                                                           limit,
+                                                           limit == null ? Integer.MAX_VALUE : limit,
                                                            offset,
                                                            sort);
         message = collector.sendRecordRequest(message);
@@ -412,7 +412,7 @@ public class BillingInfoServiceImpl
                                                            null,
                                                            pool,
                                                            client,
-                                                           limit,
+                                                           limit == null ? Integer.MAX_VALUE : limit,
                                                            offset,
                                                            sort);
         message = collector.sendRecordRequest(message);
@@ -450,7 +450,7 @@ public class BillingInfoServiceImpl
                                                           getDate(after),
                                                           type,
                                                           pool,
-                                                          limit,
+                                                          limit == null ? Integer.MAX_VALUE : limit,
                                                           offset,
                                                           sort);
 


### PR DESCRIPTION
Motivation:

The REST API allows the client to avoid setting the limit argument;
however, doing so results in an NPE when the null Integer value is
unboxed.

Modification:

Map a null value to the maximum value for int; in effect, simulating an
unlimited selection.

Result:

A bug is fixed in frontend that results in a NullPointerException for
billing queries where no limit is specified.

Target: master
Requires-notes: yes
Requires-book: no
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/12025/
Acked-by: Albert Rossi