### PR TITLE
macaroons: verifyCaveat should return false for unprocessed caveats

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/macaroons/ContextExtractingCaveatVerifier.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/ContextExtractingCaveatVerifier.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2017 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -42,16 +42,16 @@ public class ContextExtractingCaveatVerifier implements GeneralCaveatVerifier
     {
         try {
             Caveat caveat = new Caveat(serialised);
-            acceptCaveat(caveat);
-            haveCaveats = true;
-            return true;
+            boolean accepted = acceptCaveat(caveat);
+            haveCaveats |= accepted;
+            return accepted;
         } catch (InvalidCaveatException e) {
             error = e.getMessage() + ": " + serialised;
             return false;
         }
     }
 
-    private void acceptCaveat(Caveat caveat) throws InvalidCaveatException
+    private boolean acceptCaveat(Caveat caveat) throws InvalidCaveatException
     {
         String value = caveat.getValue();
 
@@ -102,7 +102,12 @@ public class ContextExtractingCaveatVerifier implements GeneralCaveatVerifier
             checkCaveat(!haveCaveats, "%s not first caveat", CaveatType.ISSUE_ID.getLabel());
             context.updateIssueId(value);
             break;
+
+        default:
+            return false;
         }
+
+        return true;
     }
 
     public MacaroonContext getContext()

--- a/modules/dcache/src/test/java/org/dcache/macaroons/ContextExtractingCaveatVerifierTest.java
+++ b/modules/dcache/src/test/java/org/dcache/macaroons/ContextExtractingCaveatVerifierTest.java
@@ -1,0 +1,50 @@
+package org.dcache.macaroons;
+
+import com.github.nitram509.jmacaroons.Macaroon;
+import com.github.nitram509.jmacaroons.MacaroonsBuilder;
+import com.github.nitram509.jmacaroons.MacaroonsVerifier;
+import com.google.common.net.InetAddresses;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class ContextExtractingCaveatVerifierTest {
+
+    private ContextExtractingCaveatVerifier contextCaveatVerifier;
+
+    @Before
+    public void setUp() {
+        contextCaveatVerifier = new ContextExtractingCaveatVerifier();
+    }
+
+    @Test
+    public void testUnsupportedCaveat() {
+        assertFalse(contextCaveatVerifier.verifyCaveat("ip:127.0.0.1"));
+    }
+
+    @Test
+    public void testMacaroonWithManyCaveat() {
+
+        String location = "https://dcache.org";
+        String secretKey = "tiramisu is better!";
+        String identifier = "junit";
+
+        Macaroon macaroon = new MacaroonsBuilder(location, secretKey, identifier)
+                .add_first_party_caveat(
+                        "ip:192.168.1.1/24"
+                )
+                .add_first_party_caveat(
+                        "before:2047-08-05T00:00:00.00Z"
+                )
+                .getMacaroon();
+
+        MacaroonsVerifier verifier = new MacaroonsVerifier(macaroon);
+
+        ClientIPCaveatVerifier clientIPVerifier = new ClientIPCaveatVerifier(InetAddresses.forString("192.168.2.1"));
+        verifier.satisfyGeneral(clientIPVerifier);
+        verifier.satisfyGeneral(contextCaveatVerifier);
+
+        assertFalse("IP address from not allowed range accepted", verifier.isValid(secretKey));
+    }
+}


### PR DESCRIPTION
Motivation:
when a valid, but unhandled caveat is process by
ContextExtractingCaveatVerifier#verifyCaveat, it should return false as
an indication that validation is not done.

Modofication:
update ContextExtractingCaveatVerifier#acceptCaveat to return true if and only if
when caveat is recognized and processed,

Result:
valid, but ignored caveats are not marked as verified.

Ticket: #9994
Acked-by: Albert Rossi
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit f9ec002012398ed7bc2de1ef075006fd3eb4753c)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>