### PR TITLE
pool: update Kafka tape events to include additional information

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/StorageInfoMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/StorageInfoMessage.java
@@ -4,15 +4,26 @@ import diskCacheV111.util.PnfsId;
 
 import dmg.cells.nucleus.CellAddressCore;
 
+/**
+ * An info message from some HSM-attached pool that describes a tape operation.
+ * It extends the existing information message by including various
+ * tape-specific details.
+ */
 public class StorageInfoMessage extends PnfsFileInfoMessage
 {
-    private long _transferTime;
-
     private static final long serialVersionUID = -4601114937008749384L;
+    public static final String RESTORE_MSG_TYPE = "restore";
+    public static final String STORE_MSG_TYPE = "store";
+
+    private long _transferTime;
+    private String _hsmInstance;
+    private String _hsmType;
+    private String _provider;
 
     public StorageInfoMessage(CellAddressCore address, PnfsId pnfsId, boolean restore)
     {
-        super(restore ? "restore" : "store", "pool", address, pnfsId);
+        super(restore ? RESTORE_MSG_TYPE : STORE_MSG_TYPE, "pool", address,
+                pnfsId);
     }
 
     public void setTransferTime(long transferTime)
@@ -23,6 +34,36 @@ public class StorageInfoMessage extends PnfsFileInfoMessage
     public long getTransferTime()
     {
         return _transferTime;
+    }
+
+    public void setHsmInstance(String name)
+    {
+        _hsmInstance = name;
+    }
+
+    public String getHsmInstance()
+    {
+        return _hsmInstance;
+    }
+
+    public void setHsmType(String type)
+    {
+        _hsmType = type;
+    }
+
+    public String getHsmType()
+    {
+        return _hsmType;
+    }
+
+    public void setHsmProvider(String provider)
+    {
+        _provider = provider;
+    }
+
+    public String getHsmProvider()
+    {
+        return _provider;
     }
 
     @Override

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -98,6 +98,7 @@ import org.dcache.namespace.FileAttribute;
 import org.dcache.pool.PoolDataBeanProvider;
 import org.dcache.pool.classic.ChecksumModule;
 import org.dcache.pool.classic.NopCompletionHandler;
+import org.dcache.pool.nearline.HsmSet.HsmDescription;
 import org.dcache.pool.nearline.json.NearlineData;
 import org.dcache.pool.nearline.json.StorageHandlerData;
 import org.dcache.pool.nearline.spi.FlushRequest;
@@ -191,6 +192,7 @@ public class NearlineStorageHandler
     private long flushTimeout = TimeUnit.HOURS.toMillis(4);
     private long removeTimeout = TimeUnit.HOURS.toMillis(4);
     private ScheduledFuture<?> timeoutFuture;
+    private boolean _addFromNearlineStorage;
 
     /**
      * Allocator used to use when space allocation is required.
@@ -219,6 +221,7 @@ public class NearlineStorageHandler
     @Qualifier("hsm")
     public void setKafkaTemplate(KafkaTemplate kafkaTemplate) {
         _kafkaSender = kafkaTemplate::sendDefault;
+        _addFromNearlineStorage = true;
     }
 
     @Required
@@ -494,6 +497,17 @@ public class NearlineStorageHandler
     @Override
     public void stickyChanged(StickyChangeEvent event)
     {
+    }
+
+    private void addFromNearlineStorage(StorageInfoMessage message, NearlineStorage storage)
+    {
+        if (_addFromNearlineStorage) {
+            HsmDescription description = hsmSet.describe(storage);
+
+            message.setHsmInstance(description.getInstance());
+            message.setHsmType(description.getType());
+            message.setHsmProvider(description.getProvider());
+        }
     }
 
     /**
@@ -1163,6 +1177,7 @@ public class NearlineStorageHandler
             infoMsg.setTransferTime(System.currentTimeMillis() - activatedAt);
             infoMsg.setFileSize(getFileAttributes().getSize());
             infoMsg.setTimeQueued(activatedAt - createdAt);
+            addFromNearlineStorage(infoMsg, storage);
 
             billingStub.notify(infoMsg);
 
@@ -1369,6 +1384,8 @@ public class NearlineStorageHandler
                 infoMsg.setResult(CacheException.DEFAULT_ERROR_CODE, cause.toString());
             }
             infoMsg.setTransferTime(System.currentTimeMillis() - activatedAt);
+            addFromNearlineStorage(infoMsg, storage);
+
             billingStub.notify(infoMsg);
 
             _kafkaSender.accept(infoMsg);


### PR DESCRIPTION
Motivation:

Support additional monitoring of flush and stage activity.

Modification:

HsmSet is updated to provide a new class HsmDescription.  This acts as a
read-only view on some HsmInfo object.  These HsmDescription objects are
created in a lazy fashion, when the HsmDescription object for some
NearlineStorage object is queried.

The StorageInfoMessage is updated to includes the HSM type, instance
name, and the NearlineStorageProvider's name.  These extra fields are
ignored by billing, but are included in Kafka event JSON under the `hsm`
field.

The JSON has another new field: `locations`, which has a JSON Array of
JSON Strings as a value.  Each JSON String is a URL.

For flush operations, the `locations` field contains the URLs returned
by the NearlineStorage.  The JSON Array will be empty if the
NearlineStorage reported a failure, or if it reported success and did
not supply any URLs.

For stage operations, the `locations` field contains the list of known
tape-location URLs, filtered so that only those for the target
nNearlineStorage are included.  This may be an empty list if dCache does
not know any URLs for the selected NearlineStorage.  It may also contain
multiple URLs.

Result:

The Kafka message emitted when a file is flushed to tape or staged back
from tape now includes the `locations` field: a JSON array of JSON
Strings, where each JSON String is a tape-location URL.  For flush
operations, this is the (potentially empty, potentially multiple) list
of URLs returned by the HSM instance.  For stage operations, this is the
(potentially empty, potentially multiple) URLs that match the selected
HSM instance.  Both messages now also describe a `hsm` JSON Object that
contain the HSM type, HSM instance name, and HSM provider.

Target: master
Requires-notes: yes
Requires-book: no
Closes: #6007
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13141/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel