### PR TITLE
TransferManager: choose better pool query message TTL

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -255,7 +255,8 @@ public abstract class TransferManager extends AbstractCellComponent
             return message;
         }
 
-        return handler.appendInfo(message);
+        long poolQueryTimeout = Math.min(envelope.getAdjustedTtl(), 30_000);
+        return handler.appendInfo(message, poolQueryTimeout);
     }
 
     public int getMaxTransfers()

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -791,7 +791,8 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         return state == RECEIVED_FIRST_POOL_REPLY_STATE;
     }
 
-    public Object appendInfo(final TransferStatusQueryMessage message)
+    public Object appendInfo(final TransferStatusQueryMessage message,
+            long poolQueryTimeout)
     {
         message.setState(state);
 
@@ -803,7 +804,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
         final ListenableFuture<IoJobInfo> future = manager.getPoolStub().
                 send(new CellPath(pool.getAddress()), "mover ls -binary " + moverId,
-                IoJobInfo.class, 30_000);
+                IoJobInfo.class, poolQueryTimeout);
         Futures.addCallback(future, new FutureCallback<IoJobInfo>()
         {
             @Override


### PR DESCRIPTION
Motivation:

The TransferManager provides the ability to query the current status of
a transfer, which is used by the WebDAV door to return HTTP-TPC progress
markers.

The progress markers have a strict deadline within which they need to
know the transfer's status.  The message from WebDAV to TransferManager
querying the transfer's status has a TTL that reflects this requirement.

However, the query from TransferManager to the pool has a hard-coded
timeout of 30 seconds.  This timeout is far too long.

Modification:

Update TransferManager so that the timeout (and corresponding TTL) for
the pool-querying message is based on the TTL of the incoming query from
the WebDAV door.

Result:

Better recovery in the case where a pool's message queue is overloaded,
as old (and now useless) requests may be simply discarded.

This patch partially addresses #5642.

Target: master

Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/12753/
Acked-by: Tigran Mkrtchyan