### PR TITLE
dcache-xrootd: update to xrootd4j 4.0.6

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/XrootdTLSHandlerFactory.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/XrootdTLSHandlerFactory.java
@@ -62,14 +62,9 @@ public class XrootdTLSHandlerFactory extends SSLHandlerFactory
                                        .findFirst().orElse(null);
     }
 
-    private final boolean startTls;
-    private final String name;
-
     public XrootdTLSHandlerFactory(Properties properties, boolean startTls) throws Exception
     {
-        super(properties);
-        this.startTls = startTls;
-        name = startTls ? SERVER_TLS : CLIENT_TLS;
+        initialize(properties, startTls);
     }
 
     @Override

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/XrootdTLSHandlerFactory.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/XrootdTLSHandlerFactory.java
@@ -62,9 +62,14 @@ public class XrootdTLSHandlerFactory extends SSLHandlerFactory
                                        .findFirst().orElse(null);
     }
 
+    private final boolean startTls;
+    private final String name;
+
     public XrootdTLSHandlerFactory(Properties properties, boolean startTls) throws Exception
     {
-        initialize(properties, startTls);
+        super(properties);
+        this.startTls = startTls;
+        name = startTls ? SERVER_TLS : CLIENT_TLS;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>4.0.6</version.xrootd4j>
+        <version.xrootd4j>4.0.7</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.1</version.dcache-view>
         <version.netty>4.1.50.Final</version.netty>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>4.0.5</version.xrootd4j>
+        <version.xrootd4j>4.0.6</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.1</version.dcache-view>
         <version.netty>4.1.50.Final</version.netty>


### PR DESCRIPTION
    * [b9964759d] xrootd4j: get source size from stat on open on TPC
    * [6fa7acff9] xrootd4j: fix how we turn off signing policy if TLS is on
    * [ab2a82412] xrootd4j: move TLS (mostly) from dCache to xrootd4j
    * [f04d501d7] xrootd4j: use CGI tpc.dlgon to determine if delegation is on
    * [7c49e0c0d] xrootd4j: move TLS (mostly) from dCache to xrootd4j
    * [22a4a296d] updated license header

Target: 7.0
Request: 6.2