### PR TITLE
ftp: add place-holder file size work-around for Globus directory listing

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -395,7 +395,18 @@ public abstract class AbstractFtpDoorV1
          * close our end of the TCP connection once any pending transfers have
          * completed.
          */
-        NO_REPLY_ON_QUIT
+        NO_REPLY_ON_QUIT,
+
+        /**
+         * Some clients (e.g., Globus) require that files returned during
+         * directory listing have a definite size.  When dCache is accepting a
+         * new file, the namespace does not know the final file's size so no
+         * file size is returned to the door.  Normally, dCache simply omits the
+         * file size information when building the response; however, this
+         * work-around results in such incomplete files being reported as having
+         * zero length.
+         */
+        USE_PLACEHOLDER_SIZE_FOR_INCOMPLETE_FILES,
     }
 
 
@@ -3183,6 +3194,21 @@ public abstract class AbstractFtpDoorV1
         case "globus-url-copy":
             _activeWorkarounds.add(WorkAround.NO_REPLY_ON_QUIT);
             break;
+
+        // Globus (Online) agent for:
+        //     Providing web-portal with directory listing,
+        //     Deleting contents.
+        // Observed commands: MLST, MLSC, DELE, RMD
+        case "globusonline-dirlist":
+            _activeWorkarounds.add(WorkAround.USE_PLACEHOLDER_SIZE_FOR_INCOMPLETE_FILES);
+            break;
+
+        // Globus (Online) agent that seems to do a recursive directory listing
+        // in preparation of data transfer.
+        // Observed commands: MLSC, MLST
+        case "gshtest":
+            _activeWorkarounds.add(WorkAround.USE_PLACEHOLDER_SIZE_FOR_INCOMPLETE_FILES);
+            break;
         }
         reply("250 OK");
     }
@@ -4851,17 +4877,30 @@ public abstract class AbstractFtpDoorV1
                     break;
                 }
             }
+
+            if (_activeWorkarounds.contains(WorkAround.USE_PLACEHOLDER_SIZE_FOR_INCOMPLETE_FILES)
+                    && _currentFacts.contains(Fact.SIZE)) {
+                attributes.add(SIMPLE_TYPE);
+            }
+
             return attributes;
         }
 
         @Override
         public void print(FsPath dir, FileAttributes dirAttr, DirectoryEntry entry)
         {
+            FileAttributes attr = entry.getFileAttributes();
+
+            if (_activeWorkarounds.contains(WorkAround.USE_PLACEHOLDER_SIZE_FOR_INCOMPLETE_FILES)
+                    && attr.isDefined(TYPE) && attr.getFileType() == FileType.REGULAR
+                    && attr.isUndefined(SIZE)) {
+                attr.setSize(0L);
+            }
+
             FsPath path = (dir == null) ? FsPath.ROOT : dir.child(entry.getName());
 
             if (!_currentFacts.isEmpty()) {
                 AccessType access;
-                FileAttributes attr = entry.getFileAttributes();
 
                 for (Fact fact: _currentFacts) {
                     switch (fact) {

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -407,6 +407,25 @@ public abstract class AbstractFtpDoorV1
          * zero length.
          */
         USE_PLACEHOLDER_SIZE_FOR_INCOMPLETE_FILES,
+
+        /**
+         * Some clients (e.g., Globus) will always request an MD5 checksum
+         * after uploading data, but do no let dCache know this via the
+         * OPTS CKSM command.  Without such a hint, the pool will calculate a
+         * default set of checksum values.  Historically, this does not include
+         * MD5.
+         * <p>
+         * The door will calculate the MD5 checksum dynamically if the client
+         * requests the MD5 checksum and the pool didn't calculated the value.
+         * However, this on-demand checksum calculation slows down the transfers
+         * and places unnecessary load on dCache.
+         * <p>
+         * This work-around informs the pool to calculate the MD5 checksum for
+         * any uploaded files.  The OPT CKSM command, SITE CHKSUM command and
+         * SCKS command continue to be supported.  Any specified algorithm
+         * specified through these commands will be calculated instead of MD5.
+         */
+        REQUEST_MD5_WHEN_UPLOADING_FILES
     }
 
 
@@ -1168,6 +1187,10 @@ public abstract class AbstractFtpDoorV1
             protocolInfo.setPassive(usePassivePool);
             protocolInfo.setMode(_xferMode);
             protocolInfo.setProtocolFamily(_protocolFamily);
+
+            if (_activeWorkarounds.contains(WorkAround.REQUEST_MD5_WHEN_UPLOADING_FILES)) {
+                protocolInfo.setChecksumType("MD5");
+            }
 
             if (_optCheckSumType != null) {
                 protocolInfo.setChecksumType(_optCheckSumType.getName());
@@ -3208,6 +3231,13 @@ public abstract class AbstractFtpDoorV1
         // Observed commands: MLSC, MLST
         case "gshtest":
             _activeWorkarounds.add(WorkAround.USE_PLACEHOLDER_SIZE_FOR_INCOMPLETE_FILES);
+
+        // Globus (Online) transfer management agent, responsible for initiating
+        // third-party copy.
+        // Observed commands: RETR, STOR, ALLO, CKSM MD5, NOOP, MLST, MODE E,
+        //     PASV, MLST, MKD, PBSZ, TYPE I, DCAU N, PBSZ, OPTS RETR
+        case "globusonline-fxp":
+            _activeWorkarounds.add(WorkAround.REQUEST_MD5_WHEN_UPLOADING_FILES);
             break;
         }
         reply("250 OK");


### PR DESCRIPTION
Motivation:

For files being currently uploaded we don't yet know the file's size.
As a result, the namespace declines to provide the file's size in the
FileAttributes object.

When making a directory listing with the MLSC command, Globus requires
files have a defined size.  It treats any lack of a SIZE fact as an
error.

Modification:

This patch adds a work-around where incomplete files (those still being
uploaded) have zero length, as a place-holder value.

Result:

Globus transfer service can now list directories that contain incomplete
files, those that are still being uploaded.

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12768/
Acked-by: Tigran Mkrtchyan