### PR TITLE
dcache-xrootd: cancel TPC transfer when client disconnects unexpected…

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -181,6 +181,10 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         /* close leftover descriptors */
         for (FileDescriptor descriptor : _descriptors) {
             if (descriptor != null) {
+                if (descriptor instanceof TpcWriteDescriptor) {
+                    ((TpcWriteDescriptor)descriptor).shutDown();
+                }
+
                 if (descriptor.isPersistOnSuccessfulClose()) {
                     descriptor.getChannel().release(new FileCorruptedCacheException(
                             "File was opened with Persist On Successful Close and not closed."));

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -361,6 +361,10 @@ public final class TpcWriteDescriptor extends WriteDescriptor
             return;
         }
 
-        client.shutDown(ctx);
+        try {
+            client.shutDown(ctx);
+        } catch (InterruptedException e) {
+            LOGGER.debug("shutDown of tpc client interrupted.");
+        }
     }
 }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -59,8 +59,11 @@ documents or software obtained from this server.
  */
 package org.dcache.xrootd.tpc;
 
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.nio.NioEventLoopGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,10 +94,7 @@ import org.dcache.xrootd.util.ByteBuffersProvider;
 import org.dcache.xrootd.util.FileStatus;
 import org.dcache.xrootd.util.ParseException;
 
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ArgInvalid;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_IOError;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ok;
+import static org.dcache.xrootd.protocol.XrootdProtocol.*;
 
 /**
  * <p>An extension of the WriteDescriptor allowing for delayed response to
@@ -333,5 +333,34 @@ public final class TpcWriteDescriptor extends WriteDescriptor
                     throws IOException
     {
         write((ByteBuffersProvider)inboundReadResponse);
+    }
+
+    public void shutDown()
+    {
+        if (client == null) {
+            return;
+        }
+
+        ChannelFuture future = client.getChannelFuture();
+        if (future == null) {
+            return;
+        }
+
+        Channel channel = future.channel();
+        if (channel == null) {
+            return;
+        }
+
+        ChannelPipeline pipeline = channel.pipeline();
+        if (pipeline == null) {
+            return;
+        }
+
+        ChannelHandlerContext ctx = pipeline.lastContext();
+        if (ctx == null) {
+            return;
+        }
+
+        client.shutDown(ctx);
     }
 }


### PR DESCRIPTION
…ly from pool

Motivation:

See https://github.com/dCache/xrootd4j/issues/9

29 Mar 2019 11:38:58 (dmsdca19-1) [] Uncaught exception in thread xrootd-tpc-client-1
java.lang.IllegalStateException: ChecksumChannel must not be written to after getChecksums

While the cause of the original two-party example
is still not understood, I have not noticed it on our systems
since 2018.   The TPC error, however, occurs sporadically on
our WLCG-DOMA-TPC test stand.

Modfication:

The third-party version appears to be provoked by a premature
disconnect after timeout by the client connected to the pool.
The disconnect on the channel provokes the finalization
of the checksum, but a write from the TPC client is
still in flight and is attempted thereafter, since
the client still carries a handle to the mover channel.

The fix is simply to shutdown the TPC client first when
the pool netty channel goes inactive.

Result:

The ChecksumChannel error is no longer observed for TPC.

Target:  master
Request: 6.1
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Patch: https://rb.dcache.org/r/12391
Closes: dCache/xrootd4j/issues/9
Acked-by: Dmitry
Acked-by: Lea