### PR TITLE
gplazma: add omnisession plugin

### DIFF
--- a/modules/gplazma2-omnisession/pom.xml
+++ b/modules/gplazma2-omnisession/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dcache</groupId>
+        <artifactId>dcache-parent</artifactId>
+	<version>6.2.26-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>gplazma2-omnisession</artifactId>
+    <packaging>jar</packaging>
+
+    <name>gPlazma 2 Omni-session plugin</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.npathai</groupId>
+            <artifactId>hamcrest-optional</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.dcache</groupId>
+            <artifactId>dcache-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dcache</groupId>
+            <artifactId>gplazma2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/Configuration.java
+++ b/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/Configuration.java
@@ -1,0 +1,41 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Set;
+
+import org.dcache.auth.attributes.LoginAttribute;
+import org.dcache.gplazma.AuthenticationException;
+
+/**
+ * The configuration for the omnisession plugin.
+ */
+public interface Configuration
+{
+    /**
+     * Provide a list of LoginAttributes for the user identified by the
+     * supplied set of principals.
+     * @param principals The identity of the user
+     * @return the LoginAttributes for this user
+     * @throws AuthenticationException if there is a problem processing this request.
+     */
+    List<LoginAttribute> attributesFor(Set<Principal> principals)
+            throws AuthenticationException;
+}

--- a/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/ConfigurationParser.java
+++ b/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/ConfigurationParser.java
@@ -1,0 +1,201 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import com.google.common.base.Splitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import diskCacheV111.util.FsPath;
+
+import org.dcache.auth.attributes.HomeDirectory;
+import org.dcache.auth.attributes.LoginAttribute;
+import org.dcache.auth.attributes.MaxUploadSize;
+import org.dcache.auth.attributes.PrefixRestriction;
+import org.dcache.auth.attributes.Restrictions;
+import org.dcache.auth.attributes.RootDirectory;
+import org.dcache.gplazma.omnisession.ParsedConfiguration.ParsedLine;
+import org.dcache.gplazma.omnisession.PrincipalPredicates.PredicateParserException;
+import org.dcache.util.ByteSizeParser;
+import org.dcache.util.ByteUnits;
+
+import static java.util.Collections.emptyList;
+import static org.dcache.util.ByteSizeParser.UnitPresence.OPTIONAL;
+import static org.dcache.util.ByteSizeParser.Whitespace.NOT_ALLOWED;
+import static org.dcache.util.Exceptions.genericCheck;
+
+/**
+ * A parser that reads the omnisession plugin's configuration file.
+ */
+public class ConfigurationParser implements LineBasedParser<Configuration>
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationParser.class);
+
+    private static final Set<String> PATH_ATTRIBUTES = Set.of("home", "root", "path");
+    private static final ByteSizeParser.Builder SIZE_PARSER = ByteSizeParser.using(ByteUnits.isoSymbol())
+            .withWhitespace(NOT_ALLOWED)
+            .withUnits(OPTIONAL);
+
+    /** Something is wrong when parsing this line. */
+    private static class BadLineException extends Exception
+    {
+        BadLineException(String message)
+        {
+            super(message);
+        }
+    }
+
+    private Optional<List<LoginAttribute>> defaultAttributes = Optional.empty();
+    private final List<ParsedLine> targetedAttributes = new ArrayList<>();
+
+    private int lineNumber;
+    private boolean badConfigFile;
+
+    public static void checkBadLine(boolean isLineOk, String message,
+            Object... args) throws BadLineException
+    {
+        genericCheck(isLineOk, BadLineException::new, message, args);
+    }
+
+    @Override
+    public void accept(String rawLine) throws UnrecoverableParsingException
+    {
+        lineNumber++;
+
+        String line = rawLine.trim();
+        if (line.isEmpty() || line.startsWith("#")) {
+            return;
+        }
+
+        try {
+            if (line.startsWith("DEFAULT ")) {
+                checkBadLine(defaultAttributes.isEmpty(), "\"DEFAULT\" is already defined.");
+                List<LoginAttribute> attributes = parseAttributes(line.substring(8));
+                defaultAttributes = Optional.of(attributes);
+            } else {
+                PrincipalPredicates.ParsedLine result;
+                try {
+                    result = PrincipalPredicates.parseFirstPredicate(line);
+                } catch (PredicateParserException e) {
+                    throw new BadLineException("Bad predicate: " + e.getMessage());
+                }
+
+                ParsedLine parsedLine;
+                try {
+                    var attributes = parseAttributes(result.remaining());
+                    parsedLine = ParsedLine.success(lineNumber, result.predicate(),
+                            attributes);
+                } catch (BadLineException e) {
+                    LOGGER.warn("Bad attributes in line {}: {}", lineNumber, e.getMessage());
+                    parsedLine = ParsedLine.failure(lineNumber, result.predicate(),
+                            e.getMessage());
+                }
+                targetedAttributes.add(parsedLine);
+            }
+        } catch (BadLineException e) {
+            badConfigFile = true;
+            throw new UnrecoverableParsingException(e.getMessage());
+        }
+    }
+
+    private List<LoginAttribute> parseAttributes(String description) throws BadLineException
+    {
+        List<LoginAttribute> attributes = new ArrayList<>();
+
+        boolean isReadOnly = false;
+        Set<Class<? extends LoginAttribute>> addedAttributes = new HashSet<>();
+
+        for (String attr : Splitter.on(' ').omitEmptyStrings().split(description)) {
+            try {
+                if (attr.equals("read-only")) {
+                    checkBadLine(!isReadOnly, "already defined 'read-only'");
+                    isReadOnly = true;
+                    attributes.add(Restrictions.readOnly());
+                    continue;
+                }
+
+                int idx = attr.indexOf(':');
+
+                checkBadLine(idx > -1, "Missing ':'");
+                checkBadLine(idx != 0, "Missing type");
+                checkBadLine(idx < attr.length()-1, "Missing argument");
+
+                String type = attr.substring(0, idx);
+                String arg = attr.substring(idx+1);
+
+                if (PATH_ATTRIBUTES.contains(type)) {
+                    checkBadLine(arg.startsWith("/"), "Argument must be an absolute"
+                            + " path");
+                }
+
+                LoginAttribute attribute;
+                switch (type) {
+                case "root":
+                    attribute = new RootDirectory(arg);
+                    break;
+
+                case "home":
+                    attribute = new HomeDirectory(arg);
+                    break;
+
+                case "prefix":
+                    attribute = new PrefixRestriction(FsPath.create(arg));
+                    break;
+
+                case "max-upload":
+                    try {
+                        attribute = new MaxUploadSize(SIZE_PARSER.parse(arg));
+                    } catch (NumberFormatException e) {
+                        throw new BadLineException("Bad file size: " + e.getMessage());
+                    }
+                    break;
+
+                default:
+                    throw new BadLineException("Unknown type \"" + type + "\"");
+                }
+
+                if (!addedAttributes.add(attribute.getClass())) {
+                    throw new BadLineException("Multiple " + type + " defined.");
+                }
+
+                attributes.add(attribute);
+            } catch (BadLineException e) {
+                throw new BadLineException("Bad attribute \"" + attr + "\": " + e.getMessage());
+            }
+        }
+
+        return attributes;
+    }
+
+    @Override
+    public Configuration build()
+    {
+        if (badConfigFile) {
+            throw new RuntimeException("Cannot create configuration from bad file.");
+        }
+
+        List<LoginAttribute> defaults = defaultAttributes.orElse(emptyList());
+        return new ParsedConfiguration(defaults, targetedAttributes);
+    }
+}

--- a/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/LineBasedParser.java
+++ b/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/LineBasedParser.java
@@ -1,0 +1,60 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A parser that can understand a configuration file's contents when the lines
+ * from that configuration file are presented one at a time.
+ * @param <T> The class that represents the file's content.
+ */
+public interface LineBasedParser<T>
+{
+    /**
+     * Problem has been detected when parsing a line of text that invalidates
+     * the whole model.  The message should describe the problem without
+     * including the line number.
+     */
+    public class UnrecoverableParsingException extends Exception
+    {
+        public UnrecoverableParsingException(String message)
+        {
+            super(requireNonNull(message));
+        }
+    }
+
+    /**
+     * Accept a new configuration line.  The lines of a file are presented
+     * one after the other until either there are no more lines or this method
+     * throws an exception.
+     * @param line the text of a line, without any new-line character.
+     * @throws UnrecoverableParsingException the line contains an error that
+     * invalidates the entire configuration file.
+     */
+    void accept(String line) throws UnrecoverableParsingException;
+
+    /**
+     * Return an object that represents the information that has just been
+     * parsed.  This method should only be called if no calls to
+     * {@link #accept(java.lang.String)} throws an exception.
+     * The returned object should be immutable.
+     * @return The representation of the parsed contents.
+     */
+    T build();
+}

--- a/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/LineByLineParser.java
+++ b/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/LineByLineParser.java
@@ -1,0 +1,73 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.dcache.gplazma.omnisession.LineBasedParser.UnrecoverableParsingException;
+
+/**
+ * This class parses the contents of a file.  It does this by assuming the
+ * file is written in UTF-8 and may be split into separate lines that
+ * can be parsed where each line is presented one after the other.
+ * <p>
+ * The actual parsing of the lines is handled by another object: some
+ * instance of LineBasedParser.
+ * @param <T> The type of state represented the parsed file.
+ */
+public class LineByLineParser<T> implements Function<Path,Optional<T>>
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(LineByLineParser.class);
+
+    private final Supplier<LineBasedParser<T>> parserFactory;
+
+    public LineByLineParser(Supplier<LineBasedParser<T>> parserFactory)
+    {
+        this.parserFactory = parserFactory;
+    }
+
+    @Override
+    public Optional<T> apply(Path file)
+    {
+        LineBasedParser<T> parser = parserFactory.get();
+
+        int lineNumber = 1;
+        try {
+            for (String line : Files.readAllLines(file)) {
+                parser.accept(line);
+                lineNumber++;
+            }
+        } catch (IOException e) {
+            LOGGER.warn("{}: {}", file, e.toString());
+            return Optional.empty();
+        } catch (UnrecoverableParsingException e) {
+            LOGGER.warn("{}:{} {}", file, lineNumber, e.getMessage());
+            return Optional.empty();
+        }
+
+        return Optional.of(parser.build());
+    }
+}

--- a/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/OmniSessionPlugin.java
+++ b/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/OmniSessionPlugin.java
@@ -1,0 +1,90 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+
+import java.nio.file.FileSystems;
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.dcache.auth.attributes.LoginAttribute;
+import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.plugins.GPlazmaSessionPlugin;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * A generic session plugin that supports configuring simple session
+ * information.
+ */
+public class OmniSessionPlugin implements GPlazmaSessionPlugin
+{
+    private static final String OMNISESSION_FILE = "gplazma.omnisession.file";
+
+    private final Supplier<Optional<Configuration>> file;
+
+    public OmniSessionPlugin(Properties properties)
+    {
+        this(configFileFrom(properties));
+    }
+
+    private static String requiredProperty(Properties properties, String name)
+    {
+        String value = properties.getProperty(name);
+        checkArgument(!Strings.isNullOrEmpty(value), "Undefined property: " + name);
+        return value;
+    }
+
+    private static ParsableFile<Configuration> configFileFrom(Properties properties)
+    {
+        var pathValue = requiredProperty(properties, OMNISESSION_FILE);
+        var path = FileSystems.getDefault().getPath(pathValue);
+        var parser = new LineByLineParser<Configuration>(ConfigurationParser::new);
+        return new ParsableFile<>(parser, path);
+    }
+
+    @VisibleForTesting
+    OmniSessionPlugin(Supplier<Optional<Configuration>> file)
+    {
+        this.file = file;
+    }
+
+    @Override
+    public void session(Set<Principal> principals, Set<Object> sessionAttributes)
+            throws AuthenticationException
+    {
+        Configuration config = file.get().orElseThrow(() -> new AuthenticationException("bad config file"));
+
+        List<LoginAttribute> attributes = config.attributesFor(principals);
+
+        Set<Class> existingSessionAttributes = sessionAttributes.stream()
+                .map(Object::getClass)
+                .collect(Collectors.toSet());
+
+        attributes.stream()
+                .filter(a -> !existingSessionAttributes.contains(a.getClass()))
+                .forEach(sessionAttributes::add);
+    }
+}

--- a/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/ParsableFile.java
+++ b/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/ParsableFile.java
@@ -1,0 +1,144 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This object represents a some generic file that may be parsed to obtain an
+ * object that represents its content.  The file is monitored for any changes
+ * so that updates to the file are reflected without requiring an
+ * explicit reload operation.
+ * <p>
+ * The processing model is as follows: the {@link #getContents()} method
+ * returns a representation of the file's contents at the time the call was
+ * made.  This method returns an Optional value that may contain the information
+ * parsed from the file.  If there is a problem (e.g., file doesn't exist,
+ * cannot be read, non-recoverable parser error) then the method returns an
+ * empty Optional, otherwise the returned value contains the parsed information
+ * from the file.
+ * <p>
+ * The object returned by {@code getContents} is immutable.  Any changes to the
+ * file's content will <b>not</b> be reflected in any existing objects; however,
+ * subsequent calls to {@code #getContents} will return objects that reflect the
+ * updated file's new content.
+ * <p>
+ * The anticipated use is to call {#getContents} relatively often, with the
+ * returned object being kept only for as long as the calling code requires
+ * consistent information.
+ * <p>
+ * This class is thread-safe.
+ *
+ * @param <T> The type of Object that represents the file's contents.
+ */
+public class ParsableFile<T> implements Supplier<Optional<T>>
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParsableFile.class);
+
+    private final Path file;
+    private final Function<Path,Optional<T>> parser;
+
+    private Instant whenStatProhibitionEnds = Instant.MIN;
+    private Instant mtimeWhenFileParsed = Instant.MIN;
+
+    private Optional<T> info = Optional.empty();
+
+    private final Clock clock;
+
+    @Nullable
+    private String lastError;
+
+    public ParsableFile(Function<Path,Optional<T>> parser, Path file)
+    {
+        this(Clock.systemUTC(), parser, file);
+    }
+
+    @VisibleForTesting
+    ParsableFile(Clock clock, Function<Path,Optional<T>> parser, Path file)
+    {
+        this.clock = clock;
+        this.parser = requireNonNull(parser);
+        this.file = requireNonNull(file);
+    }
+
+    /**
+     * Return an immutable object representing the file's contents at the time
+     * this method is called.  If there is a problem reading the contents then
+     * the returned value is empty, otherwise the return object contains
+     * the parsed state of the file.
+     * @return Optionally the current parsed content of the file.
+     */
+    @Override
+    public synchronized Optional<T> get()
+    {
+        /* REVISIT: the current model serialises all threads, with operations
+         * such as stat and parsing a file delaying any other (concurrent)
+         * threads.  A future version could do better; for example, by having
+         * any concurrent threads use non-empty cached values while the reload
+         * is taking place.
+         */
+
+        Instant now = Instant.now(clock);
+
+        // Avoid stat-ing the files too often: this can be (relatively) slow.
+        if (now.isBefore(whenStatProhibitionEnds)) {
+            return info;
+        }
+        whenStatProhibitionEnds = now.plus(1, SECONDS);
+
+        Instant fileMTime;
+        try {
+            fileMTime = Files.getLastModifiedTime(file).toInstant();
+            lastError = null; // if we see subsequent problem, log it.
+        } catch (IOException e) {
+            String thisError = e.toString();
+            if (!thisError.equals(lastError)) {
+                LOGGER.warn("Failed to stat {}: {}", file, thisError);
+                lastError = thisError;  // suppress logging the same error
+            }
+            info = Optional.empty();
+            return info;
+        }
+
+        if (fileMTime.isAfter(mtimeWhenFileParsed)) {
+            mtimeWhenFileParsed = fileMTime;
+            LOGGER.info("Reloading {}", file);
+            info = parser.apply(file);
+            info.ifPresent(Objects::requireNonNull);
+        }
+
+        return info;
+    }
+}

--- a/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/ParsedConfiguration.java
+++ b/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/ParsedConfiguration.java
@@ -1,0 +1,159 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.dcache.auth.attributes.LoginAttribute;
+import org.dcache.gplazma.AuthenticationException;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.List.copyOf;
+
+
+/**
+ * An instance of this object represents the information stored in the
+ * OmniSession configuration file at some specific time.
+ */
+public class ParsedConfiguration implements Configuration
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParsedConfiguration.class);
+
+    static class ParsedLine
+    {
+        private final Predicate<Principal> predicate;
+        private final List<LoginAttribute> attributes;
+        private final String error;
+        private final int lineNumber;
+
+        public static ParsedLine success(int lineNumber, Predicate<Principal> predicate, List<LoginAttribute> attributes)
+        {
+            return new ParsedLine(lineNumber, predicate, attributes, null);
+        }
+
+        public static ParsedLine failure(int lineNumber, Predicate<Principal> predicate, String error)
+        {
+            return new ParsedLine(lineNumber, predicate, null, error);
+        }
+
+        public boolean isFailure()
+        {
+            return error != null;
+        }
+
+        private ParsedLine(int lineNumber, Predicate<Principal> predicate, List<LoginAttribute> attributes, String error) {
+            this.predicate = predicate;
+            this.attributes = attributes;
+            this.error = error;
+            this.lineNumber = lineNumber;
+        }
+    }
+
+
+    private final List<LoginAttribute> defaultAttributes;
+    private final List<ParsedLine> configLines;
+
+    ParsedConfiguration(List<LoginAttribute> defaultAttributes,
+            List<ParsedLine> lines)
+    {
+        this.defaultAttributes = unmodifiableList(copyOf(defaultAttributes));
+        this.configLines = unmodifiableList(copyOf(lines));
+    }
+
+    @Override
+    public List<LoginAttribute> attributesFor(Set<Principal> principals)
+            throws AuthenticationException
+    {
+        Set<Class<? extends LoginAttribute>> addedAttributes = new HashSet<>();
+
+        List<LoginAttribute> attributesToAdd = new ArrayList<>();
+        StringBuilder errorLineNumbers = new StringBuilder();
+        int errorLineNumberToAdd = -1;
+
+        for (ParsedLine line : configLines) {
+            if (!principals.stream().anyMatch(p -> line.predicate.test(p))) {
+                continue;
+            }
+
+            if (line.isFailure()) {
+                if (errorLineNumberToAdd != -1) {
+                    if (errorLineNumbers.length() != 0) {
+                        errorLineNumbers.append(", ");
+                    }
+                    errorLineNumbers.append(errorLineNumberToAdd);
+                }
+                errorLineNumberToAdd = line.lineNumber;
+                LOGGER.debug("Login touched bad line {}: {}", line.lineNumber,
+                        line.error);
+            } else {
+                if (errorLineNumberToAdd == -1) {
+                    for (LoginAttribute attribute : line.attributes) {
+                        if (!addedAttributes.contains(attribute.getClass())) {
+                            addedAttributes.add(attribute.getClass());
+                            attributesToAdd.add(attribute);
+                            LOGGER.debug("Adding attribute from line {}: {}",
+                                    line.lineNumber, attribute);
+                        } else {
+                            LOGGER.debug("Skipping attribute from line {}: {}",
+                                    line.lineNumber, attribute);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (errorLineNumberToAdd != -1) {
+            boolean moreThanOneErrorLine = errorLineNumbers.length() > 0;
+            if (moreThanOneErrorLine) {
+                errorLineNumbers.append(" and ");
+            }
+
+            errorLineNumbers.append(errorLineNumberToAdd);
+
+            String msg = "Bad " + (moreThanOneErrorLine ? "lines" : "line") + ": "
+                    + errorLineNumbers;
+            LOGGER.debug("Aborting login: {}", msg);
+            throw new AuthenticationException(msg);
+        }
+
+        for (LoginAttribute attribute : defaultAttributes) {
+            if (!addedAttributes.contains(attribute.getClass())) {
+                addedAttributes.add(attribute.getClass());
+                attributesToAdd.add(attribute);
+                LOGGER.debug("Adding default attribute {}", attribute);
+            } else {
+                LOGGER.debug("Skipping default attribute {}, already applied", attribute);
+            }
+        }
+
+        if (attributesToAdd.isEmpty()) {
+            throw new AuthenticationException("Unknown user");
+        }
+
+        return attributesToAdd;
+    }
+}

--- a/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/PrincipalPredicates.java
+++ b/modules/gplazma2-omnisession/src/main/java/org/dcache/gplazma/omnisession/PrincipalPredicates.java
@@ -1,0 +1,299 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.collect.ImmutableMap;
+import org.globus.gsi.gssapi.jaas.GlobusPrincipal;
+
+import javax.security.auth.kerberos.KerberosPrincipal;
+
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.dcache.auth.EmailAddressPrincipal;
+import org.dcache.auth.EntitlementPrincipal;
+import org.dcache.auth.FQANPrincipal;
+import org.dcache.auth.GidPrincipal;
+import org.dcache.auth.GroupNamePrincipal;
+import org.dcache.auth.GroupPrincipal;
+import org.dcache.auth.OidcSubjectPrincipal;
+import org.dcache.auth.OpenIdGroupPrincipal;
+import org.dcache.auth.UidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
+import org.dcache.util.Exceptions;
+
+/**
+ * A utility class to support {@code Predicate<Principal>}.
+ */
+public class PrincipalPredicates
+{
+    private static final Pattern PRINCIPAL_PREDICATE =
+            Pattern.compile("^(?<type>[^:]+):(?<value>([^\"][^ ]*)|(\"[^\"]*\"?)) *");
+    private static final Map<String,TestablePrincipal> TESTABLE_PRINCIPAL_BY_LABEL;
+
+    static {
+        var builder = ImmutableMap.<String,TestablePrincipal>builder();
+        Arrays.stream(TestablePrincipal.values()).forEach(p -> builder.put(p.label, p));
+        TESTABLE_PRINCIPAL_BY_LABEL = builder.build();
+    }
+
+    /** Indicates a problem parsing a predicate's String representation. */
+    public static class PredicateParserException extends Exception
+    {
+        public PredicateParserException(String message)
+        {
+            super(message);
+        }
+    }
+
+    private PrincipalPredicates()
+    {
+        // Prevent instantiation.
+    }
+
+
+    /**
+     * State when parsing a predicate.
+     */
+    private enum ParserState {
+        SKIP_WHITESPACE_BEFORE_TYPE,
+        READ_TYPE,
+        READ_VALUE_INITIAL_CHAR,
+        READ_SIMPLE_VALUE,
+        READ_QUOTED_VALUE,
+    }
+
+    public static class ParsedLine
+    {
+        private final Predicate<Principal> predicate;
+        private final String remaining;
+
+        ParsedLine(Predicate<Principal> predicate, String remaining)
+        {
+            this.predicate = predicate;
+            this.remaining = remaining;
+        }
+
+        public Predicate<Principal> predicate()
+        {
+            return predicate;
+        }
+
+        public String remaining()
+        {
+            return remaining;
+        }
+    }
+
+    /**
+     * Information about the principals that may be be used to build predicates.
+     */
+    private static enum TestablePrincipal
+    {
+        DISTINGUISHED_NAME("dn", GlobusPrincipal.class) {
+            @Override
+            void checkName(String name) throws PredicateParserException
+            {
+                checkParsable(name.startsWith("/"), "DN does not start with '/'");
+            }
+        },
+
+        EMAIL("email", EmailAddressPrincipal.class) {
+            @Override
+            void checkName(String name) throws PredicateParserException
+            {
+                checkParsable(EmailAddressPrincipal.isValid(name), "Invalid email address");
+            }
+        },
+
+        GID("gid", GidPrincipal.class) {
+            @Override
+            Predicate<Principal> buildNamePredicate(String expectedName)
+                    throws PredicateParserException
+            {
+                long expectedGid;
+                try {
+                    expectedGid = Long.parseLong(expectedName);
+                } catch (NumberFormatException e) {
+                    throw new PredicateParserException(expectedName + " is not an integer");
+                }
+
+                return p -> ((GidPrincipal)p).getGid() == expectedGid;
+            }
+        },
+
+        GROUP_NAME("group", GroupNamePrincipal.class),
+        FQAN("fqan", FQANPrincipal.class) {
+            @Override
+            void checkName(String name) throws PredicateParserException
+            {
+                checkParsable(org.dcache.auth.FQAN.isValid(name), "Invalid FQAN");
+            }
+        },
+
+        KERBEROS_PRINCIPAL("kerberos", KerberosPrincipal.class) {
+            @Override
+            void checkName(String name) throws PredicateParserException
+            {
+                checkParsable(name.contains("@"), "Invalid Kerberos principal");
+            }
+        },
+
+        OIDC("oidc", OidcSubjectPrincipal.class) {
+            @Override
+            Predicate<Principal> buildNamePredicate(String expectedName)
+                    throws PredicateParserException
+            {
+                int lastAt = expectedName.lastIndexOf('@');
+
+                checkParsable(lastAt > -1, "Missing '@' in oidc predicate");
+                checkParsable(lastAt > 0, "Last '@' cannot be first character in oidc predicate");
+                checkParsable(lastAt < expectedName.length()-1, "Last '@' cannot be last character in oidc predicate");
+
+                String expectedSubClaim = expectedName.substring(0, lastAt);
+                String expectedOP = expectedName.substring(lastAt+1);
+
+                return p -> {
+                    OidcSubjectPrincipal principal = (OidcSubjectPrincipal)p;
+                    return principal.getSubClaim().equals(expectedSubClaim)
+                            && principal.getOP().equals(expectedOP);
+                };
+            }
+        },
+
+        OIDC_GROUP("oidcgrp", OpenIdGroupPrincipal.class),
+        UID("uid", UidPrincipal.class) {
+            @Override
+            Predicate<Principal> buildNamePredicate(String expectedName)
+                    throws PredicateParserException
+            {
+                long expectedUid;
+                try {
+                    expectedUid = Long.parseLong(expectedName);
+                } catch (NumberFormatException e) {
+                    throw new PredicateParserException(expectedName + " is not a valid uid");
+                }
+
+                return p -> ((UidPrincipal)p).getUid() == expectedUid;
+            }
+        },
+
+        USER_NAME("username", UserNamePrincipal.class),
+        ENTITLEMENT("entitlement", EntitlementPrincipal.class);
+
+        private final String label;
+        private final Class<? extends Principal> clazz;
+
+        TestablePrincipal(String label, Class<? extends Principal> type)
+        {
+            this.label = label;
+            this.clazz = type;
+        }
+
+        void checkName(String value) throws PredicateParserException
+        {
+        }
+
+        Predicate<Principal> buildNamePredicate(String expectedName)
+                throws PredicateParserException
+        {
+            checkName(expectedName);
+            return p -> p.getName().equals(expectedName);
+        }
+
+        public Predicate<Principal> buildPredicate(String value)
+                throws PredicateParserException
+        {
+            Predicate<Principal> predicate = p -> clazz.isAssignableFrom(p.getClass());
+
+            if (GroupPrincipal.class.isAssignableFrom(clazz) && value.contains(",")) {
+                int idx = value.lastIndexOf(',');
+                String expectedName = value.substring(0, idx);
+                boolean isPrimary = parseQualifier(value.substring(idx+1));
+
+                predicate = predicate.and(buildNamePredicate(expectedName));
+                predicate = predicate.and(p -> ((GroupPrincipal)p).isPrimaryGroup() == isPrimary);
+            } else {
+                predicate = predicate.and(buildNamePredicate(value));
+            }
+
+            return predicate;
+        }
+    }
+
+    private static void checkParsable(boolean isOk, String format, Object...args)
+            throws PredicateParserException
+    {
+        Exceptions.genericCheck(isOk, PredicateParserException::new, format, args);
+    }
+
+    private static boolean parseQualifier(String value) throws PredicateParserException
+    {
+        switch (value) {
+        case "primary":
+            return true;
+        case "nonprimary":
+            return false;
+        default:
+            throw new PredicateParserException("Unexpected value \""
+                    + value + "\", should be either 'true' or 'false'");
+        }
+    }
+
+    private static String remaining(String line, int index)
+    {
+        int i = index;
+        while (i < line.length() && CharMatcher.whitespace().matches(line.charAt(i))) {
+           i++;
+        }
+
+        if (i == line.length()) {
+            return "";
+        }
+        return line.substring(i);
+    }
+
+    public static ParsedLine parseFirstPredicate(String line)
+            throws PredicateParserException
+    {
+        Matcher m = PRINCIPAL_PREDICATE.matcher(line);
+
+        if (!m.find()) {
+            String error = line.isBlank() ? "line is empty" : "missing colon in predicate";
+            throw new PredicateParserException(error);
+        }
+
+        String typeLabel = m.group("type");
+        var type = TESTABLE_PRINCIPAL_BY_LABEL.get(typeLabel);
+        checkParsable(type != null, "Unknown principal type \"%s\"", typeLabel);
+
+        String value = m.group("value");
+        if (value.charAt(0) == '\"') {
+            checkParsable(value.charAt(value.length()-1) == '\"', "Missing close quote");
+            value = value.substring(1, value.length()-1);
+        }
+
+        var predicate = type.buildPredicate(value);
+        return new ParsedLine(predicate, line.substring(m.end()));
+    }
+}

--- a/modules/gplazma2-omnisession/src/main/resources/META-INF/gplazma-plugins.xml
+++ b/modules/gplazma2-omnisession/src/main/resources/META-INF/gplazma-plugins.xml
@@ -1,0 +1,6 @@
+<plugins>
+    <plugin>
+        <name>omnisession</name>
+        <class>org.dcache.gplazma.omnisession.OmniSessionPlugin</class>
+    </plugin>
+</plugins>

--- a/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/AdvanceableClock.java
+++ b/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/AdvanceableClock.java
@@ -1,0 +1,67 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.TemporalUnit;
+
+/**
+ * This implementation of Clock tracks some external clock, but allows for
+ * an offset.  Unlike {@ref Clock#offset}, with this implementation the
+ * offset may be adjusted over time, simulating the passing of time.
+ */
+public class AdvanceableClock extends Clock
+{
+    private final Clock inner;
+    private Duration offset = Duration.ZERO;
+
+    public AdvanceableClock(Clock inner)
+    {
+        this.inner = inner;
+    }
+
+    public AdvanceableClock(Clock inner, Duration offset)
+    {
+        this.inner = inner;
+        this.offset = offset;
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return inner.getZone();
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        return new AdvanceableClock(inner.withZone(zone), offset);
+    }
+
+    @Override
+    public Instant instant() {
+        return inner.instant().plus(offset);
+    }
+
+    public void advance(int value, TemporalUnit unit)
+    {
+        Duration delta = Duration.of(value, unit);
+        offset = offset.plus(delta);
+    }
+}

--- a/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/ConfigurationParserTest.java
+++ b/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/ConfigurationParserTest.java
@@ -1,0 +1,403 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import diskCacheV111.util.FsPath;
+
+import org.dcache.auth.attributes.HomeDirectory;
+import org.dcache.auth.attributes.LoginAttribute;
+import org.dcache.auth.attributes.MaxUploadSize;
+import org.dcache.auth.attributes.PrefixRestriction;
+import org.dcache.auth.attributes.Restrictions;
+import org.dcache.auth.attributes.RootDirectory;
+import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.omnisession.LineBasedParser.UnrecoverableParsingException;
+import org.dcache.util.PrincipalSetMaker;
+
+import static org.dcache.util.ByteUnit.BYTES;
+import static org.dcache.util.ByteUnit.GiB;
+import static org.dcache.util.PrincipalSetMaker.aSetOfPrincipals;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+public class ConfigurationParserTest
+{
+    private Configuration configuration;
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectUsersIfFileIsEmpty() throws Exception
+    {
+        givenConfig();
+
+        attributesFor(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test
+    public void shouldMatchLineWithUsername() throws Exception
+    {
+        givenConfig("username:paul root:/ home:/");
+
+        var loginAttributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(loginAttributes, containsInAnyOrder(new RootDirectory("/"),
+                new HomeDirectory("/")));
+    }
+
+    @Test
+    public void shouldAcceptCommentLine() throws Exception
+    {
+        givenConfig("# This is a line with a comment",
+                "username:paul root:/ home:/");
+
+        var loginAttributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(loginAttributes, containsInAnyOrder(new RootDirectory("/"),
+                new HomeDirectory("/")));
+    }
+
+    @Test
+    public void shouldAcceptEmptyLine() throws Exception
+    {
+        givenConfig("",
+                "username:paul root:/ home:/");
+
+        var loginAttributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(loginAttributes, containsInAnyOrder(new RootDirectory("/"),
+                new HomeDirectory("/")));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldNotMatchWithWrongUsername() throws Exception
+    {
+        givenConfig("username:paul root:/ home:/");
+
+        attributesFor(aSetOfPrincipals().withUsername("tigran"));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectLineWithoutAttributes() throws Exception
+    {
+        givenConfig("username:paul");
+
+        attributesFor(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test
+    public void shouldMatchLineWithUsernameAndRoot() throws Exception
+    {
+        givenConfig("username:paul root:/Users/paul");
+
+        var loginAttributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(loginAttributes, contains(new RootDirectory("/Users/paul")));
+    }
+
+    @Test
+    public void shouldMatchLineWithUsernameAndHome() throws Exception
+    {
+        givenConfig("username:paul home:/Users/paul");
+
+        var loginAttributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(loginAttributes, contains(new HomeDirectory("/Users/paul")));
+    }
+
+    @Test
+    public void shouldMatchLineWithUsernameAndReadOnly() throws Exception
+    {
+        givenConfig("username:paul read-only");
+
+        var loginAttributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(loginAttributes, contains(Restrictions.readOnly()));
+    }
+
+    @Test
+    public void shouldMatchLineWithUsernameAndPrefix() throws Exception
+    {
+        givenConfig("username:paul prefix:/path");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new PrefixRestriction(FsPath.create("/path"))));
+    }
+
+    @Test
+    public void shouldMatchLineWithUsernameAndMaxUpload() throws Exception
+    {
+        givenConfig("username:paul max-upload:5GiB");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes.size(), equalTo(1));
+        var restriction = (MaxUploadSize)attributes.get(0);
+
+        assertThat(restriction.getMaximumSize(), equalTo(BYTES.convert(5l, GiB)));
+    }
+
+    @Test
+    public void shouldMatchLineWithUsernameAndPrefixAndRoot() throws Exception
+    {
+        givenConfig("username:paul root:/root-path prefix:/prefix-path");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, containsInAnyOrder(
+                new PrefixRestriction(FsPath.create("/prefix-path")),
+                new RootDirectory("/root-path")));
+    }
+
+    @Test
+    public void shouldMatchFirstOfTwoLineWithUsernameAndRoot() throws Exception
+    {
+        givenConfig("username:paul root:/pauls-root",
+                "username:tigran root:/tigrans-root");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new RootDirectory("/pauls-root")));
+    }
+
+    @Test
+    public void shouldMatchSecondOfTwoLineWithUsernameAndRoot() throws Exception
+    {
+        givenConfig("username:tigran root:/tigrans-root",
+                "username:paul root:/pauls-root");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new RootDirectory("/pauls-root")));
+    }
+
+    @Test
+    public void shouldMatchFirstOfThreeLineWithUsernameAndRoot() throws Exception
+    {
+        givenConfig("username:paul root:/pauls-root",
+                "username:tigran root:/tigrans-root",
+                "username:lea root:/leas-root");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new RootDirectory("/pauls-root")));
+    }
+
+    @Test
+    public void shouldMatchSecondOfThreeLineWithUsernameAndRoot() throws Exception
+    {
+        givenConfig("username:tigran root:/tigrans-root",
+                "username:paul root:/pauls-root",
+                "username:lea root:/leas-root");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new RootDirectory("/pauls-root")));
+    }
+
+    @Test
+    public void shouldMatchThirdOfThreeLineWithUsernameAndRoot() throws Exception
+    {
+        givenConfig("username:tigran root:/tigrans-root",
+                "username:lea root:/leas-root",
+                "username:paul root:/pauls-root");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new RootDirectory("/pauls-root")));
+    }
+
+    @Test
+    public void shouldMatchDefaultWithRoot() throws Exception
+    {
+        givenConfig("DEFAULT root:/general-root");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new RootDirectory("/general-root")));
+    }
+
+    @Test
+    public void shouldMatchFirstLineWithDefault() throws Exception
+    {
+        givenConfig("username:paul root:/pauls-root",
+                "DEFAULT root:/general-root");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new RootDirectory("/pauls-root")));
+    }
+
+    @Test
+    public void shouldMatchDefaultLineWithUserAndDefault() throws Exception
+    {
+        givenConfig("username:tigran root:/tigrans-root",
+                "DEFAULT root:/general-root");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new RootDirectory("/general-root")));
+    }
+
+    @Test
+    public void shouldMatchSecondLineWithFirstLineDefault() throws Exception
+    {
+        givenConfig("DEFAULT root:/general-root",
+                "username:paul root:/pauls-root");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(new RootDirectory("/pauls-root")));
+    }
+
+    @Test
+    public void shouldMatchFirstLineAndDefault() throws Exception
+    {
+        givenConfig("username:paul read-only",
+                "DEFAULT home:/ root:/");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, containsInAnyOrder(new HomeDirectory("/"),
+                new RootDirectory("/"), Restrictions.readOnly()));
+    }
+
+    @Test
+    public void shouldMatchFirstLineAndSecondLineAndDefault() throws Exception
+    {
+        givenConfig("username:paul read-only",
+                "gid:1000 home:/",
+                "DEFAULT root:/");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul").withGid(1000));
+
+        assertThat(attributes, containsInAnyOrder(new HomeDirectory("/"),
+                new RootDirectory("/"), Restrictions.readOnly()));
+    }
+
+    @Test
+    public void shouldIgnoreRepeatedDeclarationInSubsequentLines() throws Exception
+    {
+        givenConfig("username:paul home:/Users/paul",
+                "gid:1000 home:/group-1000",
+                "DEFAULT home:/");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul").withGid(1000));
+
+        assertThat(attributes, contains(new HomeDirectory("/Users/paul")));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldFailBadAttributeOnMatchedLine() throws Exception
+    {
+        givenConfig("username:paul INVALID",
+                "username:tigran read-only");
+
+        attributesFor(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test
+    public void shouldIgnoreBadAttributeOnUnmatchedLine() throws Exception
+    {
+        givenConfig("username:paul read-only",
+                "username:tigran INVALID");
+
+        var attributes = attributesFor(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, contains(Restrictions.readOnly()));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldFailBadMaxpUload() throws Exception
+    {
+        givenConfig("username:paul max-upload:INVALID");
+
+        attributesFor(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldFailAttributeDefinedTwice() throws Exception
+    {
+        givenConfig("username:paul max-upload:1GiB max-upload:2GiB");
+
+        attributesFor(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldFailUnknownType() throws Exception
+    {
+        givenConfig("username:paul INVALID:INVALID");
+
+        attributesFor(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldFailMissingType() throws Exception
+    {
+        givenConfig("username:paul :INVALID");
+
+        attributesFor(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldFailMissingArgument() throws Exception
+    {
+        givenConfig("username:paul INVALID:");
+
+        attributesFor(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test(expected=UnrecoverableParsingException.class)
+    public void shouldRejectConfigWithBadPredicate() throws Exception
+    {
+        ConfigurationParser parser = new ConfigurationParser();
+        parser.accept("BAD-PREDICATE read-only");
+    }
+
+    @Test(expected=UnrecoverableParsingException.class)
+    public void shouldRejectConfigWithMultipleDefault() throws Exception
+    {
+        ConfigurationParser parser = new ConfigurationParser();
+        parser.accept("DEFAULT read-only");
+        parser.accept("DEFAULT read-only");
+    }
+
+    private List<LoginAttribute> attributesFor(PrincipalSetMaker maker)
+            throws AuthenticationException
+    {
+        return configuration.attributesFor(maker.build());
+    }
+
+    private void givenConfig(String...lines)
+    {
+        ConfigurationParser parser = new ConfigurationParser();
+        for (String line : lines) {
+            try {
+                parser.accept(line);
+            } catch (UnrecoverableParsingException e) {
+                fail("Parsing line \"" + line + "\" failed unexpectedly: "
+                        + e.getMessage());
+            }
+        }
+        configuration = parser.build();
+    }
+}

--- a/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/OmniSessionPluginTest.java
+++ b/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/OmniSessionPluginTest.java
@@ -1,0 +1,211 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.BDDMockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+import org.dcache.auth.attributes.HomeDirectory;
+import org.dcache.auth.attributes.LoginAttribute;
+import org.dcache.auth.attributes.RootDirectory;
+import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.plugins.GPlazmaSessionPlugin;
+import org.dcache.util.PrincipalSetMaker;
+
+import static java.util.Arrays.asList;
+import static org.dcache.util.PrincipalSetMaker.aSetOfPrincipals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+public class OmniSessionPluginTest
+{
+    private GPlazmaSessionPlugin plugin;
+    private Set<Object> attributes;
+
+    @Before
+    public void setup()
+    {
+        attributes = new HashSet<>();
+        plugin = null;
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void shouldFailIfPropertyMissing()
+    {
+        new OmniSessionPlugin(new Properties());
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldPropagateError() throws Exception
+    {
+        given(aPlugin().throwsAuthenticationException());
+
+        whenCalledWith(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRaiseErrorFileIsUnreadable() throws Exception
+    {
+        given(aPlugin().thatFailedToParse());
+
+        whenCalledWith(aSetOfPrincipals().withUsername("paul"));
+    }
+
+    @Test
+    public void shouldAddAllAttributesWhenNonExisting() throws Exception
+    {
+        given(aPlugin().thatReturns(new RootDirectory("/"),
+                new HomeDirectory("/home")));
+
+        whenCalledWith(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, containsInAnyOrder(new RootDirectory("/"),
+                new HomeDirectory("/home")));
+    }
+
+    @Test
+    public void shouldSuppressExistingAttributes() throws Exception
+    {
+        given(aPlugin().thatReturns(new RootDirectory("/"),
+                new HomeDirectory("/home")));
+
+        whenCalledWith(aSetOfPrincipals().withUsername("paul"), new RootDirectory("/root-dir"));
+
+        assertThat(attributes, containsInAnyOrder(new RootDirectory("/root-dir"),
+                new HomeDirectory("/home")));
+    }
+
+    @Test
+    public void shouldReadConfiguredFile() throws Exception
+    {
+        given(aFileBackedPlugin().withContents("DEFAULT home:/home-dir root:/root-dir"));
+
+        whenCalledWith(aSetOfPrincipals().withUsername("paul"));
+
+        assertThat(attributes, containsInAnyOrder(new RootDirectory("/root-dir"),
+                new HomeDirectory("/home-dir")));
+    }
+
+    private void whenCalledWith(PrincipalSetMaker maker)
+            throws AuthenticationException
+    {
+        plugin.session(maker.build(), attributes);
+    }
+
+    private void whenCalledWith(PrincipalSetMaker maker, LoginAttribute... existingAttributes)
+            throws AuthenticationException
+    {
+        attributes.addAll(asList(existingAttributes));
+        plugin.session(maker.build(), attributes);
+    }
+
+    private void given(PluginBuilder builder) throws Exception
+    {
+        plugin = builder.build();
+    }
+
+    private static MemoryBackedPluginBuilder aPlugin()
+    {
+        return new MemoryBackedPluginBuilder();
+    }
+
+    private FileBackedPluginBuilder aFileBackedPlugin() throws IOException
+    {
+        return new FileBackedPluginBuilder();
+    }
+
+    private interface PluginBuilder
+    {
+        GPlazmaSessionPlugin build() throws Exception;
+    }
+
+    /**
+     * Build a plugin that uses a real file in the filesystem for its
+     * configuration.
+     */
+    private static class FileBackedPluginBuilder implements PluginBuilder
+    {
+        private final Path tempFile;
+        private final StringBuilder contents = new StringBuilder();
+
+        public FileBackedPluginBuilder() throws IOException
+        {
+            tempFile = Files.createTempFile("omnisession-unittest", ".tmp");
+            tempFile.toFile().deleteOnExit();
+        }
+
+        public FileBackedPluginBuilder withContents(String... lines)
+        {
+            Arrays.stream(lines).forEach(l -> contents.append(l).append('\n'));
+            return this;
+        }
+
+        @Override
+        public GPlazmaSessionPlugin build() throws IOException
+        {
+            Files.writeString(tempFile, contents);
+            Properties properties = new Properties();
+            properties.setProperty("gplazma.omnisession.file", tempFile.toAbsolutePath().toString());
+            return new OmniSessionPlugin(properties);
+        }
+    }
+
+    private static class MemoryBackedPluginBuilder implements PluginBuilder
+    {
+        private final Configuration configuration = mock(Configuration.class);
+
+        private boolean isBad;
+
+        public MemoryBackedPluginBuilder thatFailedToParse()
+        {
+            isBad = true;
+            return this;
+        }
+
+        public MemoryBackedPluginBuilder throwsAuthenticationException() throws AuthenticationException
+        {
+            BDDMockito.given(configuration.attributesFor(any())).willThrow(AuthenticationException.class);
+            return this;
+        }
+
+        public MemoryBackedPluginBuilder thatReturns(LoginAttribute... attributes) throws AuthenticationException
+        {
+            BDDMockito.given(configuration.attributesFor(any())).willReturn(asList(attributes));
+            return this;
+        }
+
+        @Override
+        public GPlazmaSessionPlugin build()
+        {
+            Optional<Configuration> parseResult = isBad ? Optional.empty() : Optional.of(configuration);
+            return new OmniSessionPlugin(() -> parseResult);
+        }
+    }
+}

--- a/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/ParsableFileTest.java
+++ b/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/ParsableFileTest.java
@@ -1,0 +1,379 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import org.junit.Test;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.TemporalUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.hamcrest.CoreMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class ParsableFileTest
+{
+    private FileSystem fs;
+    private AdvanceableClock testClock;
+
+    @Before
+    public void setup()
+    {
+        fs = Jimfs.newFileSystem(Configuration.unix());
+        testClock = new AdvanceableClock(Clock.systemUTC());
+    }
+
+    @Test
+    public void shouldLoadFile() throws Exception
+    {
+        var model = givenAModel();
+        var path = given(aFile().withName("omnisession.conf").withContent("DEFAULT home:/ root:/"));
+        var parser = given(aParser().thatReturns(model));
+        var file = givenParsableFileOf(parser, path);
+
+        Optional<Model> received = file.get();
+
+        assertThat(received, isPresentAnd(is(theInstance(model))));
+        verify(parser).apply(path);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void shouldRejectNullModel() throws Exception
+    {
+        var path = given(aFile().withName("omnisession.conf").withContent("DEFAULT home:/ root:/"));
+        var parser = given(aParser().thatReturnsNull());
+        var file = givenParsableFileOf(parser, path);
+
+        file.get();
+    }
+
+    @Test
+    public void shouldNotLoadFileAgainIfNothingChanged() throws Exception
+    {
+        var model = givenAModel();
+        var path = given(aFile().withName("omnisession.conf").withContent("DEFAULT home:/ root:/"));
+        var parser = given(aParser().thatReturns(model));
+        var file = givenParsableFileOf(parser, path);
+        givenFileHasBeenRead(file);
+        verify(parser).apply(path);
+
+        Optional<Model> received = file.get();
+
+        assertThat(received, isPresentAnd(is(theInstance(model))));
+        verifyNoMoreInteractions(parser);
+    }
+
+    @Test
+    public void shouldReloadUpdatedFile() throws Exception
+    {
+        var model1 = givenAModel();
+        var path = given(aFile().withName("omnisession.conf").withContent("DEFAULT home:/ root:/"));
+        var parser = given(aParser().thatReturns(model1));
+        var file = givenParsableFileOf(parser, path);
+        givenFileHasBeenRead(file);
+        givenTimeHasAdvacedBy(2, SECONDS);
+        givenFileTouched(path);
+        var model2 = givenAModel();
+        givenParser(parser).nowReturns(model2);
+
+        Optional<Model> received = file.get();
+
+        verify(parser).apply(path);
+        assertThat(received, isPresentAnd(is(theInstance(model2))));
+    }
+
+    @Test
+    public void shouldNotReloadFileIfNotModified() throws Exception
+    {
+        var model = givenAModel();
+        var path = given(aFile().withName("omnisession.conf").withContent("DEFAULT home:/ root:/"));
+        var parser = given(aParser().thatReturns(model));
+        var file = givenParsableFileOf(parser, path);
+        givenFileHasBeenRead(file);
+        givenTimeHasAdvacedBy(2, SECONDS);
+
+        Optional<Model> received = file.get();
+
+        verify(parser).apply(path);
+        assertThat(received, isPresentAnd(is(theInstance(model))));
+    }
+
+    @Test
+    public void shouldAttemptReloadIfFileUpdatedAndIsNowBad() throws Exception
+    {
+        var model = givenAModel();
+        var path = given(aFile().withName("omnisession.conf").withContent("DEFAULT home:/ root:/"));
+        var parser = given(aParser().thatReturns(model));
+        var file = givenParsableFileOf(parser, path);
+        givenFileHasBeenRead(file);
+        givenTimeHasAdvacedBy(2, SECONDS);
+        givenFileTouched(path);
+        givenParser(parser).nowReturnsEmpty();
+
+        Optional<Model> received = file.get();
+
+        verify(parser).apply(path);
+        assertThat(received, isEmpty());
+    }
+
+    @Test
+    public void shouldReloadFileUpdatedFromBadToGood() throws Exception
+    {
+        var path = given(aFile().withName("omnisession.conf").withContent("INVALID DATA"));
+        var parser = given(aParser().thatReturnsEmpty());
+        var file = givenParsableFileOf(parser, path);
+        givenFileHasBeenRead(file);
+        givenTimeHasAdvacedBy(2, SECONDS);
+        givenFileTouched(path);
+        var model = givenAModel();
+        givenParser(parser).nowReturns(model);
+
+        Optional<Model> received = file.get();
+
+        verify(parser).apply(path);
+        assertThat(received, isPresentAnd(is(theInstance(model))));
+    }
+
+    @Test
+    public void shouldReturnEmptyIfFileDoesNotExist() throws Exception
+    {
+        var path = given(aFile().withName("omnisession.conf").thatDoesNotExist());
+        var parser = given(aParser().thatReturnsEmpty());
+        var file = givenParsableFileOf(parser, path);
+
+        Optional<Model> received = file.get();
+
+        verify(parser,never()).apply(any());
+    }
+
+    @Test
+    public void shouldReturnContentsRereadingNewlyWrittenFile() throws Exception
+    {
+        var path = given(aFile().withName("omnisession.conf").thatDoesNotExist());
+        var parser = given(aParser().thatReturnsEmpty());
+        var file = givenParsableFileOf(parser, path);
+        givenFileHasBeenRead(file);
+        givenTimeHasAdvacedBy(2, SECONDS);
+        givenFileUpdate(path, "DEFAULT file:/home root:/");
+        var model = givenAModel();
+        givenParser(parser).nowReturns(model);
+
+        Optional<Model> received = file.get();
+
+        verify(parser).apply(path);
+        assertThat(received, isPresentAnd(is(theInstance(model))));
+    }
+
+    private Path given(FileBuilder builder) throws IOException
+    {
+        return builder.build();
+    }
+
+    private void givenTimeHasAdvacedBy(int amount, TemporalUnit unit)
+    {
+        testClock.advance(amount, unit);
+    }
+
+    private Function<Path,Optional<Model>> given(ParserBuilder builder)
+    {
+        return builder.build();
+    }
+
+    private MockAdjuster givenParser(Function<Path,Optional<Model>> mock)
+    {
+        return new MockAdjuster(mock);
+    }
+
+    private void givenFileTouched(Path file) throws IOException, InterruptedException
+    {
+        FileTime originalFileTime = Files.getLastModifiedTime(file);
+
+        Files.setLastModifiedTime(file, FileTime.from(Instant.now()));
+
+        // We don't know the granularity of the filesystem's mtime, so let's
+        // keep trying until we succeed.
+        while (Files.getLastModifiedTime(file).equals(originalFileTime)) {
+            System.out.println("Redoing file touch.");
+            Thread.sleep(100);
+            Files.setLastModifiedTime(file, FileTime.from(Instant.now()));
+        }
+    }
+
+    private void givenFileUpdate(Path file, String contents) throws IOException
+    {
+        Files.writeString(file, contents);
+    }
+
+    private Model givenAModel()
+    {
+        return mock(Model.class);
+    }
+
+    private FileBuilder aFile()
+    {
+        return new FileBuilder();
+    }
+
+    private ParserBuilder aParser()
+    {
+        return new ParserBuilder();
+    }
+
+    private ParsableFile givenParsableFileOf(Function<Path,Optional<Model>> parser, Path path)
+    {
+        return new ParsableFile(testClock, parser, path);
+    }
+
+    private void givenFileHasBeenRead(ParsableFile file)
+    {
+        file.get();
+    }
+
+    private class FileBuilder
+    {
+        private String name;
+        private Path directory = fs.getRootDirectories().iterator().next();
+        private StringBuilder contents = new StringBuilder();
+        private boolean exists = true;
+
+        public FileBuilder withName(String name)
+        {
+            this.name = requireNonNull(name);
+            return this;
+        }
+
+        public FileBuilder inDirectory(String path) throws IOException
+        {
+            directory = fs.getPath(path);
+            Files.createDirectories(directory);
+            return this;
+        }
+
+        public FileBuilder withContent(String... lines) throws IOException
+        {
+            Arrays.stream(lines).forEach(l -> contents.append(l).append('\n'));
+            return this;
+        }
+
+        public FileBuilder thatDoesNotExist()
+        {
+            exists = false;
+            return this;
+        }
+
+        public Path build() throws IOException
+        {
+            checkState(name != null, "Missing filename");
+            Path file = directory.resolve(name);
+
+            if (exists) {
+                if (contents.length() == 0) {
+                    Files.createFile(file);
+                } else {
+                    Files.write(directory.resolve(name), Collections.singleton(contents));
+                }
+            }
+
+            return file;
+        }
+    }
+
+    private class ParserBuilder<Model>
+    {
+        private final Function<Path,Optional<Model>> parser = mock(Function.class);
+
+        public ParserBuilder thatReturns(Model model)
+        {
+            when(parser.apply(any())).thenReturn(Optional.of(model));
+            return this;
+        }
+
+        public ParserBuilder thatReturnsNull()
+        {
+            when(parser.apply(any())).thenReturn(null);
+            return this;
+        }
+
+        public ParserBuilder thatReturnsEmpty()
+        {
+            when(parser.apply(any())).thenReturn(Optional.empty());
+            return this;
+        }
+
+        public Function<Path,Optional<Model>> build()
+        {
+            return parser;
+        }
+    }
+
+    /**
+     * This class is very ugly -- or, at least, it hides the ugliness of
+     * calling the Mockito#reset method.
+     */
+    private class MockAdjuster
+    {
+        private final Function<Path,Optional<Model>> mock;
+
+        MockAdjuster(Function<Path,Optional<Model>> mock)
+        {
+            this.mock = mock;
+        }
+
+        public void nowReturns(Model model)
+        {
+            Mockito.reset(mock);
+            when(mock.apply(any())).thenReturn(Optional.of(model));
+        }
+
+        public void nowReturnsEmpty()
+        {
+            Mockito.reset(mock);
+            when(mock.apply(any())).thenReturn(Optional.empty());
+        }
+    }
+
+    /**
+     * The model representing the file's contents.
+     */
+    private interface Model
+    {
+    }
+}

--- a/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/PrincipalPredicatesTest.java
+++ b/modules/gplazma2-omnisession/src/test/java/org/dcache/gplazma/omnisession/PrincipalPredicatesTest.java
@@ -1,0 +1,545 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.omnisession;
+
+import org.globus.gsi.gssapi.jaas.GlobusPrincipal;
+import org.junit.Test;
+
+import javax.security.auth.kerberos.KerberosPrincipal;
+
+import java.security.Principal;
+import java.util.function.Predicate;
+
+import org.dcache.auth.EmailAddressPrincipal;
+import org.dcache.auth.EntitlementPrincipal;
+import org.dcache.auth.FQANPrincipal;
+import org.dcache.auth.GidPrincipal;
+import org.dcache.auth.GroupNamePrincipal;
+import org.dcache.auth.LoginNamePrincipal;
+import org.dcache.auth.OidcSubjectPrincipal;
+import org.dcache.auth.OpenIdGroupPrincipal;
+import org.dcache.auth.UidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
+import org.dcache.gplazma.omnisession.PrincipalPredicates.PredicateParserException;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+public class PrincipalPredicatesTest
+{
+    Predicate<Principal> predicate;
+    String remaining;
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldFailEmptyString() throws Exception
+    {
+        PrincipalPredicates.parseFirstPredicate("");
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldFailSpaceString() throws Exception
+    {
+        PrincipalPredicates.parseFirstPredicate(" ");
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldFailTwoSpacesString() throws Exception
+    {
+        PrincipalPredicates.parseFirstPredicate("  ");
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldFailMissingColon() throws Exception
+    {
+        PrincipalPredicates.parseFirstPredicate("dn");
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldFailMissingType() throws Exception
+    {
+        PrincipalPredicates.parseFirstPredicate(":foo");
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldFailMissingValue() throws Exception
+    {
+        PrincipalPredicates.parseFirstPredicate("dn:");
+    }
+
+    @Test
+    public void shouldParseValidUsername() throws Exception
+    {
+        givenPredicate("username:paul");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+        assertFalse(predicate.test(new LoginNamePrincipal("paul")));
+        assertFalse(predicate.test(new UserNamePrincipal("paul.millar")));
+        assertFalse(predicate.test(new UserNamePrincipal("tigran")));
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectInvalidDn() throws Exception
+    {
+        givenPredicate("dn:INVALID");
+    }
+
+    @Test
+    public void shouldParseValidDn() throws Exception
+    {
+        givenPredicate("dn:\"/C=DE/O=GermanGrid/OU=DESY/CN=Alexander Paul Millar\"");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new GlobusPrincipal("/C=DE/O=GermanGrid/OU=DESY/CN=Alexander Paul Millar")));
+        assertFalse(predicate.test(new UserNamePrincipal("Alexander Paul Millar")));
+        assertFalse(predicate.test(new GlobusPrincipal("/C=DE/O=GermanGrid/OU=DESY/CN=Robot - grid client - Paul Millar (client software tester)")));
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectInvalidEmail() throws Exception
+    {
+        givenPredicate("email:INVALID");
+    }
+
+    @Test
+    public void shouldParseValidEmail() throws Exception
+    {
+        givenPredicate("email:paul@example.org");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new EmailAddressPrincipal("paul@example.org")));
+        assertFalse(predicate.test(new UserNamePrincipal("paul@example.org")));
+        assertFalse(predicate.test(new EmailAddressPrincipal("tigran@example.org")));
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectInvalidGid() throws Exception
+    {
+        givenPredicate("gid:INVALID");
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectInvalidQualifiedGid() throws Exception
+    {
+        givenPredicate("gid:1000,FOO");
+    }
+
+    @Test
+    public void shouldParseValidGid() throws Exception
+    {
+        givenPredicate("gid:1000");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new GidPrincipal(1000, false)));
+        assertTrue(predicate.test(new GidPrincipal(1000, true)));
+        assertFalse(predicate.test(new UidPrincipal(1000)));
+        assertFalse(predicate.test(new GidPrincipal(2000, false)));
+        assertFalse(predicate.test(new GidPrincipal(2000, true)));
+    }
+
+    @Test
+    public void shouldParseValidQualifiedPrimaryGid() throws Exception
+    {
+        givenPredicate("gid:1000,primary");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new GidPrincipal(1000, true)));
+        assertFalse(predicate.test(new GidPrincipal(1000, false)));
+        assertFalse(predicate.test(new UidPrincipal(1000)));
+        assertFalse(predicate.test(new GidPrincipal(2000, false)));
+        assertFalse(predicate.test(new GidPrincipal(2000, true)));
+    }
+
+    @Test
+    public void shouldParseValidQualifiedNonprimaryGid() throws Exception
+    {
+        givenPredicate("gid:1000,nonprimary");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new GidPrincipal(1000, false)));
+        assertFalse(predicate.test(new GidPrincipal(1000, true)));
+        assertFalse(predicate.test(new UidPrincipal(1000)));
+        assertFalse(predicate.test(new GidPrincipal(2000, false)));
+        assertFalse(predicate.test(new GidPrincipal(2000, true)));
+    }
+
+    @Test
+    public void shouldParseGroupName() throws Exception
+    {
+        givenPredicate("group:hackers");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new GroupNamePrincipal("hackers", false)));
+        assertTrue(predicate.test(new GroupNamePrincipal("hackers", true)));
+        assertFalse(predicate.test(new UserNamePrincipal("hackers")));
+        assertFalse(predicate.test(new GroupNamePrincipal("normal", false)));
+        assertFalse(predicate.test(new GroupNamePrincipal("normal", true)));
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectInvalidQualifiedGroupName() throws Exception
+    {
+        givenPredicate("group:hackers,FOO");
+    }
+
+    @Test
+    public void shouldParseQualifiedPrimaryGroupName() throws Exception
+    {
+        givenPredicate("group:hackers,primary");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new GroupNamePrincipal("hackers", true)));
+        assertFalse(predicate.test(new GroupNamePrincipal("hackers", false)));
+        assertFalse(predicate.test(new UserNamePrincipal("hackers")));
+        assertFalse(predicate.test(new GroupNamePrincipal("normal", false)));
+        assertFalse(predicate.test(new GroupNamePrincipal("normal", true)));
+    }
+
+    @Test
+    public void shouldParseQualifiedNonprimaryGroupName() throws Exception
+    {
+        givenPredicate("group:hackers,nonprimary");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new GroupNamePrincipal("hackers", false)));
+        assertFalse(predicate.test(new GroupNamePrincipal("hackers", true)));
+        assertFalse(predicate.test(new UserNamePrincipal("hackers")));
+        assertFalse(predicate.test(new GroupNamePrincipal("normal", false)));
+        assertFalse(predicate.test(new GroupNamePrincipal("normal", true)));
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectInvalidFqan() throws Exception
+    {
+        givenPredicate("fqan:INVALID");
+    }
+
+    @Test
+    public void shouldParseFqan() throws Exception
+    {
+        givenPredicate("fqan:/dteam");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new FQANPrincipal("/dteam", false)));
+        assertTrue(predicate.test(new FQANPrincipal("/dteam", true)));
+        assertFalse(predicate.test(new GroupNamePrincipal("/dteam")));
+        assertFalse(predicate.test(new FQANPrincipal("/dteam/dcache", false)));
+        assertFalse(predicate.test(new FQANPrincipal("/dteam/dcache", true)));
+        assertFalse(predicate.test(new FQANPrincipal("/wlcg", false)));
+        assertFalse(predicate.test(new FQANPrincipal("/wlcg", true)));
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectInvalidQualifiedFqan() throws Exception
+    {
+        givenPredicate("fqan:/dteam,FOO");
+    }
+
+    @Test
+    public void shouldParseQualifiedPrimaryFqan() throws Exception
+    {
+        givenPredicate("fqan:/dteam,primary");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new FQANPrincipal("/dteam", true)));
+        assertFalse(predicate.test(new FQANPrincipal("/dteam", false)));
+        assertFalse(predicate.test(new GroupNamePrincipal("/dteam")));
+        assertFalse(predicate.test(new FQANPrincipal("/dteam/dcache", false)));
+        assertFalse(predicate.test(new FQANPrincipal("/dteam/dcache", true)));
+        assertFalse(predicate.test(new FQANPrincipal("/wlcg", false)));
+        assertFalse(predicate.test(new FQANPrincipal("/wlcg", true)));
+    }
+
+    @Test
+    public void shouldParseQualifiedNonprimaryFqan() throws Exception
+    {
+        givenPredicate("fqan:/dteam,nonprimary");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new FQANPrincipal("/dteam", false)));
+        assertFalse(predicate.test(new FQANPrincipal("/dteam", true)));
+        assertFalse(predicate.test(new GroupNamePrincipal("/dteam")));
+        assertFalse(predicate.test(new FQANPrincipal("/dteam/dcache", false)));
+        assertFalse(predicate.test(new FQANPrincipal("/dteam/dcache", true)));
+        assertFalse(predicate.test(new FQANPrincipal("/wlcg", false)));
+        assertFalse(predicate.test(new FQANPrincipal("/wlcg", true)));
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectInvalidKerberos() throws Exception
+    {
+        givenPredicate("kerberos:INVALID");
+    }
+
+    @Test
+    public void shouldParseKerberos() throws Exception
+    {
+        givenPredicate("kerberos:paul@DESY.DE");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new KerberosPrincipal("paul@DESY.DE")));
+        assertFalse(predicate.test(new UserNamePrincipal("paul@DESY.DE")));
+        assertFalse(predicate.test(new KerberosPrincipal("tigran@DESY.DE")));
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectOidcWithNoOP() throws Exception
+    {
+        givenPredicate("oidc:123456789");
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectOidcWithInitialAt() throws Exception
+    {
+        givenPredicate("oidc:@123456789");
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectOidcWithFinalAt() throws Exception
+    {
+        givenPredicate("oidc:123456789@");
+    }
+
+    @Test
+    public void shouldParseOidcSub() throws Exception
+    {
+        givenPredicate("oidc:123456789@OP");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new OidcSubjectPrincipal("123456789", "OP")));
+        assertFalse(predicate.test(new UserNamePrincipal("123456789")));
+        assertFalse(predicate.test(new OidcSubjectPrincipal("123456789", "OTHER-OP")));
+        assertFalse(predicate.test(new OidcSubjectPrincipal("12345678", "OP")));
+    }
+
+    @Test
+    public void shouldParseOidcSubWithAtSubClaim() throws Exception
+    {
+        givenPredicate("oidc:paul@example.org@OP");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new OidcSubjectPrincipal("paul@example.org", "OP")));
+        assertFalse(predicate.test(new UserNamePrincipal("paul@example.org")));
+        assertFalse(predicate.test(new OidcSubjectPrincipal("paul@example.org", "OTHER-OP")));
+        assertFalse(predicate.test(new OidcSubjectPrincipal("paul", "OP")));
+    }
+
+    @Test
+    public void shouldParseOidcGroup() throws Exception
+    {
+        givenPredicate("oidcgrp:/group");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new OpenIdGroupPrincipal("/group")));
+        assertFalse(predicate.test(new GroupNamePrincipal("/group")));
+        assertFalse(predicate.test(new OpenIdGroupPrincipal("/group/other")));
+        assertFalse(predicate.test(new OpenIdGroupPrincipal("/other")));
+    }
+
+    @Test(expected = PredicateParserException.class)
+    public void shouldRejectInvalidUid() throws Exception
+    {
+        givenPredicate("uid:INVALID");
+    }
+
+    @Test
+    public void shouldParseUid() throws Exception
+    {
+        givenPredicate("uid:1000");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new UidPrincipal(1000)));
+        assertFalse(predicate.test(new GidPrincipal(1000,true)));
+        assertFalse(predicate.test(new GidPrincipal(1000,false)));
+        assertFalse(predicate.test(new UidPrincipal(2000)));
+    }
+
+    @Test
+    public void shouldParseEntitlement() throws Exception
+    {
+        givenPredicate("entitlement:foo");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new EntitlementPrincipal("foo")));
+        assertFalse(predicate.test(new GroupNamePrincipal("foo",true)));
+        assertFalse(predicate.test(new GroupNamePrincipal("foo",false)));
+        assertFalse(predicate.test(new EntitlementPrincipal("bar")));
+    }
+
+    @Test
+    public void shouldParseSimpleValueWithTrailingSpace() throws Exception
+    {
+        givenPredicate("username:paul ");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseSimpleValueWithTwoTrailingSpaces() throws Exception
+    {
+        givenPredicate("username:paul  ");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseSimpleValueWithTrailingSpaceAndSingleChar() throws Exception
+    {
+        givenPredicate("username:paul f");
+
+        assertThat(remaining, equalTo("f"));
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseSimpleValueWithTwoTrailingSpacesAndSingleChar() throws Exception
+    {
+        givenPredicate("username:paul  f");
+
+        assertThat(remaining, equalTo("f"));
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseSimpleValueWithTrailingSpaceAndValue() throws Exception
+    {
+        givenPredicate("username:paul foo");
+
+        assertThat(remaining, equalTo("foo"));
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseSimpleValueWithTwoTrailingSpacesAndValue() throws Exception
+    {
+        givenPredicate("username:paul  foo");
+
+        assertThat(remaining, equalTo("foo"));
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseQuotedValue() throws Exception
+    {
+        givenPredicate("username:\"paul\"");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseQuotedValueWithTrailingSpace() throws Exception
+    {
+        givenPredicate("username:\"paul\" ");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseQuotedValueWithTwoTrailingSpaces() throws Exception
+    {
+        givenPredicate("username:\"paul\"  ");
+
+        assertThat(remaining, emptyString());
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseQuotedValueWithTrailingSpaceAndSingleChar() throws Exception
+    {
+        givenPredicate("username:\"paul\" f");
+
+        assertThat(remaining, equalTo("f"));
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseQuotedValueWithTwoTrailingSpacesAndSingleChar() throws Exception
+    {
+        givenPredicate("username:\"paul\"  f");
+
+        assertThat(remaining, equalTo("f"));
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseQuotedValueWithTrailingSpaceAndValue() throws Exception
+    {
+        givenPredicate("username:\"paul\" foo");
+
+        assertThat(remaining, equalTo("foo"));
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test
+    public void shouldParseQuotedValueWithTwoTrailingSpacesAndValue() throws Exception
+    {
+        givenPredicate("username:\"paul\"  foo");
+
+        assertThat(remaining, equalTo("foo"));
+
+        assertTrue(predicate.test(new UserNamePrincipal("paul")));
+    }
+
+    @Test(expected=PredicateParserException.class)
+    public void shouldRejectQuotedValueWithMissingCloseQuote() throws Exception
+    {
+        PrincipalPredicates.parseFirstPredicate("username:\"paul");
+    }
+
+    void givenPredicate(String arg) throws PredicateParserException
+    {
+        var result = PrincipalPredicates.parseFirstPredicate(arg);
+        predicate = result.predicate();
+        remaining = result.remaining();
+    }
+}

--- a/packages/pom.xml
+++ b/packages/pom.xml
@@ -122,6 +122,11 @@
     </dependency>
     <dependency>
         <groupId>org.dcache</groupId>
+        <artifactId>gplazma2-omnisession</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.dcache</groupId>
         <artifactId>gplazma2-multimap</artifactId>
         <version>${project.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -982,6 +982,17 @@
                 <artifactId>reflections</artifactId>
                 <version>0.9.12</version>
             </dependency>
+	    <dependency>
+                <groupId>com.github.npathai</groupId>
+                <artifactId>hamcrest-optional</artifactId>
+                <version>2.0.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1436,6 +1447,7 @@
         <module>modules/gplazma2-ldap</module>
         <module>modules/gplazma2-htpasswd</module>
         <module>modules/gplazma2-oidc</module>
+        <module>modules/gplazma2-omnisession</module>
         <module>modules/gplazma2-multimap</module>
         <module>modules/gplazma2-roles</module>
         <module>modules/gplazma2-scitoken</module>

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -125,6 +125,9 @@ gplazma.multimap.file=${dcache.paths.etc}/multi-mapfile
 #  ---- Path of the storage-authzdb file
 gplazma.authzdb.file=${dcache.paths.grid-security}/storage-authzdb
 
+#  ---- Path of the omnisession file
+gplazma.omnisession.file=${dcache.paths.etc}/omnisession.conf
+
 #  ---- Mapping order for determining the UID
 #
 #  The storage-authzdb file maps names to UID, one or more GIDs, and a


### PR DESCRIPTION
Motivation:

Most existing Session plugins are either based on external information
(NIS / LDAP) or are based on legacy file formats (kpwd, storage-authzdb)
that predate gPlazma2 and don't provide a "good fit" to gPlazma2's PAM
(or "PAM-like") login process.

There should be one, good implementation of a session plugin that uses a
local configuration that has the expressiveness of the existing
solutions, but supports a simpler configuration.

For dynamic accounts, we need some way to provide session information
without requiring an explicit configuration for each user.  External
information (NIS, LDAP) are not necessarily a good fit as they often
lack features in dCache, or contain similar information in a different
context; e.g., LDAP's home directory is not necessarily relevant for
paths within dCache.

Modification:

Add the omnisession plugin: a new gPlazma session plugin, which uses a
single configuration file that uses a straight-forward format:

    PREDICATE ATTRIBUTE ATTRIBUTE ...

Lines earlier in the document have precedence over lines later in the
document, with `DEFAULT` as a special-case predicate that always matches
last.

The Book is updated to document how to configure the omnisession plugin.

Note: the patch contains classes that are (deliberately) written so that
they may be adopted elsewhere in dCache.  This is left as 'future work'.

Result:

dCache has a new session gPlazma plugin that is designed to be a viable
alternative to the StorageAuthzDB and KPWD plugins but with shorter
(hopefully less confusing) configuration, while also being more
flexible.

Target: master
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/13008
Acked-by: Tigran Mkrtchyan