### PR TITLE
pool: do not re-read storage info when creating CacheRepositoryEntry

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
@@ -106,9 +106,10 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
             if (size == 0) {
                 try {
                     _size = _fileStore.getFileAttributeView(pnfsId).readAttributes().size();
-                    StorageInfo info = _repository.getStorageInfoMap().get(pnfsId.toString());
-                    info.setLegacySize(_size);
-                    _repository.getStorageInfoMap().put(pnfsId.toString(), info);
+                    if (_size != 0) {
+                        storageInfo.setLegacySize(_size);
+                        _repository.getStorageInfoMap().put(pnfsId.toString(), storageInfo);
+                    }
                 } catch (IOException e) {
                     _log.error("Failed to set file size: {}", e.toString());
                 }


### PR DESCRIPTION
Motivation:
The BerkeleyDB based CacheRepositoryEntryImpl updates the metadata db if
missing file size is detected. As this happens in the constructor and
existing storageInfo record was just read out of db and, thus, not
modified, there are no reasons to re-read it.

Modification:
use existing value of storageInfo record when file size must be updated
in the constructor. Update metadata db only if file size on the disk is
not zero.

Result:
less load on BerkeleyDB

Acked-by: Paul Millar
Acked-by: Lea Morschel
Target: master, 7.0, 6.2
Require-book: no
Require-notes: no
(cherry picked from commit ad0bbcbc2302461e20171e7f25fc429d2b4c88d3)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>