### PR TITLE
pool: don't scan flush/restore/remove queue to get stats

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2014 - 2020 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2014 - 2021 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -63,8 +63,10 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.annotation.concurrent.Immutable;
 
 import java.util.OptionalLong;
 
@@ -134,6 +136,43 @@ public class NearlineStorageHandler
         implements CellCommandListener, StateChangeListener, CellSetupProvider, CellLifeCycleAware, CellInfoProvider, CellIdentityAware,
                 PoolDataBeanProvider<StorageHandlerData>
 {
+
+    /**
+     * Queue occupation statistics.
+     *
+     * REVISIT: change to record type when java14 is allowed.
+     */
+    @Immutable
+    public static final class QueueStat {
+
+        private final int queued;
+        private final int active;
+        private final int canceled;
+
+        public QueueStat(int queued, int active, int canceled) {
+
+            checkArgument(queued >= 0);
+            checkArgument(active >= 0);
+            checkArgument(canceled >= 0);
+
+            this.queued = queued;
+            this.active = active;
+            this.canceled = canceled;
+        }
+
+        public int queued() {
+            return queued;
+        }
+
+        public int active() {
+            return active;
+        }
+
+        public int canceled() {
+            return canceled;
+        }
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(NearlineStorageHandler.class);
 
     private final FlushRequestContainer flushRequests = new FlushRequestContainer();
@@ -406,32 +445,35 @@ public class NearlineStorageHandler
 
     public int getActiveFetchJobs()
     {
-        return stageRequests.getCount(AbstractRequest.State.ACTIVE) + stageRequests.getCount(AbstractRequest.State.CANCELED);
+        QueueStat queueStat = stageRequests.getQueueStats();
+        return queueStat.active() + queueStat.canceled();
     }
 
     public int getFetchQueueSize()
     {
-        return stageRequests.getCount(AbstractRequest.State.QUEUED);
+        return stageRequests.getQueueStats().queued();
     }
 
     public int getActiveStoreJobs()
     {
-        return flushRequests.getCount(AbstractRequest.State.ACTIVE) + flushRequests.getCount(AbstractRequest.State.CANCELED);
+        QueueStat queueStat = flushRequests.getQueueStats();
+        return queueStat.active() + queueStat.canceled();
     }
 
     public int getStoreQueueSize()
     {
-        return flushRequests.getCount(AbstractRequest.State.QUEUED);
+        return flushRequests.getQueueStats().queued();
     }
 
     public int getActiveRemoveJobs()
     {
-        return removeRequests.getCount(AbstractRequest.State.ACTIVE) + removeRequests.getCount(AbstractRequest.State.CANCELED);
+        QueueStat queueStat = removeRequests.getQueueStats();
+        return queueStat.active() + queueStat.canceled();
     }
 
     public int getRemoveQueueSize()
     {
-        return removeRequests.getCount(AbstractRequest.State.QUEUED);
+        return removeRequests.getQueueStats().queued();
     }
 
     @Override
@@ -478,9 +520,16 @@ public class NearlineStorageHandler
 
         private final List<Future<?>> asyncTasks = new ArrayList<>();
 
-        AbstractRequest(NearlineStorage storage)
+        /**
+         * Reference to queue statistics counter.
+         */
+        private final AtomicReference<QueueStat> queueStat;
+
+        AbstractRequest(NearlineStorage storage, @Nonnull AtomicReference<QueueStat> queueStat)
         {
             this.storage = storage;
+            this.queueStat = queueStat;
+            incQueued();
         }
 
         // Implements NearlineRequest#setIncluded
@@ -515,6 +564,7 @@ public class NearlineStorageHandler
                 return Futures.immediateFailedFuture(new IllegalStateException("Request is no longer queued."));
             }
             activatedAt = System.currentTimeMillis();
+            incActiveFromQueued();
             return Futures.immediateFuture(null);
         }
 
@@ -532,8 +582,14 @@ public class NearlineStorageHandler
 
         public void cancel()
         {
-            if (state.getAndSet(State.CANCELED) != State.CANCELED) {
+            State oldState = state.getAndSet(State.CANCELED);
+            if ( oldState != State.CANCELED) {
                 storage.cancel(uuid);
+                if (oldState == State.ACTIVE) {
+                    incCancelFromActive();
+                } else {
+                    incCancelFromQueued();
+                }
                 synchronized(this) {
                     for (Future<?> task : asyncTasks) {
                         /*
@@ -583,6 +639,87 @@ public class NearlineStorageHandler
         {
             return Long.compare(createdAt, o.createdAt);
         }
+
+        public void removeFromQueue() {
+            State currentState = state.get();
+            switch (currentState) {
+                case QUEUED:
+                    decQueued();
+                    break;
+                case ACTIVE:
+                    decActive();
+                    break;
+                case CANCELED:
+                    decCanceled();
+                    break;
+                default:
+                    throw new RuntimeException();
+            }
+        }
+
+        private void incQueued() {
+            boolean isSet;
+            do {
+                QueueStat current = queueStat.get();
+                QueueStat withThis = new QueueStat(current.queued() +1, current.active(), current.canceled());
+                isSet = queueStat.compareAndSet(current, withThis);
+            } while (!isSet);
+        }
+
+        private void incActiveFromQueued() {
+            boolean isSet;
+            do {
+                QueueStat current = queueStat.get();
+                QueueStat withThis = new QueueStat(current.queued() -1, current.active() + 1, current.canceled());
+                isSet = queueStat.compareAndSet(current, withThis);
+            } while (!isSet);
+        }
+
+        private void incCancelFromActive() {
+            boolean isSet;
+            do {
+                QueueStat current = queueStat.get();
+                QueueStat withThis = new QueueStat(current.queued(), current.active() - 1, current.canceled() + 1);
+                isSet = queueStat.compareAndSet(current, withThis);
+            } while (!isSet);
+        }
+
+        private void incCancelFromQueued() {
+            boolean isSet;
+            do {
+                QueueStat current = queueStat.get();
+                QueueStat withThis = new QueueStat(current.queued() - 1, current.active(), current.canceled() + 1);
+                isSet = queueStat.compareAndSet(current, withThis);
+            } while (!isSet);
+        }
+
+        private void decQueued() {
+            boolean isSet;
+            do {
+                QueueStat current = queueStat.get();
+                QueueStat withThis = new QueueStat(current.queued() -1, current.active(), current.canceled());
+                isSet = queueStat.compareAndSet(current, withThis);
+            } while (!isSet);
+        }
+
+        private void decActive() {
+            boolean isSet;
+            do {
+                QueueStat current = queueStat.get();
+                QueueStat withThis = new QueueStat(current.queued(), current.active() - 1, current.canceled());
+                isSet = queueStat.compareAndSet(current, withThis);
+            } while (!isSet);
+        }
+
+        private void decCanceled() {
+            boolean isSet;
+            do {
+                QueueStat current = queueStat.get();
+                QueueStat withThis = new QueueStat(current.queued(), current.active(), current.canceled() -1);
+                isSet = queueStat.compareAndSet(current, withThis);
+            } while (!isSet);
+        }
+
     }
 
     /**
@@ -604,6 +741,11 @@ public class NearlineStorageHandler
         protected final ConcurrentHashMap<K, R> requests = new ConcurrentHashMap<>();
 
         private final ContainerState state = new ContainerState();
+
+        /**
+         * Queue usage statistics.
+         */
+        protected AtomicReference<QueueStat> queueStats = new AtomicReference<>(new QueueStat(0, 0, 0));
 
         public void addAll(NearlineStorage storage,
                            Iterable<F> files,
@@ -696,15 +838,12 @@ public class NearlineStorageHandler
             return state.awaitTermination(timeout, unit);
         }
 
-        public int getCount(AbstractRequest.State state)
-        {
-            int cnt = 0;
-            for (R request : requests.values()) {
-                if (request.state.get() == state) {
-                    cnt++;
-                }
-            }
-            return cnt;
+        /**
+         * Get current request states statistics.
+         * @return request states statistics.
+         */
+        public QueueStat getQueueStats() {
+            return queueStats.get();
         }
 
         /**
@@ -741,6 +880,8 @@ public class NearlineStorageHandler
             if (actualRequest == null) {
                 return Collections.emptyList();
             }
+
+            actualRequest.removeFromQueue();
             state.decrement();
             return actualRequest.callbacks();
         }
@@ -767,7 +908,7 @@ public class NearlineStorageHandler
         protected FlushRequestImpl createRequest(NearlineStorage storage, PnfsId id)
                 throws CacheException, InterruptedException
         {
-            return new FlushRequestImpl(storage, id);
+            return new FlushRequestImpl(storage, queueStats, id);
         }
 
         @Override
@@ -790,7 +931,7 @@ public class NearlineStorageHandler
                                                  FileAttributes file)
                 throws CacheException
         {
-            return new StageRequestImpl(storage, file);
+            return new StageRequestImpl(storage, queueStats, file);
         }
 
         @Override
@@ -811,7 +952,7 @@ public class NearlineStorageHandler
         @Override
         protected RemoveRequestImpl createRequest(NearlineStorage storage, URI uri)
         {
-            return new RemoveRequestImpl(storage, uri);
+            return new RemoveRequestImpl(storage, queueStats, uri);
         }
 
         @Override
@@ -826,9 +967,9 @@ public class NearlineStorageHandler
         private final ReplicaDescriptor descriptor;
         private final StorageInfoMessage infoMsg;
 
-        public FlushRequestImpl(NearlineStorage nearlineStorage, PnfsId pnfsId) throws CacheException, InterruptedException
+        public FlushRequestImpl(NearlineStorage nearlineStorage, AtomicReference<QueueStat> stats, PnfsId pnfsId) throws CacheException, InterruptedException
         {
-            super(nearlineStorage);
+            super(nearlineStorage, stats);
             descriptor = repository.openEntry(pnfsId, EnumSet.of(OpenFlags.NOATIME));
             infoMsg = new StorageInfoMessage(cellAddress, pnfsId, false);
             infoMsg.setStorageInfo(descriptor.getFileAttributes().getStorageInfo());
@@ -1094,9 +1235,9 @@ public class NearlineStorageHandler
         private final ReplicaDescriptor descriptor;
         private ListenableFuture<Void> allocationFuture;
 
-        public StageRequestImpl(NearlineStorage storage, FileAttributes fileAttributes) throws CacheException
+        public StageRequestImpl(NearlineStorage storage, AtomicReference<QueueStat> stats, FileAttributes fileAttributes) throws CacheException
         {
-            super(storage);
+            super(storage, stats);
             PnfsId pnfsId = fileAttributes.getPnfsId();
             infoMsg = new StorageInfoMessage(cellAddress, pnfsId, true);
             infoMsg.setStorageInfo(fileAttributes.getStorageInfo());
@@ -1250,9 +1391,9 @@ public class NearlineStorageHandler
     {
         private final URI uri;
 
-        RemoveRequestImpl(NearlineStorage storage, URI uri)
+        RemoveRequestImpl(NearlineStorage storage, AtomicReference<QueueStat> stats, URI uri)
         {
-            super(storage);
+            super(storage, stats);
             this.uri = uri;
             LOGGER.debug("Remove request created for {}.", uri);
         }


### PR DESCRIPTION
Motivation:
There are several cases when pool scans the various hsm queus:
  - on mover start, to check load assumptions
  - on heartbeat, to populate pool manager with load information
  - on 'info' command, to report load numbers to admin interface of
    dcache-view collectors

As this is O(n) operation, in case of a large queues those scans
might take seconds, which is unacceptable, especially wen starting
a new mover.

Modification:
Introduce QueueStat object to keep track of the current state. Use
CAS mechanism to avoid unnecessary locking. Update corresponding
getActive/getQueued methods to use the QueueStat object.

Result:
getting hsm start is O(1) and doesn't impact pools operation.

Acked-by: Svenja Meyer
Acked-by: Paul Millar
Target: master, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 3b94f8ba801dbb628d20fccba6aa1e273f2e580a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>