### PR TITLE
nearline-storage: remove disk copy if restore from HSM failed

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2014 - 2019 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2014 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -108,6 +108,7 @@ import org.dcache.pool.nearline.spi.RemoveRequest;
 import org.dcache.pool.nearline.spi.StageRequest;
 import org.dcache.pool.repository.Allocator;
 import org.dcache.pool.repository.EntryChangeEvent;
+import org.dcache.pool.repository.FileStore;
 import org.dcache.pool.repository.IllegalTransitionException;
 import org.dcache.pool.repository.ReplicaDescriptor;
 import org.dcache.pool.repository.ReplicaState;
@@ -145,6 +146,7 @@ public class NearlineStorageHandler
     private ScheduledExecutorService scheduledExecutor;
     private ListeningExecutorService executor;
     private Repository               repository;
+    private FileStore                fileStore;
     private ChecksumModule           checksumModule;
     private PnfsHandler              pnfs;
     private CellStub                 billingStub;
@@ -222,6 +224,11 @@ public class NearlineStorageHandler
     @Required
     public void setAllocator(Allocator allocator) {
         this.allocator = allocator;
+    }
+
+    @Required
+    public void setFileStore(FileStore fileStore) {
+        this.fileStore = fileStore;
     }
 
     @PostConstruct
@@ -1214,6 +1221,12 @@ public class NearlineStorageHandler
             PnfsId pnfsId = getFileAttributes().getPnfsId();
             if (cause != null) {
                 deallocateSpace();
+                // cleanup leftovers from HSM driver
+                try {
+                    fileStore.remove(pnfsId);
+                } catch (IOException e) {
+                    LOGGER.error("Failed to remove partially staged file: {}", e.getMessage());
+                }
                 if (cause instanceof InterruptedException || cause instanceof CancellationException) {
                     cause = new TimeoutCacheException("Stage was cancelled.", cause);
                 }

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -194,6 +194,7 @@
       <property name="billingStub" ref="billing-stub"/>
       <property name="hsmSet" ref="hsmset"/>
       <property name="allocator" ref="allocator" />
+      <property name="fileStore" ref="file-store" />
   </bean>
 
   <bean id="hsmset" class="org.dcache.pool.nearline.HsmSet">


### PR DESCRIPTION
Motivation:
There is challenge in pool space allocation/de-allocation in conjunction
to HSM connectivity and handling restore errors. On a one side
NearlineStorageHandler itself allocates and de-allocates space when
restoring a file, on an other hand, ReplicaRepository de-allocates the
space occupied by a file on removal. There are at least two issues with
it:

 - the allocated space de-allocated twice
 - nearline storage driver might create a disk file with a different
   size than allocated space.

as a result failing stage end up with used space miscalculation:

02 Apr 2020 17:43:35 (pool_read) [0f4:GU admin] Pool: pool_read, fault occurred in repository: Internal repository error. Pool restart required: , cause: java.lang.IllegalArgumentException: Cannot set used space to a negative value.

Modification:
To make second (file size based) de-allocation, let
NearlineStorageHandler to remove file in the store if restore failed.

Result:
double de-allocation doesn't ends up with space miscalculation.

Fixes: #5379
Acked-by: Marina Sahakyan
Target: master, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit da9e15a3531fee47075592885494f1a4ca1f4eb3)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>