### PR TITLE
authn: log failures in UnionLoginStrategy

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/auth/UnionLoginStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/UnionLoginStrategy.java
@@ -118,7 +118,9 @@ public class UnionLoginStrategy implements LoginStrategy
         }
 
         if (areCredentialsSupplied && !_shouldFallback) {
-            throw loginFailure != null ? loginFailure : new PermissionDeniedCacheException("Access denied");
+            PermissionDeniedCacheException e = loginFailure != null ? loginFailure : new PermissionDeniedCacheException("No strategy able to authenticate");
+            _log.debug("Login denied: {}", e.getMessage());
+            throw e;
         }
 
         _log.debug( "Strategies failed, trying for anonymous access");


### PR DESCRIPTION
Motivation:

The UnionLoginStrategy tries various LoginStrategy objects to
authenticate the user.  In most cases, the debug logging provides a good
description of what happened.  However, it doesn't log anything when one
of the LoginStrategy objects denies the login attempt; in particular,
the reason why the login failed is not recorded.

Modification:

Add logging at DEBUG level that describes why a login failed.

Result:

The door now provides more information about login failures at DEBUG
level.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12860/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel