### PR TITLE
dcache, frontend: release dcache-view version 1.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.xrootd4j>3.5.5</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
-        <version.dcache-view>1.6.0</version.dcache-view>
+        <version.dcache-view>1.6.1</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Changelog from v1.6.0 to v1.6.1

[5353835](dCache/dcache-view@5353835) dcache-view (rename): fix rename operation handling
[818ae8a](dCache/dcache-view@818ae8a) dcache-view (file-metadata): fix issue 225
[44a870f](dCache/dcache-view@44a870f) dcache-view (sse): make a stat call on a new entry
[7210f69](dCache/dcache-view@7210f69) dcache-view (file-sharing): fix macaroon generation
[af8ff7f](dCache/dcache-view@af8ff7f) Add support for OIDC names and Client-IDs with spaces

Target: master
Request: 6.0
Require-notes: yes
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12235/

(cherry picked from commit f308a7f395127f66bc3d5883b378d2febfe028b6)