### PR TITLE
pool: http-tpc do not loop if HEAD 'Content-Length' response is missing

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -38,6 +38,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -598,22 +599,16 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                             continue;
                         }
 
-                        Long length = getContentLength(response);
+                        OptionalLong contentLengthHeader = contentLength(response);
 
-                        // REVISIT This is to support pre-2.12 dCache, which could
-                        // give a '201 Created' response to a PUT request before
-                        // post-processing (including checksum calculation) was
-                        // completed and the final details registered in the
-                        // namespace.  This problem is fixed with dCache v2.12 or
-                        // later.
-                        if (length == null || (attributes.getSize() != 0 && length == 0)) {
-                            continue;
-                        }
-
-                        if (attributes.getSize() != length) {
-                            throw new ThirdPartyTransferFailedCacheException(
-                                    String.format("wrong Content-Length in HEAD response (%d != %d)",
-                                    length, attributes.getSize()));
+                        if (contentLengthHeader.isPresent()) {
+                            long contentLength = contentLengthHeader.getAsLong();
+                            long fileSize = attributes.getSize();
+                            checkThirdPartyTransferSuccessful(contentLength == fileSize,
+                                    "HEAD Content-Length (%d) does not match file size (%d)",
+                                    contentLength, fileSize);
+                        } else {
+                            _log.debug("HEAD response did not contain Content-Length");
                         }
 
                         String rfc3230 = headerValue(response, "Digest");
@@ -702,17 +697,17 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
         return header != null ? header.getValue() : null;
     }
 
-    private static Long getContentLength(HttpResponse response)
+    private static OptionalLong contentLength(HttpResponse response)
             throws ThirdPartyTransferFailedCacheException
     {
         Header header = response.getLastHeader("Content-Length");
 
         if (header == null) {
-            return null;
+            return OptionalLong.empty();
         }
 
         try {
-            return Long.parseLong(header.getValue());
+            return OptionalLong.of(Long.parseLong(header.getValue()));
         } catch (NumberFormatException e) {
             throw new ThirdPartyTransferFailedCacheException("server sent malformed Content-Length header", e);
         }


### PR DESCRIPTION
Motivation:

After PUSHing a file's data, dCache will always attempt to check data
was written correctly by making a HEAD request and verifying data
against what it knows.  Currently, dCache will make HEAD requests until
it receives a response with a "Content-Length" response header.

This retrying until the response contains a Content-Length header exists
as a work-around for an ancient version of dCache (2.12 and earlier)
that returned "201 Created" before the file was registered in the
namespace.  Therefore there was a race-condition between that
registration and a clients making a HEAD request.  If the client won the
race, the response would not contain the "Content-Length" header.

This work-around is no longer needed, as dCache v2.12 or earlier are no
longer in use.

The work-around is itself problematic.

An RFC-conforming server may omit the "Content-Length" header in a HEAD
response.  As a specific example, the Apache server does this for
zero-length files.  The Apache server is used by (at least) DPM and
DynaFed.  In such cases, dCache would make repeated HEAD requests,
waiting for a response that contained the "Content-Length".  Since the
Apache server will never reply with this header, the retry loop will
eventually time out, and dCache will fail the transfer.

Additionally, checking "Content-Length" of the remote file may be
unnecessary in many circumstances.

Unlike with FTP mode-S transfers, dCache can tell the server how large
is the file being uploaded.  The remote server may return an error code
if the received file is incomplete; although correct behaviour under
these circumstances seems poorly defined.

Modification:

No longer loop HEAD requests if the server fails to send a
"Content-Length" response header.  However, continue to check the file
size if the response does contain the "Content-Length" header.

Result:

HTTP-TPC transfers where dCache pushes data to an Apache server (for
example, as used by Dynafed) will now work for zero-length files.

Target: master
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Fixes: #5549
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/12618/
Acked-by: Tigran Mkrtchyan