### PR TITLE
nearline-storage: introduce  FlushRequest#getReplicaCreationTime

### DIFF
--- a/modules/dcache-nearline-spi/src/main/java/org/dcache/pool/nearline/spi/FlushRequest.java
+++ b/modules/dcache-nearline-spi/src/main/java/org/dcache/pool/nearline/spi/FlushRequest.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2014 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2014 - 2021 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -61,6 +61,12 @@ public interface FlushRequest extends NearlineRequest<Set<URI>>
      * @return Attributes of the file
      */
     FileAttributes getFileAttributes();
+
+    /**
+     * Returns replica creation time in milliseconds.
+     * @return replica creation time.
+     */
+    long getReplicaCreationTime();
 
     /**
      * Signals that the request is being activated and returns the path of the file.

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -873,6 +873,11 @@ public class NearlineStorageHandler
         }
 
         @Override
+        public long getReplicaCreationTime() {
+            return descriptor.getReplicaCreationTime();
+        }
+
+        @Override
         public long getDeadline()
         {
             return (state.get() == State.ACTIVE) ? activatedAt + flushTimeout : Long.MAX_VALUE;

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ReplicaDescriptor.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ReplicaDescriptor.java
@@ -123,4 +123,10 @@ public interface ReplicaDescriptor
      * Returns the current size of the replica.
      */
     long getReplicaSize();
+
+    /**
+     * Returns replica creation time in milliseconds.
+     * @return replica creation time.
+     */
+    long getReplicaCreationTime();
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReadHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReadHandleImpl.java
@@ -149,4 +149,9 @@ class ReadHandleImpl implements ReplicaDescriptor
     public void commit() throws IllegalStateException, InterruptedException, CacheException {
         // NOP
     }
+
+    @Override
+    public long getReplicaCreationTime() {
+        return _entry.getCreationTime();
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
@@ -418,4 +418,9 @@ class WriteHandleImpl implements ReplicaDescriptor
     {
         return _entry.getReplicaSize();
     }
+
+    @Override
+    public long getReplicaCreationTime() {
+        return _entry.getCreationTime();
+    }
 }


### PR DESCRIPTION
Motivation:
As NerlineStorage drivers might need replication creation times to apply
time based policies, FlushRequest should expose replica creation
timestamp.

Modification:
Add FlushRequest#getReplicaCreationTime and ReplicaDescriptor#getReplicaCreationTime.
Update adjust ReadHandleImpl and WriteHandleImpl implementations.

Result:
NerlineStorage drivers can use time-based policies.

Acked-by: Paul Millar
Target: master, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 66ab8dfd9aad010519da2a6f8ec41d0695f7ef39)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>