### PR TITLE
gplazma: multimap now supports OP in 'oidc' predicate

### DIFF
--- a/docs/TheBook/src/main/markdown/config-gplazma.md
+++ b/docs/TheBook/src/main/markdown/config-gplazma.md
@@ -837,11 +837,16 @@ dCache requires that authenticated credentials be mapped to posix style `usernam
 
 For example,
 
-> oidc:9889-1231-2999-12312       username:kermit
-
+> oidc:9889-1231-2999-12312@GOOGLE    username:kermit
+>
 > email:kermit.the.frog@email.com     username:thefrog
 
-In this example, it is assumed there is an additional mapping from username to uid, gid etc in files like storage-autzdb.
+In this example, the first line matches users with `sub` claim
+`9889-1231-2999-12312` from the OAuth2 Provider `GOOGLE` and adds the
+username `kermit`.  The second example matches the email address
+`kermit.the.frog@email.com` and adds the username `thefrog`.  In both
+cases, it is assumed there is an additional mapping from username to
+uid, gid etc in files like storage-autzdb.
 
 This mapping as shown above can be stored in a gplazma multi-map configuration file. The location of the multimap configuration file can be specified with another gplazma property **gplazma.multimap.file**. By default it is configured to be located in /etc/dcache/multi-mapfile.
 

--- a/modules/common/src/main/java/org/dcache/auth/OidcSubjectPrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/OidcSubjectPrincipal.java
@@ -6,23 +6,47 @@ import java.io.Serializable;
 import java.security.Principal;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 public class OidcSubjectPrincipal implements Principal, Serializable
 {
     private static final long serialVersionUID = 1L;
     private final String _sub;
+    private final String _op;
 
-    public OidcSubjectPrincipal(String sub)
+    /**
+     * Create a new principal.
+     * @param sub The value of the 'sub' claim.
+     * @param op The name/alias of the OP that asserted this claim.
+     */
+    public OidcSubjectPrincipal(String sub, String op)
     {
         checkArgument(CharMatcher.ascii().matchesAllOf(sub), "OpenId \"sub\" is not ASCII encoded");
         checkArgument(sub.length() <= 255, "OpenId \"sub\" must not exceed 255 ASCII characters");
         _sub = sub;
+        _op = requireNonNull(op);
     }
 
     @Override
     public String getName()
     {
+        return _sub + "@" + _op;
+    }
+
+    /**
+     * @return the value of the 'sub' claim.
+     */
+    public String getSubClaim()
+    {
         return _sub;
+    }
+
+    /**
+     * @return the dCache-internal alias for the OP.
+     */
+    public String getOP()
+    {
+        return _op;
     }
 
     @Override
@@ -36,18 +60,18 @@ public class OidcSubjectPrincipal implements Principal, Serializable
         }
 
         OidcSubjectPrincipal other = (OidcSubjectPrincipal) obj;
-        return _sub.equals(other._sub);
+        return _sub.equals(other._sub) && _op.equals(other._op);
     }
 
     @Override
     public int hashCode()
     {
-        return _sub.hashCode();
+        return _sub.hashCode() ^ _op.hashCode();
     }
 
     @Override
     public String toString()
     {
-        return "OidcSubjectPrincipal[" + _sub + ']';
+        return "OidcSubjectPrincipal[" + _sub + '@' + _op + ']';
     }
 }

--- a/modules/common/src/main/java/org/dcache/auth/Subjects.java
+++ b/modules/common/src/main/java/org/dcache/auth/Subjects.java
@@ -22,7 +22,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class Subjects
 {
@@ -488,7 +488,11 @@ public class Subjects
                     principal = new Origin(InetAddresses.forString(value));
                     break;
                 case "oidc":
-                    principal = new OidcSubjectPrincipal(value);
+                    int atIndex = value.lastIndexOf('@');
+                    checkArgument(atIndex != -1, "format for 'oidc' principals is <value>@<OP>");
+                    String oidcClaim = value.substring(0, atIndex);
+                    String op = value.substring(atIndex+1);
+                    principal = new OidcSubjectPrincipal(oidcClaim, op);
                     break;
                 case "email":
                     principal = new EmailAddressPrincipal(value);

--- a/modules/common/src/main/java/org/dcache/util/PrincipalSetMaker.java
+++ b/modules/common/src/main/java/org/dcache/util/PrincipalSetMaker.java
@@ -151,11 +151,13 @@ public class PrincipalSetMaker
 
     /**
      * Add an OIDC principal to the set.
-     * @param id the OIDC 'sub' of this user.
+     * @param sub the OIDC 'sub' of this user.
+     * @param op the name/alias of the OAuth2 Provider that asserted this
+     * identity.
      */
-    public PrincipalSetMaker withOidc(String id)
+    public PrincipalSetMaker withOidc(String sub, String op)
     {
-        _principals.add(new OidcSubjectPrincipal(id));
+        _principals.add(new OidcSubjectPrincipal(sub, op));
         return this;
     }
 

--- a/modules/common/src/test/java/org/dcache/auth/OidcSubjectPrincipalTest.java
+++ b/modules/common/src/test/java/org/dcache/auth/OidcSubjectPrincipalTest.java
@@ -1,0 +1,122 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.auth;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class OidcSubjectPrincipalTest
+{
+
+    @Test(expected=NullPointerException.class)
+    public void shouldRejectNullSubClaim()
+    {
+        new OidcSubjectPrincipal(null, "OP");
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void shouldRejectNullOP()
+    {
+        new OidcSubjectPrincipal("sub-claim", null);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void shouldRejectNonASCIISubClaim()
+    {
+        new OidcSubjectPrincipal("\uD80C\uDC80", "OP");
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void shouldRejectTooLongSubClaim()
+    {
+        new OidcSubjectPrincipal(
+                  "01234567890123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "123456", "OP");
+    }
+
+    @Test
+    public void shouldReturnSubClaim()
+    {
+        OidcSubjectPrincipal p = new OidcSubjectPrincipal("sub-claim", "OP");
+
+        assertThat(p.getSubClaim(), is(equalTo("sub-claim")));
+    }
+
+    @Test
+    public void shouldReturnOP()
+    {
+        OidcSubjectPrincipal p = new OidcSubjectPrincipal("sub-claim", "OP");
+
+        assertThat(p.getOP(), is(equalTo("OP")));
+    }
+
+    @Test
+    public void shouldReturnReasonableName()
+    {
+        OidcSubjectPrincipal p = new OidcSubjectPrincipal("sub-claim", "OP");
+
+        assertThat(p.getName(), is(equalTo("sub-claim@OP")));
+    }
+
+    @Test
+    public void shouldBeEqualWithSameObject()
+    {
+        OidcSubjectPrincipal p = new OidcSubjectPrincipal("sub-claim", "OP");
+
+        assertThat(p, is(equalTo(p)));
+    }
+
+    @Test
+    public void shouldBeEqualWithOidcPrincipalWithSameStrings()
+    {
+        OidcSubjectPrincipal p = new OidcSubjectPrincipal("sub-claim", "OP");
+
+        assertThat(p, is(equalTo(new OidcSubjectPrincipal("sub-claim", "OP"))));
+        assertThat(p.hashCode(), is(equalTo(new OidcSubjectPrincipal("sub-claim", "OP").hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualWithOidcPrincipalWithDifferentSubClaim()
+    {
+        OidcSubjectPrincipal p = new OidcSubjectPrincipal("sub-claim", "OP");
+
+        assertThat(p, is(not(equalTo(new OidcSubjectPrincipal("different-sub-claim", "OP")))));
+    }
+
+    @Test
+    public void shouldNotBeEqualWithOidcPrincipalWithDifferentOP()
+    {
+        OidcSubjectPrincipal p = new OidcSubjectPrincipal("sub-claim", "OP");
+
+        assertThat(p, is(not(equalTo(new OidcSubjectPrincipal("sub-claim", "other-OP")))));
+    }
+
+    @Test
+    public void shouldHaveExpectedToString()
+    {
+        OidcSubjectPrincipal p = new OidcSubjectPrincipal("sub-claim", "OP");
+
+        assertThat(p.toString(), is(equalTo("OidcSubjectPrincipal[sub-claim@OP]")));
+    }
+}

--- a/modules/common/src/test/java/org/dcache/auth/SubjectsTest.java
+++ b/modules/common/src/test/java/org/dcache/auth/SubjectsTest.java
@@ -7,9 +7,14 @@ import org.junit.Test;
 
 import javax.security.auth.Subject;
 
+import java.security.Principal;
 import java.util.HashSet;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.*;
 
 public class SubjectsTest
@@ -265,5 +270,19 @@ public class SubjectsTest
 
         assertEquals(GID1, gids[0]);
         assertEquals(GID2, gids[1]);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void shouldRejectOidcWithoutOP()
+    {
+        Subjects.principalsFromArgs(asList("oidc:sub-claim"));
+    }
+
+    @Test
+    public void shouldPrincipalsFromArgsForOidc()
+    {
+        Set<Principal> principals = Subjects.principalsFromArgs(asList("oidc:sub-claim@OP"));
+
+        assertThat(principals, hasItem(new OidcSubjectPrincipal("sub-claim", "OP")));
     }
 }

--- a/modules/gplazma2-multimap/src/main/java/org/dcache/gplazma/plugins/GplazmaMultiMapFile.java
+++ b/modules/gplazma2-multimap/src/main/java/org/dcache/gplazma/plugins/GplazmaMultiMapFile.java
@@ -38,6 +38,7 @@ import org.dcache.gplazma.AuthenticationException;
 import org.dcache.gplazma.plugins.exceptions.GplazmaParseMapFileException;
 import org.dcache.util.Args;
 import org.dcache.util.Exceptions;
+import org.dcache.util.NDC;
 
 import static org.dcache.gplazma.plugins.exceptions.GplazmaParseMapFileException.checkFormat;
 
@@ -67,7 +68,54 @@ public class GplazmaMultiMapFile
         GROUP_NAME("group", GroupNamePrincipal.class),
         FQAN("fqan", FQANPrincipal.class),
         KERBEROS_PRINCIPAL("kerberos", KerberosPrincipal.class),
-        OIDC("oidc", OidcSubjectPrincipal.class),
+        OIDC("oidc", OidcSubjectPrincipal.class) {
+            @Override
+            public Principal buildPrincipal(String value)
+                    throws GplazmaParseMapFileException
+            {
+                int atIndex = value.lastIndexOf('@');
+                checkFormat(atIndex != -1, "Missing '@' in oidc principal \"%s\"",
+                        value);
+                String claim = value.substring(0, atIndex);
+                String op = value.substring(atIndex+1);
+                return new OidcSubjectPrincipal(claim, op);
+            }
+
+            @Override
+            public PrincipalMatcher buildMatcher(String value)
+                    throws GplazmaParseMapFileException
+            {
+                int atIndex = value.lastIndexOf('@');
+                String claim = atIndex == -1 ? null : value.substring(0, atIndex);
+                String op = atIndex == -1 ? null : value.substring(atIndex+1);
+
+                NDC loadingNDC = NDC.cloneNdc();
+
+                return p -> {
+                    if (!(p instanceof OidcSubjectPrincipal)) {
+                        return false;
+                    }
+
+                    OidcSubjectPrincipal other = (OidcSubjectPrincipal)p;
+
+                    // REVISIT the following test exists only for backwards compatibility.
+                    if (other.getSubClaim().equals(value)) {
+                        NDC mappingNDC = NDC.cloneNdc();
+                        NDC.set(loadingNDC);
+                        try {
+                            LOGGER.warn("Please replace \"oidc:{}\" with \"oidc:{}@{}\"",
+                                    value, other.getSubClaim(), other.getOP());
+                        } finally {
+                            NDC.set(mappingNDC);
+                        }
+                        return true;
+                    }
+
+                    return atIndex != -1 && other.getSubClaim().equals(claim)
+                                        && other.getOP().equals(op);
+                };
+            }
+        },
         OIDC_GROUP("oidcgrp", OpenIdGroupPrincipal.class),
         UID("uid", UidPrincipal.class),
         USER_NAME("username", UserNamePrincipal.class);
@@ -165,7 +213,16 @@ public class GplazmaMultiMapFile
 
                 if (!lastLoaded.equals(mtime)) {
                     lastLoaded = mtime;
-                    map = parseMapFile();
+
+                    NDC mappingNDC = NDC.cloneNdc();
+                    try {
+                        NDC.clear();
+                        NDC.push(file.toString());
+
+                        map = parseMapFile();
+                    } finally {
+                        NDC.set(mappingNDC);
+                    }
                 }
             } catch (IOException e) {
                  throw new AuthenticationException("failed to read " + file + ": "
@@ -178,7 +235,7 @@ public class GplazmaMultiMapFile
 
     private Map<PrincipalMatcher,Set<Principal>> parseMapFile() throws IOException
     {
-        LOGGER.debug("Reading file {}", file);
+        LOGGER.debug("Reading file");
 
         Map<PrincipalMatcher,Set<Principal>> map = new LinkedHashMap<>();
 
@@ -187,6 +244,7 @@ public class GplazmaMultiMapFile
             lineCount++;
             line = line.trim();
             if (!line.isEmpty() && line.charAt(0) != '#') {
+                NDC.push("line " + lineCount);
                 try {
                     Args args = new Args(line);
                     checkFormat(args.argc() > 0, "Missing predicate matcher");
@@ -196,7 +254,9 @@ public class GplazmaMultiMapFile
                     map.put(asMatcher(matcherDescription),
                             asPrincipals(mappedPrincipalDescriptions));
                 } catch (GplazmaParseMapFileException e) {
-                    warningsConsumer.accept(file.getFileName() + ":" + lineCount + ": " + e.getMessage());
+                    warningsConsumer.accept(e.getMessage());
+                } finally {
+                    NDC.pop();
                 }
             }
         }

--- a/modules/gplazma2-multimap/src/test/java/org/dcache/gplazma/plugins/GplazmaMultiMapPluginTest.java
+++ b/modules/gplazma2-multimap/src/test/java/org/dcache/gplazma/plugins/GplazmaMultiMapPluginTest.java
@@ -49,7 +49,7 @@ public class GplazmaMultiMapPluginTest
     @Test(expected = AuthenticationException.class)
     public void shouldFailWhenFileDoesNotExist() throws Exception
     {
-        whenMapCalledWith(aSetOfPrincipals().withOidc("googleoidcsub"));
+        whenMapCalledWith(aSetOfPrincipals().withOidc("googleoidcsub", "GOOGLE"));
     }
 
     @Test(expected = AuthenticationException.class)
@@ -57,17 +57,35 @@ public class GplazmaMultiMapPluginTest
     {
         givenConfig("   ");
 
-        whenMapCalledWith(aSetOfPrincipals().withOidc("googleoidcsub"));
+        whenMapCalledWith(aSetOfPrincipals().withOidc("googleoidcsub", "GOOGLE"));
     }
 
     @Test
-    public void shouldMapOidcToUsername() throws Exception
+    public void shouldMapOidcWithoutOPToUsername() throws Exception
     {
         givenConfig("oidc:googleoidcsub  username:kermit");
 
-        whenMapCalledWith(aSetOfPrincipals().withOidc("googleoidcsub"));
+        whenMapCalledWith(aSetOfPrincipals().withOidc("googleoidcsub", "GOOGLE"));
 
         assertThat(results, hasItem(new UserNamePrincipal("kermit")));
+    }
+
+    @Test
+    public void shouldMapOidcWithOPToUsername() throws Exception
+    {
+        givenConfig("oidc:googleoidcsub@GOOGLE  username:kermit");
+
+        whenMapCalledWith(aSetOfPrincipals().withOidc("googleoidcsub", "GOOGLE"));
+
+        assertThat(results, hasItem(new UserNamePrincipal("kermit")));
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void shouldNotMapOidcWithDifferentOP() throws Exception
+    {
+        givenConfig("oidc:googleoidcsub@GITHUB  username:kermit");
+
+        whenMapCalledWith(aSetOfPrincipals().withOidc("googleoidcsub", "GOOGLE"));
     }
 
     @Test

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
@@ -360,7 +360,8 @@ public class OidcAuthPlugin implements GPlazmaAuthenticationPlugin
             JsonNode discoveryDoc = discoveryCache.get(ip);
             userinfoLookupTiming = Stopwatch.createStarted();
             String userInfoEndPoint = extractUserInfoEndPoint(discoveryDoc);
-            Set<Principal> principals = validateBearerTokenWithOpenIdProvider(token, userInfoEndPoint);
+            Set<Principal> principals = validateBearerTokenWithOpenIdProvider(ip,
+                    token, userInfoEndPoint);
             return LookupResult.success(ip, principals);
         } catch (OidcException oe) {
             return LookupResult.error(ip, oe.getMessage());
@@ -408,15 +409,15 @@ public class OidcAuthPlugin implements GPlazmaAuthenticationPlugin
         return providersByIssuer.values();
     }
 
-    private Set<Principal> validateBearerTokenWithOpenIdProvider(String token,
-            String infoUrl) throws OidcException
+    private Set<Principal> validateBearerTokenWithOpenIdProvider(IdentityProvider ip,
+            String token, String infoUrl) throws OidcException
     {
         try {
             JsonNode userInfo = getUserInfo(infoUrl, token);
             if (userInfo != null && userInfo.has("sub")) {
                 LOG.debug("UserInfo from OpenId Provider: {}", userInfo);
                 Set<Principal> principals = new HashSet<>();
-                addSub(userInfo, principals);
+                addSub(ip, userInfo, principals);
                 addNames(userInfo, principals);
                 addEmail(userInfo, principals);
                 addGroups(userInfo, principals);
@@ -475,9 +476,11 @@ public class OidcAuthPlugin implements GPlazmaAuthenticationPlugin
         }
     }
 
-    private boolean addSub(JsonNode userInfo, Set<Principal> principals)
+    private boolean addSub(IdentityProvider ip, JsonNode userInfo,
+            Set<Principal> principals)
     {
-        return principals.add(new OidcSubjectPrincipal(userInfo.get("sub").asText()));
+        String claimValue = userInfo.get("sub").asText();
+        return principals.add(new OidcSubjectPrincipal(claimValue, ip.getName()));
     }
 
     private void addGroups(JsonNode userInfo, Set<Principal> principals)

--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/OidcAuthPluginTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/OidcAuthPluginTest.java
@@ -163,7 +163,7 @@ public class OidcAuthPluginTest {
                                 .toString()),
                         withBearerToken("validtoken"));
 
-        assertThat(principals, hasSubject("214234823942934792371"));
+        assertThat(principals, hasSubject("214234823942934792371", "idc-iam.example.org"));
         assertThat(principals, hasFullName("Kermit The", "Frog", "Kermit The Frog"));
         assertThat(principals, hasEmail("kermit.the.frog@email.com"));
         assertThat(principals, hasGroup("Users"));
@@ -279,9 +279,9 @@ public class OidcAuthPluginTest {
         return (token == null) ? null : new BearerTokenCredential(token);
     }
 
-    public static Matcher<Iterable<? super OidcSubjectPrincipal>> hasSubject(String dn)
+    public static Matcher<Iterable<? super OidcSubjectPrincipal>> hasSubject(String sub, String op)
     {
-        return hasItem(new OidcSubjectPrincipal(dn));
+        return hasItem(new OidcSubjectPrincipal(sub, op));
     }
 
     public static Matcher<Iterable<? super EmailAddressPrincipal>> hasEmail(String email)


### PR DESCRIPTION
Motivation:

The 'sub' claim identifies a person; however, the value is only
guaranteed to be unique for values from the same OP.  The same 'sub'
value asserted by different OPs could identify different people.

Current, dCache only considers the 'sub' value, without considering
which OP asserted the claim.  This could result in somebody logging in
as someone else if two (trusted) OPs used the same 'sub' claim to
identify different people.

Modification:

Update the OidcSubjectPrincipal class to record and use the OP's
identity.

Update places that create an OidcSubjectPrincipal object to include the
OP's identity.

Update multimap to support OP-specific 'oidc' predicates.

For backwards compatibility, the current non-OP-specific 'oidc'
predicates continue to work, but omit a warning that the configuration
file should be updated.

Add extra unit-tests to cover new behaviour; update existing unit-tests
to include OP information.

Update multimap's NDC when loading the configuration file.  The filename
and line number are now included, while the door, gPlazma context have
been removed.

TheBook is updated to reflect the new format.

Result:

dCache may now be configured so that the multimap 'oidc' predicates
match the 'sub' claim value from a specific OAuth2 Provider using the
format SUBVALUE@OP, where 'OP' is the dCache-internal alias for the OP.
Existing multimap configuration continues to work, but admin is warned
to update the multimap configuration.

Target: master
Request: 7.1
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: yes
Closes: #5950
Patch: https://rb.dcache.org/r/13093/
Acked-by: Tigran Mkrtchyan