### PR TITLE
pool: http-tpc increase timeout waiting for remote server post-proces…

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -176,7 +176,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
      * server, in bytes per millisecond.  This is used to estimate how long
      * any file post-processing (like checksum calculation) will take.
      */
-    private static final double POST_PROCESSING_BANDWIDTH = MiB.toBytes(100) / 1_000.0;
+    private static final double POST_PROCESSING_BANDWIDTH = MiB.toBytes(10) / 1_000.0;
 
     /** Number of milliseconds between successive requests. */
     private static final long DELAY_BETWEEN_REQUESTS = 5_000;


### PR DESCRIPTION
…sing

Motivation:

When transferring a file, dCache allows the remote server to take some
time before a file is finalised.  As an example, this delay could be due
to the remote server calculating the checksum of the transferred file.

The algorithm used to calculate the deadline for the transfer uses the
file's size (if known) to determine how long to wait: larger files can
take longer to process.  In effect, through this algorithm, the deadline
places a minimum bandwidth that the remote server must provide in order
for the transfer to be successful.

Currently the minimum bandwidth is 100 MiB/s; however, in-the-wild
observations have shown some (functioning, but only barely) servers have
an effective bandwidth of ~40 MiB/s.  dCache failed transfers to these
servers because the available IO bandwidth was too low.

Modification:

Decrease the minimum bandwidth from 100 MiB/s to 10 MiB/s.

Result:

dCache pools that are undertaking HTTP-TPC transfers will now wait
longer for the remote servers to complete any post-transfer activity.
Transfers that involve heavily loaded remote servers are now more likely
to succeed.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Closes: #5354
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12537/
Acked-by: Lea Morschel