### PR TITLE
nfs-proxy: op WRITE must use the same verifier as COMMIT

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/proxy/ProxyIoWRITE.java
@@ -23,7 +23,6 @@ import org.dcache.nfs.v4.xdr.nfs_argop4;
 import org.dcache.nfs.v4.xdr.nfs_opnum4;
 import org.dcache.nfs.v4.xdr.nfs_resop4;
 import org.dcache.nfs.v4.xdr.stateid4;
-import org.dcache.nfs.v4.xdr.verifier4;
 import org.dcache.nfs.vfs.Inode;
 import org.dcache.nfs.vfs.VirtualFileSystem;
 
@@ -100,8 +99,7 @@ public class ProxyIoWRITE extends AbstractNFSv4Operation {
             res.resok4 = new WRITE4resok();
             res.resok4.count = new count4(writeResult.getBytesWritten());
             res.resok4.committed = writeResult.getStabilityLevel().toStableHow();
-            res.resok4.writeverf = new verifier4();
-            res.resok4.writeverf.value = new byte[nfs4_prot.NFS4_VERIFIER_SIZE];
+            res.resok4.writeverf = context.getRebootVerifier();
 
             _log.debug("MOVER: {}@{} written.", writeResult.getBytesWritten(), offset);
 


### PR DESCRIPTION
Motivation:
To identify that between WRITE and COMMIT server is not rebooted both
operations must return the same verifier. If they don't match, then
client will re-try write and might endup into infinite WRTIE+COMMIT
loop (as observed on the test system).

Modification:
Update WRIE to use server(door)-wide generated verifier tat is used by
COMMIT as well.

Result:
The infinite WRITE+COMMIT loop not observed any more.

Acked-by: Paul Millar
Acked-by: Albert Rossi
Acked-by: Lea Morschel
Target: master, 6.2, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit 630e2cb5885379e21f7d13a19d3083d66949e480)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>