### PR TITLE
dcache-xrootd: make 'tried'/excluded hosts an optional feature

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -179,6 +179,8 @@ public class XrootdDoor
     private final Map<Integer,XrootdTransfer> _transfers =
         new ConcurrentHashMap<>();
 
+    private boolean triedHostsEnabled;
+
     @Autowired(required = false)
     private void setKafkaTemplate(
                     @Qualifier("billing-template") KafkaTemplate kafkaTemplate )
@@ -324,6 +326,12 @@ public class XrootdDoor
         _moverTimeoutUnit = checkNotNull(unit);
     }
 
+    @Required
+    public void setTriedHostsEnabled(boolean triedHostsEnabled)
+    {
+        this.triedHostsEnabled = triedHostsEnabled;
+    }
+
     public TimeUnit getMoverTimeoutUnit()
     {
         return _moverTimeoutUnit;
@@ -343,6 +351,11 @@ public class XrootdDoor
                                                                                         _tpcFdIndex)),
                                      TPC_EVICT_DELAY, TPC_EVICT_DELAY,
                                      TimeUnit.MILLISECONDS);
+    }
+
+    public boolean isTriedHostsEnabled()
+    {
+        return triedHostsEnabled;
     }
 
     @Override

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -164,6 +164,7 @@
     <property name="moverTimeoutUnit" value="${xrootd.mover.timeout.unit}"/>
     <property name="executor" ref="scheduled-thread-pool"/>
     <property name="poolMonitor" ref="pool-monitor"/>
+    <property name="triedHostsEnabled" value="${xrootd.enable.tried-hosts}"/>
   </bean>
 
   <bean id="pool-manager-handler" class="org.dcache.poolmanager.PoolManagerHandlerSubscriber">

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -247,6 +247,27 @@ xrootd.query-config!version = dCache ${dcache.version}
 xrootd.query-config!sitename = ${dcache.description}
 xrootd.query-config!role = none
 
+#  ----- Whether the door passes the xrootd 'tried' cgi to the PoolManager
+#
+#        This option is used by the xrootd client to indicate to an xrootd
+#        manager-role server that it wishes to exclude data servers on the
+#        given host because a previous attempt to use it failed.
+#
+#        Turning this on in dCache is optional.  When it is not enabled,
+#        and the xrootd client sends the option, the door will respond with
+#        an unsupported operation error.
+#
+#        It is recommended that if this option is activated, you make sure
+#        that all doors and pools that could be used as a third-party copy
+#        source support TLS (strict or optional) if the client is to be
+#        used with the 'xroots' protocol.  This is because the vanilla xrootd
+#        third-party copy will send a retried=<host> back to the door if
+#        it expects to use TLS and TLS fails.  When this happen, if the file
+#        has replicas only on that host, access to the file will be suspended
+#        to all clients by the PoolManager.
+#
+(one-of?true|false)xrootd.enable.tried-hosts=false
+
 #  Signed hash verification ----- see dcache.properties
 #
 xrootd.security.level=${dcache.xrootd.security.level}

--- a/skel/share/services/xrootd.batch
+++ b/skel/share/services/xrootd.batch
@@ -11,6 +11,7 @@ check -strong xrootd.net.port
 check -strong xrootd.net.listen
 check -strong xrootd.net.backlog
 check -strong xrootd.enable.proxy-protocol
+check -strong xrootd.enable.tried-hosts
 check -strong xrootd.limits.threads
 check -strong xrootd.limits.login-cache.lifetime
 check -strong xrootd.limits.login-cache.lifetime.unit


### PR DESCRIPTION
Motivation:

In https://rb.dcache.org/r/11955/
master@261e78639548adadfaea38827c47efe92e1a2f41
we introduced support for the xrootd cgi "tried=<host>,".
Theoretically, this was in order to avoid, under
an xrootd redirect, reasking for a pool that was
experiencing some IO or disk failure on the node.

Unfortunately, the xrootd client does not reserve
this option only for IO or server failures, but
will use it in case connectivity to the redirected
endpoint fails.

In this case, dCache does not behave in a friendly
manner, because the PoolManager suspends access
to the file (to all future connections/requests).

We noticed this happening particularly during
TLS testing.  The xrootd TPC client will retry
against the source door if the pool it is
trying to connect to does not support TLS but
it thinks it should.

Modification:

We now introduce an option to enable this
support, which is off by default.

In the case of activation, the adminstrators
are urged to make sure that all pools and doors
that may become a TPC source for an 'xroots'
(TLS) transfer have at least OPTIONAL capability
for TLS.

Result:

Avoid locking up files unnecessarily.

Target: master
Request: 6.1
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12387/
Acked-by: Dmitry
Acked-by: Lea