### PR TITLE
common: do not log bearer token values.

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/BearerTokenCredential.java
+++ b/modules/common/src/main/java/org/dcache/auth/BearerTokenCredential.java
@@ -25,6 +25,6 @@ public class BearerTokenCredential implements Serializable
     @Override
     public String toString()
     {
-        return BearerTokenCredential.class.getSimpleName() + "[bearerToken=" + _token + ']';
+        return BearerTokenCredential.class.getSimpleName();
     }
 }


### PR DESCRIPTION
Motivation:

Bearer tokens are a very convenient security concept; however, they have
the disadvantage of being easy to steal.  Therefore, security best
practice states services should not record bearer token value in log
files.

Modification:

Update BearerTokenCredential so that the token is not return in the
toString method.

Result:

dCache no longer logs OIDC access tokens or macaroon.

Target: master
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12386/
Acked-by: Albert Rossi