### PR TITLE
gplazma: include additional algorithm in LoginResultPrinter

### DIFF
--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResultPrinter.java
@@ -83,6 +83,7 @@ public class LoginResultPrinter
                     .put("1.2.840.113549.1.1.4", "MD5 with RSA")
                     .put("1.2.840.113549.1.1.5", "SHA-1 with RSA")
                     .put("1.2.840.113549.1.1.11", "SHA-256 with RSA")
+                    .put("1.2.840.113549.1.1.12", "SHA-384 with RSA")
                     .put("1.2.840.113549.1.1.13", "SHA-512 with RSA")
                     .put("2.16.840.1.101.3.4.2.1", "SHA-256")
                     .put("2.16.840.1.101.3.4.2.2", "SHA-384")


### PR DESCRIPTION
Motivation:

Observed X.509 certificate that uses the "SHA-384 with RSA" algorithm.
This is currently printed as the OID, rather than using a (vaguely)
human understandable name

Modification:

Add OID mapping so that a more reasonable name is logged.

Result:

X.509 certificates that use the "SHA-384 with RSA" algorithm are now
logged with this name instead of the raw OID value.

Target: master
Requires-notes: yes
Requires-book: no
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12540/
Acked-by: Lea Morschel