### PR TITLE
doors: fix "lb set tags" command with no arguments

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
@@ -140,7 +140,7 @@ public class LoginBrokerPublisher
     class SetTagCommand implements Callable<String>
     {
         @Argument(required = false)
-        String[] tags;
+        String[] tags = {};
 
         @Override
         public String call()


### PR DESCRIPTION
Motivation:

Commit 9a83eb35cb4 introduced the possibility to run the "lb set tags"
command without any arguments.  This should clear all tags for this
door.

Unfortunately that patch was buggy, as the default value was null,
resulting in a NullPointerException.

Modification:

Introduce an empty list as the default value.

Result:

A bug is fixed where running the "lb set tags" admin command without any
arguments triggers a NullPointerException.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12075/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel