### PR TITLE
archetype: configure maven-compiler-plugin to use java11

### DIFF
--- a/archetypes/dcache-nearline-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/dcache-nearline-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <version.dcache>${dcache}</version.dcache>
+        <java.version>11</java.version>
     </properties>
 
     <licenses>
@@ -39,6 +40,18 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <showDeprecation>true</showDeprecation>
+                    <release>${java.version}</release>
+                    <!-- without forking compilation happens in the
+                    same process, so no arguments are applied -->
+                    <fork>true</fork>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
Motivation:
The test project built with dcache-nearline-plugin-archetype should
use up-to-date maven-compiler-plugin as well as java11

Modification:
update archetype to enforce java11 and latest version of
maven-compiler-plugin for newly generated project.

Result:
it's possible to build and install dcache-nearline-plugin-archetype

Acked-by: Albert Rossi
Target: master, 6.2
Require-book: no
Require-notes: no
(cherry picked from commit 16c6cb46b17b342303a29e1bae45a8c83ad441c3)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>