### PR TITLE
pnfsmanager: avoid NPE if file is deleted during directory listing

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
@@ -70,6 +70,9 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
                     return inode.statCache().getAccessLatency();
                 }
                 dirInode = inode.getParent();
+                if (dirInode == null) {
+                    throw new FileNotFoundCacheException("File " + inode + " has been deleted.");
+                }
             }
 
             Optional<String> accessLatency = getFirstLine(dirInode.getTag("AccessLatency"));
@@ -109,6 +112,9 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
                     return inode.statCache().getRetentionPolicy();
                 }
                 dirInode = inode.getParent();
+                if (dirInode == null) {
+                    throw new FileNotFoundCacheException("File " + inode + " has been deleted.");
+                }
             }
 
             Optional<String> retentionPolicy = getFirstLine(dirInode.getTag("RetentionPolicy"));
@@ -159,8 +165,11 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
             info =  getDirStorageInfo(inode);
             dirInode = inode;
         } else {
-            info =  getFileStorageInfo(inode);
             dirInode = inode.getParent();
+            if (dirInode == null) {
+                throw new FileNotFoundCacheException("File " + inode + " has been deleted.");
+            }
+            info =  getFileStorageInfo(inode);
         }
 
         // overwrite hsm type with hsmInstance tag


### PR DESCRIPTION
Motivation:

We have had reports of a NPE:

    25 Jun 2020 11:41:59 (PnfsManager) [...] java.lang.NullPointerException
    java.lang.NullPointerException: null
            at org.dcache.chimera.namespace.ChimeraHsmStorageInfoExtractor.getAccessLatency(ChimeraHsmStorageInfoExtractor.java:75)
            at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.getFileAttributes(ChimeraNameSpaceProvider.java:909)
            at org.dcache.chimera.namespace.ChimeraNameSpaceProvider.list(ChimeraNameSpaceProvider.java:1202)
            at diskCacheV111.namespace.ForwardingNameSpaceProvider.list(ForwardingNameSpaceProvider.java:177)
            at diskCacheV111.namespace.MonitoringNameSpaceProvider.list(MonitoringNameSpaceProvider.java:308)
            at diskCacheV111.namespace.PnfsManagerV3.listDirectory(PnfsManagerV3.java:1550)
            at diskCacheV111.namespace.PnfsManagerV3.processMessageTransactionally_aroundBody4(PnfsManagerV3.java:1736)
            at diskCacheV111.namespace.PnfsManagerV3$AjcClosure5.run(PnfsManagerV3.java:1)
            at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96cproceed(AbstractTransactionAspect.aj:66)
            at org.springframework.transaction.aspectj.AbstractTransactionAspect$AbstractTransactionAspect$1.proceedWithInvocation(AbstractTransactionAspect.aj:72)
            at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:294)
            at org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96c(AbstractTransactionAspect.aj:70)
            at diskCacheV111.namespace.PnfsManagerV3.processMessageTransactionally(PnfsManagerV3.java:1709)
            at diskCacheV111.namespace.PnfsManagerV3.processPnfsMessage(PnfsManagerV3.java:1680)
            at diskCacheV111.namespace.PnfsManagerV3$ProcessThread.run(PnfsManagerV3.java:1596)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
            at java.base/java.lang.Thread.run(Thread.java:834)

The problem is caused by phantom reads, when a file is removed after a
directory listing has started, but before all information about that
file has been gathered.

Modification:

Update ChimeraHsmStorageInfoExtractor to be aware that a file may have
no parent (because it has been unlinked) despited the cached stat
information describing the file as existing.

Result:

No NullPointerException if a file is deleted while a directory listing
is being compiled.

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Closes: #5460
Patch: https://rb.dcache.org/r/12438/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel