### PR TITLE
pinmanager: use PoolManagerStub when talking to pool manager

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
@@ -36,6 +36,7 @@ import org.dcache.cells.CellStub;
 import org.dcache.cells.MessageReply;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.pinmanager.model.Pin;
+import org.dcache.poolmanager.PoolManagerStub;
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.poolmanager.PoolSelector;
 import org.dcache.poolmanager.SelectedPool;
@@ -97,7 +98,7 @@ public class PinRequestProcessor
     private PinDao _dao;
     private CellStub _poolStub;
     private CellStub _pnfsStub;
-    private CellStub _poolManagerStub;
+    private PoolManagerStub _poolManagerStub;
     private CheckStagePermission _checkStagePermission;
     private long _maxLifetime;
     private TimeUnit _maxLifetimeUnit;
@@ -135,7 +136,7 @@ public class PinRequestProcessor
     }
 
     @Required
-    public void setPoolManagerStub(CellStub stub)
+    public void setPoolManagerStub(PoolManagerStub stub)
     {
         _poolManagerStub = stub;
     }
@@ -345,7 +346,7 @@ public class PinRequestProcessor
                                          task.getReadPoolSelectionContext(),
                                          checkStaging(task));
         msg.setSubject(task.getSubject());
-        CellStub.addCallback(_poolManagerStub.send(msg),
+        CellStub.addCallback(_poolManagerStub.sendAsync(msg),
                              new AbstractMessageCallback<PoolMgrSelectReadPoolMsg>()
                              {
                                  @Override
@@ -523,7 +524,7 @@ public class PinRequestProcessor
     private Date getExpirationTimeForPoolSelection()
     {
         long now = System.currentTimeMillis();
-        long timeout = _poolManagerStub.getTimeoutInMillis();
+        long timeout = _poolManagerStub.getPoolManagerTimeoutInMillis();
         return new Date(now + 2 * (timeout + RETRY_DELAY));
     }
 

--- a/modules/dcache/src/main/java/org/dcache/poolmanager/PoolManagerStub.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/PoolManagerStub.java
@@ -91,6 +91,13 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
     }
 
     /**
+     * Returns the communication timeout with Pool Manager in milliseconds.
+     */
+    public long getPoolManagerTimeoutInMillis() {
+        return maxPoolManagerTimeoutUnit.toMillis(maxPoolManagerTimeout);
+    }
+
+    /**
      * Sets a maximum timeout for pool requests.
      *
      * <p>If {@link PoolManagerStub#startAsync(CellAddressCore, PoolIoFileMessage, long)} is
@@ -106,6 +113,13 @@ public class PoolManagerStub implements CellMessageSender, CellIdentityAware
     public void setMaximumPoolTimeoutUnit(TimeUnit unit)
     {
         maxPoolTimeoutUnit = unit;
+    }
+
+    /**
+     * Returns the communication timeout with Pool in milliseconds.
+     */
+    public long getPoolTimeoutInMillis() {
+        return maxPoolTimeoutUnit.toMillis(maxPoolTimeout);
     }
 
     /**

--- a/modules/dcache/src/main/resources/org/dcache/pinmanager/pinmanager.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pinmanager/pinmanager.xml
@@ -60,9 +60,21 @@
       <property name="serviceName" value="${pinmanager.cell.service}"/>
   </bean>
 
+  <bean id="pool-manager-handler" class="org.dcache.poolmanager.PoolManagerHandlerSubscriber">
+      <description>Pool manager client</description>
+      <property name="poolManager" ref="pool-manager-stub"/>
+  </bean>
   <bean id="pin-processor" class="org.dcache.pinmanager.PinRequestProcessor">
       <description>Processes pin requests</description>
-      <property name="poolManagerStub" ref="pool-manager-stub"/>
+      <property name="poolManagerStub">
+          <bean class="org.dcache.poolmanager.PoolManagerStub">
+              <property name="handler" ref="pool-manager-handler"/>
+              <property name="maximumPoolManagerTimeout" value="${pinmanager.service.poolmanager.timeout}"/>
+              <property name="maximumPoolManagerTimeoutUnit" value="${pinmanager.service.poolmanager.timeout.unit}"/>
+              <property name="maximumPoolTimeout" value="${pinmanager.service.pool.timeout}"/>
+              <property name="maximumPoolTimeoutUnit" value="${pinmanager.service.pool.timeout.unit}"/>
+          </bean>
+      </property>
       <property name="poolStub" ref="pool-stub"/>
       <property name="pnfsStub" ref="pnfs-stub"/>
       <property name="dao" ref="dao"/>


### PR DESCRIPTION
Motivation:
In HA setup when multiple PoolManagers are running the PinManager must
use PoolManagerStub in a combination of PoolManagerHandler to make use
of RendezvousPoolManagerHandler, that will send all state/p2p requests
to the same instance of PoolManager, if possible.

Modification:
update PinRequestProcessor to use PoolManagerStub instead of CellStub.
Update pinmanager.xml to inject PoolManagerStub and PoolManagerHandler.
Update PinManagerTests to match code changes.

Result:
PinManager uses RendezvousPoolManagerHandler when multiple PoolManagers
configured.

Ticket: #9966
Acked-by: Albert Rossi
Acked-by: Paul Millar
Target: master, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit 465f6cb4f1930777cec7934e90adfcc20d5760a0)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>