### PR TITLE
dcache-xroot: fix upload transfer checksum failure (stable branches)

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -98,6 +98,7 @@ import org.dcache.util.Transfer;
 import org.dcache.util.TransferRetryPolicies;
 import org.dcache.util.TransferRetryPolicy;
 import org.dcache.vehicles.FileAttributes;
+import org.dcache.vehicles.PnfsGetFileAttributes;
 import org.dcache.vehicles.PnfsListDirectoryMessage;
 import org.dcache.vehicles.XrootdDoorAdressInfoMessage;
 import org.dcache.vehicles.XrootdProtocolInfo;
@@ -178,6 +179,16 @@ public class XrootdDoor
      */
     private final Map<Integer,XrootdTransfer> _transfers =
         new ConcurrentHashMap<>();
+
+    /*
+     *  Map of upload transfer path to pnfsid.
+     *
+     *  This is a stable branch fix for a bug in the handling of xrootd persist-on-successful-close.
+     *  When requesting attributes, use the pnfsid registered on open instead of the path,
+     *  which may not yet have been finalized because the pool sent an OK to the client
+     *  prematurely (that problem will be rectified on master).
+     */
+    private final Map<String, PnfsId> _uploadPaths =  new ConcurrentHashMap<>();
 
     @Autowired(required = false)
     private void setKafkaTemplate(
@@ -369,7 +380,7 @@ public class XrootdDoor
                             path,
                             options,
                             EnumSet.of(PNFSID, SIZE, STORAGEINFO));
-            msg = _pnfsStub.sendAndWait(msg);
+            _pnfsStub.sendAndWait(msg);
         } catch (InterruptedException ex) {
             throw new CacheException("Operation interrupted", ex);
         } catch (NoRouteToCellException ex) {
@@ -428,7 +439,19 @@ public class XrootdDoor
                     notifyBilling(rc, message);
                     _log.warn("Post upload operation failed: {} (error code={})",
                             message, rc);
+                } finally {
+                    _uploadPaths.remove(path.toString());
                 }
+            }
+
+            @Override
+            public synchronized InetSocketAddress waitForRedirect(long millis)
+                throws CacheException, InterruptedException {
+                InetSocketAddress address = super.waitForRedirect(millis);
+                if (address != null) {
+                    _uploadPaths.put(path.toString(), getPnfsId());
+                }
+                return address;
             }
         };
         transfer.setCellAddress(getCellAddress());
@@ -481,6 +504,21 @@ public class XrootdDoor
         transfer.setFileHandle(_handleCounter.getAndIncrement());
         transfer.setKafkaSender(_kafkaSender);
         return transfer;
+    }
+
+    private FileAttributes getFileAttributes(FsPath path,
+                                             Set<FileAttribute> requestedAttributes,
+                                             PnfsHandler pnfsHandler)
+        throws CacheException
+    {
+        PnfsId pnfsId = _uploadPaths.get(path.toString());
+        if (pnfsId != null) {
+            PnfsGetFileAttributes request = new PnfsGetFileAttributes(pnfsId, requestedAttributes);
+            request.setPnfsPath(path.toString());
+            return pnfsHandler.request(request).getFileAttributes();
+        } else {
+            return pnfsHandler.getFileAttributes(path.toString(), requestedAttributes);
+        }
     }
 
     public XrootdTransfer
@@ -604,6 +642,7 @@ public class XrootdDoor
                     throw e;
                 }
             }
+
             maxUploadSize.ifPresent(transfer::setMaximumLength);
             if (size != null) {
                 checkResourceNotMissing(!maxUploadSize.isPresent() || size
@@ -649,6 +688,7 @@ public class XrootdDoor
                 _transfers.remove(handle);
             }
         }
+
         return transfer;
     }
 
@@ -1063,8 +1103,7 @@ public class XrootdDoor
     {
         PnfsHandler pnfsHandler = new PnfsHandler(_pnfs, subject, restriction);
         Set<FileAttribute> requestedAttributes = EnumSet.of(CHECKSUM);
-        FileAttributes attributes =
-                pnfsHandler.getFileAttributes(fullPath.toString(), requestedAttributes);
+        FileAttributes attributes = getFileAttributes(fullPath, requestedAttributes, pnfsHandler);
         return attributes.getChecksums();
     }
 
@@ -1075,7 +1114,7 @@ public class XrootdDoor
          */
         PnfsHandler pnfsHandler = new PnfsHandler(_pnfs, subject, restriction);
         Set<FileAttribute> requestedAttributes = getRequiredAttributesForFileStatus();
-        FileAttributes attributes = pnfsHandler.getFileAttributes(fullPath.toString(), requestedAttributes);
+        FileAttributes attributes = getFileAttributes(fullPath, requestedAttributes, pnfsHandler);
         return getFileStatus(subject, restriction, fullPath, clientHost, attributes);
     }
 
@@ -1118,8 +1157,7 @@ public class XrootdDoor
             try {
                 Set<FileAttribute> requestedAttributes = EnumSet.of(TYPE);
                 requestedAttributes.addAll(_pdp.getRequiredAttributes());
-                FileAttributes attributes =
-                        pnfsHandler.getFileAttributes(allPaths[i].toString(), requestedAttributes);
+                FileAttributes attributes = getFileAttributes(allPaths[i], requestedAttributes, pnfsHandler);
                 flags[i] = getFileStatusFlags(subject, restriction, allPaths[i], attributes);
             } catch (CacheException e) {
                 if (e.getRc() != CacheException.FILE_NOT_FOUND &&


### PR DESCRIPTION
Motivation:

GitHub #5882 Xroot: successful write but copy still fails with "no such file"

For xroot, there are two kinds of write transfers.  The first is a write
directly to the given namespace path; the second creates an upload path
and commits to the actual path only if it succeeds.  The kXR_open directive
indicating this latter write is kXR_posc ("persist on successful close").

This transactional write, however, opens up a potential time slice between
the receipt of an OK response from the close request and the actual
commit to the namespace.  If the client is fast enough in issuing any
successive commands, it may find that the path has not yet registered
and receive a FileNotFound error.

This happens with a gfal scenario in which kXR_posc is included AND
a checksum request is issued on the same connection as open on the
door (even after redirect from the pool). This was experienced intermittently
particularly with small files < 25k.

The problem has gone undiscovered because our testing usually
involves the xrdcp client directly, which actually reconnects to the door
on redirect for the checksum, creating sufficient delay to find the
file path metadata committed.

Modification:

The actual fix, which is to move the path commit logic into the pool,
will be applied on master only in a separate patch.

The stable branch fix, which involves only the door, is to
map upload transfer paths against the pnfsid registered on
open, and to use that in all file attribute lookups instead
of the path in those cases.

Result:

The gfal scenario, and hopefully any others which depend on
the presence of the committed path, now works.

Target: 7.1
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Closes:  #5882
Patch: https://rb.dcache.org/r/13032
Acked-by: Tigran
Acked-by: Paul