### PR TITLE
gplazma: provide single-line summary in pinboard for each login failure

### DIFF
--- a/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
+++ b/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
@@ -205,6 +205,7 @@ public class Gplazma2LoginStrategy
             org.dcache.gplazma.LoginReply reply = _gplazma.login(filteredSubject);
             return convertLoginReply(reply);
         } catch (AuthenticationException e) {
+            LOGGER.info("Login failed: {}", e.getMessage());
             // We deliberately hide the reason why the login failed from the
             // rest of dCache.  This is to prevent a brute-force attack
             // discovering whether certain user accounts exist.


### PR DESCRIPTION
Motivation:

gPlazma records a detailed explaination why a login attempt failured.
This is recorded at WARN level, so that the information is stored for
later inspection.  However, because a user or client may repeat a failed
login attempt, this is only done for the first time: subsequent login
failures are not logged.

It is sometimes useful to distinguish between subsequent login failures
and successful login.

More detailed results are also logged at DEBUG level; however, this
provides too much information to be enabled for any length of time.

Modification:

Record a single-line summary for each login failures at INFO level.
This makes all login failures available in the pinboard.

Result:

All login failures are now recoreded in pinboard as a single-line
summary, explaining why the login attempt failed.

Target: master
Requires-notes: no
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12859/
Acked-by: Lea Morschel