### PR TITLE
webdav-transfermanager: fail gracefully if transfermanager restarted

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -485,6 +485,15 @@ public class RemoteTransferHandler implements CellMessageReceiver
                 message.setExplanation("client went away");
                 try {
                     _transferManager.sendAndWait(message);
+                } catch (MissingResourceCacheException e) {
+                    /* Tried to cancel a transfer, but the transfer-manager
+                     * reported there is no such transfer.  Either the transfer
+                     * complete message was lost or the transfer-service was
+                     * restarted.  As the client has cancelled the transfer and
+                     * there is no transfer, we have nothing further to do.
+                     */
+                    failure("client went away, but failed to cancel transfer: "
+                            + e.getMessage());
                 } catch (NoRouteToCellException | CacheException e) {
                     LOG.error("Failed to cancel transfer id={}: {}", _id, e.toString());
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -217,6 +217,7 @@ public abstract class TransferManager extends AbstractCellComponent
     }
 
     public CancelTransferMessage messageArrived(CancelTransferMessage message)
+            throws MissingResourceCacheException
     {
         long id = message.getId();
         TransferManagerHandler h = getHandler(id);
@@ -224,8 +225,7 @@ public abstract class TransferManager extends AbstractCellComponent
             String explanation = message.getExplanation();
             h.cancel(explanation != null ? explanation : "at the request of door");
         } else {
-            // FIXME: shouldn't this throw an exception?
-            log.error("cannot find handler with id={} for CancelTransferMessage", id);
+            throw new MissingResourceCacheException("No transfer with id " + id);
         }
         return message;
     }


### PR DESCRIPTION
Motivation:

Restarting the transfermanager with on-going HTTP-TPC transfers results
in transfermanager loosing knowledge of those transfers.  If the client
(e.g., FTS) then aborts the transfer then the WebDAV door contact
transfermanager to cancel the transfer, a request that transfermanager
logs but otherwise ignores.

The result is an endless loop, spamming the log file with entries like:

    cannot find handler with id=1611786718594000 for CancelTransferMessage

every time the WebDAV door tries to send a performace report (typically
5 seconds).

Modification:

Have transfermanager throw an exception if the request to cancel a
transfer targets an unknown transfer.

Have WebDAV react to that specific exception by immediately failing the
transfer.

Result:

Restarting transfermanager while there are ongoing HTTP-TPC transfers no
longer results in an endless loop, with transfermanager logging a
message every ~5 seconds per ongoing HTTP-TPC transfer.

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Closes: #5697
Patch: https://rb.dcache.org/r/12804/
Acked-by: Tigran Mkrtchyan