### PR TITLE
SRM : Fix IPV6 logging for SRM

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
@@ -378,7 +378,7 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
         X509Credential credential = Axis.getDelegatedCredential().orElse(null);
         String remoteIP = Axis.getRemoteAddress();
         String remoteHost = isClientDNSLookup ?
-                            InetAddresses.forString(remoteIP).getCanonicalHostName() : remoteIP;
+                            InetAddresses.forUriString(remoteIP).getCanonicalHostName() : remoteIP;
 
         Set<LoginAttribute> loginAttributes = AuthenticationHandler.getLoginAttributes(Axis.getHttpServletRequest());
 

--- a/modules/srm-server/src/main/java/org/dcache/srm/util/Axis.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/util/Axis.java
@@ -90,7 +90,7 @@ public class Axis
     public static InetSocketAddress getRemoteSocketAddress()
     {
         HttpServletRequest r = getHttpServletRequest();
-        return new InetSocketAddress(InetAddresses.forString(r.getRemoteAddr()), r.getRemotePort());
+        return new InetSocketAddress(InetAddresses.forUriString(r.getRemoteAddr()), r.getRemotePort());
     }
 
     public static String getRequestHeader(String name)


### PR DESCRIPTION
Motivation:-

SRM module does not work with IPV6 in dcache 7.1.1 version
It throws error :-
java.lang.IllegalArgumentException: '[2001:1458:301:cd:0:0:100:44]' is
not an IP string literal.
at
com.google.common.net.InetAddresses.formatIllegalArgumentException(InetAddresses.java:989)
    at com.google.common.net.InetAddresses.forString(InetAddresses.java:140)
    at org.dcache.srm.util.Axis.getRemoteSocketAddress(Axis.java:93)
    at diskCacheV111.srm.SrmHandler$AccessLogger.response(SrmHandler.java:889)
    at diskCacheV111.srm.SrmHandler.handleRequest(SrmHandler.java:369)
    at diskCacheV111.srm.SrmHandlerAdapter.srmPing(SrmHandlerAdapter.java:367)

Modification:-
Change InetAddresses.forString to InetAddresses.forUriString in
1) dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java - srmHandler function
2) srm-server/src/main/java/org/dcache/srm/util/Axis.java - InetSocketAddress function

Result:-
SRM module works with ipv6 address.

Target: master
Require-notes: yes
Require-book: no
Request: 7.1
Ticket: 10145
Patch: https://rb.dcache.org/r/13091/
Acked-by: lea