### PR TITLE
pool: http-tpc PUT request are repeatable

### DIFF
--- a/modules/cells/src/main/java/dmg/util/Exceptions.java
+++ b/modules/cells/src/main/java/dmg/util/Exceptions.java
@@ -19,7 +19,7 @@ public class Exceptions
     {
     }
 
-    private static String meaningfulMessage(Throwable t)
+    public static String meaningfulMessage(Throwable t)
     {
         return t.getMessage() != null ? t.getMessage() : t.getClass().getName();
     }

--- a/modules/dcache-nfs/src/test/java/org/dcache/chimera/nfsv41/door/MonitoringVfsTest.java
+++ b/modules/dcache-nfs/src/test/java/org/dcache/chimera/nfsv41/door/MonitoringVfsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Deutsches Elektronen-Synchroton,
+ * Copyright (c) 2018 - 2020 Deutsches Elektronen-Synchroton,
  * Member of the Helmholtz Association, (DESY), HAMBURG, GERMANY
  *
  * This library is free software; you can redistribute it and/or modify
@@ -55,14 +55,12 @@ import static org.dcache.nfs.vfs.Stat.S_TYPE;
 import static org.dcache.nfs.vfs.Stat.Type.REGULAR;
 import static org.dcache.nfs.vfs.VirtualFileSystem.StabilityLevel.UNSTABLE;
 import static org.dcache.util.PrincipalSetMaker.aSetOfPrincipals;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.*;
+import static org.hamcrest.CoreMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class MonitoringVfsTest
@@ -482,7 +480,7 @@ public class MonitoringVfsTest
         PnfsId targetId = new PnfsId("000000000000000000000000000000000002");
         Inode parent = anInode().withId(1L).withPnfsId(parentId).build();
         Inode target = anInode().withId(2L).withPnfsId(targetId).withLink(parent, "target").build();
-        given(inner.read(eq(target), any(), anyInt(), anyInt())).willReturn(100);
+        given(inner.read(eq(target), any(), anyLong(), anyInt())).willReturn(100);
         byte[] data = new byte[1024];
 
         int result = monitor.read(target, data, 0, 1024);
@@ -507,7 +505,7 @@ public class MonitoringVfsTest
         PnfsId targetId = new PnfsId("000000000000000000000000000000000002");
         Inode parent = anInode().withId(1L).withPnfsId(parentId).build();
         Inode target = anInode().withId(2L).withPnfsId(targetId).withLink(parent, "target").build();
-        willThrow(IOException.class).given(inner).read(any(), any(), anyInt(), anyInt());
+        willThrow(IOException.class).given(inner).read(any(), any(), anyLong(), anyInt());
         byte[] data = new byte[1024];
 
         try {

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -404,7 +404,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     private void sendAndCheckFile(RemoteHttpDataTransferProtocolInfo info)
             throws ThirdPartyTransferFailedCacheException
     {
-        sendFile(info, _channel.getFileAttributes().getSize());
+        sendFile(info);
 
         try {
             verifyRemoteFile(info);
@@ -415,7 +415,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
         }
     }
 
-    private void sendFile(RemoteHttpDataTransferProtocolInfo info, long length)
+    private void sendFile(RemoteHttpDataTransferProtocolInfo info)
             throws ThirdPartyTransferFailedCacheException
     {
         URI location = info.getUri();
@@ -423,7 +423,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
 
         try {
             for (int redirectionCount = 0; redirectionCount < MAX_REDIRECTIONS; redirectionCount++) {
-                HttpPut put = buildPutRequest(info, location, length,
+                HttpPut put = buildPutRequest(info, location,
                         redirectionCount > 0 ? REDIRECTED_REQUEST : INITIAL_REQUEST);
 
                 try (CloseableHttpResponse response = _client.execute(put)) {
@@ -511,7 +511,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
      * @return A corresponding PUT request.
      */
     private HttpPut buildPutRequest(RemoteHttpDataTransferProtocolInfo info,
-            URI location, long length, Set<HeaderFlags> flags)
+            URI location, Set<HeaderFlags> flags)
     {
         HttpPut put = new HttpPut(location);
         put.setConfig(RequestConfig.custom()
@@ -520,7 +520,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                                   .setSocketTimeout(0)
                                   .build());
         addHeadersToRequest(info, put, flags);
-        put.setEntity(new InputStreamEntity(Channels.newInputStream(_channel), length));
+        put.setEntity(new RepositoryChannelEntity(_channel));
 
         // FIXME add SO_KEEPALIVE setting
 

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RepositoryChannelEntity.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RepositoryChannelEntity.java
@@ -1,0 +1,162 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2020 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.pool.movers;
+
+import org.apache.http.entity.AbstractHttpEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+
+import dmg.util.Exceptions;
+
+import org.dcache.pool.repository.RepositoryChannel;
+
+/**
+ * An HttpEntity based on repository channel.  This is broadly similar
+ * to Apache's InputStreamEntity with the following differences:
+ * <ul>
+ * <li>Objects are backed by RepositoryChannel objects, rather than an InputStream</li>
+ * <li>The supplied RepositoryChannel is never closed; for example, the
+ * {@literal getContent} method returns an InputStream where the {@literal close}
+ * method does not do anything.</li>
+ * <li>The Entity is repeatable.</li>
+ * <li>In the absence of any errors, this HttpEntity knows the file's size.  If
+ * the repository cannot determine the file's size then a chunked encoded
+ * transfer will be used.</li>
+ * <ul>
+ */
+public class RepositoryChannelEntity extends AbstractHttpEntity
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryChannelEntity.class);
+
+    private final RepositoryChannel channel;
+
+    public RepositoryChannelEntity(RepositoryChannel channel)
+    {
+        this.channel = channel;
+    }
+
+    @Override
+    public boolean isRepeatable()
+    {
+        return true;
+    }
+
+    @Override
+    public long getContentLength()
+    {
+        try {
+            return channel.size();
+        } catch (IOException e) {
+            LOGGER.warn("Failed to discover file size: {}", Exceptions.meaningfulMessage(e));
+            return -1; // triggers a chunked encoded transfer.
+        }
+    }
+
+    @Override
+    public InputStream getContent() throws IOException
+    {
+        final InputStream stream = Channels.newInputStream(channel);
+
+        return new InputStream() {
+            @Override
+            public int read() throws IOException
+            {
+                return stream.read();
+            }
+
+            @Override
+            public int read(byte b[]) throws IOException
+            {
+                return stream.read(b);
+            }
+
+            @Override
+            public int read(byte b[], int off, int len) throws IOException
+            {
+                return stream.read(b, off, len);
+            }
+
+            @Override
+            public long skip(long n) throws IOException
+            {
+                return stream.skip(n);
+            }
+
+            @Override
+            public int available() throws IOException
+            {
+                return stream.available();
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                // Suppress stream.close(), as this would call channel.close(),
+                // which would prevent using this HttpEntity in multiple
+                // requests.
+            }
+
+            @Override
+            public void mark(int readlimit)
+            {
+                stream.mark(readlimit);
+            }
+
+            @Override
+            public void reset() throws IOException
+            {
+                stream.reset();
+            }
+
+            @Override
+            public boolean markSupported()
+            {
+                return stream.markSupported();
+            }
+        };
+    }
+
+    @Override
+    public void writeTo(OutputStream outstream) throws IOException
+    {
+        final byte[] buffer = new byte[OUTPUT_BUFFER_SIZE];
+        ByteBuffer bb = ByteBuffer.wrap(buffer);
+
+        long offset = 0l;
+        int l;
+        while ((l = channel.read(bb, offset)) != -1) {
+            outstream.write(buffer, 0, l);
+            offset += l;
+            bb.clear();
+        }
+
+        // Suppress calling channel.close() here to allow entity reuse.
+    }
+
+    @Override
+    public boolean isStreaming()
+    {
+        return true;
+    }
+}

--- a/modules/dcache/src/test/java/diskCacheV111/namespace/EventNotifierTest.java
+++ b/modules/dcache/src/test/java/diskCacheV111/namespace/EventNotifierTest.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2018 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2018 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -58,12 +58,10 @@ import static org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.
 import static org.apache.curator.utils.ZKPaths.makePath;
 import static org.dcache.namespace.events.EventType.IN_MOVE_SELF;
 import static org.dcache.namespace.FileType.REGULAR;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
+import static org.hamcrest.CoreMatchers.*;
 
 public class EventNotifierTest
 {

--- a/modules/dcache/src/test/java/diskCacheV111/namespace/MonitoringNameSpaceProviderTest.java
+++ b/modules/dcache/src/test/java/diskCacheV111/namespace/MonitoringNameSpaceProviderTest.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2018 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2018 - 2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -44,12 +44,13 @@ import org.dcache.namespace.events.EventType;
 import org.dcache.vehicles.FileAttributes;
 
 import static org.dcache.util.PrincipalSetMaker.aSetOfPrincipals;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.hamcrest.text.IsEmptyString.emptyOrNullString;
+import static org.mockito.hamcrest.MockitoHamcrest.*;
 
 public class MonitoringNameSpaceProviderTest
 {
@@ -223,7 +224,7 @@ public class MonitoringNameSpaceProviderTest
         PnfsId target = new PnfsId("000000000000000000000000000000000002");
         given(inner.pathToPnfsid(any(), eq("/foo"), anyBoolean())).willReturn(target);
         willAnswer(i -> {
-                    ListHandler h = i.getArgumentAt(5, ListHandler.class);
+                    ListHandler h = i.getArgument(5, ListHandler.class);
                     h.addEntry("bar", new FileAttributes());
                     return null;
                 }).given(inner).list(any(), eq("/foo"), any(), any(), any(), any());
@@ -250,7 +251,7 @@ public class MonitoringNameSpaceProviderTest
         PnfsId target = new PnfsId("000000000000000000000000000000000002");
         given(inner.pathToPnfsid(any(), eq("/foo"), anyBoolean())).willReturn(target);
         willAnswer(i -> {
-                    ListHandler h = i.getArgumentAt(5, ListHandler.class);
+                    ListHandler h = i.getArgument(5, ListHandler.class);
                     h.addEntry("bar-1", new FileAttributes());
                     h.addEntry("bar-2", new FileAttributes());
                     return null;
@@ -576,7 +577,7 @@ public class MonitoringNameSpaceProviderTest
                 (Set<FileAttribute>)argThat(hasItem(FileAttribute.ACCESS_TIME)));
         assertThat(result.getAccessTime(), is(equalTo(42L)));
         verify(receiver).notifyMovedEvent(eq(EventType.IN_MOVED_TO), eq(parent),
-                eq("file-1"), argThat(not(isEmptyOrNullString())), eq(FileType.REGULAR));
+                eq("file-1"), argThat(not(emptyOrNullString())), eq(FileType.REGULAR));
     }
 
     @Test

--- a/modules/dcache/src/test/java/org/dcache/http/HttpPoolRequestHandlerTests.java
+++ b/modules/dcache/src/test/java/org/dcache/http/HttpPoolRequestHandlerTests.java
@@ -27,7 +27,6 @@ import org.hamcrest.Description;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.python.google.common.collect.Lists;
@@ -70,10 +69,12 @@ import static io.netty.handler.codec.http.HttpHeaders.Values.BYTES;
 import static io.netty.handler.codec.http.HttpMethod.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.hamcrest.MockitoHamcrest.*;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -557,25 +558,25 @@ public class HttpPoolRequestHandlerTests
         ChecksumChannel checksums = new ChecksumChannel(repoChannel, EnumSet.noneOf(ChecksumType.class));
 
         Answer<Void> acceptChecksum = (i) -> {
-                    checksums.addType(i.getArgumentAt(0, ChecksumType.class));
+                    checksums.addType(i.getArgument(0, ChecksumType.class));
                     return null;
                 };
-        Mockito.doAnswer(acceptChecksum).when(channel).addChecksumType(anyObject());
-        given(channel.write((ByteBuffer)anyObject()))
+        Mockito.doAnswer(acceptChecksum).when(channel).addChecksumType(any());
+        given(channel.write((ByteBuffer)any()))
                 .willAnswer((i) -> {
-                    ByteBuffer src = i.getArgumentAt(0, ByteBuffer.class);
+                    ByteBuffer src = i.getArgument(0, ByteBuffer.class);
                     return checksums.write(src);
                 });
-        given(channel.write((ByteBuffer[])anyObject()))
+        given(channel.write((ByteBuffer[])any()))
                 .willAnswer((i) -> {
-                    ByteBuffer[] src = i.getArgumentAt(0, ByteBuffer[].class);
+                    ByteBuffer[] src = i.getArgument(0, ByteBuffer[].class);
                     return checksums.write(src);
                 });
-        given(channel.write(anyObject(), anyInt(), anyInt()))
+        given(channel.write(any(), anyInt(), anyInt()))
                 .willAnswer((i) -> {
-                    ByteBuffer[] arg = i.getArgumentAt(0, ByteBuffer[].class);
-                    int offset = i.getArgumentAt(1, Integer.class);
-                    int length = i.getArgumentAt(2, Integer.class);
+                    ByteBuffer[] arg = i.getArgument(0, ByteBuffer[].class);
+                    int offset = i.getArgument(1, Integer.class);
+                    int length = i.getArgument(2, Integer.class);
                     return checksums.write(arg, offset, length);
                 });
 

--- a/modules/dcache/src/test/java/org/dcache/pool/movers/ChecksumChannelTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/movers/ChecksumChannelTest.java
@@ -26,13 +26,15 @@ import org.dcache.util.ChecksumType;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.dcache.util.ByteUnit.KiB;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.hamcrest.MockitoHamcrest.*;
+
 
 public class ChecksumChannelTest {
 
@@ -139,7 +141,7 @@ public class ChecksumChannelTest {
         buffers[0].rewind();
         chksumChannel.write(buffers[0], 0);
 
-        assertThat(chksumChannel.getChecksums(), is(empty()));
+        assertThat(chksumChannel.getChecksums(), empty());
     }
 
     @Test
@@ -151,7 +153,7 @@ public class ChecksumChannelTest {
             fail("Pick a blocksize > 1 for testing correct handling of partly overlapping writes!");
         }
 
-        assertThat(chksumChannel.getChecksums(), is(empty()));
+        assertThat(chksumChannel.getChecksums(), empty());
     }
 
     @Test
@@ -184,7 +186,7 @@ public class ChecksumChannelTest {
         csc.write(buffers[3], 3);
         csc.write(buffers[2], 2);
 
-        assertThat(csc.getChecksums(), is(not(empty())));
+        assertThat(csc.getChecksums(), not(empty()));
     }
 
     @Test
@@ -263,14 +265,14 @@ public class ChecksumChannelTest {
         chksumChannel._readBackBuffer = ByteBuffer.allocate(readBackCapacity);
         chksumChannel._channel = mock(FileRepositoryChannel.class);
         when(chksumChannel._channel.write(any(), anyLong())).thenReturn(writeBufferCapacity);
-        when(chksumChannel._channel.read(any(), longThat(lessThan(0L)))).thenThrow(new IllegalArgumentException("Negative Position"));
-        when(chksumChannel._channel.read(any(), longThat(greaterThanOrEqualTo(0L)))).thenReturn(readBackCapacity);
+        when(chksumChannel._channel.read(any(), longThat(l -> l < 0L))).thenThrow(new IllegalArgumentException("Negative Position"));
+        when(chksumChannel._channel.read(any(), longThat(l -> l >=0L))).thenReturn(readBackCapacity);
         for (long i = writeBuffer.capacity(); i < 2L*Integer.MAX_VALUE; i += writeBufferCapacity) {
             chksumChannel.write(writeBuffer, i);
             writeBuffer.rewind();
         }
         chksumChannel.write(writeBuffer, 0);
-        assertThat(chksumChannel.getChecksums(), is(not(empty())));
+        assertThat(chksumChannel.getChecksums(), not(empty()));
         assertThat(chksumChannel.getChecksums(), contains(notNullValue()));
     }
 

--- a/modules/dcache/src/test/java/org/dcache/pool/movers/RepositoryChannelEntityTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/movers/RepositoryChannelEntityTest.java
@@ -1,0 +1,155 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2020 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.pool.movers;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.dcache.pool.repository.RepositoryChannel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+public class RepositoryChannelEntityTest
+{
+    private static final String CHANNEL_DATA = "THIS IS SOME TEST DATA";
+    private static final byte[] CHANNEL_RAW_DATA = CHANNEL_DATA.getBytes(StandardCharsets.UTF_8);
+
+    private RepositoryChannel channel;
+    private RepositoryChannelEntity entity;
+
+    @Before
+    public void setup() throws Exception
+    {
+        channel = mock(RepositoryChannel.class);
+
+        given(channel.read(any(), anyLong())).willAnswer(i -> {
+                    ByteBuffer bb = i.getArgument(0);
+                    int requestedOffset = ((Long)i.getArgument(1)).intValue();
+
+                    int requestedEnd = requestedOffset + bb.remaining();
+                    int boundedEnd = Math.min(requestedEnd, CHANNEL_RAW_DATA.length);
+                    int boundedOffset = Math.min(requestedOffset, CHANNEL_RAW_DATA.length);
+
+                    int transferred = boundedEnd - boundedOffset;
+
+                    boolean isEof = bb.remaining() > 0 && transferred == 0;
+
+                    bb.put(CHANNEL_RAW_DATA, boundedOffset, transferred);
+
+                    return isEof ? -1 : transferred;
+                });
+
+        entity = new RepositoryChannelEntity(channel);
+    }
+
+    @Test
+    public void shouldBeRepeatable()
+    {
+        assertTrue(entity.isRepeatable());
+    }
+
+    @Test
+    public void shouldBeStreaming()
+    {
+        assertTrue(entity.isStreaming());
+    }
+
+    @Test
+    public void shouldNotBeChunked()
+    {
+        assertFalse(entity.isChunked());
+    }
+
+    @Test
+    public void shouldNotSpecifyContentType()
+    {
+        assertThat(entity.getContentType(), equalTo(null));
+    }
+
+    @Test
+    public void shouldNotSpecifyContentEncoding()
+    {
+        assertThat(entity.getContentEncoding(), equalTo(null));
+    }
+
+    @Test
+    public void shouldReturnKnownFileSize() throws Exception
+    {
+        given(channel.size()).willReturn(10240L);
+
+        long size = entity.getContentLength();
+
+        assertThat(size, equalTo(10240L));
+    }
+
+    @Test
+    public void shouldChunkEncodeForUnknownFileSize() throws Exception
+    {
+        given(channel.size()).willThrow(new IOException("Unable to stat file"));
+
+        long size = entity.getContentLength();
+
+        assertThat(size, equalTo(-1L));
+    }
+
+    @Test
+    public void shouldNotCloseStreamOnGetContentClose() throws Exception
+    {
+        entity.getContent().close();
+
+        verify(channel, never()).close();
+    }
+
+    @Test
+    public void shouldNotCloseStreamOnWriteTo() throws Exception
+    {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        entity.writeTo(output);
+
+        verify(channel, never()).close();
+        assertThat(output.toString("UTF-8"), equalTo(CHANNEL_DATA));
+    }
+
+    @Test
+    public void shouldSupportMultipleWriteTo() throws Exception
+    {
+        ByteArrayOutputStream output1 = new ByteArrayOutputStream();
+        ByteArrayOutputStream output2 = new ByteArrayOutputStream();
+
+        entity.writeTo(output1);
+        entity.writeTo(output2);
+
+        verify(channel, never()).close();
+        assertThat(output1.toString("UTF-8"), equalTo(CHANNEL_DATA));
+        assertThat(output2.toString("UTF-8"), equalTo(CHANNEL_DATA));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -947,38 +947,19 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.6.2</version>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.4</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- powermock-api-mockito depends on mockito-all,
-                     which includes all dependencies, including
-                     hamcrest, in the jar file.  Unfortunate this
-                     version of hamcrest (v1.1?) is incompatible with
-                     the version we compile against.  Somehow maven 3
-                     works (different CP order?), but using maven 2
-                     has unit-tests in error due to NoSuchMethod
-                     exceptions.
-
-                     Here, we replace mockito-all with mockito-core,
-                     which exposes the hamcrest dependency in the pom
-                     file.  This allowing maven to do the right
-                     thing. -->
-                <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-all</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
+            <version>3.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -989,7 +970,7 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.6.2</version>
+            <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Motivation:

If the remote server takes too long to respond to an HTTP PUT request
that uses the expect-100-continue negotiation then the pool for will
spontaneously send the entity.  This behaviour is standards-compliant
and common across all HTTP client libraries, not just Apache library
used by the pool.  The pool's timeout is just three seconds.

(For dCache, the WebDAV door receiving the HTTP PUT request will likely
redirect the client to the pool.  This can take longer than three
seconds, especially if pools are busy and the mover is queued.)

Therefore, if the receiving dCache door takes too long to reply then the
client will sent the file's content to the door, only to receive the
redirection response.  This then forces the pool to send the file's
content again, which it currently cannot do.  The transfer then fails.

Modification:

Introduce a new HttpEntity class that allows the pool to send the file
content multiple times, as a result of redirection responses.

Result:

The HTTP-TPC PUSH requests (which use the HTTP PUT request to send data)
are now more robust against slow remote servers that redirect the
transfer.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12536/
Acked-by: Tigran Mkrtchyan