### PR TITLE
build: avoid shipping log4j with dCache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
Motivation:

Some libraries expect to use the log4j interface.  To support these
libraries with our choice of logger (logback) we include the
log4j-over-slf4j.  This implements the log4j API, using the slf4j
interface, the latter of which logback supports.

Commit 69e773cac9f correctly removed the log4j exclusion from curator
(which was meant for the transitive dependency: zookeeper) as this
commit also excluded zookeeper from curator.  However that commit failed
to add the log4j exclusion to the explicit zookeeper dependency.

This resulted in dCache shipping with both log4j and log4j-over-slf4j.
For libraries (such as zookeeper) that use the log4j API, it is
ambiguous which jar package is used.  In practice, it depends on the
package order, which depends on the directory listing order.

Modification:

Exclude the log4j dependency in zookeeper.  This dependency is how log4j
is ending up with dCache.  Instead zookeeper's dependency on the log4j
API is satisfied via the log4j-over-stf4j bridging library.

Result:

Fix a potential cause where logging messages from the zookeeper client
(built into dCache) and server (the 'zookeeper' service) are lost.

Target: master
Request: 6.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12033/
Acked-by: Albert Rossi