### PR TITLE
checksum-module: add missing map to JSON info

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumModuleV1.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumModuleV1.java
@@ -187,6 +187,7 @@ public class ChecksumModuleV1
         Map<String, String> policies = new HashMap<>();
         _policy.stream().forEach((p) -> policies.put(p.name(), getPolicy(p)));
         policies.put(ON_TRANSFER.name(), "on");
+        info.setPolicies(policies);
         if (hasPolicy(SCRUB)) {
             if (!Double.isInfinite(_throughputLimit)) {
                 info.setThroughputLimitInMibPerSec(BYTES.toMiB(_throughputLimit));


### PR DESCRIPTION
Motivation:

The policies map should be added to the JSON info object
returned for checksum module information.

Modification:

Add it.

Result:

JSON object data is complete.

Target: master
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13071/
Acked-by: Lea