### PR TITLE
pool: update configuration to split http-tpc and remote-gsiftp CA set…

### DIFF
--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -459,12 +459,12 @@
   <bean id="remote-http-transfer-service" class="org.dcache.pool.classic.RemoteHttpTransferService"
           depends-on="rep" destroy-method="shutdown">
       <property name="postTransferService" ref="post-transfer-service"/>
-      <property name="certificateAuthorityPath" value="${pool.authn.capath}"/>
-      <property name="certificateAuthorityUpdateInterval" value="${pool.authn.capath.refresh}"/>
-      <property name="certificateAuthorityUpdateIntervalUnit" value="${pool.authn.capath.refresh.unit}"/>
-      <property name="namespaceMode" value="${pool.authn.namespace-mode}"/>
-      <property name="crlCheckingMode" value="${pool.authn.crl-mode}"/>
-      <property name="ocspCheckingMode" value="${pool.authn.ocsp-mode}"/>
+      <property name="certificateAuthorityPath" value="${pool.mover.http-tpc.authn.capath}"/>
+      <property name="certificateAuthorityUpdateInterval" value="${pool.mover.http-tpc.authn.capath.refresh}"/>
+      <property name="certificateAuthorityUpdateIntervalUnit" value="${pool.mover.http-tpc.authn.capath.refresh.unit}"/>
+      <property name="namespaceMode" value="${pool.mover.http-tpc.authn.namespace-mode}"/>
+      <property name="crlCheckingMode" value="${pool.mover.http-tpc.authn.crl-mode}"/>
+      <property name="ocspCheckingMode" value="${pool.mover.http-tpc.authn.ocsp-mode}"/>
   </bean>
 
   <bean id="banned-ciphers" class="org.dcache.util.Crypto"
@@ -475,12 +475,12 @@
   <bean id="remote-gsiftp-transfer-service" class="org.dcache.pool.classic.RemoteGsiftpTransferService"
           depends-on="rep" destroy-method="shutdown">
       <property name="postTransferService" ref="post-transfer-service"/>
-      <property name="certificateAuthorityPath" value="${pool.authn.capath}"/>
-      <property name="certificateAuthorityUpdateInterval" value="${pool.authn.capath.refresh}"/>
-      <property name="certificateAuthorityUpdateIntervalUnit" value="${pool.authn.capath.refresh.unit}"/>
-      <property name="namespaceMode" value="${pool.authn.namespace-mode}"/>
-      <property name="crlCheckingMode" value="${pool.authn.crl-mode}"/>
-      <property name="ocspCheckingMode" value="${pool.authn.ocsp-mode}"/>
+      <property name="certificateAuthorityPath" value="${pool.mover.remote-gsiftp.authn.capath}"/>
+      <property name="certificateAuthorityUpdateInterval" value="${pool.mover.remote-gsiftp.authn.capath.refresh}"/>
+      <property name="certificateAuthorityUpdateIntervalUnit" value="${pool.mover.remote-gsiftp.authn.capath.refresh.unit}"/>
+      <property name="namespaceMode" value="${pool.mover.remote-gsiftp.authn.namespace-mode}"/>
+      <property name="crlCheckingMode" value="${pool.mover.remote-gsiftp.authn.crl-mode}"/>
+      <property name="ocspCheckingMode" value="${pool.mover.remote-gsiftp.authn.ocsp-mode}"/>
       <property name="bannedCiphers" ref="banned-ciphers"/>
       <property name="portRange">
           <bean class="org.dcache.util.PortRange">

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -514,12 +514,89 @@ pool.mover.http.port.max = ${dcache.net.wan.port.max}
 pool.mover.ftp.port.min = ${dcache.net.wan.port.min}
 pool.mover.ftp.port.max = ${dcache.net.wan.port.max}
 
+#  --- HTTP-TPC settings
+#
+#  These settings control how HTTP-TPC operates.
+#
+#  Which certificate authorities (CAs) to trust when verifying the
+#  remote host's certificate.
+#
+pool.mover.http-tpc.authn.capath = ${pool.authn.capath}
+pool.mover.http-tpc.authn.capath.refresh=${pool.authn.capath.refresh}
+(one-of?MILLISECONDS|\
+	SECONDS|\
+	MINUTES|\
+	HOURS|\
+	DAYS|\
+	${pool.authn.capath.refresh.unit})\
+pool.mover.http-tpc.authn.capath.refresh.unit=${pool.authn.capath.refresh.unit}
+
+#   The (certificate authority) Namespace usage mode
+#
+(one-of?GLOBUS_EUGRIDPMA|EUGRIDPMA_GLOBUS|GLOBUS|EUGRIDPMA|GLOBUS_EUGRIDPMA_REQUIRE|EUGRIDPMA_GLOBUS_REQUIRE|GLOBUS_REQUIRE|EUGRIDPMA_REQUIRE|EUGRIDPMA_AND_GLOBUS|EUGRIDPMA_AND_GLOBUS_REQUIRE|IGNORE|${pool.authn.namespace-mode})\
+pool.mover.http-tpc.authn.namespace-mode=${pool.authn.namespace-mode}
+
+#   Certificate Revocation List (CRL) usage mode
+#
+(one-of?REQUIRE|IF_VALID|IGNORE|${pool.authn.crl-mode})\
+pool.mover.http-tpc.authn.crl-mode=${pool.authn.crl-mode}
+
+#   On-line Certificate Status Protocol (OCSP) usage mode
+#
+(one-of?REQUIRE|IF_AVAILABLE|IGNORE|${pool.authn.ocsp-mode})\
+pool.mover.http-tpc.authn.ocsp-mode=${pool.authn.ocsp-mode}
+
+#    Disabling specific ciphers
+#
+(any-of?DISABLE_EC|DISABLE_RC4|${pool.authn.ciphers})\
+pool.mover.http-tpc.authn.ciphers = ${pool.authn.ciphers}
+
+
+
+#  --- Remote gsiftp transfers settings
+#
+#  These are settings for the pool's embedded gsiftp client.  Note:
+#  most gsiftp transfers do NOT use the embedded gsiftp client, as FTP
+#  can do third-party transfers without requiring an embedded client.
+#
+#  Which certificate authorities (CAs) to trust when verifying the
+#  remote host's certificate.
+#
+pool.mover.remote-gsiftp.authn.capath = ${pool.authn.capath}
+pool.mover.remote-gsiftp.authn.capath.refresh=${pool.authn.capath.refresh}
+(one-of?MILLISECONDS|\
+	SECONDS|\
+	MINUTES|\
+	HOURS|\
+	DAYS|\
+	${pool.authn.capath.refresh.unit})\
+pool.mover.remote-gsiftp.authn.capath.refresh.unit=${pool.authn.capath.refresh.unit}
+
+#   The (certificate authority) Namespace usage mode
+#
+(one-of?GLOBUS_EUGRIDPMA|EUGRIDPMA_GLOBUS|GLOBUS|EUGRIDPMA|GLOBUS_EUGRIDPMA_REQUIRE|EUGRIDPMA_GLOBUS_REQUIRE|GLOBUS_REQUIRE|EUGRIDPMA_REQUIRE|EUGRIDPMA_AND_GLOBUS|EUGRIDPMA_AND_GLOBUS_REQUIRE|IGNORE|${pool.authn.namespace-mode})\
+pool.mover.remote-gsiftp.authn.namespace-mode=${pool.authn.namespace-mode}
+
+#   Certificate Revocation List (CRL) usage mode
+#
+(one-of?REQUIRE|IF_VALID|IGNORE|${pool.authn.crl-mode})\
+pool.mover.remote-gsiftp.authn.crl-mode=${pool.authn.crl-mode}
+
+#   On-line Certificate Status Protocol (OCSP) usage mode
+#
+(one-of?REQUIRE|IF_AVAILABLE|IGNORE|${pool.authn.ocsp-mode})\
+pool.mover.remote-gsiftp.authn.ocsp-mode=${pool.authn.ocsp-mode}
+
+#    Disabling specific ciphers
+#
+(any-of?DISABLE_EC|DISABLE_RC4|${pool.authn.ciphers})\
+pool.mover.remote-gsiftp.authn.ciphers = ${pool.authn.ciphers}
+
 #  ---- Directory containing trusted CA certificates
 #
 #   The directory containing the certificate authority (CA)
 #   certificates that the pool should trust when accepting or making
-#   remote connections.  Currently only secure HTTP (https)
-#   connections react to this property.
+#   remote connections.  Used by HTTP-TPC and the gsiftp client.
 #
 pool.authn.capath = ${dcache.authn.capath}
 

--- a/skel/share/services/pool.batch
+++ b/skel/share/services/pool.batch
@@ -19,6 +19,22 @@ check -strong pool.authn.crl-mode
 check -strong pool.authn.ocsp-mode
 check pool.authn.ciphers
 
+check -strong pool.mover.http-tpc.authn.capath
+check -strong pool.mover.http-tpc.authn.capath.refresh
+check -strong pool.mover.http-tpc.authn.capath.refresh.unit
+check -strong pool.mover.http-tpc.authn.namespace-mode
+check -strong pool.mover.http-tpc.authn.crl-mode
+check -strong pool.mover.http-tpc.authn.ocsp-mode
+check pool.mover.http-tpc.authn.ciphers
+
+check -strong pool.mover.remote-gsiftp.authn.capath
+check -strong pool.mover.remote-gsiftp.authn.capath.refresh
+check -strong pool.mover.remote-gsiftp.authn.capath.refresh.unit
+check -strong pool.mover.remote-gsiftp.authn.namespace-mode
+check -strong pool.mover.remote-gsiftp.authn.crl-mode
+check -strong pool.mover.remote-gsiftp.authn.ocsp-mode
+check pool.mover.remote-gsiftp.authn.ciphers
+
 check -strong pool.limits.worker-threads
 check -strong pool.limits.nearline-threads
 check -strong pool.enable.repository-check


### PR DESCRIPTION
…tings

Motivation:

Support finer control over which CAs are acceptable for different
protocols.

Adopt the 'pool.mover.X' naming convention for properties that affect a
specific network protocol.

Modification:

Introduce new configuration properties.

The defaults for these new properties have been chosen so that just
upgrading has no effect.

NOTE: We may want to drop 'pool.authn.capath' (and similar) properties
in the future.

Result:

New configuration properties for the pool have been introduced so that
it is possible to configure how HTTP-TPC verifies the remote server's
certificate.  The defaults are chosen so that, without any explicit
configuration, the pool continues with its previous behaviour.

Target: master
Request: 7.1
See: #5927
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13064/
Acked-by: Tigran Mkrtchyan