### PR TITLE
pool: repository account capacity correctly if file channel closed

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Required;
 
 import java.io.SyncFailedException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.CompletionHandler;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.ExecutorService;
@@ -152,6 +153,8 @@ public abstract class AbstractMoverProtocolTransferService
                             } catch (SyncFailedException e) {
                                 fileIoChannel.sync();
                                 LOGGER.info("First sync failed [{}], but second sync suceeded", e );
+                            } catch (ClosedChannelException e) {
+                                LOGGER.debug("Replica channel closed by mover");
                             }
                         }
                     } else {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
@@ -150,7 +150,7 @@ class WriteHandleImpl implements ReplicaDescriptor
                 : OPEN_OPTIONS;
 
         RepositoryChannel channel = new AllocatorAwareRepositoryChannel(_entry.openChannel(options),
-                _allocator);
+                _repository, _fileAttributes.getPnfsId(), _allocator);
         hasChannelBeenCreated = true;
         return channel;
     }

--- a/modules/dcache/src/test/java/org/dcache/pool/repository/AllocatorAwareRepositoryChannelTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/repository/AllocatorAwareRepositoryChannelTest.java
@@ -2,9 +2,12 @@ package org.dcache.pool.repository;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
+
+import diskCacheV111.util.PnfsId;
 
 import static org.mockito.Mockito.*;
 import static org.dcache.pool.repository.AllocatorAwareRepositoryChannel.SPACE_INC;
@@ -13,16 +16,20 @@ import static org.dcache.pool.repository.AllocatorAwareRepositoryChannel.SPACE_I
  *
  */
 public class AllocatorAwareRepositoryChannelTest {
+    private static final PnfsId ID = new PnfsId("000000000000000000000000000000000000");
 
     private RepositoryChannel inner;
     private AllocatorAwareRepositoryChannel allocatorChannel;
     private Allocator allocator;
+    private Repository repository;
 
     @Before
     public void setUp() throws IOException {
         inner = mock(RepositoryChannel.class);
         allocator = mock(Allocator.class);
-        allocatorChannel = new AllocatorAwareRepositoryChannel(inner, allocator);
+        repository = mock(Repository.class);
+        allocatorChannel = new AllocatorAwareRepositoryChannel(inner, repository,
+                ID, allocator);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Java NIO2 Channel contract states that if a thread undergoing IO is
interrupted then that channel is closed when that thread returns.

The dCache pool works by wrapping the RepositoryChannel with various
layered functionality.  One such layer involves updating the pool
capacity information as the client writes data: the
AllocatorAwareRepositoryChannel.  This object is stateful and reconciles
any discrepency when the channel is explicitly closed.

The largest discrepency comes when a file is uploaded with known size
only to be cancelled.  The incoming file's size is pre-allocated,
reducing the pools capacity.  Should the upload be cancelled, the
AllocatorAwareRepositoryChannel will release the unused capacity when
close is called.

Currently, the AllocatorAwareRepositoryChannel is written assuming the
underlying channel is not closed.  However, if the mover is interrupted
while writing to the local filesystem, this cannot be true.  The result
is the AllocatorAwareRepositoryChannel#close method does not release the
unused capacity and the pool appears to shrink by the corresponding
amount.  Over several failed uploads, this loss may be significant,
requiring a pool restart to recover.

Modification:

Inject the Repository into the AllocatorAwareRepositoryChannel.  This
allows the close method to use a fall-back: should the RepositoryChannel
be already closed, AllocatorAwareRepositoryChannel can discover the
uploaded replica's size by querying the repository.

Result:

Pool will no longer loose capacity when an upload with known size (e.g.,
HTTP, HTTP-TPC, FTP) fails under certain circumstances.  In particular,
HTTP-TPC is particularly prone to this failure mode.

Target: master
Patch: https://rb.dcache.org/r/12393/
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Fixes: #5059
Fixes: #4311
Acked-by: Tigran Mkrtchyan
Acked-by: Albert Rossi