### PR TITLE
cells: do not re-define zookeeper watcher

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellGlue.java
@@ -94,29 +94,16 @@ class CellGlue
 
     private static CuratorFramework withMonitoring(CuratorFramework curator)
     {
-        curator.getConnectionStateListenable().addListener((c,s) -> {
+        curator.getConnectionStateListenable().addListener((c,s) ->
                     EVENT_LOGGER.info("[CURATOR: {}] connection state now {}",
-                            c.getState(), s);
+                            c.getState(), s));
 
-                    if (s == ConnectionState.CONNECTED) {
-                        try {
-                            ZooKeeper zk = c.getZookeeperClient().getZooKeeper();
-                            zk.register((WatchedEvent event) -> {
-                                        EVENT_LOGGER.info("[ZOOKEEPER] event "
-                                                + "type={}, state={}, path={}",
-                                                event.getType(), event.getState(),
-                                                event.getPath());
-                                    });
-                        } catch (Exception e) {
-                            EVENT_LOGGER.error("Failed to register ZK logging", e);
-                        }
-                    }
-                });
         curator.getCuratorListenable().addListener((c,e) ->
                     EVENT_LOGGER.info("[CURATOR: {}] event: type={}, name={}, "
                             + "path={}, rc={}, children={}",
                             c.getState(), e.getType(), e.getName(), e.getPath(),
                             e.getResultCode(), e.getChildren()));
+
         curator.getUnhandledErrorListenable().addListener((m,e) ->
                     EVENT_LOGGER.warn("[CURATOR: {}] unhandled error \"{}\": {}",
                             curator.getState(), m, e.getMessage()));


### PR DESCRIPTION
Motivation:
In commit 0be9a6782af3890b0a886cb3721dd210ae10c15a the default watcher
of zookeeper client was re-defined with a one, which logs connection
state. Unfortunately, as zookeeper client can have only one watcher,
curators own watcher was overwritten and, as a result, the reconnection
ability was disabled.

2020-01-13 10:34:11,821 [CURATOR: STARTED] connection state now CONNECTED
2020-01-13 10:34:11,820 [CURATOR: STARTED] event: type=WATCHED, name=null, path=null, rc=3, children=null
2020-01-13 10:36:02,085 [ZOOKEEPER] event type=None, state=Disconnected, path=null
2020-01-13 10:36:59,180 [ZOOKEEPER] event type=None, state=Expired, path=null

Modification:
do not re-define zookeeper watcher.

Result:
curator client is able to restore the connection to ZK server after
network partitioning.

2020-01-13 10:59:17,248 [CURATOR: STARTED] event: type=WATCHED, name=null, path=null, rc=3, children=null
2020-01-13 10:59:17,248 [CURATOR: STARTED] connection state now CONNECTED
2020-01-13 10:59:50,796 [ZOOKEEPER] event type=None, state=Disconnected, path=null
2020-01-13 11:01:06,667 [ZOOKEEPER] event type=None, state=Expired, path=null
2020-01-13 11:11:53,375 [CURATOR: STOPPED] event: type=CLOSING, name=null, path=null, rc=0, children=null
2020-01-13 11:12:01,874 [CURATOR: STARTED] event: type=WATCHED, name=null, path=null, rc=3, children=null
2020-01-13 11:12:01,874 [CURATOR: STARTED] connection state now CONNECTED
2020-01-13 11:12:48,657 [CURATOR: STARTED] event: type=WATCHED, name=null, path=null, rc=0, children=null
2020-01-13 11:12:48,657 [CURATOR: STARTED] connection state now SUSPENDED
2020-01-13 11:13:29,928 [CURATOR: STARTED] event: type=WATCHED, name=null, path=null, rc=-112, children=null
2020-01-13 11:13:29,929 [CURATOR: STARTED] connection state now LOST
2020-01-13 11:16:13,880 [CURATOR: STARTED] event: type=WATCHED, name=null, path=null, rc=3, children=null
2020-01-13 11:16:13,881 [CURATOR: STARTED] connection state now RECONNECTED
2020-01-13 11:38:02,712 [CURATOR: STOPPED] event: type=CLOSING, name=null, path=null, rc=0, children=null
2020-01-13 11:38:10,836 [CURATOR: STARTED] event: type=WATCHED, name=null, path=null, rc=3, children=null
2020-01-13 11:38:10,837 [CURATOR: STARTED] connection state now CONNECTED

Acked-by: Paul Millar
Acked-by: Lea Morschel
Acked-by: Albert Rossi
Target: master, 6.0, 5.2, 5.1, 5.0, 4.2
Require-book: no
Require-notes: yes
(cherry picked from commit 7100e62a4c102f4c0a3f1b46da687ba0854e81e6)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>