### PR TITLE
webdav: include DAV header in OPTIONS requests.

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/CrossOriginResourceSharingHandler.java
@@ -82,10 +82,10 @@ public class CrossOriginResourceSharingHandler extends AbstractHandler
             response.setHeader("Access-Control-Allow-Headers",
                     "Authorization, Content-Type, Suppress-WWW-Authenticate");
             response.setHeader("Access-Control-Allow-Credentials", "true");
-            response.setStatus(HttpServletResponse.SC_OK);
-            Request base_request = (request instanceof Request) ?
-                    (Request)request: HttpConnection.getCurrentConnection().getHttpChannel().getRequest();
-            base_request.setHandled(true);
+
+            /* Note: we do not mark the request as handled.  This is to allow
+             * other handlers to add response headers.
+             */
         }
     }
 }


### PR DESCRIPTION
Motivation:

RFC 4918 requires OPTIONS requests to include the "DAV" header. Commit
385b77f introduced a regression where this does not happen.  Without
this response header, some clients reject dCache WebDAV endpoint as
invalid.

Modification:

Allow OPTIONS requests to proceed past the CORS filter.  This allows Milton
to add the required HTTP response headers to an OPTIONS request.

Result:

A regression is fixed where the WebDAV door failed to follow RFC 4918.
This make some clients reject dCache WebDAV door as a valid WebDAV
endpoint.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Request: 4.2
Requires-notes: true
Requires-book: no
Fixes: #5271
Ticket: https://rt.dcache.org/Ticket/Display.html?id=9841
Patch: https://rb.dcache.org/r/12164/
Acked-by: Lea Morschel