### PR TITLE
webdav/frontend: ensure cancelled HTTP-TPC transfers are logged

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/AbstractLoggingHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AbstractLoggingHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.security.auth.Subject;
 import javax.servlet.ServletException;
@@ -34,6 +35,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 
 import dmg.cells.nucleus.CDC;
 
@@ -50,6 +52,9 @@ public abstract class AbstractLoggingHandler extends HandlerWrapper
 {
     private static final String X509_CERTIFICATE_ATTRIBUTE =
             "javax.servlet.request.X509Certificate";
+    private static final String REMOTE_ADDRESS = "org.dcache.remote-address";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractLoggingHandler.class);
 
     /** The SLF4J Logger to which we send access log entries. */
     protected abstract Logger accessLogger();
@@ -64,6 +69,11 @@ public abstract class AbstractLoggingHandler extends HandlerWrapper
     {
         if (isStarted() && !baseRequest.isHandled()) {
             Stopwatch processingTime = Stopwatch.createStarted();
+
+            // Cache the remote client address because the client may disconnect
+            // while dCache is processing the request, in which case Jetty
+            // "forgets".
+            request.setAttribute(REMOTE_ADDRESS, remoteAddress(request).orElse(null));
 
             super.handle(target, baseRequest, request, response);
 
@@ -87,12 +97,36 @@ public abstract class AbstractLoggingHandler extends HandlerWrapper
         log.add("response.code", response.getStatus());
         log.add("response.reason", getReason(response));
         log.add("location", response.getHeader("Location"));
-        InetAddress addr = InetAddresses.forString(request.getRemoteAddr());
-        log.add("socket.remote", new InetSocketAddress(addr, request.getRemotePort()));
+        log.add("socket.remote", (InetSocketAddress) request.getAttribute(REMOTE_ADDRESS));
         log.add("user-agent", request.getHeader("User-Agent"));
 
         log.add("user.dn", getCertificateName(request));
         log.add("user.mapped", getSubject(request));
+    }
+
+    /**
+     * Provide this connection's remote address; that is, the address of the
+     * client.  The method returns Optional.empty if this cannot be determined,
+     * for whatever reason.
+     */
+    private static Optional<InetSocketAddress> remoteAddress(HttpServletRequest request)
+    {
+        String addrString = request.getRemoteAddr();
+        int port = request.getRemotePort();
+
+        if (addrString.isEmpty() || port == 0) { // Sometimes Jetty just doesn't know (!)
+            return Optional.empty();
+        }
+
+        InetAddress addr;
+        try {
+            addr = InetAddresses.forUriString(addrString);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Cannot build internet address: {}", e.getMessage());
+            return Optional.empty();
+        }
+
+        return Optional.of(new InetSocketAddress(addr, port));
     }
 
     private static String getReason(HttpServletResponse response)


### PR DESCRIPTION
Motivation:

There are reports of the access log file missing entries. This problem
seems to be triggered if the client disconnects before dCache has
finished processing the request, which is certainly true for cancelled
HTTP-TPC transfers.

The cause seems to be that Jetty "forgets" the remote address if the
connection has been terminated.  If this happens then Jetty returning an
empty string as the (String representation of) the remote IP address and
zero as the port numbers.

An empty string is not a valid IP address, so the Guava library throws
IllegalArgumentException, which (in turn) results in nothing being
logged in the access log file.

Modification:

Cache the remote address before processing the request.  This ensures we
have the information later when logging the result.

Move remote address handling into a separate method, which handles the
Jetty-doesn't-know case.  This new method also more robust against badly
formatted IP addresses.

Result:

Avoid problems that can result in missing entries in the access log
file for WebDAV and frontend requests.

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12752/
Acked-by: Lea Morschel