### PR TITLE
nfs: drop internal mover re-start loop

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1400,17 +1400,6 @@ public class NFSv41Door extends AbstractCellComponent implements
              * it's timed out or ready.
              */
             if (!isFirstAttempt() && !_redirectFuture.isDone()) {
-
-                /*
-                 * An attempt to re-active a mover when one is expected.
-                 * It safe to do so as pool can detect existing mover for a given
-                 * transfer.
-                 */
-
-                if (getPool() != null && !hasMover()) {
-                    _log.warn("Recovering from lost start-mover reply from pool {}", getPool());
-                    _redirectFuture = startMoverAsync(NFS_REQUEST_BLOCKING);
-                }
                 throw new LayoutTryLaterException("Waiting for pool to become ready.");
             }
 


### PR DESCRIPTION
Motivation:
If door failed to start a mover due to timeout or 'no route to cell',
then pool selection or mover start is retried. However, as the retry
procedure in the transfer class was not idempotent, the nfs door has
it's own workaround to avoid extra pool selection. This partial
solution plays not well with retry logic of transfer class and
produced inconsistent results.

Modification:
Drop custom re-try loop in the nfs door. Update transfer class to skip
pool selection, unless told to do so (commit a63c6894412d96 to handle
"no route to cell" exceptions).

Result:
lost messages to start mover successfully delivered after number of
retries.

Acked-by: Albert Rossi
Acked-by: Paul Millar
Target: master, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit be85181a7067a683ff79ddeffdd75dce1f1339c8)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>