### PR TITLE
dcache-xrootd: don't initialize delegation provider when there is no …

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/security/ProxyDelegationStore.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/security/ProxyDelegationStore.java
@@ -23,7 +23,6 @@ import org.italiangrid.voms.ac.VOMSACValidator;
 import org.italiangrid.voms.store.VOMSTrustStore;
 import org.italiangrid.voms.store.VOMSTrustStores;
 import org.italiangrid.voms.util.CertificateValidatorBuilder;
-import org.springframework.beans.factory.annotation.Required;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -65,13 +64,11 @@ public class ProxyDelegationStore
                                                     certChainValidator);
     }
 
-    @Required
     public void setVomsDir(String vomsDir)
     {
         this.vomsDir = vomsDir;
     }
 
-    @Required
     public void setCaCertificatePath(String caCertificatePath)
     {
         this.caCertificatePath = caCertificatePath;
@@ -82,13 +79,11 @@ public class ProxyDelegationStore
         this.keyPairCache = keyPairCache;
     }
 
-    @Required
     public void setTrustAnchorRefreshInterval(long trustAnchorRefreshInterval)
     {
         this.trustAnchorRefreshInterval = trustAnchorRefreshInterval;
     }
 
-    @Required
     public void setTrustAnchorRefreshIntervalUnit(TimeUnit trustAnchorRefreshIntervalUnit)
     {
         this.trustAnchorRefreshIntervalUnit = trustAnchorRefreshIntervalUnit;

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/spring/GplazmaAwareChannelHandlerFactoryFactoryBean.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/spring/GplazmaAwareChannelHandlerFactoryFactoryBean.java
@@ -7,8 +7,10 @@ import org.springframework.beans.factory.annotation.Required;
 
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.concurrent.TimeUnit;
 
 import org.dcache.auth.LoginStrategy;
+import org.dcache.gsi.KeyPairCache;
 import org.dcache.xrootd.door.LoginAuthenticationHandlerFactory;
 import org.dcache.xrootd.plugins.AuthenticationFactory;
 import org.dcache.xrootd.plugins.AuthenticationProvider;
@@ -67,6 +69,13 @@ public class GplazmaAwareChannelHandlerFactoryFactoryBean
         }
     }
 
+    public void shutdown()
+    {
+        if (_gsiDelegationProvider != null) {
+            _gsiDelegationProvider.shutdown();
+        }
+    }
+
     @Required
     public void setLoginStrategy(LoginStrategy loginStrategy)
     {
@@ -78,12 +87,6 @@ public class GplazmaAwareChannelHandlerFactoryFactoryBean
             LoginStrategy anonymousLoginStrategy)
     {
         _anonymousLoginStrategy = anonymousLoginStrategy;
-    }
-
-    @Required
-    public void setGsiDelegationProvider(ProxyDelegationStore gsiDelegationProvider)
-    {
-        _gsiDelegationProvider = gsiDelegationProvider;
     }
 
     @Override
@@ -138,7 +141,7 @@ public class GplazmaAwareChannelHandlerFactoryFactoryBean
             try {
                 if (factory instanceof GSIProxyDelegationClientFactory) {
                     ((GSIProxyDelegationClientFactory)factory)
-                                    .setProvider(_gsiDelegationProvider);
+                                    .setProvider(getGsiProxyDelegationProvider());
                 }
                 if (factory.createClient(name, _properties) != null) {
                     return factory;
@@ -151,5 +154,33 @@ public class GplazmaAwareChannelHandlerFactoryFactoryBean
 
         LOGGER.debug("No delegation client for {}.", name);
         return null;
+    }
+
+    private ProxyDelegationStore getGsiProxyDelegationProvider()
+    {
+        LOGGER.debug("get ProxyDelegationProvider called");
+
+        /*
+         *  Should be singleton.
+         */
+        if (_gsiDelegationProvider != null) {
+            return _gsiDelegationProvider;
+        }
+
+        LOGGER.debug("constructing and initializing ProxyDelegationStore");
+
+        String caPath = _properties.getProperty("xrootd.gsi.ca.path");
+        Long refresh  = Long.valueOf(_properties.getProperty("xrootd.gsi.ca.refresh"));
+        TimeUnit refreshUnit = TimeUnit.valueOf(_properties.getProperty("xrootd.gsi.ca.refresh.unit"));
+        String vomsDir = _properties.getProperty("xrootd.gsi.vomsdir.dir");
+        _gsiDelegationProvider = new ProxyDelegationStore();
+        _gsiDelegationProvider.setCaCertificatePath(caPath);
+        _gsiDelegationProvider.setTrustAnchorRefreshInterval(refresh);
+        _gsiDelegationProvider.setTrustAnchorRefreshIntervalUnit(refreshUnit);
+        _gsiDelegationProvider.setVomsDir(vomsDir);
+        _gsiDelegationProvider.setKeyPairCache(new KeyPairCache(1, TimeUnit.MINUTES));
+        _gsiDelegationProvider.initialize();
+
+        return _gsiDelegationProvider;
     }
 }

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -133,28 +133,13 @@
     <property name="plugins" value="access-log"/>
   </bean>
 
-  <bean id="delegation-provider"
-        class="org.dcache.xrootd.security.ProxyDelegationStore"
-        init-method="initialize" destroy-method="shutdown">
-    <property name="caCertificatePath" value="${xrootd.gsi.ca.path}"/>
-    <property name="trustAnchorRefreshInterval" value="${xrootd.gsi.ca.refresh}"/>
-    <property name="trustAnchorRefreshIntervalUnit" value="${xrootd.gsi.ca.refresh.unit}"/>
-    <property name="vomsDir" value="${xrootd.gsi.vomsdir.dir}"/>
-    <property name="keyPairCache">
-      <bean class="org.dcache.gsi.KeyPairCache">
-        <constructor-arg value="1"/>
-        <constructor-arg value="MINUTES"/>
-      </bean>
-    </property>
-  </bean>
-
   <bean id="channelhandler-factories"
-        class="org.dcache.xrootd.spring.GplazmaAwareChannelHandlerFactoryFactoryBean">
+        class="org.dcache.xrootd.spring.GplazmaAwareChannelHandlerFactoryFactoryBean"
+        destroy-method="shutdown">
       <description>Factory for channel handlers</description>
       <property name="plugins" value="${xrootd.plugins}"/>
       <property name="loginStrategy" ref="loginstrategy"/>
       <property name="anonymousLoginStrategy" ref="anonymous-loginstrategy"/>
-      <property name="gsiDelegationProvider" ref="delegation-provider"/>
   </bean>
 
   <bean id="door" class="org.dcache.xrootd.door.XrootdDoor">


### PR DESCRIPTION
…gsi module

Motivation:

RT #9853, Doors no longer fail in dCache 5.2
brings to light two separate issues.  This
patch corrects the first.

With 5.2, we introduced proxy delegation
into the xrootd door.  In order to delegate,
xrootd needs an implementation of a delegate
provider.  This class in injected from Spring.

However, the injection automatically initializes
the provider, loading the Voms verification
classes.  These depend on the voms.dir path.

When there is no GSI, there should be no
requirement that such a voms dir exist.

Modification:

Create the provider (store) only when adding
it to the GSI Authn Client.

This is done now programmatically in Java.

Result:

Door does not fail to start if there
is no voms directory on the host.

Target: master
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12208/
Bug: RT9853
Requires-book: no
Requires-notes: yes
Acked-by: Dmitry