### PR TITLE
dcache-xrootd: refit checksum handling after xrootd4j bug fix

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -31,7 +31,6 @@ import java.nio.channels.ClosedChannelException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
@@ -57,7 +56,6 @@ import org.dcache.auth.attributes.RootDirectory;
 import org.dcache.cells.AbstractMessageCallback;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.util.Checksum;
-import org.dcache.util.Checksums;
 import org.dcache.util.list.DirectoryEntry;
 import org.dcache.vehicles.PnfsListDirectoryMessage;
 import org.dcache.xrootd.core.XrootdException;
@@ -792,42 +790,15 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
 
         case kXR_Qcksum:
             try {
-                ChecksumInfo info = new ChecksumInfo(msg.getArgs());
-                Set<Checksum> checksums = _door.getChecksums(createFullPath(info.getPath()),
+                ChecksumInfo info = new ChecksumInfo(msg.getPath(),
+                                                     msg.getOpaque());
+                Set<Checksum> checksums = _door.getChecksums(createFullPath(msg.getPath()),
                                                              msg.getSubject(),
                                                              _authz);
-                if (!checksums.isEmpty()) {
-                    Optional<String> type = info.getType();
-                    Optional<Checksum> result;
-
-                    if (type.isPresent()) {
-                        result = checksums.stream()
-                                          .filter((c) -> type.get()
-                                                             .equalsIgnoreCase(c.getType()
-                                                                                .getName()))
-                                          .findFirst();
-                    } else {
-                        result = Optional.of(Checksums.preferrredOrder().min(checksums));
-                    }
-
-                    /**
-                     * xrdcp expects lower case names for checksum algorithms
-                     * https://github.com/xrootd/xrootd/issues/459
-                     * TODO: remove toLowerCase() call when above issue is addressed
-                     */
-                    if (result.isPresent()) {
-                        Checksum checksum = result.get();
-                        return new QueryResponse(msg,checksum.getType().getName()
-                                                             .toLowerCase()
-                                                             + " "
-                                                             + checksum.getValue());
-                    }
-                }
+                return selectChecksum(info, checksums, msg);
             } catch (CacheException e) {
                 throw xrootdException(e);
             }
-            throw new XrootdException(kXR_Unsupported, "No checksum available for this file.");
-
         default:
             return unsupported(ctx, msg);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>3.5.4</version.xrootd4j>
+        <version.xrootd4j>3.5.5</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.5.5</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Motivation:

When multiple checksums are defined on a pool,
xrdcp fails if -C is expressed as an argument.
This is because it receives the first checksum
in the natural ordering, because the xrootd
value for cks.type is not being received.
(see https://rb.dcache.org/r/12018 and
GitHub https://github.com/dCache/dcache/issues/5147).

Modfication:

Make code depend on fixed releases of
xrootd4j.  Adjust the construction
of ChecksumInfo and also the use of
getArgs->getPath on the pool.

Result:

xrdcp -C works again.

Target: master
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12019
Depends-on: https://rb.dcache.org/r/12018
Bug: #dCache/dcache/5147
Acked-by: Paul