### PR TITLE
check if checksums are present and throw CacheException if they are not

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/ChecksumCalculatingTransfer.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/ChecksumCalculatingTransfer.java
@@ -63,7 +63,10 @@ public class ChecksumCalculatingTransfer extends Transfer
 
         setAdditionalAttributes(EnumSet.of(FileAttribute.CHECKSUM));
         readNameSpaceEntry(false);
-        Checksum existingChecksum = Checksums.preferrredOrder().max(getFileAttributes().getChecksums());
+        if (getFileAttributes().getChecksums().isEmpty()) {
+            throw new CacheException("No checksums found.");
+        }
+        Checksum existingChecksum = Checksums.preferredOrder().max(getFileAttributes().getChecksums());
         MessageDigest verifyingDigest = existingChecksum.getType().createMessageDigest();
         MessageDigest desiredDigest = desiredType.createMessageDigest();
 

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/AbstractXrootdRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/AbstractXrootdRequestHandler.java
@@ -115,7 +115,7 @@ public class AbstractXrootdRequestHandler extends XrootdRequestHandler
                                 + "but not of the requested type.");
             }
 
-            Checksum checksum = Checksums.preferrredOrder().min(checksums);
+            Checksum checksum = Checksums.preferredOrder().min(checksums);
             return new QueryResponse(msg,checksum.getType()
                                                       .getName()
                                                       .toLowerCase()

--- a/modules/dcache/src/main/java/org/dcache/util/Checksums.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Checksums.java
@@ -213,7 +213,7 @@ public class Checksums
                         .findFirst());
     }
 
-    public static Ordering<Checksum> preferrredOrder()
+    public static Ordering<Checksum> preferredOrder()
     {
         return PREFERRED_CHECKSUM_ORDERING;
     }


### PR DESCRIPTION
Motivation:

Sometimes file checksums are missing in namespace. Running globus-url-copy
of these files requiring checksum verification leads to an NPE exception in
ChecksumCalculatingTransfer.

Modification:

Check that an empty set of checksums is returned from the namespace and throw
CacheException if it is.

Result:

No stack trace server side. Transfer requiring checksum verification fails
(still) with an error saying that "No checksums found"

RB: https://rb.dcache.org/r/12906/
Acked-by: Paul Millar

Target: trunk
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2

Require-book: no
Require-notes: yes