### PR TITLE
frontend: bump swagger version to 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -952,7 +952,7 @@
             <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jersey2-jaxrs</artifactId>
-                <version>1.5.17</version>
+                <version>1.6.2</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.plugin</groupId>


### PR DESCRIPTION
Motivation:

Commit 6cd3caf88b bumped the version of Jackson from 2.10.1 to 2.12.1.
The newer version removed a deprecated method on which swagger was
relying.  The result is described in #5894.

Modification:

Update swagger to v1.6.2.  This version is built with a newer version of
Jackson, so does not suffer from the same problem.

Result:

Fix regression in generating swagger JSON for frontend's REST API.

Target: master
Request: 7.1
Requires-notes: true
Requires-book: no
Closes: #5894
Patch: https://rb.dcache.org/r/13029/
Acked-by: Lea Morschel
Acked-by: Tigran Mkrtchyan