### PR TITLE
common-auth: mark UidPrincipal as In/Out principal

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/UidPrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/UidPrincipal.java
@@ -13,6 +13,7 @@ import java.security.Principal;
  * @since 2.1
  */
 @AuthenticationOutput
+@AuthenticationInput
 public class UidPrincipal implements Principal, Serializable
 {
     private static final long serialVersionUID = 1489893133915358418L;


### PR DESCRIPTION
fixes regression introduced in b4fe9166f4

Motivation:
As UidPrincipal used by NFS to 'login' when a user has more
than 16 secondary groups it have to be marked as AuthenticationInput as
well as AuthenticationOutput principal.

Modification:
mark UidPrincipal as In/Out principal

Result:
fixed regression introduced by limiting UidPrincipal to be only an
output principal.

Acked-by: Paul Millar
Target: master, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 267d1c2f8c78f7f2e7958ec021ca2be5daa99ca1)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>