### PR TITLE
nearline-storage: fix store cancel regression

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -599,12 +599,12 @@ public class NearlineStorageHandler
         {
             State oldState = state.getAndSet(State.CANCELED);
             if ( oldState != State.CANCELED) {
-                storage.cancel(uuid);
                 if (oldState == State.ACTIVE) {
                     incCancelFromActive();
                 } else {
                     incCancelFromQueued();
                 }
+                storage.cancel(uuid);
                 synchronized(this) {
                     for (Future<?> task : asyncTasks) {
                         /*


### PR DESCRIPTION
Fixes: 4759b3fe2e

Motivation:
we should update the number of canceled requests before
NearlineStorage#cancel is called as cancel will decrease the number of
canceled requests when the request is removed from the flush queue.

Caused by: java.lang.IllegalArgumentException: null
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:127)
        at org.dcache.pool.nearline.NearlineStorageHandler$QueueStat.<init>(NearlineStorageHandler.java:156)
        at org.dcache.pool.nearline.NearlineStorageHandler$AbstractRequest.decCanceled(NearlineStorageHandler.java:718)
        at org.dcache.pool.nearline.NearlineStorageHandler$AbstractRequest.removeFromQueue(NearlineStorageHandler.java:653)
        at org.dcache.pool.nearline.NearlineStorageHandler$AbstractRequestContainer.remove(NearlineStorageHandler.java:884)
        at org.dcache.pool.nearline.NearlineStorageHandler$AbstractRequestContainer.removeAndCallback(NearlineStorageHandler.java:858)
        at org.dcache.pool.nearline.NearlineStorageHandler$FlushRequestImpl.done(NearlineStorageHandler.java:1172)
        at org.dcache.pool.nearline.NearlineStorageHandler$FlushRequestImpl.failed(NearlineStorageHandler.java:1048)
        at org.dcache.SapphireDriver.lambda$cancel$1(SapphireDriver.java:121)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at org.dcache.SapphireDriver.cancel(SapphireDriver.java:118)
        at org.dcache.pool.nearline.NearlineStorageHandler$AbstractRequest.cancel(NearlineStorageHandler.java:587)
        at org.dcache.pool.nearline.NearlineStorageHandler$AbstractRequestContainer.cancel(NearlineStorageHandler.java:797)
        at org.dcache.pool.nearline.NearlineStorageHandler$StoreKillCommand.call(NearlineStorageHandler.java:1533)
        at org.dcache.pool.nearline.NearlineStorageHandler$StoreKillCommand.call(NearlineStorageHandler.java:1522)
        at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:145)
        ... 14 common frames omitted

Modification:
adjust number of canceled requests before propagating the cancel to a
NearlineStorage.

Result:
The miscalculation and corresponding stack trace are gone.

Acked-by: Lea Morschel
Acked-by: Paul Millar
Target: master, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 38542b78972752eedd73e9a5de1947612eee763a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>