### PR TITLE
dcache-xrootd: upgrade xrootd4j to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.35.v20201120</version.jetty>
-        <version.xrootd4j>4.1.0</version.xrootd4j>
+        <version.xrootd4j>4.1.1</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.3</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>


### PR DESCRIPTION
Fixes problem with netty LogHandler slowing down TPC client
(cutting bandwidth by a factor of 10).

master@357da2ebf735b6151d0ef554b26aac42610a6352

Target: master
Request: 7.1  [4.1.1]
Request: 7.0  [4.0.8]
Request: 6.2  [4.0.8]
Patch: https://rb.dcache.org/r/13041/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran
Acked-by: Lea