### PR TITLE
xrootd/pool: improve access log to record more details of kXR_query

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandler.java
@@ -51,6 +51,7 @@ import org.dcache.xrootd.protocol.messages.OpenRequest;
 import org.dcache.xrootd.protocol.messages.OpenResponse;
 import org.dcache.xrootd.protocol.messages.PathRequest;
 import org.dcache.xrootd.protocol.messages.PrepareRequest;
+import org.dcache.xrootd.protocol.messages.QueryRequest;
 import org.dcache.xrootd.protocol.messages.ReadRequest;
 import org.dcache.xrootd.protocol.messages.ReadVRequest;
 import org.dcache.xrootd.protocol.messages.RedirectResponse;
@@ -73,6 +74,9 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.*;
 public class AccessLogHandler extends ChannelDuplexHandler
 {
     protected final Logger logger;
+
+    // FIXME Value currently undefined within version of xrootd4j
+    private static final int kXR_Qopaqug = 64;
 
     public AccessLogHandler(Logger logger)
     {
@@ -175,6 +179,13 @@ public class AccessLogHandler extends ChannelDuplexHandler
                     } else {
                         log.add("files", ((PrepareRequest) request).getPathList().length);
                     }
+                } else if (request instanceof QueryRequest) {
+                    log.add("reqcode", getQueryReqCode(request));
+                    int fhandle = ((QueryRequest) request).getFhandle();
+                    if (fhandle != 0) {
+                        log.add("fhandle", fhandle);
+                    }
+                    log.add("args", Strings.emptyToNull(((QueryRequest) request).getArgs()));
                 } else if (request instanceof StatxRequest) {
                     if (((StatxRequest) request).getPaths().length == 1) {
                         log.add("path", ((StatxRequest) request).getPaths()[0]);
@@ -302,6 +313,37 @@ public class AccessLogHandler extends ChannelDuplexHandler
             return "waitresp";
         default:
             return String.valueOf(status);
+        }
+    }
+
+    private static String getQueryReqCode(XrootdRequest request)
+    {
+        int reqcode = ((QueryRequest)request).getReqcode();
+        switch (reqcode) {
+        case kXR_QStats:
+            return "QStats";
+        case kXR_QPrep:
+            return "QPrep";
+        case kXR_Qcksum:
+            return "QCksum";
+        case kXR_Qxattr:
+            return "QXattr";
+        case kXR_Qspace:
+            return "QSpace";
+        case kXR_Qckscan:
+            return "QCksCan";
+        case kXR_Qconfig:
+            return "QConfig";
+        case kXR_Qvisa:
+            return "QVisa";
+        case kXR_Qopaque:
+            return "QOpaque";
+        case kXR_Qopaquf:
+            return "QOpaquf";
+        case kXR_Qopaqug:
+            return "QOpaqug";
+        default:
+            return String.valueOf(reqcode);
         }
     }
 


### PR DESCRIPTION
Motivation:

The xrootd xrdcp client can fail operations if it does not like dCache's
response from a kXR_query request.  However, currently the access log
file do not include any details about the kXR_query request, making
post-hoc diagnostic difficult.

Modification:

Add additional fields for kXR_query request logging.

Result:

The xroot protocol access log entries for the xrootd door and pool have
been enhanced to include information about the kXR_query requests.

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12706/
Acked-by: Dmitry Litvintsev
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel