### PR TITLE
dcache-frontend: change transfer rate to compute what it advertised

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -600,9 +600,24 @@ public class TransferObserverV1
             } else {
                 page.td("transferred", "-");
             }
-            page.td("speed", transfer.getTransferRate());
+            page.td("speed", getTransferRate(transfer));
         }
         page.endRow();
+    }
+
+    private Long getTransferRate(TransferInfo info) {
+        Long bytes = info.getBytesTransferred();
+        if (bytes == null) {
+            return 0L;
+        }
+
+        Long time = info.getTransferTime();
+        if (time == null) {
+            return 0L;
+        }
+
+        long secs = time / 1000;
+        return secs > 0.0 ? BYTES.toKiB(bytes) / secs : 0L;
     }
 
     private String createHtmlTable(List<TransferBean> transfers) {

--- a/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
@@ -241,7 +241,7 @@ public class TransferInfo implements Comparable<TransferInfo>, InvalidatableItem
         }
 
         long secs = transferTime / 1000;
-        return secs > 0.0 ? BYTES.toKiB(bytesTransferred) / secs : 0L;
+        return secs > 0.0 ? BYTES.toMiB(bytesTransferred) / secs : 0L;
     }
 
     public Long getTransferTime() {


### PR DESCRIPTION
Motivation:

dcache-view currently displays MB/sec for transfer rate, but the
value is the old KB/sec.

Modification:

Make the auxiliary method on TransferInfo provide MB/sec, which
is more useful.  Retain KB/sec in old page by allowing
it to compute KB/sec there.

Result:

Pages display the values advertised.

Target: master
Patch: https://rb.dcache.org/r/12801
Acked-by: Dmitry
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2