### PR TITLE
nfs: fix access to path before namespace info available

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1611,7 +1611,11 @@ public class NFSv41Door extends AbstractCellComponent implements
             /*
              * NFS door doesn't know the path and expects that namespace will populate it as a part of storage info.
              */
-            return getFileAttributes().getStorageInfo().getKey("path");
+            if (getFileAttributes().isDefined(FileAttribute.STORAGEINFO)) {
+                return getFileAttributes().getStorageInfo().getKey("path");
+            } else {
+                return "N/A";
+            }
         }
     }
 


### PR DESCRIPTION
fixes commit df5e6f9710

Motivation:
As frontend queries the active transfer information, it might hit the
nfs door before transfer's storage info is populated. Thus we might get:

```
Caused by: java.lang.IllegalStateException: Attribute is not defined: STORAGEINFO
	at org.dcache.vehicles.FileAttributes.guard(FileAttributes.java:290)
	at org.dcache.vehicles.FileAttributes.getStorageInfo(FileAttributes.java:491)
	at org.dcache.chimera.nfsv41.door.NFSv41Door$NfsTransfer.getBillingPath(NFSv41Door.java:1609)
	at org.dcache.chimera.nfsv41.door.NFSv41Door$NfsTransfer.getTransferPath(NFSv41Door.java:1600)
	at org.dcache.util.Transfer.getIoDoorEntry(Transfer.java:717)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.concurrent.ConcurrentHashMap$ValueSpliterator.forEachRemaining(ConcurrentHashMap.java:3605)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at org.dcache.chimera.nfsv41.door.NFSv41Door$GetDoorInfoCmd.call(NFSv41Door.java:1645)
	at org.dcache.chimera.nfsv41.door.NFSv41Door$GetDoorInfoCmd.call(NFSv41Door.java:1634)
	at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:145)
	... 14 common frames omitted
```

Modification:
Check that storage info is available before using it.

Result:
No annoying stack traces.

Acked-by: Lea Morschel
Acked-by: Svenja Meyer
Target: master, 7.0, 6.2
Require-book: no
Require-notes: no
(cherry picked from commit 9efc24d08033064badb7cc46425d1e2676858831)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>