### PR TITLE
gplazma: add util to convert authzdb file to omnisession

### DIFF
--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/AuthzdbToOmnisession.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/plugins/AuthzdbToOmnisession.java
@@ -1,0 +1,87 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.plugins;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Program to convert an storage-authzdb plugin configuration file into
+ * an omnisession plugin configuration file.
+ */
+public class AuthzdbToOmnisession
+{
+    private static void fail(String why)
+    {
+        System.err.println(why);
+        System.exit(1);
+    }
+
+    public static void main(String[] args)
+    {
+        if (args.length != 2) {
+            fail("Require two arguments");
+        }
+
+        Path target = FileSystems.getDefault().getPath(args[1]);
+
+        try {
+            Files.deleteIfExists(target);
+
+            Path src = FileSystems.getDefault().getPath(args[0]);
+            var lines = Files.readAllLines(src);
+            System.out.println("Reading authzdb configuration from " + src);
+
+            StringBuilder sb = new StringBuilder();
+            var parser = new AuthzMapLineParser();
+            for (String line : lines) {
+                if (line.startsWith("version 2.")) {
+                    continue;
+                }
+
+                var entry = parser.accept(line);
+
+                if (entry == null) {
+                    sb.append(line);
+                } else {
+                    var info = entry.getValue();
+                    sb.append("username:").append(info.getUsername());
+
+                    if (info.isReadOnly()) {
+                        sb.append(" read-only");
+                    }
+
+                    sb.append(" home:").append(info.getHome());
+
+                    sb.append(" root:").append(info.getRoot());
+
+                    info.getMaxUpload().ifPresent(s -> sb.append(" max-upload:").append(s));
+                }
+
+                sb.append('\n');
+            }
+
+            Files.writeString(target, sb);
+            System.out.println("Omnisession configuration written to " + target);
+        } catch (IOException e) {
+            fail(e.toString());
+        }
+    }
+}

--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -101,6 +101,7 @@ rm -rf "$RPM_BUILD_ROOT"
 /usr/sbin/dcache-info-provider
 /usr/sbin/dcache-billing-indexer
 /usr/sbin/dcache-wait-for-cells
+/usr/sbin/dcache-convert-authzdb-to-omnisession
 /usr/bin/chimera
 /usr/bin/dcache
 /usr/bin/dcache-star

--- a/skel/sbin/dcache-convert-authzdb-to-omnisession
+++ b/skel/sbin/dcache-convert-authzdb-to-omnisession
@@ -1,0 +1,107 @@
+#!/bin/sh
+
+@DCACHE_LOAD_CONFIG@
+
+printUsage() {
+    echo "Usage:"
+    echo ""
+    echo "    convert-authzdb-to-omnisession [-f] [-c] [AUTHZDB_CONFIG [OMNISESSION_CONFIG]]"
+    echo
+    echo "This utility converts an authzdb plugin configuration to the equivalent"
+    echo "omnisession configuration.  The utility accepts two arguments, both of"
+    echo "which are optional."
+    echo
+    echo "    -f              overwrite existing files."
+    echo
+    echo "    -c              do not check for authzdb usage."
+    echo
+    echo "    AUTHZDB_CONFIG  the configuration file for the authzdb configuration"
+    echo "                    file.  If not specified then the default location is"
+    echo "                    used."
+    echo
+    echo "    OMNISESSION_CONFIG  the configuration file for the omnisession"
+    echo "                    configuration file.  If not specified then the default"
+    echo "                    location is used."
+    echo
+    echo "If the OMNISESSION_CONFIG file already exists then this script will NOT run, so"
+    echo "it will not overwrite this file.  Specify the '-f' option to overwrite the existing"
+    echo "file."
+    echo
+    echo "If gPlazma is not configured to use 'authzdb' as a session plugin then this script"
+    echo "will NOT run.  Specify the '-c' option to override this behaviuor."
+}
+
+fail() { # $1 - why
+    echo "$1" >&1
+    echo >&1
+    printUsage >&1
+    exit 1
+}
+
+if [ "$1" = "-f" ]; then
+    overwrite=1
+    shift
+fi
+
+if [ "$1" = "-c" ]; then
+    dontCheck=1
+    shift
+fi
+
+[ $# -le 2 ] || fail "You supplied $# arguments and a maximum of two is expected."
+
+gplazmaFile=$(getProperty gplazma.configuration.file)
+
+[ -f $gplazmaFile ] || [ -z "$dontCheck" ] || fail "Cannot find gPlazma configuration file."
+
+grep -q session.*authzdb $gplazmaFile || [ "$dontCheck" = "1" ] || fail "gPlazma is not using authzdb as a session plugin."
+
+if [ $# -ge 1 ]; then
+    SRC=$1
+else
+    SRC=$(getProperty gplazma.authzdb.file)
+fi
+
+[ -e "$SRC" ] || fail "Cannot convert file because $SRC does not exist."
+[ -f "$SRC" ] || fail "Cannot convert file because $SRC is not a file."
+[ -r "$SRC" ] || fail "Cannot convert file because $SRC is not readable."
+
+if [ $# -ge 2 ]; then
+    TARGET=$1
+else
+    TARGET=$(getProperty gplazma.omnisession.file)
+fi
+
+[ ! -e "$TARGET" ] || [ "$overwrite" = 1 ] || fail "$TARGET exists and '-f' was not specified."
+[ ! -e "$TARGET" ] || [ -f "$TARGET" ] || fail "$TARGET exists and is not a file."
+
+export CLASSPATH="$(printLimitedClassPath slf4j-api logback-classic \
+        logback-core logback-console-config guava dcache-common gplazma2-grid)"
+quickJava org.dcache.gplazma.plugins.AuthzdbToOmnisession "$SRC" "$TARGET"
+
+if [ $? -eq 0 ]; then
+    haveOmnisession=0
+    grep -q session.*omnisession $gplazmaFile && haveOmnisession=1
+
+    if [ $haveOmnisession = 0 ]; then
+	currentLine=$(grep session.*authzdb $gplazmaFile)
+	gplazma_conf=$(basename  $gplazmaFile)
+	echo
+	echo "To complete the migration, you should update your '${gplazma_conf}' file by"
+	if [ "$currentLine" = "" ]; then
+	    echo "adding the following line:"
+	    echo
+	    echo "    session requisite omnisession"
+	else
+	    newLine=$(echo $currentLine | awk '/session .* authzdb/{print "session "$2" omnisession"}')
+	    echo "replacing the line:"
+	    echo
+	    echo "    $currentLine"
+	    echo
+	    echo "with the following line:"
+	    echo
+	    echo "    $newLine"
+	fi
+	echo
+    fi
+fi


### PR DESCRIPTION
Motivation:

To support the removal of authzdb plugin, we should provide an easy way
for sites to migrate their existing configuration from using authzdb (as
a session plugin) to omnisession.

Note: it is also possible to use the authzdb plugin as a mapping plugin.
This utility does not help in migrating that use to some alternative
solution.

Modification:

Add utility to convert a authzdb configuration file to the equivalent
omnisession plugin.

It should work out-of-the-box, but the source and destination paths may
be overridden.

The gplazma.conf file is NOT updated, but suggested instructions are
included.

Result:

Sites now have a utility to help them migrating from authzdb to
omnisession.

Target: master
Requires-notes: yes
Requires-book: perhaps
Patch: https://rb.dcache.org/r/13026/
Acked-by: Tigran Mkrtchyan
Request: 7.1
Request: 7.0
Request: 6.2