### PR TITLE
frontend: bump dCacheView to v1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.xrootd4j>3.5.10</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
-        <version.dcache-view>1.6.1</version.dcache-view>
+        <version.dcache-view>1.6.2</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Motivation:

Fix reported problems in dCacheView

Modification:

Updated dCacheView to v1.6.2.  This has the following changelog:

    437f2214d48127c4b38ecbacb26bc558a2e27c2c (tag: v1.6.2) [maven-release-plugin] prepare release v1.6.2
    ed3244b770127c0797a799159fec3b63217fb2a1 Drop unnecessary information in ancillary build files
    62b617234448f837196ee6f7dbb337238544b74b sharing: fix sharing for one week.
    d4de473ea81afe6cfb7f24595f126f0104b12605 uploads: fix progress bar
    9e486c4482fae29677f371f2d62302fb44485137 dcache-view (webdav): fix door selection
    422c28dc296bba1b020e494e4e7201d1d86dd9d6 [bower, package and package-lock] prepare for next development iteration
    3449f84f49d39ae4814bd3c241345cf4fc0abfb1 [maven-release-plugin] prepare for next development iteration

Result:

The following issues are resolved:
     dCache/dcache-view#244  Requesting a "one week" macaroon fails
     dCache/dcache-view#245  Uploading files do not show transfer progress
     dCache/dcache-view#231  dCacheView: use the right WebDAV door

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Patch: https://rb.dcache.org/r/12974/
Acked-by: Lea Morschel