### PR TITLE
poolmanager: fix NPE if pool delays stage without giving a reason

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -1846,8 +1846,9 @@ public class RequestContainerV5
                     // best candidate is the right one
                     return RequestStatusCode.OK;
                 case CacheException.HSM_DELAY_ERROR:
-                    _currentRm = "Suspend by HSM request : " + reply.getErrorObject() == null
-                            ? "No info" : reply.getErrorObject().toString();
+                    String explanation = reply.getErrorObject() == null
+                                    ? "No info" : reply.getErrorObject().toString();
+                    _currentRm = "Suspend by HSM request : " + explanation;
                     return RequestStatusCode.DELAY;
                 default:
                     _currentRm = reply.getErrorObject() == null


### PR DESCRIPTION
Motivation:

When poolmanager requests that a pool stage a file, the pool may return
the special error code HSM_DELAY_ERROR (10013).  On receiving this
error, poolmanager suspends the request.

This is currently triggered only by the HSM script, and only if the
script returns 71.

The error object may contain an explanation, describing why the pool
requested that poolmanager suspend the request.  If not, poolmanager
attempts to generate a default message.

Unfortunately, the code is buggy: if the return message's error object
is `null` then the code throws a NPE.

NB #1: Currently, the pool will always provide an (non-null) error
object when returning HSM_DELAY_ERROR.  Backporting of this patch is
requested because it ensures correctness (and I want my unit-tests to
pass).

NB #2: Recent refactoring of 'master' has removed this bug; therefore,
this patch is for pull-requests only.

Modification:

Rework logic to avoid the NPE, while also making the code clearer.

Result:

No user or admin observable changes.

PoolManager is safe against possible future changes of the pool.

Requires-notes: no
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12931/
Acked-by: Tigran Mkrtchyan