### PR TITLE
SrmManager: avoid spamming if PinManager is down

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/BringOnlineFileRequest.java
@@ -543,7 +543,8 @@ public final class BringOnlineFileRequest extends FileRequest<BringOnlineRequest
                     }
                 } catch (SRMInternalErrorException e) {
                     if (!fr.getState().isFinal()) {
-                        Scheduler.getScheduler(fr.getSchedulerId()).execute(fr);
+                        Scheduler.getScheduler(fr.getSchedulerId()).schedule(fr,
+                                1, TimeUnit.SECONDS);
                     }
                 } catch (SRMException e) {
                     fr.setStateAndStatusCode(


### PR DESCRIPTION
Motivation:

If PinManager is down then attempts to pin a file will fail immediate.
The SrmManager will then immediately attempt to pin the file again,
resulting in a tight loop that will consume high levels of CPU until
PinManager is started again.

Modification:

Introduce a short delay between receiving a failure and once more
attempting to pin the file.

Result:

Fix a problem resulting in high CPU use in SrmManager if clients are
attempting to pin a file and PinManager is unavailable.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12084/
Acked-by: Tigran Mkrtchyan