### PR TITLE
pool: fix pool size reporting when static/runtime config is not defined.

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/json/RepositoryData.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/json/RepositoryData.java
@@ -205,8 +205,8 @@ public class RepositoryData implements Serializable {
                                    "    [" + fileSystemRatioFreeToTotal + "]");
         pw.println("Limits for maximum disk space");
         pw.println("    File system          : " + fileSystemMaxSpace);
-        pw.println("    Statically configured: " + staticallyConfiguredMax);
-        pw.println("    Runtime configured   : " + runtimeConfiguredMax);
+        pw.println("    Statically configured: " + (staticallyConfiguredMax == null? "-" : staticallyConfiguredMax.toString()));
+        pw.println("    Runtime configured   : " + (runtimeConfiguredMax == null? "-" : runtimeConfiguredMax.toString()));
     }
 
     public void setFileSystemFree(Long fileSystemFree) {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReplicaRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReplicaRepository.java
@@ -1033,8 +1033,8 @@ public class ReplicaRepository
             info.setFileSystemFree(fsFree);
             info.setFileSystemRatioFreeToTotal(((double) fsFree) / fsTotal);
             info.setFileSystemMaxSpace(fsFree + used);
-            info.setStaticallyConfiguredMax(_staticMaxSize.longValue());
-            info.setRuntimeConfiguredMax(getConfiguredMaxSize().longValue());
+            info.setStaticallyConfiguredMax(_staticMaxSize.isSpecified() ? _staticMaxSize.longValue(): null);
+            info.setRuntimeConfiguredMax(_runtimeMaxSize.isSpecified() ? _runtimeMaxSize.longValue() : null);
         } finally {
             _stateLock.readLock().unlock();
         }

--- a/modules/dcache/src/test/java/org/dcache/tests/repository/RepositorySubsystemTest.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/repository/RepositorySubsystemTest.java
@@ -636,17 +636,6 @@ public class RepositorySubsystemTest
         assertSpaceRecord(3072, 0, 1024, 1024);
     }
 
-    @Test
-    public void testGetConfiguredSize()
-        throws IOException, CacheException, InterruptedException
-    {
-        repository.init();
-        repository.load();
-        stateChangeEvents.clear();
-
-        assertEquals(repoSize, repository.getDataObject().getRuntimeConfiguredMax().longValue());
-    }
-
     @Test(expected=IllegalArgumentException.class)
     public void testSetSizeNegative()
         throws IOException, CacheException, InterruptedException


### PR DESCRIPTION
Motivation:
The pool's repository reports several space limits, which either coming
from pool.size property, so called static configuration, pool's setup,
so called runtime configuration and file system size. If the first two
is not defined, then 8EB is reported:

File system : 469868042256384
Statically configured: 9223372036854775807
Runtime configured : 9223372036854775807

Though this large number gives a hint to be treated as 'undefined' it
still not distinguishable from a valid 8EB configuration.

Modification:
Update pool to report undefined values as '-' (like in earlier dcache
versions 3.2?)

Result:

More clarity:

no limits defined:

Limits for maximum disk space
    File system          : 778665549711
    Statically configured: -
    Runtime configured   : -

pool.size=8g, max diskspace 1g:

Limits for maximum disk space
    File system          : 778675695503
    Statically configured: 8589934592
    Runtime configured   : 1073741824

pool.size not defined, max disksize 4g:

Limits for maximum disk space
    File system          : 778967994255
    Statically configured: -
    Runtime configured   : 4294967296

Ticket: #9516
Acked-by: Albert Rossi
Acked-by: Lea Morschel
Target: master, 7.1, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit b4f957b4b946d8a1227c4c45d8a839898416dad8)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>