### PR TITLE
webdav: avoid logging non-error as an error

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -644,6 +644,11 @@ public class RemoteTransferHandler implements CellMessageReceiver
                     PnfsHandler pnfs = new PnfsHandler(_pnfs, null);
                     pnfs.deletePnfsEntry(_pnfsId, _path.toString(),
                             EnumSet.of(FileType.REGULAR), EnumSet.noneOf(FileAttribute.class));
+                } catch (FileNotFoundCacheException e) {
+                    // This is OK: either a new upload has started or the user
+                    // has deleted the file some other way.
+                    LOGGER.debug("Failed to clear up after failed transfer: {}",
+                            e.getMessage());
                 } catch (CacheException e) {
                     LOGGER.warn("Failed to clear up after failed transfer: {}",
                             e.getMessage());


### PR DESCRIPTION
Motivation:

On an unsuccessful HTTP-TPC pull request, dCache will delete the file.
If this deletion does not work then an error is logged.

Observed log entries like:

    15 Nov 2019 08:17:43 (webdav-secure-grid) [door:webdav-secure-grid@dCacheDomain:AAWXXWLGKeA RemoteTransferManager TransferFailed] Failed to clear up after failed transfer: No such file or directory: /VOs/dteam/tpc-test/https/domatest/file26_c082e21c-b1b9-4822-a58f-b044e942cd19
    15 Nov 2019 08:43:47 (webdav-secure-grid) [door:webdav-secure-grid@dCacheDomain:AAWXXbqh2Pg RemoteTransferManager TransferFailed] Failed to clear up after failed transfer: PNFSID does not correspond to provided file.

The first entry suggests the client deleted the file itself.  Perhaps
the client disconnected to abort the transfer and while this was being
processed, the client also deleted the incomplete transferred file.

The second suggests a subsequent attempt to transfer the file was
initiated before the cleanup from the first attempt had completed.

In both cases, it is unnecessary to log this information at WARN level,
since (in both cases) the incomplete file has been deleted.

Modification:

Log any FileNotFoundCacheException returned by PnfsManager when cleaning
up a failed pull request at DEBUG level.

Result:

Failures to delete the incomplete file from a failed HTTP-TPC pull
request, where the incomplete file has been deleted by some other means
are now logged at DEBUG level, rather than WARN level.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12046/
Acked-by: Albert Rossi