### PR TITLE
webdav: fix CORS when all clients are allowed to connect

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
@@ -65,12 +65,17 @@ public class CrossOriginResourceSharingHandler extends AbstractHandler
                        HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
     {
         String clientOrigin = request.getHeader("origin");
-        if (_allowedClientOrigins.contains(clientOrigin)) {
+
+        if (_allowedClientOrigins.isEmpty()) {
+            response.setHeader("Access-Control-Allow-Origin", "*");
+        } else if (_allowedClientOrigins.contains(clientOrigin)) {
             response.setHeader("Access-Control-Allow-Origin", clientOrigin);
+
             if (_allowedClientOrigins.size() > 1) {
                 response.setHeader("Vary", "Origin");
             }
         }
+
         if ("OPTIONS".equals(request.getMethod())) {
             response.setHeader("Allow", "GET, PUT, POST, DELETE");
             response.setHeader("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE");


### PR DESCRIPTION
Motivation:

Web browsers (at least, chrome) require the Access-Control-Allow-Origin
HTTP response header be sent as a reply to a CORS pre-flight OPTIONS
request.  This is particularly important for dCacheView, as all
transfers use a WebDAV door.

Currently, if the webdav.allowed.client.origins configuration property
is empty (the default value) then the WebDAV door will not include an
Access-Control-Allow-Origin HTTP header when responding to an OPTIONS
request.

This breaks all dCacheView transfers.  Although explicitly configuring
the allowed origin provides a work-around, the default configuration
should work.

Modification:

Always include a 'Access-Control-Allow-Origin' response header when
replying to a CORS OPTIONS request.  If all origins are allowed then use
'*' as the value.

Result:

Fix transfers through dCacheView when the webdav door is configured with
empty webdav.allowed.client.origins value, which is the default value.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: no
Requires-book: no