### PR TITLE
frontend: create a log entry when we return 500 Internal Server Error

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/events/streams/metronome/Metronome.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/events/streams/metronome/Metronome.java
@@ -145,8 +145,9 @@ public class Metronome implements EventStream
             String msg = index == -1 ? e.getMessage() : e.getMessage().substring(0, index);
             throw new BadRequestException("Bad selector value: " + msg);
         } catch (IOException e) {
-            throw new InternalServerErrorException("Unable to process selector: "
-                    + e.getMessage());
+            String message = "Unable to process selector: " + e.getMessage();
+            LOGGER.warn(message);
+            throw new InternalServerErrorException(message);
         }
     }
 }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/qos/QosManagement.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/qos/QosManagement.java
@@ -8,6 +8,8 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -39,6 +41,7 @@ import org.dcache.restful.util.RequestUser;
 @Api(value = "qos", authorizations = {@Authorization("basicAuth")})
 @Path("/qos-management/qos/")
 public class QosManagement {
+    private static final Logger LOGGER = LoggerFactory.getLogger(QosManagement.class);
 
     public static final String DISK = "disk";
     public static final String TAPE = "tape";
@@ -64,41 +67,29 @@ public class QosManagement {
     @Produces(MediaType.APPLICATION_JSON)
     public String getQosList(@ApiParam(value = "The kind of object to query.",
                                      allowableValues="file,directory")
-                             @PathParam("type") String qosValue) throws CacheException {
+                             @PathParam("type") String qosValue) {
 
         JSONObject json = new JSONObject();
 
-
-        try {
-            if (RequestUser.isAnonymous()) {
-                throw new PermissionDeniedCacheException("Permission denied");
-            }
-
-            // query the lis of available QoS for file objects
-            if ("file".equals(qosValue)) {
-                JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE, DISK_TAPE, VOLATILE));
-                json.put("name", list);
-            }
-            // query the lis of available QoS for directory objects
-            else if ("directory".equals(qosValue.trim())) {
-                JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE, DISK_TAPE, VOLATILE));
-                json.put("name", list);
-            } else {
-                throw new NotFoundException();
-            }
-
-            json.put("status", "200");
-            json.put("message", "successful");
-
-        } catch (PermissionDeniedCacheException e) {
-            if (RequestUser.isAnonymous()) {
-                throw new NotAuthorizedException(e);
-            } else {
-                throw new ForbiddenException(e);
-            }
-        } catch (CacheException e) {
-            throw new InternalServerErrorException(e);
+        if (RequestUser.isAnonymous()) {
+            throw new NotAuthorizedException("Permission denied");
         }
+
+        // query the lis of available QoS for file objects
+        if ("file".equals(qosValue)) {
+            JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE, DISK_TAPE, VOLATILE));
+            json.put("name", list);
+        }
+        // query the lis of available QoS for directory objects
+        else if ("directory".equals(qosValue.trim())) {
+            JSONArray list = new JSONArray(Arrays.asList(DISK, TAPE, DISK_TAPE, VOLATILE));
+            json.put("name", list);
+        } else {
+            throw new NotFoundException();
+        }
+
+        json.put("status", "200");
+        json.put("message", "successful");
 
         return json.toString();
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/EventResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/EventResources.java
@@ -30,6 +30,8 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.ResponseHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.stereotype.Component;
 
@@ -162,6 +164,7 @@ public class EventResources
         public long timeout;
     }
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventResources.class);
     private static final int MINIMUM_DISCONNECT_TIMEOUT = 1;
     private static final int MAX_CLIENT_ID_LENGTH = 256;
 
@@ -551,7 +554,9 @@ public class EventResources
             throw new BadRequestException("Failed condition: " + result.getMessage());
 
         default:
-            throw new InternalServerErrorException("Unexpected status: " + result.getStatus());
+            String message = "Unexpected status: " + result.getStatus();
+            LOGGER.warn(message);
+            throw new InternalServerErrorException(message);
         }
     }
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/alarms/AlarmsResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/alarms/AlarmsResources.java
@@ -70,6 +70,8 @@ import io.swagger.annotations.ExampleProperty;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -97,6 +99,8 @@ import java.util.Map;
 
 import diskCacheV111.util.CacheException;
 
+import dmg.util.Exceptions;
+
 import org.dcache.alarms.LogEntry;
 import org.dcache.restful.services.alarms.AlarmsInfoService;
 import org.dcache.restful.util.HttpServletRequests;
@@ -113,6 +117,8 @@ import static org.dcache.restful.providers.SuccessfulResponse.successfulResponse
 @Api(value = "alarms", authorizations = {@Authorization("basicAuth")})
 @Path("/alarms")
 public final class AlarmsResources {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AlarmsResources.class);
+
     @Context
     private HttpServletRequest request;
 
@@ -178,6 +184,7 @@ public final class AlarmsResources {
         } catch (IllegalArgumentException e) {
             throw new BadRequestException(e);
         } catch (CacheException | InterruptedException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
     }
@@ -254,6 +261,7 @@ public final class AlarmsResources {
         } catch (JSONException | IllegalArgumentException e) {
             throw new BadRequestException(e);
         } catch (CacheException | InterruptedException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
 
@@ -305,6 +313,7 @@ public final class AlarmsResources {
         } catch (JSONException | IllegalArgumentException e) {
             throw new BadRequestException(e);
         } catch (CacheException | InterruptedException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
 
@@ -336,6 +345,7 @@ public final class AlarmsResources {
         } catch (JSONException | IllegalArgumentException e) {
             throw new BadRequestException(e);
         } catch (CacheException | InterruptedException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/billing/BillingResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/billing/BillingResources.java
@@ -65,6 +65,8 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.stereotype.Component;
 
@@ -92,6 +94,7 @@ import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.PnfsId;
 
 import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.util.Exceptions;
 
 import org.dcache.restful.providers.PagedList;
 import org.dcache.restful.providers.billing.BillingDataGrid;
@@ -112,6 +115,8 @@ import static org.dcache.restful.providers.PagedList.TOTAL_COUNT_HEADER;
 @Api(value = "billing", authorizations = {@Authorization("basicAuth")})
 @Path("/billing")
 public class BillingResources {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BillingResources.class);
+
     @Inject
     private BillingInfoService service;
 
@@ -168,6 +173,7 @@ public class BillingResources {
         } catch (FileNotFoundCacheException e) {
             throw new NotFoundException(e);
         } catch (NoRouteToCellException | InterruptedException | CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         } catch (IllegalArgumentException | ParseException e) {
             throw new BadRequestException(e.getMessage(), e);
@@ -224,6 +230,7 @@ public class BillingResources {
         } catch (FileNotFoundCacheException e) {
             throw new NotFoundException(e);
         } catch (NoRouteToCellException | InterruptedException | CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         } catch (IllegalArgumentException | ParseException e) {
             throw new BadRequestException(e.getMessage(), e);
@@ -283,6 +290,7 @@ public class BillingResources {
         } catch (FileNotFoundCacheException e) {
             throw new NotFoundException(e);
         } catch (NoRouteToCellException | InterruptedException | CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         } catch (IllegalArgumentException | ParseException e ) {
             throw new BadRequestException(e.getMessage(), e);
@@ -335,6 +343,7 @@ public class BillingResources {
         } catch (FileNotFoundCacheException e) {
             throw new NotFoundException(e);
         } catch (NoRouteToCellException | InterruptedException | CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         } catch (IllegalArgumentException | ParseException e) {
             throw new BadRequestException(e.getMessage(), e);
@@ -387,6 +396,7 @@ public class BillingResources {
         } catch (FileNotFoundCacheException e) {
             throw new NotFoundException(e);
         } catch (NoRouteToCellException | InterruptedException | CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         } catch (IllegalArgumentException | ParseException e) {
             throw new BadRequestException(e.getMessage(), e);
@@ -414,10 +424,12 @@ public class BillingResources {
                        try {
                            gridData.add(service.getHistogram(key));
                        } catch (CacheException e1) {
+                           LOGGER.warn(e1.getMessage());
                            throw new InternalServerErrorException(e1);
                        }
                    });
         } catch (CacheException e) {
+            LOGGER.warn(e.getMessage());
             throw new InternalServerErrorException(e);
         }
 
@@ -455,6 +467,7 @@ public class BillingResources {
         try {
             return service.getHistogram(key);
         } catch (CacheException e) {
+            LOGGER.warn(e.getMessage());
             throw new InternalServerErrorException(e);
         } catch (IllegalArgumentException e) {
             throw new BadRequestException(e);
@@ -477,6 +490,7 @@ public class BillingResources {
         try {
             return service.getGrid();
         } catch (CacheException e) {
+            LOGGER.warn(e.getMessage());
             throw new InternalServerErrorException(e);
         }
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -50,6 +50,7 @@ import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
 
 import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.util.Exceptions;
 
 import org.dcache.cells.CellStub;
 import org.dcache.http.PathMapper;
@@ -216,6 +217,7 @@ public class FileResources {
                 throw new ForbiddenException(e);
             }
         } catch (CacheException | InterruptedException | NoRouteToCellException ex) {
+            LOG.warn(Exceptions.meaningfulMessage(ex));
             throw new InternalServerErrorException(ex);
         }
         return fileAttributes;
@@ -384,6 +386,7 @@ public class FileResources {
         } catch (JSONException | IllegalArgumentException | CacheException e) {
             throw new BadRequestException(e);
         } catch (Exception e) {
+            LOG.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
         return successfulResponse(Response.Status.OK);

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/IdResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/IdResources.java
@@ -65,6 +65,8 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -93,6 +95,7 @@ import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
 
 import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.util.Exceptions;
 
 import org.dcache.cells.CellStub;
 import org.dcache.http.PathMapper;
@@ -113,6 +116,8 @@ import org.dcache.vehicles.FileAttributes;
 @Api(value = "namespace", authorizations = {@Authorization("basicAuth")})
 @Path("/id")
 public class IdResources {
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdResources.class);
+
     @Context
     private HttpServletRequest request;
 
@@ -194,6 +199,7 @@ public class IdResources {
                 throw new ForbiddenException(e);
             }
         } catch (CacheException | InterruptedException | NoRouteToCellException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
@@ -68,6 +68,8 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.ResponseHeader;
 import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.stereotype.Component;
 
@@ -110,6 +112,7 @@ import diskCacheV111.vehicles.PoolMoverKillMessage;
 
 import dmg.cells.nucleus.CellPath;
 import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.util.Exceptions;
 
 import org.dcache.cells.CellStub;
 import org.dcache.pool.nearline.json.NearlineData;
@@ -136,6 +139,8 @@ import static org.dcache.restful.providers.SuccessfulResponse.successfulResponse
 @Api(value = "pools", authorizations = {@Authorization("basicAuth")})
 @Path("/pools")
 public final class PoolInfoResources {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PoolInfoResources.class);
+
     private static final String TYPE_ERROR =
                     "type specification %s not supported; please indicate all "
                                     + "door-initiated movers by an undefined "
@@ -344,6 +349,7 @@ public final class PoolInfoResources {
                 }
             }
         } catch (InterruptedException | NoRouteToCellException | CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
 
@@ -439,6 +445,7 @@ public final class PoolInfoResources {
             response.addIntHeader(TOTAL_COUNT_HEADER, count);
             return list;
         } catch (InterruptedException | NoRouteToCellException | CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
     }
@@ -473,9 +480,11 @@ public final class PoolInfoResources {
             if (e.getRc() == CacheException.MOVER_NOT_FOUND) {
                 transferInfoService.setCancelled(pool, id);
             } else {
+                LOGGER.warn(Exceptions.meaningfulMessage(e));
                 throw new InternalServerErrorException(e);
             }
         } catch (InterruptedException | NoRouteToCellException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
 
@@ -520,6 +529,7 @@ public final class PoolInfoResources {
         } catch (JSONException | IllegalArgumentException | IOException e) {
             throw new BadRequestException(e);
         } catch (InterruptedException | NoRouteToCellException | CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
@@ -65,6 +65,8 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.stereotype.Component;
 
@@ -82,6 +84,8 @@ import java.util.UUID;
 
 import diskCacheV111.util.CacheException;
 
+import dmg.util.Exceptions;
+
 import org.dcache.restful.providers.SnapshotList;
 import org.dcache.restful.providers.restores.RestoreInfo;
 import org.dcache.restful.services.restores.RestoresInfoService;
@@ -96,6 +100,8 @@ import org.dcache.restful.util.RequestUser;
 @Api(value = "pools", authorizations = {@Authorization("basicAuth")})
 @Path("/restores")
 public final class RestoreResources {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestoreResources.class);
+
     @Inject
     private RestoresInfoService service;
 
@@ -159,6 +165,7 @@ public final class RestoreResources {
                                status,
                                sort);
         } catch (CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/PoolPreferenceResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/selection/PoolPreferenceResources.java
@@ -66,6 +66,8 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -88,6 +90,7 @@ import diskCacheV111.poolManager.PoolPreferenceLevel;
 import diskCacheV111.util.CacheException;
 
 import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.util.Exceptions;
 
 import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.PoolMonitor;
@@ -103,6 +106,8 @@ import org.dcache.restful.providers.selection.PreferenceResult;
 @Api(value = "poolmanager", authorizations = {@Authorization("basicAuth")})
 @Path("/pool-preferences")
 public final class PoolPreferenceResources {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PoolPreferenceResources.class);
+
     @Inject
     private PoolMonitor poolMonitor;
 
@@ -156,6 +161,7 @@ public final class PoolPreferenceResources {
         } catch (JSONException | IllegalArgumentException e) {
             throw new BadRequestException(e);
         } catch (CacheException | InterruptedException | NoRouteToCellException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/space/SpaceManagerResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/space/SpaceManagerResources.java
@@ -65,6 +65,8 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -94,6 +96,7 @@ import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.util.VOInfo;
 
 import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.util.Exceptions;
 
 import org.dcache.cells.CellStub;
 import org.dcache.restful.providers.space.LinkGroupInfo;
@@ -108,6 +111,7 @@ import org.dcache.restful.providers.space.SpaceToken;
 @Api(value = "spacemanager", authorizations = {@Authorization("basicAuth")})
 @Path("/space")
 public final class SpaceManagerResources {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpaceManagerResources.class);
     private final static String FORBIDDEN = "Spacemanager info only accessible to "
                                                 + "admin users.";
     @Inject
@@ -172,6 +176,7 @@ public final class SpaceManagerResources {
                         .map(LinkGroupInfo::new)
                         .collect(Collectors.toList());
         } catch (CacheException | InterruptedException | NoRouteToCellException ex) {
+            LOGGER.warn(Exceptions.meaningfulMessage(ex));
             throw new InternalServerErrorException(ex);
         }
     }
@@ -228,6 +233,7 @@ public final class SpaceManagerResources {
                         .map(SpaceToken::new)
                         .collect(Collectors.toList());
         } catch (CacheException | InterruptedException | NoRouteToCellException ex) {
+            LOGGER.warn(Exceptions.meaningfulMessage(ex));
             throw new InternalServerErrorException(ex);
         }
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/transfers/TransferResources.java
@@ -65,6 +65,8 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -81,6 +83,8 @@ import java.util.UUID;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.TransferInfo;
 
+import dmg.util.Exceptions;
+
 import org.dcache.restful.providers.SnapshotList;
 import org.dcache.restful.services.transfers.TransferInfoService;
 import org.dcache.restful.util.RequestUser;
@@ -94,6 +98,8 @@ import org.dcache.restful.util.RequestUser;
 @Api(value = "transfers", authorizations = { @Authorization("basicAuth") })
 @Path("/transfers")
 public final class TransferResources {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransferResources.class);
+
     @Inject
     private TransferInfoService service;
     private boolean unlimitedOperationVisibility;
@@ -171,6 +177,7 @@ public final class TransferResources {
                                client,
                                sort);
         } catch (CacheException e) {
+            LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);
         }
     }


### PR DESCRIPTION
Motivation:

There are situations where dCache frontend will return 500 Internal
Server Error to the client.  However, when this happens, there is a
reasonable expectation that the log file contains details of what went
wrong.

Currently this doesn't happen: frontend logs nothing.  This can make
diagnosing and fixing such problems quite tricky.

Modification:

Add logging so frontend records the problem before throwing
InternalServerErrorException.

Note: this patch deliberately does not modify ErrorResponseProvider
because throwing InternalServerErrorException should only be about
creating the error response for the client, dCache-internal logging
shouldn't happen as a side-effect of this.

The exception handling in QosManagement is simplified to show that it
doesn't throw InternalServerErrorException (or CacheException for that
matter).

BulkServiceCommunicator is updated to propagate any RuntimeException or
Error (e.g,. OutOfMemoryError).  These would otherwise be suppressed.

Result:

Frontend now logs any time it returns 500 Internal Server Error to the
client.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12800/
Acked-by: Tigran Mkrtchyan