### PR TITLE
dcache: qos migration policy engine should not raise JVM error when n…

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/qos/MigrationPolicyEngine.java
+++ b/modules/dcache/src/main/java/org/dcache/qos/MigrationPolicyEngine.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import diskCacheV111.poolManager.PoolSelectionUnit;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.vehicles.PoolManagerGetPoolsByHsmMessage;
 import diskCacheV111.vehicles.PoolManagerPoolInformation;
 
@@ -79,17 +80,17 @@ public class MigrationPolicyEngine
     public void adjust() throws InterruptedException, CacheException,
                     NoRouteToCellException
     {
-        Collection<String> targetPools = getTargetPools(fileAttributes,
-                                                        cellStub);
-
         Collection<String> sourcePools = getSourcePools(fileAttributes);
 
         if (sourcePools.isEmpty()) {
-            throw new CacheException("No file locations found");
+            throw new FileNotFoundCacheException("No source locations found");
         }
 
+        Collection<String> targetPools = getTargetPools(fileAttributes,
+                                                        cellStub);
+
         if (targetPools.isEmpty()) {
-            throw new InternalError("No HSM pool found");
+            throw new FileNotFoundCacheException("No HSM pool available");
         }
 
         List<String> samePools = targetPools.stream()


### PR DESCRIPTION
…o tape pool found

Motivation:

If no tape pool is found when a tape transition is requested,
the frontend dumps a stack trace ending in:

```
Caused by: java.lang.InternalError: No HSM pool found
	at org.dcache.qos.MigrationPolicyEngine.adjust(MigrationPolicyEngine.java:92)
	at org.dcache.qos.QoSTransitionEngine.adjustQoS(QoSTransitionEngine.java:251)
	at org.dcache.restful.resources.namespace.FileResources.cmrResources(FileResources.java:292)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
...
```

This is because it treats this like an Internal JVM error.

Modification:

Change to FileNotFoundCacheException.

Result:

Normal behavior (HTTP error code reported back with "No HSM pool found").

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/12270/
Acked-by: Lea
Acked-by: Olufemi