### PR TITLE
pool: rework interrupt processing on p2p

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
@@ -19,11 +19,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.SyncFailedException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.channels.Channels;
+import java.nio.channels.ClosedChannelException;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -319,7 +321,7 @@ class Companion
         }
     }
 
-    private Set<Checksum> copy(String uri, ReplicaDescriptor handle) throws IOException
+    private Set<Checksum> copy(String uri, ReplicaDescriptor handle) throws IOException, InterruptedException
     {
         EnumSet<ChecksumType> knownChecksumTypes = EnumSet.noneOf(ChecksumType.class);
         try {
@@ -328,7 +330,8 @@ class Companion
             _log.warn("Failed to fetch checksum information: {}", e.getMessage());
         }
 
-        try (RepositoryChannel channel = handle.createChannel()) {
+        RepositoryChannel channel = handle.createChannel();
+        try {
             HttpGet get = new HttpGet(uri);
             get.addHeader(HttpHeaders.CONNECTION, HTTP.CONN_CLOSE);
             get.setConfig(RequestConfig.custom()
@@ -373,6 +376,12 @@ class Companion
             return channel.optionallyAs(ChecksumChannel.class)
                     .map(ChecksumChannel::getChecksums)
                     .orElseThrow(() -> new IllegalStateException("Missing ChecksumChannel"));
+        } catch (ClosedChannelException | InterruptedIOException e) {
+            // clear interrupted status
+            Thread.interrupted();
+            throw new InterruptedException();
+        } finally {
+            channel.close();
         }
     }
 


### PR DESCRIPTION
Motivation:
as in commit a5e4f7adbe, the interruption of slow p2p transfers might
set thread interrupt status and falsely disable pool.

Modification:
clear interrupt status before closing the channel.

Result:
interrupted p2p transfer don't disable pool (at leas in synthetic tests)

Ticket: #9968
Acked-by: Lea Morschel
Acked-by: Albert Rossi
Target: master, 6.2, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit f17f280dfb86b2b9617bae8908b94ed99a09b5f8)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>