### PR TITLE
webdav:HTTPS PUT req issue

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -785,6 +785,7 @@ public class DcacheResourceFactory
 
         String uri = null;
         WriteTransfer transfer = new WriteTransfer(_pnfs, subject, restriction, path);
+        transfer.setSSL(_redirectToHttps && ServletRequest.getRequest().isSecure());
         _transfers.put((int) transfer.getId(), transfer);
         try {
             transfer.createNameSpaceEntry();


### PR DESCRIPTION
Motivation

webdav HTTPS redirect to encrypt transfers is working for GET requests but it is not for PUT requests and  after redirect the location is  still with http.

The problem was that the isSSl flag, based on the value of which either https or http protocl is used,  was not set  for upload.

Modification

Https PUT is possible.

Target: master, 6.2, 6.1, 6.0, 5.2
Require-book: no
Require-notes: yes
Acked-by: Paul Millar
Patch: https://rb.dcache.org/r/12631/