### PR TITLE
SrmManager: fix handling of saved requests on start-up

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -848,8 +848,19 @@ public final class Storage
         checkValidPath(surl.getHost() != null, "missing host");
         checkValidPath(!CharMatcher.whitespace().matchesAllOf(surl.getHost()), "empty host");
 
+        Collection<LoginBrokerInfo> doors = loginBrokerSource.doors();
+
+
+        if (!doors.stream().map(LoginBrokerInfo::getProtocolFamily).anyMatch(s -> s.equals(srmProtocol))) {
+            /*  We have SRM activity without (apparently) any SRM doors.  This
+             *  is likely from an SrmManager starting up and attempting to
+             *  continue incomplete (for srmBringOnline) or queud activity.
+             */
+            return true;
+        }
+
         int port = surl.getPort();
-        boolean result = loginBrokerSource.anyMatch(i -> (port == -1 || port == i.getPort())
+        boolean result = doors.stream().anyMatch(i -> (port == -1 || port == i.getPort())
                 && i.getProtocolFamily().equals(srmProtocol)
                 && i.getAddresses().stream()
                         .map(InetAddress::getHostName)
@@ -857,7 +868,7 @@ public final class Storage
         if (_log.isDebugEnabled() && result == false) {
             StringBuilder sb = new StringBuilder();
             sb.append("Identifying SURL ").append(surl).append(" as non-local: no matching door:\n");
-            for (LoginBrokerInfo i : loginBrokerSource.doors()) {
+            for (LoginBrokerInfo i : doors) {
                 sb.append("    ").append(i.toString()).append(" ");
                 if (port != -1 && port != i.getPort()) {
                     sb.append("mismatch on port");


### PR DESCRIPTION
Motivation:

On startup, SrmManager will attempt to reactivate any INPROGRESS
srmBringOnline, and (in general) start any QUEUED jobs.  If the restart
also restarted the SRM door, and SrmManager starts up before SRM then
it's possible that SrmManager will not know of running SRM doors.

The result is that SrmManager will believe SURLs are all non-local and
fail all reaquests.

Modification:

Check if SrmManager knows any SRM doors.  If there are no known SRM
doors then accept all SURLs as local.

Results:

Fix regression where SrmManager will reject all QUEUED jobs and
INPROGRESS BringOnline requests on restart, if there are no SRM doors
running when SrmManager starts.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/12083/
Acked-by: Tigran Mkrtchyan