### PR TITLE
pool/pnfsmanager: don't accept a non-Enstore flush without locations

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
@@ -116,4 +116,9 @@ public class ChimeraEnstoreStorageInfoExtractor extends ChimeraHsmStorageInfoExt
         return !s.equals(UriUtils.decode(s, StandardCharsets.UTF_8));
     }
 
+    @Override
+    protected void checkFlushUpdate(StorageInfo info) throws CacheException
+    {
+        /* No checks needed: Enstore updates the namespace directly. */
+    }
 }

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
@@ -22,6 +22,8 @@ import org.dcache.chimera.StorageGenericLocation;
 import org.dcache.chimera.posix.Stat;
 import org.dcache.chimera.store.InodeStorageInformation;
 
+import static diskCacheV111.util.CacheException.INVALID_UPDATE;
+
 public abstract class ChimeraHsmStorageInfoExtractor implements
        ChimeraStorageInfoExtractable {
 
@@ -210,6 +212,8 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
 
         try {
             if(dCacheStorageInfo.isSetAddLocation() ) {
+                checkFlushUpdate(dCacheStorageInfo);
+
                 List<URI> locationURIs = dCacheStorageInfo.locations();
 
                 if( !locationURIs.isEmpty() ) {
@@ -246,5 +250,15 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
             }
         }
         return Optional.empty();
+    }
+
+    protected void checkFlushUpdate(StorageInfo info) throws CacheException
+    {
+        List<URI> locations = info.locations();
+
+        if (locations.isEmpty()) {
+            throw new CacheException(INVALID_UPDATE, "Flush was successful but"
+                    + " no extra (tape) locations were reported.");
+        }
     }
 }

--- a/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractorTest.java
+++ b/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractorTest.java
@@ -1,0 +1,119 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.chimera.namespace;
+
+import org.junit.Test;
+
+import diskCacheV111.util.AccessLatency;
+import diskCacheV111.util.RetentionPolicy;
+import diskCacheV111.vehicles.StorageInfo;
+
+import org.dcache.chimera.FsInode;
+
+import static com.google.common.base.Preconditions.checkState;
+import static diskCacheV111.util.RetentionPolicy.REPLICA;
+import static diskCacheV111.util.AccessLatency.ONLINE;
+import static org.dcache.util.StorageInfoBuilder.aStorageInfo;
+import static org.dcache.chimera.namespace.FsInodeBuilder.aFile;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.dcache.chimera.namespace.InodeStorageInformationMatcher.matchesAnInodeStorageInformation;
+
+public class ChimeraEnstoreStorageInfoExtractorTest
+{
+    private ChimeraEnstoreStorageInfoExtractor extractor;
+
+    @Test
+    public void shouldAcceptFlushUpdateWithLocation() throws Exception
+    {
+        given(anExtractor().withDefaultAccessLatency(ONLINE).withDefaultRetentionPolicy(REPLICA));
+        FsInode inode = aFile().build();
+        StorageInfo info = aStorageInfo()
+                        .withIsSetAddLocation()
+                        .withHsm("enstore-instance")
+                        .withKey("store", "store-group")
+                        .withKey("group", "store-subgroup")
+                        .withLocation("enstore://enstore-instance/specific-ID")
+                        .build();
+
+        extractor.setStorageInfo(inode, info);
+
+        verify(inode.getFs()).addInodeLocation(inode, 0, "enstore://enstore-instance/specific-ID");
+        verify(inode.getFs()).setStorageInfo(eq(inode), argThat(matchesAnInodeStorageInformation()
+                        .withHsm("enstore-instance")
+                        .withInode(inode)
+                        .withStorageGroup("store-group")
+                        .withStorageSubgroup("store-subgroup")));
+    }
+
+    @Test
+    public void shouldIgnoreFlushUpdateWithoutLocation() throws Exception
+    {
+        given(anExtractor().withDefaultAccessLatency(ONLINE).withDefaultRetentionPolicy(REPLICA));
+        FsInode inode = aFile().build();
+        StorageInfo info = aStorageInfo()
+                        .withIsSetAddLocation()
+                        .withHsm("enstore-instance")
+                        .withKey("store", "store-group")
+                        .withKey("group", "store-subgroup")
+                        // Note: NO locations.
+                        .build();
+
+        extractor.setStorageInfo(inode, info);
+
+        verify(inode.getFs(), never()).addInodeLocation(any(), anyInt(), any());
+        verify(inode.getFs(), never()).setStorageInfo(any(), any());
+    }
+
+    private void given(ExtractorBuilder builder)
+    {
+        extractor = builder.build();
+    }
+
+    public ExtractorBuilder anExtractor()
+    {
+        return new ExtractorBuilder();
+    }
+
+    private static class ExtractorBuilder
+    {
+        private AccessLatency defaultAccessLatency;
+        private RetentionPolicy defaultRetentionPolicy;
+
+        public ExtractorBuilder withDefaultAccessLatency(AccessLatency latency)
+        {
+            defaultAccessLatency = latency;
+            return this;
+        }
+
+        public ExtractorBuilder withDefaultRetentionPolicy(RetentionPolicy policy)
+        {
+            defaultRetentionPolicy = policy;
+            return this;
+        }
+
+        public ChimeraEnstoreStorageInfoExtractor build()
+        {
+            checkState(defaultAccessLatency != null, "defaultAccessLatency not set");
+            checkState(defaultRetentionPolicy != null, "defaultRetentionPolicy not set");
+            return new ChimeraEnstoreStorageInfoExtractor(defaultAccessLatency,
+                    defaultRetentionPolicy);
+        }
+    }
+}

--- a/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/ChimeraOsmStorageInfoExtractorTest.java
+++ b/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/ChimeraOsmStorageInfoExtractorTest.java
@@ -1,0 +1,185 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.chimera.namespace;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import diskCacheV111.util.AccessLatency;
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.RetentionPolicy;
+import diskCacheV111.vehicles.StorageInfo;
+
+import org.dcache.chimera.FsInode;
+
+import static com.google.common.base.Preconditions.checkState;
+import static diskCacheV111.util.RetentionPolicy.REPLICA;
+import static diskCacheV111.util.AccessLatency.ONLINE;
+import static org.dcache.chimera.namespace.FsInodeBuilder.aFile;
+import static org.dcache.chimera.namespace.InodeStorageInformationMatcher.matchesAnInodeStorageInformation;
+import static org.dcache.util.StorageInfoBuilder.aStorageInfo;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class ChimeraOsmStorageInfoExtractorTest
+{
+    private ChimeraOsmStorageInfoExtractor extractor;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldAcceptFlushUpdateWithLocation() throws Exception
+    {
+        given(anExtractor().withDefaultAccessLatency(ONLINE).withDefaultRetentionPolicy(REPLICA));
+        FsInode inode = aFile().build();
+        StorageInfo info = aStorageInfo()
+                        .withIsSetAddLocation()
+                        .withHsm("osm-instance")
+                        .withKey("store", "store-group")
+                        .withKey("group", "store-subgroup")
+                        .withLocation("osm://osm-instance/specific-ID")
+                        .build();
+
+        extractor.setStorageInfo(inode, info);
+
+        verify(inode.getFs()).addInodeLocation(inode, 0, "osm://osm-instance/specific-ID");
+        verify(inode.getFs()).setStorageInfo(eq(inode), argThat(matchesAnInodeStorageInformation()
+                        .withHsm("osm-instance")
+                        .withInode(inode)
+                        .withStorageGroup("store-group")
+                        .withStorageSubgroup("store-subgroup")));
+    }
+
+    @Test
+    public void shouldIngoreNonFlushUpdate() throws Exception
+    {
+        given(anExtractor().withDefaultAccessLatency(ONLINE).withDefaultRetentionPolicy(REPLICA));
+        FsInode inode = aFile().build();
+        StorageInfo info = aStorageInfo()
+                        // Note: withIsSetAddLocation NOT called.
+                        .withHsm("osm-instance")
+                        .withKey("store", "store-group")
+                        .withKey("group", "store-subgroup")
+                        .withLocation("osm://osm-instance/specific-ID")
+                        .build();
+
+        extractor.setStorageInfo(inode, info);
+
+        verify(inode.getFs(), never()).addInodeLocation(any(), anyInt(), any());
+        verify(inode.getFs(), never()).setStorageInfo(any(), any());
+    }
+
+    @Test
+    public void shouldRejectFlushUpdateWithNoLocation() throws Exception
+    {
+        thrown.expect(aCacheExceptionWithRc(10031));
+
+        given(anExtractor().withDefaultAccessLatency(ONLINE).withDefaultRetentionPolicy(REPLICA));
+
+        extractor.setStorageInfo(aFile().build(),
+                aStorageInfo()
+                        .withIsSetAddLocation()
+                        .withHsm("osm-instance")
+                        .withKey("store", "store-group")
+                        .withKey("group", "store-subgroup")
+                        // Note: there are no locations defined.
+                        .build());
+    }
+
+    private void given(ExtractorBuilder builder)
+    {
+        extractor = builder.build();
+    }
+
+    public ExtractorBuilder anExtractor()
+    {
+        return new ExtractorBuilder();
+    }
+
+    private static class ExtractorBuilder
+    {
+        private AccessLatency defaultAccessLatency;
+        private RetentionPolicy defaultRetentionPolicy;
+
+        public ExtractorBuilder withDefaultAccessLatency(AccessLatency latency)
+        {
+            defaultAccessLatency = latency;
+            return this;
+        }
+
+        public ExtractorBuilder withDefaultRetentionPolicy(RetentionPolicy policy)
+        {
+            defaultRetentionPolicy = policy;
+            return this;
+        }
+
+        public ChimeraOsmStorageInfoExtractor build()
+        {
+            checkState(defaultAccessLatency != null, "defaultAccessLatency not set");
+            checkState(defaultRetentionPolicy != null, "defaultRetentionPolicy not set");
+            return new ChimeraOsmStorageInfoExtractor(defaultAccessLatency,
+                    defaultRetentionPolicy);
+        }
+    }
+
+    private static CacheExceptionMatcher aCacheExceptionWithRc(int rc)
+    {
+        return new CacheExceptionMatcher(rc);
+    }
+
+    public static class CacheExceptionMatcher extends BaseMatcher<Object>
+    {
+        private final int expectedRc;
+
+        public CacheExceptionMatcher(int expectedRc)
+        {
+            this.expectedRc = expectedRc;
+        }
+
+        @Override
+        public boolean matches(Object actual)
+        {
+            return (actual instanceof CacheException)
+                    &&
+                    ((CacheException)actual).getRc() == expectedRc;
+        }
+
+        @Override
+        public void describeMismatch(Object actual, Description mismatchDescription)
+        {
+            if (!(actual instanceof CacheException)) {
+                mismatchDescription.appendText(actual.getClass().getCanonicalName());
+            } else {
+                CacheException other = (CacheException)actual;
+                mismatchDescription.appendText("a CacheException with rc "
+                        + other.getRc());
+            }
+        }
+
+        @Override
+        public void describeTo(Description description)
+        {
+            description.appendText("a CacheException with rc " + expectedRc);
+        }
+    }
+}

--- a/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/FsInodeBuilder.java
+++ b/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/FsInodeBuilder.java
@@ -1,0 +1,49 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.chimera.namespace;
+
+import org.dcache.chimera.FileSystemProvider;
+import org.dcache.chimera.FsInode;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * A builder class for creating FsInode objects.  The built objects are real,
+ * but the FileSystemProvider is mocked.
+ */
+public class FsInodeBuilder
+{
+    private final FileSystemProvider fsProvider = mock(FileSystemProvider.class);
+    private long ino = 0;
+
+    public static FsInodeBuilder aFile()
+    {
+        return new FsInodeBuilder();
+    }
+
+    public FsInodeBuilder withInode(long id)
+    {
+        ino = id;
+        return this;
+    }
+
+    public FsInode build()
+    {
+        return new FsInode(fsProvider, ino);
+    }
+}

--- a/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/InodeStorageInformationMatcher.java
+++ b/modules/dcache-chimera/src/test/java/org/dcache/chimera/namespace/InodeStorageInformationMatcher.java
@@ -1,0 +1,64 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.dcache.chimera.namespace;
+
+import org.mockito.ArgumentMatcher;
+
+import org.dcache.chimera.FsInode;
+import org.dcache.chimera.store.InodeStorageInformation;
+
+/**
+ * An Mockito ArgumentMatcher for InodeStorageInformation with a fluent
+ * interface.
+ */
+public class InodeStorageInformationMatcher implements ArgumentMatcher<InodeStorageInformation>
+{
+    private FsInode inode;
+    private String hsm;
+    private String group;
+    private String subgroup;
+
+    public static InodeStorageInformationMatcher matchesAnInodeStorageInformation()
+    {
+        return new InodeStorageInformationMatcher();
+    }
+
+    public InodeStorageInformationMatcher withInode(FsInode inode)
+    {
+        this.inode = inode;
+        return this;
+    }
+
+    public InodeStorageInformationMatcher withHsm(String hsm)
+    {
+        this.hsm = hsm;
+        return this;
+    }
+
+    public InodeStorageInformationMatcher withStorageGroup(String group)
+    {
+        this.group = group;
+        return this;
+    }
+
+    public InodeStorageInformationMatcher withStorageSubgroup(String subgroup)
+    {
+        this.subgroup = subgroup;
+        return this;
+    }
+
+    @Override
+    public boolean matches(InodeStorageInformation argument)
+    {
+        return (inode == null || inode.equals(argument.inode()))
+                &&
+                (hsm == null || hsm.equals(argument.hsmName()))
+                &&
+                (group == null || group.equals(argument.storageGroup()))
+                &&
+                (subgroup == null || subgroup.equals(argument.storageSubGroup()));
+    }
+}

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/util/CacheException.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/util/CacheException.java
@@ -144,6 +144,12 @@ public class CacheException extends Exception
     public static final int NO_ATTRIBUTE = 10030;
 
     /**
+     * An attempt was made to change some recorded information; however, that
+     * change was not acceptable.
+     */
+    public static final int INVALID_UPDATE = 10031;
+
+    /**
      * default error code. <b>It's recommended to use more specific error
      * codes</b>
      */

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/StorageInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/StorageInfo.java
@@ -82,12 +82,28 @@ public interface StorageInfo
     void addLocation(URI newLocation);
 
     /**
-     *
-     * @return true if new location is added and
-     * have to be stored by PnfsManager
+     * Whether the StorageInfo contains updated information as a result of a
+     * flush operation.  In particular, {@link #locations() } returns any
+     * additional (tape) locations, {@link #getHsm()} contains the HSM
+     * involved, and {@link getKey} contains other information as key-value
+     * pairs.
+     * @return true if this update is the result of flushing a file to tape.
      * @since 1.8
      */
     boolean isSetAddLocation();
+
+    /**
+     * Control whether this StorageInfo contains updated information as a result
+     * of a flush operation.  By default a StorageInfo object is marked as NOT
+     * containing an update from flushing a file to tape.  Calling this method
+     * with {@literal true} marks that the StorageInfo contains information from
+     * a tape flush.  When set to {@literal true}, the caller is responsible for
+     * calling {@link #addLocation(java.net.URI) } for any additional (tape)
+     * locations, {@link #setHsm(java.lang.String) } to describe the HSM
+     * involved, and {@link #setKey(java.lang.String, java.lang.String) } for
+     * any HSM-specific data.
+     * @param isSet whether the information comes from flushing a file to tape.
+     */
     void isSetAddLocation(boolean isSet);
 
 

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1098,11 +1098,11 @@ public class NearlineStorageHandler
         {
             FileAttributes fileAttributes = descriptor.getFileAttributes();
             StorageInfo storageInfo = fileAttributes.getStorageInfo().clone();
+            storageInfo.isSetAddLocation(true);
             for (URI uri : uris) {
                 try {
                     HsmLocationExtractorFactory.validate(uri);
                     storageInfo.addLocation(uri);
-                    storageInfo.isSetAddLocation(true);
                 } catch (IllegalArgumentException e) {
                     throw new CacheException(2, e.getMessage(), e);
                 }
@@ -1116,15 +1116,17 @@ public class NearlineStorageHandler
         }
 
         private void notifyNamespace(PnfsId pnfsid, FileAttributes fileAttributes)
-                throws InterruptedException
+                throws InterruptedException, CacheException
         {
+            retrying:
             while (true) {
                 try {
                     pnfs.fileFlushed(pnfsid, fileAttributes);
                     break;
                 } catch (CacheException e) {
-                    if (e.getRc() == CacheException.FILE_NOT_FOUND ||
-                            e.getRc() == CacheException.NOT_IN_TRASH) {
+                    switch (e.getRc()) {
+                    case CacheException.NOT_IN_TRASH:
+                    case CacheException.FILE_NOT_FOUND:
                         /* In case the file was deleted, we are presented
                          * with the problem that the file is now on tape,
                          * however the location has not been registered
@@ -1133,27 +1135,46 @@ public class NearlineStorageHandler
                          * seems to be to remove the file from tape here.
                          * For now we ignore this issue (REVISIT).
                          */
-                        break;
-                    }
+                        break retrying;
 
-                    /* The message to the PnfsManager failed. There are several
-                     * possible reasons for this; we may have lost the
-                     * connection to the PnfsManager; the PnfsManager may have
-                     * lost its connection to the namespace or otherwise be in
-                     * trouble; bugs; etc.
-                     *
-                     * We keep retrying until we succeed. This will effectively
-                     * block this thread from flushing any other files, which
-                     * seems sensible when we have trouble talking to the
-                     * PnfsManager. If the pool crashes or gets restarted while
-                     * waiting here, we will end up flushing the file again. We
-                     * assume that the nearline storage is able to eliminate the
-                     * duplicate; or at least tolerate the duplicate (given that
-                     * this situation should be rare, we can live with a little
-                     * bit of wasted tape).
-                     */
-                    LOGGER.error("Error notifying pnfsmanager about a flushed file: {} ({})",
-                            e.getMessage(), e.getRc());
+                    case CacheException.INVALID_UPDATE:
+                        /* PnfsManager has indicated that there was a problem
+                         * updating the file with the information describing the
+                         * flush.  This is despite the flush operation returning
+                         * successfully.
+                         *
+                         * Given this discrepency, we MUST NOT automatically
+                         * retry the request, as this could lead to multiple
+                         * copies of the file's data being stored on tape.
+                         * Instead some kind of manual intevention is required.
+                         *
+                         * A CacheException with an rc in [30, 40) has the
+                         * effect of failing the request.  A failed flush
+                         * request is NOT automatically retried, but requires
+                         * manual (admin) intervention before retrying.
+                         */
+                        throw new CacheException(30, e.getMessage());
+
+                    default:
+                        /* The message to the PnfsManager failed. There are several
+                         * possible reasons for this; we may have lost the
+                         * connection to the PnfsManager; the PnfsManager may have
+                         * lost its connection to the namespace or otherwise be in
+                         * trouble; bugs; etc.
+                         *
+                         * We keep retrying until we succeed. This will effectively
+                         * block this thread from flushing any other files, which
+                         * seems sensible when we have trouble talking to the
+                         * PnfsManager. If the pool crashes or gets restarted while
+                         * waiting here, we will end up flushing the file again. We
+                         * assume that the nearline storage is able to eliminate the
+                         * duplicate; or at least tolerate the duplicate (given that
+                         * this situation should be rare, we can live with a little
+                         * bit of wasted tape).
+                         */
+                        LOGGER.error("Error notifying pnfsmanager about a flushed file: {} ({})",
+                                e.getMessage(), e.getRc());
+                    }
                 }
                 TimeUnit.MINUTES.sleep(2);
             }

--- a/modules/dcache/src/main/java/org/dcache/util/StorageInfoBuilder.java
+++ b/modules/dcache/src/main/java/org/dcache/util/StorageInfoBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.util;
+
+import java.net.URI;
+
+import diskCacheV111.vehicles.GenericStorageInfo;
+import diskCacheV111.vehicles.StorageInfo;
+
+/**
+ * A fluent class to build a StorageInfo.
+ */
+public class StorageInfoBuilder
+{
+    private final GenericStorageInfo info = new GenericStorageInfo();
+
+    public StorageInfoBuilder withLocation(String uri)
+    {
+        info.addLocation(URI.create(uri));
+        return this;
+    }
+
+    public StorageInfoBuilder withHsm(String hsm)
+    {
+        info.setHsm(hsm);
+        return this;
+    }
+
+    public StorageInfoBuilder withKey(String key, String value)
+    {
+        info.setKey(key, value);
+        return this;
+    }
+
+    public StorageInfoBuilder withIsSetAddLocation()
+    {
+        info.isSetAddLocation(true);
+        return this;
+    }
+
+    public StorageInfoBuilder withIsSetAddLocation(boolean value)
+    {
+        info.isSetAddLocation(value);
+        return this;
+    }
+
+    public StorageInfo build()
+    {
+        return info;
+    }
+
+    public static StorageInfoBuilder aStorageInfo()
+    {
+        return new StorageInfoBuilder();
+    }
+}


### PR DESCRIPTION
Motivation:

Currently, a pool will accept that a file was successfully flushed even
if flush activity did not provide any URIs.  A flush without any URI
makes no sense for most storage systesm because dCache will not have any
way to recall/stage the file from tape later on.  This only makes sense
for Enstore, as it directly modifies the namespace (bypassing dCache).

Given dCache believes the file was successfully written to tape then
dCache will mark the disk replica cache-only and, over time, it will be
garbage collected.  Given dCache has no way of recalling the file from
tape (if a non-Enstore storage is used), the file then becomes
unavailable.

This scenario can happen if (for example) the HSM is configured to use a
script and that script returns successfully (return-code 0) but without
printing anything on stdout.

Depending on what ancillary information is available, it may prove
impossible to track down the missing data (assuming it was written
succesfully to tape), in which case this problem creates a possible
route for data-loss.

Modification:

Update StorageInfo to alter the semantics of `isSetAddLocation`.
Currently `isSetAddLocation` is true only for flush operations where
`locations` returns a non-empty Set.  With the new semantics, the
`isSetAddLocation` is true for any flush operation, including those
where `locations` returns an empty Set.

Note that, currently, ChimeraHsmStorageInfoExtractor#setStorageInfo does
nothing if `isSetAddLocation` is true but `locations` returns an empty
set.  Therefore, this change in semantics in `isSetAddLocation` has no
effect if PnfsManager is not also updated.

Add a framework that allows PnfsManager to fail a flush operation, so
that the failed flush will moved that file into a failed state,
requiring manual intervention from an operator before retrying.

Add a check in ChimeraHsmStorageInfoExtractor that an update resulting
from a flush operation is rejected if that update contains no new
locations.  ChimeraEnstoreStorageInfoExtractor is updated to avoid this
check: it is valid for an Enstore flush to contain no additional
locations.

Add unit-tests to verify correct behaviour of
ChimeraEnstoreStorageInfoExtractor and ChimeraOsmStorageInfoExtractor.

Result:

Fix a problem where dCache accepts a HSM script that, when called to
flush a file, returns successfully but without providing any URIs on
stdout.  Such requests are considered failed, with the flush request
blocked until retried explicitly with the `queue activate PNFSID`
admin command.

Target: master
Requires-notes: yes
Requires-book: no
Bug: #6007
Request: 7.1
Request: 7.0
Request: 6.2
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel
Patch: https://rb.dcache.org/r/13130/