### PR TITLE
pool: do not fail transfer if RFC3230 is badly formed.

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Checksums.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Checksums.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -161,12 +162,17 @@ public class Checksums
      */
     public static Set<Checksum> decodeRfc3230(String digest)
     {
-        Map<String,String> parts = RFC3230_SPLITTER.split(nullToEmpty(digest));
+        try {
+            Map<String,String> parts = RFC3230_SPLITTER.split(nullToEmpty(digest));
 
-        Map<String,Checksum> checksums = transformEntries(parts,
-                RFC3230_TO_CHECKSUM);
+            Map<String,Checksum> checksums = transformEntries(parts,
+                    RFC3230_TO_CHECKSUM);
 
-        return checksums.values().stream().filter(Objects::nonNull).collect(Collectors.toSet());
+            return checksums.values().stream().filter(Objects::nonNull).collect(Collectors.toSet());
+        } catch (IllegalArgumentException e) {
+            _log.warn("Bad RFC3230 Digest value \"{}\": {}", digest, e.getMessage());
+            return Collections.emptySet();
+        }
     }
 
     /**


### PR DESCRIPTION
Motivation:

Observed HTTP-TPC transfers failing with the following stack-trace:

    23 Jul 2020 23:20:41 (pool2) [door:webdav-secure-grid@dCacheDomain:AAWrIm24BwA RemoteTransferManager PoolAcceptFile 0000FAEB1CCE2E9B45A1B016A938B086A0A6] Transfer failed due to a bug
    java.lang.IllegalArgumentException: Chunk [Adler32:be007e86] is not a valid entry
            at com.google.common.base.Preconditions.checkArgument(Preconditions.java:210)
            at com.google.common.base.Splitter$MapSplitter.split(Splitter.java:493)
            at org.dcache.util.Checksums.decodeRfc3230(Checksums.java:164)
            at org.dcache.pool.movers.RemoteHttpDataTransferProtocol.receiveFile(RemoteHttpDataTransferProtocol.java:310)
            at org.dcache.pool.movers.RemoteHttpDataTransferProtocol.runIO(RemoteHttpDataTransferProtocol.java:280)
            at org.dcache.pool.movers.RemoteHttpsDataTransferProtocol.runIO(RemoteHttpsDataTransferProtocol.java:59)
            at org.dcache.pool.classic.AbstractMoverProtocolTransferService$MoverTask.runMoverForWrite(AbstractMoverProtocolTransferService.java:204)
            at org.dcache.pool.classic.AbstractMoverProtocolTransferService$MoverTask.run(AbstractMoverProtocolTransferService.java:144)
            at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:149)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
            at java.base/java.lang.Thread.run(Thread.java:834)

The Digest header value should be 'Adler32=be007e86'.  Note the '='
instead of a ':'.

dCache should be robust against such malformed values.  In particular,
it should not log a stack-trace.  The transfer may still succeed if the
client (FTS) has indicated that checksum verification is not required.

Modification:

Catch the IAE, log it and treat the Digest value as if it were not
given.

Result:

Fix failing HTTP-TPC transfers where the remote party sends a malformed
RFC 3230 checksum value.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12488/
Acked-by: Tigran Mkrtchyan