### PR TITLE
chimera: fix dot file parser to handle weird file names

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/PnfsCommandProcessor.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PnfsCommandProcessor.java
@@ -16,21 +16,36 @@
  */
 package org.dcache.chimera;
 
-import java.util.StringTokenizer;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PnfsCommandProcessor {
 
     public static String[] process(String command) {
 
-        StringTokenizer st = new StringTokenizer(command.substring(1), "[()]");
+        List<String> list = new ArrayList<>();
+        int begin = 0;
+        int deep = 0;
 
-        int len = st.countTokens();
+        for(int i = 0; i < command.length(); i++) {
 
-        String[] list = new String[len];
-        for (int i = 0; st.hasMoreTokens(); i++) {
-            list[i] = st.nextToken();
+            char c = command.charAt(i);
+            switch(c) {
+                case '(':
+                    deep++;
+                    if (deep == 1) {
+                        begin = i+1;
+                    }
+                    break;
+                case ')':
+                    deep--;
+                    if (deep == 0) {
+                        list.add(command.substring(begin, i));
+                    }
+                    break;
+            }
         }
 
-        return list;
+        return list.isEmpty() ? new String[] {command} : list.toArray(new String[0]);
     }
 }

--- a/modules/chimera/src/test/java/org/dcache/chimera/PnfsCommandProcessorTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/PnfsCommandProcessorTest.java
@@ -1,0 +1,40 @@
+package org.dcache.chimera;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import static org.dcache.chimera.PnfsCommandProcessor.process;
+
+public class PnfsCommandProcessorTest {
+
+    @Test
+    public void shouldReturnParcsedElements() {
+
+        String[] cmd = process(".(arg1)(arg2)");
+        assertEquals("Invalid number of arguments", 2, cmd.length);
+        assertArrayEquals(new String[]{"arg1", "arg2"}, cmd);
+    }
+
+    @Test
+    public void shouldReturnSameElementOnMissingBrackets() {
+        String[] cmd = process("arg1");
+        assertEquals("Invalid number of arguments", 1, cmd.length);
+        assertArrayEquals(new String[]{"arg1"}, cmd);
+    }
+
+    @Test
+    public void shouldIgnoreNastedBrackets() {
+        String[] cmd = process(".(get)(parameters_dict_gen'+str(i).zfill(4)+'.csv)(locality)");
+        assertEquals("Invalid number of arguments", 3, cmd.length);
+        assertArrayEquals(new String[]{"get",
+            "parameters_dict_gen'+str(i).zfill(4)+'.csv", "locality"}, cmd);
+    }
+
+    @Test
+    public void shouldIgnoreOpenBrackets() {
+        String[] cmd = process(".(arg1)(parameters");
+        assertEquals("Invalid number of arguments", 1, cmd.length);
+        assertArrayEquals(new String[]{"arg1"}, cmd);
+    }
+
+}


### PR DESCRIPTION
Motivation:
If a file has brackets in the name, then dCache treats them as magic dot
files.

Modification:
update PnfsCommandProcessor to detect and ignore nested brackets. Added
unit tests to validate parser.

Result:
Weird files like parameters_dict_gen'+str(i).zfill(4)+'.csv do not
confuse PnfsCommandProcessor.

Acked-by: Paul Millar
Target: master
Fixes: #5547 
Require-book: no
Require-notes: yes
(cherry picked from commit 1dee55f9847c7221b791b228007aadb24d4cde1e)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>