### PR TITLE
pool: http-tpc PUT request are repeatable

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -404,7 +404,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     private void sendAndCheckFile(RemoteHttpDataTransferProtocolInfo info)
             throws ThirdPartyTransferFailedCacheException
     {
-        sendFile(info, _channel.getFileAttributes().getSize());
+        sendFile(info);
 
         try {
             verifyRemoteFile(info);
@@ -415,7 +415,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
         }
     }
 
-    private void sendFile(RemoteHttpDataTransferProtocolInfo info, long length)
+    private void sendFile(RemoteHttpDataTransferProtocolInfo info)
             throws ThirdPartyTransferFailedCacheException
     {
         URI location = info.getUri();
@@ -423,7 +423,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
 
         try {
             for (int redirectionCount = 0; redirectionCount < MAX_REDIRECTIONS; redirectionCount++) {
-                HttpPut put = buildPutRequest(info, location, length,
+                HttpPut put = buildPutRequest(info, location,
                         redirectionCount > 0 ? REDIRECTED_REQUEST : INITIAL_REQUEST);
 
                 try (CloseableHttpResponse response = _client.execute(put)) {
@@ -511,7 +511,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
      * @return A corresponding PUT request.
      */
     private HttpPut buildPutRequest(RemoteHttpDataTransferProtocolInfo info,
-            URI location, long length, Set<HeaderFlags> flags)
+            URI location, Set<HeaderFlags> flags)
     {
         HttpPut put = new HttpPut(location);
         put.setConfig(RequestConfig.custom()
@@ -520,7 +520,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                                   .setSocketTimeout(0)
                                   .build());
         addHeadersToRequest(info, put, flags);
-        put.setEntity(new InputStreamEntity(Channels.newInputStream(_channel), length));
+        put.setEntity(new RepositoryChannelEntity(_channel));
 
         // FIXME add SO_KEEPALIVE setting
 

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RepositoryChannelEntity.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RepositoryChannelEntity.java
@@ -1,0 +1,162 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2020 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.pool.movers;
+
+import org.apache.http.entity.AbstractHttpEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+
+import dmg.util.Exceptions;
+
+import org.dcache.pool.repository.RepositoryChannel;
+
+/**
+ * An HttpEntity based on repository channel.  This is broadly similar
+ * to Apache's InputStreamEntity with the following differences:
+ * <ul>
+ * <li>Objects are backed by RepositoryChannel objects, rather than an InputStream</li>
+ * <li>The supplied RepositoryChannel is never closed; for example, the
+ * {@literal getContent} method returns an InputStream where the {@literal close}
+ * method does not do anything.</li>
+ * <li>The Entity is repeatable.</li>
+ * <li>In the absence of any errors, this HttpEntity knows the file's size.  If
+ * the repository cannot determine the file's size then a chunked encoded
+ * transfer will be used.</li>
+ * <ul>
+ */
+public class RepositoryChannelEntity extends AbstractHttpEntity
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryChannelEntity.class);
+
+    private final RepositoryChannel channel;
+
+    public RepositoryChannelEntity(RepositoryChannel channel)
+    {
+        this.channel = channel;
+    }
+
+    @Override
+    public boolean isRepeatable()
+    {
+        return true;
+    }
+
+    @Override
+    public long getContentLength()
+    {
+        try {
+            return channel.size();
+        } catch (IOException e) {
+            LOGGER.warn("Failed to discover file size: {}", Exceptions.meaningfulMessage(e));
+            return -1; // triggers a chunked encoded transfer.
+        }
+    }
+
+    @Override
+    public InputStream getContent() throws IOException
+    {
+        final InputStream stream = Channels.newInputStream(channel);
+
+        return new InputStream() {
+            @Override
+            public int read() throws IOException
+            {
+                return stream.read();
+            }
+
+            @Override
+            public int read(byte b[]) throws IOException
+            {
+                return stream.read(b);
+            }
+
+            @Override
+            public int read(byte b[], int off, int len) throws IOException
+            {
+                return stream.read(b, off, len);
+            }
+
+            @Override
+            public long skip(long n) throws IOException
+            {
+                return stream.skip(n);
+            }
+
+            @Override
+            public int available() throws IOException
+            {
+                return stream.available();
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                // Suppress stream.close(), as this would call channel.close(),
+                // which would prevent using this HttpEntity in multiple
+                // requests.
+            }
+
+            @Override
+            public void mark(int readlimit)
+            {
+                stream.mark(readlimit);
+            }
+
+            @Override
+            public void reset() throws IOException
+            {
+                stream.reset();
+            }
+
+            @Override
+            public boolean markSupported()
+            {
+                return stream.markSupported();
+            }
+        };
+    }
+
+    @Override
+    public void writeTo(OutputStream outstream) throws IOException
+    {
+        final byte[] buffer = new byte[OUTPUT_BUFFER_SIZE];
+        ByteBuffer bb = ByteBuffer.wrap(buffer);
+
+        long offset = 0l;
+        int l;
+        while ((l = channel.read(bb, offset)) != -1) {
+            outstream.write(buffer, 0, l);
+            offset += l;
+            bb.clear();
+        }
+
+        // Suppress calling channel.close() here to allow entity reuse.
+    }
+
+    @Override
+    public boolean isStreaming()
+    {
+        return true;
+    }
+}

--- a/modules/dcache/src/test/java/org/dcache/pool/movers/RepositoryChannelEntityTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/movers/RepositoryChannelEntityTest.java
@@ -1,0 +1,155 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2020 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.pool.movers;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.dcache.pool.repository.RepositoryChannel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+public class RepositoryChannelEntityTest
+{
+    private static final String CHANNEL_DATA = "THIS IS SOME TEST DATA";
+    private static final byte[] CHANNEL_RAW_DATA = CHANNEL_DATA.getBytes(StandardCharsets.UTF_8);
+
+    private RepositoryChannel channel;
+    private RepositoryChannelEntity entity;
+
+    @Before
+    public void setup() throws Exception
+    {
+        channel = mock(RepositoryChannel.class);
+
+        given(channel.read(any(), anyLong())).willAnswer(i -> {
+                    ByteBuffer bb = i.getArgument(0);
+                    int requestedOffset = ((Long)i.getArgument(1)).intValue();
+
+                    int requestedEnd = requestedOffset + bb.remaining();
+                    int boundedEnd = Math.min(requestedEnd, CHANNEL_RAW_DATA.length);
+                    int boundedOffset = Math.min(requestedOffset, CHANNEL_RAW_DATA.length);
+
+                    int transferred = boundedEnd - boundedOffset;
+
+                    boolean isEof = bb.remaining() > 0 && transferred == 0;
+
+                    bb.put(CHANNEL_RAW_DATA, boundedOffset, transferred);
+
+                    return isEof ? -1 : transferred;
+                });
+
+        entity = new RepositoryChannelEntity(channel);
+    }
+
+    @Test
+    public void shouldBeRepeatable()
+    {
+        assertTrue(entity.isRepeatable());
+    }
+
+    @Test
+    public void shouldBeStreaming()
+    {
+        assertTrue(entity.isStreaming());
+    }
+
+    @Test
+    public void shouldNotBeChunked()
+    {
+        assertFalse(entity.isChunked());
+    }
+
+    @Test
+    public void shouldNotSpecifyContentType()
+    {
+        assertThat(entity.getContentType(), equalTo(null));
+    }
+
+    @Test
+    public void shouldNotSpecifyContentEncoding()
+    {
+        assertThat(entity.getContentEncoding(), equalTo(null));
+    }
+
+    @Test
+    public void shouldReturnKnownFileSize() throws Exception
+    {
+        given(channel.size()).willReturn(10240L);
+
+        long size = entity.getContentLength();
+
+        assertThat(size, equalTo(10240L));
+    }
+
+    @Test
+    public void shouldChunkEncodeForUnknownFileSize() throws Exception
+    {
+        given(channel.size()).willThrow(new IOException("Unable to stat file"));
+
+        long size = entity.getContentLength();
+
+        assertThat(size, equalTo(-1L));
+    }
+
+    @Test
+    public void shouldNotCloseStreamOnGetContentClose() throws Exception
+    {
+        entity.getContent().close();
+
+        verify(channel, never()).close();
+    }
+
+    @Test
+    public void shouldNotCloseStreamOnWriteTo() throws Exception
+    {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        entity.writeTo(output);
+
+        verify(channel, never()).close();
+        assertThat(output.toString("UTF-8"), equalTo(CHANNEL_DATA));
+    }
+
+    @Test
+    public void shouldSupportMultipleWriteTo() throws Exception
+    {
+        ByteArrayOutputStream output1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream output2 = new ByteArrayOutputStream();
+
+        entity.writeTo(output1);
+        entity.writeTo(output2);
+
+        verify(channel, never()).close();
+        assertThat(output1.toString("UTF-8"), equalTo(CHANNEL_DATA));
+        assertThat(output2.toString("UTF-8"), equalTo(CHANNEL_DATA));
+    }
+}


### PR DESCRIPTION
Motivation:

If the remote server takes too long to respond to an HTTP PUT request
that uses the expect-100-continue negotiation then the pool for will
spontaneously send the entity.  This behaviour is standards-compliant
and common across all HTTP client libraries, not just Apache library
used by the pool.  The pool's timeout is just three seconds.

(For dCache, the WebDAV door receiving the HTTP PUT request will likely
redirect the client to the pool.  This can take longer than three
seconds, especially if pools are busy and the mover is queued.)

Therefore, if the receiving dCache door takes too long to reply then the
client will sent the file's content to the door, only to receive the
redirection response.  This then forces the pool to send the file's
content again, which it currently cannot do.  The transfer then fails.

Modification:

Introduce a new HttpEntity class that allows the pool to send the file
content multiple times, as a result of redirection responses.

Result:

The HTTP-TPC PUSH requests (which use the HTTP PUT request to send data)
are now more robust against slow remote servers that redirect the
transfer.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12536/
Acked-by: Tigran Mkrtchyan