### PR TITLE
systemd: fix generator run after reboot

### DIFF
--- a/skel/lib/systemd/system-generators/dcache-generator
+++ b/skel/lib/systemd/system-generators/dcache-generator
@@ -12,6 +12,14 @@ export PATH
 wantdir="$1/dcache.target.wants"
 mkdir "$wantdir"
 
+#
+# Linux shell by default uses /tmp directory for temporary files,
+# including here-document (cat > << EOF...). When generator runs
+# the /root (thus /tmp) are mounted read-only.
+#
+# Point shell to a read-write directory
+export TMPDIR=/run/tmpfiles.d/
+
 for domain in $(getProperty dcache.domains); do
     RESTART_DELAY="$(getProperty dcache.restart.delay "$domain")"
     USER="$(getProperty dcache.user "$domain")"


### PR DESCRIPTION
Motivation:
Linux shell (bash) by default uses /tmp directory for temporary files,
including for so called `here-document` (cat > << EOF...). When generator runs
the /root (thus /tmp, if not a dedicated partition) are mounted as read-only.

Modification:
Point shell to a read-write directory

Result:
dcache-generator successfully runs after restart

Fixes: #5527
Acked-by: Albert Rossi
Target: master, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 40bf8f65242e0037f10f78537916d620959707fe)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>