### PR TITLE
ftp: do not leak sockets when calculating checksums dynamically

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/ChecksumCalculatingTransfer.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/ChecksumCalculatingTransfer.java
@@ -60,49 +60,54 @@ public class ChecksumCalculatingTransfer extends Transfer
             InterruptedException, IOException, NoSuchAlgorithmException
     {
         boolean success = false;
-        ServerSocketChannel ssc = ServerSocketChannel.open();
-        portRange.bind(ssc.socket(), localAddress);
+
         setAdditionalAttributes(EnumSet.of(FileAttribute.CHECKSUM));
         readNameSpaceEntry(false);
-        LOGGER.debug("calculating checksum using port {}", ssc.getLocalAddress());
-        setProtocolInfo(new GFtpProtocolInfo("GFtp", 1, 0,
-                (InetSocketAddress) ssc.getLocalAddress(), 1, 1, 1,
-                MiB.toBytes(1), 0, getFileAttributes().getSize()));
         Checksum existingChecksum = Checksums.preferrredOrder().max(getFileAttributes().getChecksums());
-        try {
-            selectPoolAndStartMover(TransferRetryPolicies.tryOncePolicy());
-            SocketChannel s = ssc.accept();
-            ByteBuffer buffer = ByteBuffer.allocate(MiB.toBytes(1));
-            MessageDigest desiredDigest = desiredType.createMessageDigest();
-            MessageDigest verifyingDigest = existingChecksum.getType().createMessageDigest();
+        MessageDigest verifyingDigest = existingChecksum.getType().createMessageDigest();
+        MessageDigest desiredDigest = desiredType.createMessageDigest();
 
-            while (s.read(buffer) > -1) {
-                advanceCalculated(buffer.position());
-                buffer.flip();
-                desiredDigest.update(buffer);
-                buffer.rewind();
-                verifyingDigest.update(buffer);
-                buffer.clear();
-            }
+        try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
+            portRange.bind(ssc.socket(), localAddress);
+            LOGGER.debug("calculating checksum using port {}", ssc.getLocalAddress());
+            setProtocolInfo(new GFtpProtocolInfo("GFtp", 1, 0,
+                    (InetSocketAddress) ssc.getLocalAddress(), 1, 1, 1,
+                    MiB.toBytes(1), 0, getFileAttributes().getSize()));
+            try {
+                selectPoolAndStartMover(TransferRetryPolicies.tryOncePolicy());
 
-            if (!waitForMover(30_000)) {
-                throw new TimeoutCacheException("copy: wait for DoorTransferFinishedMessage expired");
-            }
+                try (SocketChannel s = ssc.accept()) {
+                    ByteBuffer buffer = ByteBuffer.allocate(MiB.toBytes(1));
 
-            success = true;
+                    while (s.read(buffer) > -1) {
+                        advanceCalculated(buffer.position());
+                        buffer.flip();
+                        desiredDigest.update(buffer);
+                        buffer.rewind();
+                        verifyingDigest.update(buffer);
+                        buffer.clear();
+                    }
+                }
 
-            if (getCalculated() != getFileAttributes().getSize()) {
-                throw new CacheException("File size mismatch: " + getCalculated() + " != " + getFileAttributes().getSize());
-            }
+                if (!waitForMover(30_000)) {
+                    throw new TimeoutCacheException("copy: wait for DoorTransferFinishedMessage expired");
+                }
 
-            Checksum verifyingChecksum = new Checksum(verifyingDigest);
-            if (!existingChecksum.equals(verifyingChecksum)) {
-                throw new CacheException("Corrupt data: " + verifyingChecksum + " != " + existingChecksum);
-            }
-            return new Checksum(desiredDigest);
-        } finally {
-            if (!success) {
-                killMover(0, "killed by failure");
+                success = true;
+
+                if (getCalculated() != getFileAttributes().getSize()) {
+                    throw new CacheException("File size mismatch: " + getCalculated() + " != " + getFileAttributes().getSize());
+                }
+
+                Checksum verifyingChecksum = new Checksum(verifyingDigest);
+                if (!existingChecksum.equals(verifyingChecksum)) {
+                    throw new CacheException("Corrupt data: " + verifyingChecksum + " != " + existingChecksum);
+                }
+                return new Checksum(desiredDigest);
+            } finally {
+                if (!success) {
+                    killMover(0, "killed by failure");
+                }
             }
         }
     }


### PR DESCRIPTION
Motivation:

The FtpDoor supports dynamic checksum calculation by streaming the
file's content to the door, similar to an active MODE-S download.  This
requires the door to listen for an incoming TCP connection and consume
the contents.

Currently the door neglects to close either the establish TCP connection
or the server socket.  The door will eventually run out of ephemeral
ports and stop working.

Modification:

Add try-with-resource to ensure server socket and established socket are
closed.  The patch includes some very minor refactoring to facilitate
this.

Result:

The FTP no longer leaking sockets when dynamically calculating file
checksums (e.g., MD5).  In practise, this issue only affects transfers
via the Globus transfer service.

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12770/
Acked-by: Tigran Mkrtchyan