### PR TITLE
nfs: add possibility to configure BerkeleyDB client store

### DIFF
--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -190,9 +190,13 @@
         <property name="root" value="/"/>
     </bean>
 
-
     <bean name="clientStore" class="org.dcache.nfs.v4.BerkeleyDBClientStore" destroy-method="close">
         <constructor-arg value="${nfs.clientdb.location}" />
+        <constructor-arg>
+                <bean class="org.dcache.util.configuration.ConfigurationMapFactoryBean">
+                    <property name="prefix" value="nfs.clientdb.config"/>
+                </bean>
+        </constructor-arg>
     </bean>
 
     <bean abstract="true" id="door" class="org.dcache.chimera.nfsv41.door.NFSv41Door"

--- a/skel/share/defaults/nfs.properties
+++ b/skel/share/defaults/nfs.properties
@@ -278,4 +278,24 @@ nfs.kafka.producer.bootstrap.servers =  ${dcache.kafka.bootstrap-servers}
 #
 nfs.clientdb.location=${dcache.paths.nfs}
 
+#  ---- Configuration properties for Berkeley DB Java client DB
+#
+#   Berkeley DB Java edition is used by NFS door to store client records.
+#   The database provides a large number of tuning options. These are mapped
+#   to the nfs.clientdb.config prefix.
+#
+#   Consult the Oracle Berkeley DB Java Edition documentation at
+#
+#       http://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/EnvironmentConfig.html
+#
+#   for details.
+#
+#   WARNING: Be aware that these settings may influence the consistency
+#   of the data.
+#
+(prefix)nfs.clientdb.config = Configuration for the meta data database
+
+nfs.clientdb.config!je.freeDisk = 0
+
+
 (prefix)nfs.kafka.producer.configs =  Configuration for Kafka Producer


### PR DESCRIPTION
Motivation:
The BerkeleyDB used by NFS door to store client records. As default
configuration of BerkeleyDB is too restrictive, a simple way to
change the configuration is required.

Modification:
Introduce nfs.clientdb.config property prefix to populate the
BerkeleyDB configuration. Update nfs door to inject configuration
into client store. Set freeDisk property to zero, as (a) client
db is quite small and (b) loosing this information is not critical
for current implementation (write after reboot is not supported).

Result:
- the nfs door is not picky about free disk space in /var/lib/dcache/nfs
- the  BerkeleyDB used as client store by nfs door can be configured
  with properties.

Fixes: #5810
Ticket: #10135
Acked-by: Marina Sahakyan
Acked-by: Lea Morschel
Target: master, 7.1, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 77eadb32ae9a38f82680c864435c9d7a0f93c1d6)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>