### PR TITLE
dcache-history,dcache-frontend: guard against unconfigured sweeper hi…

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
+++ b/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
@@ -324,13 +324,19 @@ public final class PoolInfoCollectorUtils {
 
         for (CountingHistogram h : allHistograms) {
             Double highestBin = h.getHighestBin();
-            double currentMaxBin = highestBin == null ?
-                            Double.MIN_VALUE : highestBin;
-            if (currentMaxBin > maxBinValue) {
-                standard = h;
-                maxBinValue = currentMaxBin;
+            /*
+             *  REVISIT.   This is a temporary fix for backport (6.1).
+             *  A null highestBin means the histogram has
+             *  not been initialized; this also means the metadata
+             *  object will be null.
+             */
+            if (highestBin != null) {
+                metadata.mergeStatistics(h.getMetadata());
+                if (highestBin > maxBinValue) {
+                    standard = h;
+                    maxBinValue = highestBin;
+                }
             }
-            metadata.mergeStatistics(h.getMetadata());
         }
 
         int binCount = standard.getBinCount();


### PR DESCRIPTION
…stogram

Motivation:

GH Issue #5359.

The NPE stack trace arises because the pool
data could be sent with a default sweeper data
object.  This object currently contains
a default counting histogram object, but
that object in turn has internal fields,
in particular, the metadata field, which
have not been initialized, causing
a NPE on processing.

Modification:

In this patch we just guard against
processing an uninitialized counting
histogram.

A subsequent patch (for master only)
will modify how the Sweeper initializes
histograms.

Result:

Should not see the NPE reported below.

Target: master
Bug: dcache/issues/5359
Patch: https://rb.dcache.org/r/12264/
Request: 6.1
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Closes: #5359
Acked-by: Olufemi