### PR TITLE
rpm: make dcache package depend on java-11

### DIFF
--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -14,7 +14,7 @@ Requires(preun): chkconfig
 # This is for /sbin/service
 Requires(preun): initscripts
 Requires: which
-Requires: java
+Requires: java-11
 
 License: Distributable
 Group: Applications/System


### PR DESCRIPTION
Motivation:
the `Requires: java` in the spec creates a dependency on java8.

Modification:
make package depend on java-11

Result:
no dependency on java-8

Acked-by: Lea Morschel
Acked-by: Albert Rossi
Target: master, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 12da1f5c310751983a0ed6af2b778611537f1b62)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>