### PR TITLE
scripts: fix variable ordering in dcache-storage-descriptor

### DIFF
--- a/skel/sbin/dcache-storage-descriptor
+++ b/skel/sbin/dcache-storage-descriptor
@@ -32,10 +32,10 @@ output="$(getProperty storage-descriptor.output.path)"
 if [ $# -ge 1 ]; then
     infoUrl="$1"
 else
+    host="$(getProperty storage-descriptor.http.host)"
+    port="$(getProperty storage-descriptor.http.port)"
     infoUrl="http://${host}:${port}/info"
 fi
-host="$(getProperty storage-descriptor.http.host)"
-port="$(getProperty storage-descriptor.http.port)"
 
 entities=$(mktemp)
 catalog=$(mktemp)


### PR DESCRIPTION
Motivation:

The dcache-storage-descriptor currently does not work unless a URL
argument is supplied.  However, the URL argument is supposed to be
optional, with the script using default values.

Modification:

Ensure the configured host and port values are established before their
use.

Result:

The dcache-storage-descriptor command no longer requires a URL argument.

Target: master
Requires-notes: yes
Requires-book: no
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/12070/
Acked-by: Tigran Mkrtchyan