### PR TITLE
authn: add missing hashCode and equals methods for BearerTokenCredential

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/BearerTokenCredential.java
+++ b/modules/common/src/main/java/org/dcache/auth/BearerTokenCredential.java
@@ -23,6 +23,28 @@ public class BearerTokenCredential implements Serializable
     }
 
     @Override
+    public int hashCode()
+    {
+        return _token.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == this) {
+            return true;
+        }
+
+        if (!(o instanceof BearerTokenCredential)) {
+            return false;
+        }
+
+        BearerTokenCredential other = (BearerTokenCredential)o;
+
+        return _token.equals(other._token);
+    }
+
+    @Override
     public String toString()
     {
         return BearerTokenCredential.class.getSimpleName();


### PR DESCRIPTION
Motivation:

Many (all?) doors use a cache (CachingLoginStrategy), both to limit the
impact on gPlazma of many identical requests and to reduce latency.
This considers requests to be "the same" as a cached value if the
Subject (containing information from the client) is equal.
Subject#equals requires equality on the set of credentials and
principals, which (in turn) requires equality of individual credential
objects.

Currently, BearerTokenCredential does not implement equals; therefore,
all BearerTokenCredential objects are considered non-equal and no bearer
token (e.g., OIDC or OAuth2/JWT) login attempt is cached.

Modification:

Implement equals (and hashCode) for BearerTokenCredential

Result:

Bearer token (OIDC and OAuth2/JWT tokens) login attempts are now cached
by doors, according to that doors caching policy.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12862/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel