### PR TITLE
pool: preserve CDC on p2p transfer

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
@@ -3,6 +3,7 @@ package org.dcache.pool.p2p;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import dmg.cells.nucleus.CDC;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.StatusLine;
@@ -567,10 +568,12 @@ class Companion
      */
     void beginTransfer(final String uri)
     {
+        final CDC cdc = new CDC();
         new Thread("P2P Transfer - " + _pnfsId + " " + _sourcePoolName) {
             @Override
             public void run()
             {
+                cdc.restore();
                 transfer(uri);
             }
         }.start();


### PR DESCRIPTION
Motivation:

Resilience (and subsequently the QoS Engine) relies
upon the CDC Session Id to identify transfers or
messages resulting from activity initiated there
(e.g., migration tasks).   This is largely in
order to avoid reprocessing Add and Clear Cache
Location messages from PnfsManager.

In order for this to work, all execution must
be done through CDC preserving executor services
or manually restore the CDC on new threads.

Currently, the passage from the MigrationModuleService
to the P2P client breaks the CDC context by starting
an independent thread.

Modification:

Manually restore the CDC context.

Result:

CDC context, and session id are preserved and
visible to PnfsManager and subsequently to the
service receiving the update (Resilience/QoS).

This is a bug, but it is largely invisible to the user.

Target: master
Request:  6.2
Request:  6.1
Request:  6.0
Request:  5.2
Patch:  https://rb.dcache.org/r/12645/
Requires-notes: no
Requires-book: no
Acked-by: Paul
Acked-by: Lea