### PR TITLE
dcache-xroot: update to xrootd4j-4.0.5

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -354,6 +354,8 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
 
             return new RedirectResponse<>(req, host,address.getPort(),
                                           opaqueString, "");
+        } catch (ParseException e) {
+            return withError(req, kXR_ArgInvalid, "Path arguments do not parse");
         } catch (FileNotFoundCacheException e) {
             return withError(req, xrootdErrorCode(e.getRc()), "No such file");
         } catch (FileExistsCacheException e) {
@@ -397,7 +399,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler
                                                 Map<String,String> opaque,
                                                 FsPath fsPath,
                                                 String remoteHost)
-                    throws CacheException
+                    throws CacheException, ParseException
     {
         if (!_door.isReadAllowed(fsPath)) {
             throw new PermissionDeniedCacheException(

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -344,6 +344,8 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
                     file.release();
                 }
             }
+        } catch (ParseException e) {
+            throw new XrootdException(kXR_ArgInvalid, e.getMessage());
         }  catch (IOException e) {
             throw new XrootdException(kXR_IOError, e.getMessage());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.11.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>3.5.8</version.xrootd4j>
+        <version.xrootd4j>3.5.9</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.1</version.dcache-view>
         <version.netty>4.1.45.Final</version.netty>


### PR DESCRIPTION
update to xrootd4j 4.0.5

Fixes improper use of destination token when
contacting source server during third-pary transfer.
9ef36cf8a35e0aedf1da526f47d1aadc7ebe43e6
https://rb.dcache.org/r/12828

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Acked-by: Lea