### PR TITLE
pool: clear mover thread's interrupted state before returning to pool

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2015 - 2017 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2015 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -197,6 +197,8 @@ public abstract class AbstractMoverProtocolTransferService
         }
 
         private synchronized void cleanThread() {
+            // clear the interrupted status in case that mover thread was interrupted by timeout manager
+            _thread.interrupted();
             _thread = null;
         }
 


### PR DESCRIPTION
Motivation:
When a legacy mover is killed by job timeout manager thread interruption
mechanism is used. As mover thread is taken from a thread pool, the next
task might see this interrupted state, if not cleared. This state can be
checked bu other components and trigger false errors:

04 Jun 2020 18:17:55 (xxxx) [] Pool: xxxx, fault occurred in
repository: Internal repository error. Pool restart required: , cause:
CacheException(rc=204;msg=Meta data update failed and a pool restart is
required: (JE 7.3.7) Environment must be closed, caused by:
com.sleepycat.je.ThreadInterruptedException: Environment invalid because of
previous exception: (JE 7.3.7) /dcache/pool/meta
java.lang.InterruptedException THREAD_INTERRUPTED: InterruptedException may
cause incorrect internal state, unable to continue. Environment is invalid
and must be closed.)

Modification:
reset thread interrupt state when a legacy mover is about to return the thread
into the thread pool.

Result:
Pool is not disabled itself after slow running mover is killed by jtm.

Ticket: #9968
Acked-by: Dmitry Litvintsev
Target: master, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit 0132c7aca4f552acee3fd64f4494cfcbc35798ad)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>