### PR TITLE
pool: http-tpc add support for multiple trust stores

### DIFF
--- a/modules/common-security/src/main/java/org/dcache/security/trust/AggregateX509TrustManager.java
+++ b/modules/common-security/src/main/java/org/dcache/security/trust/AggregateX509TrustManager.java
@@ -1,0 +1,100 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.security.trust;
+
+import javax.net.ssl.X509TrustManager;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Aggregate multiple X509TrustManager instances where a certificate chain is
+ * accepted if at least one of the X509TrustManager instances accepts it.
+ */
+public class AggregateX509TrustManager implements X509TrustManager
+{
+    private final List<X509TrustManager> trustManagers;
+
+    public AggregateX509TrustManager(List<X509TrustManager> managers)
+    {
+        trustManagers = requireNonNull(managers);
+    }
+
+    @FunctionalInterface
+    private interface CertificateCheck
+    {
+        void appliedTo(X509TrustManager manager) throws CertificateException;
+    }
+
+    private void genericCheck(CertificateCheck check) throws CertificateException
+    {
+        if (trustManagers.isEmpty()) {
+            throw new CertificateException("No certificates are trusted.");
+        }
+
+        StringBuilder errorMessage = null;
+
+        for (var tm : trustManagers) {
+            try {
+                check.appliedTo(tm);
+                return;
+            } catch (CertificateException e) {
+                if (e.getMessage() != null) {
+                    if (errorMessage == null) {
+                        errorMessage = new StringBuilder();
+                    } else {
+                        errorMessage.append("; ");
+
+                    }
+                    errorMessage.append(e.getMessage());
+                }
+            }
+        }
+
+        throw errorMessage == null
+                ? new CertificateException()
+                : new CertificateException(errorMessage.toString());
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType)
+            throws CertificateException
+    {
+        genericCheck(tm -> tm.checkClientTrusted(chain, authType));
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType)
+            throws CertificateException
+    {
+        genericCheck(tm -> tm.checkServerTrusted(chain, authType));
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers()
+    {
+        return trustManagers.stream()
+                .map(X509TrustManager::getAcceptedIssuers)
+                .flatMap(Arrays::stream)
+                .toArray(X509Certificate[]::new);
+    }
+}

--- a/modules/common-security/src/test/java/org/dcache/security/trust/AggregateX509TrustManagerTest.java
+++ b/modules/common-security/src/test/java/org/dcache/security/trust/AggregateX509TrustManagerTest.java
@@ -1,0 +1,305 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.security.trust;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.BDDMockito;
+
+import javax.net.ssl.X509TrustManager;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class AggregateX509TrustManagerTest
+{
+    private X509TrustManager manager;
+    private List<X509TrustManager> inner;
+
+    @Before
+    public void setup()
+    {
+        manager = null;
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void shouldThrowNpeIfConstructedWithNull()
+    {
+        new AggregateX509TrustManager(null);
+    }
+
+    @Test(expected=CertificateException.class)
+    public void shouldRejectClientWithEmptyManager() throws Exception
+    {
+        givenTrustManagers();
+
+        X509Certificate[] chain = new X509Certificate[0];
+        manager.checkClientTrusted(chain, "TLS");
+    }
+
+    @Test
+    public void shouldAcceptClientWithSingleAcceptingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager());
+
+        X509Certificate[] chain = new X509Certificate[0];
+        manager.checkClientTrusted(chain, "TLS");
+
+        verify(inner.get(0)).checkClientTrusted(chain, "TLS");
+        verify(inner.get(0), never()).checkServerTrusted(any(), any());
+        verify(inner.get(0), never()).getAcceptedIssuers();
+    }
+
+    @Test
+    public void shouldAcceptServerWithSingleAcceptingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager());
+
+        X509Certificate[] chain = new X509Certificate[0];
+        manager.checkServerTrusted(chain, "TLS");
+
+        verify(inner.get(0), never()).checkClientTrusted(any(), any());
+        verify(inner.get(0)).checkServerTrusted(chain, "TLS");
+        verify(inner.get(0), never()).getAcceptedIssuers();
+    }
+
+    @Test(expected=CertificateException.class)
+    public void shouldRejectClientWithSingleRejectingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager().thatFailsClientsWith(new CertificateException()));
+
+        manager.checkClientTrusted(new X509Certificate[0], "TLS");
+    }
+
+    @Test(expected=CertificateException.class)
+    public void shouldRejectServerWithSingleRejectingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager().thatFailsServerWith(new CertificateException()));
+
+        manager.checkServerTrusted(new X509Certificate[0], "TLS");
+    }
+
+    @Test
+    public void shouldReturnAcceptedIssuersFromSingleManager() throws Exception
+    {
+        X509Certificate issuer = mock(X509Certificate.class);
+        givenTrustManagers(aTrustManager().thatAcceptsIssuers(issuer));
+
+        X509Certificate[] issuers = manager.getAcceptedIssuers();
+
+        verify(inner.get(0), never()).checkClientTrusted(any(), any());
+        verify(inner.get(0), never()).checkServerTrusted(any(), any());
+        verify(inner.get(0)).getAcceptedIssuers();
+        assertThat(issuers, is(arrayContaining(issuer)));
+    }
+
+    @Test
+    public void shouldAcceptClientWithTwoAcceptingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager(), aTrustManager());
+
+        X509Certificate[] chain = new X509Certificate[0];
+        manager.checkClientTrusted(chain, "TLS");
+
+        verify(inner.get(0)).checkClientTrusted(chain, "TLS");
+        verify(inner.get(0), never()).checkServerTrusted(any(), any());
+        verify(inner.get(0), never()).getAcceptedIssuers();
+        verify(inner.get(1), never()).checkServerTrusted(any(), any());
+        verify(inner.get(1), never()).getAcceptedIssuers();
+    }
+
+    @Test
+    public void shouldAcceptServerWithTwoAcceptingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager(), aTrustManager());
+
+        X509Certificate[] chain = new X509Certificate[0];
+        manager.checkServerTrusted(chain, "TLS");
+
+        verify(inner.get(0), never()).checkClientTrusted(any(), any());
+        verify(inner.get(0)).checkServerTrusted(chain, "TLS");
+        verify(inner.get(0), never()).getAcceptedIssuers();
+        verify(inner.get(1), never()).checkClientTrusted(any(), any());
+        verify(inner.get(1), never()).getAcceptedIssuers();
+    }
+
+    @Test
+    public void shouldAcceptClientWithARejectingManagerAndAcceptingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager().thatFailsClientsWith(new CertificateException("msg")),
+                aTrustManager());
+
+        X509Certificate[] chain = new X509Certificate[0];
+        manager.checkClientTrusted(chain, "TLS");
+
+        verify(inner.get(0)).checkClientTrusted(chain, "TLS");
+        verify(inner.get(0), never()).checkServerTrusted(any(), any());
+        verify(inner.get(0), never()).getAcceptedIssuers();
+        verify(inner.get(1)).checkClientTrusted(chain, "TLS");
+        verify(inner.get(1), never()).checkServerTrusted(any(), any());
+        verify(inner.get(1), never()).getAcceptedIssuers();
+    }
+
+    @Test
+    public void shouldAcceptServerWithARejectingManagerAndAcceptingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager().thatFailsServerWith(new CertificateException("msg")),
+                aTrustManager());
+
+        X509Certificate[] chain = new X509Certificate[0];
+        manager.checkServerTrusted(chain, "TLS");
+
+        verify(inner.get(0), never()).checkClientTrusted(any(), any());
+        verify(inner.get(0)).checkServerTrusted(chain, "TLS");
+        verify(inner.get(0), never()).getAcceptedIssuers();
+        verify(inner.get(1), never()).checkClientTrusted(any(), any());
+        verify(inner.get(1)).checkServerTrusted(chain, "TLS");
+        verify(inner.get(1), never()).getAcceptedIssuers();
+    }
+
+    @Test
+    public void shouldAcceptClientWithAnAcceptingManagerAndRejectingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager(),
+                aTrustManager().thatFailsClientsWith(new CertificateException("msg")));
+
+        X509Certificate[] chain = new X509Certificate[0];
+        manager.checkClientTrusted(chain, "TLS");
+
+        verify(inner.get(0)).checkClientTrusted(chain, "TLS");
+        verify(inner.get(0), never()).checkServerTrusted(any(), any());
+        verify(inner.get(0), never()).getAcceptedIssuers();
+        verify(inner.get(1), never()).checkServerTrusted(any(), any());
+        verify(inner.get(1), never()).getAcceptedIssuers();
+    }
+
+    @Test
+    public void shouldAcceptServerWithAnAcceptingManagerAndRejectingManager() throws Exception
+    {
+        givenTrustManagers(aTrustManager(),
+                aTrustManager().thatFailsServerWith(new CertificateException("msg")));
+
+        X509Certificate[] chain = new X509Certificate[0];
+        manager.checkServerTrusted(chain, "TLS");
+
+        verify(inner.get(0)).checkServerTrusted(chain, "TLS");
+        verify(inner.get(0), never()).checkClientTrusted(any(), any());
+        verify(inner.get(0), never()).getAcceptedIssuers();
+        verify(inner.get(1), never()).checkClientTrusted(any(), any());
+        verify(inner.get(1), never()).getAcceptedIssuers();
+    }
+
+    @Test(expected=CertificateException.class)
+    public void shouldRejectClientWithTwoRejectingManagers() throws Exception
+    {
+        givenTrustManagers(aTrustManager().thatFailsClientsWith(new CertificateException("msg1")),
+                aTrustManager().thatFailsClientsWith(new CertificateException("msg2")));
+
+        manager.checkClientTrusted(new X509Certificate[0], "TLS");
+    }
+
+    @Test(expected=CertificateException.class)
+    public void shouldRejectServerWithTwoRejectingManagers() throws Exception
+    {
+        givenTrustManagers(aTrustManager().thatFailsServerWith(new CertificateException("msg1")),
+                aTrustManager().thatFailsServerWith(new CertificateException("msg2")));
+
+        manager.checkServerTrusted(new X509Certificate[0], "TLS");
+    }
+
+    @Test
+    public void shouldReturnAcceptedIssuersFromTwoManagers() throws Exception
+    {
+        X509Certificate issuer1 = mock(X509Certificate.class);
+        X509Certificate issuer2 = mock(X509Certificate.class);
+        givenTrustManagers(aTrustManager().thatAcceptsIssuers(issuer1),
+                aTrustManager().thatAcceptsIssuers(issuer2));
+
+        X509Certificate[] issuers = manager.getAcceptedIssuers();
+
+        verify(inner.get(0), never()).checkClientTrusted(any(), any());
+        verify(inner.get(0), never()).checkServerTrusted(any(), any());
+        verify(inner.get(0)).getAcceptedIssuers();
+        verify(inner.get(1), never()).checkClientTrusted(any(), any());
+        verify(inner.get(1), never()).checkServerTrusted(any(), any());
+        verify(inner.get(1)).getAcceptedIssuers();
+        assertThat(issuers, is(arrayContainingInAnyOrder(issuer1, issuer2)));
+    }
+
+    private void givenTrustManagers(MockX509TrustManagerBuilder... builders)
+    {
+        inner = Arrays.stream(builders)
+                .map(MockX509TrustManagerBuilder::build)
+                .collect(Collectors.toList());
+
+        manager = new AggregateX509TrustManager(inner);
+    }
+
+    private MockX509TrustManagerBuilder aTrustManager()
+    {
+        return new MockX509TrustManagerBuilder();
+    }
+
+    /**
+     * Fluent builder for mocking X509TrustManager
+     */
+    private static class MockX509TrustManagerBuilder
+    {
+        private final X509TrustManager manager = mock(X509TrustManager.class);
+
+        public MockX509TrustManagerBuilder thatFailsClientsWith(CertificateException e)
+        {
+            try {
+                BDDMockito.willThrow(e).given(manager).checkClientTrusted(any(), any());
+            } catch (CertificateException e1) {
+                throw new RuntimeException(e1);
+            }
+            return this;
+        }
+
+        public MockX509TrustManagerBuilder thatFailsServerWith(CertificateException e)
+        {
+            try {
+                BDDMockito.willThrow(e).given(manager).checkServerTrusted(any(), any());
+            } catch (CertificateException e1) {
+                throw new RuntimeException(e1);
+            }
+            return this;
+        }
+
+        public MockX509TrustManagerBuilder thatAcceptsIssuers(X509Certificate... issuers)
+        {
+            BDDMockito.given(manager.getAcceptedIssuers()).willReturn(issuers);
+            return this;
+        }
+
+        public X509TrustManager build()
+        {
+            return manager;
+        }
+    }
+
+}

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteHttpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteHttpTransferService.java
@@ -17,14 +17,23 @@
  */
 package org.dcache.pool.classic;
 
+import com.google.common.base.Splitter;
 import eu.emi.security.authn.x509.OCSPParametes;
 import eu.emi.security.authn.x509.ProxySupport;
 import eu.emi.security.authn.x509.RevocationParameters;
-import eu.emi.security.authn.x509.X509CertChainValidator;
+import eu.emi.security.authn.x509.helpers.ssl.SSLTrustManager;
 import eu.emi.security.authn.x509.impl.OpensslCertChainValidator;
 import eu.emi.security.authn.x509.impl.ValidatorParams;
 
-import java.io.IOException;
+import javax.annotation.PostConstruct;
+import javax.net.ssl.X509TrustManager;
+
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.vehicles.ProtocolInfo;
@@ -34,19 +43,21 @@ import diskCacheV111.vehicles.RemoteHttpsDataTransferProtocolInfo;
 import org.dcache.pool.movers.MoverProtocol;
 import org.dcache.pool.movers.RemoteHttpDataTransferProtocol;
 import org.dcache.pool.movers.RemoteHttpsDataTransferProtocol;
-
-import static org.dcache.util.Files.checkDirectory;
+import org.dcache.security.trust.AggregateX509TrustManager;
 
 public class RemoteHttpTransferService extends SecureRemoteTransferService
 {
-    private OpensslCertChainValidator validator;
+    private final List<Runnable> onShutdownTasks = new ArrayList<>();
+
+    private X509TrustManager trustManager;
 
     @Override
     protected MoverProtocol createMoverProtocol(ProtocolInfo info) throws Exception
     {
         MoverProtocol moverProtocol;
         if (info instanceof RemoteHttpsDataTransferProtocolInfo) {
-            moverProtocol = new RemoteHttpsDataTransferProtocol(getCellEndpoint(), getValidator(), secureRandom);
+            moverProtocol = new RemoteHttpsDataTransferProtocol(getCellEndpoint(),
+                    trustManager, secureRandom);
         } else if (info instanceof RemoteHttpDataTransferProtocolInfo) {
             moverProtocol = new RemoteHttpDataTransferProtocol(getCellEndpoint());
         } else {
@@ -56,28 +67,35 @@ public class RemoteHttpTransferService extends SecureRemoteTransferService
         return moverProtocol;
     }
 
+    @PostConstruct
+    public void init()
+    {
+        FileSystem defaultFileSystem = FileSystems.getDefault();
+
+        var trustManagers = Splitter.on(':').omitEmptyStrings().splitToList(getCertificateAuthorityPath()).stream()
+                .map(defaultFileSystem::getPath)
+                .map(this::buildTrustManager)
+                .collect(Collectors.toList());
+
+        trustManager = new AggregateX509TrustManager(trustManagers);
+    }
+
+    private X509TrustManager buildTrustManager(Path path)
+    {
+        var ocspParameters = new OCSPParametes(getOcspCheckingMode());
+        var revocationParams = new RevocationParameters(getCrlCheckingMode(), ocspParameters);
+        var validatorParams = new ValidatorParams(revocationParams, ProxySupport.ALLOW);
+        long updateInterval = getCertificateAuthorityUpdateIntervalUnit().toMillis(getCertificateAuthorityUpdateInterval());
+        var validator = new OpensslCertChainValidator(path.toString(), true,
+                getNamespaceMode(), updateInterval, validatorParams, false);
+        onShutdownTasks.add(validator::dispose);
+        return new SSLTrustManager(validator);
+    }
+
     @Override
     public void shutdown()
     {
         super.shutdown();
-        synchronized (this) {
-            if (validator != null) {
-                validator.dispose();
-            }
-        }
-    }
-
-    private synchronized X509CertChainValidator getValidator() throws IOException
-    {
-        if (validator == null) {
-            checkDirectory(getCertificateAuthorityPath());
-            OCSPParametes ocspParameters = new OCSPParametes(getOcspCheckingMode());
-            ValidatorParams validatorParams =
-                    new ValidatorParams(new RevocationParameters(getCrlCheckingMode(), ocspParameters), ProxySupport.ALLOW);
-            long updateInterval = getCertificateAuthorityUpdateIntervalUnit().toMillis(getCertificateAuthorityUpdateInterval());
-            validator = new OpensslCertChainValidator(getCertificateAuthorityPath(), true, getNamespaceMode(), updateInterval, validatorParams,
-                                                      false);
-        }
-        return validator;
+        onShutdownTasks.forEach(Runnable::run);
     }
 }


### PR DESCRIPTION
Motivation:

When dCache is acting as a client, it needs to decide whether or not to
trust the remote server's certificate.  Currently this uses the same
trust anchors as checking a client's (i.e., user's) certificates, which
is an OpenSSL-style directory typically populated with the IGTF trust
anchors.

However, dCache pools may wish to trust a wider range of certificate
authorities: the standard IGTF CAs and some additional ones.

Modification:

Add a X509TrustManager implementation that aggragates multiple "inner"
X509TrustManager with the semantics that a certificate is trusted if any
one of the inner X509TrustManager instances trusts the certificate.

Update dCache to interpret the existing CA path as a colon-separated
list of path elements (similar to the PATH environment variable).  Each
path element is added as a trust anchor store.  If the path is a
directory then the OpenSSL format is assumed, otherwise a single-file
containing PEM files is assumed.

Result:

It is now possible to configure dCache to support multiple trust stores
for HTTP-TPC.

Target: master
Request: 7.1
See: #5927
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13065
Acked-by: Tigran Mkrtchyan