### PR TITLE
authn: add missing hashCode and equals methods for PasswordCredential

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/PasswordCredential.java
+++ b/modules/common/src/main/java/org/dcache/auth/PasswordCredential.java
@@ -30,6 +30,27 @@ public class PasswordCredential implements Serializable
     }
 
     @Override
+    public int hashCode()
+    {
+        return _username.hashCode() ^ _password.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == this) {
+            return true;
+        }
+
+        if (!(o instanceof PasswordCredential)) {
+            return false;
+        }
+
+        PasswordCredential other = (PasswordCredential)o;
+        return _username.equals(other._username) && _password.equals(other._password);
+    }
+
+    @Override
     public String toString()
     {
         return PasswordCredential.class.getSimpleName() + "[user=" + _username + ']';


### PR DESCRIPTION
Motivation:

Many (all?) doors use a cache (CachingLoginStrategy), both to limit the
impact on gPlazma of many identical requests and to reduce latency.
This considers requests to be "the same" as a cached value if the
Subject (containing information from the client) is equal.
Subject#equals requires equality on the set of credentials and
principals, which (in turn) requires equality of individual credential
objects.

Currently, PasswordCredential does not implement equals; therefore, all
PasswordCredential objects are considered non-equal and no
username+password login attempt is cached.

Modification:

Implement equals (and hashCode) for PasswordCredential

Result:

Username + password login attempts are now cached in doors, according to
that doors caching policy.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12861/
Acked-by: Tigran Mkrtchyan