### PR TITLE
webdav : set Access-Control-Allow-Credentials to true

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
@@ -65,6 +65,7 @@ public class CrossOriginResourceSharingHandler extends AbstractHandler
                        HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
     {
         String clientOrigin = request.getHeader("origin");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
 
         if (_allowedClientOrigins.isEmpty()) {
             response.setHeader("Access-Control-Allow-Origin", "*");
@@ -81,7 +82,6 @@ public class CrossOriginResourceSharingHandler extends AbstractHandler
             response.setHeader("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE");
             response.setHeader("Access-Control-Allow-Headers",
                     "Authorization, Content-Type, Suppress-WWW-Authenticate");
-            response.setHeader("Access-Control-Allow-Credentials", "true");
             response.setStatus(HttpServletResponse.SC_OK);
             Request base_request = (request instanceof Request) ?
                     (Request)request: HttpConnection.getCurrentConnection().getHttpChannel().getRequest();


### PR DESCRIPTION
Motivation:

When making a cross-origin call to webdav door from e.g.
the frontend by using dcache-view, this call will be
blocked if the client want to forward the user certificate.
This is because of CORS policy which required that server
should indicate whether to expose the credential mode of
the browser request.

Modification:

Set Access-Control-Allow-Credentials to true in the CORS
handler for all request.

Result:

Hopefully, no more blocked request due to CORS policy.

Target: master
Request: 6.0
Request: 5.2
Require-notes: no
Require-book: no
Acked-by: Lea Morschel
Acked-by: Paul Millar
Fixes: https://github.com/dCache/dcache/issues/5248

Reviewed at https://rb.dcache.org/r/12134/

(cherry picked from commit 20e47c97c49dd461e8298db465bbf38e2cff7161)