### PR TITLE
dcache-frontend: remove unnecessary login requirement on restores and…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
@@ -146,8 +146,6 @@ public final class RestoreResources {
                                                  @DefaultValue("pool,started")
                                                  @QueryParam("sort") String sort) {
         try {
-            RequestUser.checkAuthenticated();
-
             if (!RequestUser.canViewFileOperations(unlimitedOperationVisibility)) {
                 throw new ForbiddenException("Restores can only be accessed by admin users.");
             }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
@@ -152,8 +152,6 @@ public final class TransferResources {
                                                    @DefaultValue("door,waiting")
                                                    @QueryParam("sort") String sort) {
         try {
-            RequestUser.checkAuthenticated();
-
             Long suid = RequestUser.getSubjectUidForFileOperations(unlimitedOperationVisibility);
 
             return service.get(token,


### PR DESCRIPTION
… transfers

Motivation:

The frontend property

```
frontend.authz.unlimited-operation-visibility
```

is intended to allow administrative data to
be visible to all users rather than only
those asserting the admin role.

In the cases (such as with billing
records) where there is also data obtained
by a PnfsHandler, the underlying ACLs will
trump a 'true' value on this flag, but for
GET operations on restores and transfers,
it shouldn't.

Currently, the latter two operations are
erroneously protected by requiring that
the user be authenticated, so that
access without a certificate or login
is not possible even with the flag set
to true.

Modification:

Remove the authentication checks.

Result:

The flag works as it should:
when false, users see only their
own transfers, and those with
admin role see everything;
when true, everyone sees
everything.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12205/
Acked-by: Dmitry
Acked-by: Lea