### PR TITLE
cleaner: add support for db password file

### DIFF
--- a/modules/dcache-chimera/src/main/resources/org/chimera/chimera-cleaner.xml
+++ b/modules/dcache-chimera/src/main/resources/org/chimera/chimera-cleaner.xml
@@ -51,10 +51,9 @@
                     <bean class="com.zaxxer.hikari.HikariConfig">
                         <property name="jdbcUrl" value="${cleaner.db.url}"/>
                         <property name="username" value="${cleaner.db.user}"/>
-                        <property name="password" value="${cleaner.db.password}"/>
+                        <property name="password" value="#{ T(diskCacheV111.util.Pgpass).getPassword('${cleaner.db.password.file}', '${cleaner.db.url}', '${cleaner.db.user}', '${cleaner.db.password}') }"/>
                         <property name="minimumIdle" value="${cleaner.db.connections.idle}"/>
                         <property name="maximumPoolSize" value="${cleaner.db.connections.max}"/>
-
                     </bean>
                 </constructor-arg>
             </bean>

--- a/skel/share/defaults/cleaner.properties
+++ b/skel/share/defaults/cleaner.properties
@@ -150,6 +150,7 @@ cleaner.service.grace-period = 0
 (immutable)cleaner.db.name=${chimera.db.name}
 (immutable)cleaner.db.user=${chimera.db.user}
 (immutable)cleaner.db.password=${chimera.db.password}
+(immutable)cleaner.db.password.file=${chimera.db.password.file}
 (immutable)cleaner.db.url=${chimera.db.url}
 cleaner.db.schema.auto=false
 


### PR DESCRIPTION
Motivation:
To get rid of db password from dcache config files all database
configurations should support password file.

Modification:
add password file support for chimera cleaner

Result:
chimera db password can be stored in a dedicated file.

Fixes: #2928
Acked-by: Lea Morschel
Acked-by: Paul Millar
Target: master, 6.2, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit 64fec26ecd86147aa991c868f8c923d6553d7150)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>