### PR TITLE
util: fix pgpass support for jdbc urls with options

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/Pgpass.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/Pgpass.java
@@ -58,6 +58,14 @@ public class Pgpass {
         return null;
     }
 
+    private String stripProperties(String s) {
+
+        int i = s.indexOf('?');
+        if (i != -1) {
+            return s.substring(0, i);
+        }
+        return s;
+    }
     private boolean parseUrl(String url) {
         // -jdbcUrl=jdbc:postgresql:database
         // -jdbcUrl=jdbc:postgresql://host/database
@@ -67,9 +75,9 @@ public class Pgpass {
         _port = "5432";
         if (r.length==1) {
             String[] r1 = r[0].split(":");
-            _database = r1[r1.length-1];
+            _database = stripProperties(r1[r1.length-1]);
         } else if (r.length==4) {
-            _database = r[r.length-1];
+            _database = stripProperties(r[r.length-1]);
             String[] r1 = r[2].split(":");
             _hostname = r1[0];
             if (r1.length==2) {

--- a/modules/dcache/src/test/java/diskCacheV111/util/PgpassTest.java
+++ b/modules/dcache/src/test/java/diskCacheV111/util/PgpassTest.java
@@ -7,11 +7,13 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Some tests for the {@link Pgpass} class
@@ -27,7 +29,11 @@ public class PgpassTest {
     @Before
     public void setUp() throws IOException {
         tempFile = File.createTempFile("pgpass", ".testfile");
+        Files.writeString(tempFile.toPath(), "dbhost:5432:foo:dbuser:dbpass\nlocalhost:*:foo:dbuser:dbpass2",
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE);
 
+        Files.setPosixFilePermissions(tempFile.toPath(), Set.of(PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_READ));
         pgpass = new Pgpass(tempFile.getCanonicalPath());
     }
 
@@ -48,5 +54,44 @@ public class PgpassTest {
         Files.setPosixFilePermissions(tempFile.toPath(), referencePermissions);
 
         assertNull(pgpass.getPgpass("dummy", "dummy", "dummy", "dummy"));
+    }
+
+
+    @Test
+    public void testReadingExistingRecord() {
+        String pass = pgpass.getPgpass("dbhost", "5432", "foo", "dbuser");
+        assertEquals("dbpass", pass);
+    }
+
+    @Test
+    public void testDbUrlWithoutParams() throws Exception {
+        String pass = Pgpass.getPassword(tempFile.getCanonicalPath(),
+                "jdbc:postgresql://dbhost/foo", "dbuser",
+                "");
+        assertEquals("dbpass", pass);
+    }
+
+    @Test
+    public void testDbUrlWithParams() throws Exception {
+        String pass = Pgpass.getPassword(tempFile.getCanonicalPath(),
+                "jdbc:postgresql://dbhost/foo?prepareThreshold=3&targetServerType=master", "dbuser",
+                "");
+        assertEquals("dbpass", pass);
+    }
+
+    @Test
+    public void testDbUrlWithPortAndParams() throws Exception {
+        String pass = Pgpass.getPassword(tempFile.getCanonicalPath(),
+                "jdbc:postgresql://dbhost:5432/foo?prepareThreshold=3&targetServerType=master", "dbuser",
+                "");
+        assertEquals("dbpass", pass);
+    }
+
+    @Test
+    public void testDbUrlWithoutHost() throws Exception {
+        String pass = Pgpass.getPassword(tempFile.getCanonicalPath(),
+                "jdbc:postgresql:foo", "dbuser",
+                "");
+        assertEquals("dbpass2", pass);
     }
 }


### PR DESCRIPTION
Motivation:
Pgpass class shold handle correctly jdbc urls with options as  dcache often uses them.

Modification:
fix Pgpass to correctly handle urls with options.

Acked-by: Albert Rossi
Target: master, 6.2, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit e0a3eef7e5f0849d08317869e9f4eab6ef75d0ae)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>