### PR TITLE
dcache-xrootd: always create missing directories on write

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -267,14 +267,20 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
             */
             XrootdTransfer transfer;
             if (neededPerm == FilePerm.WRITE) {
-                boolean createDir = req.isMkPath();
+                /**
+                 *  boolean createDir = req.isMkPath() has
+                 *  been changed to default to true
+                 *  so as to conform to the general expectations that this
+                 *  behavior should not depend on the client.
+                 */
                 boolean overwrite = req.isDelete() && !req.isNew();
                 boolean persistOnSuccessfulClose = (req.getOptions()
                         & XrootdProtocol.kXR_posc) == XrootdProtocol.kXR_posc;
                 // TODO: replace with req.isPersistOnSuccessfulClose() with the latest xrootd4j
 
+
                 transfer = _door.write(remoteAddress, path,
-                        ioQueue, uuid, createDir, overwrite, size, _maximumUploadSize,
+                        ioQueue, uuid, true, overwrite, size, _maximumUploadSize,
                         localAddress, req.getSubject(), _authz, persistOnSuccessfulClose,
                         ((_isLoggedIn) ? _userRootPath : _rootPath),
                         req.getSession().getDelegatedCredential());


### PR DESCRIPTION
Motivation:

The xrootd client has a command-line option, '--path', which
tells the server to create missing directories.  This option
is included in two-party copy, but setting it for TPC has
no effect.   TPCs which wish to write to dCache (as destination)
to a non-existent subdirectory fail.

At the same time, the vanilla xrootd server defaults to
making all missing directories.

Modification:

Change the dCache door to behave like the xrootd server.
This avoids having inconsistent behavior between different
clients (FTS, gfal, xrdcp) and meets the general
expectation that missing directories will be created on
the fly.

Result:

dCache no longer fails in these cases.

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Bug: https://github.com/dCache/dcache/issues/5397
Patch: https://rb.dcache.org/r/12326/
Closes: #5397
Requires-notes: yes
Requires-book: no
Acked-by: Dmitry