### PR TITLE
nearline-storage: remove disk copy if restore from HSM failed

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -194,6 +194,7 @@
       <property name="billingStub" ref="billing-stub"/>
       <property name="hsmSet" ref="hsmset"/>
       <property name="allocator" ref="allocator" />
+      <property name="fileStore" ref="file-store" />
   </bean>
 
   <bean id="hsmset" class="org.dcache.pool.nearline.HsmSet">


### PR DESCRIPTION
Motivation:
There is challenge in pool space allocation/de-allocation in conjunction
to HSM connectivity and handling restore errors. On a one side
NearlineStorageHandler itself allocates and de-allocates space when
restoring a file, on an other hand, ReplicaRepository de-allocates the
space occupied by a file on removal. There are at least two issues with
it:

 - the allocated space de-allocated twice
 - nearline storage driver might create a disk file with a different
   size than allocated space.

as a result failing stage end up with used space miscalculation:

02 Apr 2020 17:43:35 (pool_read) [0f4:GU admin] Pool: pool_read, fault occurred in repository: Internal repository error. Pool restart required: , cause: java.lang.IllegalArgumentException: Cannot set used space to a negative value.

Modification:
To make second (file size based) de-allocation, let
NearlineStorageHandler to remove file in the store if restore failed.

Result:
double de-allocation doesn't ends up with space miscalculation.

Fixes: #5379
Acked-by: Marina Sahakyan
Target: master, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit da9e15a3531fee47075592885494f1a4ca1f4eb3)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>