### PR TITLE
dcache-resilience: ignore broken cached files

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -424,7 +424,7 @@ public final class FileUpdate {
          */
         if (AccessLatency.NEARLINE.equals(attributes.getAccessLatency())) {
             LOGGER.trace("validateForAction, access latency is NEARLINE, "
-                                         + "setting count for {} to 0.",
+                                         + "setting required for {} to 0.",
                          pnfsId);
             required = 0;
         }
@@ -437,8 +437,12 @@ public final class FileUpdate {
                      locations, valid, count);
 
         if (count == 0) {
-            LOGGER.debug("{}, requirements are already met.", pnfsId);
-            return false;
+            Set<String> broken =  verifier.getBroken(verified);
+            if (broken.isEmpty()) {
+                LOGGER.debug("{}, requirements are already met.", pnfsId);
+                return false;
+            }
+            count = broken.size();
         }
 
         /*


### PR DESCRIPTION
Motivation:

master@c367e9fad850e4ff83560cf11edf38fc7ded313f
https://rb.dcache.org/r/11643/

changed the way resilience handles file "removal"
(no longer setting the repository entry to 'removed'
but simply by caching the replica).

This change, however, did not take into account
the handling of broken files.  Since its inception,
resilience has always tried to handle all but the
last sticky replica that was broken by removal
and recopy.

However, when removal was changed to simple
removal of the sticky bit, the logic governing
broken files was no longer valid.  Encountering
a broken file, it would indiscriminately attempt
to remove it, whether it was cached or not;
this now leads to an infinite loop, with the
file operation continuously iterating without
doing any further work.

This situation can potentially hang the pool scans
(if there are as many broken files as there are
scan threads), and even the file operation
queue.

Modification:

The current patch repairs this situation,
maintaining the intended semantics:
upon discovery of a broken sticky replica,
it is cached, and if another replica is
required, it is made.

Result:

No longer any potential for stalled
operations when encountering broken replicas.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12513/
Acked-by: Tigran