### PR TITLE
frontend: bump dCacheView to v1.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.xrootd4j>3.5.10</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
-        <version.dcache-view>1.5.7</version.dcache-view>
+        <version.dcache-view>1.5.8</version.dcache-view>
         <version.netty>4.1.10.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Motivation:

Fix reported problems in dCacheView

Modification:

Updated dCacheView to v1.5.8.  This has the following changelog:

    55f4e8106050d0990670c182ae556739ad576cb5 (tag: v1.5.8) [maven-release-plugin] prepare release v1.5.8
    5bc0c88da351c288d04ed659ad4c4a77470282b7 Drop unnecessary information in ancillary build files
    5342230d0ff80afcfe6cac397b7fdb789658beb9 sharing: fix sharing for one week.
    26cd2f4c9b1ea0889bef285127c4fb43b0e751b0 uploads: fix progress bar
    c35927e3656686705101c848c75079989a10ec65 dcache-view (webdav): fix door selection
    8ed867a7ddba55b28c84b422fea39e194ecf872c [bower, package and package-lock] prepare for next development iteration
    84ae1fb8f3c1ef68fe8cad87bb12707c02fe54d8 [maven-release-plugin] prepare for next development iteration

Result:

The following issues are resolved:
     dCache/dcache-view#244  Requesting a "one week" macaroon fails
     dCache/dcache-view#245  Uploading files do not show transfer progress
     dCache/dcache-view#231  dCacheView: use the right WebDAV door

Requires-notes: yes
Requires-book: no
Request: 5.2
Patch: https://rb.dcache.org/r/12974
Acked-by: Lea Morschel