### PR TITLE
namespace: ensure that file's path always set on GetAttributes

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
-import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.DoorRequestInfoMessage;
@@ -1350,7 +1349,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         NfsTransfer(PnfsHandler pnfs, NFS4Client client, NFS4State openStateId,
                 Inode nfsInode, Subject ioSubject) throws ChimeraNFSException {
-            super(pnfs, Subjects.ROOT, Restrictions.none(), ioSubject,  FsPath.ROOT);
+            super(pnfs, Subjects.ROOT, Restrictions.none(), ioSubject,  null);
 
             _nfsInode = nfsInode;
 
@@ -1597,6 +1596,22 @@ public class NFSv41Door extends AbstractCellComponent implements
             killMover(0, "layout recall on pool down");
             // keep NFSTransfer#shutdown happy
             finished((CacheException) null);
+        }
+
+        @Override
+        public String getTransferPath()
+        {
+            // no difference for nfs
+            return this.getBillingPath();
+        }
+
+        @Override
+        public synchronized String getBillingPath()
+        {
+            /*
+             * NFS door doesn't know the path and expects that namespace will populate it as a part of storage info.
+             */
+            return getFileAttributes().getStorageInfo().getKey("path");
         }
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -2202,7 +2202,9 @@ public class PnfsManagerV3
             if (attrs.isDefined(FileAttribute.STORAGEINFO)) {
                 StorageInfo storageInfo = attrs.getStorageInfo();
                 if (storageInfo.getKey("path") == null) {
-                    storageInfo.setKey("path", message.getPnfsPath());
+                    String path = message.getPnfsPath() != null?
+                            message.getPnfsPath() : _nameSpaceProvider.pnfsidToPath(subject, pnfsId);
+                    storageInfo.setKey("path", path);
                 }
                 storageInfo.setKey("uid", Integer.toString(attrs.getOwner()));
                 storageInfo.setKey("gid", Integer.toString(attrs.getGroup()));


### PR DESCRIPTION
Motivation:
Billing and HSM connectivity expects that file's path is always
provided. Though, this is the case for URL based protocols, others
(read NFS) don't do that.

Modification:
Update PnfsManagerV3 to always set path, if storageInfo is requested.
Update nfs door to use path in storageInfo for billing.

Result:
Path information available for all transfers.

Acked-by: Paul Millar
Target: master, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit df5e6f9710a13340879c3d66c420cea4ce62219e)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>