### PR TITLE
common: fix LoAPrincipal deserialisation

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/LoA.java
+++ b/modules/common/src/main/java/org/dcache/auth/LoA.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2015-2019 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2015-2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -120,6 +120,13 @@ public enum LoA
      * of generalisation</a>.
      */
     IGTF_LOA_CEDAR("IGTF:CEDAR"),
+
+    /**
+     * DO NOT USE.  This is an incorrect label.  It is included here only for
+     * backwards compatibility when deserializing LoA; for example, within
+     * an LoAPrincipal.
+     */
+    IGTF_LOA_CEDER("IGTF:CEDER"),
 
     /**
      * The IGTF DOGWOOD LoA profile.  This is derived from {@link #IGTF_AP_IOTA}.

--- a/modules/common/src/main/java/org/dcache/auth/LoAPrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/LoAPrincipal.java
@@ -58,4 +58,22 @@ public class LoAPrincipal implements Principal, Serializable
     {
         return getClass().getSimpleName() + '[' + getName() + ']';
     }
+
+    private Object readResolve()
+    {
+        if (_loa == LoA.IGTF_LOA_CEDER) {
+            return new LoAPrincipal(LoA.IGTF_LOA_CEDAR);
+        }
+
+        return this;
+    }
+
+    private Object writeReplace()
+    {
+        if (_loa == LoA.IGTF_LOA_CEDER) {
+            return new LoAPrincipal(LoA.IGTF_LOA_CEDAR);
+        }
+
+        return this;
+    }
 }

--- a/modules/common/src/test/java/org/dcache/auth/LoAPrincipalTest.java
+++ b/modules/common/src/test/java/org/dcache/auth/LoAPrincipalTest.java
@@ -1,0 +1,149 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2020 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.auth;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Base64;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.*;
+
+public class LoAPrincipalTest
+{
+    /** Base64 encoded serialisation of LoAPrincipal(LoA.IGTF_LOA_CEDER). */
+    private static final String SERIALIZED_IGTF_LOA_CEDER =
+            "rO0ABXNyABxvcmcuZGNhY2hlLmF1dGguTG9BUHJpbmNpcGFsAAAAAAAAAAECAAFM"
+            + "AARfbG9hdAAVTG9yZy9kY2FjaGUvYXV0aC9Mb0E7eHB+cgATb3JnLmRjYWNoZS"
+            + "5hdXRoLkxvQQAAAAAAAAAAEgAAeHIADmphdmEubGFuZy5FbnVtAAAAAAAAAAAS"
+            + "AAB4cHQADklHVEZfTE9BX0NFREVS";
+
+    /** Base64 encoded serialisation of LoAPrincipal(LoA.IGTF_LOA_CEDAR). */
+    private static final String SERIALIZED_IGTF_LOA_CEDAR =
+            "rO0ABXNyABxvcmcuZGNhY2hlLmF1dGguTG9BUHJpbmNpcGFsAAAAAAAAAAECAAFM"
+            + "AARfbG9hdAAVTG9yZy9kY2FjaGUvYXV0aC9Mb0E7eHB+cgATb3JnLmRjYWNoZS"
+            + "5hdXRoLkxvQQAAAAAAAAAAEgAAeHIADmphdmEubGFuZy5FbnVtAAAAAAAAAAAS"
+            + "AAB4cHQADklHVEZfTE9BX0NFREFS";
+
+    private byte[] serialise(Object target) throws IOException
+    {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(bytes);
+        out.writeObject(target);
+        out.close();
+        return bytes.toByteArray();
+    }
+
+    private <T> T deserialise(byte[] data, Class<T> expectedType)
+            throws IOException, ClassNotFoundException
+    {
+        ByteArrayInputStream bytes = new ByteArrayInputStream(data);
+        ObjectInputStream in = new ObjectInputStream(bytes);
+        Object rawObject = in.readObject();
+        return expectedType.cast(rawObject);
+    }
+
+    private String serialiseToString(Object target) throws IOException
+    {
+        byte[] data = serialise(target);
+        return Base64.getEncoder().withoutPadding().encodeToString(data);
+    }
+
+    private <T> T deserialiseFromString(String data, Class<T> expectedType)
+            throws IOException, ClassNotFoundException
+    {
+        byte[] rawData = Base64.getDecoder().decode(data);
+        return deserialise(rawData, expectedType);
+    }
+
+    private LoAPrincipal serialiseRoundTrip(LoAPrincipal in) throws IOException, ClassNotFoundException
+    {
+        byte[] data = serialise(in);
+        return deserialise(data, LoAPrincipal.class);
+    }
+
+    @Test
+    public void shouldRoundTripClassic() throws Exception
+    {
+        LoAPrincipal classic = new LoAPrincipal(LoA.IGTF_AP_CLASSIC);
+
+        LoAPrincipal roundTripClassic = serialiseRoundTrip(classic);
+
+        assertThat(roundTripClassic, equalTo(classic));
+    }
+
+    @Test
+    public void shouldRoundTripCedar() throws Exception
+    {
+        LoAPrincipal cedar = new LoAPrincipal(LoA.IGTF_LOA_CEDAR);
+
+        LoAPrincipal roundTripClassic = serialiseRoundTrip(cedar);
+
+        assertThat(roundTripClassic, equalTo(cedar));
+    }
+
+    @Test
+    public void shouldRoundTripCederAsCedar() throws Exception
+    {
+        LoAPrincipal ceder = new LoAPrincipal(LoA.IGTF_LOA_CEDER);
+
+        LoAPrincipal roundTrip = serialiseRoundTrip(ceder);
+
+        assertThat(roundTrip, not(equalTo(ceder)));
+        assertThat(roundTrip.getLoA(), equalTo(LoA.IGTF_LOA_CEDAR));
+    }
+
+    @Test
+    public void shouldSerialiseCedarAsCedar() throws Exception
+    {
+        String serialised = serialiseToString(new LoAPrincipal(LoA.IGTF_LOA_CEDAR));
+
+        assertThat(serialised, equalTo(SERIALIZED_IGTF_LOA_CEDAR));
+    }
+
+    @Test
+    public void shouldSerialiseCederAsCedar() throws Exception
+    {
+        String serialised = serialiseToString(new LoAPrincipal(LoA.IGTF_LOA_CEDER));
+
+        assertThat(serialised, equalTo(SERIALIZED_IGTF_LOA_CEDAR));
+    }
+
+    @Test
+    public void shouldDeserialiseCedarAsCedar() throws Exception
+    {
+        LoAPrincipal deserialisedPrincipal = deserialiseFromString(SERIALIZED_IGTF_LOA_CEDAR, LoAPrincipal.class);
+
+        assertThat(deserialisedPrincipal, equalTo(new LoAPrincipal(LoA.IGTF_LOA_CEDAR)));
+    }
+
+    @Test
+    public void shouldDeserialiseCederAsCedar() throws Exception
+    {
+        LoAPrincipal deserialisedPrincipal = deserialiseFromString(SERIALIZED_IGTF_LOA_CEDER, LoAPrincipal.class);
+
+        assertThat(deserialisedPrincipal, equalTo(new LoAPrincipal(LoA.IGTF_LOA_CEDAR)));
+    }
+}


### PR DESCRIPTION
Motivation:

Commit 08c05ea854 attempted to rename an LoA enum value that had
mistakenly been committed with the wrong name.  The commit replaced
IGTF_LOA_CEDER with IGTF_LOA_CEDAR.

Unfortunately, this commit failed to recognise that the Subject returned
from gPlazma is serialized by PersistentLoginUserManager; therefore SRM
may attempt to deserialise the "wrong" LoA enum value (IGTF_LOA_CEDER)
when the corresponding user attempts to use SRM.  As this enum no longer
exists, those users' attempts to use SRM will fail.

What is worse, PersistentLoginUserManager may serialise LoAPrincipal
objects with the new enum (IGTF_LOA_CEDAR).  This leads to a catch-22
situation, where neither the new code nor the old code works correctly.

Modification:

Reintroduce the old enum (IGTF_LOA_CEDER), to allow deserialisation to
succeed.

Update the LoAPrincipal class to have custom serialisation and
deserialisation handling.  In particular, when deserialising, any
LoAPrincipal with the wrong LoA (IGTF_LOA_CEDER) is automatically mapped
to an LoAPrincipal with the correct LoA (IGTF_LOA_CEDAR).

Although there shouldn't be any further LoAPrincipal objects created
with the wrong LoA (IGTF_LOA_CEDER), as a precaution, any LoAPrincipal
with this LoA is serialized with the correct LoA (IGTF_LOA_CEDAR).

Result:

Fix a bug where SRM complains 'enum constant IGTF_LOA_CEDER does not
exist'.

Target: master
Request: 6.1
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12406/
Acked-by: Lea Morschel