### PR TITLE
poolmanager: fix rogue 'null' value in `_fifo` from commit 1501f056ce

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -947,7 +947,7 @@ public class RequestContainerV5
            //
            //
            //
-           add(null) ;
+           startStateEngine();
         }
 
         public List<CellMessage> getMessages() {
@@ -1188,9 +1188,16 @@ public class RequestContainerV5
            synchronized( _fifo ){
                _log.info( "Adding Object : {}", obj ) ;
                _fifo.addFirst(obj) ;
-               if( _stateEngineActive ) {
-                   return;
-               }
+
+                if (!_stateEngineActive) {
+                    startStateEngine();
+                }
+           }
+        }
+
+        private void startStateEngine()
+        {
+           synchronized (_fifo) {
                _log.info( "Starting Engine" ) ;
                _stateEngineActive = true ;
                try {


### PR DESCRIPTION
Motivation:

A recent commit (1501f056ce) refactored how pool-manager handles state
in the FSM.  Unfortunately, this introduced a works-by-accident problem.

When PoolManager receives a read request for a specific file, it creates
a PoolRequestHandler object (to track this read request) and injects a
`null` value on that object's TODO list (`_fifo`).  This `null` value is
injected simply to start the FSM task (which runs on a separate thread),
in order that it will process the request.  Subsequent read requests for
the same file are folded into the same PoolRequestHandler object without
interacting with the FSM task: nothing is injected into `_fifo`.

Prior to commit 1501f056ce, this initial 'null' entry in `_fifo` is
consumed by the FSM task as it starts up, leaving `_fifo` empty by the
time the read request is actually processed.

With commit 1501f056ce, this entry is no longer consumed, so the `null`
value remain in `_fifo` while the FSM is doing its initial processing of
the request.

If the read request can be satisfied without requiring any "sleeping"
(i.e., no pool-to-pool transfer or staging) then the current code works
fine as-is.  The `null` value is never read from `_fifo`, but that
doesn't matter.

If the FSM determines that read request should trigger pool-to-pool or
staging then, having sent a message to the pool (requesting it initiates
either pool-to-pool or staging), the FSM task will consume the `null`
value from `_fifo` and misinterpret it to mean the queue is empty.

In almost every realistic case, once the `null` value is consumed, the
`_fifo` will be empty.  Therefore, this misinterpretation does not cause
a problem.  The code "works by accident".

There is an edge case where this can cause a problem: if the pool
replies to the pool2pool/stage request *before* the FSM task consumes
the `null` value (from `_fifo`) then `_fifo` will not be empty when the
FSM task mistakenly believes it is.  If this happens then the transfer
will be stuck.  After some time, the transfer will be suspended because
a failed ping test (poolmanager believes the pool has been restarted or
a message has been lost).

Perhaps the most likely way to trigger this scenario is by running a
pool in the same domain as poolmanger and the pool immediately rejecting
the request.  It seems very unlikely otherwise.

Modification:

Do not inject a `null` value to start the FSM task.

Result:

Fix a (vanishingly small) likelihood of a pool-manager suspending
transfers if a read request triggers staging or pool-to-pool and the
pool responds amazingly quickly.

Target: master
Request: 7.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12940/
Acked-by: Tigran Mkrtchyan