### PR TITLE
config: fix typo in property name

### DIFF
--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -210,7 +210,7 @@ dcap.net.allowed-subnets=${dcache.net.allowed-subnets}
 (obsolete)dcap.cell.export = See dcap.cell.consume
 #  ---- Kafka service enabled
 #
-(one-of?true|false|${dcache.enable.kafka})dcacp.enable.kafka = ${dcache.enable.kafka}
+(one-of?true|false|${dcache.enable.kafka})dcap.enable.kafka = ${dcache.enable.kafka}
 dcap.kafka.maximum-block = ${dcache.kafka.maximum-block}
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS|${dcache.kafka.maximum-block.unit})\
 dcap.kafka.maximum-block.unit = ${dcache.kafka.maximum-block.unit}

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -112,7 +112,7 @@ create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
              -pinManager=${dcap.service.pinmanager} \
              -gplazma=\"${dcap.service.gplazma}\" \
              -billing=\"${dcap.service.billing}\" \
-             -kafka=\"${dcacp.enable.kafka}\" \
+             -kafka=\"${dcap.enable.kafka}\" \
              -bootstrap-server-kafka=\"${dcap.kafka.bootstrap-servers}\" \
 	     -kafka-topic=\"${dcap.kafka.topic}\" \
              -kafka-max-block=${dcap.kafka.maximum-block}\


### PR DESCRIPTION
	Patch: https://rb.dcache.org/r/12117/

        Require-book: no
	Require-notes: no
        Target: trunk
	Request: 5.2
	Request: 6.0
	Request: 5.1
	Request: 5.0