### PR TITLE
gplamza: oidc support fetching username and groups direct from OP

### DIFF
--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/IdentityProvider.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/IdentityProvider.java
@@ -18,7 +18,8 @@
  */
 package org.dcache.gplazma.oidc;
 
-import com.google.common.base.Strings;
+
+import com.google.common.base.Splitter;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -41,6 +42,8 @@ public class IdentityProvider
     private final String name;
     private final URI issuer;
     private final URI configuration;
+    private final boolean acceptUsername;
+    private final boolean acceptGroups;
 
     public IdentityProvider(String name, String description)
     {
@@ -56,6 +59,27 @@ public class IdentityProvider
             throw new IllegalArgumentException("Invalid endpoint " + endpoint + ": " + e.getMessage());
         }
         configuration = issuer.resolve(withTrailingSlash(issuer.getPath()) + ".well-known/openid-configuration");
+
+        boolean username = false;
+        boolean groups = false;
+        String acceptValue = args.getOption("accept");
+        if (acceptValue != null) {
+            for (String item : Splitter.on(',').split(acceptValue)) {
+                switch (item) {
+                case "username":
+                    username = true;
+                    break;
+                case "groups":
+                    groups = true;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown accept item \"" + item + "\"");
+                }
+            }
+        }
+
+        acceptUsername = username;
+        acceptGroups = groups;
     }
 
     private static String withTrailingSlash(String path)
@@ -71,6 +95,16 @@ public class IdentityProvider
     public URI getIssuerEndpoint()
     {
         return issuer;
+    }
+
+    public boolean isUsernameAccepted()
+    {
+        return acceptUsername;
+    }
+
+    public boolean areGroupsAccepted()
+    {
+        return acceptGroups;
     }
 
     /**


### PR DESCRIPTION
Motivation:

Add support to configure gPlazma accept more information from the OP.

The OP has the concept of a username, that is (optionally) makes
available as the 'preferred_username' claim.  In general, this has no
correlation with dCache's usernames (why should Google and a dCache
instance be sync-ed?); however there be OPs where their usernames and
dCache usernames are aligned.  This is (perhaps) mostly likely when a
site is running their own "infrastructure proxy", through which users
are authenticating.

If the OP's and dCache's usernames match then it's helpful for dCache to
extract the 'preferred_username' claim value as the UserNamePrincipal.

Similarly, the OP may provide group information as the (non-standard)
'groups' field.  By default, dCache maps such groups these to
OpenIdGroupPrincipal principals, allowing subsequent gPlazma modules to
map these to dCache groups (or to ignore them).

However, an OP might assert group-membership information that is
compatible with dCache's internal groups.  If so, then it is helpful for
dCache to extract the 'groups' claim as GroupNamePrincipal, with a
trivial name-space mapping.

Modification:

Add the 'accept' option to allow an admin to configure gPlazma's OIDC
plugin so that a specifc OP is trusted to provide compatible
information.  The accept option's value is a comma-separated list of
items that are trusted.  Currently supported options are 'username' and
'groups'.

Result:

The OIDC gplazma plugin may be configured to extract the
UserNamePrincipal from the OP "preferred_username" claim, or to identify
GroupNamePrincipal information from the OPs "groups" claim.  The default
behaviour is to ignore the "preferred_username" claim and to map
"groups" claim to a set of OpenIdGroupPrincipal.

Target: master
Request: 7.1
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/12996/
Acked-by: Tigran Mkrtchyan