### PR TITLE
dcache-core: correct reported units of transfer size and speed

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -97,8 +97,8 @@ public class TransferObserverV1
                     "JobState",           //  13
                     "Submitted",          //  14
                     "Time",               //  15
-                    "Trans.&nbsp;(KB)",   //  16
-                    "Speed&nbsp;(KB/s)",  //  17
+                    "Trans.&nbsp;(KiB)",   //  16
+                    "Speed&nbsp;(KiB/s)",  //  17
                     "Running"             //  18
     };
 
@@ -639,8 +639,8 @@ public class TransferObserverV1
                         "status", "Status",
                         "waiting", "Waiting",
                         "state", "S",
-                        "transferred", "Trans.&nbsp;(KB)",
-                        "speed", "Speed&nbsp;(KB/s)");
+                        "transferred", "Trans.&nbsp;(KiB)",
+                        "speed", "Speed&nbsp;(KiB/s)");
         transfers.stream().forEach((t) -> createHtmlTableRow(page, t));
         page.endTable();
         page.addFooter(getClass().getName());


### PR DESCRIPTION
Motivation:
The old web pages claim the transfer size and speed are reported in KB and KB/s, although the actually used units are KiB and KiB/s. Reporting the correct unit is important for monitoring.

Modification:
Changed KB to KiB and KB/s to KiB/s.

Result:
The correct units are reported for transfer size and speed.

Target: master
Request: 7.1
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Ticket: #10155
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13101/
Acked-by: Albert Rossi