### PR TITLE
dcache: allow pool compatibility with Xrootd-2 and Xrootd-4 versions

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -475,6 +475,7 @@
         <map>
             <entry key="NFS4-4" value-ref="nfs-transfer-service" />
             <entry key="Xrootd-2" value-ref="xrootd-transfer-service"/>
+            <entry key="Xrootd-4" value-ref="xrootd-transfer-service"/>
             <entry key="Http-1" value-ref="http-transfer-service"/>
             <entry key="RemoteHttpDataTransfer-1" value-ref="remote-http-transfer-service"/>
             <entry key="RemoteHttpsDataTransfer-1" value-ref="remote-http-transfer-service"/>


### PR DESCRIPTION
Backports

https://rb.dcache.org/r/12043/
master@a602c361724f21eba2eb077689deb780b9bb2584

https://rb.dcache.org/r/12009
master@473972bf3a3a99cd355d180e25eeb8c2a8da1c08

These were backported to 6.0 and 5.2, but not
to 5.1 or 5.0.  The door change, however, was
backported to 5.1 and 5.0, so it needs to
be supported here.

Target: 5.1
Target: 5.0