### PR TITLE
nfs: avoid NPE on error path

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1303,7 +1303,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
                 // failed without any pool has been selected.
                 // Depending on the error client may re-try the requests.
-                if (_redirectFuture.isDone() && getPool() == null) {
+                if (_redirectFuture != null && _redirectFuture.isDone() && getPool() == null) {
                     _redirectFuture = null;
                 }
 


### PR DESCRIPTION
if door failed before transfer class goes into async mode, then request
object is null and error processing will fail with NPE.

Acked-by: Paul Millar
Target: master, 6.0, 5.2
Require-book: no
Require-notes: no
(cherry picked from commit b255159a3a34b31c96c201a497715cf90ecf66dd)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>