### PR TITLE
pool: http-tpc drop 'Accept-Encoding' on HEAD requests

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -658,6 +658,14 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
         head.setConfig(RequestConfig.custom()
                                   .setConnectTimeout(CONNECTION_TIMEOUT)
                                   .setSocketTimeout(socketTimeout)
+
+                                   /* When making a HEAD request, we want to use
+                                    * the 'Content-Length' response header to
+                                    * learn of the file's size.  This only works
+                                    * if the remote server does not compress the
+                                    * content or otherwise encode it.
+                                    */
+                                  .setContentCompressionEnabled(false)
                                   .build());
         addHeadersToRequest(info, head, INITIAL_REQUEST);
         return head;


### PR DESCRIPTION
Motivation:

HTTP includes a feature where the entity (the file) may be optionally
encoded in some fashion, as negoatiated between the client and server.
This is typically done to compress the file, so it is transferred
faster.  If compressed the transmitted entity will have a different
(smaller) size, so the Content-Length field will be shorter.

By default, the Apache HTTP Components client supports compression and
advertises its support to the server via the Accept-Encoding request
header.

When making a HEAD request (after a successful PUT request), dCache
wishes to learn how large is the remote file.  As the HEAD request
reports the headers that would have been sent if the request was a GET
request, the Content-Length will reflect the compressed file size if the
server supports compression.

(As it happens the Apache httpd server suppresses Content-Length if the
client has negotiated compression, since it does not know at the time
of the HEAD request the compressed file's size)

Modification:

Suppress the Accept-Encoding request header for HEAD requests.

Result:

http-tpc PUSH requests are successful when targeting an Apache server.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12641/
Acked-by: Albert Rossi