### PR TITLE
dcache, frontend: release dcache-view version 1.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.xrootd4j>3.4.5</version.xrootd4j>
         <version.jersey>2.26</version.jersey>
-        <version.dcache-view>1.5.6</version.dcache-view>
+        <version.dcache-view>1.5.7</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.5.6 to v1.5.7

[1eff351](dCache/dcache-view@1eff351) dcache-view (rename): fix rename operation handling
[fb5b979](dCache/dcache-view@fb5b979) dcache-view (file-metadata): fix issue 225
[f562169](dCache/dcache-view@f562169) dcache-view (file-sharing): fix macaroon generation
[37d7b3a](dCache/dcache-view@37d7b3a) Add support for OIDC names and Client-IDs with spaces

Request: 5.2
Request: 5.1
Request: 5.0
Require-notes: yes
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12236/