### PR TITLE
dcap: fix automatic door retry on transient errors

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/doors/LineBasedDoor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/LineBasedDoor.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2016 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -36,6 +36,7 @@ import dmg.cells.nucleus.CellInfoProvider;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.util.CommandExitException;
+import dmg.util.KeepAliveListener;
 import dmg.util.StreamEngine;
 
 import org.dcache.cells.AbstractCell;
@@ -55,7 +56,7 @@ import org.dcache.util.Transfer;
  * is processing a line.
  */
 public class LineBasedDoor
-    extends AbstractCell implements Runnable
+    extends AbstractCell implements Runnable, KeepAliveListener
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(LineBasedDoor.class);
 
@@ -255,6 +256,13 @@ public class LineBasedDoor
         pw.println("     User Host  : " + engine.getInetAddress().getHostAddress());
         if (interpreter instanceof CellInfoProvider) {
             ((CellInfoProvider) interpreter).getInfo(pw);
+        }
+    }
+
+    @Override
+    public void keepAlive() {
+        if (interpreter instanceof KeepAliveListener) {
+            KeepAliveListener.class.cast(interpreter).keepAlive();
         }
     }
 


### PR DESCRIPTION
Motivation:
With commit 1a60fc09dfdb dcap door was refactored to use LineBasedDoor
abstraction. As LineBasedDoor class doesn't implement KeepAliveListener,
the retry functionality was lost. As a result file restores was hanging
until manual restart by operators.

Modification:
update LineBasedDoor to implement KeepAliveListener and forward to
actual door implementation.

Result:
restore of automatic dcap door retries on transient errors.

Acked-by: Lea Morschel
Acked-by: Paul Millar
Acked-by: Albert Rossi
Acked-by: Dmitry Litvintsev
Reported-by: FNAL, DESY
Target: master, 6.2, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
(cherry picked from commit cd8eac91df050928bb506ee90115ffa60f2115c8)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>