### PR TITLE
gplazma: ldap throw exception if no principal is added

### DIFF
--- a/modules/gplazma2-ldap/src/test/java/org/dcache/gplazma/plugins/LdapTest.java
+++ b/modules/gplazma2-ldap/src/test/java/org/dcache/gplazma/plugins/LdapTest.java
@@ -141,12 +141,10 @@ public class LdapTest {
         assertThat("expected GID not found", principals, hasItem(ACTOR_GID_PRINCIPAL));
     }
 
-    @Test
-    public void shouldDoNothingForNonExisting() throws AuthenticationException {
+    @Test(expected=AuthenticationException.class)
+    public void shouldThrowExceptionForNonExisting() throws AuthenticationException {
         Set<Principal> principals = Sets.newHashSet(NON_EXISTING_PRINCIPAL);
         plugin.map(principals);
-        assertThat("unexpected number of returned principals", principals, hasSize(1));
-        assertThat("expected USERNAME not found", principals, hasItem(NON_EXISTING_PRINCIPAL));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

The gPlazma Mapping plugin contract is that a mapping plugin should
either add (at least) one principal or it has failed.  A failed mapping
plugin throws an AuthenticationException to indicate why it failed.

Currently, the ldap plugin never throws an AuthenticationException, even
when it has added no principals.  This makes it hard to use the ldap
plugin with other mapping plugins.

Modification:

Update plugin to throw the expected exception if it fails to add any
principals.  The exception's message provides a short explanation on why
the mapping request failed.

Result:

The LDAP plugin behaviuor now more closely follows that of other mapping
plugins.  This allows deployments where LDAP is tried first and, if that
fails to identify the user, fall-back strategies are used.

Target: master
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13000/
Acked-by: Albert Rossi
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel