### PR TITLE
dcache-xrootd: fix compatible level security for sigver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>3.5.5</version.xrootd4j>
+        <version.xrootd4j>3.5.6</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.5.7</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
Motivation:

Fix a bug where setting the
security level to 'compatible'
was forcing a signed hash on
all open calls rather than
just opens for write.

Modification:

Upgrade to xrootd4j 3.5.6

Result:

Compatible level behaves correctly.

Target: 6.1, 6.0, 5.2, 5.1, 5.0
Requires-notes: yes
Requires-book: no

See xrootd4j patch: https://rb.dcache.org/r/12321
master@0406002401d73d39a9b43f48ee769637cabd76b6