### PR TITLE
rpm take build directory path into quotes

### DIFF
--- a/modules/srm-client/src/main/rpm/dcache-srmclient.spec
+++ b/modules/srm-client/src/main/rpm/dcache-srmclient.spec
@@ -26,6 +26,9 @@ This package contains the client components.
 
 %preun
 
+%clean
+rm -rf "$RPM_BUILD_ROOT"
+
 %files
 %defattr(-,root,root)
 %attr(0755,root,root) /usr/bin/adler32

--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -106,7 +106,7 @@ if [ $1 -eq 0 ] ; then
 fi
 
 %clean
-rm -rf $RPM_BUILD_ROOT
+rm -rf "$RPM_BUILD_ROOT"
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
Motivation:
If we don't escape rpmuild paths, then weird directories with space and
'&&' makes a hard time for rpm cleanup step.

```
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.ksiVtf
+ umask 022
+ cd '/scratch/jenkins/jenkins/workspace/Build-tagged-6.2/Environment/CentOS-8 && javac-11.0 && git && mvn && user-jenkins/module/modules/srm-client/profile_option/-P rpm/modules/srm-cl
ient/target/rpmbuild/BUILD'
+ /usr/bin/rm -rf /scratch/jenkins/jenkins/workspace/Build-tagged-6.2/Environment/CentOS-8
+ javac-11.0
/var/tmp/rpm-tmp.ksiVtf: line 33: javac-11.0: command not found
+ exit 127
```

Modification:
take build directory path into quotes

Result:
rpmbuild works for directories with spaces and '&&' in the name.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1918361

Acked-by: Lea Morschel
Acked-by: Paul Millar
Target: master, 7.0, 6.2, 6.1, 6.0, 5.2
Require-book: no
Require-notes: no
(cherry picked from commit 647e117195aed2abe2bf29cb19d06dc45e144e4a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>