### PR TITLE
frontend: bump version of dCacheView

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.jetty>9.4.18.v20190429</version.jetty>
         <version.xrootd4j>3.5.10</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
-        <version.dcache-view>1.6.2</version.dcache-view>
+        <version.dcache-view>1.6.3</version.dcache-view>
         <version.netty>4.1.45.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -468,15 +468,19 @@ frontend.static.path = /scripts/config.js
 #
 #       dcache-view.endpoints.webdav
 #
-#           dCacheView uses the webapi for meta data access, but
-#           actual file transfers are served from the regular webdav
-#           door.
+#           dCacheView uses a WebDAV door for data transfers (uploads
+#           and downloads) and for requesting Macaroons.
 #
-#           If left empty, is is assumed the webdav service runs on
-#           the same host as the frontend door on port 2880. One could
-#           set this to something like https://example.org:443/.
+#           By default, dCacheView will search for WebDAV doors with
+#           the tag 'dcache-view' and where the door-root is '/'.  If
+#           there are multiple such doors, dCacheView will select the
+#           least loaded.
 #
-#           MUST end with a slash if non-empty.
+#           This auto-detection behaviour may be overridden by specifying
+#           the 'dcache-view.endpoints.webdav' property.  The value
+#           is the URL of the WebDAV endpoint to use
+#           (e.g., https://example.org:443/ ).  Any non-empty value
+#           MUST end with a slash.
 #
 #       dcache-view.org-name
 #


### PR DESCRIPTION
Motivation:

dCacheView v1.6.3 contains the following improvements:

    5cb0ec23a0117828dc944df36a1954349fc4850d (tag: v1.6.3) [maven-release-plugin] prepare release v1.6.3
    f71a7f11a776c2fa0c6c45215e0ed88d132e1690 webdav: interpret 'dcache-view.endpoints.webdav' as an override
    7f160ac089875cbac6087e95326bcf46c9c47955 [maven-release-plugin] prepare for next development iteration

Modification:

Update pom to select dCacheView v1.6.3

Result:

The 'dcache-view.endpoints.webdav' property now overrides any
auto-discovered WebDAV endpoint, making explicit configuration easier.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Patch: https://rb.dcache.org/r/12994/
Acked-by: Lea Morschel