### PR TITLE
dcache,frontend: release dcache-view version 1.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.xrootd4j>3.4.5</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.5.5</version.dcache-view>
+        <version.dcache-view>1.5.6</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.5.5 to v1.5.6

[697af99](dCache/dcache-view@697af99) dcache-view (view-file): fix issue 215
[b2f9766](dCache/dcache-view@b2f9766) dcache-view (dv.js): fix TypeError issue
[a6a862b](dCache/dcache-view@a6a862b) dcache-view (shared-file): fix minor issue with drag and drop
[fceb83a](dCache/dcache-view@fceb83a) dcache-view (dv.js): use findViewFile method
[92120c0](dCache/dcache-view@92120c0) dcache-view (file-sharing): fix issue 189 and dcache/5036 (part 2)
[8295622](dCache/dcache-view@8295622) dcache-view (file-sharing): fix issue 189 and dcache/5036
[faf4dea](dCache/dcache-view@faf4dea) dcache-view (download and upload): fix issue with certifcate
[8a034c5](dCache/dcache-view@8a034c5) dcache-view (login-page): fix the incorrect description text
[598e27e](dCache/dcache-view@598e27e) dcache-view: fix the drop-down qos transition choices
[59eb747](dCache/dcache-view@59eb747) dcache-view: fix all-pools group space computation
[71d93a1](dCache/dcache-view@71d93a1) dcache-view (admim): fix persistence authentication issue
[2cdcef2](dCache/dcache-view@2cdcef2) dcache-view (rename): allow cert user to perform rename
[bc67c68](dCache/dcache-view@bc67c68) dcache-view: upgrade npm dependecies

Request: 5.2
Request: 5.1
Request: 5.0
Require-notes: yes
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12175/