### PR TITLE
poolmanager: fix _waitingFor access outside of synchronized block

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RequestContainerV5.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Required;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -850,6 +851,7 @@ public class RequestContainerV5
         private final List<Consumer<RequestState>> _observers = new CopyOnWriteArrayList<>();
 
 
+        @GuardedBy("RequestContainerV5.this._messageHash")
         private UOID _waitingFor;
 
         private String _status = "Idle";
@@ -1106,11 +1108,11 @@ public class RequestContainerV5
         // we only allow to run a single thread at a time.
         //
         private void clearSteering() {
-            if (_waitingFor != null) {
-                synchronized (_messageHash) {
+            synchronized (_messageHash) {
+                if (_waitingFor != null) {
                     _messageHash.remove(_waitingFor);
+                    _waitingFor = null;
                 }
-                _waitingFor = null;
             }
         }
 


### PR DESCRIPTION
Motivation:

For the most part, the `_waitingFor` field member is protected against
races between in-bound message delivery and the `PoolRequestHandler`
object "giving up" on the in-bound message by using the `_messageHash`
monitor.

The `clearSteering` method breaks this strategy, by testing for non-zero
values and updating the field-member's value outside the monitor.

Modification:

Update `clearSteering` so that `_waitingFor` is only accessed from
within the `_messageHash` monitor.

Annotate the field-member to document how concurrency is to be handled.

Result:

A very rare race-condition is fixed that could be triggered if a pool
completes a stage or pool-to-pool request (to satisfy a client's read
request) immediately before dying, with the pool-manager's periodic
checking noticing this at the same time.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.1
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/12887/
Acked-by: Tigran Mkrtchyan