### PR TITLE
webdav: fix regression from commit a2b252c07f

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
@@ -173,7 +173,7 @@ public class AuthenticationHandler extends HandlerWrapper {
             } catch (PermissionDeniedCacheException e) {
                 LOG.info("Login failed for {} on {}: {}", request.getMethod(),
                         request.getPathInfo(), e.getMessage());
-                servletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED,
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED,
                         e.getMessage());
                 baseRequest.setHandled(true);
             } catch (CacheException e) {


### PR DESCRIPTION
Motivation:

If the user attempts to use the WebDAV door without authenticating and
the door is configured with:

    webdav.authz.anonymous-operations=NONE

(which is the default) then dCache fails to include the
`WWW-Authenticate` header in the 401 response.  The result is that,
under these circumstances, a web-browsers does not prompt the user for
their password.

Modification:

Fix mistake where a login failure is send using the original
ServletResponse rather than the wrapped instance.

Result:

Fixed a regression in WebDAV where login failures and attempts to use
the door anonymously (when this is not allowed) fail without a
web-browser prompting the user to present their username + password.

Target: master
Request: 7.1
Requires-notes: yes
Requires-book: no
Closes: #5880
Ticket: https://rt.dcache.org/Ticket/Display.html?id=10159
Patch: https://rb.dcache.org/r/13145/
Acked-by: Tigran Mkrtchyan