### PR TITLE
gplazma: add support for eduPersonEntitlement assertions

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/EntitlementPrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/EntitlementPrincipal.java
@@ -1,0 +1,75 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2020 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.auth;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.Principal;
+
+/**
+ * A Principal that represents an eduPersonEntitlement asserted value.
+ * The eduPerson set of assertions are defined by REFEDS.  For further details
+ * see:
+ * https://wiki.refeds.org/display/STAN/eduPerson+2020-01#eduPerson202001-eduPersonEntitlement
+ */
+public class EntitlementPrincipal implements Principal
+{
+    private final String name;
+
+    public EntitlementPrincipal(String value) throws URISyntaxException
+    {
+        URI uri = new URI(value);
+
+        // REVISIT validate URI further?
+
+        this.name = uri.toASCIIString();
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return name.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (other == this) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        EntitlementPrincipal otherEntitlement = (EntitlementPrincipal) other;
+        return otherEntitlement.name.equals(name);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Entitlement[" + name + "]";
+    }
+}

--- a/modules/gplazma2-multimap/src/main/java/org/dcache/gplazma/plugins/GplazmaMultiMapFile.java
+++ b/modules/gplazma2-multimap/src/main/java/org/dcache/gplazma/plugins/GplazmaMultiMapFile.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.dcache.auth.EmailAddressPrincipal;
+import org.dcache.auth.EntitlementPrincipal;
 import org.dcache.auth.FQANPrincipal;
 import org.dcache.auth.GidPrincipal;
 import org.dcache.auth.GroupNamePrincipal;
@@ -70,7 +71,8 @@ public class GplazmaMultiMapFile
         OIDC("oidc", OidcSubjectPrincipal.class),
         OIDC_GROUP("oidcgrp", OpenIdGroupPrincipal.class),
         UID("uid", UidPrincipal.class),
-        USER_NAME("username", UserNamePrincipal.class);
+        USER_NAME("username", UserNamePrincipal.class),
+        ENTITLEMENT("entitlement", EntitlementPrincipal.class);
 
         private final String label;
         private final Class<? extends Principal> groupType;


### PR DESCRIPTION
Motivation:

eduPerson is a standard family of related assertions that an IdP may use
to describe the person who just authenticated.  The eduPersonEntitlement
(ePE) assertions provide a way for the IdP to include some authorisation
information.

eduPerson is normally used within SAML; however, the REFEDS guidelines
document describe how SAML assertions may be included as OIDC claims:

    https://wiki.refeds.org/display/STAN/eduPerson+2020-01

The AARC guidelines G002 describes how group-membership information
should be expressed as ePE assertions using a specific format:

    https://aarc-project.eu/guidelines/aarc-g002/

Note that the AARC group ePE statements are more rich than normal group
membership statements.  They support different group namespaces and also
identify which agent is asserting group membership.

In Helmholtz, Unity server provides the login service, which asserts
group-membership as ePE assertions (per AARC-G002).

Rather than parsing the group-membership entitlement assertions, this
patch adds general support for handling ePE assertions.  The indended
use is for the admin to configure gPlazma to map certain ePE assertions
to corresopnding group/gid values.

A subsequent patch could add support for parsing the AARC-G002 group
values; for example, by allowing the admin to declare per-namespace
mapping of AARC-G002 groups to dCache groups, along with a list of
entities that are trusted to assert group-membership in that namespace.
This might result in easier-to-maintain configuration (although that
isn't clear!) but would be an optional, additional feature on top of
this patch.

Modification:

Add an EntitlementPrincipal to hold entitlement information.

The oidc plugin is updated to parse eduperson_entitlement values and add
the corresponding principals.

Support is added to multimap that allows rules to match on Entitlement
principals.  This allows multimap to map a specific entitlement value to
group/gid information.

Result:

dCache now supports OPs that assert group-membership with
eduPersonEntitlement claims (as described by AARC guideline G002).  The
multimap plugin may be used to map these to corresponding group/gid
values.

Target: master
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12832/
Acked-by: Albert Rossi
Acked-by: Dmitry Litvintsev