### PR TITLE
pool: fix HTTPS support under heavy load

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2013-2015 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2013-2020 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -154,7 +154,7 @@ public class HttpTransferService extends NettyTransferService<HttpProtocolInfo>
         addChannelHandlers(ch.pipeline());
     }
 
-    protected void addChannelHandlers(ChannelPipeline pipeline)
+    protected void addChannelHandlers(ChannelPipeline pipeline) throws Exception
     {
         // construct HttpRequestDecoder as netty defaults, except configurable chunk size
         pipeline.addLast("decoder", new HttpRequestDecoder(4096, 8192, getChunkSize(), true));


### PR DESCRIPTION
Motivation:

Fix two issues:

First, under heavy load, pool-direct HTTPS transfers start to fail.

This comes from sharing the SSLEngine between different TCP connections.

Second, HTTPS transfers trigger unnecessary credential reloading.

The SSLContext (within which the server's credential is stored) is
created each time the Netty server is started, requiring the pool to
reload the server credential from disk.  Under low load, this happens
for each HTTPS transfer.  The server credential does not change that
often; typically once per year.

Modification:

Create an SSLContext "provider" (actually, Callable) on pool startup.
Invoke this provider to provide a fail-fast behaviour: the pool will
fail to start-up if there are any problems: credential cannot be loaded,
the trust directory is missing, ...

Create the SSLEngine instance when a client connects, using the
SSLContext provider.  Unless the server credential has been modified,
this will use a cached SSLContext.

Result:

Fixed a problem where redirected transfers involving the client uses
HTTPS when communicating directly with the pool would fail under
moderate-to-heavy load.

A minor performance issue is also resolved.

Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Closes: #5618
Patch: https://rb.dcache.org/r/12678/
Acked-by: Tigran Mkrtchyan