### PR TITLE
srm: log transfer protocols in access log

### DIFF
--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
@@ -199,6 +199,7 @@ import org.dcache.srm.v2_2.TRequestTokenReturn;
 import org.dcache.srm.v2_2.TReturnStatus;
 import org.dcache.srm.v2_2.TSURLReturnStatus;
 import org.dcache.srm.v2_2.TStatusCode;
+import org.dcache.srm.v2_2.TTransferParameters;
 import org.dcache.util.CertificateFactories;
 import org.dcache.util.NetLoggerBuilder;
 
@@ -1145,6 +1146,8 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
             logArray(log, "request.surl", request.getArrayOfFileRequests(),
                     ArrayOfTGetFileRequest::getRequestArray,
                     TGetFileRequest::getSourceSURL);
+            log.add("request.protocols",
+                    describeTransferProtocols(request.getTransferParameters()));
 
             logFileStatus(log, response.getArrayOfFileStatuses(),
                     ArrayOfTGetRequestFileStatus::getStatusArray, TGetRequestFileStatus::getStatus);
@@ -1168,6 +1171,8 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
             logArray(log, "request.surl", request.getArrayOfFileRequests(),
                     ArrayOfTPutFileRequest::getRequestArray,
                     TPutFileRequest::getTargetSURL);
+            log.add("request.protocols",
+                    describeTransferProtocols(request.getTransferParameters()));
 
             ArrayOfTPutRequestFileStatus statuses = response.getArrayOfFileStatuses();
             log.addSingleValue("turl", statuses, ArrayOfTPutRequestFileStatus::getStatusArray,
@@ -1209,6 +1214,12 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
             logFileStatus(log, response.getArrayOfFileStatuses(), ArrayOfTCopyRequestFileStatus::getStatusArray, TCopyRequestFileStatus::getStatus);
         }
 
+        private void log(NetLoggerBuilder log, SrmReserveSpaceRequest request, SrmReserveSpaceResponse response)
+        {
+            log.add("request.protocols",
+                    describeTransferProtocols(request.getTransferParameters()));
+        }
+
         private void log(NetLoggerBuilder log, SrmStatusOfCopyRequestRequest request, SrmStatusOfCopyRequestResponse response)
         {
             logArray(log, "request.src-surl", request.getArrayOfSourceSURLs(),
@@ -1237,6 +1248,8 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
                     TGetFileRequest::getSourceSURL);
             log.add("request.desiredLifeTime", request.getDesiredLifeTime());
             log.add("request.desiredTotalRequestTime", request.getDesiredTotalRequestTime());
+            log.add("request.protocols",
+                    describeTransferProtocols(request.getTransferParameters()));
 
             logFileStatus(log, response.getArrayOfFileStatuses(),
                     ArrayOfTBringOnlineRequestFileStatus::getStatusArray,
@@ -1253,6 +1266,47 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware
             logFileStatus(log, response.getArrayOfFileStatuses(),
                     ArrayOfTBringOnlineRequestFileStatus::getStatusArray,
                     TBringOnlineRequestFileStatus::getStatus);
+        }
+
+        private String describeTransferProtocols(TTransferParameters parameters)
+        {
+            if (parameters == null) {
+                return null;
+            }
+
+            ArrayOfString arrayTransferProtocols = parameters.getArrayOfTransferProtocols();
+            if (arrayTransferProtocols == null) {
+                return null;
+            }
+
+            String[] transferProtocols = arrayTransferProtocols.getStringArray();
+            if (transferProtocols == null || transferProtocols.length == 0) {
+                return null;
+            }
+
+            if (transferProtocols.length == 1) {
+                return transferProtocols [0];
+            }
+
+            Map<String,Integer> listedProtocols = new HashMap<>();
+            int lastIndex = transferProtocols.length-1;
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i <= lastIndex; i++) {
+                String protocol = transferProtocols [i];
+
+                Integer previousIndex = listedProtocols.get(protocol);
+                if (previousIndex == null) {
+                    sb.append(protocol);
+                    listedProtocols.put(protocol, i);
+                } else {
+                    sb.append('\\').append(previousIndex + 1); // use 1-index in references.
+                }
+                if (i < lastIndex) {
+                    sb.append(',');
+                }
+            }
+            return sb.toString();
         }
 
         /**


### PR DESCRIPTION
Motivation:

For various operations the SRM protocol allows clients to list which
protocol they support. This list is taken as ordered indicating the
client's preferences; for example, if dCache supports the first item
then that protocol should be used.

There have been problems reported where dCache has (or appears to have)
made the wrong choice when selecting the correct protocol.  Currently,
it is impossible to know whether the problem lies with the client
sending the wrong list of protocols or from a bug within dCache.

Modification:

Add an extra 'request.protocols' element in the access log file for
requests where the client may supply protocols.  If the array is empty
or missing then nothing is logged.

The logged value is a comma-separated list of protocols.  Repeated
values are replaced with a reference to the 1-base index.

Result:

The access log file for SRM requests now includes the client-supplied
list of protocols, if any were provided.

Target: master
Closes: #5971
Request: 7.1
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13109/
Acked-by: Lea Morschel