### PR TITLE
srm-common: make X509 client authn optional, support bearer tokens

### DIFF
--- a/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
@@ -38,6 +38,7 @@ import eu.emi.security.authn.x509.impl.ValidatorParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -104,7 +105,13 @@ public class CanlContextFactory implements SslContextFactory
     public SSLContext getContext(X509Credential credential)
             throws GeneralSecurityException
     {
-        KeyManager[] keyManagers = { credential.getKeyManager() };
+        KeyManager[] keyManagers;
+        if (credential == null) {
+            keyManagers = null;
+        } else {
+            keyManagers = new KeyManager[1];
+            keyManagers [0] = credential.getKeyManager();
+        }
         SSLContext context = SSLContext.getInstance("TLS");
         context.init(keyManagers, trustManagers, secureRandom);
         return context;

--- a/modules/common-security/src/main/java/org/dcache/ssl/SslContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/SslContextFactory.java
@@ -19,6 +19,7 @@ package org.dcache.ssl;
 
 import eu.emi.security.authn.x509.X509Credential;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 
 import java.security.GeneralSecurityException;
@@ -28,5 +29,12 @@ import java.security.GeneralSecurityException;
  */
 public interface SslContextFactory
 {
-    SSLContext getContext(X509Credential credential) throws GeneralSecurityException;
+    /**
+     * Provides an SSLContext that will use the supplied optional client
+     * credential for authentication.
+     * @param credential the credential to use, or null if no X.509 credential.
+     * @return an SSLContext to use with an SSLSocket.
+     * @throws GeneralSecurityException if there is a problem establishing the context.
+     */
+    SSLContext getContext(@Nullable X509Credential credential) throws GeneralSecurityException;
 }

--- a/modules/srm-common/src/main/java/org/dcache/srm/util/Credentials.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/util/Credentials.java
@@ -5,6 +5,7 @@ import eu.emi.security.authn.x509.X509Credential;
 import java.io.IOException;
 import java.security.cert.X509Certificate;
 import java.util.Date;
+import java.util.Optional;
 
 /**
  * Utility class with static methods to handle X.509 Credentials.
@@ -27,6 +28,16 @@ public class Credentials
 
         if (certificate.getNotBefore().after(now)) {
             throw new IOException("X.509 credential not yet valid");
+        }
+
+        return credential;
+    }
+
+    public static Optional<X509Credential> checkValid(Optional<X509Credential> credential)
+            throws IOException
+    {
+        if (credential.isPresent()) {
+            checkValid(credential.get());
         }
 
         return credential;


### PR DESCRIPTION
Motivation:

As a step towards our SRM client code supporting bearer-token
authentication, the common code should make X.509 optional and allow the
code to supply a bearer token.

Modification:

Update common client code to make X.509 optional.

Backwards compatible constructors are included to reduce the size of
this patch.

Add support for an optional bearer token.  If present, the value is
prefixed with the term "Bearer" and used in the "Authorization" HTTP
request header.

It is allowed that both an X.509 credential and a bearer token are
presented to the server.

The credential check is loosened.  The client code will now complain if
neither an X.509 credential nor a bearer token is presented.

Result:

No user or admin observable changes.

Target: master
Request: 6.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/12566/
Acked-by: Tigran Mkrtchyan