### PR TITLE
dcache-core: fix embedded ZooKeeper persisting stale ephemeral nodes

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/zookeeper/service/ZooKeeperCell.java
+++ b/modules/dcache/src/main/java/org/dcache/zookeeper/service/ZooKeeperCell.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2015 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2015 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -116,7 +116,7 @@ public class ZooKeeperCell extends AbstractCell
         zkServer.setMinSessionTimeout(minSessionTimeout == -1 ? -1 : (int) minSessionTimeoutUnit.toMillis(minSessionTimeout));
         zkServer.setMaxSessionTimeout(maxSessionTimeout == -1 ? -1 : (int) maxSessionTimeoutUnit.toMillis(maxSessionTimeout));
 
-        zkServer.setZKDatabase(new ZKDatabase(txnLog)); // Work-around https://issues.apache.org/jira/browse/ZOOKEEPER-2810
+        zkServer.startdata(); // Work-around https://issues.apache.org/jira/browse/ZOOKEEPER-2810
         zkServer.createSessionTracker(); // Work around https://issues.apache.org/jira/browse/ZOOKEEPER-2812
 
         ServerCnxnFactory cnxnFactory;


### PR DESCRIPTION
Motivation:

The services PinManager and recently Cleaner rely on ZooKeeper for leader election in order to be replicable as an HA service. In a special ZooKeeper directory HA services create an ephemeral node that is removed when its creator vanishes. Among these nodes a leader is chosen and only the associated service instance will resume work. There have been several occasions where in a dCache instance using an embedded ZooKeeper server such HA services stopped working because an ephemeral node was elected leader that has no associated service anymore; it should have been deleted. This state might go undetected for a longer time, and removing such stale nodes in order for the services to continue functioning as intended requires manual intervention.

Modification:

The embedded ZooKeeper server contains several fixes for issues that were also reported to the ZooKeeper issue tracker. One of these issues describes a possible race condition, because the acceptor thread is created and started even though the database might only be initialized later on (issue 2810). Another possible race condition is caused by the acceptor threads being created and started before initializing the ZooKeeper server object (issue 2812). If an incoming connection wins the race, an Exception is thrown and logged. In order to prevent this from happening, the database and then the session tracker are explicitly created before the NIOServerCnxnFactory#startup. However, although the database is created correctly, it is not initialized, so that the SessionTracker gets passed an empty HashMap instead of a correct listing of sessionsWithTimeouts on startup. On occasions when sessions are not removed before the dCache ZooKeeper cell shutdown, the associated stale ephemeral nodes are never expired and persisted indefinitely, leading to the observed problems.

The explicit database creation is replaced with ZooKeeperServer#startdata, which not only creates the database from the transaction logs when it does not yet exist, but also initializes the database, which was previously missing. During the subsequent creation of the session tracker, it now gets passed the correct sessionsWithTimeouts data.

Result:

No easily reproducible creation of stale ephemeral nodes in the embedded ZooKeeper server is observed. The functioning of HA services using ZooKeeper-based leader elections is more reliable.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Ticket: #5475
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12520/
Acked-by: Tigran Mkrtchyan