### PR TITLE
dcache-resilience: protect access of pool info map against NoSuchElem…

### DIFF
--- a/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/FileOperationMapTest.java
+++ b/modules/dcache-resilience/src/test/java/org/dcache/resilience/data/FileOperationMapTest.java
@@ -330,6 +330,74 @@ public final class FileOperationMapTest extends TestBase {
         assertNotNull(fileOperationMap.getOperation(operation.getPnfsId()));
     }
 
+    @Test
+    public void shouldNotFailWhenPostProcessDiscoversRemovedPool()
+                    throws Exception {
+        givenANewPnfsId();
+        afterOperationAdded(1);
+        String source = attributes.getLocations().iterator().next();
+        afterSourceAndTargetAreUpdatedTo(source,"resilient_pool-12");
+        afterPoolIsRemoved(source);
+        whenScanIsRun();
+        whenOperationSucceedsFor(operation.getPnfsId());
+        /*
+         *  Should not throw an exception.
+         */
+        whenScanIsRun();
+        assertNull(fileOperationMap.getOperation(operation.getPnfsId()));
+    }
+
+    @Test
+    public void shouldNotFailWhenPostProcessDiscoversRemovedPoolGroup()
+        throws Exception {
+        givenANewPnfsId();
+        afterOperationAdded(1);
+        String source = attributes.getLocations().iterator().next();
+        afterSourceAndTargetAreUpdatedTo(source,"resilient_pool-12");
+        afterOperationGroupIsRemoved();
+        whenScanIsRun();
+        whenOperationSucceedsFor(operation.getPnfsId());
+        /*
+         *  Should not throw an exception.
+         */
+        whenScanIsRun();
+        assertNull(fileOperationMap.getOperation(operation.getPnfsId()));
+    }
+
+    @Test
+    public void shouldNotFailWhenPostProcessDiscoversRemovedStorageUnit()
+        throws Exception {
+        givenANewPnfsId();
+        afterOperationAdded(1);
+        afterSourceAndTargetAreUpdatedTo(attributes.getLocations().iterator().next(),
+                                  "resilient_pool-12");
+        afterOperationStorageUnitIsRemoved();
+        whenScanIsRun();
+        whenOperationSucceedsFor(operation.getPnfsId());
+        /*
+         *  Should not throw an exception.
+         */
+        whenScanIsRun();
+        assertNull(fileOperationMap.getOperation(operation.getPnfsId()));
+    }
+
+    @Test
+    public void shouldNotFailWhenOperationIsCancelledBecauseOfPoolRemoval()
+        throws Exception {
+        givenANewPnfsId();
+        afterOperationAdded(1);
+        String source = attributes.getLocations().iterator().next();
+        afterSourceAndTargetAreUpdatedTo(source,"resilient_pool-12");
+        afterPoolIsRemoved(source);
+        whenScanIsRun();
+        whenRunningOperationIsCancelled();
+        /*
+         *  Should not throw an exception.
+         */
+        whenScanIsRun();
+        assertNull(fileOperationMap.getOperation(operation.getPnfsId()));
+    }
+
     @After
     public void tearDown() {
         if (checkpoint.exists()) {
@@ -350,6 +418,20 @@ public final class FileOperationMapTest extends TestBase {
         fileOperationMap.register(update);
         operation = new FileOperation(
                         fileOperationMap.getOperation(attributes.getPnfsId()));
+    }
+
+    private void afterPoolIsRemoved(String pool) throws Exception {
+        poolInfoMap.removePool(pool);
+    }
+
+    private void afterOperationGroupIsRemoved() throws Exception {
+        String group = poolInfoMap.getGroup(operation.getPoolGroup());
+        poolInfoMap.removeUnit(group);
+    }
+
+    private void afterOperationStorageUnitIsRemoved() throws Exception {
+        String unit = poolInfoMap.getUnit(operation.getStorageUnit());
+        poolInfoMap.removeUnit(unit);
     }
 
     private void afterSourceAndTargetAreUpdatedTo(String source,

--- a/modules/dcache/src/main/java/org/dcache/util/NonReindexableList.java
+++ b/modules/dcache/src/main/java/org/dcache/util/NonReindexableList.java
@@ -104,8 +104,32 @@ import java.util.stream.Stream;
  * <p>Not thread-safe.</p>
  */
 public final class NonReindexableList<E> implements List<E> {
+    public static final int MISSING_INDEX = -1728;
+    public static final String MISSING = "missing_element";
+
+    public static int safeIndexOf(String key, NonReindexableList<String> list) {
+        try {
+            return list.indexOf(key);
+        } catch (NoSuchElementException e) {
+            return MISSING_INDEX;
+        }
+    }
+
+    public static String safeGet(int index, NonReindexableList<String> list) {
+        try {
+            if (index == MISSING_INDEX) {
+                return MISSING;
+            }
+            return list.get(index);
+        } catch (NoSuchElementException e) {
+            return MISSING;
+        }
+    }
+
     private static final String UNSUPPORTED_ERROR_MSG
                     = "This list can only be modified by appending or removing.";
+
+
 
     private final Map<E, Integer> index = new HashMap<>();
     private final Map<Integer, E> list = new HashMap<>();


### PR DESCRIPTION
…entException

Motivation:

In designing the PoolInfoMap, we created a special class, the NonReindexableList,
in order to be able to remove elements from a list without reassigning stale
index numbers.  This was so that we could update the map and not have waiting
file operations reference unexpected pools, units or groups.

This map throws a NoSuchElementException if get finds a null at an (old) index,
or if an element is not in the list.  This was to avoid having to handle
nulls.  The idea was that if the list were being accessed this way, something
was wrong (a bug).

However, recently I have discovered that there is a (non-buggy) condition which
was unaccounted for, where it is possible that operations could try to reference
stale information.  This occurs _at the point of removal_.  That is, when the
pool monitor contains information suggesting the removal of a pool from the
psu, resilience triggers a cancel on any existing operations referencing those
pools.  The code paths from cancel is such that an attempt to retrieve
those old units, pools or groups is indeed made after the write lock on the
map is released.  Depending on where it happens, stack traces such as the
following may occur.  The uncaught exception kills the file operation map
thread.

```
03 Aug 2020 14:37:37 () [] Uncaught exception in thread FileOperationMap  -- handle stale information
java.util.NoSuchElementException: p-noble-stkendca12a-10
        at org.dcache.util.NonReindexableList.indexOf(NonReindexableList.java:192)
        at org.dcache.resilience.data.PoolInfoMap.getPoolIndex(PoolInfoMap.java:412)
        at org.dcache.resilience.data.FileFilter.matchesPool(FileFilter.java:98)
        at org.dcache.resilience.data.FileCancelFilter.matchesPool(FileCancelFilter.java:79)
        at org.dcache.resilience.data.FileFilter.matches(FileFilter.java:163)
```

In some cases, an NPE may also occur if a null value is actually given to
the map.

Motivation:

To be entirely safe, we wrap all access to the three NonReindexableLists
with "safe" accessors which either return a "Missing" string name or
an index which is understood to represent a missing (former) entry.

We have also adjusted several methods not to call other methods which
would unnecessarily cause the thread to re-enter the read lock (for
efficiency).

We have also added to JUnit tests to test that no exception is thrown.

Result:

More robust handling of PSU changes which remove pool, unit or group
mappings.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12507/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran