### PR TITLE
pool: update xrootd-tpc authenication default

### DIFF
--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -345,35 +345,44 @@ pool.mover.xrootd.plugins=
 
 #  ---- Xrootd third-party client authentication plugins
 #
-#   Comma separated list of plugins to inject into the xrootd tpc client
-#   request processing chain.
+#   A comma separated list of authentication mechanisms.
 #
-#   Currently xrootd servers require an authentication step between them
-#   during third-party transfer.  When dCache is the destination, it uses
-#   a client to read the data, piping it to a mover which then writes it
-#   to the selected pool.  The client needs to authenticate, and this
-#   is handled by these plugin implementations, named by protocol.
+#   When dCache is the destination in an xrootd third-party transfer
+#   it uses an embedded xrootd client to fetch data from the remote
+#   xrootd server.  In order to fetch that data, the client must first
+#   authenticate with the remote xrootd server.
 #
-#   No plugins means dCache can be used as third party destination only
-#   with xrootd servers that require no authentication.
+#   There are several ways the dCache xrootd client can authenticate.
+#   The following configuration property controls which of these
+#   authentication schemes are enabled and available to the client.
 #
-#   dCache ships with:
+#   Authentication schemes are pluggable, so more mechanisms may be
+#   added, independently of dCache.org.
 #
-#        gsi   - request to the source server from dcache will
-#                use a key-exchange process to identify the end-user.
+#   Note that specifying no plugins means dCache can only fetch data
+#   from xrootd servers that require no authentication.
 #
-#        unix  - request to the source server from dcache will
-#                use unix authentication.
+#   dCache ships with the following plugins.
 #
-#                NOTE: third-party copying between dCache instances or doors
-#                requires this plugin on destination pools in addition to
-#                any other auth plugins, if hash signing is enforced on
-#                the pools (see pool.xrootd.security.force-signing).
+#        gsi   - dCache will use an X.509 credential to authenticate.
 #
-#        The default is unix, since this will also be required in order
-#                to communicate with an EOS source.
+#                This requires that the pool has an X.509 credential:
+#                either the xrootd client initiating the xrootd-TPC
+#                delegates one to dCache or the pool has one it can
+#                use for all transfers.
 #
-pool.mover.xrootd.tpc-authn-plugins=unix
+#        unix  - dCache will use "unix authentication" to authenticate.
+#
+#                NOTE: third-party copying between dCache instances or
+#                doors requires this plugin on destination pools in
+#                addition to any other auth plugins, if hash signing
+#                is enforced on the pools (see
+#                pool.xrootd.security.force-signing).
+#
+#   The default includes 'unix', since EOS requires unix
+#   authentication.
+#
+pool.mover.xrootd.tpc-authn-plugins=gsi,unix
 
 #  ---- Xrootd mover-idle timeout
 #


### PR DESCRIPTION
Motivation:

Sites increasingly need 'gsi' xrootd-tpc authentication.

The configuration property description is a little hard to read.

Modification:

Change default from "unix" to "gsi,unix".

Update configuration property text.

Result:

dCache pools now support GSI-based xrootd-TPC by default.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12605/
Acked-by: Albert Rossi