### PR TITLE
skel: repair erroneous batch directives before cell creation

### DIFF
--- a/skel/share/services/alarms.batch
+++ b/skel/share/services/alarms.batch
@@ -38,6 +38,7 @@ end
 onerror continue
 eval ${alarms.enable.cleaner} true ==
 exec env checkAlarmCleanerProperites -ifok
+onerror shutdown
 
 create org.dcache.alarms.logback.LogServerCell ${alarms.cell.name} \
         "classpath:org/dcache/alarms/logback/alarms.xml \

--- a/skel/share/services/xrootd.batch
+++ b/skel/share/services/xrootd.batch
@@ -38,8 +38,7 @@ check -strong xrootd.authz.user
 check xrootd.authz.read-paths
 check xrootd.authz.write-paths
 
-onerror continue
-
+onerror shutdown
 create org.dcache.cells.UniversalSpringCell ${xrootd.cell.name} \
        "classpath:org/dcache/xrootd/door/xrootd.xml \
         -consume=${xrootd.cell.consume} \


### PR DESCRIPTION
Motivation:

The alarms and xrootd .batch scripts
erroneously leave the script in the state
of

```
onerror continue
```

during the 'create' call; this causes
fatal errors to stall the JVM without
exit.

Modification:

Change the directive to

```
onerror shutdown
```

as in all the other batch scripts.

Result:

Domain is not left in zombie state
after a fatal error, but restarts,
as it should.

Target: master
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Patch: https://rb.dcache.org/r/12210/
Closes: dcache/issues/#5308
Bug: dcache/issues/5308
RT #9853: Doors no longer fail in dCache 5.2
Requires-book: no
Requires-notes: yes
Acked-by: Dmitry