### PR TITLE
gplazma: multimap support files with multiple primary gids

### DIFF
--- a/modules/gplazma2-multimap/src/test/java/org/dcache/gplazma/plugins/GplazmaMultiMapPluginTest.java
+++ b/modules/gplazma2-multimap/src/test/java/org/dcache/gplazma/plugins/GplazmaMultiMapPluginTest.java
@@ -166,6 +166,56 @@ public class GplazmaMultiMapPluginTest
                 .withPrimaryGid(2000));
 
         assertThat(results, hasItem(new GidPrincipal(1000, false)));
+        assertThat(results, not(hasItem(new GidPrincipal(1000, true))));
+    }
+
+    @Test
+    public void shouldReturnSinglePrimaryGidWithMultipleMappedPrimaryGids() throws Exception
+    {
+        givenConfig("username:paul  gid:1000,true\n"
+                  + "group:foo  gid:2000,true");
+
+        whenMapCalledWith(aSetOfPrincipals()
+                .withUsername("paul")
+                .withGroupname("foo"));
+
+        assertThat(results, hasItem(new GidPrincipal(1000, true)));
+        assertThat(results, hasItem(new GidPrincipal(2000, false)));
+        assertThat(results, not(hasItem(new GidPrincipal(1000, false))));
+        assertThat(results, not(hasItem(new GidPrincipal(2000, true))));
+    }
+
+    @Test
+    public void shouldReturnSinglePrimaryGidWithMultipleMappedPrimaryGidsReverseOrder() throws Exception
+    {
+        givenConfig("group:foo  gid:2000,true\n"
+                  + "username:paul  gid:1000,true");
+
+        whenMapCalledWith(aSetOfPrincipals()
+                .withUsername("paul")
+                .withGroupname("foo"));
+
+        assertThat(results, hasItem(new GidPrincipal(2000, true)));
+        assertThat(results, hasItem(new GidPrincipal(1000, false)));
+        assertThat(results, not(hasItem(new GidPrincipal(2000, false))));
+        assertThat(results, not(hasItem(new GidPrincipal(1000, true))));
+    }
+
+    @Test
+    public void shouldReturnOnlyNonPrimaryGidsWhenPrimaryGidAlreadyPresent() throws Exception
+    {
+        givenConfig("username:paul  gid:1000,true\n"
+                  + "group:foo  gid:2000,true");
+
+        whenMapCalledWith(aSetOfPrincipals()
+                .withUsername("paul")
+                .withGroupname("foo")
+                .withPrimaryGid(20));
+
+        assertThat(results, hasItem(new GidPrincipal(1000, false)));
+        assertThat(results, hasItem(new GidPrincipal(2000, false)));
+        assertThat(results, not(hasItem(new GidPrincipal(1000, true))));
+        assertThat(results, not(hasItem(new GidPrincipal(2000, true))));
     }
 
     /*------------------------- Helpers ---------------------------*/


### PR DESCRIPTION
Motivation:

If a gid is derived from a hierarchical group membership then it may be
desirable for subgroup members to adopt their subgroup as their primary
gid.

For example, consider an OP that defines two groups: 'VO' and
'VO/group', where all members of 'VO/group' are also a member of 'VO'.
It may be desirable for members of group 'VO/group' to have the gid
corresponding to 'VO/group' be the primary gid, while non-members of
'VO/group' have the gid correponding to 'VO' be the primary gid.

Such a configuration might be attempted with:

    openidgrp:VO/group  gid:1001,true
    openidgrp:VO        gid:1000,true

This does not work, as all members of the group "VO/group" are
(automatically) a member of group "VO".  Therefore, members of
"VO/group" will have two primary gids.

The solution is for only the first matching principal (in document
order) with a primary gid to be kept.  All other primary gid are mapped
to the non-primary gid.

Modification:

Swap matching order: the list of matchers (from the file) is iterated
over first, with each matcher tested against the supplied principals.
This is done to preserve the file ordering.

Update code to test whether multiple primary gids are defined.  If so,
keep the first primary gid (document order) and convert others to
non-primary equivalent.

Result:

The multimap plugin now supports multiple primary gid mapped principals.
If supplied principals result in multiple primary gids being mapped then
the first principal (in the configuration file's order) is kept and all
other primary gids are converted to the equivalent non-primary gid.

Target: master
Requires-notes: yes
Requires-book: no
Request: 6.0
Patch: https://rb.dcache.org/r/12141/
Acked-by: Tigran Mkrtchyan