### PR TITLE
dcache: restore pool compatibility with doors sending 'Xrootd-2' prot…

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -470,6 +470,10 @@
       <property name="factories">
         <map>
             <entry key="NFS4-4" value-ref="nfs-transfer-service" />
+            <!-- Xrootd-2 is here for backward compatibility with doors
+                 that have not been updated to the new version and should
+                 be removed in the future. -->
+            <entry key="Xrootd-2" value-ref="xrootd-transfer-service"/>
             <entry key="Xrootd-4" value-ref="xrootd-transfer-service"/>
             <entry key="Http-1" value-ref="http-transfer-service"/>
             <entry key="RemoteHttpDataTransfer-1" value-ref="remote-http-transfer-service"/>


### PR DESCRIPTION
…ocol version

Motivation:

master@473972bf3a3a99cd355d180e25eeb8c2a8da1c08
https://rb.dcache.org/r/120009

replaced the transfer service mapping to Xrootd-2 with Xrootd-4,
but this will make the pool incompatible with any door that
has not been upgraded with the new versioning code.

Modification:

Restore the Xrootd-2 mapping, leaving both.

Result:

Compatibility with pre-versioning-change doors.

Target: master
Request: 5.2
Request: 6.0
Patch: https://rb.dcache.org/r/12043/
Acked-by: Lea
Acked-by: Paul