### PR TITLE
pool: https avoid sharing SSLEngine between TCP connections

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/HttpsTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpsTransferService.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2017-2018 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2017-2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -50,7 +50,6 @@ public class HttpsTransferService extends HttpTransferService
 
     private static final String PROTOCOL_HTTPS = "https";
 
-    private volatile SSLEngine _sslEngine;
     private SSLContext _sslContext;
 
     public void setSslContext(SSLContext sslContext)
@@ -102,23 +101,12 @@ public class HttpsTransferService extends HttpTransferService
     }
 
     @Override
-    protected synchronized void startServer() throws IOException {
-        super.startServer();
-        try {
-            _sslEngine = _sslContext.createSSLEngine();
-            _sslEngine.setUseClientMode(false);
-            _sslEngine.setWantClientAuth(false);
-        } catch (Exception e) {
-            throw new IOException("Failed to create SSL engine: " + e, e);
-        }
-
-    }
-
-    @Override
     protected void addChannelHandlers(ChannelPipeline pipeline)
     {
-        pipeline.addLast("ssl", new SslHandler(_sslEngine));
+        SSLEngine engine = _sslContext.createSSLEngine();
+        engine.setUseClientMode(false);
+        engine.setWantClientAuth(false);
+        pipeline.addLast("ssl", new SslHandler(engine));
         super.addChannelHandlers(pipeline);
     }
-
 }


### PR DESCRIPTION
Motivation:

Problems have been reported when dCache is configured to redirect
clients to pools with encryption enabled, and dCache is in heavy use
with multiple concurrent uploads.

The problem stems from an SSLEngine instance being shared between
multiple TCP connections.

An SSLEngine is intended to be used once per TCP connection; however,
currently the HttpsTransferService generates a single SSLEngine instance
when Netty server starts and uses this for all TCP connections.

Modification:

Create a new SSLEngine when accepting a new TCP connection.  This
SSLEngine has a lifetime of the TCP connection.

Result:

Fix a problem where, under heavy load, redirected https transfers result
in garbled SSL information, preventing the HTTP client from working.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Closes: #5618
Patch: https://rb.dcache.org/r/12676/
Acked-by: Lea Morschel