### PR TITLE
dcache-frontend: remove retry flag on sendAndWait to history service

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/pool/PoolHistoriesHandler.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/pool/PoolHistoriesHandler.java
@@ -91,8 +91,6 @@ import org.dcache.vehicles.histograms.AggregateFileLifetimeRequestMessage;
 import org.dcache.vehicles.histograms.PoolTimeseriesRequestMessage;
 import org.dcache.vehicles.histograms.PoolTimeseriesRequestMessage.TimeseriesType;
 
-import static dmg.cells.nucleus.CellEndpoint.SendFlag.RETRY_ON_NO_ROUTE_TO_CELL;
-
 /**
  * <p>Called during the collection gathering in order to obtain
  * historical (i.e., stateful) pool data such as queue/mover timeseries
@@ -165,8 +163,7 @@ public final class PoolHistoriesHandler extends PoolInfoAggregator
 
         try {
             message = historyService.sendAndWait(message,
-                                                 historyService.getTimeoutInMillis(),
-                                                 RETRY_ON_NO_ROUTE_TO_CELL);
+                                                 historyService.getTimeoutInMillis());
         } catch (NoRouteToCellException | InterruptedException | TimeoutCacheException e) {
             LOGGER.debug("Could not fetch aggregated lifetime data for {}: {}.",
                          poolGroup, e.getMessage());
@@ -204,8 +201,7 @@ public final class PoolHistoriesHandler extends PoolInfoAggregator
         message.setPool(pool);
         message.setKeys(types);
         return historyService.sendAndWait(message,
-                                          historyService.getTimeoutInMillis(),
-                                          RETRY_ON_NO_ROUTE_TO_CELL);
+                                          historyService.getTimeoutInMillis());
     }
 
     @Override


### PR DESCRIPTION
Motivation:

When frontend is run in a core domain and there is
no history service reachable, the retry on no route
to cell ends up spamming the message queues.

Modification:

Since the collector sweeps periodically, it
will automatically detect if the cell is available
at the next pass.   So the RETRY_ON_NO_ROUTE_TO_CELL
flag is unnecessary, and is removed.

Result:

No proliferation of messages.

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Patch: https://rb.dcache.org/r/12322/
Requires-book: no
Requires-notes: yes
Acked-by: Dmitry
Acked-by: Lea