### PR TITLE
build(deps): bump version.jackson from 2.10.1 to 2.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
              when upgrading logback. -->
         <version.logback>1.2.3</version.logback>
         <version.logback.contrib>0.1.5</version.logback.contrib>
-        <version.jackson>2.10.1</version.jackson>
+        <version.jackson>2.12.1</version.jackson>
         <version.jna>5.4.0</version.jna>
         <version.fst>2.56</version.fst>
 


### PR DESCRIPTION
Bumps `version.jackson` from 2.10.1 to 2.12.1.

Updates `jackson-databind` from 2.10.1 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-annotations` from 2.10.1 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-core` from 2.10.1 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.10.1...jackson-core-2.12.1)

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit 6cd3caf88bf4e4598e9ea3f0d82589b144aa8d8a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>