### PR TITLE
libs: remove dependency on jackson-mapper-asl

### DIFF
--- a/modules/dcache-webdav/pom.xml
+++ b/modules/dcache-webdav/pom.xml
@@ -96,9 +96,8 @@
           <artifactId>httpclient</artifactId>
       </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.7</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/owncloud/OwnCloudHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/owncloud/OwnCloudHandler.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2016 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,11 +17,11 @@
  */
 package org.dcache.webdav.owncloud;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.util.StringUtil;
-import org.codehaus.jackson.map.*;
 import org.springframework.http.MediaType;
 
 import javax.servlet.http.HttpServletRequest;

--- a/modules/gplazma2-oidc/pom.xml
+++ b/modules/gplazma2-oidc/pom.xml
@@ -43,8 +43,8 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
@@ -1,5 +1,6 @@
 package org.dcache.gplazma.oidc;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
@@ -12,7 +13,6 @@ import com.google.common.net.InternetDomainName;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
-import org.codehaus.jackson.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/helpers/JsonHttpClient.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/helpers/JsonHttpClient.java
@@ -1,5 +1,7 @@
 package org.dcache.gplazma.oidc.helpers;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.base.Stopwatch;
 import org.apache.http.Header;
@@ -12,8 +14,6 @@ import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeader;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/OidcAuthPluginTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/OidcAuthPluginTest.java
@@ -1,7 +1,7 @@
 package org.dcache.gplazma.oidc;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;

--- a/modules/gplazma2-scitoken/pom.xml
+++ b/modules/gplazma2-scitoken/pom.xml
@@ -38,8 +38,8 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/ForwardingJsonNode.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/ForwardingJsonNode.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2019 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,10 +17,13 @@
  */
 package org.dcache.gplazma.scitoken;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -37,9 +40,9 @@ public abstract class ForwardingJsonNode extends JsonNode
     }
 
     @Override
-    public JsonParser.NumberType getNumberType()
+    public JsonParser.NumberType numberType()
     {
-        return delegate().getNumberType();
+        return delegate().numberType();
     }
 
     @Override
@@ -121,8 +124,38 @@ public abstract class ForwardingJsonNode extends JsonNode
     }
 
     @Override
+    public <T extends JsonNode> T deepCopy() {
+        return delegate().deepCopy();
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         return delegate().equals(o);
+    }
+
+    @Override
+    protected JsonNode _at(JsonPointer jsonPointer) {
+        return null;
+    }
+
+    @Override
+    public JsonNodeType getNodeType() {
+        return delegate().getNodeType();
+    }
+
+    @Override
+    public JsonParser traverse(ObjectCodec objectCodec) {
+        return delegate().traverse(objectCodec);
+    }
+
+    @Override
+    public void serialize(JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        delegate().serialize(jsonGenerator,serializerProvider);
+    }
+
+    @Override
+    public void serializeWithType(JsonGenerator jsonGenerator, SerializerProvider serializerProvider, TypeSerializer typeSerializer) throws IOException {
+        delegate().serializeWithType(jsonGenerator, serializerProvider, typeSerializer);
     }
 }

--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/HttpJsonNode.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/HttpJsonNode.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2019 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,15 +17,22 @@
  */
 package org.dcache.gplazma.scitoken;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.MissingNode;
 import com.google.common.net.MediaType;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.MissingNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,10 +42,10 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static java.util.Objects.requireNonNull;
 import static org.dcache.util.Exceptions.messageOrClassName;
 
 /**
@@ -86,7 +93,7 @@ public class HttpJsonNode extends PreparationJsonNode
 
     public HttpJsonNode(HttpClient client, Supplier<Optional<String>> url, Duration cacheHit, Duration cacheMiss)
     {
-        this.client = requireNonNull(client);
+        this.client = Objects.requireNonNull(client);
         this.urlSupplier = url;
         this.cacheHit = cacheHit;
         this.cacheMiss = cacheMiss;
@@ -168,5 +175,30 @@ public class HttpJsonNode extends PreparationJsonNode
     protected JsonNode delegate()
     {
         return cached;
+    }
+
+    @Override
+    protected JsonNode _at(JsonPointer jsonPointer) {
+        return cached.at(jsonPointer);
+    }
+
+    @Override
+    public JsonNodeType getNodeType() {
+        return cached.getNodeType();
+    }
+
+    @Override
+    public JsonParser traverse(ObjectCodec objectCodec) {
+        return cached.traverse();
+    }
+
+    @Override
+    public void serialize(JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serializeWithType(JsonGenerator jsonGenerator, SerializerProvider serializerProvider, TypeSerializer typeSerializer) throws IOException {
+        throw new UnsupportedOperationException();
     }
 }

--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2019 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,10 +17,10 @@
  */
 package org.dcache.gplazma.scitoken;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.ImmutableSet;
 import org.apache.http.client.HttpClient;
-import org.codehaus.jackson.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/PreparationJsonNode.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/PreparationJsonNode.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2019 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,9 +17,9 @@
  */
 package org.dcache.gplazma.scitoken;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.List;
 
@@ -38,10 +38,10 @@ public abstract class PreparationJsonNode extends ForwardingJsonNode
     }
 
     @Override
-    public JsonParser.NumberType getNumberType()
+    public JsonParser.NumberType numberType()
     {
         prepare();
-        return super.getNumberType();
+        return super.numberType();
     }
 
     @Override

--- a/modules/gplazma2-scitoken/src/test/java/org/dcache/gplazma/scitoken/SciTokenPluginTest.java
+++ b/modules/gplazma2-scitoken/src/test/java/org/dcache/gplazma/scitoken/SciTokenPluginTest.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2020 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2020 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,15 +17,15 @@
  */
 package org.dcache.gplazma.scitoken;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;

--- a/modules/gplazma2/pom.xml
+++ b/modules/gplazma2/pom.xml
@@ -40,8 +40,8 @@
         <artifactId>canl</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2019 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,9 +17,9 @@
  */
 package org.dcache.gplazma.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +100,7 @@ public class JsonWebToken
         checkArgument(elements.size() == 3, "Wrong number of '.' in token");
 
         JsonNode header = decodeToJson(elements.get(0));
-        alg = header.get("alg").getTextValue();
+        alg = header.get("alg").textValue();
         typ = getOptionalString(header, "typ");
         kid = getOptionalString(header, "kid");
 
@@ -111,7 +111,7 @@ public class JsonWebToken
     private String getOptionalString(JsonNode object, String key)
     {
         JsonNode node = object.get(key);
-        return node == null ? null : node.getTextValue();
+        return node == null ? null : node.textValue();
     }
 
     @Nullable
@@ -155,7 +155,7 @@ public class JsonWebToken
     {
         return Optional.ofNullable(payload.get(key))
                 .filter(JsonNode::isTextual)
-                .map(JsonNode::getTextValue);
+                .map(JsonNode::textValue);
     }
 
     /**
@@ -181,10 +181,10 @@ public class JsonWebToken
         if (node.isArray()) {
             return StreamSupport.stream(node.spliterator(), false)
                     .filter(JsonNode::isTextual) // Non text array elements are simply ignored
-                    .map(JsonNode::getTextValue)
+                    .map(JsonNode::textValue)
                     .collect(Collectors.toList());
         } else  if (node.isTextual()) {
-            return Collections.singletonList(node.getTextValue());
+            return Collections.singletonList(node.textValue());
         } else {
             throw new RuntimeException("Unable to convert node " + node
                     + " to List<String>");

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/util/JsonWebTokenTest.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/util/JsonWebTokenTest.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2019 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2019 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,7 @@
              when upgrading logback. -->
         <version.logback>1.2.3</version.logback>
         <version.logback.contrib>0.1.5</version.logback.contrib>
-        <version.jackson.databind>2.10.1</version.jackson.databind>
-        <version.jackson.annotations>2.10.1</version.jackson.annotations>
-        <version.jackson.core>2.10.1</version.jackson.core>
+        <version.jackson>2.10.1</version.jackson>
         <version.jna>5.4.0</version.jna>
         <version.fst>2.56</version.fst>
 
@@ -789,11 +787,6 @@
                 <version>3.6.1</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <version>1.9.7</version>
-            </dependency>
-            <dependency>
                 <groupId>org.python</groupId>
                 <artifactId>jython</artifactId>
                 <version>2.5.3</version>
@@ -943,19 +936,19 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.jackson.databind}</version>
+                <version>${version.jackson}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${version.jackson.annotations}</version>
+                <version>${version.jackson}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>${version.jackson.core}</version>
+                <version>${version.jackson}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Motivation:
jackson-mapper-asl is (a) broken CVE-2016-3720 and (b) deprecated and
replaced by  jackson-databind.

Modification:
remove dependency on jackson-mapper-asl and use single property to
defive all jackson components versions. Update dcache codebase to match
changes.

Result:
no out-of-data dependency.

Acked-by: Marina Sahakyan
Target: master, 6.0, 5.2
Require-book: no
Require-notes: yes