### PR TITLE
pool: clean interrupted state after mover complete (again)

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
+import java.io.InterruptedIOException;
 import java.io.SyncFailedException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.channels.ClosedChannelException;
@@ -178,9 +179,15 @@ public abstract class AbstractMoverProtocolTransferService
             }
         }
 
-        private void runMover(RepositoryChannel fileIoChannel) throws Exception
-        {
-            _mover.getMover().runIO(_mover.getFileAttributes(), fileIoChannel, _mover.getProtocolInfo(), _mover.getIoMode());
+        private void runMover(RepositoryChannel fileIoChannel) throws Exception {
+            try {
+                _mover.getMover().runIO(_mover.getFileAttributes(), fileIoChannel, _mover.getProtocolInfo(), _mover.getIoMode());
+            } finally {
+                // if mover was interrupted outside of any blocking IO operation or a wait/sleep/join ... calls
+                if (Thread.interrupted()) {
+                    throw new InterruptedException("Mover thread was interrupted.");
+                }
+            }
         }
 
         private synchronized void setThread() throws InterruptedException {
@@ -191,8 +198,6 @@ public abstract class AbstractMoverProtocolTransferService
         }
 
         private synchronized void cleanThread() {
-            // clear the interrupted status in case that mover thread was interrupted by timeout manager
-            _thread.interrupted();
             _thread = null;
         }
 

--- a/modules/dcache/src/test/java/org/dcache/pool/classic/AbstractMoverProtocolTransferServiceTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/classic/AbstractMoverProtocolTransferServiceTest.java
@@ -1,0 +1,235 @@
+package org.dcache.pool.classic;
+
+import diskCacheV111.vehicles.ProtocolInfo;
+import org.dcache.pool.movers.MoverProtocol;
+import org.dcache.pool.movers.MoverProtocolMover;
+import org.dcache.pool.repository.ForwardingRepositoryChannel;
+import org.dcache.pool.repository.RepositoryChannel;
+import org.dcache.vehicles.FileAttributes;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.nio.channels.CompletionHandler;
+import java.nio.file.OpenOption;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertFalse;
+
+public class AbstractMoverProtocolTransferServiceTest {
+
+    private AbstractMoverProtocolTransferService transferService;
+    private InterruptAwareRepositoryChannel channel;
+    private MoverProtocolMover moverProtocolMover;
+
+    @Before
+    public void setUp() throws Exception {
+        channel = new InterruptAwareRepositoryChannel();
+        moverProtocolMover = mock(MoverProtocolMover.class);
+        when(moverProtocolMover.openChannel()).thenReturn(channel);
+
+        transferService = new AbstractMoverProtocolTransferService() {
+            @Override
+            protected MoverProtocol createMoverProtocol(ProtocolInfo info) throws Exception {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void testMoverInterruption() throws Exception {
+
+        BlockingCompletionHandler completionHandler = new BlockingCompletionHandler();
+
+        when(moverProtocolMover.getMover()).thenReturn(new ThreadInterruptingMover());
+
+        transferService.executeMover(moverProtocolMover, completionHandler);
+        completionHandler.await();
+        assertFalse("Interrupted thread passed to RepositoryChannel", channel.isInterrupted());
+        assertTrue("Exception is not propagated", completionHandler.getThrowable().isPresent());
+    }
+
+    @Test
+    public void testMoverThrowingInterrupedException() throws Exception {
+
+        BlockingCompletionHandler completionHandler = new BlockingCompletionHandler();
+        when(moverProtocolMover.getMover()).thenReturn(new InterruptedThrowingMover());
+
+        transferService.executeMover(moverProtocolMover, completionHandler);
+        completionHandler.await();
+        assertFalse("Interrupted thread passed to RepositoryChannel", channel.isInterrupted());
+        assertTrue("Exception is not propagated", completionHandler.getThrowable().isPresent());
+    }
+
+    @Test
+    public void testMoverThrowingInterrupedIOException() throws Exception {
+
+        BlockingCompletionHandler completionHandler = new BlockingCompletionHandler();
+        when(moverProtocolMover.getMover()).thenReturn(new InterruptedIOThrowingMover());
+
+        transferService.executeMover(moverProtocolMover, completionHandler);
+        completionHandler.await();
+        assertFalse("Interrupted thread passed to RepositoryChannel", channel.isInterrupted());
+        assertTrue("Exception is not propagated", completionHandler.getThrowable().isPresent());
+    }
+
+    @Test
+    public void testMoverCancel() throws Exception {
+
+        BlockingCompletionHandler completionHandler = new BlockingCompletionHandler();
+
+        when(moverProtocolMover.getMover()).thenReturn(new ThreadBlockingMover());
+
+        transferService.executeMover(moverProtocolMover, completionHandler).cancel("bang-bang!");
+        completionHandler.await();
+
+        assertFalse("Interrupted thread passed to RepositoryChannel", channel.isInterrupted());
+        assertTrue("Exception is not propagated", completionHandler.getThrowable().isPresent());
+    }
+
+
+    private static class InterruptAwareRepositoryChannel extends ForwardingRepositoryChannel {
+
+        private volatile boolean isInterrupted;
+        private final RepositoryChannel inner = mock(RepositoryChannel.class);
+
+        @Override
+        protected RepositoryChannel delegate() {
+            return inner;
+        }
+
+        @Override
+        public void close() throws IOException {
+            isInterrupted = Thread.currentThread().isInterrupted();
+        }
+
+        public boolean isInterrupted() {
+            return isInterrupted;
+        }
+    }
+
+    private static class ThreadInterruptingMover implements MoverProtocol {
+
+        @Override
+        public void runIO(FileAttributes fileAttributes, RepositoryChannel diskFile, ProtocolInfo protocol, Set<? extends OpenOption> access) throws Exception {
+            Thread.currentThread().interrupt();
+        }
+
+        @Override
+        public long getBytesTransferred() {
+            return 0;
+        }
+
+        @Override
+        public long getTransferTime() {
+            return 0;
+        }
+
+        @Override
+        public long getLastTransferred() {
+            return 0;
+        }
+    }
+
+    private static class InterruptedIOThrowingMover implements MoverProtocol {
+
+        @Override
+        public void runIO(FileAttributes fileAttributes, RepositoryChannel diskFile, ProtocolInfo protocol, Set<? extends OpenOption> access) throws Exception {
+            // IO is interrupted, flag is set and  InterruptedIOException is thrown
+            Thread.currentThread().interrupt();
+            throw new InterruptedIOException();
+        }
+
+        @Override
+        public long getBytesTransferred() {
+            return 0;
+        }
+
+        @Override
+        public long getTransferTime() {
+            return 0;
+        }
+
+        @Override
+        public long getLastTransferred() {
+            return 0;
+        }
+    }
+
+    private static class InterruptedThrowingMover implements MoverProtocol {
+
+        @Override
+        public void runIO(FileAttributes fileAttributes, RepositoryChannel diskFile, ProtocolInfo protocol, Set<? extends OpenOption> access) throws Exception {
+            throw new InterruptedException();
+        }
+
+        @Override
+        public long getBytesTransferred() {
+            return 0;
+        }
+
+        @Override
+        public long getTransferTime() {
+            return 0;
+        }
+
+        @Override
+        public long getLastTransferred() {
+            return 0;
+        }
+    }
+
+    private static class ThreadBlockingMover implements MoverProtocol {
+
+        @Override
+        public void runIO(FileAttributes fileAttributes, RepositoryChannel diskFile, ProtocolInfo protocol, Set<? extends OpenOption> access) throws Exception {
+            Thread.sleep(5000);
+        }
+
+        @Override
+        public long getBytesTransferred() {
+            return 0;
+        }
+
+        @Override
+        public long getTransferTime() {
+            return 0;
+        }
+
+        @Override
+        public long getLastTransferred() {
+            return 0;
+        }
+    }
+
+    private static class BlockingCompletionHandler implements CompletionHandler<Void, Void> {
+        private final CountDownLatch countDownLatch = new CountDownLatch(1);
+        private volatile Throwable t;
+
+        @Override
+        public void completed(Void result, Void attachment) {
+            countDownLatch.countDown();
+        }
+
+        @Override
+        public void failed(Throwable exc, Void attachment) {
+            t = exc;
+            countDownLatch.countDown();
+        }
+
+        public void await() throws InterruptedException {
+            countDownLatch.await();
+        }
+
+        public Optional<Throwable> getThrowable() {
+            return Optional.ofNullable(t);
+        }
+    }
+
+}


### PR DESCRIPTION
Motivation:
The commit 0132c7aca4  added clean of thread's interrupted state after
mover complete, however that cleanup was happening much after
interrupted thread accesses pool repository.

Modification:
clean interrupted state cleanup right after mover execution is complete.
Note, that we don't need that when InterruptedException is catch as
interrupted state is not set in that case.

added unit tests for various  mover interruption scenarios.

Result:
Yes another false repository error is fixed.

Ticket: #9968
Acked-by: Paul Millar
Acked-by: Albert Rossi
Target: master, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit be5de06f6b803bb0f64ee98e811e44eb39b015a8)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>