### PR TITLE
logging: add an option to control logger destination

### DIFF
--- a/skel/etc/logback.xml
+++ b/skel/etc/logback.xml
@@ -62,11 +62,24 @@
        runtime through the dCache admin shell.
   -->
 
-  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>${dcache.log.format.file}</pattern>
-    </encoder>
-  </appender>
+  <if condition='"${dcache.log.destination}".equals("file")'>
+    <then>
+      <appender name="stdout" class="ch.qos.logback.core.FileAppender">
+        <file>${dcache.log.file}</file>
+        <encoder>
+            <pattern>${dcache.log.format.file}</pattern>
+        </encoder>
+      </appender>
+    </then>
+    <else>
+      <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+          <pattern>${dcache.log.format.file}</pattern>
+        </encoder>
+      </appender>
+    </else>
+  </if>
+
 
   <appender name="pinboard" class="dmg.util.PinboardAppender">
     <layout>

--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -1407,3 +1407,21 @@ dcache.plugins.storage-info-extractor = org.dcache.chimera.namespace.ChimeraOsmS
 # Set this option to false if use of sysV-like scripts should be allowed
 #
 (not-for-services,one-of?true|false)dcache.systemd.strict=true
+
+
+#
+# Control where dCache sends its log messages.
+#
+# When the log destination is `console`, then the logs are sent to standard
+# output. If dCache is running as systemd service, the standard output is
+# redirected to the journald facility. If dCache runs as system-V service,
+# then stdout is redirected to the log file.
+#
+# As 3rd party components used by dCache can ignore logger configuration, for
+# example JVM native debugging, some log messages might be printed to the console.
+# Thus we recommend to using `console` as destination for log messages.
+#
+# The location of the log file controlled by the `dcache.log.file`
+# property.
+#
+(not-for-services,one-of?console|file)dcache.log.destination=console


### PR DESCRIPTION
Motivation:
on of the main concerns of migration to systemd is loosing the standard
log files. As dCache uses logback for logging, a corresponding
configuration might restore this functionality.

Modification:
introduce `dcache.log.destination` property that controls the log
destination. The default value `console` preserves the current
behaviour: systemd services log to journald, system-V services log to
stdout (redirected to /var/log/dcache/<domain>.log).

The option `file` instruct logback to send message to the location
defined by `dcache.log.file` property. The plain file FileAppender is
used as dCache packages already comes with pre-defined logrotate
configuration.

Result:
The log files can be enforced even with systemd deployments.

Acked-by: Paul Millar
Acked-by: Albert Rossi
Target: master, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 1a01bfc088053458affa432060f4fbbd388fdc8e)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>