### PR TITLE
dcache-xroot: prevent attempt to write to channel for which checksum …

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/FileDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/FileDescriptor.java
@@ -52,4 +52,9 @@ public interface FileDescriptor
      * Whether the file was opened with kXR_posc.
      */
     boolean isPersistOnSuccessfulClose();
+
+    /**
+     * Option to postprocess.  Default is NOP.
+     */
+    default void close() {}
 }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -178,10 +178,10 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
         /* close leftover descriptors */
         for (FileDescriptor descriptor : _descriptors) {
             if (descriptor != null) {
-                if (descriptor instanceof TpcWriteDescriptor) {
-                    ((TpcWriteDescriptor)descriptor).shutDown();
-                }
-
+                /*
+                 *  Does not affect read descriptors.
+                 */
+                descriptor.close();
                 if (descriptor.isPersistOnSuccessfulClose()) {
                     descriptor.getChannel().release(new FileCorruptedCacheException(
                             "File was opened with Persist On Successful Close and not closed."));
@@ -774,8 +774,11 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler
          *  The alternative adopted here is to implement a forcible close by releasing
          *  all references to the mover.
          */
-        NettyTransferService<XrootdProtocolInfo>.NettyMoverChannel channel
-                        = _descriptors.get(fd).getChannel();
+
+        FileDescriptor descriptor = _descriptors.get(fd);
+        descriptor.close();
+
+        NettyTransferService<XrootdProtocolInfo>.NettyMoverChannel channel = descriptor.getChannel();
 
         /*
          *  Stop any timer in case this is a reconnect.

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -330,8 +330,10 @@ public final class TpcWriteDescriptor extends WriteDescriptor
         write((ByteBuffersProvider)inboundReadResponse);
     }
 
-    public void shutDown()
+    public void close()
     {
+        super.close();
+
         if (client == null) {
             return;
         }


### PR DESCRIPTION
…has been computed

Motivation:

Refer to GH possible race in get checksum #9 https://github.com/dCache/xrootd4j/issues/9
and RT 10172 xrootd server error while processing write.

This issue was resolved for TPC by making sure the client was shut down properly.
The issue seemed to disappear (for us at FNAL) for two-party write, but the
new ticket from PIC suggests we are still susceptible to it when clients
close prematurely (before the write is finished) or are for some reason
disconnected.   The seems to be happening on persist-on-close writes, but
I do not think it is strictly related to that.

It would appear from looking at this problem with fresh eyes
that what is needed is to make sure that "in flight" write
requests do not grab hold of a descriptor whose channel has been
released and try to write to it.  In some sense, the problem
is analogous to https://rb.dcache.org/r/12917/
dcache-xroot: Allow client to reattempt open on pool when I/O stalls.

Modification:

The solution proposed here is to generalize the shutdown() method
that was added to the TPCWriteDescriptor into a close() method
which is called synchronously with the write and sync methods,
and which flags the descriptor as closed.  In the latter case,
any write or sync calls using the descriptor after it has been
so disabled will just silently return.

Result:

Hopefully, no more checksum channel IllegalStateExceptions from
interactions with the client of this sort.

Target: master
Request: 7.1
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Patch: https://rb.dcache.org/r/13119/
Bug: RT 10172
Closes: https://github.com/dCache/xrootd4j/issues/9
Requires-notes: yes
Requires-book: no
Acked-by: Marina