### PR TITLE
vehicles: internalize common strings in StorageInfo

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/EnstoreStorageInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/EnstoreStorageInfo.java
@@ -2,6 +2,7 @@ package diskCacheV111.vehicles ;
 
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 
 /**
@@ -10,8 +11,8 @@ import java.io.ObjectInputStream;
   * attributes.
   */
 public class EnstoreStorageInfo extends GenericStorageInfo {
-   private final String _family;
-   private final String _group;
+   private String _family;
+   private String _group;
    private String _volume   = "<unknown>" ;
    private String _location = "<unknown>" ;
    private String _path;
@@ -69,6 +70,19 @@ public class EnstoreStorageInfo extends GenericStorageInfo {
             return _family;
          default:
             return super.getKey(key);
+      }
+   }
+
+   private void readObject(java.io.ObjectInputStream stream)
+           throws IOException, ClassNotFoundException
+   {
+      stream.defaultReadObject();
+      if (_group != null) {
+         _group = _group.intern();
+      }
+
+      if (_family != null) {
+         _family = _family.intern();
       }
    }
 

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/OSMStorageInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/OSMStorageInfo.java
@@ -1,11 +1,13 @@
 package diskCacheV111.vehicles;
 
+import java.io.IOException;
+
 public class OSMStorageInfo extends GenericStorageInfo {
 
    private static final long serialVersionUID = 4260226401319935542L;
 
-   private final String _store;
-   private final String _group;
+   private String _store;
+   private String _group;
 
    public OSMStorageInfo( String store , String group ){
 	   super();
@@ -49,5 +51,18 @@ public class OSMStorageInfo extends GenericStorageInfo {
              ';';
 
    }
+
+    private void readObject(java.io.ObjectInputStream stream)
+            throws IOException, ClassNotFoundException
+    {
+        stream.defaultReadObject();
+        if (_group != null) {
+            _group = _group.intern();
+        }
+
+        if (_store != null) {
+            _store = _store.intern();
+        }
+    }
 }
 


### PR DESCRIPTION
Motivation:
Typically systems have handful of different storage classes. However, as
StorageInfo object is often used after de-serialization, due to network
transport or re-read from metadata db pool contains large number of
clones.

Modification:
update OSMStorageInfo and EnstoreStorageInfo to internalize common
strings.

Result:
less memory consumption on pools.

Acked-by: Paul Millar
Target: master, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 6f91955d64353b19f3cf56dd11fe70a0b7126828)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>