### PR TITLE
skel: add explicit replicable property even when value is false

### DIFF
--- a/skel/share/defaults/admin.properties
+++ b/skel/share/defaults/admin.properties
@@ -9,6 +9,21 @@ admin.cell.name = admin
 
 admin.cell.subscribe = ${admin.loginbroker.update-topic}
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)admin.cell.replicable = false
+
 # System identification as shown in the admin prompt
 admin.prompt = ${host.name}
 

--- a/skel/share/defaults/alarms.properties
+++ b/skel/share/defaults/alarms.properties
@@ -18,6 +18,21 @@ alarms.cell.name=alarms
 #
 alarms.cell.consume=${alarms.cell.name}
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)alarms.cell.replicable = false
+
 #  ---- Host on which this service is running
 alarms.net.host=${dcache.log.server.host}
 

--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -10,6 +10,21 @@ bulk.cell.name=${dcache.service.bulk}
 bulk.cell.consume=${bulk.cell.name}
 bulk.cell.subscribe=${bulk.pool-monitor.topic}
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)bulk.cell.replicable = false
+
 bulk.ping.cell.name=${dcache.service.bulk.ping}
 bulk.ping.cell.consume=${bulk.ping.cell.name}
 

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -39,6 +39,21 @@ frontend.cell.consume=${frontend.cell.name}
 
 frontend.cell.subscribe=${frontend.pool-monitor.topic},${frontend.loginbroker.update-topic},${frontend.restore-requests.topic}
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)frontend.cell.replicable = false
+
 # Cell address of alarms service
 frontend.service.alarms=${dcache.service.alarms}
 

--- a/skel/share/defaults/history.properties
+++ b/skel/share/defaults/history.properties
@@ -20,6 +20,21 @@ history.cell.consume=${history.cell.name}
 
 history.cell.subscribe=${history.pool-monitor.topic}
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)history.cell.replicable = false
+
 #  ---- Concurrency.  Number of threads for processing incoming messages.
 #       logging events.
 #

--- a/skel/share/defaults/httpd.properties
+++ b/skel/share/defaults/httpd.properties
@@ -7,6 +7,21 @@ httpd.cell.name=httpd
 
 httpd.cell.subscribe=${httpd.loginbroker.update-topic},${httpd.pool-monitor-topic},${httpd.restore-requests.topic}
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)httpd.cell.replicable = false
+
 #
 #    Optional config file for configurig the httpd
 #    service. If present, it is executed as a batch

--- a/skel/share/defaults/ping.properties
+++ b/skel/share/defaults/ping.properties
@@ -9,6 +9,21 @@ ping.cell.name=${dcache.service.ping}
 
 ping.cell.consume=${ping.cell.name}
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)ping.cell.replicable = false
+
 # ---- Maximum amount of time the service will wait to reply to a message.
 #      The service uses this value to generate a random number for the
 #      timeout.

--- a/skel/share/defaults/resilience.properties
+++ b/skel/share/defaults/resilience.properties
@@ -30,6 +30,21 @@ resilience.cell.subscribe=${resilience.cache-location-topic},\
   ${resilience.corrupt-file-topic},\
   ${resilience.pool-monitor-topic}
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)resilience.cell.replicable = false
+
 # ---- Resilience listens for location updates from PnfsManager.
 #
 resilience.cache-location-topic=CacheLocationTopic

--- a/skel/share/defaults/statistics.properties
+++ b/skel/share/defaults/statistics.properties
@@ -5,6 +5,21 @@
 
 statistics.cell.name=PoolStatistics
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)statistics.cell.replicable = false
+
 #  ---- Directory for storing statistics.
 #
 #   This is the directory under which the statistics module will

--- a/skel/share/defaults/transfermanagers.properties
+++ b/skel/share/defaults/transfermanagers.properties
@@ -16,6 +16,21 @@ transfermanagers.cell.name=RemoteTransferManager
 #
 transfermanagers.cell.consume = ${transfermanagers.cell.name}
 
+#  ----- Whether the service is replicable
+#
+#   Any service in dCache can have several instances as long as these
+#   represent separate logical services. Some services can have several
+#   instances representing the same logical service, providing some
+#   degree of fault tolerance and load balancing. Such services are said
+#   to be replicable.
+#
+#   Instances of a logical service share the same service name, and it is
+#   important that the configuration for such instances is synchronized.
+#
+#   This property indicates if this service is replicable.
+#
+(immutable)transfermanagers.cell.replicable = false
+
 # Timeout for pool requests
 transfermanagers.service.pool.timeout = 300
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)transfermanagers.service.pool.timeout.unit=SECONDS


### PR DESCRIPTION
Motivation:

While the `dcache services` command will list services which
do not define this property as not being replicable, the
feature should probably be explicitly searchable in the
properties files.

Modification:

For core services which are not doors, add
```
(immutable)<name>.cell.replicable = false
```
plus the explanatory comment.

NOTE:  transfermanagers.properties has been marked
as not replicable, but needs review.

Result:

Whether a cell/service supports HA or not can
now be derived from the properties file (except
for doors).

Target: master
Request: 7.1
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13111/
Acked-by: Lea