### PR TITLE
systemd: add option to enforce systemd

### DIFF
--- a/docs/TheBook/src/main/markdown/install.md
+++ b/docs/TheBook/src/main/markdown/install.md
@@ -793,6 +793,14 @@ possible to configure pools so they are limited.
 Finally, dCache can be started now.
 
 There are two ways to start dCache. These are as a classic `sysV` -like daemon or as a  `systemd` service.
+The latter one is preferred and enforced by default when the hosts operating system supports it. To change this
+be behavior set
+
+```
+dcache.systemd.strict=false
+```
+
+in *dcache.conf* or in the *layout* file.
 
 #### Using sysV -like daemon
 

--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -206,11 +206,20 @@ deprecationWarning()
     if [ -x /usr/bin/systemctl ]; then
         script="$(printCanonicalPath $0)"
         if [ $script = "/usr/bin/dcache" ]; then
-            echo ""
-            echo "WARNING:"
-            echo "  \"`basename $0` $1\" is deprecated and will be removed in the future."
-            echo "   Please consider switching to systemctl to manage dCache."
-            echo ""
+            strict="$(getProperty dcache.systemd.strict)"
+            if [ $strict = "true" ]; then
+              echo ""
+              echo "The dCache is managed by systemd."
+              echo "Please use 'systemctl' instead."
+              echo ""
+              exit 1
+            else
+              echo ""
+              echo "WARNING:"
+              echo "  \"`basename $0` $1\" is deprecated and will be removed in the future."
+              echo "   Please consider switching to systemctl to manage dCache."
+              echo ""
+            fi
         fi
     fi
 }

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1400,3 +1400,10 @@ dcache.xrootd.security.force-signing=false
 (one-of?ONLINE|NEARLINE)dcache.default-access-latency=NEARLINE
 (one-of?CUSTODIAL|REPLICA|OUTPUT)dcache.default-retention-policy=CUSTODIAL
 dcache.plugins.storage-info-extractor = org.dcache.chimera.namespace.ChimeraOsmStorageInfoExtractor
+
+#
+# Allow legacy `dcache start/stop/status` on systemd capable systems.
+#
+# Set this option to false if use of sysV-like scripts should be allowed
+#
+(not-for-services,one-of?true|false)dcache.systemd.strict=true


### PR DESCRIPTION
Motivation:
based on feedback from admins, systemd enabled systems should not allow
use of sysV-like scripts in parallel their combination makes dcache
start/stop/status behavior unpredictable.

Modification:
Add `dcache.systemd.strict` options, defaults to `true` to forse use of
systemctl on systemd capable platforms.

Result:
clear policy on use of systemd and sysV-like startup scripts

Acked-by: Lea Morschel
Target: master, 6.2
Require-book: yes
Require-notes: yes
(cherry picked from commit 55a855c5d598b324f1fc8e437dbf04dffe78bdb1)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>