### PR TITLE
common: update how BearerToken is shown in Subjects#toString

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/Subjects.java
+++ b/modules/common/src/main/java/org/dcache/auth/Subjects.java
@@ -523,7 +523,7 @@ public class Subjects
     }
 
     /**
-     * Provide a one-line description of argument.  This is obstensibly the
+     * Provide a one-line description of argument.  This is ostensibly the
      * same job as Subject#toString.  In contrast, this method never includes
      * any line-break characters, provides a better description for X.509 proxy
      * chains, and uses a more terse format.
@@ -556,7 +556,7 @@ public class Subjects
                 sb.append("username-with-password:");
                 appendOptionallyInQuotes(sb, username);
             } else if (credential instanceof BearerTokenCredential) {
-                String token = ((BearerTokenCredential)credential).getToken();
+                String token = ((BearerTokenCredential)credential).describeToken();
                 sb.append("bearer-token:");
                 appendOptionallyInQuotes(sb, token);
             } else {


### PR DESCRIPTION
Motivation:

The Subjects#toString provides a single-line output that represents a
Subject.  The toString method in Subject can result in multi-line output
and is otherwise quite wasteful in the space it uses.

Currently, this method includes the complete BearerToken.  This is
undesirable, as bearer tokens must be protected against accidental
disclosure.

Modification:

Update Subjects#toString method to use the logging-safe representation
of a bearer token.

Result:

Printing of bearer tokens is improved to provide better assurance that
bearer tokens are not leaked.

Target: master
Requires-notes: yes
Requres-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12866/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel