### PR TITLE
gplazma: scitoken add support for multiple audience claims

### DIFF
--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/SciTokenPlugin.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/SciTokenPlugin.java
@@ -157,9 +157,9 @@ public class SciTokenPlugin implements GPlazmaAuthenticationPlugin
                 "is not yet valid");
 
         // REVISIT obtain door IP address and DNS lookup URL to see if it matches
-        Optional<String> aud = token.getPayloadString("aud");
-        checkAuthentication(!aud.isPresent() || audienceTargets.contains(aud.get()),
-                "intended for %s", aud.orElse("unknown"));
+        List<String> aud = token.getPayloadStringOrArray("aud");
+        checkAuthentication(aud.isEmpty() || audienceTargets.stream().anyMatch(aud::contains),
+                "intended for %s", aud);
 
         return token;
     }


### PR DESCRIPTION
Motivation:

RFC 7519 describes the JSON Web Token format.  For the audience ('aud')
claim, it states:

   If the principal
   processing the claim does not identify itself with a value in the
   "aud" claim when this claim is present, then the JWT MUST be
   rejected.  In the general case, the "aud" value is an array of case-
   sensitive strings, each containing a StringOrURI value.  In the
   special case when the JWT has one audience, the "aud" value MAY be a
   single case-sensitive string containing a StringOrURI value.

Currently, the SciToken plugin assumes the "aud" claim is a JSON String,
which is only a special case.  If the "aud" claim is a JSON Array then
the value will be ignored.

Modification:

Update code to match processing expectations from RFC 7519.

Result:

The SciToken gplazma plugin now supports the audience ('aud') claim
where the claim's value is an array.  This allows dCache to support
SciTokens with multiple audience values.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12031/
Acked-by: Albert Rossi
Acked-by: Lea Morschel