### PR TITLE
nfs: do not wait for mover to shutdown for reads

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1388,7 +1388,8 @@ public class NFSv41Door extends AbstractCellComponent implements
             killMover(0, "killed by door: returning layout");
 
             try {
-                if (!waitForMover(NFS_REQUEST_BLOCKING)) {
+                // wait for clean mover shutdown only for writes only
+                if (isWrite() && !waitForMover(NFS_REQUEST_BLOCKING)) {
                     throw new DelayException("Mover not stopped");
                 }
             } catch (FileNotFoundCacheException e) {


### PR DESCRIPTION
Motivation:
as result of closing read-mover shouldn't be propagated to client (as we
assume that it's make real difference for the client), there are no
reasons to block client and wait until mover is actually stopped.

Modification:
layoutreturn, which is triggered during close, wait only for write
movers to report client that file is stored on pool and location is
registered and the namespace.

Result:
a slight performance improvement for IO on small files.

Acked-by: Marina Sahakyan
Target: master
Requires-book: no
Requires-notes: yes
(cherry picked from commit 22d935c84fcd3bae8ecfdddfccd5a1ce23a9367e)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>