### PR TITLE
pnfsmanager: filter high-order bits from POSIX mode

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -978,7 +978,7 @@ public class ChimeraNameSpaceProvider
                 break;
             case MODE:
                 stat = inode.statCache();
-                attributes.setMode(stat.getMode());
+                attributes.setMode(stat.getMode() & UnixPermission.S_PERMS);
                 break;
             case PNFSID:
                 attributes.setPnfsId(inode.getPnfsId());


### PR DESCRIPTION
Motivation:

Chimera stores the kind of a file and the Unix permissions in the same
integer field in the database.

Within dCache, these two pieces of information are transported
independently, as two fields within a FileAttributes object:
FileAttribute.TYPE and FileAttribute.MODE.

Currently, the FileAttribute.MODE contains the complete Chimera integer
value, where the low-order bits are the Unix permissions and the
high-order bits describe the file type.

In many cases, the consumer of this information further breaks down the
information, so select only the Unix permissions bits.  However, there
are doors (frontend, in particular) where the Unix permission is
returned as an integer value.

As further motivation: when assigning attributes (via the
PnfsSetFileAttributes message) only the low-order bits from
FileAttribute.MODE are used.  The high-order bits are ignored.
Therefore, the current behaviour is asymmetric between
PnfsGetFileAttributes (which exposes the high-order bits) and
PnfsSetFileAttributes (which ignores the high-order bits.

Modification:

Filter out high-order bits from the Unix permissions mode when an
internal component is querying the namespace.

Result:

The frontend support for querying a file's metadata via PNFS-ID now
shows the Unix permissions, without including the file-type high-order
bits.

Target: master
Request: 7.0
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/12998/
Acked-by: Albert Rossi
Acked-by: Lea Morschel