### PR TITLE
pool (xrootd): make tpc security plugin default unix

### DIFF
--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -369,7 +369,10 @@ pool.mover.xrootd.plugins=
 #                any other auth plugins, if hash signing is enforced on
 #                the pools (see pool.xrootd.security.force-signing).
 #
-pool.mover.xrootd.tpc-authn-plugins=
+#        The default is unix, since this will also be required in order
+#                to communicate with an EOS source.
+#
+pool.mover.xrootd.tpc-authn-plugins=unix
 
 #  ---- Xrootd mover-idle timeout
 #


### PR DESCRIPTION
Motivation:

The unix xrootd tpc security plugin was included in order to
enable the dCache TPC client to use a dCache pool as source
when signed hash verification is on
(see:  https://www.dcache.org/manuals/Book-6.1/config-xrootd.shtml#signed-hash-verification-support).

It turns out, however, that EOS also does not support GSI
on its data servers, and thus requires either UNIX or SSS.

Modification:

Make unix enabled by default in the properties for the pool.

Result:

No special configuration necessary for organizations (like Tier 1)
needing to communicate with EOS.

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Patch: https://rb.dcache.org/r/12358/
Requires-notes: yes
Requires-book: no
Acked-by: Lea