### PR TITLE
authn: fix "login dump cache" admin command output

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/auth/CachingLoginStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/CachingLoginStrategy.java
@@ -186,7 +186,7 @@ public class CachingLoginStrategy implements LoginStrategy, CellCommandListener,
             try {
                 CheckedFuture<LoginReply, CacheException> out = _loginCache.getIfPresent(s);
                 if (out != null) {
-                    sb.append("   ").append(s.getPrincipals()).append(" => ");
+                    sb.append("   ").append(Subjects.toString(s)).append(" => ");
                     sb.append(out.checkedGet()).append('\n');
                 }
             } catch (CacheException e) {


### PR DESCRIPTION
Motivation:

The "login dump cache" admin command should show the contents of the
three CachingLoginStrategy's caches (login attempts, forward and reverse
mapping).  There are two problems with the login attempt cache output.

First, the code uses the toString method of the Set returned by
Subject#getPrincipals.  There are no guarantees what format this
returns.  As it happens, the Set returned by Subject#getPrincipals does
not overwrite toString, so the output is simply the class name and a
hexadecimal identifier -- providing no useful information.

Second, the output shows only the principals sent by the door.  For some
login attempts, the door sends public or private credentials in addition
to principals.  Therefore, the returned information is incomplete.

Modification:

Use Subjects#toString to describe the Subject with which the door is
attempting to log in the user.

Result:

A doors "login dump cache" admin command has been fixed to show the
information sent by the door along with the login result.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12863/
Acked-by: Lea Morschel