### PR TITLE
srm-client: prevent unhelpful NullPointerException

### DIFF
--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMClient.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMClient.java
@@ -168,11 +168,11 @@ public abstract class SRMClient
             if (configuration.isUseproxy()) {
                 cred = configuration.getX509_user_proxy() == null
                         ? Optional.<X509Credential>empty()
-                        : Optional.of(new PEMCredential(configuration.getX509_user_proxy(), (char[]) null));
+                        : Optional.of(new PEMCredential(configuration.getX509_user_proxy(), new char[]{}));
             } else {
                 cred = configuration.getX509_user_key() == null || configuration.getX509_user_cert() == null
                         ? Optional.<X509Credential>empty()
-                        : Optional.of(new PEMCredential(configuration.getX509_user_key(), configuration.getX509_user_cert(), null));
+                        : Optional.of(new PEMCredential(configuration.getX509_user_key(), configuration.getX509_user_cert(), new char[]{}));
             }
         }
 


### PR DESCRIPTION
Motivation:
When attempting to use a password protected X.509 certificate with the srm client, a NullPointerException is logged without any further information. This is a bug and does not help discover the underlying problem.

Modification:
The SRMClient attempts to get the credential by creating a new instance of PEMCredential, which expects a key password as a char array. Because it is assumed that the key is not password protected, a value of null is passed, leading to a NullPointerException later on.
This is changed to instead passing an empty char array, which will result in a more helpful error message.

Result:
A better error message is logged when attempting to use a password protected credential:
srm client error:
java.io.IOException: Error decrypting private key: the password is incorrect or the PEM data is corrupted.

Target: master
Request: 7.0
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/12667/
Acked-by: Tigran Mkrtchyan