### PR TITLE
pool: support removing MongoDB storage-info entry

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/mongo/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/mongo/CacheRepositoryEntryImpl.java
@@ -249,7 +249,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.Up
             if (attributes.isDefined(FileAttribute.STORAGEINFO)) {
                 setStorageInfo(StorageInfos.extractFrom(attributes));
             } else {
-                setStorageInfo(null);
+                removeStorageInfo();
             }
         } catch (IOException e) {
             throw new DiskErrorCacheException("Failed to set file attributes for " + pnfsId + ": " + messageOrClassName(e), e);
@@ -280,6 +280,11 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord, ReplicaRecord.Up
         collection.updateOne(dbKey, new Document("$set", siDoc), UPSERT);
 
         this.storageInfo = si;
+    }
+
+    private synchronized void removeStorageInfo() throws IOException {
+        storageInfo = null;
+        collection.deleteOne(dbKey);
     }
 
     private void load() throws IOException {


### PR DESCRIPTION
Motivation:

The MongoDB-backed pool-metadata storage writes a file's storage-info
into MongoDB as a JSON record.  This currently results in a NPE if the
replica is updated without the FileAttributes containing the file's
StorageInfo.

Modification:

Remove the MongoDB record if the replica is updated without specifying a
storage info.  This might not be correct; however, it is consistent
behaviour with how BerkeleyDB handles this situation.

Result:

Fixed NullPointerException bug in MongoDB-backed pool metadata storage.

Fixed SpotBugs NORMAL-level warning.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12594/
Acked-by: Tigran Mkrtchyan