### PR TITLE
pool: improve messages when migration job is cancelled.

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/PoolOperationMap.java
@@ -390,7 +390,7 @@ public class PoolOperationMap extends RunnableModule {
                  *  NB:  we cannot do anything about child pnfsid tasks here.
                  *  This must be handled by the caller.
                  */
-                running.remove(pool).task.cancel(null);
+                running.remove(pool).task.cancel("pool no longer resilient");
             } else if (waiting.remove(pool) == null) {
                 idle.remove(pool);
             }
@@ -618,7 +618,7 @@ public class PoolOperationMap extends RunnableModule {
                  *  which need to be zeroed out in order to guarantee
                  *  the second operation will complete successfully.
                  */
-                operation.task.cancel(null);
+                operation.task.cancel("pool " + update.pool + " changed");
                 FileFilter fileFilter = new FileCancelFilter();
                 fileFilter.setForceRemoval(true);
                 fileFilter.setParent(update.pool);
@@ -750,7 +750,7 @@ public class PoolOperationMap extends RunnableModule {
     private void cancel(String pool, PoolOperation operation,
                     Map<String, PoolOperation> queue) {
         if (operation.task != null) {
-            operation.task.cancel(null);
+            operation.task.cancel("resilient admin command");
             operation.task = null;
         }
 
@@ -1043,7 +1043,7 @@ public class PoolOperationMap extends RunnableModule {
                 if (filter.matches(k, operation)) {
                     if (!include) {
                         if (operation.task != null) {
-                            operation.task.cancel(null);
+                            operation.task.cancel("pool include/exclude admin command");
                         }
                         operation.state = State.EXCLUDED;
                         queue.remove(k);

--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/ResilientFileTask.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/util/ResilientFileTask.java
@@ -216,7 +216,7 @@ public final class ResilientFileTask extends ErrorAwareTask implements Cancellab
         cancelled = true;
 
         if (migrationTask != null) {
-            migrationTask.cancel();
+            migrationTask.cancel(explanation);
         }
 
         if (future != null) {

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/PoolMigrationJobCancelMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/PoolMigrationJobCancelMessage.java
@@ -1,18 +1,27 @@
 package org.dcache.pool.migration;
 
+import static java.util.Objects.requireNonNull;
+
 public class PoolMigrationJobCancelMessage extends PoolMigrationJobMessage
 {
     private static final long serialVersionUID = 7250151494463302009L;
     private final boolean _forced;
+    private final String _reason;
 
-    public PoolMigrationJobCancelMessage(String id, boolean forced)
+    public PoolMigrationJobCancelMessage(String id, boolean forced, String reason)
     {
         super(id);
         _forced = forced;
+        _reason = requireNonNull(reason);
     }
 
     public boolean isForced()
     {
         return _forced;
+    }
+
+    public String getReason()
+    {
+        return _reason;
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
@@ -11,6 +11,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ScheduledFuture;
@@ -74,6 +75,7 @@ public class Task
     private Deque<String> _locations = new ArrayDeque<>(0);
     private final Set<String> _replicas = new HashSet<>();
     private CellPath _target;
+    private Optional<String> _cancelReason = Optional.empty();
 
     public Task(TaskParameters parameters,
                 TaskCompletionHandler callbackHandler,
@@ -405,9 +407,16 @@ public class Task
      * Cancels the task, if not already completed. This will trigger a
      * notification (postponed).
      */
-    public synchronized void cancel()
+    public synchronized void cancel(String why)
     {
+        assert !_cancelReason.isPresent();
+        _cancelReason = Optional.of(why);
         _fsm.cancel();
+    }
+
+    public synchronized String getCancelReason()
+    {
+        return _cancelReason.orElse("an unknown reason");
     }
 
     /**

--- a/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
+++ b/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
@@ -636,7 +636,9 @@ Entry
         cancel
                 Failed
                 {
-                        fail(DEFAULT_ERROR_CODE, "Failed to cancel task");
+                        fail(DEFAULT_ERROR_CODE,
+                             String.format("Cancelling task (%s) failed (data migrated but pin movement still underway)",
+                                           ctxt.getCancelReason()));
                 }
 }
 
@@ -658,8 +660,8 @@ Exit
                 Failed
                 {
                         fail(TIMEOUT,
-                             String.format("Failed to cancel task (no response from %s)",
-                                           ctxt.getTarget()));
+                             String.format("Cancelling task (%s) failed (no response from %s)",
+                                           ctxt.getCancelReason(), ctxt.getTarget()));
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
                 [ message.getReturnCode() != 0 ]
@@ -670,7 +672,9 @@ Exit
                 [ message.getReturnCode() == 0 && ctxt.getMustMovePins() ]
                 Failed
                 {
-                        fail(DEFAULT_ERROR_CODE, "Failed to cancel task");
+                        fail(DEFAULT_ERROR_CODE,
+                             String.format("Cancelling task (%s) failed (data migrated but still pins to move)",
+                                           ctxt.getCancelReason()));
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
                 [ message.getReturnCode() == 0 ]
@@ -688,7 +692,9 @@ Exit
         cancel_noroute
                 Failed
                 {
-                        fail(SERVICE_UNAVAILABLE, "Failed to cancel task (no route)");
+                        fail(SERVICE_UNAVAILABLE,
+                             String.format("Cancelling task (%s) failed (no route)",
+                                           ctxt.getCancelReason()));
                 }
         cancel_timeout
                 nil


### PR DESCRIPTION
Motivation:

If a migration job is cancelled and this cancellation itself fails then
the log entry can say simply "Failed to cancel task".  This is
unsatisfactory for two reasons:

    1. it is unclear why cancelling the task failed.

    2. it is unclear what triggered the cancellation.

Modification:

Update the two places where "Failed to cancel task" is recorded to
provide more information.

Update the four places where cancellation can fail so message includes
the reason for the cancellation.

Introduce an explanation field when requesting a task is cancelled.
Logging about cancellation problems include the reason why the task was
cancelled.

Include a reason for job cancellation in PoolMigrationJobCancelMessage,
with Rebalancer updated to provide this information.

Result:

migration module provides better error messages about cancellation.

Target: master
Requires-notes: yes
Requires-book: no
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Closes: #5185
Patch: https://rb.dcache.org/r/12064/
Acked-by: Lea Morschel
Acked-by: Albert Rossi