### PR TITLE
frontend: avoid NPE when request has no media type

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/interceptors/LoggingInterceptor.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/interceptors/LoggingInterceptor.java
@@ -108,7 +108,8 @@ public class LoggingInterceptor implements ReaderInterceptor, WriterInterceptor
             return null; /* suppress recording anything */
         } else if (Utf8.isWellFormed(entityData)) {
             String data = new String(entityData, StandardCharsets.UTF_8);
-            if (context.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)) {
+            MediaType type = context.getMediaType();
+            if (type != null && type.isCompatible(MediaType.APPLICATION_JSON_TYPE)) {
                 data = minimiseJson(data);
             }
             return truncate(data);


### PR DESCRIPTION
Motivation:

Observed following NPE

```
13 Dec 2019 09:27:55 (Frontend-prometheus) [] /api/v1/events/channels/KsAB35Lu9u_CD6KI5i-w_A/subscriptions/inotify
javax.servlet.ServletException: org.glassfish.jersey.server.internal.process.MappableException: java.lang.NullPointerException
        at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:408)
        at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:346)
        at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:365)
        at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:318)
        at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:873)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:542)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1345)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:480)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1247)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
        at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:61)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.dcache.http.AuthenticationHandler.access$101(AuthenticationHandler.java:63)
        at org.dcache.http.AuthenticationHandler.lambda$handle$0(AuthenticationHandler.java:162)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:360)
        at org.dcache.http.AuthenticationHandler.handle(AuthenticationHandler.java:160)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.dcache.http.AbstractLoggingHandler.handle(AbstractLoggingHandler.java:65)
        at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:61)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.rewrite.handler.RewriteHandler.handle(RewriteHandler.java:335)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.Server.handle(Server.java:505)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:370)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:267)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
        at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.onFillable(SslConnection.java:427)
        at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:321)
        at org.eclipse.jetty.io.ssl.SslConnection$2.succeeded(SslConnection.java:159)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:698)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:804)
        at java.lang.Thread.run(Thread.java:748)
Caused by: org.glassfish.jersey.server.internal.process.MappableException: java.lang.NullPointerException
        at org.glassfish.jersey.server.internal.MappableExceptionWrapperInterceptor.aroundWriteTo(MappableExceptionWrapperInterceptor.java:67)
        at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:139)
        at org.glassfish.jersey.message.internal.MessageBodyFactory.writeTo(MessageBodyFactory.java:1111)
        at org.glassfish.jersey.server.ServerRuntime$Responder.writeResponse(ServerRuntime.java:638)
        at org.glassfish.jersey.server.ServerRuntime$Responder.processResponse(ServerRuntime.java:371)
        at org.glassfish.jersey.server.ServerRuntime$Responder.process(ServerRuntime.java:417)
        at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:261)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
        at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
        at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:232)
        at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:679)
        at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:392)
        ... 44 common frames omitted
Caused by: java.lang.NullPointerException: null
        at org.dcache.restful.interceptors.LoggingInterceptor.describeEntity(LoggingInterceptor.java:111)
        at org.dcache.restful.interceptors.LoggingInterceptor.aroundWriteTo(LoggingInterceptor.java:85)
        at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:139)
        at org.glassfish.jersey.server.internal.JsonWithPaddingInterceptor.aroundWriteTo(JsonWithPaddingInterceptor.java:85)
        at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:139)
        at org.glassfish.jersey.server.internal.MappableExceptionWrapperInterceptor.aroundWriteTo(MappableExceptionWrapperInterceptor.java:61)
        ... 59 common frames omitted
```

Modification:

Verify the MediaType is set at all before comparing it to `application/json`.

Result:

Avoid a NPE bug in frontend (which is then logged as a stack-trace) that
is triggered when the reply does not contain a media type.

Target: master
Requires-notes: yes
Requires-book: no
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Patch: https://rb.dcache.org/r/12123/
Acked-by: Albert Rossi
Acked-by: Lea Morschel