### PR TITLE
pool: include pool name in health-check reports

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/CDCThreadPoolTaskScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/util/CDCThreadPoolTaskScheduler.java
@@ -1,0 +1,38 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * A variant of Spring's ThreadPoolTaskScheduler that preserves the CDC.
+ */
+public class CDCThreadPoolTaskScheduler extends ThreadPoolTaskScheduler
+{
+    @Override
+    protected ScheduledExecutorService createExecutor(int poolSize,
+            ThreadFactory threadFactory, RejectedExecutionHandler rejectedExecutionHandler)
+    {
+        ScheduledExecutorService service = super.createExecutor(poolSize, threadFactory, rejectedExecutionHandler);
+        return new CDCScheduledExecutorServiceDecorator(service);
+    }
+}

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -548,7 +548,8 @@
       <task:scheduled ref="healthcheck" method="run" fixed-delay="60000"/>
     </task:scheduled-tasks>
 
-    <task:scheduler id="healthcheck-scheduler"/>
+    <!-- Instead of <task:scheduler id="healthcheck-scheduler"/> -->
+    <bean id="healthcheck-scheduler" class="org.dcache.util.CDCThreadPoolTaskScheduler"/>
   </beans>
 
   <beans profile="backend-ceph">


### PR DESCRIPTION
Motivation:

Currently, the periodic pool health-check operations log problems
without recording in which pool the problem was found.  For example:

    12 Nov 2019 03:32:13 () [] Used space is less than the sum of precious and removable space (this may be a temporary problem - if it persists then please report it to support@dcache.org).

This is a problem if a domain hosts multiple pools.

Modification:

Create a new scheduler class, based on Spring's ThreadPoolTaskScheduler,
that captures the CDC when defining a task and then later injects that
CDC when running tasks.  When creating tasks through Spring XML's "task"
namespace, the captured CDC is that of the Spring cell during
initialisation.

Update the pool's Spring configuration to use the CDC-preserving
implementation.

Result:

Pool health-check log messages now include the pool's name.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Bug: #5162
Patch: https://rb.dcache.org/r/12044/
Acked-by: Albert Rossi