### PR TITLE
pool: fix issue #5491 NoSuchFileException

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/CacheEntryImpl.java
@@ -26,13 +26,14 @@ public class CacheEntryImpl implements CacheEntry
     public CacheEntryImpl(ReplicaRecord entry) throws CacheException
     {
         synchronized (entry) {
-            _size = entry.getReplicaSize();
+            _state = entry.getState();
+            //when status is NEW or FROM_STORE we know that file is not on a disk and the size is 0
+            _size = _state == ReplicaState.NEW || _state == ReplicaState.FROM_STORE ? 0 : entry.getReplicaSize();
             _created_at = entry.getCreationTime();
             _accessed_at = entry.getLastAccessTime();
             _linkCount = entry.getLinkCount();
             _isSticky = entry.isSticky();
             _sticky = entry.stickyRecords();
-            _state = entry.getState();
             _fileAttributes = entry.getFileAttributes();
         }
     }


### PR DESCRIPTION
Pool repository attempts to read the file size from before file is staged:

 (pool_read) [door:NFS-nairi@dCacheDomain:AAWrIHzV1Ug PoolManager PoolFetchFile 00007B547338066143BE9D5E3681B4F049D5] Failed to read file size: java.nio.file.NoSuchFileException: /home/tigran/eProjects/dcache/packages/system-test/target/dcache/var/pools/pool_read/data/00007B547338066143BE9D5E3681B4F049D5

Acked-by: Lea Morschel
Target: master, 6.2
Require-book: no
Require-notes: no