### PR TITLE
webdav/transfermanager: fail gracefully on restart, for perf marker

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -56,6 +56,7 @@ import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileExistsCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
+import diskCacheV111.util.MissingResourceCacheException;
 import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
@@ -343,6 +344,7 @@ public class RemoteTransferHandler implements CellMessageReceiver
         private PnfsId _pnfsId;
         private boolean _finished;
         private Optional<String> _digestValue;
+        private boolean _transferReportedAsUnknown;
 
         public RemoteTransfer(OutputStream out, Subject subject, Restriction restriction,
                 FsPath path, URI destination, @Nullable Object credential,
@@ -698,6 +700,24 @@ public class RemoteTransferHandler implements CellMessageReceiver
                 TransferStatusQueryMessage reply = CellStub.getMessage(future);
                 state = reply.getState();
                 info = reply.getMoverInfo();
+            } catch (MissingResourceCacheException e) {
+                /*  RemoteTransferManager claims not to know about this
+                 *  transfer.  The most likely explanation is that the service
+                 *  has been restarted.  If the pool has already accepted the
+                 *  mover then the transfer will not be affected by this
+                 *  restart; however, we now have no way to monitor the
+                 *  progress or cancel it.  The best we can do is to tell the
+                 *  client the transfer has failed.
+                 */
+
+                /* We wait for two failures as a work-around for the race
+                 * between WebDAV processing a TransferCompleteMessage and the
+                 * progress marker query.
+                 */
+                if (_transferReportedAsUnknown) {
+                    failure("RemoteTransferManager restarted");
+                }
+                _transferReportedAsUnknown = true;
             } catch (NoRouteToCellException | CacheException e) {
                 LOG.warn("Failed to fetch information for progress marker: {}",
                         e.getMessage());

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -23,6 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.MissingResourceCacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.DoorTransferFinishedMessage;
 import diskCacheV111.vehicles.IpProtocolInfo;
@@ -247,12 +248,13 @@ public abstract class TransferManager extends AbstractCellComponent
     // of this method is required because two-argument methods are
     // called preferentially.
     public Object messageArrived(CellMessage envelope, TransferStatusQueryMessage message)
+            throws MissingResourceCacheException
     {
-        TransferManagerHandler handler = getHandler(message.getId());
+        long id = message.getId();
+        TransferManagerHandler handler = getHandler(id);
 
         if (handler == null) {
-            message.setState(TransferManagerHandler.UNKNOWN_ID);
-            return message;
+            throw new MissingResourceCacheException("No transfer with id " + id);
         }
 
         long poolQueryTimeout = Math.min(envelope.getAdjustedTtl(), 30_000);


### PR DESCRIPTION
Motivation:

When collecting information for the performance marker, the WebDAV door
may learn that transfer-manager no longer knows about the transfer.

This will not change: all subsequent queries to transfer-manager will
fail in the same way.  Therefore continuing the transfer makes no sense.
Doing so is just waiting for the client (FTS) to time-out.

Note that there is a race-condition.  The transfer-manager "forgets"
about the transfer immediately after sending the door a message
describing the result of the transfer.  If the transfer-progress query
is sent (by WebDAV to remote-transfer-manager) after transfer-manager
has sent the TransferCompleteMessage message but before the WebDAV door
has processed that message then the transfer could mistakenly fail the
transfer.

Modification:

Add an exception to mark that a transfer is no longer known.

Only fail the transfer after two query failures.  This is a work-around
for the race condition, by giving the WebDAV door sufficient time to
process the message.

Result:

An HTTP-TPC transfer will abort automatically if transfer-manager is
restarted, without waiting for the client (FTS) to time-out.

This is related to github issue #5697, although it isn't the direct
solution to that problem.

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no