### PR TITLE
default: fix unit info for bandwidth measurements in billing.properties

### DIFF
--- a/skel/share/defaults/billing.properties
+++ b/skel/share/defaults/billing.properties
@@ -150,9 +150,9 @@ billing.text.dir = ${dcache.paths.billing}
 #   p2p                Boolean      True if transfer is pool to pool
 #   transferPath       String       Actual transfer path
 #   meanReadBandwidth  Double       Mean of instantaneous IO bandwidth when
-#                                   reading (MiB/s)
+#                                   reading (bytes/s)
 #   meanWriteBandwidth Double       Mean of instantaneous IO bandwidth when
-#                                   writing (MiB/s)
+#                                   writing (bytes/s)
 #   readIdle           Long         Time spent not waiting disk reads to
 #                                   complete (ms) or '-' if there were no reads.
 #   readActive         Long         Time spent waiting for disk reads to


### PR DESCRIPTION
bytes/sec, not MiB/sec

See RT #10078] billing record parameter units.

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12813/
Acked-by: Tigran