### PR TITLE
dcache-xroot: update to xrootd4j-4.0.5

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -19,15 +19,30 @@ package org.dcache.xrootd.door;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Range;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Required;
-import org.springframework.kafka.core.KafkaTemplate;
-
-import javax.security.auth.Subject;
-
+import diskCacheV111.poolManager.PoolMonitorV5;
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileExistsCacheException;
+import diskCacheV111.util.FileLocality;
+import diskCacheV111.util.FsPath;
+import diskCacheV111.util.PermissionDeniedCacheException;
+import diskCacheV111.util.PnfsHandler;
+import diskCacheV111.util.PnfsId;
+import diskCacheV111.vehicles.DoorRequestInfoMessage;
+import diskCacheV111.vehicles.DoorTransferFinishedMessage;
+import diskCacheV111.vehicles.IoDoorEntry;
+import diskCacheV111.vehicles.IoDoorInfo;
+import diskCacheV111.vehicles.PnfsCancelUpload;
+import diskCacheV111.vehicles.PnfsCommitUpload;
+import diskCacheV111.vehicles.PnfsCreateUploadPath;
+import diskCacheV111.vehicles.PoolIoFileMessage;
+import diskCacheV111.vehicles.PoolMoverKillMessage;
+import dmg.cells.nucleus.AbstractCellComponent;
+import dmg.cells.nucleus.CellCommandListener;
+import dmg.cells.nucleus.CellInfoProvider;
+import dmg.cells.nucleus.CellMessageReceiver;
+import dmg.cells.nucleus.CellPath;
+import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.cells.services.login.LoginManagerChildrenInfo;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
@@ -47,33 +62,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-
-import diskCacheV111.poolManager.PoolMonitorV5;
-import diskCacheV111.util.CacheException;
-import diskCacheV111.util.FileExistsCacheException;
-import diskCacheV111.util.FileLocality;
-import diskCacheV111.util.FsPath;
-import diskCacheV111.util.PermissionDeniedCacheException;
-import diskCacheV111.util.PnfsHandler;
-import diskCacheV111.util.PnfsId;
-import diskCacheV111.vehicles.DoorRequestInfoMessage;
-import diskCacheV111.vehicles.DoorTransferFinishedMessage;
-import diskCacheV111.vehicles.IoDoorEntry;
-import diskCacheV111.vehicles.IoDoorInfo;
-import diskCacheV111.vehicles.PnfsCancelUpload;
-import diskCacheV111.vehicles.PnfsCommitUpload;
-import diskCacheV111.vehicles.PnfsCreateUploadPath;
-import diskCacheV111.vehicles.PoolIoFileMessage;
-import diskCacheV111.vehicles.PoolMoverKillMessage;
-
-import dmg.cells.nucleus.AbstractCellComponent;
-import dmg.cells.nucleus.CellCommandListener;
-import dmg.cells.nucleus.CellInfoProvider;
-import dmg.cells.nucleus.CellMessageReceiver;
-import dmg.cells.nucleus.CellPath;
-import dmg.cells.nucleus.NoRouteToCellException;
-import dmg.cells.services.login.LoginManagerChildrenInfo;
-
+import javax.security.auth.Subject;
 import org.dcache.acl.enums.AccessType;
 import org.dcache.auth.Origin;
 import org.dcache.auth.Subjects;
@@ -105,11 +94,29 @@ import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.dcache.xrootd.tpc.XrootdTpcInfo;
 import org.dcache.xrootd.tpc.XrootdTpcInfoCleanerTask;
 import org.dcache.xrootd.util.FileStatus;
+import org.dcache.xrootd.util.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.kafka.core.KafkaTemplate;
 
-import static java.util.Objects.requireNonNull;
 import static diskCacheV111.util.MissingResourceCacheException.checkResourceNotMissing;
-import static org.dcache.namespace.FileAttribute.*;
-import static org.dcache.xrootd.protocol.XrootdProtocol.*;
+import static java.util.Objects.requireNonNull;
+import static org.dcache.namespace.FileAttribute.CHECKSUM;
+import static org.dcache.namespace.FileAttribute.MODIFICATION_TIME;
+import static org.dcache.namespace.FileAttribute.PNFSID;
+import static org.dcache.namespace.FileAttribute.SIZE;
+import static org.dcache.namespace.FileAttribute.STORAGEINFO;
+import static org.dcache.namespace.FileAttribute.TYPE;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_isDir;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_offline;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_other;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_poscpend;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_readable;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_writable;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_xset;
 
 /**
  * Shared cell component used to interface with the rest of
@@ -411,7 +418,7 @@ public class XrootdDoor
                     String ioQueue, UUID uuid, InetSocketAddress local,
                     Subject subject, Restriction restriction, boolean createDir,
                     boolean overwrite, Long size, FsPath uploadPath,
-                    Map<String,String> opaque) {
+                    Map<String,String> opaque) throws ParseException {
 
         XrootdTransfer transfer = new XrootdTransfer(_pnfs, subject, restriction,
                 uploadPath, opaque) {
@@ -463,7 +470,7 @@ public class XrootdDoor
         createTransfer(InetSocketAddress client, FsPath path, Set<String> tried,
                        String ioQueue, UUID uuid, InetSocketAddress local, Subject subject,
                        Restriction restriction,
-                       Map<String,String> opaque)
+                       Map<String,String> opaque) throws ParseException
     {
         XrootdTransfer transfer =
             new XrootdTransfer(_pnfs, subject, restriction, path, opaque) {
@@ -504,7 +511,7 @@ public class XrootdDoor
         read(InetSocketAddress client, FsPath path, Set<String> tried,
              String ioQueue, UUID uuid, InetSocketAddress local,
              Subject subject, Restriction restriction, Map<String,String> opaque)
-        throws CacheException, InterruptedException
+        throws CacheException, InterruptedException, ParseException
     {
         if (!isReadAllowed(path)) {
             throw new PermissionDeniedCacheException("Read permission denied");
@@ -579,7 +586,7 @@ public class XrootdDoor
                     InetSocketAddress local, Subject subject, Restriction restriction,
                     boolean persistOnSuccessfulClose, FsPath rootPath,
                     Serializable delegatedProxy, Map<String,String> opaque)
-                    throws CacheException, InterruptedException {
+                    throws CacheException, InterruptedException, ParseException {
 
         if (!isWriteAllowed(path)) {
             throw new PermissionDeniedCacheException("Write permission denied");

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -412,6 +412,8 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
 
             return new RedirectResponse<>(req, host,address.getPort(),
                                           opaqueString, "");
+        } catch (ParseException e) {
+            return withError(req, kXR_ArgInvalid, "Path arguments do not parse");
         } catch (FileNotFoundCacheException e) {
             return withError(req, xrootdErrorCode(e.getRc()), "No such file");
         } catch (FileExistsCacheException e) {
@@ -458,7 +460,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                                                 Map<String,String> opaque,
                                                 FsPath fsPath,
                                                 String remoteHost)
-                    throws CacheException, XrootdException
+                    throws CacheException, XrootdException, ParseException
     {
         if (!_door.isReadAllowed(fsPath)) {
             throw new PermissionDeniedCacheException(

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
@@ -19,6 +19,7 @@ import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.XrootdProtocolInfo;
 import org.dcache.xrootd.protocol.XrootdProtocol;
 import org.dcache.xrootd.tpc.XrootdTpcInfo;
+import org.dcache.xrootd.util.ParseException;
 
 public class XrootdTransfer extends RedirectedTransfer<InetSocketAddress>
 {
@@ -29,7 +30,7 @@ public class XrootdTransfer extends RedirectedTransfer<InetSocketAddress>
     private final XrootdTpcInfo tpcInfo;
 
     public XrootdTransfer(PnfsHandler pnfs, Subject subject,
-            Restriction restriction, FsPath path, Map<String,String> opaque) {
+            Restriction restriction, FsPath path, Map<String,String> opaque) throws ParseException {
         super(pnfs, subject, restriction, path);
         tpcInfo = new XrootdTpcInfo(opaque);
     }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -315,19 +315,19 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
             if (uuid == null) {
                 _log.info("Request to open {} contains no UUID.", msg.getPath());
                 throw new XrootdException(kXR_NotAuthorized, "Request lacks the "
-                                + UUID_PREFIX + " property.");
+                    + UUID_PREFIX + " property.");
             }
 
             enforceClientTlsIfDestinationRequiresItForTpc(opaqueMap);
 
             NettyTransferService<XrootdProtocolInfo>.NettyMoverChannel file
-                            = _server.openFile(uuid, false);
+                = _server.openFile(uuid, false);
             if (file == null) {
                 _log.info("No mover found for {} with UUID {}.", msg.getPath(), uuid);
                 return redirectToDoor(ctx, msg, () ->
                 {
                     throw new XrootdException(kXR_NotAuthorized, UUID_PREFIX
-                                    + " is no longer valid.");
+                        + " is no longer valid.");
                 });
             }
 
@@ -340,8 +340,8 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                     throw new XrootdException(kXR_Unsupported, "File exists.");
                 } else if ((msg.isNew() || msg.isReadWrite()) && isWrite) {
                     boolean posc = (msg.getOptions() & kXR_posc) == kXR_posc ||
-                                    file.getProtocolInfo().getFlags()
-                                        .contains(XrootdProtocolInfo.Flags.POSC);
+                        file.getProtocolInfo().getFlags()
+                            .contains(XrootdProtocolInfo.Flags.POSC);
                     if (opaqueMap.containsKey("tpc.src")) {
                         _log.debug("Request to open {} is as third-party destination.", msg);
 
@@ -349,10 +349,10 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                         tpcInfo.setDelegatedProxy(file.getProtocolInfo().getDelegatedCredential());
 
                         descriptor = new TpcWriteDescriptor(file, posc, ctx,
-                                                            _server,
-                                                            opaqueMap.get("org.dcache.xrootd.client"),
-                                                            tpcInfo,
-                                                            tlsSessionInfo);
+                            _server,
+                            opaqueMap.get("org.dcache.xrootd.client"),
+                            tpcInfo,
+                            tlsSessionInfo);
                     } else {
                         descriptor = new WriteDescriptor(file, posc);
                     }
@@ -375,6 +375,8 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                     file.release();
                 }
             }
+        } catch (ParseException e) {
+            throw new XrootdException(kXR_ArgInvalid, e.getMessage());
         }  catch (IOException e) {
             throw new XrootdException(kXR_IOError, e.getMessage());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>4.0.4</version.xrootd4j>
+        <version.xrootd4j>4.0.5</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.1</version.dcache-view>
         <version.netty>4.1.50.Final</version.netty>


### PR DESCRIPTION
update to xrootd4j 4.0.5

Fixes improper use of destination token when
contacting source server during third-pary transfer.
9ef36cf8a35e0aedf1da526f47d1aadc7ebe43e6
https://rb.dcache.org/r/12828

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Acked-by: Lea