### PR TITLE
libs: use sshd-core 2.7.0

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/AdminShellFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/AdminShellFactory.java
@@ -1,7 +1,8 @@
 package org.dcache.services.ssh2;
 
-import org.apache.sshd.common.Factory;
+import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
+import org.apache.sshd.server.shell.ShellFactory;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.io.File;
@@ -14,7 +15,7 @@ import dmg.cells.nucleus.CellMessageSender;
 import org.dcache.cells.CellStub;
 import org.dcache.util.list.ListDirectoryHandler;
 
-public class ShellFactory implements Factory<Command>, CellMessageSender
+public class AdminShellFactory implements ShellFactory, CellMessageSender
 {
     private CellEndpoint _endpoint;
     private File _historyFile;
@@ -80,12 +81,12 @@ public class ShellFactory implements Factory<Command>, CellMessageSender
     }
 
     @Override
-    public Command create()
+    public Command createShell(ChannelSession channelSession)
     {
-        return new ShellCommand(_historyFile, _historySize, _useColor, createShell());
+        return new ShellCommand(_historyFile, _historySize, _useColor, createAdminShell());
     }
 
-    private UserAdminShell createShell()
+    private UserAdminShell createAdminShell()
     {
         UserAdminShell shell = new UserAdminShell(_prompt);
         shell.setCellEndpoint(_endpoint);

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/AnsiTerminalCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/AnsiTerminalCommand.java
@@ -5,6 +5,7 @@ import jline.console.ConsoleReader;
 import jline.console.history.FileHistory;
 import jline.console.history.MemoryHistory;
 import jline.console.history.PersistentHistory;
+import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
@@ -78,7 +79,7 @@ public class AnsiTerminalCommand implements Command, Runnable {
     }
 
     @Override
-    public void destroy() {
+    public void destroy(ChannelSession channelSession) {
         Thread thread = _pipeThread;
         if (thread != null) {
             thread.interrupt();
@@ -109,7 +110,7 @@ public class AnsiTerminalCommand implements Command, Runnable {
     }
 
     @Override
-    public void start(Environment env) throws IOException {
+    public void start(ChannelSession channelSession, Environment env) throws IOException {
         _pipedOut = new PipedOutputStream();
         _pipedIn = new PipedInputStream(_pipedOut);
         _userAdminShell.setUser(env.getEnv().get(Environment.ENV_USER));

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/DirectCommandFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/DirectCommandFactory.java
@@ -59,6 +59,7 @@ documents or software obtained from this server.
  */
 package org.dcache.services.ssh2;
 
+import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.command.CommandFactory;
 import org.springframework.beans.factory.annotation.Required;
@@ -127,7 +128,7 @@ public class DirectCommandFactory implements CommandFactory, CellMessageSender
     }
 
     @Override
-    public Command createCommand(String command) {
+    public Command createCommand(ChannelSession channelSession, String command) {
         checkArgument(command != null, "No command");
         return new DirectCommand(Arrays.asList(command.split(COMMAND_SEPARATOR)),
                 endpoint,

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacyAdminShellCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacyAdminShellCommand.java
@@ -5,6 +5,7 @@ import jline.console.ConsoleReader;
 import jline.console.history.FileHistory;
 import jline.console.history.MemoryHistory;
 import jline.console.history.PersistentHistory;
+import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
@@ -69,7 +70,7 @@ public class LegacyAdminShellCommand implements Command, Runnable
     }
 
     @Override
-    public void destroy() {
+    public void destroy(ChannelSession channelSession) {
         if (_adminShellThread != null) {
             _adminShellThread.interrupt();
         }
@@ -96,7 +97,7 @@ public class LegacyAdminShellCommand implements Command, Runnable
     }
 
     @Override
-    public void start(Environment env) throws IOException {
+    public void start(ChannelSession channelSession, Environment env) throws IOException {
         String user = env.getEnv().get(Environment.ENV_USER);
         _shell = new LegacyAdminShell(user, _endpoint, _prompt);
         _console = new ConsoleReader(_in, _out, new ConsoleReaderTerminal(env)) {

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacySubsystemFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacySubsystemFactory.java
@@ -1,15 +1,17 @@
 package org.dcache.services.ssh2;
 
-import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
+import org.apache.sshd.server.subsystem.SubsystemFactory;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.io.File;
+import java.io.IOException;
 
 import dmg.cells.nucleus.CellEndpoint;
 import dmg.cells.nucleus.CellMessageSender;
 
-public class LegacySubsystemFactory implements NamedFactory<Command>, CellMessageSender
+public class LegacySubsystemFactory implements SubsystemFactory, CellMessageSender
 {
     private CellEndpoint _endpoint;
 
@@ -53,8 +55,7 @@ public class LegacySubsystemFactory implements NamedFactory<Command>, CellMessag
     }
 
     @Override
-    public Command create()
-    {
+    public Command createSubsystem(ChannelSession channelSession) throws IOException {
         return new LegacyAdminShellCommand(_endpoint, _historyFile, _historySize, _prompt, _useColor);
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/NoTerminalCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/NoTerminalCommand.java
@@ -1,5 +1,6 @@
 package org.dcache.services.ssh2;
 
+import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
@@ -45,7 +46,7 @@ public class NoTerminalCommand implements Command, Runnable
     }
 
     @Override
-    public void destroy() {
+    public void destroy(ChannelSession channelSession) {
     }
 
     @Override
@@ -69,7 +70,7 @@ public class NoTerminalCommand implements Command, Runnable
     }
 
     @Override
-    public void start(Environment env) throws IOException {
+    public void start(ChannelSession channelSession, Environment env) throws IOException {
         _userAdminShell.setUser(env.getEnv().get(Environment.ENV_USER));
         CDC cdc = new CDC();
         _adminShellThread = new Thread(() -> cdc.execute(this));

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -117,7 +117,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
     }
 
     public void setPort(int port) {
-        _log.debug("Ssh2 port set to: {}", String.valueOf(port));
+        _log.debug("Ssh2 port set to: {}", port);
         _port = port;
     }
 

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -3,24 +3,24 @@ package org.dcache.services.ssh2;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
-import org.apache.sshd.common.Factory;
-import org.apache.sshd.common.FactoryManager;
-import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.common.PropertyResolverUtils;
+import org.apache.sshd.common.AttributeRepository;
 import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
 import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
 import org.apache.sshd.common.keyprovider.KeyPairProvider;
 import org.apache.sshd.common.session.Session;
 import org.apache.sshd.common.session.SessionListener;
-import org.apache.sshd.common.util.security.SecurityUtils;
-import org.apache.sshd.server.command.Command;
+import org.apache.sshd.core.CoreModuleProperties;
+import org.apache.sshd.server.auth.pubkey.AuthorizedKeyEntriesPublickeyAuthenticator;
 import org.apache.sshd.server.command.CommandFactory;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.gss.GSSAuthenticator;
 import org.apache.sshd.server.auth.password.PasswordAuthenticator;
-import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
+import org.apache.sshd.server.config.keys.AuthorizedKeysAuthenticator;
 import org.apache.sshd.server.session.ServerSession;
 
+import org.apache.sshd.server.shell.ShellFactory;
+import org.apache.sshd.server.subsystem.SubsystemFactory;
 import org.dcache.auth.LoginNamePrincipal;
 import org.dcache.auth.LoginReply;
 import org.dcache.auth.LoginStrategy;
@@ -38,15 +38,14 @@ import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosPrincipal;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.GeneralSecurityException;
 import java.security.PublicKey;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -78,6 +77,11 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
     private static final Logger _log = LoggerFactory.getLogger(Ssh2Admin.class);
     private static final Logger _accessLog =
             LoggerFactory.getLogger("org.dcache.access.ssh2");
+
+    /**
+     * Attribute to avoid double logging of public kay based logins.
+     */
+    public static final AttributeRepository.AttributeKey<Boolean> LOGGED = new AttributeRepository.AttributeKey<>();
 
     // get the user part from a public key line like
     // ... ssh-rsa AAAA...... user@hostname
@@ -151,7 +155,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
     }
 
     @Required
-    public void setShellFactory(Factory<Command> shellCommand) {
+    public void setShellFactory(ShellFactory shellCommand) {
         _server.setShellFactory(shellCommand);
     }
 
@@ -161,7 +165,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
     }
 
     @Required
-    public void setSubsystemFactories(List<NamedFactory<Command>> subsystemFactories)
+    public void setSubsystemFactories(List<SubsystemFactory> subsystemFactories)
     {
         _server.setSubsystemFactories(subsystemFactories);
     }
@@ -223,15 +227,16 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
     }
 
     private void configureKeyFiles() {
-        KeyPairProvider keyPair = SecurityUtils.createGeneratorHostKeyProvider(_hostKey);
+        KeyPairProvider keyPair = new FileKeyPairProvider(_hostKey);
         _server.setKeyPairProvider(keyPair);
     }
 
     private void startServer() {
-        long effectiveTimeout = _idleTimeoutUnit.toMillis(_idleTimeout);
-        PropertyResolverUtils.updateProperty(_server, FactoryManager.IDLE_TIMEOUT, effectiveTimeout);
-        // esure, that read timeout is longer than idle timeout
-        PropertyResolverUtils.updateProperty(_server, FactoryManager.NIO2_READ_TIMEOUT, effectiveTimeout*2);
+        // Duration#of is picky about overflows
+        Duration effectiveTimeout = Duration.ofMillis(_idleTimeoutUnit.toMillis(_idleTimeout));
+        CoreModuleProperties.IDLE_TIMEOUT.set(_server, effectiveTimeout);
+        // ensure, that read timeout is longer than idle timeout
+        CoreModuleProperties.NIO2_READ_TIMEOUT.set(_server, effectiveTimeout);
 
         _server.setPort(_port);
         _server.setHost(_host);
@@ -269,17 +274,6 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
                 .add("successful", successful)
                 .add("reason", reason)
                 .toLogger(_accessLog);
-
-        // set session parameter
-        if (successful) {
-            try {
-                session.setAuthenticated();
-                session.setUsername(username);
-            } catch (IOException e) {
-                _log.error("Failed to set Authenticated: {}",
-                        e.getMessage());
-            }
-        }
     }
 
     private class AdminPasswordAuthenticator implements PasswordAuthenticator {
@@ -316,7 +310,11 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
         }
     }
 
-    private class AdminPublickeyAuthenticator implements PublickeyAuthenticator {
+    private class AdminPublickeyAuthenticator extends AuthorizedKeysAuthenticator {
+
+        public AdminPublickeyAuthenticator() {
+            super(_authorizedKeyList.toPath());
+        }
 
         private String getUserFromKeyLine(String line) {
             Matcher m = _pubKeyFileUsername.matcher(line);
@@ -329,48 +327,39 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
         @Override
         public boolean authenticate(String userName, PublicKey key,
                 ServerSession session) {
-            boolean successful = false;
+
+            _log.debug("Authentication username set to: {} publicKey: {}", userName, key);
+
             String reason = null;
-            _log.debug("Authentication username set to: {} publicKey: {}",
-                    userName, key);
-            try {
-                for(AuthorizedKeyEntry ke: AuthorizedKeyEntry.readAuthorizedKeys(_authorizedKeyList.toPath())) {
-                    PublicKey publicKey = ke.resolvePublicKey(null);
-
-                    String hostspec = ke.getLoginOptions().getOrDefault("from", "");
-                    if (!isValidHost(hostspec, session)) {
-                        reason = "key file: publickey used from unallowed host";
-                        continue;
-                    }
-
-                    if (publicKey.equals(key)) {
-                        String keyUsername = getUserFromKeyLine(ke.getComment());
-                        if (keyUsername.isEmpty()) {
-                            reason = "key file: no username@host for publickey set";
-                            continue;
-                        }
-                        if (!keyUsername.equals(userName)) {
-                            reason = "key file: different username for "
-                                    + "publickey expected";
-                            continue;
-                        }
-                        successful = true;
-                        break;
-                    }
+            boolean successful = super.authenticate(userName, key, session);
+            if (successful) {
+                AuthorizedKeyEntry ke = session.getAttribute(AuthorizedKeyEntriesPublickeyAuthenticator.AUTHORIZED_KEY);
+                String hostspec = ke.getLoginOptions().getOrDefault("from", "");
+                if (!isValidHost(hostspec, session)) {
+                    reason = "key file: publickey used from unallowed host";
+                    successful = false;
                 }
-            } catch (FileNotFoundException e) {
-                _log.debug("File not found: {}", _authorizedKeyList);
-            } catch (IOException | GeneralSecurityException e) {
-                _log.error("Failed to read {}: {}", _authorizedKeyList,
-                        e.getMessage());
+                String keyUsername = getUserFromKeyLine(ke.getComment());
+                if (keyUsername.isEmpty()) {
+                    reason = "key file: no username@host for publickey set";
+                    successful = false;
+                }
+                if (!keyUsername.equals(userName)) {
+                    reason = "key file: different username for "
+                            + "publickey expected";
+                    successful = false;
+                }
+            } else {
+                reason = "key file: no matching key found";
             }
 
             // the method gets called twice while pubkey authentication,
-            // to avoid duplicate logging, check if already authenticated
-            if (!session.isAuthenticated()) {
-                String method = "PublicKey (" + key.getAlgorithm() + " "
-                        + KeyUtils.getFingerPrint(key) + ")";
+            // to avoid duplicate logging, check if already logged
+            // REVISIT: we need to investigate the reason of duplicate logging
+            if(session.getAttribute(LOGGED) == null) {
+                String method = "PublicKey (" + key.getAlgorithm() + " " + KeyUtils.getFingerPrint(key) + ")";
                 logLoginTry(userName, session, method, successful, reason);
+                session.setAttribute(LOGGED, true);
             }
             return successful;
         }

--- a/modules/dcache/src/main/resources/org/dcache/services/ssh2/ssh2Admin.xml
+++ b/modules/dcache/src/main/resources/org/dcache/services/ssh2/ssh2Admin.xml
@@ -64,7 +64,7 @@
         <property name="cellStub" ref="gplazma"/>
     </bean>
 
-    <bean id="shell-factory" class="org.dcache.services.ssh2.ShellFactory">
+    <bean id="shell-factory" class="org.dcache.services.ssh2.AdminShellFactory">
         <property name="historyFile" value="${admin.paths.history}"/>
         <property name="historySize" value="${admin.history.size}"/>
         <property name="useColor" value="${admin.enable.colors}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@
 	    <dependency>
 	      <groupId>org.apache.sshd</groupId>
 	      <artifactId>sshd-core</artifactId>
-	      <version>2.1.0</version>
+	      <version>2.7.0</version>
 	    </dependency>
             <dependency>
                 <!-- Newer versions have two problems. A performance regression causes it to block on non-responding network


### PR DESCRIPTION
Motivation:
The newer OSes disable by default unsecure ciphers and enforce the
stronger once.

Modification:
Update sshd-core to up-to-date version to make use of new ciphers.
Adjust code to match API changes. Mina-sshd provides methods to parse
and validate keys as well as internal caching. Make use of them ensures
the optimal use.

Result:
better compatibility with new ssh clients

Acked-by:
Target: master
Require-book: no
Require-notes: yes