### PR TITLE
dcache-frontend: allow pool enable/disable to use boolean JSON value

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/pool/PoolModeUpdate.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/pool/PoolModeUpdate.java
@@ -101,15 +101,15 @@ public class PoolModeUpdate implements Serializable {
         return PoolV2Mode.ENABLED;
     }
 
-    public void setRdonly(boolean rdonly) {
-        this.rdonly = rdonly;
+    public void setRdonly(Boolean rdonly) {
+        this.rdonly = rdonly == null ? false : rdonly;
     }
 
-    public void setResilience(boolean resilience) {
-        this.resilience = resilience;
+    public void setResilience(Boolean resilience) {
+        this.resilience = resilience == null ? false : resilience;
     }
 
-    public void setStrict(boolean strict) {
-        this.strict = strict;
+    public void setStrict(Boolean strict) {
+        this.strict = strict == null ? false: strict;
     }
 }


### PR DESCRIPTION
Motivation:

see https://github.com/dCache/dcache/issues/4626

From RESTful admin API, the POST to
pools/{name}/usage/mode -d {"rdonly":true}

fails but {"rdonly": "true"} succeeds.

This is because the ObjectMapper needs
an actual object parameter, not a primitive
on the setter.

Modification:

change the parameters from boolean to Boolean.

Result:

Both boolean and string work.

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Bug: #4626
Patch: https://rb.dcache.org/r/12246/
Acked-by: Olufemi