### PR TITLE
webdav/frontend: fix IPv6 address logging

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/AbstractLoggingHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AbstractLoggingHandler.java
@@ -114,7 +114,7 @@ public abstract class AbstractLoggingHandler extends HandlerWrapper
 
         InetAddress addr;
         try {
-            addr = InetAddresses.forUriString(addrString);
+            addr = InetAddresses.forString(addrString);
         } catch (IllegalArgumentException e) {
             LOGGER.warn("Cannot build internet address: {}", e.getMessage());
             return Optional.empty();


### PR DESCRIPTION
Motivation:

Commit 7fb112950f0 fixed a problem where incomplete HTTP-TPC transfers
were not logged.

An earlier commit (8e4d90e797) merged a pull-request that bumped the
Jetty version number.  This version bump had a number of consequences,
introducing a number of regressions.  One such regression was that the
new version of Jetty fixed how IPv6 addresses were returned.  In
previous Jetty versions IPv6 addresses were returned without the
enclosing square brackets, which is wrong.

In addition to fixing the broken HTTP-TPC transfer logging, commit
7fb112950f0 also updated the Guava method used to parse string IP
addresses.  While this change is correct for 'master' branch, that part
should not have been back-ported.

The result is dCache now logs errors like:

    Cannot build internet address: Not a valid URI IP literal: '2001:1458:d00:1b:0:0:0:43f'

Modification:

Change which Guava string passing method to use so that the logging
class now expects the previous (wrong) IPv6 format: an address without
square brackets.

Result:

Fix a regression where dCache would complain about badly formatted IPv6
addresses, preventing those addresses from being included in the access
log files.

Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no