### PR TITLE
pool: drop Authorization HTTP header on redirected

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpsDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpsDataTransferProtocol.java
@@ -3,8 +3,7 @@ package org.dcache.pool.movers;
 import eu.emi.security.authn.x509.X509CertChainValidator;
 import eu.emi.security.authn.x509.helpers.ssl.SSLTrustManager;
 import eu.emi.security.authn.x509.impl.KeyAndCertCredential;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
@@ -61,7 +60,7 @@ public class RemoteHttpsDataTransferProtocol extends RemoteHttpDataTransferProto
     }
 
     @Override
-    public CloseableHttpClient createHttpClient() throws CacheException
+    protected HttpClientBuilder customise(HttpClientBuilder builder) throws CacheException
     {
         try {
             KeyManager[] keyManagers;
@@ -76,7 +75,7 @@ public class RemoteHttpsDataTransferProtocol extends RemoteHttpDataTransferProto
                     keyManagers,
                     new TrustManager[]{trustManager},
                     secureRandom);
-            return HttpClients.custom().setUserAgent(USER_AGENT).setSSLContext(context).build();
+            return super.customise(builder).setSSLContext(context);
         } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
             throw new CacheException("failed to build http client: " + e.getMessage(), e);
         }


### PR DESCRIPTION
Motivation:

It is fairly commonly established that an HTTP client should drop any
Authorization HTTP request header(s) when following a redirection; that
is, the subsequent HTTP request after the initial request returned a 30x
status code should not contain an Authorization header.

Currently dCache HTTP-TPC code keeps the Authorization header in
subsequent requests.  In addition to going against best practice, this
results in failed transfers for Dynafed for token-based HTTP-TPC because
the underlying library handles the redirected request (with both an
Authorization header and the auth token embedded in the URL) as an
attempt to use the Authorization header (containing the auth token),
which the target server does not understand.

Modification:

(Note: redirection of GET, HEAD and DELETE requests are handled by the
Apache HttpClient library, while redirection for PUT is handled by our
own code.)

Refactor how HttpClient is created; and, in particular, how the
TLS/HTTPS client is created.  This is to make the code DRY.

Update HttpClient builder to inject custom RedirectionStrategy that
drops the Authorization header on redirection.

Update code that adds HTTP request headers to be aware whether or not
the request is a redirection.  If it is a redirection, then the
Authorization header is dropped.

Result:

When making an HTTP third-party copy (HTTP-TPC), dCache no longer sends
the "Authorization" HTTP request header in any subsequent request when
the remote server responds with a redirection.

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Closes: #5386
Patch: https://rb.dcache.org/r/12335/
Acked-by: Tigran Mkrtchyan