### PR TITLE
dcache-frontend,history: protect against missing highest bin in histo…

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
+++ b/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
@@ -323,7 +323,9 @@ public final class PoolInfoCollectorUtils {
         HistogramMetadata metadata = new HistogramMetadata();
 
         for (CountingHistogram h : allHistograms) {
-            double currentMaxBin = h.getHighestBin();
+            Double highestBin = h.getHighestBin();
+            double currentMaxBin = highestBin == null ?
+                            Double.MIN_VALUE : highestBin;
             if (currentMaxBin > maxBinValue) {
                 standard = h;
                 maxBinValue = currentMaxBin;


### PR DESCRIPTION
…gram data

Motivation:

Issue: https://github.com/dCache/dcache/issues/5340

Stack trace in logs:

```
03 Mar 2020 11:23:39 (Frontend-xxxxx) [] Uncaught exception in thread pool-56-thread-1
java.lang.NullPointerException: null
        at org.dcache.util.collector.pools.PoolInfoCollectorUtils.mergeLastAccess(PoolInfoCollectorUtils.java:326)
        at org.dcache.restful.util.pool.PoolHistoriesHandler.getAggregateFileLifetime(PoolHistoriesHandler.java:193)
        at org.dcache.restful.util.pool.PoolHistoriesHandler.update(PoolHistoriesHandler.java:265)
        at org.dcache.util.collector.pools.PoolInfoAggregator.lambda$aggregateDataForPoolGroups$0(PoolInfoAggregator.java:100)
        at ...
```

Modification:

Check for null value.

Result:

No trace:

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Bug: #5340
Patch: https://rb.dcache.org/r/12247/
Acked-by: Olufemi