### PR TITLE
dcache-xrootd: bump to xrootd4j 3.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>3.5.6</version.xrootd4j>
+        <version.xrootd4j>3.5.7</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.1</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>


### PR DESCRIPTION
bump to xrootd4j 3.5.7

The upgrade includes:

2e756bd7dadf26c382344f9cc55fef9945ba8ede loosen yet again username validation https://rb.dcache.org/r/12390/
83e87edbe1956760b16f266f9e0c625d75eff07c loosen validation of username 'pid' https://rb.dcache.org/r/12378/
f18a83791e08301e6075753dacd806214c71ff8d remove kXR_auth from signed hash compatible https://rb.dcache.org/r/12330/

for dCache releases:

v4.0.1 => v4.0.3
v3.5.6 => v3.5.7
v3.4.6 => v3.4.7

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Request: 5.1
Request: 5.0
Acked-by: Lea
Patch: https://rb.dcache.org/r/12419/