### PR TITLE
dcache-resilience: avoid NPE in file operation cancel

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileOperation.java
@@ -418,7 +418,7 @@ public final class FileOperation {
 
         lastUpdate = System.currentTimeMillis();
         if (task != null) {
-            task.cancel(null);
+            task.cancel("file operation cancelled (admin)");
         }
         retried = 0;
 


### PR DESCRIPTION
Motivation:

RB #12065 (commit master@db1e28987d) added a message to
improve understanding of why a migration task was cancelled.

It also enforced the non-null presence of this message:

```
 _cancelReason = Optional.of(why);
```

If why is null, this throws an NPE (instead of ofNullable(why));

While this patch altered a number of loci in Resilience to
provide the necessary string, it neglected one.

FileOperation.cancel was originally made to provide NULL
to the ResilientFileTask.cancel because the explanation
was originally optional.

See:

RB #9688 (commit master@f4e5691).

Modification:

Provide an explanation.

Result:

No NPE if FileOperation is canceled while its
sub task is running.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12505/
Closes: #5501
Acked-by: Tigran
Acked-by: Lea