### PR TITLE
pool: do not update file size on flush

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -965,7 +965,6 @@ public class NearlineStorageHandler
                     .accessLatency(fileAttributes.getAccessLatency())
                     .retentionPolicy(fileAttributes.getRetentionPolicy())
                     .storageInfo(storageInfo)
-                    .size(fileAttributes.getSize())
                     .build();
         }
 


### PR DESCRIPTION
Motivation:
The file attributes sent by pool after flush to namespace will update
existing attributes. There are no reasons to update the file size as
well.

Modification:
do not update file size on flush

Result:
less operations on db after flush

Acked-by: Lea Morschel
Acked-by: Paul Millar
Target: master, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 65dfad74e57d704268cb56dbbbfbb521297dabdc)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>