### PR TITLE
frontend: fix memory leak in long-running SSE connections

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/interceptors/LimitedTeeOutputStream.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/interceptors/LimitedTeeOutputStream.java
@@ -1,0 +1,117 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2020 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.restful.interceptors;
+
+import org.apache.commons.io.output.ProxyOutputStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * A TeeOutputStream that limits the {@literal branch} OutputStream to
+ * a maximum size.  The {@link #isBranchTruncated()} method describes whether
+ * the branch OutputStream has been truncated.
+ * @see org.apache.commons.io.output.TeeOutputStream
+ */
+public class LimitedTeeOutputStream extends ProxyOutputStream
+{
+    private final long limit;
+    private boolean isBranchTruncated;
+    protected final OutputStream branch;
+    private long count;
+    private int writeToBranch;
+
+    public LimitedTeeOutputStream(OutputStream out, OutputStream branch, long limit)
+    {
+        super(out);
+        this.branch = branch;
+        checkArgument(limit > 0, "Limit must be a positive value");
+        this.limit = limit;
+    }
+
+    @Override
+    public synchronized void write(byte[] b) throws IOException
+    {
+        super.write(b);
+        if (writeToBranch > 0) {
+            branch.write(b, 0, writeToBranch);
+        }
+    }
+
+    @Override
+    public synchronized void write(byte[] b, int off, int len) throws IOException
+    {
+        super.write(b, off, len);
+        if (writeToBranch > 0) {
+            branch.write(b, off, writeToBranch);
+        }
+    }
+
+    @Override
+    public synchronized void write(int b) throws IOException
+    {
+        super.write(b);
+        if (writeToBranch > 0) {
+            branch.write(b);
+        }
+    }
+
+    @Override
+    public void flush() throws IOException
+    {
+        super.flush();
+        branch.flush();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        try {
+            super.close();
+        } finally {
+            this.branch.close();
+        }
+    }
+
+    @Override
+    protected void beforeWrite(int n)
+    {
+        writeToBranch = (int) Math.min(limit-count, n);
+
+        if (writeToBranch < n) {
+            isBranchTruncated = true;
+        }
+    }
+
+    @Override
+    protected void afterWrite(int n) throws IOException
+    {
+        count += writeToBranch;
+    }
+
+    /**
+     * Whether the copied output to branch has been limited.
+     */
+    public boolean isBranchTruncated()
+    {
+        return isBranchTruncated;
+    }
+}
+

--- a/modules/dcache-frontend/src/test/java/org/dcache/restful/interceptors/LimitedTeeOutputStreamTest.java
+++ b/modules/dcache-frontend/src/test/java/org/dcache/restful/interceptors/LimitedTeeOutputStreamTest.java
@@ -1,0 +1,218 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2020 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.restful.interceptors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+
+public class LimitedTeeOutputStreamTest
+{
+    private ByteArrayOutputStream out;
+    private ByteArrayOutputStream branch;
+    private LimitedTeeOutputStream tee;
+
+    @Before
+    public void setup()
+    {
+        out = new ByteArrayOutputStream();
+        branch = new ByteArrayOutputStream();
+    }
+
+    @Test
+    public void shouldBeInitiallyEmpty()
+    {
+        given(limitedTee().withLimit(10));
+
+        assertThat(out.size(), equalTo(0));
+        assertThat(branch.size(), equalTo(0));
+        assertFalse(tee.isBranchTruncated());
+    }
+
+    @Test
+    public void shouldTeeAllSubLimitInputWithByteArray() throws Exception
+    {
+        byte[] testData = "Test data".getBytes(UTF_8);
+        assert testData.length == 9;
+
+        given(limitedTee().withLimit(10));
+
+        tee.write(testData);
+
+        assertThat(out.toByteArray(), equalTo(testData));
+        assertThat(branch.toByteArray(), equalTo(testData));
+        assertFalse(tee.isBranchTruncated());
+    }
+
+    @Test
+    public void shouldTeeAllSubLimitInputWithByte() throws Exception
+    {
+        byte[] testData = "Test data".getBytes(UTF_8);
+        assert testData.length == 9;
+
+        given(limitedTee().withLimit(10));
+
+        for (byte b : testData) {
+            tee.write(b);
+        }
+
+        assertThat(out.toByteArray(), equalTo(testData));
+        assertThat(branch.toByteArray(), equalTo(testData));
+        assertFalse(tee.isBranchTruncated());
+    }
+
+    @Test
+    public void shouldTeeAllSubLimitInputWithByteArrayRange() throws Exception
+    {
+        byte[] testData = "Test data".getBytes(UTF_8);
+        assert testData.length == 9;
+
+        given(limitedTee().withLimit(10));
+
+        tee.write(testData, 0, testData.length);
+
+        assertThat(out.toByteArray(), equalTo(testData));
+        assertThat(branch.toByteArray(), equalTo(testData));
+        assertFalse(tee.isBranchTruncated());
+    }
+
+    @Test
+    public void shouldTeeAllLimitInputWithByteArray() throws Exception
+    {
+        byte[] testData = "Test data!".getBytes(UTF_8);
+        assert testData.length == 10;
+
+        given(limitedTee().withLimit(10));
+
+        tee.write(testData);
+
+        assertThat(out.toByteArray(), equalTo(testData));
+        assertThat(branch.toByteArray(), equalTo(testData));
+        assertFalse(tee.isBranchTruncated());
+    }
+
+    @Test
+    public void shouldTeeAllLimitInputWithByte() throws Exception
+    {
+        byte[] testData = "Test data!".getBytes(UTF_8);
+        assert testData.length == 10;
+
+        given(limitedTee().withLimit(10));
+
+        for (byte b : testData) {
+            tee.write(b);
+        }
+
+        assertThat(out.toByteArray(), equalTo(testData));
+        assertThat(branch.toByteArray(), equalTo(testData));
+        assertFalse(tee.isBranchTruncated());
+    }
+
+    @Test
+    public void shouldTeeAllLimitInputWithByteArrayRange() throws Exception
+    {
+        byte[] testData = "Test data!".getBytes(UTF_8);
+        assert testData.length == 10;
+
+        given(limitedTee().withLimit(10));
+
+        tee.write(testData, 0, testData.length);
+
+        assertThat(out.toByteArray(), equalTo(testData));
+        assertThat(branch.toByteArray(), equalTo(testData));
+        assertFalse(tee.isBranchTruncated());
+    }
+
+    @Test
+    public void shouldTruncateBranchWithLargeByteArrayInput() throws Exception
+    {
+        byte[] testData = "My test data!".getBytes(UTF_8);
+        assert testData.length == 13;
+
+        given(limitedTee().withLimit(10));
+
+        tee.write(testData);
+
+        assertThat(out.toByteArray(), equalTo(testData));
+        assertThat(branch.toByteArray(), equalTo("My test da".getBytes(UTF_8)));
+        assertTrue(tee.isBranchTruncated());
+    }
+
+    @Test
+    public void shouldTruncateBranchWithLargeSingleByteInput() throws Exception
+    {
+        byte[] testData = "My test data!".getBytes(UTF_8);
+        assert testData.length == 13;
+
+        given(limitedTee().withLimit(10));
+
+        for (byte b : testData) {
+            tee.write(b);
+        }
+
+        assertThat(out.toByteArray(), equalTo(testData));
+        assertThat(branch.toByteArray(), equalTo("My test da".getBytes(UTF_8)));
+        assertTrue(tee.isBranchTruncated());
+    }
+
+    @Test
+    public void shouldTruncateBranchWithLargeSingleByteArrayOffsetInput() throws Exception
+    {
+        byte[] testData = "My test data!".getBytes(UTF_8);
+        assert testData.length == 13;
+
+        given(limitedTee().withLimit(10));
+
+        tee.write(testData, 0, testData.length);
+
+        assertThat(out.toByteArray(), equalTo(testData));
+        assertThat(branch.toByteArray(), equalTo("My test da".getBytes(UTF_8)));
+        assertTrue(tee.isBranchTruncated());
+    }
+
+    private void given(LimitedTeeBuilder builder)
+    {
+        tee = builder.build();
+    }
+
+    private LimitedTeeBuilder limitedTee()
+    {
+        return new LimitedTeeBuilder();
+    }
+
+    private class LimitedTeeBuilder
+    {
+        private long limit;
+
+        LimitedTeeBuilder withLimit(long value)
+        {
+            limit = value;
+            return this;
+        }
+
+        LimitedTeeOutputStream build()
+        {
+            return new LimitedTeeOutputStream(out, branch, limit);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Commit 2377c86 introduced logging that captured the request and response
entities for frontend requests so that they may be logged.  This
contained a bug where a long-running SSE connection that receives many
events will consume increasing memory until all memory in the JVM is
exhausted, killing the domain.

This problem comes from how LoggingInteceptor retains a copy of the
response entity.  For large response entities (e.g., directory listing)
the output is truncated when written to the log file; however, while
processing the request, the complete response entity is captured.

An SSE client typically makes a GET request that (apart from networking
problems or dCache restarts) never terminates.  Therefore the response
entity will contain an ever-increasing list of events (which are sent to
the client progressively, using chuncked-encoded).  As the GET request
does not terminate, the captured response entity continues to grow as
more events are sent, eventually exhausing the available memory.

Modification:

Add a modified "tee" class that limits the size of the branch output.

Update the LoggingInterceptor to make use of this limiting tee.

Result:

Fix a bug where an SSE client that receives many events without the
connection breaking will eventually exhause all memory in the JVM.

Target: master
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12242/
Acked-by: Albert Rossi