### PR TITLE
login-broker: fix 'lb set update' command

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerPublisher.java
@@ -112,7 +112,7 @@ public class LoginBrokerPublisher
         public String call() throws IllegalArgumentException
         {
             checkArgument(time >= 2, "Update time out of range.");
-            setBrokerUpdateTime(_brokerUpdateTime, _brokerUpdateTimeUnit);
+            setBrokerUpdateTime(time, TimeUnit.SECONDS);
             return "";
         }
     }


### PR DESCRIPTION
Motivation:
the 'lb set update` command ignores the provided value and set the
existing one again.

Modification:
pass admin provided values to the lb configuration.

Result:
lb update time's can be modified through admin interface.

Acked-by: Lea Morschel
Acked-by: Paul Millar
Target: master, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit 80a905a01ab97977d3f2a26fd06680d2fb7e1735)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>