### PR TITLE
pnfsmanager: fix NPE regression from 3dfed7e8b0

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -2026,6 +2026,9 @@ public class PnfsManagerV3
     private void postProcessSetFileAttributes(PnfsSetFileAttributes message)
     {
         FileAttributes attributes = message.getFileAttributes();
+        if (attributes == null) {
+            return;
+        }
         Optional<AccessLatency> al = attributes.getAccessLatencyIfPresent();
         Optional<RetentionPolicy> rp = attributes.getRetentionPolicyIfPresent();
         if (al.isPresent() || rp. isPresent()) {


### PR DESCRIPTION
Motivation:

Commit 3dfed7e8b0 introduced a regression because it assumes that a
successful entry creation will have a non-null set of file attributes.

This is not true if a symbolic link is created, in which case there is
an NPE.

Modification:

Update code to check if value is non-null.

Result:

A regression is fixed the prevents creating a symbolic link.

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/12985/
Acked-by: Dmitry Litvintsev
Acked-by: Lea Morschel
Acked-by: Albert Rossi