### PR TITLE
pom: update to xrootd4j 4.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>4.0.3</version.xrootd4j>
+        <version.xrootd4j>4.0.4</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.1</version.dcache-view>
         <version.netty>4.1.50.Final</version.netty>


### PR DESCRIPTION
bump to 4.0.4

fixes #5065 (confusing error message when gsi is used but certificates dir missing on pool)
https://rb.dcache.org/r/12656/
master@62f770b98f40d6787abe2e6e4b41b7e2b5bf30ad

Target: master
Patch: https://rb.dcache.org/r/12662/
Request: 7.0
Request: 6.2
Request: 6.1  (3.5.8)
Request: 6.0  (3.5.8)
Request: 5.2  (3.5.8)
Acked-by: Lea
Acked-by: Paul
Requires-notes: yes
Requires-book: no