### PR TITLE
dcache: add null check to pool info collector util

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
+++ b/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
@@ -67,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -75,6 +76,7 @@ import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPool;
 import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPoolGroup;
 import diskCacheV111.pools.json.PoolCostData;
 import diskCacheV111.pools.json.PoolQueueData;
+
 import org.dcache.pool.classic.json.SweeperData;
 import org.dcache.pool.json.PoolData;
 import org.dcache.pool.json.PoolDataDetails;
@@ -294,8 +296,11 @@ public final class PoolInfoCollectorUtils {
         List<CountingHistogram> allHistograms =
                         pools.stream()
                              .map(PoolInfoWrapper::getInfo)
+                             .filter(Objects::nonNull)
                              .map(PoolData::getSweeperData)
+                             .filter(Objects::nonNull)
                              .map(SweeperData::getLastAccessHistogram)
+                             .filter(Objects::nonNull)
                              .collect(Collectors.toList());
 
         CountingHistogram groupHistogram


### PR DESCRIPTION
Motivation:

04 Dec 2019 14:38:23 (Frontend-discordia) [] Uncaught exception in thread pool-19-thread-2
java.lang.NullPointerException: null
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
        at org.dcache.util.collector.pools.PoolInfoCollectorUtils.mergeLastAccess(PoolInfoCollectorUtils.java:299)
	...

(yet another undiscovered case where the composed object can
be null).

Modification:

This patch merely adds null checks to the method indicated as
the source of this issue.  This is not the optimatl solution,
but it is one which will not require updating the pools.

A better way of dealing with this issue will be
introduced in a subsequent patch (master only).

Result:

Stop this NPE from occurring.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Bug:  dCache/dcache/issues/#5220
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12128/
Closes: #5220
Acked-by: Paul