### PR TITLE
Fix tape-reserved size calculation

### DIFF
--- a/skel/share/xml/xslt/storage-descriptor.xsl
+++ b/skel/share/xml/xslt/storage-descriptor.xsl
@@ -242,7 +242,7 @@
   <xsl:if test="collection">
     <xsl:variable name="total" select="sum(collection/space/total)"/>
     <xsl:variable name="used" select="sum(collection/space/used)"/>
-    <xsl:variable name="reserved" select="sum(collection/space/used)"/>
+    <xsl:variable name="reserved" select="sum(collection/space/reserved)"/>
 
     <xsl:text>        "nearline": {&#x0a;</xsl:text>
     <xsl:value-of select="concat('            &quot;totalsize&quot;: ',$total,',&#x0a;')"/>


### PR DESCRIPTION
Calculation of used and reserved tape sizes looks like copy-paste and
condition in sum() for reserved was no changed.
Fixed now.

Signed-off-by: Igor Tkachenko <IATkachenko@gmail.com>