### PR TITLE
libraries: upgrade version of canl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
             <dependency>
                 <groupId>eu.eu-emi.security</groupId>
                 <artifactId>canl</artifactId>
-                <version>2.5.1</version>
+                <version>2.6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.italiangrid</groupId>


### PR DESCRIPTION
Movation:

Fix CA roll-over problem

Modification:

Latest version of canl

Result:

Deployment should not have problems if a CA certificate is updated.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2