### PR TITLE
src: unify all instances of logger to a same style

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/ActiveAdapter.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/proxy/ActiveAdapter.java
@@ -105,7 +105,7 @@ import static org.dcache.util.Strings.indentLines;
  */
 public class ActiveAdapter implements Runnable, ProxyAdapter
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(ActiveAdapter.class);
 
     /* After the transfer is completed we only expect the key for the
@@ -235,15 +235,15 @@ public class ActiveAdapter implements Runnable, ProxyAdapter
     }
 
     protected void say(String s) {
-        _log.info("ActiveAdapter: {}", s);
+        LOGGER.info("ActiveAdapter: {}", s);
     }
 
     protected void esay(String s) {
-        _log.error("ActiveAdapter: {}", s);
+        LOGGER.error("ActiveAdapter: {}", s);
     }
 
     protected void esay(Throwable t) {
-        _log.error(t.getMessage(), t);
+        LOGGER.error(t.getMessage(), t);
     }
 
     /*

--- a/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/pool/movers/GFtpProtocol_2_nio.java
@@ -59,7 +59,6 @@ import org.dcache.util.ChecksumType;
 import org.dcache.util.LineIndentingPrintWriter;
 import org.dcache.util.NetworkUtils;
 import org.dcache.util.PortRange;
-import org.dcache.util.TimeUtils;
 import org.dcache.vehicles.FileAttributes;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -73,7 +72,7 @@ import static org.dcache.util.Strings.*;
 public class GFtpProtocol_2_nio implements ConnectionMonitor,
         MoverProtocol, ChecksumMover, CellArgsAware
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
             LoggerFactory.getLogger(GFtpProtocol_2_nio.class);
     private static final Logger _logSpaceAllocation =
             LoggerFactory.getLogger("logger.dev.org.dcache.poolspacemonitor." +
@@ -247,7 +246,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
             _inProgress = true;
             _multiplexer.add(mode);
 
-            _log.trace("Entering event loop");
+            LOGGER.trace("Entering event loop");
             _multiplexer.loop();
         } catch (ClosedByInterruptException e) {
             /* Many NIO operations throw a ClosedByInterruptException
@@ -277,7 +276,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
 
             /* Close all open channels.
              */
-            _log.trace("Left event loop and closing channels");
+            LOGGER.trace("Left event loop and closing channels");
             _multiplexer.close();
 
             /* Log some useful information about the transfer.
@@ -285,10 +284,10 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
             long amount = getBytesTransferred();
             long time = getTransferTime();
             if (time > 0) {
-                _log.info("Transfer finished: {} bytes transferred in {} seconds = {} MB/s",
+                LOGGER.info("Transfer finished: {} bytes transferred in {} seconds = {} MB/s",
                                           amount, time / 1000.0, BYTES.toMiB(1000.0 * amount / time));
             } else {
-                _log.info("Transfer finished: {} bytes transferred in less than 1 ms", amount);
+                LOGGER.info("Transfer finished: {} bytes transferred in less than 1 ms", amount);
             }
         }
 
@@ -308,14 +307,14 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         }
 
         if (!ChecksumType.isValid(type)) {
-            _log.error("CRC Algorithm is not supported: {}", type);
+            LOGGER.error("CRC Algorithm is not supported: {}", type);
             return;
         }
 
         Optional<ChecksumChannel> checksumChannel = _fileChannel.optionallyAs(ChecksumChannel.class);
 
         if (!checksumChannel.isPresent()) {
-            _log.warn("Unable to calculate {} checksum as checksum"
+            LOGGER.warn("Unable to calculate {} checksum as checksum"
                     + " calculation is disabled for this transfer.", type);
             return;
         }
@@ -323,7 +322,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         try {
             checksumChannel.get().addType(ChecksumType.getChecksumType(type));
         } catch (IOException e) {
-            _log.error("Unable to add {} checksum calculation: {}",
+            LOGGER.error("Unable to add {} checksum calculation: {}",
                     type, org.dcache.util.Exceptions.messageOrClassName(e));
         }
     }
@@ -357,7 +356,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         ProtocolFamily protocolFamily = gftpProtocolInfo.getProtocolFamily();
         _fileChannel = fileChannel;
 
-        _log.debug("version={}, role={}, mode={}, host={} buffer={}, passive={}, parallelism={}",
+        LOGGER.debug("version={}, role={}, mode={}, host={} buffer={}, passive={}, parallelism={}",
                   version, role, gftpProtocolInfo.getMode(),
                   address, bufferSize, passive, parallelism);
 
@@ -471,18 +470,18 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
             long fileSize   = fileChannel.size();
             if (offset < 0) {
                 String err = "prm_offset is " + offset;
-                _log.error(err);
+                LOGGER.error(err);
                 throw new IllegalArgumentException(err);
             }
             if (size < 0) {
                 String err = "prm_offset is " + size;
-                _log.error(err);
+                LOGGER.error(err);
                 throw new IllegalArgumentException(err);
             }
             if (offset + size > fileSize) {
                 String err = "invalid prm_offset=" + offset + " and prm_size "
                         + size + " for file of size " + fileSize;
-                _log.error(err);
+                LOGGER.error(err);
                 throw new IllegalArgumentException(err);
             }
             mode.setPartialRetrieveParameters(offset, size);
@@ -505,7 +504,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
                 error.ifPresent(msg -> pw.println("Cause: " + msg));
                 getInfo(pw);
                 String info = sw.toString();
-                _log.warn("Incomplete transfer; details follow:\n{}",
+                LOGGER.warn("Incomplete transfer; details follow:\n{}",
                         info.substring(0, info.length()-1)); // Strip final '\n'
             }
 
@@ -582,7 +581,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         checkArgument(position >= 0, "Position must be non-negative");
         checkArgument(size >= 0, "Size must be non-negative");
 
-        _log.trace("received {} {}", position, size);
+        LOGGER.trace("received {} {}", position, size);
 
         _blockLog.addBlock(position, size);
         _bytesTransferred += size;
@@ -597,7 +596,7 @@ public class GFtpProtocol_2_nio implements ConnectionMonitor,
         checkArgument(position >= 0, "Position must be non-negative");
         checkArgument(size >= 0, "Size must be non-negative");
 
-        _log.trace("send {} {}", position, size);
+        LOGGER.trace("send {} {}", position, size);
 
         _blockLog.addBlock(position, size);
         _bytesTransferred += size;

--- a/modules/dcache/src/main/java/diskCacheV111/admin/LegacyAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/LegacyAdminShell.java
@@ -27,13 +27,9 @@ import diskCacheV111.util.PnfsId;
 import diskCacheV111.util.SpreadAndWait;
 import diskCacheV111.util.TimeoutCacheException;
 import diskCacheV111.vehicles.DCapProtocolInfo;
-import diskCacheV111.vehicles.Message;
 import diskCacheV111.vehicles.PnfsFlagMessage;
 import diskCacheV111.vehicles.PnfsGetCacheLocationsMessage;
 import diskCacheV111.vehicles.Pool2PoolTransferMsg;
-import diskCacheV111.vehicles.PoolLinkInfo;
-import diskCacheV111.vehicles.PoolMgrGetPoolByLink;
-import diskCacheV111.vehicles.PoolMgrGetPoolLinks;
 import diskCacheV111.vehicles.PoolMgrReplicateFileMsg;
 import diskCacheV111.vehicles.PoolModifyModeMessage;
 import diskCacheV111.vehicles.PoolModifyPersistencyMessage;
@@ -70,7 +66,7 @@ public class LegacyAdminShell
         extends CommandInterpreter
         implements Completer
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
             LoggerFactory.getLogger(LegacyAdminShell.class);
 
     private static final String ADMIN_COMMAND_NOOP = "xyzzy";
@@ -509,7 +505,7 @@ public class LegacyAdminShell
         try {
             spreader.waitForReplies();
         } catch (InterruptedException ex) {
-            _log.info("InterruptedException while waiting for a reply from pools {}", ex.toString());
+            LOGGER.info("InterruptedException while waiting for a reply from pools {}", ex.toString());
         }
 
         return spreader.getReplies();
@@ -1245,7 +1241,7 @@ public class LegacyAdminShell
             throw new IllegalArgumentException("Cannot cd to this cell as it doesn't exist.");
         } catch (CacheException e) {
             // Some other failure, but apparently the cell exists
-            _log.info("Cell probe failed: {}", e.getMessage());
+            LOGGER.info("Cell probe failed: {}", e.getMessage());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -1264,14 +1260,14 @@ public class LegacyAdminShell
             }
             return _completer.complete(buffer, cursor, candidates);
         } catch (Exception e) {
-            _log.info("Completion failed: {}", e.toString());
+            LOGGER.info("Completion failed: {}", e.toString());
             return -1;
         }
     }
 
     public Object executeCommand(String str) throws CommandException, InterruptedException, NoRouteToCellException
     {
-        _log.info("String command (super) {}", str);
+        LOGGER.info("String command (super) {}", str);
 
         if (str.trim().isEmpty()) {
             return "";
@@ -1312,7 +1308,7 @@ public class LegacyAdminShell
 
     private Object localCommand(Args args) throws CommandException
     {
-        _log.info("Local command {}", args);
+        LOGGER.info("Local command {}", args);
         Object or = command(args);
         if (or == null) {
             return "";
@@ -1386,7 +1382,7 @@ public class LegacyAdminShell
     public Object executeCommand(CellPath destination, Object str)
             throws InterruptedException, TimeoutCacheException, NoRouteToCellException
     {
-        _log.info("Object command ({}) {}",destination, str);
+        LOGGER.info("Object command ({}) {}",destination, str);
 
         return sendCommand(destination, str.toString());
     }

--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserAdminShell.java
@@ -101,7 +101,7 @@ public class UserAdminShell
         extends CommandInterpreter
         implements Completer
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
             LoggerFactory.getLogger(UserAdminShell.class);
 
     private static final Logger ACCESS_LOGGER =
@@ -332,7 +332,7 @@ public class UserAdminShell
         /* Log and ignore any errors. */
         return catchingAsync(future, Throwable.class,
                              t -> {
-                                 _log.debug("Failed to query the System cell of domain {}: {}", domain, t);
+                                 LOGGER.debug("Failed to query the System cell of domain {}: {}", domain, t);
                                  return immediateFuture(emptyList());
                              });
     }
@@ -645,7 +645,7 @@ public class UserAdminShell
                     throw new CommandException(1, "Cell does not exist.");
                 }
                 // Some other failure, but apparently the cell exists
-                _log.info("Cell probe failed: {}", e.getCause().toString());
+                LOGGER.info("Cell probe failed: {}", e.getCause().toString());
                 return new Position(cell, path);
             }
         }
@@ -866,7 +866,7 @@ public class UserAdminShell
             }
             return _completer.complete(buffer, cursor, candidates);
         } catch (CommandException | NoRouteToCellException e) {
-            _log.info("Completion failed: {}", e.toString());
+            LOGGER.info("Completion failed: {}", e.toString());
             return -1;
         } catch (InterruptedException | AclException e) {
             return -1;
@@ -892,7 +892,7 @@ public class UserAdminShell
             }
             return 0;
         } catch (CacheException | NoRouteToCellException | ExecutionException e) {
-            _log.info("Completion failed: {}", e.toString());
+            LOGGER.info("Completion failed: {}", e.toString());
             return -1;
         } catch (InterruptedException e) {
             return -1;
@@ -932,7 +932,7 @@ public class UserAdminShell
             }
             return 0;
         } catch (CacheException | NoRouteToCellException | ExecutionException e) {
-            _log.info("Completion failed: {}", e.toString());
+            LOGGER.info("Completion failed: {}", e.toString());
             return -1;
         } catch (InterruptedException e) {
             return -1;
@@ -995,7 +995,7 @@ public class UserAdminShell
             } catch (InterruptedException e) {
                 return -1;
             } catch (CacheException e) {
-                _log.info("Completion failed: {}", e.toString());
+                LOGGER.info("Completion failed: {}", e.toString());
                 return -1;
             }
             return endIndex + 1;
@@ -1020,7 +1020,7 @@ public class UserAdminShell
                     return arguments.completeTail(createRemoteCompleter(new CellPath(Iterables.get(locations, 0))));
                 }
             } catch (CacheException | NoRouteToCellException e) {
-                _log.info("Completion failed: {}", e.toString());
+                LOGGER.info("Completion failed: {}", e.toString());
                 return -1;
             } catch (InterruptedException e) {
                 return -1;
@@ -1110,7 +1110,7 @@ public class UserAdminShell
             HelpCompleter completer = new HelpCompleter(String.valueOf(help));
             return completer.complete(buffer, cursor, candidates);
         } catch (NoRouteToCellException | CommandException | AclException e) {
-            _log.info("Completion failed: {}", e.toString());
+            LOGGER.info("Completion failed: {}", e.toString());
             return -1;
         } catch (InterruptedException e) {
             return -1;
@@ -1119,7 +1119,7 @@ public class UserAdminShell
 
     public Object executeCommand(String str) throws CommandException, InterruptedException, NoRouteToCellException, AclException
     {
-        _log.info("String command (super) {}", str);
+        LOGGER.info("String command (super) {}", str);
 
         if (str.trim().isEmpty()) {
             return "";
@@ -1147,7 +1147,7 @@ public class UserAdminShell
 
     private Serializable localCommand(Args args) throws CommandException
     {
-        _log.info("Local command {}", args);
+        LOGGER.info("Local command {}", args);
         Object or = command(args);
         if (or == null) {
             return "";

--- a/modules/dcache/src/main/java/diskCacheV111/admin/UserMetaDataProviderFnal.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/UserMetaDataProviderFnal.java
@@ -21,7 +21,7 @@ import org.dcache.util.Args;
  */
 public class UserMetaDataProviderFnal implements UserMetaDataProvider {
 
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(UserMetaDataProviderFnal.class);
 
     private final CellAdapter _cell    ;
@@ -131,27 +131,27 @@ public class UserMetaDataProviderFnal implements UserMetaDataProvider {
             authf = new KAuthFile(_kpwdFilePath);
         }
         catch ( Exception e ) {
-            _log.warn("User authentication file not found: {}", e.toString());
+            LOGGER.warn("User authentication file not found: {}", e.toString());
             return answer;
         }
         if (userRole.startsWith("UNSPECIFIED")) {
 
             userRole = authf.getIdMapping(userPrincipal);
-            _log.warn("userRole={}", userRole);
+            LOGGER.warn("userRole={}", userRole);
 
             if(userRole == null) {
-                _log.warn("User {} not found.", userPrincipal);
+                LOGGER.warn("User {} not found.", userPrincipal);
                 return answer;
             }
         }
         pwdRecord = authf.getUserRecord(userRole);
         if( pwdRecord == null ) {
-            _log.warn("User {} not found.", userRole);
+            LOGGER.warn("User {} not found.", userRole);
             return answer;
         }
 
         if( !((UserAuthRecord)pwdRecord).hasSecureIdentity(userPrincipal) ) {
-            _log.warn(userPrincipal+": Permission denied");
+            LOGGER.warn(userPrincipal+": Permission denied");
             return answer;
         }
         uid  = pwdRecord.UID;
@@ -162,7 +162,7 @@ public class UserMetaDataProviderFnal implements UserMetaDataProvider {
         answer.put("gid", String.valueOf(gid));
         answer.put("home", home);
 
-        _log.info("User {} logged in", userRole);
+        LOGGER.info("User {} logged in", userRole);
         return answer;
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -47,7 +47,7 @@ import static org.dcache.util.ByteUnit.BYTES;
 public class TransferObserverV1
     extends CellAdapter
     implements Runnable {
-    private static final Logger _log = LoggerFactory.getLogger(TransferObserverV1.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransferObserverV1.class);
 
     private final CellNucleus _nucleus;
     private final CellStub _cellStub;
@@ -300,7 +300,7 @@ public class TransferObserverV1
                 _update = Long.parseLong(updateString) * 1000L;
             }
         } catch (NumberFormatException e) {
-            _log.warn("Illegal value for -update: {}", updateString);
+            LOGGER.warn("Illegal value for -update: {}", updateString);
         }
 
         useInterpreter(true);
@@ -421,7 +421,7 @@ public class TransferObserverV1
                     collectDataSequentially();
                     _timeUsed = System.currentTimeMillis() - start;
                 } catch (RuntimeException ee) {
-                    _log.error(ee.toString(), ee);
+                    LOGGER.error(ee.toString(), ee);
                 }
 
                 synchronized (this) {
@@ -429,7 +429,7 @@ public class TransferObserverV1
                 }
             }
         } catch (InterruptedException e) {
-            _log.info("Data collector interrupted");
+            LOGGER.info("Data collector interrupted");
         }
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/cells/WebCollectorV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/WebCollectorV3.java
@@ -38,7 +38,7 @@ import static org.dcache.util.ByteUnit.BYTES;
 
 public class WebCollectorV3 extends CellAdapter implements Runnable
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(WebCollectorV3.class);
 
     protected static final String OPTION_REPEATHEADER = "repeatHeader";
@@ -75,7 +75,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
         {
             long start = System.currentTimeMillis();
             wait(_mode ? _shortPeriod / 2 : _regularPeriod / 2);
-            _log.debug("Woke up after {} millis", (System.currentTimeMillis() - start));
+            LOGGER.debug("Woke up after {} millis", (System.currentTimeMillis() - start));
         }
 
         private synchronized void setShortPeriod(long shortPeriod)
@@ -101,7 +101,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
                 if (!_mode) {
                     _mode = true;
                     notifyAll();
-                    _log.info("Aggressive changed to ON");
+                    LOGGER.info("Aggressive changed to ON");
                 }
 
             } else if (_mode &&
@@ -109,7 +109,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
                        (_shortPeriod * _retentionFactor)) {
                 _mode = false;
                 notifyAll();
-                _log.info("Aggressive changed to OFF");
+                LOGGER.info("Aggressive changed to OFF");
             }
 
         }
@@ -203,9 +203,9 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
                 optionString = _args.getOpt(OPTION_REPEATHEADER);
                 _repeatHeader = Math.max(0, Integer.parseInt(optionString));
             } catch (NumberFormatException e) {
-                _log.warn("Parsing error in in {} command : {}", OPTION_REPEATHEADER, optionString);
+                LOGGER.warn("Parsing error in in {} command : {}", OPTION_REPEATHEADER, optionString);
             }
-            _log.info("Repeat header set to {}", _repeatHeader);
+            LOGGER.info("Repeat header set to {}", _repeatHeader);
         }
 
         String optionString = _args.getOpt("aggressive");
@@ -215,7 +215,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
 
         aggressive = !aggressive;
 
-        _log.info("Aggressive mode : {}", aggressive);
+        LOGGER.info("Aggressive mode : {}", aggressive);
 
         _sleepHandler = new SleepHandler(aggressive);
     }
@@ -230,8 +230,8 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
         }
         _senderThread = _nucleus.newThread(this, "sender");
         _senderThread.start();
-        _log.info("Sender started");
-        _log.info("Collector will be started a bit delayed");
+        LOGGER.info("Sender started");
+        LOGGER.info("Collector will be started a bit delayed");
         _collectThread = _nucleus.newThread(WebCollectorV3.this, "collector");
         _collectThread.start();
     }
@@ -242,7 +242,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
         if (_infoMap.containsKey(address) || _queues.contains(address)) {
             return false;
         }
-        _log.debug("Adding {)", address);
+        LOGGER.debug("Adding {)", address);
         if (address.isLocalAddress()) {
             _queues.add(address);
             sendPing(address);
@@ -256,7 +256,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
 
     private void removeQuery(String destination)
     {
-        _log.debug("Removing {}", destination);
+        LOGGER.debug("Removing {}", destination);
         synchronized (_infoLock) {
             _infoMap.remove(new CellAddressCore(destination));
         }
@@ -280,7 +280,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
         } catch (InterruptedException e1) {
             return;
         }
-        _log.info("Collector now started as well");
+        LOGGER.info("Collector now started as well");
 
         try {
             while (!Thread.interrupted()) {
@@ -290,7 +290,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
                 _sleepHandler.sleep();
             }
         } catch (InterruptedException e) {
-            _log.info("Collector Thread interrupted");
+            LOGGER.info("Collector Thread interrupted");
         }
     }
 
@@ -312,19 +312,19 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
                 }
             }
         } catch (InterruptedException iie) {
-            _log.info("Sender Thread interrupted");
+            LOGGER.info("Sender Thread interrupted");
         }
     }
 
     private void sendPing(CellAddressCore address)
     {
-        _log.debug("Sending ping to : {}", address);
+        LOGGER.debug("Sending ping to : {}", address);
         sendMessage(new CellMessage(address, new PingMessage()));
     }
 
     private void sendQuery(CellQueryInfo info)
     {
-        _log.debug("Sending query to : {}", info.getDestination());
+        LOGGER.debug("Sending query to : {}", info.getDestination());
         sendMessage(info.getCellMessage());
     }
 
@@ -338,7 +338,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
         if (reply instanceof LoginBrokerInfo) {
             LoginBrokerInfo brokerInfo = (LoginBrokerInfo) reply;
             synchronized (_infoLock) {
-                _log.debug("Login broker reports: {}@{}", brokerInfo.getCellName(), brokerInfo.getDomainName());
+                LOGGER.debug("Login broker reports: {}@{}", brokerInfo.getCellName(), brokerInfo.getDomainName());
                 if (addQuery(new CellAddressCore(brokerInfo.getCellName(), brokerInfo.getDomainName()))) {
                     modified++;
                 }
@@ -357,14 +357,14 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
                     // We may have registered the cell as a well known cell
                     info = _infoMap.get(new CellAddressCore(address.getCellName()));
                     if (info == null) {
-                        _log.info("Unexpected reply arrived from: {}", path);
+                        LOGGER.info("Unexpected reply arrived from: {}", path);
                         return;
                     }
                 }
             }
 
             if (reply instanceof CellInfo) {
-                _log.debug("CellInfo: {}", ((CellInfo) reply).getCellName());
+                LOGGER.debug("CellInfo: {}", ((CellInfo) reply).getCellName());
                 info.infoArrived((CellInfo) reply);
             }
             if (reply instanceof PoolManagerCellInfo) {
@@ -673,7 +673,7 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
             double yellow  = round(100 * freespace / (float)total);
             double magenta = Math.max(0, 100 - red - green - yellow);
 
-            _log.info(cellInfo.getCellName() + " : " +
+            LOGGER.info(cellInfo.getCellName() + " : " +
                 ";total=" + total + ";free=" + freespace +
                 ";precious=" + precious + ";removable=" + removable);
 
@@ -847,9 +847,9 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
     private synchronized void printPoolActionTable2(HTMLBuilder page)
     {
         // get the translated list
-        _log.debug("Preparing pool cost table");
+        LOGGER.debug("Preparing pool cost table");
         List<PoolCostEntry> list = preparePoolCostTable();
-        _log.debug("Preparing pool cost table done {}", list.size());
+        LOGGER.debug("Preparing pool cost table done {}", list.size());
         // calculate the totals ...
         TreeMap<String, int[]> moverMap = new TreeMap<>();
         int[][] total = new int[5][3];
@@ -961,11 +961,11 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
     @Override
     protected void stopping()
     {
-        _log.info("Clean Up sequence started");
+        LOGGER.info("Clean Up sequence started");
         //
         // wait for the worker to be done
         //
-        _log.info("Waiting for collector thread to be finished");
+        LOGGER.info("Waiting for collector thread to be finished");
         _collectThread.interrupt();
         _senderThread.interrupt();
         try {
@@ -980,9 +980,9 @@ public class WebCollectorV3 extends CellAdapter implements Runnable
     public void stopped()
     {
         _nucleus.getDomainContext().remove("cellInfoTable.html");
-        _log.info("cellInfoTable.html removed from domain context");
+        LOGGER.info("cellInfoTable.html removed from domain context");
 
-        _log.info("Clean Up sequence done");
+        LOGGER.info("Clean Up sequence done");
     }
 
     @Override

--- a/modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/CopyManager.java
@@ -51,7 +51,7 @@ import static org.dcache.util.TransferRetryPolicy.tryOnce;
 public class CopyManager extends AbstractCellComponent
     implements CellMessageReceiver, CellCommandListener, CellInfoProvider
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(CopyManager.class);
 
     private final Map<Integer, CopyHandler> _activeTransfers =
@@ -293,7 +293,7 @@ public class CopyManager extends AbstractCellComponent
                 CopyManagerMessage message =
                     (CopyManagerMessage) _envelope.getMessageObject();
                 try {
-                    _log.info("starting processing transfer message with id {}",
+                    LOGGER.info("starting processing transfer message with id {}",
                               message.getId());
 
                     copy(message.getSubject(),
@@ -324,14 +324,14 @@ public class CopyManager extends AbstractCellComponent
                     finishTransfer();
                     message.increaseNumberOfPerformedRetries();
                     if (requeue) {
-                        _log.info("putting on queue for retry: {}", _envelope);
+                        LOGGER.info("putting on queue for retry: {}", _envelope);
                         putOnQueue(_envelope);
                     } else {
                         try {
                             _envelope.revertDirection();
                             sendMessage(_envelope);
                         } catch (RuntimeException e) {
-                            _log.warn(e.toString(), e);
+                            LOGGER.warn(e.toString(), e);
                         }
                     }
                 }
@@ -396,11 +396,11 @@ public class CopyManager extends AbstractCellComponent
                 if (!_target.waitForMover(timeout)) {
                     throw new TimeoutCacheException("copy: wait for DoorTransferFinishedMessage expired");
                 }
-                _log.info("transfer finished successfully");
+                LOGGER.info("transfer finished successfully");
                 success = true;
             } catch (CacheException e) {
                 _target.setStatus("Failed: " + e.toString());
-                _log.warn(e.toString());
+                LOGGER.warn(e.toString());
                 explanation = "copy failed: " + e.getMessage();
                 throw e;
             } catch (InterruptedException e) {
@@ -477,20 +477,20 @@ public class CopyManager extends AbstractCellComponent
 
     private synchronized boolean newTransfer()
     {
-        _log.debug("newTransfer() numTransfers = {} maxTransfers = {}",
+        LOGGER.debug("newTransfer() numTransfers = {} maxTransfers = {}",
                    _numTransfers, _maxTransfers);
         if (_numTransfers == _maxTransfers) {
-            _log.debug("newTransfer() returns false");
+            LOGGER.debug("newTransfer() returns false");
             return false;
         }
-        _log.debug("newTransfer() INCREMENT and return true");
+        LOGGER.debug("newTransfer() INCREMENT and return true");
         _numTransfers++;
         return true;
     }
 
     private synchronized void finishTransfer()
     {
-        _log.debug("finishTransfer() numTransfers = {} DECREMENT",
+        LOGGER.debug("finishTransfer() numTransfers = {} DECREMENT",
                    _numTransfers);
         _numTransfers--;
     }

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/HsmControlOsm.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/HsmControlOsm.java
@@ -27,7 +27,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class HsmControlOsm extends CellAdapter implements Runnable {
 
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(HsmControlOsm.class);
 
     private static final int MAX_QUEUE_SIZE = 100 ;
@@ -80,24 +80,24 @@ public class HsmControlOsm extends CellAdapter implements Runnable {
             error = "Queue size exceeded "+ MAX_QUEUE_SIZE + ", Request rejected";
         }
        _failed ++ ;
-       _log.warn(error);
+       LOGGER.warn(error);
        ((Message)obj).setFailed( 33 , error ) ;
        msg.revertDirection() ;
        try{
           sendMessage( msg ) ;
        }catch(RuntimeException ee ){
-          _log.warn("Problem replying : {}", ee.toString() ) ;
+          LOGGER.warn("Problem replying : {}", ee.toString() ) ;
        }
     }
     @Override
     public void run(){
         // HsmControlGetBfDetailsMsg
-        _log.info("Starting working thread");
+        LOGGER.info("Starting working thread");
         try{
             while( true ){
                 CellMessage msg = _fifo.poll();
                 if( msg == null ){
-                    _log.warn("fifo empty");
+                    LOGGER.warn("fifo empty");
                     break ;
                 }
                 Message request = (Message)msg.getMessageObject() ;
@@ -114,24 +114,24 @@ public class HsmControlOsm extends CellAdapter implements Runnable {
                    try{
                       sendMessage( msg ) ;
                    }catch(RuntimeException ee ){
-                      _log.warn("Problem replying : {}", ee.toString() ) ;
+                      LOGGER.warn("Problem replying : {}", ee.toString() ) ;
                    }
                 }catch(Exception eee ){
                    _failed ++ ;
-                   _log.warn(eee.toString(), eee);
+                   LOGGER.warn(eee.toString(), eee);
                    request.setFailed( 34 , eee.toString() ) ;
                    msg.revertDirection() ;
                    try{
                       sendMessage( msg ) ;
                    }catch(RuntimeException ee ){
-                      _log.warn("Problem replying : {}", ee.toString() ) ;
+                      LOGGER.warn("Problem replying : {}", ee.toString() ) ;
                    }
                 }
             }
         }catch(Exception ee ){
-            _log.warn("Got exception from run while : {}", ee.toString());
+            LOGGER.warn("Got exception from run while : {}", ee.toString());
         }finally{
-            _log.info("Working thread finished");
+            LOGGER.info("Working thread finished");
         }
     }
     private final Map<String, Object[]> _driverMap = new HashMap<>() ;
@@ -201,7 +201,7 @@ public class HsmControlOsm extends CellAdapter implements Runnable {
         }
 
         HsmControllable hc = (HsmControllable)values[1] ;
-        _log.info("Controller found for {}  -> {}", hsm, values[0]);
+        LOGGER.info("Controller found for {}  -> {}", hsm, values[0]);
         hc.getBfDetails( storageInfo );
 
     }

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HsmFlushControlManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HsmFlushControlManager.java
@@ -47,7 +47,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class HsmFlushControlManager  extends CellAdapter {
 
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(HsmFlushControlManager.class);
 
     private final CellNucleus _nucleus;
@@ -109,7 +109,7 @@ public class HsmFlushControlManager  extends CellAdapter {
             try {
                 _getPoolCollectionTicker = Long.parseLong(tmp) * 60L * 1000L;
             } catch (Exception ee) {
-                _log.warn("Illegal value for poolCollectionUpdate : {} (choosing {} millis)", tmp, _getPoolCollectionTicker);
+                LOGGER.warn("Illegal value for poolCollectionUpdate : {} (choosing {} millis)", tmp, _getPoolCollectionTicker);
             }
         }
         tmp = args.getOpt("gainControlUpdate");
@@ -118,7 +118,7 @@ public class HsmFlushControlManager  extends CellAdapter {
             try {
                 _queueWatch.setGainControlTicker(gainControlTicker = Long.parseLong(tmp) * 60L * 1000L);
             } catch (Exception ee) {
-                _log.warn(
+                LOGGER.warn(
                         "Illegal value for gainControlUpdate : {} (choosing {} millis)", tmp, gainControlTicker);
             }
         }
@@ -127,7 +127,7 @@ public class HsmFlushControlManager  extends CellAdapter {
             try {
                 _timerInterval = Long.parseLong(tmp) * 1000L;
             } catch (Exception ee) {
-                _log.warn("Illegal value for timer : {} (choosing {} millis)", tmp, _timerInterval);
+                LOGGER.warn("Illegal value for timer : {} (choosing {} millis)", tmp, _timerInterval);
             }
         }
         useInterpreter(true);
@@ -151,13 +151,13 @@ public class HsmFlushControlManager  extends CellAdapter {
        }
        @Override
        public void run(){
-          _log.info("QueueWatch started" ) ;
+          LOGGER.info("QueueWatch started" ) ;
 
           try{
-             _log.info("QueueWatch : waiting awhile before starting");
+             LOGGER.info("QueueWatch : waiting awhile before starting");
               Thread.sleep(10000);
           }catch(InterruptedException ie ){
-             _log.warn("QueueWatch: interrupted during initial wait. Stopping");
+             LOGGER.warn("QueueWatch: interrupted during initial wait. Stopping");
              return ;
           }
           _status = "Running Collector" ;
@@ -196,7 +196,7 @@ public class HsmFlushControlManager  extends CellAdapter {
                 }
              }
           }
-          _log.info( "QueueWatch stopped" ) ;
+          LOGGER.info( "QueueWatch stopped" ) ;
        }
        public synchronized void triggerGainControl(){
           next_sendGainControl = System.currentTimeMillis() - 10 ;
@@ -234,7 +234,7 @@ public class HsmFlushControlManager  extends CellAdapter {
                                _control ? gainControlInterval : 0L);
 
                if (LOG_ENABLED) {
-                   _log.info("sendFlushControlMessage : sending PoolFlushGainControlMessage to {}", poolName);
+                   LOGGER.info("sendFlushControlMessage : sending PoolFlushGainControlMessage to {}", poolName);
                }
                sendMessage(new CellMessage(new CellPath(poolName), msg));
            }
@@ -403,7 +403,7 @@ public class HsmFlushControlManager  extends CellAdapter {
            sendMessage( new CellMessage( new CellAddressCore("PoolManager") , msg ) ) ;
 
        }catch(RuntimeException ee ){
-           _log.warn("setPoolReadOnly : couldn't sent message to PoolManager{}", ee.toString());
+           LOGGER.warn("setPoolReadOnly : couldn't sent message to PoolManager{}", ee.toString());
        }
     }
     private void queryPoolMode( String poolName ){
@@ -417,7 +417,7 @@ public class HsmFlushControlManager  extends CellAdapter {
            sendMessage( new CellMessage( new CellAddressCore("PoolManager") , msg ) ) ;
 
        }catch(RuntimeException ee ){
-           _log.warn("queryPoolMode : couldn't sent message to PoolManager{}", ee.toString());
+           LOGGER.warn("queryPoolMode : couldn't sent message to PoolManager{}", ee.toString());
        }
     }
     private class PoolCollector implements FutureCallback<Object[]>
@@ -466,7 +466,7 @@ public class HsmFlushControlManager  extends CellAdapter {
        }
        private synchronized void runCollector( Collection<String> list ){
            if( _active ){
-              _log.warn("runCollector : Still running") ;
+              LOGGER.warn("runCollector : Still running") ;
               return ;
            }
            _active = true ;
@@ -474,7 +474,7 @@ public class HsmFlushControlManager  extends CellAdapter {
            for (Object o : list) {
                String command = "psux ls pgroup " + o;
                if (LOG_ENABLED) {
-                   _log.info("runCollector sending : {} to {}", command, path);
+                   LOGGER.info("runCollector sending : {} to {}", command, path);
                }
                Futures.addCallback(_poolManager.send(command, Object[].class), this);
                _waitingFor++;
@@ -484,19 +484,19 @@ public class HsmFlushControlManager  extends CellAdapter {
           _waitingFor-- ;
           if( _waitingFor == 0 ){
              if(LOG_ENABLED) {
-                 _log.info("PoolCollector : we are done : {}", _poolGroupHash);
+                 LOGGER.info("PoolCollector : we are done : {}", _poolGroupHash);
              }
              _active = false ;
              HashMap<String, HFCPool> map = new HashMap<>() ;
              if(LOG_ENABLED) {
-                 _log.info("Creating ping set");
+                 LOGGER.info("Creating ping set");
              }
               for (Object o : _poolGroupHash.values()) {
                   Object[] c = (Object[]) o;
                   for (Object aC : c) {
                       String pool = (String) aC;
                       if (LOG_ENABLED) {
-                          _log.info("Adding pool : {}", pool);
+                          LOGGER.info("Adding pool : {}", pool);
                       }
                       HFCPool p = _configuredPoolList.get(pool);
                       map.put(pool, p == null ? new HFCPool(pool) : p);
@@ -536,16 +536,16 @@ public class HsmFlushControlManager  extends CellAdapter {
         public void onSuccess(Object[] reply)
         {
             if(LOG_ENABLED) {
-                _log.info("answer Arrived: {}", Arrays.toString(reply));
+                LOGGER.info("answer Arrived: {}", Arrays.toString(reply));
             }
             if (reply.length >= 3 && reply[0] instanceof String && reply[1] instanceof Object []) {
                 String poolGroupName = (String) reply[0] ;
                 _poolGroupHash.put( poolGroupName , (Object[]) reply[1]);
                 if(LOG_ENABLED) {
-                    _log.info("PoolCollector : {} pools arrived for {}", ((Object[]) reply[1]).length, poolGroupName);
+                    LOGGER.info("PoolCollector : {} pools arrived for {}", ((Object[]) reply[1]).length, poolGroupName);
                 }
             }else{
-                _log.warn("PoolCollector : invalid reply arrived");
+                LOGGER.warn("PoolCollector : invalid reply arrived");
             }
             answer();
         }
@@ -553,7 +553,7 @@ public class HsmFlushControlManager  extends CellAdapter {
         @Override
         public void onFailure(Throwable t)
         {
-            _log.warn("PoolCollector : onFailure : {}", t.toString());
+            LOGGER.warn("PoolCollector : onFailure : {}", t.toString());
             answer() ;
         }
     }
@@ -941,7 +941,7 @@ public class HsmFlushControlManager  extends CellAdapter {
            Event   event;
            boolean done     = false ;
            boolean initDone = false ;
-           _log.info(_printoutName+": Worker event loop started for "+_schedulerName );
+           LOGGER.info(_printoutName+": Worker event loop started for "+_schedulerName );
 
            while( ( ! Thread.interrupted() ) && ( ! done ) ){
 
@@ -1035,11 +1035,11 @@ public class HsmFlushControlManager  extends CellAdapter {
 
                    }
                }catch(Throwable t ){
-                   _log.warn(_printoutName+": Exception reported by "+event.type+" : "+t, t);
+                   LOGGER.warn(_printoutName+": Exception reported by "+event.type+" : "+t, t);
                }
            }
-           _log.info(_printoutName+": Worker event loop stopped");
-           _log.info(_printoutName+": Preparing unload");
+           LOGGER.info(_printoutName+": Worker event loop stopped");
+           LOGGER.info(_printoutName+": Preparing unload");
 
            synchronized( this ){
 
@@ -1050,7 +1050,7 @@ public class HsmFlushControlManager  extends CellAdapter {
                try{
                    _scheduler.prepareUnload() ;
                }catch(Throwable t ){
-                   _log.warn(_printoutName+": Exception in prepareUnload "+t, t);
+                   LOGGER.warn(_printoutName+": Exception in prepareUnload "+t, t);
                }
 
                _scheduler = null ;
@@ -1219,19 +1219,19 @@ public class HsmFlushControlManager  extends CellAdapter {
     //
     private void poolFlushDoFlushMessageArrived( PoolFlushDoFlushMessage msg ){
         if(LOG_ENABLED) {
-            _log.info("poolFlushDoFlushMessageArrived : {}", msg);
+            LOGGER.info("poolFlushDoFlushMessageArrived : {}", msg);
         }
         String poolName  = msg.getPoolName() ;
         synchronized( _poolCollector ){
             HFCPool pool = _poolCollector.getPoolByName( poolName) ;
             if( pool == null ){
-               _log.warn("poolFlushDoFlushMessageArrived : message arrived for non configured pool : {}", poolName);
+               LOGGER.warn("poolFlushDoFlushMessageArrived : message arrived for non configured pool : {}", poolName);
                return ;
             }
             String storageClass = msg.getStorageClassName()+"@"+msg.getHsmName() ;
             HFCFlushInfo info = pool.flushInfos.get( storageClass );
             if( info == null ){
-               _log.warn("poolFlushDoFlushMessageArrived : message arrived for non existing storage class : {}", storageClass);
+               LOGGER.warn("poolFlushDoFlushMessageArrived : message arrived for non existing storage class : {}", storageClass);
                //
                // the real one doesn't exists anymore, so we simulate one.
                //
@@ -1239,7 +1239,7 @@ public class HsmFlushControlManager  extends CellAdapter {
             }
             if( msg.getReturnCode() != 0 ){
                if(LOG_ENABLED) {
-                   _log.info("Flush failed (msg={}) : {}", (msg
+                   LOGGER.info("Flush failed (msg={}) : {}", (msg
                            .isFinished() ? "Finished" : "Ack"), msg);
                }
 
@@ -1251,7 +1251,7 @@ public class HsmFlushControlManager  extends CellAdapter {
             }
             if( msg.isFinished() ){
                 if(LOG_ENABLED) {
-                    _log.info("Flush finished : {}", msg);
+                    LOGGER.info("Flush finished : {}", msg);
                 }
 
                 updateFlushCellAndFlushInfos( msg , pool ) ;
@@ -1264,12 +1264,12 @@ public class HsmFlushControlManager  extends CellAdapter {
     }
     private void poolFlushGainControlMessageDidntArrive( String poolName ){
         if(LOG_ENABLED) {
-            _log.info("poolFlushGainControlMessageDidntArrive : {}", poolName);
+            LOGGER.info("poolFlushGainControlMessageDidntArrive : {}", poolName);
         }
         synchronized( _poolCollector ){
             HFCPool pool = _poolCollector.getPoolByName( poolName) ;
             if( pool == null ){
-               _log.warn("PoolFlushGainControlMessage : message arrived for non configured pool : {}", poolName);
+               LOGGER.warn("PoolFlushGainControlMessage : message arrived for non configured pool : {}", poolName);
                return ;
             }
             pool.isActive    = false ;
@@ -1308,13 +1308,13 @@ public class HsmFlushControlManager  extends CellAdapter {
     }
     private void poolFlushGainControlMessageArrived( PoolFlushGainControlMessage msg ){
         if(LOG_ENABLED) {
-            _log.info("PoolFlushGainControlMessage : {}", msg);
+            LOGGER.info("PoolFlushGainControlMessage : {}", msg);
         }
         String poolName  = msg.getPoolName() ;
         synchronized( _poolCollector ){
             HFCPool pool = _poolCollector.getPoolByName( poolName) ;
             if( pool == null ){
-               _log.warn("PoolFlushGainControlMessage : message arrived for non configured pool : {}", poolName);
+               LOGGER.warn("PoolFlushGainControlMessage : message arrived for non configured pool : {}", poolName);
                return ;
             }
 
@@ -1325,14 +1325,14 @@ public class HsmFlushControlManager  extends CellAdapter {
     }
     private void poolModeInfoArrived( PoolManagerPoolModeMessage msg ){
         if(LOG_ENABLED) {
-            _log.info("PoolManagerPoolModeMessage : {}", msg);
+            LOGGER.info("PoolManagerPoolModeMessage : {}", msg);
         }
         String poolName  = msg.getPoolName() ;
         synchronized( _poolCollector ){
 
             HFCPool pool = _poolCollector.getPoolByName( poolName) ;
             if( pool == null ){
-               _log.warn("poolModeInfoArrived : message arrived for non configured pool : {}", poolName);
+               LOGGER.warn("poolModeInfoArrived : message arrived for non configured pool : {}", poolName);
                return ;
             }
             pool.mode = msg.getPoolMode() ;
@@ -1369,12 +1369,12 @@ public class HsmFlushControlManager  extends CellAdapter {
           CellPath        path = nrtc.getDestinationPath() ;
           CellAddressCore core = path.getDestinationAddress() ;
           String          cellName = core.getCellName() ;
-          _log.warn( "NoRouteToCell : {} ({})", cellName, path);
+          LOGGER.warn( "NoRouteToCell : {} ({})", cellName, path);
 
           poolFlushGainControlMessageDidntArrive( cellName ) ;
 
        }else{
-          _log.warn("Unknown message arrived ({}) : {}", msg.getSourcePath(), msg.getMessageObject() ) ;
+          LOGGER.warn("Unknown message arrived ({}) : {}", msg.getSourcePath(), msg.getMessageObject() ) ;
          _failed ++ ;
        }
     }

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HttpHsmFlushMgrEngineV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/HttpHsmFlushMgrEngineV1.java
@@ -35,7 +35,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageSender
 {
-   private static final Logger _log =
+   private static final Logger LOGGER =
        LoggerFactory.getLogger(HttpHsmFlushMgrEngineV1.class);
 
    private CellEndpoint _endpoint;
@@ -50,7 +50,7 @@ public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageS
    public HttpHsmFlushMgrEngineV1(String [] argsString ){
 
        for( int i = 0 ; i < argsString.length ; i++ ){
-          _log.info("HttpPoolMgrEngineV3 : argument : {} : {}", i, argsString[i]);
+          LOGGER.info("HttpPoolMgrEngineV3 : argument : {} : {}", i, argsString[i]);
           if( argsString[i].startsWith("css=") ){
               decodeCss( argsString[i].substring(4) ) ;
           }else if( argsString[i].startsWith("mgr=") ){
@@ -67,8 +67,8 @@ public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageS
           _managerList.add("FlushManager");
       }
 
-      _log.info("Using Manager  : {}", _managerList ) ;
-      _log.info("Using CSS file : {}", _cssFile ) ;
+      LOGGER.info("Using Manager  : {}", _managerList ) ;
+      LOGGER.info("Using CSS file : {}", _cssFile ) ;
 
    }
 
@@ -134,7 +134,7 @@ public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageS
 
              CellStub flushManager = new CellStub(_endpoint, new CellPath(flushManagerName), 20, SECONDS);
 
-             _log.info("MAP -> {}", optionsMap);
+             LOGGER.info("MAP -> {}", optionsMap);
 
              printFlushHeader( pw ,  "Flush Info");
              printDirectory( pw ) ;
@@ -342,7 +342,7 @@ public class HttpHsmFlushMgrEngineV1 implements HttpResponseEngine, CellMessageS
           output.append("Exception in command : ").append(command).append("\n") ;
           output.append("     ").append(e.getClass().getName()).
              append(" -> ").append( e.getMessage() ).append("\n") ;
-          _log.warn(e.toString());
+          LOGGER.warn(e.toString());
       }
    }
 

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/AlternateFlush.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/AlternateFlush.java
@@ -30,7 +30,7 @@ import org.dcache.util.Args;
  */
  public class AlternateFlush implements HsmFlushSchedulable {
 
-     private static final Logger _log =
+     private static final Logger LOGGER =
          LoggerFactory.getLogger(AlternateFlush.class);
 
      private HsmFlushControlCore _core;
@@ -110,7 +110,7 @@ import org.dcache.util.Args;
      private static final int QUERY_ALL_POOLS_IO_MODE = 1 ;
 
      public AlternateFlush( CellAdapter cell , HsmFlushControlCore core ){
-         _log.info("AlternateFlush started");
+         LOGGER.info("AlternateFlush started");
          _core        = core ;
          _interpreter = new CommandInterpreter( this ) ;
      }
@@ -122,7 +122,7 @@ import org.dcache.util.Args;
      @Override
      public void init(){
          if(_evt) {
-             _log.info("EVENT : Initiating ...");
+             LOGGER.info("EVENT : Initiating ...");
          }
 
          Args args = _core.getDriverArgs() ;
@@ -130,13 +130,13 @@ import org.dcache.util.Args;
          // printout what we got from our master
          //
          for( int i = 0 ; i < args.argc() ; i++ ){
-             _log.info("    args {} : {}", i, args.argv(i)) ;
+             LOGGER.info("    args {} : {}", i, args.argv(i)) ;
          }
          for( int i = 0 ; i < args.optc() ; i++ ){
-             _log.info("    opts {}={}", args.optv(i), args.getOpt(args.optv(i))) ;
+             LOGGER.info("    opts {}={}", args.optv(i), args.getOpt(args.optv(i))) ;
          }
          for (Object pool : _core.getConfiguredPools()) {
-             _log.info("    configured pool : {}", pool.toString());
+             LOGGER.info("    configured pool : {}", pool.toString());
          }
          //
          //  reset the pool modes of all pools we are responsible for.
@@ -146,7 +146,7 @@ import org.dcache.util.Args;
              HsmFlushControlCore.Pool pool = (HsmFlushControlCore.Pool) o;
              pool.setDriverHandle(new Pool(pool.getName(), pool));
              pool.setReadOnly(false);
-             _log.info("init : setting readonly=false : {}", pool.getName());
+             LOGGER.info("init : setting readonly=false : {}", pool.getName());
          }
 
      }
@@ -154,7 +154,7 @@ import org.dcache.util.Args;
      public void propertiesUpdated( Map<String,Object> properties ){
 
         if(_evt) {
-            _log.info("EVENT : propertiesUpdated : {}", properties);
+            LOGGER.info("EVENT : propertiesUpdated : {}", properties);
         }
 
         Set<String> keys = new HashSet<>( properties.keySet() ) ;
@@ -194,7 +194,7 @@ import org.dcache.util.Args;
                          }
                          _countToFlush = count;
                      } catch (Exception ee) {
-                         _log.warn("Exception while seting {} {}", key, ee.toString());
+                         LOGGER.warn("Exception while seting {} {}", key, ee.toString());
                      }
                  }
                  break;
@@ -210,7 +210,7 @@ import org.dcache.util.Args;
                          }
                          _flushAtOnce = count;
                      } catch (Exception ee) {
-                         _log.warn("Exception while seting {} {}", key, ee.toString());
+                         LOGGER.warn("Exception while seting {} {}", key, ee.toString());
                      }
                  }
                  break;
@@ -227,7 +227,7 @@ import org.dcache.util.Args;
 
                          _percentageToFlush = percent;
                      } catch (Exception ee) {
-                         _log.warn("Exception while seting {} {}", key, ee.toString());
+                         LOGGER.warn("Exception while seting {} {}", key, ee.toString());
                      }
                  }
                  break;
@@ -254,7 +254,7 @@ import org.dcache.util.Args;
      public void poolIoModeUpdated( String poolName ,  HsmFlushControlCore.Pool pool ){
 
          if(_evt) {
-             _log.info("EVENT : poolIoModeUpdated : {}", pool);
+             LOGGER.info("EVENT : poolIoModeUpdated : {}", pool);
          }
 
          Pool ip = getInternalPool( pool ) ;
@@ -266,12 +266,12 @@ import org.dcache.util.Args;
      public void flushingDone( String poolName , String storageClassName , HsmFlushControlCore.FlushInfo flushInfo  ){
 
          if(_evt) {
-             _log.info("EVENT : flushingDone : pool ={};class={}", poolName, storageClassName /* + "flushInfo="+flushInfo */);
+             LOGGER.info("EVENT : flushingDone : pool ={};class={}", poolName, storageClassName /* + "flushInfo="+flushInfo */);
          }
 
          HsmFlushControlCore.Pool pool = _core.getPoolByName( poolName ) ;
          if( pool == null ){
-            _log.warn("flushingDone for a non configured pool : {}", poolName);
+            LOGGER.warn("flushingDone for a non configured pool : {}", poolName);
             return ;
          }
 
@@ -282,7 +282,7 @@ import org.dcache.util.Args;
 
          if( ip.flushCounter <= 0 ){
              ip.flushCounter = 0 ;
-             _log.info("flushingDone : pool finished all flushing : {} ; setting back to readWrite mode", poolName);
+             LOGGER.info("flushingDone : pool finished all flushing : {} ; setting back to readWrite mode", poolName);
              pool.setReadOnly(false);
          }
      /*
@@ -296,13 +296,13 @@ import org.dcache.util.Args;
      @Override
      public void reset(){
          if(_evt) {
-             _log.info("EVENT : reset");
+             LOGGER.info("EVENT : reset");
          }
      }
      @Override
      public void timer(){
          if(_evt) {
-             _log.info("EVENT : timer");
+             LOGGER.info("EVENT : timer");
          }
          //
          //
@@ -318,7 +318,7 @@ import org.dcache.util.Args;
             }
             set.add( poolName ) ;
 
-            _log.info("timer : Good candidate to flush : {}", poolName);
+            LOGGER.info("timer : Good candidate to flush : {}", poolName);
 
             Pool ip = getInternalPool( pool ) ;
             if( ! ip.modeReady ) {
@@ -335,10 +335,10 @@ import org.dcache.util.Args;
      public void poolFlushInfoUpdated( String poolName , HsmFlushControlCore.Pool pool ){
 
          if(_evt) {
-             _log.info("EVENT : poolFlushInfoUpdated : {}", pool.getName());
+             LOGGER.info("EVENT : poolFlushInfoUpdated : {}", pool.getName());
          }
          if( ! pool.isActive() ){
-             _log.info( "poolFlushInfoUpdated : Pool : {} inactive", poolName);
+             LOGGER.info( "poolFlushInfoUpdated : Pool : {} inactive", poolName);
              return ;
          }
          //
@@ -353,7 +353,7 @@ import org.dcache.util.Args;
      @Override
      public void command( Args args  ){
          if(_evt) {
-             _log.info("EVENT : command : {}", args);
+             LOGGER.info("EVENT : command : {}", args);
          }
          if (args.argc() == 0) {
              return;
@@ -364,27 +364,27 @@ import org.dcache.util.Args;
                  throw new
                          Exception("Null pointer from command call");
              }
-             _log.info("Command returns : {}", reply.toString() );
+             LOGGER.info("Command returns : {}", reply.toString() );
          }catch(Exception ee ){
-             _log.warn("Command returns an exception ({}) : {}", ee.getClass().getName(), ee.toString());
+             LOGGER.warn("Command returns an exception ({}) : {}", ee.getClass().getName(), ee.toString());
          }
      }
      @Override
      public void prepareUnload(){
          if(_evt) {
-             _log.info("EVENT : Preparing unload (ignoring)");
+             LOGGER.info("EVENT : Preparing unload (ignoring)");
          }
      }
      @Override
      public void configuredPoolAdded( String poolName ){
 
          if(_evt) {
-             _log.info("EVENT : Configured pool added : {}", poolName);
+             LOGGER.info("EVENT : Configured pool added : {}", poolName);
          }
 
          HsmFlushControlCore.Pool pool = _core.getPoolByName( poolName ) ;
          if( pool == null ){
-            _log.warn("Pool not found in _core database : {}", poolName);
+            LOGGER.warn("Pool not found in _core database : {}", poolName);
             return ;
          }
 
@@ -396,13 +396,13 @@ import org.dcache.util.Args;
      @Override
      public void poolSetupUpdated(){
          if(_evt) {
-             _log.info("EVENT : Pool Setup updated (ignoring)");
+             LOGGER.info("EVENT : Pool Setup updated (ignoring)");
          }
      }
      @Override
      public void configuredPoolRemoved( String poolName ){
          if(_evt) {
-             _log.info("EVENT : Configured pool removed : {}  (ignoring)", poolName);
+             LOGGER.info("EVENT : Configured pool removed : {}  (ignoring)", poolName);
          }
      }
      //-------------------------------------------------------------------------------------------
@@ -424,7 +424,7 @@ import org.dcache.util.Args;
 
             Pool ip = (Pool)pool.getDriverHandle() ;
             if( ip == null ){
-               _log.warn("getInternalPool : Unconfigured pool arrived {}; configuring", pool.getName());
+               LOGGER.warn("getInternalPool : Unconfigured pool arrived {}; configuring", pool.getName());
                pool.setDriverHandle( ip = new Pool( pool.getName() , pool ) ) ;
             }
             return ip ;
@@ -445,18 +445,18 @@ import org.dcache.util.Args;
 
              long size = flush.getTotalPendingFileSize();
 
-             _log.info("flushPool : class = {} size = {} flushing = {}", info.getName(), size, info.isFlushing());
+             LOGGER.info("flushPool : class = {} size = {} flushing = {}", info.getName(), size, info.isFlushing());
              //
              // is precious size > 0 and are we not yet flushing ?
              //
              try {
                  if ((size > 0L) && !info.isFlushing()) {
-                     _log.info("flushPool : !!! flushing {} {}", pool.getName(), info.getName());
+                     LOGGER.info("flushPool : !!! flushing {} {}", pool.getName(), info.getName());
                      info.flush(_flushAtOnce);
                      flushing++;
                  }
              } catch (Exception ee) {
-                 _log.warn("flushPool : Problem flushing {} {} {}", pool.getName(), info.getName(), ee.toString());
+                 LOGGER.warn("flushPool : Problem flushing {} {} {}", pool.getName(), info.getName(), ee.toString());
              }
 
          }
@@ -512,7 +512,7 @@ import org.dcache.util.Args;
 
          for (HsmFlushControlCore.Pool pool : pools) {
              if (_ntf) {
-                 _log.info("nextToFlush : checking pool {}", pool);
+                 LOGGER.info("nextToFlush : checking pool {}", pool);
              }
 
              if (!pool.isActive()) {
@@ -523,7 +523,7 @@ import org.dcache.util.Args;
 
              if (ip.isFlushing()) {
                  if (_ntf) {
-                     _log.info("nextToFlush : is already flushing {}", pool.getName());
+                     LOGGER.info("nextToFlush : is already flushing {}", pool.getName());
                  }
              } else {
                  list.add(ip);
@@ -534,12 +534,12 @@ import org.dcache.util.Args;
          //
          if( list.size() < 2 ){
              if(_ntf) {
-                 _log.info("nextToFlush : currently not enough pools to write on ({})", list.size());
+                 LOGGER.info("nextToFlush : currently not enough pools to write on ({})", list.size());
              }
              return null ;
          }
          if(_ntf) {
-             _log.info("nextToFlush : possible candidates : {}", list);
+             LOGGER.info("nextToFlush : possible candidates : {}", list);
          }
          /**
            *  Get pool with highest pending file count and pool with highest
@@ -561,11 +561,11 @@ import org.dcache.util.Args;
              }
          }
          if(_ntf) {
-             _log.info("nextToFlush : highest percentage found for : {} ({})", poolWithHighestPercentage
+             LOGGER.info("nextToFlush : highest percentage found for : {} ({})", poolWithHighestPercentage
                      .pool.getName(), highestPercentage );
          }
          if(_ntf) {
-             _log.info("nextToFlush : highest counter    found for : {} ({})", poolWithHighestCounter
+             LOGGER.info("nextToFlush : highest counter    found for : {} ({})", poolWithHighestCounter
                      .pool.getName(), highestCounter );
          }
          if( highestPercentage > _percentageToFlush  ) {

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/AlternatingFlushSchedulerV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/AlternatingFlushSchedulerV1.java
@@ -39,7 +39,7 @@ import static org.dcache.util.ByteUnit.MiB;
  */
  public class AlternatingFlushSchedulerV1 implements HsmFlushSchedulable {
 
-     private static final Logger _log =
+     private static final Logger LOGGER =
          LoggerFactory.getLogger(AlternatingFlushSchedulerV1.class);
 
      private HsmFlushControlCore _core;
@@ -226,13 +226,13 @@ import static org.dcache.util.ByteUnit.MiB;
          public void poolIoModeUpdated( Pool ip , boolean newIsReadOnly ){
 
             if(_parameter._p_poolset) {
-                _log.info("PROGRESS-H({}/{}) new pool i/o mode {}", _name, ip._name, newIsReadOnly);
+                LOGGER.info("PROGRESS-H({}/{}) new pool i/o mode {}", _name, ip._name, newIsReadOnly);
             }
             //
             // new pool mode arrived, in wrong state
             //
             if( _progressState != PS_WAITING_FOR_STATE_CHANGE ){
-              _log.warn("PROGRESS-H({}/{}) Warning : new pool i/o mode arrived unexpectedly in state {}", _name,
+              LOGGER.warn("PROGRESS-H({}/{}) Warning : new pool i/o mode arrived unexpectedly in state {}", _name,
                       ip._name, _progressState);
               return ;
             }
@@ -240,7 +240,7 @@ import static org.dcache.util.ByteUnit.MiB;
             // wrong pool mode arrived
             //
             if( ip._expectedReadOnly != newIsReadOnly ){
-              _log.warn("PROGRESS-H({}/{}) Warning : got I/O mode rdonly={} expected rdOnly={}", _name,
+              LOGGER.warn("PROGRESS-H({}/{}) Warning : got I/O mode rdonly={} expected rdOnly={}", _name,
                       ip._name, newIsReadOnly, _expectedReadOnly);
               return ;
             }
@@ -260,7 +260,7 @@ import static org.dcache.util.ByteUnit.MiB;
                  }
              }
             if(_parameter._p_poolset) {
-                _log.info("PROGRESS-H({}/{}) new pool i/o mode total={};rdOnly={}", _name, ip._name, total, modeOk);
+                LOGGER.info("PROGRESS-H({}/{}) new pool i/o mode total={};rdOnly={}", _name, ip._name, total, modeOk);
             }
             //
             // not yet
@@ -275,7 +275,7 @@ import static org.dcache.util.ByteUnit.MiB;
                // all pools are readyOnly; flush them all.
                //
                if(_parameter._p_poolset) {
-                   _log.info("PROGRESS-H({}/{}) new pool i/o mode done; Flushing all", _name, ip._name);
+                   LOGGER.info("PROGRESS-H({}/{}) new pool i/o mode done; Flushing all", _name, ip._name);
                }
                int flushed = 0 ;
                 for (Object o : _poolMap.values()) {
@@ -288,19 +288,19 @@ import static org.dcache.util.ByteUnit.MiB;
                 }
                if( flushed > 0 ){
                   if(_parameter._p_poolset) {
-                      _log.info("PROGRESS-H(" + _name + "/" + ip._name + ") new pool i/o mode done; flushed " + flushed + " pools");
+                      LOGGER.info("PROGRESS-H(" + _name + "/" + ip._name + ") new pool i/o mode done; flushed " + flushed + " pools");
                   }
                   newState( PS_WAITING_FOR_FLUSH_DONE ) ;
                }else{
                   if(_parameter._p_poolset) {
-                      _log.info("PROGRESS-H({}/{}) new pool i/o mode done; nothing to flush; " +
+                      LOGGER.info("PROGRESS-H({}/{}) new pool i/o mode done; nothing to flush; " +
                               "switching back to read/write", _name, ip._name );
                   }
                   switchToNewPoolMode(false);
                }
             }else{
                if(_parameter._p_poolset) {
-                   _log.info("PROGRESS-H({}/{}) new pool i/o mode done; Switching back to IDLE", _name, ip._name );
+                   LOGGER.info("PROGRESS-H({}/{}) new pool i/o mode done; Switching back to IDLE", _name, ip._name );
                }
 
                newState( PS_IDLE ) ;
@@ -309,7 +309,7 @@ import static org.dcache.util.ByteUnit.MiB;
          public boolean inProgress(){ return _progressState != 0 ; }
          public void flushingDone( Pool ip  , String storageClassName , HsmFlushControlCore.FlushInfo flushInfo  ){
             if(_parameter._p_poolset) {
-                _log.info("PROGRESS-H({}/{}) flushingDone", _name, ip._name );
+                LOGGER.info("PROGRESS-H({}/{}) flushingDone", _name, ip._name );
             }
             //
             // check if all are done
@@ -327,7 +327,7 @@ import static org.dcache.util.ByteUnit.MiB;
                  }
              }
             if(_parameter._p_poolset) {
-                _log.info("PROGRESS-H(" + _name + "/" + ip._name + ") flushing done : total=" + total + ";flushDone=" + flushDone);
+                LOGGER.info("PROGRESS-H(" + _name + "/" + ip._name + ") flushing done : total=" + total + ";flushDone=" + flushDone);
             }
             if( flushDone < total ) {
                 return;
@@ -336,7 +336,7 @@ import static org.dcache.util.ByteUnit.MiB;
          }
          private void flushAll(){
             if(_parameter._p_poolset) {
-                _log.info("PROGRESS-H({}) flush all; switching to readOnly", _name );
+                LOGGER.info("PROGRESS-H({}) flush all; switching to readOnly", _name );
             }
             switchToNewPoolMode(true);
          }
@@ -376,7 +376,7 @@ import static org.dcache.util.ByteUnit.MiB;
 
          Pool ip = (Pool)pool.getDriverHandle() ;
          if( ip == null ){
-            _log.warn("getInternalPool : Yet unconfigured pool arrived {}; configuring", pool.getName());
+            LOGGER.warn("getInternalPool : Yet unconfigured pool arrived {}; configuring", pool.getName());
             pool.setDriverHandle( ip = new Pool( pool.getName() , pool ) ) ;
          }
          return ip ;
@@ -385,7 +385,7 @@ import static org.dcache.util.ByteUnit.MiB;
 
 
      public AlternatingFlushSchedulerV1( CellAdapter cell , HsmFlushControlCore core ){
-         _log.info("AlternateFlush started");
+         LOGGER.info("AlternateFlush started");
          _core        = core ;
          _interpreter = new CommandInterpreter( this ) ;
      }
@@ -396,7 +396,7 @@ import static org.dcache.util.ByteUnit.MiB;
      @Override
      public void init(){
          if(_parameter._p_events) {
-             _log.info("EVENT : Initiating ...");
+             LOGGER.info("EVENT : Initiating ...");
          }
 
          Args args = _core.getDriverArgs() ;
@@ -404,13 +404,13 @@ import static org.dcache.util.ByteUnit.MiB;
          // printout what we got from our master
          //
          for( int i = 0 ; i < args.argc() ; i++ ){
-             _log.info("    args {} : ", i, args.argv(i)) ;
+             LOGGER.info("    args {} : ", i, args.argv(i)) ;
          }
          for( int i = 0 ; i < args.optc() ; i++ ){
-             _log.info("    opts {}={}", args.optv(i), args.getOpt(args.optv(i))) ;
+             LOGGER.info("    opts {}={}", args.optv(i), args.getOpt(args.optv(i))) ;
          }
          for (Object o : _core.getConfiguredPools()) {
-             _log.info("    configured pool : {}", (o).toString());
+             LOGGER.info("    configured pool : {}", (o).toString());
          }
          //
          //  Walk through the already known pools, create our internal presentation
@@ -420,7 +420,7 @@ import static org.dcache.util.ByteUnit.MiB;
 
              HsmFlushControlCore.Pool pool = (HsmFlushControlCore.Pool) o;
              Pool ip = getInternalPool(pool);
-             _log.info("init : {} {}", pool.getName(), ip);
+             LOGGER.info("init : {} {}", pool.getName(), ip);
          }
          String tmp = args.getOpt("driver-config-file") ;
          if( tmp != null ) {
@@ -435,7 +435,7 @@ import static org.dcache.util.ByteUnit.MiB;
      @Override
      public void propertiesUpdated( Map<String,Object> properties ){
          if(_parameter._p_events) {
-             _log.info("EVENT : propertiesUpdated : {}", properties);
+             LOGGER.info("EVENT : propertiesUpdated : {}", properties);
          }
         _parameter.propertiesUpdated( properties ) ;
      }
@@ -447,11 +447,11 @@ import static org.dcache.util.ByteUnit.MiB;
      public void poolIoModeUpdated( String poolName ,  HsmFlushControlCore.Pool pool ){
 
          if(_parameter._p_events) {
-             _log.info("EVENT : poolIoModeUpdated : {}", pool);
+             LOGGER.info("EVENT : poolIoModeUpdated : {}", pool);
          }
 
          if( ! pool.isActive() ){
-            _log.warn("poolIoModeUpdated : Pool {} not yet active (ignoring)", poolName);
+            LOGGER.warn("poolIoModeUpdated : Pool {} not yet active (ignoring)", poolName);
             return ;
          }
 
@@ -468,16 +468,16 @@ import static org.dcache.util.ByteUnit.MiB;
      public void flushingDone( String poolName , String storageClassName , HsmFlushControlCore.FlushInfo flushInfo  ){
 
          if(_parameter._p_events) {
-             _log.info("EVENT : flushingDone : pool ={};class={}", poolName, storageClassName /* + "flushInfo="+flushInfo */);
+             LOGGER.info("EVENT : flushingDone : pool ={};class={}", poolName, storageClassName /* + "flushInfo="+flushInfo */);
          }
 
          HsmFlushControlCore.Pool pool = _core.getPoolByName( poolName ) ;
          if( pool == null ){
-            _log.warn("flushingDone : for a non configured pool : {}", poolName);
+            LOGGER.warn("flushingDone : for a non configured pool : {}", poolName);
             return ;
          }
          if( ! pool.isActive() ){
-            _log.warn("flushingDone : Pool {} not yet active (ignoring)", poolName);
+            LOGGER.warn("flushingDone : Pool {} not yet active (ignoring)", poolName);
             return ;
          }
 
@@ -495,11 +495,11 @@ import static org.dcache.util.ByteUnit.MiB;
      public void poolFlushInfoUpdated( String poolName , HsmFlushControlCore.Pool pool ){
 
          if(_parameter._p_events) {
-             _log.info("EVENT : poolFlushInfoUpdated : {}", pool.getName());
+             LOGGER.info("EVENT : poolFlushInfoUpdated : {}", pool.getName());
          }
          //
          if( ! pool.isActive() ){
-            _log.warn("poolFlushInfoUpdated : Pool {} not yet active (ignoring)", poolName);
+            LOGGER.warn("poolFlushInfoUpdated : Pool {} not yet active (ignoring)", poolName);
             return ;
          }
          Pool ip = getInternalPool( pool ) ;
@@ -510,13 +510,13 @@ import static org.dcache.util.ByteUnit.MiB;
      @Override
      public void reset(){
          if(_parameter._p_events) {
-             _log.info("EVENT : reset");
+             LOGGER.info("EVENT : reset");
          }
      }
      @Override
      public void timer(){
          if(_parameter._p_events) {
-             _log.info("EVENT : timer");
+             LOGGER.info("EVENT : timer");
          }
            //
            // check if the property file has been changed.
@@ -545,7 +545,7 @@ import static org.dcache.util.ByteUnit.MiB;
      @Override
      public void command( Args args  ){
          if(_parameter._p_events) {
-             _log.info("EVENT : command : {}", args);
+             LOGGER.info("EVENT : command : {}", args);
          }
          if (args.argc() == 0) {
              return;
@@ -556,31 +556,31 @@ import static org.dcache.util.ByteUnit.MiB;
                  throw new
                          Exception("Null pointer from command call");
              }
-             _log.info("Command returns : {}", reply.toString() );
+             LOGGER.info("Command returns : {}", reply.toString() );
          }catch(Exception ee ){
-             _log.warn("Command returns an exception ({}) : {}", ee.getClass().getName(), ee.toString());
+             LOGGER.warn("Command returns an exception ({}) : {}", ee.getClass().getName(), ee.toString());
          }
      }
      @Override
      public void prepareUnload(){
          if(_parameter._p_events) {
-             _log.info("EVENT : Preparing unload (ignoring)");
+             LOGGER.info("EVENT : Preparing unload (ignoring)");
          }
      }
      @Override
      public void configuredPoolAdded( String poolName ){
 
          if(_parameter._p_events) {
-             _log.info("EVENT : Configured pool added : {}", poolName);
+             LOGGER.info("EVENT : Configured pool added : {}", poolName);
          }
 
          HsmFlushControlCore.Pool pool = _core.getPoolByName( poolName ) ;
          if( pool == null ){
-            _log.warn("Pool not found in _core database : {}", poolName);
+            LOGGER.warn("Pool not found in _core database : {}", poolName);
             return ;
          }
          if( ! pool.isActive() ){
-            _log.warn("Pool {} not yet active (ignoring)", poolName);
+            LOGGER.warn("Pool {} not yet active (ignoring)", poolName);
             return ;
          }
          Pool ip = getInternalPool( pool ) ;
@@ -589,13 +589,13 @@ import static org.dcache.util.ByteUnit.MiB;
      @Override
      public void poolSetupUpdated(){
          if(_parameter._p_events) {
-             _log.info("EVENT : Pool Setup updated (ignoring)");
+             LOGGER.info("EVENT : Pool Setup updated (ignoring)");
          }
      }
      @Override
      public void configuredPoolRemoved( String poolName ){
          if(_parameter._p_events) {
-             _log.info("EVENT : Configured pool removed : {}  (ignoring)", poolName );
+             LOGGER.info("EVENT : Configured pool removed : {}  (ignoring)", poolName );
          }
      }
      //-----------------------------------------------------------------------------------------
@@ -605,7 +605,7 @@ import static org.dcache.util.ByteUnit.MiB;
      private void processPoolsetRules(){
 
          if(_parameter._p_rules) {
-             _log.info("RULES : Processing PoolSet Rules...");
+             LOGGER.info("RULES : Processing PoolSet Rules...");
          }
          int totalAvailable = 0 ;
          int totalReadOnly  = 0 ;
@@ -649,13 +649,13 @@ import static org.dcache.util.ByteUnit.MiB;
 
          }
          if(_parameter._p_rules) {
-             _log.info("RULES : statistics : total={};readOnly={};flushing={};progress={};candidates={}",
+             LOGGER.info("RULES : statistics : total={};readOnly={};flushing={};progress={};candidates={}",
                      totalAvailable, totalReadOnly, totalFlushing, inProgress, candidates.size());
          }
 
          if(candidates.isEmpty()){
             if(_parameter._p_rules) {
-                _log.info("RULES : no candidates found");
+                LOGGER.info("RULES : no candidates found");
             }
             return ;
          }
@@ -667,14 +667,14 @@ import static org.dcache.util.ByteUnit.MiB;
          if(_parameter._p_rules){
              for (Object candidate : candidates) {
                  Pool pp = (Pool) candidate;
-                 _log.info("RULES : weight of {} {}", pp._name, getPoolMetric(pp));
+                 LOGGER.info("RULES : weight of {} {}", pp._name, getPoolMetric(pp));
              }
          }
          Collections.sort( candidates , _poolComparator );
          //
          Pool ip = candidates.get(0);
          if(_parameter._p_rules) {
-             _log.info("RULES : weight of top " + ip._name + " " + getPoolMetric(ip));
+             LOGGER.info("RULES : weight of top " + ip._name + " " + getPoolMetric(ip));
          }
          //
          // step through all candidates and check if they would overbook the max number
@@ -687,7 +687,7 @@ import static org.dcache.util.ByteUnit.MiB;
              PoolSet ps = pp.getParentPoolSet();
 
              if (_parameter._p_rules) {
-                 _log.info("RULES : checking {}/ {} {}", pp._name, ps._name, getPoolMetric(pp));
+                 LOGGER.info("RULES : checking {}/ {} {}", pp._name, ps._name, getPoolMetric(pp));
              }
 
              Collection<String> potentialRdOnlyPools = new HashSet<>(rdOnlyHash);
@@ -695,13 +695,13 @@ import static org.dcache.util.ByteUnit.MiB;
                  potentialRdOnlyPools.add(o.toString());
              }
              if (_parameter._p_rules) {
-                 _log.info("RULES : potential rdOnlyPools : {}", potentialRdOnlyPools);
+                 LOGGER.info("RULES : potential rdOnlyPools : {}", potentialRdOnlyPools);
              }
              int total = potentialRdOnlyPools.size();
 
              if (total > (int) ((double) totalAvailable * _parameter._percentageToFlush)) {
                  if (_parameter._p_rules) {
-                     _log.info("RULES : {} would be too many pools ReadOnly ({} out of {})",
+                     LOGGER.info("RULES : {} would be too many pools ReadOnly ({} out of {})",
                              ps._name, total, totalAvailable );
                  }
                  continue;
@@ -712,13 +712,13 @@ import static org.dcache.util.ByteUnit.MiB;
          }
          if( best == null){
             if(_parameter._p_rules) {
-                _log.info("RULES : no candidates found after all");
+                LOGGER.info("RULES : no candidates found after all");
             }
             return ;
          }
 
          if(_parameter._p_rules) {
-             _log.info("RULES : flushing poolset : {} with pools {}", best._name, best.keySet());
+             LOGGER.info("RULES : flushing poolset : {} with pools {}", best._name, best.keySet());
          }
 
          best.flushAll() ;
@@ -777,17 +777,17 @@ import static org.dcache.util.ByteUnit.MiB;
            for (Map.Entry<String, PoolSet> hostEntry : _hostMap.entrySet()) {
                String hostName = hostEntry.getKey();
                PoolSet hostMap = hostEntry.getValue();
-               _log.info(" >>{}<<", hostName);
+               LOGGER.info(" >>{}<<", hostName);
                for (Map.Entry<String, Pool> e : hostMap.entrySet()) {
                    String name = e.getKey();
-                   _log.info("     {}{}", name, (extended ? e.getValue()
+                   LOGGER.info("     {}{}", name, (extended ? e.getValue()
                            .toString() : ""));
                }
            }
        }else if( configuredView ){
            for (Object o : _core.getConfiguredPools()) {
                HsmFlushControlCore.Pool pool = (HsmFlushControlCore.Pool) o;
-               _log.info(String.valueOf(pool));
+               LOGGER.info(String.valueOf(pool));
 
            }
 
@@ -831,19 +831,19 @@ import static org.dcache.util.ByteUnit.MiB;
 
              long size = flush.getTotalPendingFileSize();
 
-             _log.info("flushPool : class = {} size = {} flushing = {}", info.getName(), size, info.isFlushing());
+             LOGGER.info("flushPool : class = {} size = {} flushing = {}", info.getName(), size, info.isFlushing());
              //
              // is precious size > 0 and are we not yet flushing ?
              //
              try {
                  if ((size > 0L) && !info.isFlushing()) {
-                     _log.info("flushPool : !!! flushing {} of {} {}", _parameter._flushAtOnce, pool.
+                     LOGGER.info("flushPool : !!! flushing {} of {} {}", _parameter._flushAtOnce, pool.
                              getName(), info.getName());
                      info.flush(_parameter._flushAtOnce);
                      flushing++;
                  }
              } catch (Exception ee) {
-                 _log.warn("flushPool : Problem flushing {} {} {}", pool.getName(), info.getName(), ee.toString());
+                 LOGGER.warn("flushPool : Problem flushing {} {} {}", pool.getName(), info.getName(), ee.toString());
              }
 
          }
@@ -995,7 +995,7 @@ import static org.dcache.util.ByteUnit.MiB;
                         properties.remove(key);
                     }
                 } catch (Exception ee) {
-                    _log.warn("Exception while seting {} {}", key, ee.toString());
+                    LOGGER.warn("Exception while seting {} {}", key, ee.toString());
                 }
             }
            //

--- a/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/HandlerExample.java
+++ b/modules/dcache/src/main/java/diskCacheV111/hsmControl/flush/driver/HandlerExample.java
@@ -27,7 +27,7 @@ import org.dcache.util.Args;
  */
 public class HandlerExample implements HsmFlushSchedulable {
 
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(HandlerExample.class);
 
      private HsmFlushControlCore _core;
@@ -48,52 +48,52 @@ public class HandlerExample implements HsmFlushSchedulable {
      }
 
      public HandlerExample( CellAdapter cell , HsmFlushControlCore core ){
-         _log.info("HandlerExample started");
+         LOGGER.info("HandlerExample started");
          _core = core ;
          _interpreter = new CommandInterpreter( this ) ;
      }
      @Override
      public void init(){
-         _log.info("init called");
+         LOGGER.info("init called");
          Args args = _core.getDriverArgs() ;
          for( int i = 0 ; i < args.argc() ; i++ ){
-             _log.info("    args {} : ", i, args.argv(i)) ;
+             LOGGER.info("    args {} : ", i, args.argv(i)) ;
          }
          for( int i = 0 ; i < args.optc() ; i++ ){
-             _log.info("    opts {}={}", args.optv(i), args.getOpt(args.optv(i))) ;
+             LOGGER.info("    opts {}={}", args.optv(i), args.getOpt(args.optv(i))) ;
          }
          _doNothing = args.hasOption("do-nothing") ;
          _properties.put( "mode" , _doNothing ? "manual" : "auto" ) ;
 
          for (Object o : _core.getConfiguredPoolNames()) {
              String poolName = o.toString();
-             _log.info("    configured pool : {}{}", poolName, _core.getPoolByName(poolName).toString());
+             LOGGER.info("    configured pool : {}{}", poolName, _core.getPoolByName(poolName).toString());
              _poolHash.put(poolName, new Pool(poolName));
          }
      }
      @Override
      public void prepareUnload(){
-         _log.info("preparing unload");
+         LOGGER.info("preparing unload");
      }
      @Override
      public void configuredPoolAdded( String poolName ){
-         _log.info("configured pool added : {}", poolName);
+         LOGGER.info("configured pool added : {}", poolName);
 
      }
      @Override
      public void configuredPoolRemoved( String poolName ){
-         _log.info("configured pool removed : {}", poolName);
+         LOGGER.info("configured pool removed : {}", poolName);
          _poolHash.remove( poolName ) ;
      }
      @Override
      public void flushingDone( String poolName , String storageClassName , HsmFlushControlCore.FlushInfo flushInfo  ){
 
-         _log.info("flushingDone : pool ={};class={}", poolName, storageClassName /* + "flushInfo="+flushInfo */ );
+         LOGGER.info("flushingDone : pool ={};class={}", poolName, storageClassName /* + "flushInfo="+flushInfo */ );
 
      }
      @Override
      public void command( Args args  ){
-         _log.info("command : {}", args);
+         LOGGER.info("command : {}", args);
          if (args.argc() == 0) {
              return;
          }
@@ -105,10 +105,10 @@ public class HandlerExample implements HsmFlushSchedulable {
                          Exception("Null pointer from command call");
              }
 
-             _log.info("Command returns : {}", reply.toString() );
+             LOGGER.info("Command returns : {}", reply.toString() );
 
          }catch(Exception ee ){
-             _log.warn("Command returns an exception ({}) : {}", ee.getClass().getName(), ee.toString());
+             LOGGER.warn("Command returns an exception ({}) : {}", ee.getClass().getName(), ee.toString());
          }
      }
      public String ac_set_mode_$_1( Args args ){
@@ -131,19 +131,19 @@ public class HandlerExample implements HsmFlushSchedulable {
      }
      @Override
      public void poolSetupUpdated(){
-         _log.info("pool Setup updated");
+         LOGGER.info("pool Setup updated");
      }
      @Override
      public void poolIoModeUpdated( String poolName ,  HsmFlushControlCore.Pool pool ){
-         _log.info("pool io mode updated : {}", pool);
+         LOGGER.info("pool io mode updated : {}", pool);
      }
      @Override
      public void reset(){
-         _log.info("EVENT : reset");
+         LOGGER.info("EVENT : reset");
      }
      @Override
      public void timer(){
-         _log.info( "Timer at : {}", System.currentTimeMillis());
+         LOGGER.info( "Timer at : {}", System.currentTimeMillis());
      }
      @Override
      public void propertiesUpdated( Map<String,Object> properties )
@@ -201,7 +201,7 @@ public class HandlerExample implements HsmFlushSchedulable {
          }
 
          if( ! pool.isActive() ){
-             _log.info( "poolFlushInfoUpdated : Pool : {} inactive", poolName);
+             LOGGER.info( "poolFlushInfoUpdated : Pool : {} inactive", poolName);
              return ;
          }
          PoolCellInfo cellInfo = pool.getCellInfo() ;
@@ -212,7 +212,7 @@ public class HandlerExample implements HsmFlushSchedulable {
          long total    = spaceInfo.getTotalSpace() ;
          long precious = spaceInfo.getPreciousSpace() ;
 
-         _log.info( "poolFlushInfoUpdated : Pool : {};total={};precious={}", poolName, total, precious);
+         LOGGER.info( "poolFlushInfoUpdated : Pool : {};total={};precious={}", poolName, total, precious);
          //
          // loop over all storage classes of this pool and flush
          // those with have some files pending and which are not yet
@@ -228,18 +228,18 @@ public class HandlerExample implements HsmFlushSchedulable {
 
              long size = flush.getTotalPendingFileSize();
 
-             _log.info("poolFlushInfoUpdated :       class = {} size = {} flushing = {}", storageClass, size,
+             LOGGER.info("poolFlushInfoUpdated :       class = {} size = {} flushing = {}", storageClass, size,
                      info.isFlushing());
              //
              // is precious size > 0 and are we not yet flushing ?
              //
              try {
                  if ((size > 0L) && !info.isFlushing()) {
-                     _log.info("poolFlushInfoUpdated :       flushing {} {}", poolName, storageClass);
+                     LOGGER.info("poolFlushInfoUpdated :       flushing {} {}", poolName, storageClass);
                      info.flush(0);
                  }
              } catch (Exception ee) {
-                 _log.warn("poolFlushInfoUpdated : Problem flushing {} {} {}", poolName, storageClass, ee.toString());
+                 LOGGER.warn("poolFlushInfoUpdated : Problem flushing {} {} {}", poolName, storageClass, ee.toString());
              }
 
          }

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -147,7 +147,7 @@ public class PnfsManagerV3
     extends AbstractCellComponent
     implements CellCommandListener, CellMessageReceiver, CellInfoProvider, LeaderLatchListener
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(PnfsManagerV3.class);
 
     private static final int THRESHOLD_DISABLED = 0;
@@ -328,7 +328,7 @@ public class PnfsManagerV3
     {
         _cacheModificationRelay =
             Strings.isNullOrEmpty(path) ? null : new CellPath(path);
-        _log.info("CacheModificationRelay = {}",
+        LOGGER.info("CacheModificationRelay = {}",
                   (_cacheModificationRelay == null) ? "NONE" : _cacheModificationRelay.toString());
     }
 
@@ -337,7 +337,7 @@ public class PnfsManagerV3
     {
         _attributesRelay =
                         Strings.isNullOrEmpty(path) ? null : new CellPath(path);
-        _log.info("attributesRelay = {}",
+        LOGGER.info("attributesRelay = {}",
                   (_attributesRelay == null) ? "NONE" : _attributesRelay.toString());
     }
 
@@ -345,7 +345,7 @@ public class PnfsManagerV3
     public void setLogSlowThreshold(long threshold)
     {
         _logSlowThreshold = threshold;
-        _log.info("logSlowThreshold {}",
+        LOGGER.info("logSlowThreshold {}",
                   (_logSlowThreshold == THRESHOLD_DISABLED) ? "NONE" : String.valueOf(_logSlowThreshold));
     }
 
@@ -420,7 +420,7 @@ public class PnfsManagerV3
         _stub = new CellStub(getCellEndpoint());
 
         _fifos = new BlockingQueue[_threads];
-        _log.info("Starting {} threads", _fifos.length);
+        LOGGER.info("Starting {} threads", _fifos.length);
         for (int i = 0; i < _fifos.length; i++) {
             if (_queueMaxSize > 0) {
                 _fifos[i] = new LinkedBlockingQueue<>(_queueMaxSize);
@@ -481,7 +481,7 @@ public class PnfsManagerV3
                                                try {
                                                    updateFsStat();
                                                } catch (CacheException ignore) {
-                                                   _log.error("Failed to tun updateFsStat: {}", ignore.getMessage());
+                                                   LOGGER.error("Failed to tun updateFsStat: {}", ignore.getMessage());
                                                }
                                            }
                                        }),
@@ -1552,7 +1552,7 @@ public class PnfsManagerV3
 
             Object msgObject = envelope.getMessageObject();
             if (!(msgObject instanceof PnfsListDirectoryMessage)) {
-                _log.warn("Found non PnfsListDirectoryMessage {} on _listQueue", msgObject);
+                LOGGER.warn("Found non PnfsListDirectoryMessage {} on _listQueue", msgObject);
                 return;
             }
             PnfsListDirectoryMessage message = (PnfsListDirectoryMessage) msgObject;
@@ -1577,7 +1577,7 @@ public class PnfsManagerV3
         BlockingQueue<CellMessage> fifo = _fifos[queueId];
         Object[] fifoContent = fifo.toArray();
 
-        _log.warn("PnfsManager thread #{} queue dump ({}):", queueId, fifoContent.length);
+        LOGGER.warn("PnfsManager thread #{} queue dump ({}):", queueId, fifoContent.length);
 
         StringBuilder sb = new StringBuilder();
 
@@ -1586,7 +1586,7 @@ public class PnfsManagerV3
             sb.append(fifoContent[i]).append('\n');
         }
 
-        _log.warn( sb.toString() );
+        LOGGER.warn( sb.toString() );
     }
 
     private Set<Checksum> getChecksums(Subject subject, PnfsId pnfsId)
@@ -1605,7 +1605,7 @@ public class PnfsManagerV3
         String flagName  = pnfsMessage.getFlagName() ;
         String value     = pnfsMessage.getValue() ;
         Subject subject = pnfsMessage.getSubject();
-        _log.info("update flag "+operation+" flag="+flagName+" value="+
+        LOGGER.info("update flag "+operation+" flag="+flagName+" value="+
                   value+" for "+pnfsId);
 
         try{
@@ -1621,10 +1621,10 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException e) {
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (CacheException e) {
-            _log.warn("Exception in updateFlag: " + e);
+            LOGGER.warn("Exception in updateFlag: " + e);
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.error("Exception in updateFlag", e);
+            LOGGER.error("Exception in updateFlag", e);
             pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -1637,12 +1637,12 @@ public class PnfsManagerV3
         FileAttributes attributes;
         switch (operation) {
         case SET:
-            _log.info("flags set " + pnfsId + " " + flagName + "=" + value);
+            LOGGER.info("flags set " + pnfsId + " " + flagName + "=" + value);
             _nameSpaceProvider.setFileAttributes(subject, pnfsId,
                     FileAttributes.ofFlag(flagName, value), EnumSet.noneOf(FileAttribute.class));
             break;
         case SETNOOVERWRITE:
-            _log.info("flags set (dontoverwrite) " + pnfsId + " " + flagName + "=" + value);
+            LOGGER.info("flags set (dontoverwrite) " + pnfsId + " " + flagName + "=" + value);
             attributes = _nameSpaceProvider.getFileAttributes(subject, pnfsId, EnumSet.of(FileAttribute.FLAGS));
             String current = attributes.getFlags().get(flagName);
             if ((current == null) || (!current.equals(value))) {
@@ -1653,10 +1653,10 @@ public class PnfsManagerV3
         case GET:
             attributes = _nameSpaceProvider.getFileAttributes(subject, pnfsId, EnumSet.of(FileAttribute.FLAGS));
             String v = attributes.getFlags().get(flagName);
-            _log.info("flags ls " + pnfsId + " " + flagName + " -> " + v);
+            LOGGER.info("flags ls " + pnfsId + " " + flagName + " -> " + v);
             return v;
         case REMOVE:
-            _log.info("flags remove " + pnfsId + " " + flagName);
+            LOGGER.info("flags remove " + pnfsId + " " + flagName);
             _nameSpaceProvider.removeFileAttribute(subject, pnfsId, flagName);
             break;
         }
@@ -1664,7 +1664,7 @@ public class PnfsManagerV3
     }
 
     public void addCacheLocation(PnfsAddCacheLocationMessage pnfsMessage){
-        _log.info("addCacheLocation : {} for {}", pnfsMessage.getPoolName(), pnfsMessage.getPnfsId());
+        LOGGER.info("addCacheLocation : {} for {}", pnfsMessage.getPoolName(), pnfsMessage.getPnfsId());
         try {
             /* At this point, the file is no longer new and should
              * really have level 2 set. Otherwise we would not be able
@@ -1694,10 +1694,10 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException fnf ) {
             pnfsMessage.setFailed(CacheException.FILE_NOT_FOUND, fnf.getMessage() );
         } catch (CacheException e){
-            _log.warn("Exception in addCacheLocation: {}", e.toString());
+            LOGGER.warn("Exception in addCacheLocation: {}", e.toString());
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e){
-            _log.error("Exception in addCacheLocation", e);
+            LOGGER.error("Exception in addCacheLocation", e);
             pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,"Exception in addCacheLocation");
         }
 
@@ -1706,7 +1706,7 @@ public class PnfsManagerV3
 
     public void clearCacheLocation(PnfsClearCacheLocationMessage pnfsMessage){
         PnfsId pnfsId = pnfsMessage.getPnfsId();
-        _log.info("clearCacheLocation : {} for {}", pnfsMessage.getPoolName(), pnfsId);
+        LOGGER.info("clearCacheLocation : {} for {}", pnfsMessage.getPoolName(), pnfsId);
         try {
             checkMask(pnfsMessage);
             checkRestriction(pnfsMessage, UPDATE_METADATA);
@@ -1717,10 +1717,10 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException fnf ) {
             pnfsMessage.setFailed(CacheException.FILE_NOT_FOUND, fnf.getMessage() );
         } catch (CacheException e){
-            _log.warn("Exception in clearCacheLocation for {}: {}", pnfsId, e.toString());
+            LOGGER.warn("Exception in clearCacheLocation for {}: {}", pnfsId, e.toString());
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e){
-            _log.error("Exception in clearCacheLocation for "+pnfsId, e);
+            LOGGER.error("Exception in clearCacheLocation for "+pnfsId, e);
             pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e.getMessage() );
         }
 
@@ -1731,7 +1731,7 @@ public class PnfsManagerV3
         Subject subject = pnfsMessage.getSubject();
         try {
             PnfsId pnfsId = populatePnfsId(pnfsMessage);
-            _log.info("get cache locations for {}", pnfsId);
+            LOGGER.info("get cache locations for {}", pnfsId);
 
             checkMask(pnfsMessage);
             checkRestriction(pnfsMessage, READ_METADATA);
@@ -1740,10 +1740,10 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException fnf ) {
             pnfsMessage.setFailed(CacheException.FILE_NOT_FOUND, fnf.getMessage() );
         } catch (CacheException e){
-            _log.warn("Exception in getCacheLocations: {}", e.toString());
+            LOGGER.warn("Exception in getCacheLocations: {}", e.toString());
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e){
-            _log.error("Exception in getCacheLocations", e);
+            LOGGER.error("Exception in getCacheLocations", e);
             pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
                                   "Pnfs lookup failed");
         }
@@ -1821,7 +1821,7 @@ public class PnfsManagerV3
 
             switch (type) {
             case DIR:
-                _log.info("create directory {}", path);
+                LOGGER.info("create directory {}", path);
                 checkMkdirAllowed(pnfsMessage);
 
                 PnfsId pnfsId = _nameSpaceProvider.createDirectory(subject, path,
@@ -1837,7 +1837,7 @@ public class PnfsManagerV3
                 // We declare the request to be successful because
                 // the createEntry seem to be ok.
                 try{
-                    _log.info( "Trying to get storageInfo for {}", pnfsId);
+                    LOGGER.info( "Trying to get storageInfo for {}", pnfsId);
 
                     /* If we were allowed to create the entry above, then
                      * we also ought to be allowed to read it here. Hence
@@ -1845,12 +1845,12 @@ public class PnfsManagerV3
                      */
                     attrs = _nameSpaceProvider.getFileAttributes(ROOT, pnfsId, requested);
                 } catch (CacheException e) {
-                    _log.warn("Can't determine storageInfo: {}", e.toString());
+                    LOGGER.warn("Can't determine storageInfo: {}", e.toString());
                 }
                 break;
 
             case REGULAR:
-                _log.info("create file {}", path);
+                LOGGER.info("create file {}", path);
                 checkRestriction(pnfsMessage, UPLOAD);
                 requested.add(FileAttribute.STORAGEINFO);
                 requested.add(FileAttribute.PNFSID);
@@ -1875,7 +1875,7 @@ public class PnfsManagerV3
             case LINK:
                 checkArgument(pnfsMessage instanceof PnfsCreateSymLinkMessage);
                 String destination = ((PnfsCreateSymLinkMessage)pnfsMessage).getDestination();
-                _log.info("create symlink {} to {}", path, destination);
+                LOGGER.info("create symlink {} to {}", path, destination);
 
                 checkRestrictionOnParent(pnfsMessage, MANAGE);
 
@@ -1894,7 +1894,7 @@ public class PnfsManagerV3
         } catch (CacheException e) {
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.error("Bug found when creating entry:", e);
+            LOGGER.error("Bug found when creating entry:", e);
             pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -1916,7 +1916,7 @@ public class PnfsManagerV3
         } catch (CacheException e) {
             message.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.error("Create upload path failed", e);
+            LOGGER.error("Create upload path failed", e);
             message.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -1935,7 +1935,7 @@ public class PnfsManagerV3
         } catch (CacheException e) {
             message.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.error("Commit upload path failed", e);
+            LOGGER.error("Commit upload path failed", e);
             message.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -1971,7 +1971,7 @@ public class PnfsManagerV3
         } catch (CacheException e) {
             message.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.error("Cancel upload path failed", e);
+            LOGGER.error("Cancel upload path failed", e);
             message.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -1996,7 +1996,7 @@ public class PnfsManagerV3
             FileAttributes attributes;
 
             if (path != null) {
-                _log.info("delete PNFS entry for {}", path);
+                LOGGER.info("delete PNFS entry for {}", path);
                 if (pnfsId != null) {
                     attributes = _nameSpaceProvider.deleteEntry(subject, allowed,
                             pnfsId, path, requested);
@@ -2007,7 +2007,7 @@ public class PnfsManagerV3
                     pnfsMessage.setPnfsId(attributes.getPnfsId());
                 }
             } else {
-                _log.info("delete PNFS entry for {}", pnfsId);
+                LOGGER.info("delete PNFS entry for {}", pnfsId);
                 attributes = _nameSpaceProvider.deleteEntry(subject, allowed,
                         pnfsId, requested);
             }
@@ -2017,10 +2017,10 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException e) {
             pnfsMessage.setFailed(CacheException.FILE_NOT_FOUND, e.getMessage());
         } catch (CacheException e) {
-            _log.warn("Failed to delete entry: {}", e.getMessage());
+            LOGGER.warn("Failed to delete entry: {}", e.getMessage());
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.error("Failed to delete entry", e);
+            LOGGER.error("Failed to delete entry", e);
             pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -2039,7 +2039,7 @@ public class PnfsManagerV3
                 }
                 sourcePath = _nameSpaceProvider.pnfsidToPath(msg.getSubject(), pnfsId);
             }
-            _log.info("Rename {} to new name: {}", sourcePath, destinationPath);
+            LOGGER.info("Rename {} to new name: {}", sourcePath, destinationPath);
             checkRestriction(msg, MANAGE, FsPath.create(sourcePath).parent());
             checkRestriction(msg, MANAGE, FsPath.create(destinationPath).parent());
             boolean overwrite = msg.getOverwrite()
@@ -2048,7 +2048,7 @@ public class PnfsManagerV3
         } catch (CacheException e){
             msg.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.error(e.toString(), e);
+            LOGGER.error(e.toString(), e);
             msg.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
                           "Pnfs rename failed");
         }
@@ -2070,7 +2070,7 @@ public class PnfsManagerV3
         }
 
         try {
-            _log.info("map:  id2path for {}", pnfsId);
+            LOGGER.info("map:  id2path for {}", pnfsId);
             String path = pathfinder(subject, pnfsId);
             checkRestriction(pnfsMessage, READ_METADATA, FsPath.create(path));
             pnfsMessage.setGlobalPath(path);
@@ -2079,9 +2079,9 @@ public class PnfsManagerV3
             pnfsMessage.setFailed( CacheException.FILE_NOT_FOUND , fnf.getMessage() ) ;
         }catch (CacheException ce) {
             pnfsMessage.setFailed(ce.getRc(), ce.getMessage());
-            _log.warn("mapPath: {}", ce.getMessage());
+            LOGGER.warn("mapPath: {}", ce.getMessage());
         } catch (RuntimeException e) {
-            _log.error("Exception in mapPath (pathfinder) " + e, e);
+            LOGGER.error("Exception in mapPath (pathfinder) " + e, e);
             pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -2094,10 +2094,10 @@ public class PnfsManagerV3
             _nameSpaceProvider.find(msg.getSubject(), pnfsId)
                     .forEach(l -> msg.addLocation(l.getParent(), l.getName()));
         } catch (CacheException e) {
-            _log.warn(e.toString());
+            LOGGER.warn(e.toString());
             msg.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.error(e.toString(), e);
+            LOGGER.error(e.toString(), e);
             msg.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
                           e.getMessage());
         }
@@ -2209,10 +2209,10 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException | NotDirCacheException e) {
             msg.setFailed(e.getRc(), e.getMessage());
         } catch (CacheException e) {
-            _log.warn(e.toString());
+            LOGGER.warn(e.toString());
             msg.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.error(e.toString(), e);
+            LOGGER.error(e.toString(), e);
             msg.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
                           e.getMessage());
         }
@@ -2279,7 +2279,7 @@ public class PnfsManagerV3
                          */
                         PnfsMessage pnfs = (PnfsMessage) message.getMessageObject();
                         if (message.getLocalAge() > message.getAdjustedTtl() && useEarlyDiscard(pnfs)) {
-                            _log.warn("Discarding {} because its time to live has been exceeded.",
+                            LOGGER.warn("Discarding {} because its time to live has been exceeded.",
                                       pnfs.getClass().getSimpleName());
                             sendTimeout(message, "TTL exceeded");
                             continue;
@@ -2288,7 +2288,7 @@ public class PnfsManagerV3
                         processPnfsMessage(message, pnfs);
                         fold(pnfs);
                     } catch (Throwable e) {
-                        _log.warn("processPnfsMessage: {} : {}", Thread.currentThread().getName(), e);
+                        LOGGER.warn("processPnfsMessage: {} : {}", Thread.currentThread().getName(), e);
                     } finally {
                         clearActivity();
                         CDC.clearMessageContext();
@@ -2313,7 +2313,7 @@ public class PnfsManagerV3
                     }
 
                     if (other.fold(message)) {
-                        _log.info("Folded {}", other.getClass().getSimpleName());
+                        LOGGER.info("Folded {}", other.getClass().getSimpleName());
                         _foldedCounters.incrementRequests(message.getClass());
 
                         i.remove();
@@ -2550,13 +2550,13 @@ public class PnfsManagerV3
         int index;
         if (pnfsId != null) {
             index = (int) (Math.abs((long) pnfsId.hashCode()) % _threads);
-            _log.info("Using thread [{}] {}", pnfsId, index);
+            LOGGER.info("Using thread [{}] {}", pnfsId, index);
         } else if (path != null) {
             index = (int) (Math.abs((long) path.hashCode()) % _threads);
-            _log.info("Using thread [{}] {}", path, index);
+            LOGGER.info("Using thread [{}] {}", path, index);
         } else {
             index = _random.nextInt(_fifos.length);
-            _log.info("Using random thread {}", index);
+            LOGGER.info("Using random thread {}", index);
         }
 
         /*
@@ -2578,22 +2578,22 @@ public class PnfsManagerV3
             }
         } catch (TransactionException e) {
             if (pnfsMessage.getReturnCode() == 0) {
-                _log.error("Name space transaction failed: {}", e.getMessage());
+                LOGGER.error("Name space transaction failed: {}", e.getMessage());
                 pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, "Name space transaction failed.");
             }
         }
 
         if (pnfsMessage.getReturnCode() == CacheException.INVALID_ARGS) {
-            _log.error("Inconsistent message {} received form {}",
+            LOGGER.error("Inconsistent message {} received form {}",
                        pnfsMessage.getClass(), message.getSourcePath());
         }
 
         long duration = System.currentTimeMillis() - ctime;
         _gauges.update(pnfsMessage.getClass(), duration);
         if (_logSlowThreshold != THRESHOLD_DISABLED && duration > _logSlowThreshold) {
-            _log.warn("{} processed in {} ms", pnfsMessage.getClass(), duration);
+            LOGGER.warn("{} processed in {} ms", pnfsMessage.getClass(), duration);
         } else {
-            _log.info("{} processed in {} ms", pnfsMessage.getClass(), duration);
+            LOGGER.info("{} processed in {} ms", pnfsMessage.getClass(), duration);
         }
 
         postProcessMessage(message, pnfsMessage);
@@ -2645,7 +2645,7 @@ public class PnfsManagerV3
         } else if (pnfsMessage instanceof PnfsRemoveExtendedAttributesMessage) {
             removeExtendedAttributes((PnfsRemoveExtendedAttributesMessage) pnfsMessage);
         } else {
-            _log.warn("Unexpected message class [{}] from source [{}]",
+            LOGGER.warn("Unexpected message class [{}] from source [{}]",
                       pnfsMessage.getClass(), message.getSourcePath());
             return false;
         }
@@ -2742,7 +2742,7 @@ public class PnfsManagerV3
         } catch (CacheException e) {
             pnfsMessage.setFailed(e.getRc(), e.getMessage());
         } catch (RuntimeException e) {
-            _log.warn("Failed to process flush notification", e);
+            LOGGER.warn("Failed to process flush notification", e);
             pnfsMessage.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -2878,10 +2878,10 @@ public class PnfsManagerV3
         } catch (FileNotFoundCacheException e){
             message.setFailed(e.getRc(), e);
         } catch (CacheException e) {
-            _log.warn("Error while retrieving file attributes: {}", e.getMessage());
+            LOGGER.warn("Error while retrieving file attributes: {}", e.getMessage());
             message.setFailed(e.getRc(), e);
         } catch (RuntimeException e) {
-            _log.error("Error while retrieving file attributes: " + e.getMessage(), e);
+            LOGGER.error("Error while retrieving file attributes: " + e.getMessage(), e);
             message.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -2918,10 +2918,10 @@ public class PnfsManagerV3
         }catch(FileNotFoundCacheException e){
             message.setFailed(e.getRc(), e);
         }catch(CacheException e) {
-            _log.warn("Error while updating file attributes: " + e.getMessage());
+            LOGGER.warn("Error while updating file attributes: " + e.getMessage());
             message.setFailed(e.getRc(), e);
         }catch(RuntimeException e) {
-            _log.error("Error while updating file attributes: " + e.getMessage(), e);
+            LOGGER.error("Error while updating file attributes: " + e.getMessage(), e);
             message.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e);
         }
     }
@@ -3230,7 +3230,7 @@ public class PnfsManagerV3
                 checkRestriction(message.getRestriction(), message.getAccessMask(),
                         activity, path);
             } else {
-                _log.warn("Restriction check by-passed due to missing path; please report this to <support@dCache.org>");
+                LOGGER.warn("Restriction check by-passed due to missing path; please report this to <support@dCache.org>");
             }
         }
     }

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/HttpPoolMgrEngineV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/HttpPoolMgrEngineV3.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.HTMLWriter;
@@ -68,7 +67,7 @@ public class HttpPoolMgrEngineV3 implements
     private static final String PARAMETER_SORT = "sort";
     private static final String PARAMETER_STORE = "store";
     private static final String PARAMETER_TYPE = "type";
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(HttpPoolMgrEngineV3.class);
 
     private static final long TIMEOUT = 20000;
@@ -122,15 +121,15 @@ public class HttpPoolMgrEngineV3 implements
         _pnfsManagerAddress = arguments.getOption("pnfsmanager");
 
         for (int i = 0; i < argsString.length; i++) {
-            _log.info("HttpPoolMgrEngineV3 : argument : {} : {}", i, argsString[i]);
+            LOGGER.info("HttpPoolMgrEngineV3 : argument : {} : {}", i, argsString[i]);
             if (argsString[i].equals("addStorageInfo")) {
                 _addStorageInfo = true;
-                _log.info("Option accepted : addStorageInfo");
+                LOGGER.info("Option accepted : addStorageInfo");
             } else if (argsString[i].equals("addHsmInfo")) {
                 _addHsmInfo = true;
-                _log.info("Option accepted : addHsmInfo");
+                LOGGER.info("Option accepted : addHsmInfo");
             } else if (argsString[i].startsWith("details=")) {
-                _log.info("Details for lazy restore : {}", argsString[i]);
+                LOGGER.info("Details for lazy restore : {}", argsString[i]);
                 decodeDetails(argsString[i]);
             } else if (argsString[i].equals("cacheLifetime")) {
                 _receiver.setLifetime(Integer.parseInt(argsString[i]));
@@ -142,7 +141,7 @@ public class HttpPoolMgrEngineV3 implements
         }
         _receiver.initialize();
         _restoreCollector = new Thread(this, "restore-collector");
-        _log.info("Using CSS file : {}", _cssFile);
+        LOGGER.info("Using CSS file : {}", _cssFile);
     }
 
     @Override
@@ -177,7 +176,7 @@ public class HttpPoolMgrEngineV3 implements
         try {
             _restoreCollector.join();
         } catch (InterruptedException e) {
-            _log.warn("Interrupted while waiting for restore-collector to terminate");
+            LOGGER.warn("Interrupted while waiting for restore-collector to terminate");
         }
         _pm.beforeStop();
     }
@@ -206,7 +205,7 @@ public class HttpPoolMgrEngineV3 implements
     @Override
     public void run()
     {
-        _log.info("Restore Collector Thread started");
+        LOGGER.info("Restore Collector Thread started");
         try {
             while (!Thread.interrupted()) {
                 try {
@@ -215,11 +214,11 @@ public class HttpPoolMgrEngineV3 implements
                     }
                     runRestoreCollector();
                 } catch(NoRouteToCellException e) {
-                    _log.warn("Restore Collector got : " + e, e);
+                    LOGGER.warn("Restore Collector got : " + e, e);
                 }
             }
         } catch (InterruptedException e) {
-            _log.debug("Restore Collector interrupted");
+            LOGGER.debug("Restore Collector interrupted");
         }
     }
 
@@ -320,7 +319,7 @@ public class HttpPoolMgrEngineV3 implements
 
                 agedList.add(a);
             } catch (Exception e) {
-                _log.warn(e.toString(), e);
+                LOGGER.warn(e.toString(), e);
             }
         }
         _lazyRestoreList = agedList;
@@ -333,7 +332,7 @@ public class HttpPoolMgrEngineV3 implements
                 new HsmControlGetBfDetailsMsg(new PnfsId(pnfsId),storageInfo,"default");
             return _hsmController.sendAndWait(msg).getStorageInfo();
         } catch (InterruptedException | CacheException | NoRouteToCellException e) {
-            _log.warn(e.toString(), e);
+            LOGGER.warn(e.toString(), e);
             return null;
         }
     }
@@ -344,7 +343,7 @@ public class HttpPoolMgrEngineV3 implements
             PnfsMapPathMessage msg = new PnfsMapPathMessage(new PnfsId(pnfsId));
             return _pnfsManager.sendAndWait(msg).getGlobalPath();
         } catch (InterruptedException | CacheException | NoRouteToCellException e) {
-            _log.warn(e.toString());
+            LOGGER.warn(e.toString());
             return null;
         }
     }
@@ -356,7 +355,7 @@ public class HttpPoolMgrEngineV3 implements
                     new PnfsGetFileAttributes(new PnfsId(pnfsId), EnumSet.of(FileAttribute.SIZE, FileAttribute.STORAGEINFO));
             return _pnfsManager.sendAndWait(msg).getFileAttributes();
         } catch (InterruptedException | CacheException | NoRouteToCellException e) {
-            _log.warn(e.toString());
+            LOGGER.warn(e.toString());
             return null;
         }
     }

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolManagerV5.java
@@ -95,7 +95,7 @@ public class PoolManagerV5
     private WatchdogThread     _watchdog;
     private PoolMonitorThread _poolMonitorThread;
 
-    private static final Logger _log = LoggerFactory.getLogger(PoolManagerV5.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PoolManagerV5.class);
 
     private final ExecutorService _executor = new CDCExecutorServiceDecorator<>(
             Executors.newCachedThreadPool(
@@ -183,7 +183,7 @@ public class PoolManagerV5
             _watchdog = new WatchdogThread();
         }
         _poolMonitorThread = new PoolMonitorThread();
-        _log.info("Watchdog : {}", _watchdog);
+        LOGGER.info("Watchdog : {}", _watchdog);
     }
 
     @Override
@@ -266,13 +266,13 @@ public class PoolManagerV5
                 _sleepTimer = sleeping * 1000L;
 
             } catch (Exception ee) {
-                _log.warn("WatchdogThread : illegal arguments [{}] (using defaults) {}", parameter, ee.getMessage());
+                LOGGER.warn("WatchdogThread : illegal arguments [{}] (using defaults) {}", parameter, ee.getMessage());
             }
         }
 
         @Override
         public void run() {
-            _log.debug("watchdog thread activated");
+            LOGGER.debug("watchdog thread activated");
             try {
                 while (true) {
                     Thread.sleep(_sleepTimer);
@@ -281,7 +281,7 @@ public class PoolManagerV5
                 }
             } catch (InterruptedException ignored) {
             }
-            _log.debug("watchdog finished");
+            LOGGER.debug("watchdog finished");
         }
 
         @Override
@@ -304,9 +304,9 @@ public class PoolManagerV5
             try {
                 limiter.acquire();
                 while (!Thread.interrupted()) {
-                    if (_log.isDebugEnabled()) { // For RT 9250.
+                    if (LOGGER.isDebugEnabled()) { // For RT 9250.
                         if (_poolMonitor.getPoolSelectionUnit().getLinkGroups().isEmpty()) {
-                            _log.debug("notifying with PoolMonitor that has empty linkgroups");
+                            LOGGER.debug("notifying with PoolMonitor that has empty linkgroups");
                         }
                     }
                     _poolMonitorTopic.notify(_poolMonitor);
@@ -365,7 +365,7 @@ public class PoolManagerV5
                     _requestContainer.poolStatusChanged(name, PoolStatusChangedMessage.DOWN);
                     sendPoolStatusRelay(name, PoolStatusChangedMessage.DOWN,
                                         null, 666, "DEAD");
-                    _log.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.POOL_DOWN, name),
+                    LOGGER.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.POOL_DOWN, name),
                                "Pool {} declared as DOWN: no ping in "
                                + deathDetectedTimer/1000 +" seconds.", name);
                 }
@@ -410,7 +410,7 @@ public class PoolManagerV5
 
     public void messageArrived(CellMessage envelope, PoolManagerPoolUpMessage poolMessage)
     {
-        _log.debug("PoolUp message from {} with mode {} and serialId {}",
+        LOGGER.debug("PoolUp message from {} with mode {} and serialId {}",
                    poolMessage.getPoolName(), poolMessage.getPoolMode(), poolMessage.getSerialId());
 
         String poolName = poolMessage.getPoolName();
@@ -741,7 +741,7 @@ public class PoolManagerV5
            FileAttributes fileAttributes = _request.getFileAttributes();
            ProtocolInfo protocolInfo = _request.getProtocolInfo();
 
-           _log.info("{} write handler started", _pnfsId);
+           LOGGER.info("{} write handler started", _pnfsId);
            long started = System.currentTimeMillis();
 
            SelectedPool pool;
@@ -752,7 +752,7 @@ public class PoolManagerV5
                                         _request.getLinkGroup(),
                                         _request.getExcludedHosts())
                        .selectWritePool(_request.getPreallocated());
-               _log.info("{} write handler selected {} after {} ms", _pnfsId, pool.name(),
+               LOGGER.info("{} write handler selected {} after {} ms", _pnfsId, pool.name(),
                          System.currentTimeMillis() - started);
            } catch (CacheException ce) {
                requestFailed(ce.getRc(), ce.getMessage());

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolMonitorV5.java
@@ -54,7 +54,7 @@ import static org.dcache.namespace.FileAttribute.*;
 public class PoolMonitorV5
     extends SerializablePoolMonitor
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(PoolMonitorV5.class);
 
     private static final long serialVersionUID = -2400834413958127412L;
@@ -184,7 +184,7 @@ public class PoolMonitorV5
                 return _fileAttributes.getLocations();
             }
 
-            _log.debug("filtering file locations for {}, "
+            LOGGER.debug("filtering file locations for {}, "
                                        + "excluded hosts {}.",
                        _fileAttributes.getPnfsId(),
                        _excludedHosts);
@@ -289,11 +289,11 @@ public class PoolMonitorV5
             throws CacheException
         {
             Collection<String> locations = filteredFileLocations();
-            _log.debug("[read] Expected from pnfs: {}", locations);
+            LOGGER.debug("[read] Expected from pnfs: {}", locations);
 
             Map<String,PoolInfo> onlinePoolsWithFile =
                 _costModule.getPoolInfoAsMap(locations);
-            _log.debug("[read] Online pools: {}", onlinePoolsWithFile);
+            LOGGER.debug("[read] Online pools: {}", onlinePoolsWithFile);
 
             /* Is the file in any of the online pools?
              */
@@ -320,7 +320,7 @@ public class PoolMonitorV5
 
             for (int prio = 0; prio < level.length; prio++) {
                 List<String> poolsInCurrentLevel = level[prio].getPoolList();
-                _log.debug("[read] Allowed pools at level {}: {}",
+                LOGGER.debug("[read] Allowed pools at level {}: {}",
                            prio, poolsInCurrentLevel);
 
                 if (poolsInCurrentLevel.isEmpty()) {
@@ -338,7 +338,7 @@ public class PoolMonitorV5
                         pools.add(info);
                     }
                 }
-                _log.debug("[read] Available pools at level {}: {}",
+                LOGGER.debug("[read] Available pools at level {}: {}",
                            prio, pools);
 
                 /* If allowed, fallback to next link if current link doesn't point
@@ -421,11 +421,11 @@ public class PoolMonitorV5
             throws CacheException
         {
             Collection<String> locations = filteredFileLocations();
-            _log.debug("[p2p] Expected source from pnfs: {}", locations);
+            LOGGER.debug("[p2p] Expected source from pnfs: {}", locations);
 
             Map<String,PoolInfo> sources =
                 _costModule.getPoolInfoAsMap(locations);
-            _log.debug("[p2p] Online source pools: {}", sources.values());
+            LOGGER.debug("[p2p] Online source pools: {}", sources.values());
 
             if (sources.isEmpty()) {
                 throw new CacheException("P2P denied: No source pools available");
@@ -454,7 +454,7 @@ public class PoolMonitorV5
                                 .filter(Objects::nonNull)
                                 .collect(toList());
                 if (!pools.isEmpty()) {
-                    _log.debug("[p2p] Online destination candidates: {}", pools);
+                    LOGGER.debug("[p2p] Online destination candidates: {}", pools);
                     Partition partition =
                         _partitionManager.getPartition(level.getTag());
                     return partition.selectPool2Pool(_costModule,
@@ -474,7 +474,7 @@ public class PoolMonitorV5
             throws CacheException
         {
             Collection<String> locations = filteredFileLocations();
-            _log.debug("[stage] Existing locations of the file: {}", locations);
+            LOGGER.debug("[stage] Existing locations of the file: {}", locations);
 
             CostException costException = null;
             for (PoolPreferenceLevel level: match(DirectionType.CACHE)) {
@@ -486,7 +486,7 @@ public class PoolMonitorV5
                                     .filter(Objects::nonNull)
                                     .collect(toList());
                     if (!pools.isEmpty()) {
-                        _log.debug("[stage] Online stage candidates: {}", pools);
+                        LOGGER.debug("[stage] Online stage candidates: {}", pools);
                         Partition partition =
                             _partitionManager.getPartition(level.getTag());
                         return partition.selectStagePool(_costModule, pools,
@@ -535,11 +535,11 @@ public class PoolMonitorV5
                 };
 
             Collection<String> locations = _fileAttributes.getLocations();
-            _log.debug("[pin] Expected from pnfs: {}", locations);
+            LOGGER.debug("[pin] Expected from pnfs: {}", locations);
 
             Map<String,PoolInfo> onlinePools =
                 _costModule.getPoolInfoAsMap(locations);
-            _log.debug("[pin] Online pools: {}", onlinePools.values());
+            LOGGER.debug("[pin] Online pools: {}", onlinePools.values());
 
             boolean isRequestSatisfiable = false;
             PoolPreferenceLevel[] levels = match(DirectionType.READ);

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -63,7 +63,7 @@ public class PoolSelectionUnitV2
         CellCommandListener, CellLifeCycleAware
 {
     private static final String __version = "$Id: PoolSelectionUnitV2.java,v 1.42 2007-10-25 14:03:54 tigran Exp $";
-    private static final Logger _log = LoggerFactory.getLogger(PoolSelectionUnitV2.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PoolSelectionUnitV2.class);
     private static final String NO_NET = "<no net>";
 
     @Override
@@ -509,7 +509,7 @@ public class PoolSelectionUnitV2
                     || !Objects.equals(pool.getCanonicalHostName(), Optional.ofNullable(canonicalHostName));
 
             if (mode.getMode() != oldMode.getMode()) {
-                _log.warn("Pool {} changed from mode {}  to {}.", poolName, oldMode, mode);
+                LOGGER.warn("Pool {} changed from mode {}  to {}.", poolName, oldMode, mode);
             }
 
             pool.setAddress(address);
@@ -572,7 +572,7 @@ public class PoolSelectionUnitV2
 
         Map<String, String> variableMap = storageInfo.getMap();
 
-        _log.debug("running match: type={} store={} dCacheUnit={} net={} protocol={} keys={} locations={} linkGroup={}",
+        LOGGER.debug("running match: type={} store={} dCacheUnit={} net={} protocol={} keys={} locations={} linkGroup={}",
                         type, storeUnitName, dCacheUnitName, netUnitName, protocolUnitName,
                         variableMap, storageInfo.locations(), linkGroupName);
 
@@ -632,7 +632,7 @@ public class PoolSelectionUnitV2
                         if ((unit = _units.get(template)) == null) {
 
                             if ((unit = _units.get("*@*")) == null) {
-                                _log.debug("no matching storage unit found for: {}", storeUnitName);
+                                LOGGER.debug("no matching storage unit found for: {}", storeUnitName);
                                 throw new IllegalArgumentException(
                                                 "Unit not found : " + storeUnitName);
                             }
@@ -642,7 +642,7 @@ public class PoolSelectionUnitV2
                                         "IllegalUnitFormat : " + storeUnitName);
                     }
                 }
-                _log.debug("matching storage unit found for: {}", storeUnitName);
+                LOGGER.debug("matching storage unit found for: {}", storeUnitName);
                 list.add(unit);
             }
             if (protocolUnitName != null) {
@@ -650,32 +650,32 @@ public class PoolSelectionUnitV2
                 Unit unit = findProtocolUnit(protocolUnitName);
                 //
                 if (unit == null){
-                    _log.debug("no matching protocol unit found for: {}", protocolUnitName);
+                    LOGGER.debug("no matching protocol unit found for: {}", protocolUnitName);
                     throw new IllegalArgumentException("Unit not found : "
                                     + protocolUnitName);
                 }
-                _log.debug("matching protocol unit found: {}", unit);
+                LOGGER.debug("matching protocol unit found: {}", unit);
                 list.add(unit);
             }
             if (dCacheUnitName != null) {
                 Unit unit = _units.get(dCacheUnitName);
                 if (unit == null) {
-                    _log.debug("no matching dCache unit found for: {}", dCacheUnitName);
+                    LOGGER.debug("no matching dCache unit found for: {}", dCacheUnitName);
                     throw new IllegalArgumentException("Unit not found : "
                                     + dCacheUnitName);
                 }
-                _log.debug("matching dCache unit found: {}", unit);
+                LOGGER.debug("matching dCache unit found: {}", unit);
                 list.add(unit);
             }
             if (netUnitName != null) {
                 try {
                     Unit unit = _netHandler.match(netUnitName);
                     if (unit == null) {
-                        _log.debug("no matching net unit found for: {}", netUnitName);
+                        LOGGER.debug("no matching net unit found for: {}", netUnitName);
                         throw new IllegalArgumentException(
                                         "Unit not matched : " + netUnitName);
                     }
-                    _log.debug("matching net unit found: {}", unit);
+                    LOGGER.debug("matching net unit found: {}", unit);
                     list.add(unit);
                 } catch (UnknownHostException uhe) {
                     throw new IllegalArgumentException(
@@ -709,7 +709,7 @@ public class PoolSelectionUnitV2
             if (linkGroupName != null) {
                 linkGroup = _linkGroups.get(linkGroupName);
                 if (linkGroup == null) {
-                    _log.debug("LinkGroup not found : {}", linkGroupName );
+                    LOGGER.debug("LinkGroup not found : {}", linkGroupName );
                     throw new IllegalArgumentException("LinkGroup not found : "
                                     + linkGroupName);
                 }
@@ -812,7 +812,7 @@ public class PoolSelectionUnitV2
                     for (PoolCore poolCore : link._poolList.values()) {
                         if (poolCore instanceof Pool) {
                             Pool pool = (Pool) poolCore;
-                            _log.debug("Pool: {} can read from tape? : {}", pool, pool.canReadFromTape());
+                            LOGGER.debug("Pool: {} can read from tape? : {}", pool, pool.canReadFromTape());
                             if (((type == DirectionType.READ && pool.canRead())
                                             || (type == DirectionType.CACHE && pool.canReadFromTape()
                                             && poolCanStageFile(pool, fileAttributes))
@@ -820,7 +820,7 @@ public class PoolSelectionUnitV2
                                             || (type == DirectionType.P2P && pool.canWriteForP2P()))
                                             && (_allPoolsActive || pool.isActive())) {
                                 if (exclude.test(pool.getName())) {
-                                    _log.debug("Qualifying pool {} is on excluded host {}; skipping.",
+                                    LOGGER.debug("Qualifying pool {} is on excluded host {}; skipping.",
                                                pool.getName(),
                                                pool.getCanonicalHostName());
                                 } else {
@@ -829,7 +829,7 @@ public class PoolSelectionUnitV2
                             }
                         } else {
                             for (Pool pool : ((PGroup)poolCore)._poolList.values()) {
-                                _log.debug("Pool: {} can read from tape? : {}", pool, pool.canReadFromTape());
+                                LOGGER.debug("Pool: {} can read from tape? : {}", pool, pool.canReadFromTape());
                                 if (((type == DirectionType.READ && pool.canRead())
                                                 || (type == DirectionType.CACHE && pool.canReadFromTape()
                                                 && poolCanStageFile(pool, fileAttributes))
@@ -837,7 +837,7 @@ public class PoolSelectionUnitV2
                                                 || (type == DirectionType.P2P && pool.canWriteForP2P()))
                                                 && (_allPoolsActive || pool.isActive())) {
                                     if (exclude.test(pool.getName())) {
-                                        _log.debug("Qualifying pool {} is on excluded host {}; skipping.",
+                                        LOGGER.debug("Qualifying pool {} is on excluded host {}; skipping.",
                                                    pool.getName(),
                                                    pool.getCanonicalHostName());
                                     } else {
@@ -855,7 +855,7 @@ public class PoolSelectionUnitV2
             runlock();
         }
 
-        if( _log.isDebugEnabled() ) {
+        if( LOGGER.isDebugEnabled() ) {
 
             StringBuilder sb = new StringBuilder("match done: ");
 
@@ -865,7 +865,7 @@ public class PoolSelectionUnitV2
                     sb.append(" ").append(poolName);
                 }
             }
-            _log.debug(sb.toString());
+            LOGGER.debug(sb.toString());
         }
         return result;
     }
@@ -982,14 +982,14 @@ public class PoolSelectionUnitV2
                             // only consider link if it isn't in any link group
                             // ( "default link group" )
                             //
-                            _log.debug("link {} matching to unit {}", link.getName(), unit);
+                            LOGGER.debug("link {} matching to unit {}", link.getName(), unit);
                             map.put(link.getName(), link);
                         }
                     } else if (linkGroup.contains(link)) {
                         //
                         // only take link if it is in the specified link group
                         //
-                        _log.debug("link {} matching to unit {}", link.getName(), unit);
+                        LOGGER.debug("link {} matching to unit {}", link.getName(), unit);
                         map.put(link.getName(), link);
                     }
                 }
@@ -2430,7 +2430,7 @@ public class PoolSelectionUnitV2
                 }
             }
         }
-        _log.debug("{}: matching hsm ({}) found?: {}", pool.getName(), file.getHsm(), rc);
+        LOGGER.debug("{}: matching hsm ({}) found?: {}", pool.getName(), file.getHsm(), rc);
         return rc;
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/FileHoppingManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/FileHoppingManager.java
@@ -40,7 +40,7 @@ import static com.google.common.base.Preconditions.checkArgument;
   */
 public class FileHoppingManager extends CellAdapter {
 
-   private static final Logger _log =
+   private static final Logger LOGGER =
        LoggerFactory.getLogger(FileHoppingManager.class);
 
    private final CellNucleus _nucleus;
@@ -105,13 +105,13 @@ public class FileHoppingManager extends CellAdapter {
                 continue;
             }
             try{
-               _log.info( "Executing : {}", line ) ;
+               LOGGER.info( "Executing : {}", line ) ;
                String answer = command( line ) ;
                if(!answer.isEmpty()) {
-                   _log.info("Answer    : {}", answer);
+                   LOGGER.info("Answer    : {}", answer);
                }
             }catch( Exception ee ){
-               _log.warn("Exception : {}", ee.toString() ) ;
+               LOGGER.warn("Exception : {}", ee.toString() ) ;
             }
          }
       }finally{
@@ -389,18 +389,18 @@ public class FileHoppingManager extends CellAdapter {
    }
     @Override
     public void messageToForward(  CellMessage cellMessage ){
-        _log.info("Message to forward : {}", cellMessage.getMessageObject().getClass().getName());
+        LOGGER.info("Message to forward : {}", cellMessage.getMessageObject().getClass().getName());
         // super.messageToForward(cellMessage);
     }
    public void replicateReplyArrived( CellMessage message , PoolMgrReplicateFileMsg replicate ){
-      _log.info("replicateReplyArrived : {}", message);
+      LOGGER.info("replicateReplyArrived : {}", message);
    }
    @Override
    public void messageArrived( CellMessage message ){
 
       Object   request     = message.getMessageObject() ;
 
-      _log.info("messageArrived : {} : {}", request, message);
+      LOGGER.info("messageArrived : {} : {}", request, message);
       if( request instanceof PoolMgrReplicateFileMsg ){
 
          PoolMgrReplicateFileMsg replicate = (PoolMgrReplicateFileMsg)request ;
@@ -438,7 +438,7 @@ public class FileHoppingManager extends CellAdapter {
 
                  matchCount++;
 
-                 _log.info("Entry found for : SC=<{}> source={} : {}", storageClass, replicationSource, entry);
+                 LOGGER.info("Entry found for : SC=<{}> source={} : {}", storageClass, replicationSource, entry);
                  entry._hit++;
 
                  CellPath path = entry._path == null ? _defaultDestinationPath : entry._path;
@@ -451,7 +451,7 @@ public class FileHoppingManager extends CellAdapter {
                  try {
                      sendMessage(new CellMessage(path.clone(), replicate));
                  } catch (RuntimeException ee) {
-                     _log.warn("Problem : couldn't forward message to : {} : {}", entry._path, ee.toString());
+                     LOGGER.warn("Problem : couldn't forward message to : {} : {}", entry._path, ee.toString());
                  }
 
                  if (!entry._continue) {
@@ -459,7 +459,7 @@ public class FileHoppingManager extends CellAdapter {
                  }
              }
          }
-         _log.info("Total match count for <{}> was {}", storageClass, matchCount ) ;
+         LOGGER.info("Total match count for <{}> was {}", storageClass, matchCount ) ;
 
       }
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -121,7 +121,7 @@ import static org.dcache.util.ByteUnit.BYTES;
   */
 public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnable {
 
-    private static final Logger _log = LoggerFactory.getLogger(PoolStatisticsV0.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PoolStatisticsV0.class);
 
     /*
      *   Magic spells to get the infos out of the different cells.
@@ -434,34 +434,34 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
             }
 
             try {
-                _log.info("Starting hourly run for : {}", path);
+                LOGGER.info("Starting hourly run for : {}", path);
 
                 createHourlyRawFile(path, _calendar);
 
-                _log.info("Hourly run finished for : {}", path);
+                LOGGER.info("Hourly run finished for : {}", path);
 
                 File today = getTodayPath(_calendar);
-                _log.info("Creating daily file : {}", today);
+                LOGGER.info("Creating daily file : {}", today);
 
                 //noinspection ResultOfMethodCallIgnored
                 Files.copy(path.toPath(), today.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
-                _log.info("Daily file done : {}", today);
+                LOGGER.info("Daily file done : {}", today);
 
                 File yesterday = getYesterdayPath(_calendar);
                 if (yesterday.exists()) {
                     File diffFile  = getTodayDiffPath(_calendar);
-                    _log.info("Starting diff run for : {}", yesterday);
+                    LOGGER.info("Starting diff run for : {}", yesterday);
 
                     createDiffFile(today, yesterday, diffFile);
 
-                    _log.info("Finishing diff run for : {}", diffFile);
+                    LOGGER.info("Finishing diff run for : {}", diffFile);
                 }
                 if (_calendar.get(Calendar.HOUR_OF_DAY) == 23) {
                     resetBillingStatistics();
                 }
             } catch(Exception ee) {
-                _log.warn("Failed to create file {}: {}", path,
+                LOGGER.warn("Failed to create file {}: {}", path,
                         Exceptions.messageOrClassName(ee));
                 path.delete();
             }
@@ -470,7 +470,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
                 return;
             }
             try {
-                _log.info("Creating html tree");
+                LOGGER.info("Creating html tree");
                 prepareDailyHtmlFiles(_calendar);
                 if (_calendar.get(Calendar.HOUR_OF_DAY) == 23) {
                     updateHtmlMonth(_calendar);
@@ -478,7 +478,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
                     updateHtmlTop();
                 }
             } catch(Exception eee) {
-                _log.warn("Exception in creating html tree for : "+path, eee);
+                LOGGER.warn("Exception in creating html tree for : "+path, eee);
             }
         }
     }
@@ -486,7 +486,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
     @Override
     public void run(CellCron.TimerTask task) {
         if (task == _hourly) {
-            _log.info("Hourly ticker : {}", new Date());
+            LOGGER.info("Hourly ticker : {}", new Date());
             Calendar calendar = (Calendar)task.getCalendar().clone();
             new HourlyRunner(calendar);
             task.repeatNextHour();
@@ -753,13 +753,13 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
                         @Override
                         public void run() {
                             try {
-                                _log.info("Starting internal Manual run");
+                                LOGGER.info("Starting internal Manual run");
                                 synchronized(PoolStatisticsV0.this) { _recentPoolStatistics = null; }
                                 Map<String,Map<String,long[]>> map = createStatisticsMap();
                                 synchronized(PoolStatisticsV0.this) { _recentPoolStatistics = map; }
-                                _log.info("Finishing internal Manual run");
+                                LOGGER.info("Finishing internal Manual run");
                             } catch(Exception e) {
-                                _log.info("Aborting internal Manual run {}", e.toString());
+                                LOGGER.info("Aborting internal Manual run {}", e.toString());
                             }
                         }
                     },
@@ -770,11 +770,11 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
             final File file = new File(args.argv(0));
             _nucleus.newThread(() -> {
                 try {
-                    _log.info("Starting Manual run for file : {}", file);
+                    LOGGER.info("Starting Manual run for file : {}", file);
                     createHourlyRawFile(file, new GregorianCalendar());
-                    _log.info("Finishing Manual run for file : {}", file);
+                    LOGGER.info("Finishing Manual run for file : {}", file);
                 } catch(Exception e) {
-                    _log.info("Aborting Manual run for file : {} {}", file, e.toString());
+                    LOGGER.info("Aborting Manual run for file : {} {}", file, e.toString());
                 }
             }, file.toString()).start();
 
@@ -1019,7 +1019,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
 
         File diffFile  = getTodayDiffPath(calendar);
         if (! diffFile.exists()) {
-            _log.warn("prepareDailyHtmlFiles : File not found : {}", diffFile);
+            LOGGER.warn("prepareDailyHtmlFiles : File not found : {}", diffFile);
             return;
         }
         File dir = getHtmlPath(calendar);
@@ -1039,7 +1039,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
             printIndex(new File(dir, "index.html"), getNiceDayOfCalendar(calendar));
 
         } catch(IOException ee) {
-            _log.warn("Can't prepare Html directory : "+dir, ee);
+            LOGGER.warn("Can't prepare Html directory : "+dir, ee);
         }
     }
 
@@ -1308,7 +1308,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
             NoRouteToCellException,
             IOException
     {
-        _log.info("getPoolRepositoryStatistics : asking PoolManager for cell info");
+        LOGGER.info("getPoolRepositoryStatistics : asking PoolManager for cell info");
 
         PoolManagerCellInfo info;
         try {
@@ -1317,13 +1317,13 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
             throw new IOException(e.getMessage(), e);
         }
 
-        _log.info("getPoolRepositoryStatistics :  PoolManager replied : {}", info);
+        LOGGER.info("getPoolRepositoryStatistics :  PoolManager replied : {}", info);
 
         Map<String, Map<String, long[]>> map = new HashMap<>();
         for (Map.Entry<String,CellAddressCore> pool : info.getPoolMap().entrySet()) {
             CellAddressCore address = pool.getValue();
             try {
-                _log.info("getPoolRepositoryStatistics : asking {} for statistics", address);
+                LOGGER.info("getPoolRepositoryStatistics : asking {} for statistics", address);
                 Object[] result =
                         _poolStub.sendAndWait(new CellPath(address), GET_REP_STATISTICS, Object[].class);
                 Map<String, long[]> classMap = new HashMap<>();
@@ -1331,21 +1331,21 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
                     Object[] e = (Object[]) entry;
                     classMap.put((String) e[0], (long[]) e[1]);
                 }
-                _log.info("getPoolRepositoryStatistics : {} replied with {}", address, classMap);
+                LOGGER.info("getPoolRepositoryStatistics : {} replied with {}", address, classMap);
                 map.put(pool.getKey(), classMap);
 
             } catch (InterruptedException ie) {
-                _log.warn("getPoolRepositoryStatistics : sendAndWait interrupted");
+                LOGGER.warn("getPoolRepositoryStatistics : sendAndWait interrupted");
                 throw ie;
             } catch (CacheException e) {
-                _log.warn("getPoolRepositoryStatistics : {} : {}", address, e.getMessage());
+                LOGGER.warn("getPoolRepositoryStatistics : {} : {}", address, e.getMessage());
             }
         }
         return map;
     }
 
     private void resetBillingStatistics() {
-        _log.info("Resetting Billing statistics");
+        LOGGER.info("Resetting Billing statistics");
         _billing.notify(RESET_POOL_STATISTICS);
     }
     //
@@ -1373,7 +1373,7 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
             throws InterruptedException,
             IOException, NoRouteToCellException
     {
-        _log.info("getBillingStatistics : asking billing for generic pool statistics");
+        LOGGER.info("getBillingStatistics : asking billing for generic pool statistics");
         Map<String,Map<String,long[]>> generic;
         try {
             //noinspection unchecked
@@ -1381,22 +1381,22 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
         } catch (CacheException e) {
             throw new IOException(e.getMessage(), e);
         }
-        _log.info("getBillingStatistics :  billing replied with {}", generic);
+        LOGGER.info("getBillingStatistics :  billing replied with {}", generic);
 
         Map<String, Map<String, long[]>> map = new HashMap<>();
         for (String poolName: generic.keySet()) {
             try {
-                _log.info("getBillingStatistics : asking billing for [{}] statistics", poolName);
+                LOGGER.info("getBillingStatistics : asking billing for [{}] statistics", poolName);
                 //noinspection unchecked
                 Map<String,long[]> result = _billing.sendAndWait(GET_POOL_STATISTICS + " " + poolName, Map.class);
-                _log.info("getBillingStatistics : billing replied with {}", result);
+                LOGGER.info("getBillingStatistics : billing replied with {}", result);
 
                 map.put(poolName, result);
             } catch(InterruptedException ie) {
-                _log.warn("'get pool statistics' : sendAndWait interrupted");
+                LOGGER.warn("'get pool statistics' : sendAndWait interrupted");
                 throw ie;
             } catch (CacheException e) {
-                _log.warn("'get pool statistics' : {} : {}", poolName, e.getMessage());
+                LOGGER.warn("'get pool statistics' : {} : {}", poolName, e.getMessage());
             }
         }
         return map;

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -56,7 +56,7 @@ public abstract class TransferManager extends AbstractCellComponent
                                       implements CellCommandListener,
                                                  CellMessageReceiver, CellInfoProvider
 {
-    private static final Logger log = LoggerFactory.getLogger(TransferManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransferManager.class);
     private final Map<Long, TransferManagerHandler> _activeTransfers =
             new ConcurrentHashMap<>();
     private int _maxTransfers;
@@ -183,14 +183,14 @@ public abstract class TransferManager extends AbstractCellComponent
                 TransferManagerHandler handler = e.getValue();
                 Matcher m = p.matcher(String.valueOf(id));
                 if (m.matches()) {
-                    log.debug("pattern: \"{}\" matches id=\"{}\"", args.argv(0), id);
+                    LOGGER.debug("pattern: \"{}\" matches id=\"{}\"", args.argv(0), id);
                     if (pool != null && pool.equals(handler.getPool().getName())) {
                         handlersToKill.add(handler);
                     } else if (pool == null) {
                         handlersToKill.add(handler);
                     }
                 } else {
-                    log.debug("pattern: \"{}\" does not match id=\"{}\"", args.argv(0), id);
+                    LOGGER.debug("pattern: \"{}\" does not match id=\"{}\"", args.argv(0), id);
                 }
             }
             if (handlersToKill.isEmpty()) {
@@ -203,7 +203,7 @@ public abstract class TransferManager extends AbstractCellComponent
             }
             return sb.toString();
         } catch (Exception e) {
-            log.error(e.toString());
+            LOGGER.error(e.toString());
             return e.toString();
         }
     }
@@ -273,20 +273,20 @@ public abstract class TransferManager extends AbstractCellComponent
 
     private synchronized boolean newTransfer()
     {
-        log.debug("newTransfer() num_transfers = {} max_transfers={}",
+        LOGGER.debug("newTransfer() num_transfers = {} max_transfers={}",
                 _numTransfers, _maxTransfers);
         if (_numTransfers == _maxTransfers) {
-            log.debug("newTransfer() returns false");
+            LOGGER.debug("newTransfer() returns false");
             return false;
         }
-        log.debug("newTransfer() INCREMENT and return true");
+        LOGGER.debug("newTransfer() INCREMENT and return true");
         _numTransfers++;
         return true;
     }
 
     synchronized void finishTransfer()
     {
-        log.debug("finishTransfer() num_transfers = {} DECREMENT", _numTransfers);
+        LOGGER.debug("finishTransfer() num_transfers = {} DECREMENT", _numTransfers);
         _numTransfers--;
     }
 
@@ -296,9 +296,9 @@ public abstract class TransferManager extends AbstractCellComponent
             try {
                 nextMessageID = idGenerator.next();
             } catch (Exception e) {
-                log.error("Having trouble getting getNextMessageID from DB");
-                log.error(e.toString());
-                log.error("will nullify requestsPropertyStorage");
+                LOGGER.error("Having trouble getting getNextMessageID from DB");
+                LOGGER.error(e.toString());
+                LOGGER.error("will nullify requestsPropertyStorage");
                 idGenerator = null;
                 getNextMessageID();
             }
@@ -330,13 +330,13 @@ public abstract class TransferManager extends AbstractCellComponent
                 if (task != null) {
                     TransferManagerHandler handler = getHandler(id);
                     if (handler == null) {
-                        log.warn("Transfer {} is (apparently) still ongoing"
+                        LOGGER.warn("Transfer {} is (apparently) still ongoing"
                                 + " after {} {} but unable to find the transfer"
                                 + " to kill it.", id, _moverTimeout,
                                 _moverTimeoutUnit);
                         return;
                     }
-                    log.warn("Killing transfer {}, which is still ongoing after"
+                    LOGGER.warn("Killing transfer {}, which is still ongoing after"
                             + " {} {}.", id, _moverTimeout, _moverTimeoutUnit);
                     handler.timeout();
                 }
@@ -354,7 +354,7 @@ public abstract class TransferManager extends AbstractCellComponent
     {
         TimerTask tt = _moverTimeoutTimerTasks.remove(id);
         if (tt != null) {
-            log.debug("Cancelling the mover timer for handler id {}", id);
+            LOGGER.debug("Cancelling the mover timer for handler id {}", id);
             tt.cancel();
         }
     }
@@ -369,9 +369,9 @@ public abstract class TransferManager extends AbstractCellComponent
                     tx.begin();
                     pm.makePersistent(handler);
                     tx.commit();
-                    log.debug("Recording new handler into database.");
+                    LOGGER.debug("Recording new handler into database.");
                 } catch (Exception e) {
-                    log.error(e.toString());
+                    LOGGER.error(e.toString());
                 } finally {
                         rollbackIfActive(tx);
                 }
@@ -398,9 +398,9 @@ public abstract class TransferManager extends AbstractCellComponent
                     pm.deletePersistent(handler);
                     pm.makePersistent(handlerBackup);
                     tx.commit();
-                    log.debug("handler removed from db");
+                    LOGGER.debug("handler removed from db");
                 } catch (Exception e) {
-                    log.error(e.toString());
+                    LOGGER.error(e.toString());
                 } finally {
                     rollbackIfActive(tx);
                 }
@@ -471,10 +471,10 @@ public abstract class TransferManager extends AbstractCellComponent
                     tx.begin();
                     pm.makePersistent(o);
                     tx.commit();
-                    log.debug("[{}]: Recording new state of handler into database.",
+                    LOGGER.debug("[{}]: Recording new state of handler into database.",
                                 o);
                 } catch (Exception e) {
-                    log.error("[{}]: failed to persist object: {}.",
+                    LOGGER.error("[{}]: failed to persist object: {}.",
                                 o, e.getMessage());
                 } finally {
                     rollbackIfActive(tx);

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -63,7 +63,7 @@ import static org.dcache.namespace.FileAttribute.*;
 
 public class TransferManagerHandler extends AbstractMessageCallback<Message>
 {
-    private static final Logger log =
+    private static final Logger LOGGER =
             LoggerFactory.getLogger(TransferManagerHandler.class);
 
     private static final int MAXIMUM_POOL_SELECTION_ATTEMPTS = 10;
@@ -191,7 +191,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void handle()
     {
-        log.debug("handling:  {}", toString(true));
+        LOGGER.debug("handling:  {}", toString(true));
         int last_slash_pos = pnfsPath.lastIndexOf('/');
         if (last_slash_pos == -1) {
             transferRequest.setFailed(2,
@@ -247,7 +247,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                     createEntryResponseArrived(create_msg);
                     return;
                 }
-                log.error(this.toString() + " got unexpected PnfsCreateEntryMessage "
+                LOGGER.error(this.toString() + " got unexpected PnfsCreateEntryMessage "
                         + " : " + create_msg + " ; Ignoring");
             } else if (message instanceof PnfsGetFileAttributes) {
                 PnfsGetFileAttributes attributesMessage =
@@ -266,7 +266,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                     return;
                 }
 
-                log.error(this.toString() + " got unexpected PnfsGetStorageInfoMessage "
+                LOGGER.error(this.toString() + " got unexpected PnfsGetStorageInfoMessage "
                         + " : " + attributesMessage + " ; Ignoring");
             } else if (message instanceof PoolMgrSelectPoolMsg) {
                 PoolMgrSelectPoolMsg select_pool_msg =
@@ -276,7 +276,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                     poolInfoArrived(select_pool_msg);
                     return;
                 }
-                log.error(this.toString() + " got unexpected PoolMgrSelectPoolMsg "
+                LOGGER.error(this.toString() + " got unexpected PoolMgrSelectPoolMsg "
                         + " : " + select_pool_msg + " ; Ignoring");
             } else if (message instanceof PoolIoFileMessage) {
                 PoolIoFileMessage first_pool_reply =
@@ -286,20 +286,20 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                     poolFirstReplyArrived(first_pool_reply);
                     return;
                 }
-                log.error(this.toString() + " got unexpected PoolIoFileMessage "
+                LOGGER.error(this.toString() + " got unexpected PoolIoFileMessage "
                         + " : " + first_pool_reply + " ; Ignoring");
             } else if (message instanceof PnfsDeleteEntryMessage) {
                 PnfsDeleteEntryMessage deleteReply = (PnfsDeleteEntryMessage) message;
                 if (state == WAITING_FOR_PNFS_ENTRY_DELETE) {
                     setState(RECEIVED_PNFS_ENTRY_DELETE);
-                    log.debug("Received PnfsDeleteEntryMessage, Deleted  : {}",
+                    LOGGER.debug("Received PnfsDeleteEntryMessage, Deleted  : {}",
                             deleteReply.getPnfsPath());
                     sendErrorReply();
                 }
             }
             manager.persist(this);
         } catch (RuntimeException e) {
-            log.error("Bug detected in transfermanager, please report this to <support@dCache.org>", e);
+            LOGGER.error("Bug detected in transfermanager, please report this to <support@dCache.org>", e);
             failure(1, "Bug detected: " + e);
         }
     }
@@ -326,7 +326,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             case CacheException.POOL_DISABLED:
             case CacheException.FILE_NOT_IN_REPOSITORY:
             case CacheException.CANNOT_CREATE_MOVER:
-                log.debug("Pool {} reported rc={}; retrying pool selection",
+                LOGGER.debug("Pool {} reported rc={}; retrying pool selection",
                         pool.getAddress(), rc);
                 retryPoolSelection(rc, error);
                 break;
@@ -346,7 +346,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
             default:
                 if (numberOfMoverStartRetries++ < MAXIMUM_MOVER_START_ATTEMPTS) {
-                    log.debug("Pool {} reported rc={}; scheduling another attempt to start mover",
+                    LOGGER.debug("Pool {} reported rc={}; scheduling another attempt to start mover",
                             pool.getAddress(), rc);
                     executor.execute(() -> {
                                 try {
@@ -359,7 +359,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                                 }
                             });
                 } else {
-                    log.debug("Too many attempts to start mover on pool {},"
+                    LOGGER.debug("Too many attempts to start mover on pool {},"
                             + " retrying pool selection", pool.getAddress());
                     retryPoolSelection(rc, error);
                 }
@@ -380,7 +380,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             break;
 
         case WAITING_FOR_PNFS_ENTRY_DELETE:
-            log.warn("Delete attempt ({} of {}) failed: {}", numberOfRetries + 1,
+            LOGGER.warn("Delete attempt ({} of {}) failed: {}", numberOfRetries + 1,
                     manager.getMaxNumberOfDeleteRetries(), error);
             numberOfRetries++;
             if (numberOfRetries < manager.getMaxNumberOfDeleteRetries()) {
@@ -462,7 +462,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                     return;
                 }
                 for (PnfsId pnfsid : manager.justRequestedIDs) {
-                    log.debug("found pnfsid: {}", pnfsid);
+                    LOGGER.debug("found pnfsid: {}", pnfsid);
                 }
                 manager.justRequestedIDs.add(pnfsId);
             }
@@ -473,7 +473,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                     msg.getFileAttributes();
         }
 
-        log.debug("storageInfoArrived(uid={} gid={} pnfsid={} fileAttributes={}", info.getUid(), info.getGid(),
+        LOGGER.debug("storageInfoArrived(uid={} gid={} pnfsid={} fileAttributes={}", info.getUid(), info.getGid(),
                   pnfsId, fileAttributes);
         selectPool();
     }
@@ -486,7 +486,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
                 : new PoolMgrSelectReadPoolMsg(fileAttributes, protocol_info, _readPoolSelectionContext);
         request.setBillingPath(pnfsPath);
         request.setSubject(transferRequest.getSubject());
-        log.debug("PoolMgrSelectPoolMsg: {}", request);
+        LOGGER.debug("PoolMgrSelectPoolMsg: {}", request);
         setState(WAITING_FOR_POOL_INFO_STATE);
         manager.persist(this);
         CellStub.addCallback(manager.getPoolManagerStub().sendAsync(request), this, executor);
@@ -494,7 +494,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void poolInfoArrived(PoolMgrSelectPoolMsg pool_info)
     {
-        log.debug("poolManagerReply = {}", pool_info);
+        LOGGER.debug("poolManagerReply = {}", pool_info);
 
         if (pool_info instanceof PoolMgrSelectReadPoolMsg) {
             _readPoolSelectionContext =
@@ -504,7 +504,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         setPool(pool_info.getPool());
         fileAttributes = pool_info.getFileAttributes();
         manager.persist(this);
-        log.debug("Positive reply from pool {}", pool);
+        LOGGER.debug("Positive reply from pool {}", pool);
         startMoverOnThePool();
     }
 
@@ -537,10 +537,10 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void poolFirstReplyArrived(PoolIoFileMessage poolMessage)
     {
-        log.debug("poolReply = {}", poolMessage);
+        LOGGER.debug("poolReply = {}", poolMessage);
         info.setTimeQueued(info.getTimeQueued() + System.currentTimeMillis());
-        log.debug("Pool {} will deliver file {} mover id is {}", pool, pnfsId, poolMessage.getMoverId());
-        log.debug("Starting moverTimeout timer");
+        LOGGER.debug("Pool {} will deliver file {} mover id is {}", pool, pnfsId, poolMessage.getMoverId());
+        LOGGER.debug("Starting moverTimeout timer");
         manager.startTimer(id);
         setMoverId(poolMessage.getMoverId());
         manager.persist(this);
@@ -564,7 +564,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void poolDoorMessageArrived(DoorTransferFinishedMessage doorMessage)
     {
-        log.debug("poolDoorMessageArrived, doorMessage.getReturnCode()={}", doorMessage.getReturnCode());
+        LOGGER.debug("poolDoorMessageArrived, doorMessage.getReturnCode()={}", doorMessage.getReturnCode());
         if (doorMessage.getReturnCode() != 0) {
             sendErrorReply(CacheException.THIRD_PARTY_TRANSFER_FAILED,
                     doorMessage.getErrorObject());
@@ -578,14 +578,14 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         _replyCode = replyCode;
         _errorObject = errorObject;
 
-        if (log.isDebugEnabled()) {
-            log.debug("sending error reply {}:{} for {}", replyCode,
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("sending error reply {}:{} for {}", replyCode,
                     errorObject, toString(true));
         }
 
         if (store && created) {// Timur: I think this check  is not needed, we might not ever get storage info and pnfs id: && pnfsId != null && aMetadata != null && aMetadata.getFileSize() == 0) {
             if (state != WAITING_FOR_PNFS_ENTRY_DELETE && state != RECEIVED_PNFS_ENTRY_DELETE) {
-                log.debug("deleting pnfs entry we created: {}", pnfsPath);
+                LOGGER.debug("deleting pnfs entry we created: {}", pnfsPath);
                 deletePnfsEntry();
                 return;
             }
@@ -616,7 +616,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             TransferFailedMessage errorReply = new TransferFailedMessage(transferRequest, replyCode, errorObject);
             manager.sendMessage(new CellMessage(requestor, errorReply));
         } catch (RuntimeException e) {
-            log.error(e.toString());
+            LOGGER.error(e.toString());
             //can not do much more here!!!
         }
         //this will allow the handler to be garbage collected
@@ -629,8 +629,8 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
         int replyCode = _replyCode;
         Serializable errorObject = _errorObject;
 
-        if (log.isDebugEnabled()) {
-            log.debug("sending error reply {}:{} for {}", replyCode,
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("sending error reply {}:{} for {}", replyCode,
                     errorObject, toString(true));
         }
 
@@ -659,7 +659,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             TransferFailedMessage errorReply = new TransferFailedMessage(transferRequest, replyCode, errorObject);
             manager.sendMessage(new CellMessage(requestor, errorReply));
         } catch (RuntimeException e) {
-            log.error(e.toString());
+            LOGGER.error(e.toString());
             //can not do much more here!!!
         }
         //this will allow the handler to be garbage collected
@@ -669,7 +669,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void sendSuccessReply()
     {
-        log.debug("sendSuccessReply for: {}", toString(true));
+        LOGGER.debug("sendSuccessReply for: {}", toString(true));
         if (info.getTimeQueued() < 0) {
             info.setTimeQueued(info.getTimeQueued() + System
                     .currentTimeMillis());
@@ -693,7 +693,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             TransferCompleteMessage errorReply = new TransferCompleteMessage(transferRequest);
             manager.sendMessage(new CellMessage(requestor, errorReply));
         } catch (RuntimeException e) {
-            log.error(e.toString());
+            LOGGER.error(e.toString());
             //can not do much more here!!!
         }
         //this will allow the handler to be garbage collected
@@ -707,7 +707,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
     void sendDoorRequestInfo(int code, String msg)
     {
         info.setResult(code, msg);
-        log.debug("Sending info: {}", info);
+        LOGGER.debug("Sending info: {}", info);
         manager.getBillingStub().notify(info);
     }
 
@@ -721,7 +721,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void cancel(String explanation)
     {
-        log.debug("transfer cancelled: {}", explanation);
+        LOGGER.debug("transfer cancelled: {}", explanation);
 
         if (moverId != null) {
             killMover(moverId, explanation);
@@ -843,7 +843,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
 
     public void killMover(int moverId, String explanation)
     {
-        log.debug("sending mover kill to pool {} for moverId={}", pool, moverId);
+        LOGGER.debug("sending mover kill to pool {} for moverId={}", pool, moverId);
         PoolMoverKillMessage killMessage = new PoolMoverKillMessage(pool.getName(), moverId,
                 "killed by TransferManagerHandler: " + explanation);
         killMessage.setReplyRequired(false);

--- a/modules/dcache/src/main/java/diskCacheV111/services/web/ContextPictureEngine.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/web/ContextPictureEngine.java
@@ -33,7 +33,7 @@ public interface HttpRequest {
 
 public class ContextPictureEngine implements HttpResponseEngine, DomainContextAware
 {
-   private static final Logger _log =
+   private static final Logger LOGGER =
        LoggerFactory.getLogger(ContextPictureEngine.class);
 
     private Map<String, Object> context;
@@ -54,9 +54,9 @@ public class ContextPictureEngine implements HttpResponseEngine, DomainContextAw
       String [] tokens = request.getRequestTokens() ;
       int       offset = request.getRequestTokenOffset() ;
 
-      _log.info("Offset : {}", offset);
+      LOGGER.info("Offset : {}", offset);
       for( int i =0 ; i < tokens.length ;i++ ){
-         _log.info(i + " -> " + tokens[i]);
+         LOGGER.info(i + " -> " + tokens[i]);
       }
       if( tokens.length < 2 ) {
           throw new

--- a/modules/dcache/src/main/java/diskCacheV111/services/web/PoolInfoObserverV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/web/PoolInfoObserverV3.java
@@ -25,7 +25,7 @@ import org.dcache.util.Args;
 
 public class PoolInfoObserverV3 extends AbstractCell
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(PoolInfoObserverV3.class);
 
     private static final String THREAD_NAME = "pool-info-observer";
@@ -65,9 +65,9 @@ public class PoolInfoObserverV3 extends AbstractCell
                             try {
                                 refresh();
                             } catch (CacheException | NoRouteToCellException e) {
-                                _log.error("Failed to update topology map: {}", e.getMessage());
+                                LOGGER.error("Failed to update topology map: {}", e.getMessage());
                             } catch (RuntimeException e) {
-                                _log.error("Failed to update topology map: {}", e.toString());
+                                LOGGER.error("Failed to update topology map: {}", e.toString());
                             }
 
                             Thread.sleep(_interval * 1000);
@@ -87,7 +87,7 @@ public class PoolInfoObserverV3 extends AbstractCell
 
     public void messageArrived(NoRouteToCellException e)
     {
-        _log.warn(e.getMessage());
+        LOGGER.warn(e.getMessage());
     }
 
     private void refresh()
@@ -114,7 +114,7 @@ public class PoolInfoObserverV3 extends AbstractCell
             if ((props.length < 3) ||
                 (! (props[0] instanceof String)) ||
                 (! (props[1] instanceof Object []))) {
-                _log.error("Unexpected reply from PoolManager: {}", props);
+                LOGGER.error("Unexpected reply from PoolManager: {}", props);
                 continue;
             }
             for (Object p: (Object[]) props[1]) {
@@ -152,7 +152,7 @@ public class PoolInfoObserverV3 extends AbstractCell
                                     @Override
                                     public void onFailure(Throwable t)
                                     {
-                                        _log.warn("Failed to query {}: {}", pool, t.getMessage());
+                                        LOGGER.warn("Failed to query {}: {}", pool, t.getMessage());
                                         latch.countDown();
                                     }
                                 });

--- a/modules/dcache/src/main/java/diskCacheV111/util/RunSystem.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/RunSystem.java
@@ -13,7 +13,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 public class RunSystem implements Runnable {
-    private static final Logger _log = LoggerFactory.getLogger(RunSystem.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RunSystem.class);
     private static final Runtime __runtime = Runtime.getRuntime() ;
     private final String[] _exec ;
     private final int    _maxLines ;
@@ -54,7 +54,7 @@ public class RunSystem implements Runnable {
     }
 
     private void say(String str) {
-        _log.debug("[{}] {}", _id, str);
+        LOGGER.debug("[{}] {}", _id, str);
     }
 
     private void interruptReaders(){

--- a/modules/dcache/src/main/java/org/dcache/acl/AclAdmin.java
+++ b/modules/dcache/src/main/java/org/dcache/acl/AclAdmin.java
@@ -46,7 +46,7 @@ public class AclAdmin
 
     public static final String OPTION_HELP = "h";
 
-    private static final Logger _logger =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(AclAdmin.class);
 
     private NameSpaceProvider _nameSpaceProvider;

--- a/modules/dcache/src/main/java/org/dcache/auth/MacaroonLoginStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/MacaroonLoginStrategy.java
@@ -52,7 +52,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  */
 public class MacaroonLoginStrategy implements LoginStrategy
 {
-    private static final Logger LOG = LoggerFactory.getLogger(MacaroonLoginStrategy.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MacaroonLoginStrategy.class);
 
     private final MacaroonProcessor processor;
 
@@ -64,7 +64,7 @@ public class MacaroonLoginStrategy implements LoginStrategy
     @Override
     public LoginReply login(Subject subject) throws CacheException
     {
-        LOG.debug("Login attempted: {}", subject);
+        LOGGER.debug("Login attempted: {}", subject);
         Origin origin = extractClientIP(subject);
         String macaroon = extractCredential(subject);
 
@@ -88,7 +88,7 @@ public class MacaroonLoginStrategy implements LoginStrategy
             principals.add(origin);
             principals.add(new MacaroonPrincipal(context.getId()));
 
-            LOG.debug("Login successful: {}", reply);
+            LOGGER.debug("Login successful: {}", reply);
             return reply;
         } catch (InvalidMacaroonException e) {
             throw new PermissionDeniedCacheException("macaroon login denied: " + e.getMessage());

--- a/modules/dcache/src/main/java/org/dcache/auth/UnionLoginStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/UnionLoginStrategy.java
@@ -37,7 +37,7 @@ import org.dcache.auth.attributes.Restrictions;
  */
 public class UnionLoginStrategy implements LoginStrategy
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(UnionLoginStrategy.class);
 
     /**
@@ -64,7 +64,7 @@ public class UnionLoginStrategy implements LoginStrategy
 
     public void setAnonymousAccess(AccessLevel level)
     {
-        _log.debug( "Setting anonymous access to {}", level);
+        LOGGER.debug( "Setting anonymous access to {}", level);
         _anonymousAccess = level;
     }
 
@@ -97,11 +97,11 @@ public class UnionLoginStrategy implements LoginStrategy
         PermissionDeniedCacheException loginFailure = null;
         try {
             for (LoginStrategy strategy: _loginStrategies) {
-                _log.debug( "Attempting login strategy: {}", strategy.getClass().getName());
+                LOGGER.debug( "Attempting login strategy: {}", strategy.getClass().getName());
 
                 try {
                     LoginReply login = strategy.login(subject);
-                    _log.debug( "Login strategy returned {}", login.getSubject());
+                    LOGGER.debug( "Login strategy returned {}", login.getSubject());
                     if (!Subjects.isNobody(login.getSubject())) {
                         return login;
                     }
@@ -109,7 +109,7 @@ public class UnionLoginStrategy implements LoginStrategy
                     /* LoginStrategies throw IllegalArgumentException when
                      * provided with a Subject they cannot handle.
                      */
-                    _log.debug("Login failed with IllegalArgumentException for {}: {}", subject,
+                    LOGGER.debug("Login failed with IllegalArgumentException for {}: {}", subject,
                             e.getMessage());
                 }
             }
@@ -119,16 +119,16 @@ public class UnionLoginStrategy implements LoginStrategy
 
         if (areCredentialsSupplied && !_shouldFallback) {
             PermissionDeniedCacheException e = loginFailure != null ? loginFailure : new PermissionDeniedCacheException("No strategy able to authenticate");
-            _log.debug("Login denied: {}", e.getMessage());
+            LOGGER.debug("Login denied: {}", e.getMessage());
             throw e;
         }
 
-        _log.debug( "Strategies failed, trying for anonymous access");
+        LOGGER.debug( "Strategies failed, trying for anonymous access");
 
         LoginReply reply = new LoginReply();
         switch (_anonymousAccess) {
         case READONLY:
-            _log.debug( "Allowing read-only access as an anonymous user");
+            LOGGER.debug( "Allowing read-only access as an anonymous user");
             reply.getLoginAttributes().add(Restrictions.readOnly());
             if (origin.isPresent()) {
                 reply.getSubject().getPrincipals().add(origin.get());
@@ -136,14 +136,14 @@ public class UnionLoginStrategy implements LoginStrategy
             break;
 
         case FULL:
-            _log.debug( "Allowing full access as an anonymous user");
+            LOGGER.debug( "Allowing full access as an anonymous user");
             if (origin.isPresent()) {
                 reply.getSubject().getPrincipals().add(origin.get());
             }
             break;
 
         default:
-            _log.debug( "Login failed");
+            LOGGER.debug( "Login failed");
             throw loginFailure != null ? loginFailure : new PermissionDeniedCacheException("Access denied");
         }
         return reply;

--- a/modules/dcache/src/main/java/org/dcache/boot/Domain.java
+++ b/modules/dcache/src/main/java/org/dcache/boot/Domain.java
@@ -51,7 +51,7 @@ public class Domain
 {
     private static final String SYSTEM_CELL_NAME = "System";
 
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(SystemCell.class);
 
     private static final Logger EVENT_LOGGER = LoggerFactory.getLogger("org.dcache.zookeeper");
@@ -138,7 +138,7 @@ public class Domain
         SystemCell systemCell = SystemCell.create(domainName,
                 createCuratorFramework(), zone, cellSerializer);
         systemCell.start().get();
-        _log.info("Starting {}", domainName);
+        LOGGER.info("Starting {}", domainName);
 
         executePreload(systemCell);
         for (ConfigurationProperties serviceConfig: _services) {
@@ -146,7 +146,7 @@ public class Domain
         }
 
         if (_services.isEmpty()) {
-            _log.warn("No services found. Domain appears to be empty.");
+            LOGGER.warn("No services found. Domain appears to be empty.");
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/cells/LeadershipListenerGroup.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/LeadershipListenerGroup.java
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class LeadershipListenerGroup implements LeaderLatchListener {
 
-    private static final Logger log = LoggerFactory.getLogger(LeadershipListenerGroup.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LeadershipListenerGroup.class);
 
     private final Set<LeaderLatchListener> leaderElectionAwareComponents = new HashSet<>();
 
@@ -42,13 +42,13 @@ public class LeadershipListenerGroup implements LeaderLatchListener {
 
     @Override
     public void isLeader() {
-        log.info("HA: Assuming leader role.");
+        LOGGER.info("HA: Assuming leader role.");
         leaderElectionAwareComponents.forEach(LeaderLatchListener::isLeader);
     }
 
     @Override
     public void notLeader() {
-        log.info("HA: Dropping leader role.");
+        LOGGER.info("HA: Dropping leader role.");
         leaderElectionAwareComponents.forEach(LeaderLatchListener::notLeader);
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
@@ -37,7 +37,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -76,7 +75,7 @@ import static org.dcache.util.StringMarkup.quotedString;
  */
 public class HttpPoolRequestHandler extends HttpRequestHandler
 {
-    private static final Logger _logger =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(HttpPoolRequestHandler.class);
 
     private static final String DIGEST = "Digest";
@@ -260,7 +259,7 @@ public class HttpPoolRequestHandler extends HttpRequestHandler
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception
     {
-        _logger.debug("HTTP connection from {} established", ctx.channel().remoteAddress());
+        LOGGER.debug("HTTP connection from {} established", ctx.channel().remoteAddress());
     }
 
     private static FileReleaseErrors uploadsSeeError(Exception e)
@@ -290,14 +289,14 @@ public class HttpPoolRequestHandler extends HttpRequestHandler
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception
     {
-        _logger.debug("HTTP connection from {} closed", ctx.channel().remoteAddress());
+        LOGGER.debug("HTTP connection from {} closed", ctx.channel().remoteAddress());
         releaseAllFiles(uploadsSeeError(new FileCorruptedCacheException("Connection lost before end of file.")));
     }
 
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable t)
     {
         if (t instanceof ClosedChannelException) {
-            _logger.info("Connection {} unexpectedly closed.", ctx.channel());
+            LOGGER.info("Connection {} unexpectedly closed.", ctx.channel());
         } else if (t instanceof Exception) {
             releaseAllFiles(downloadsSeeError(new CacheException(t.toString(), t))
                     .uploadsSeeError(new FileCorruptedCacheException("Connection lost before end of file: " + t, t)));
@@ -315,8 +314,8 @@ public class HttpPoolRequestHandler extends HttpRequestHandler
         if (event instanceof IdleStateEvent) {
             IdleStateEvent idleStateEvent = (IdleStateEvent) event;
             if (idleStateEvent.state() == IdleState.ALL_IDLE) {
-                if (_logger.isInfoEnabled()) {
-                    _logger.info("Connection from {} id idle; disconnecting.",
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("Connection from {} id idle; disconnecting.",
                                  ctx.channel().remoteAddress());
                 }
                 releaseAllFiles(uploadsSeeError(new FileCorruptedCacheException("Channel idle for too long during upload.")));
@@ -355,7 +354,7 @@ public class HttpPoolRequestHandler extends HttpRequestHandler
                 : "entity";
 
         if (!dr.isFinished()) {
-            _logger.warn("Client sent incomplete {}", type);
+            LOGGER.warn("Client sent incomplete {}", type);
             return true;
         }
 
@@ -374,7 +373,7 @@ public class HttpPoolRequestHandler extends HttpRequestHandler
                             : escapeNonASCII(message));
         }
 
-        _logger.warn("Client sent malformed {}: {}", type, description);
+        LOGGER.warn("Client sent malformed {}: {}", type, description);
         return true;
     }
 
@@ -660,7 +659,7 @@ public class HttpPoolRequestHandler extends HttpRequestHandler
         Map<String, List<String>> params = queryStringDecoder.parameters();
         if (!params.containsKey(HttpTransferService.UUID_QUERY_PARAM)) {
             if(!request.getUri().equals("/favicon.ico")) {
-                _logger.error("Received request without UUID in the query " +
+                LOGGER.error("Received request without UUID in the query " +
                         "string. Request-URI was {}", request.getUri());
             }
 
@@ -684,7 +683,7 @@ public class HttpPoolRequestHandler extends HttpRequestHandler
         FsPath transferFile = FsPath.create(file.getProtocolInfo().getPath());
 
         if (!requestedFile.equals(transferFile)) {
-            _logger.warn("Received an illegal request for file {}, while serving {}",
+            LOGGER.warn("Received an illegal request for file {}, while serving {}",
                     requestedFile,
                     transferFile);
             throw new IllegalArgumentException("The file you specified does " +

--- a/modules/dcache/src/main/java/org/dcache/http/KeepAliveHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/KeepAliveHandler.java
@@ -41,7 +41,7 @@ import java.util.Deque;
  */
 public class KeepAliveHandler extends ChannelDuplexHandler
 {
-    private static final Logger LOG = LoggerFactory.getLogger(KeepAliveHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeepAliveHandler.class);
 
     private boolean _hasPreviousRequest;
     private boolean _isLastRequestKeepAlive;
@@ -73,7 +73,7 @@ public class KeepAliveHandler extends ChannelDuplexHandler
                  * reply to any further traffic with a RST, tearing down the
                  * client side of the TCP connection.
                  */
-                LOG.debug("Broken client sent request after previously asking " +
+                LOGGER.debug("Broken client sent request after previously asking " +
                         "the connection be closed.");
                 return;
             }

--- a/modules/dcache/src/main/java/org/dcache/kafka/LoggingProducerListener.java
+++ b/modules/dcache/src/main/java/org/dcache/kafka/LoggingProducerListener.java
@@ -24,7 +24,7 @@ import org.springframework.kafka.support.ProducerListener;
 
 public class LoggingProducerListener implements ProducerListener {
 
-    private static final Logger _log = LoggerFactory.getLogger(LoggingProducerListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingProducerListener.class);
 
 
     @Override
@@ -34,7 +34,7 @@ public class LoggingProducerListener implements ProducerListener {
 
     @Override
     public void onError(String topic, Integer partition, Object key, Object value, Exception exception) {
-        _log.error("Unable to send message to topic {} on  partition {}, with key {} and value {} : {}",
+        LOGGER.error("Unable to send message to topic {} on  partition {}, with key {} and value {} : {}",
                 topic, partition, key, value, exception.getMessage());
     }
 

--- a/modules/dcache/src/main/java/org/dcache/macaroons/InMemorySecretStorage.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/InMemorySecretStorage.java
@@ -21,12 +21,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -39,7 +36,7 @@ import java.util.TreeMap;
  */
 public class InMemorySecretStorage
 {
-    private static final Logger LOG = LoggerFactory.getLogger(InMemorySecretStorage.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(InMemorySecretStorage.class);
 
     private final SortedMap<Instant,IdentifiedSecret> _secrets = new TreeMap<>();
     private final Map<String,IdentifiedSecret> _secretsByIdentifier = new HashMap<>();
@@ -58,7 +55,7 @@ public class InMemorySecretStorage
      */
     public synchronized IdentifiedSecret put(Instant expiry, IdentifiedSecret secret)
     {
-        LOG.debug("Adding secret {} expiring at {}", secret.getIdentifier(), expiry);
+        LOGGER.debug("Adding secret {} expiring at {}", secret.getIdentifier(), expiry);
         _secrets.put(expiry, secret);
         _secretsByIdentifier.put(secret.getIdentifier(), secret);
         return secret;
@@ -74,12 +71,12 @@ public class InMemorySecretStorage
             String id = secret.getIdentifier();
             secret = _secretsByIdentifier.remove(id);
             if (secret == null) {
-                LOG.warn("Removed secret {} expiring at {}, but failed to remove from identifier map", id, expiry);
+                LOGGER.warn("Removed secret {} expiring at {}, but failed to remove from identifier map", id, expiry);
             } else {
-                LOG.debug("Removed secret {} expiring at {}", id, expiry);
+                LOGGER.debug("Removed secret {} expiring at {}", id, expiry);
             }
         } else {
-            LOG.debug("Requested removal of secret expiring at {}, but none found", expiry);
+            LOGGER.debug("Requested removal of secret expiring at {}, but none found", expiry);
         }
     }
 
@@ -107,7 +104,7 @@ public class InMemorySecretStorage
      */
     public synchronized Set<Instant> expiringBefore(Instant cutoff)
     {
-        LOG.debug("Checking for expired secrets");
+        LOGGER.debug("Checking for expired secrets");
 
         Set<Instant> expired = _secrets.headMap(cutoff).keySet();
 

--- a/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonContext.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonContext.java
@@ -45,7 +45,7 @@ import static org.dcache.macaroons.InvalidCaveatException.checkCaveat;
  */
 public class MacaroonContext
 {
-    private static final Logger LOG = LoggerFactory.getLogger(MacaroonContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MacaroonContext.class);
 
     private FsPath root = FsPath.ROOT;
     private FsPath home = FsPath.ROOT;
@@ -61,13 +61,13 @@ public class MacaroonContext
 
     public void updateHome(String directory) throws InvalidCaveatException
     {
-        LOG.debug("Updating home: {}", directory);
+        LOGGER.debug("Updating home: {}", directory);
         home = root.resolve(directory);
     }
 
     public void setHome(FsPath path)
     {
-        LOG.debug("Setting home to {}", path);
+        LOGGER.debug("Setting home to {}", path);
         home = path;
     }
 
@@ -78,7 +78,7 @@ public class MacaroonContext
 
     public void setRoot(FsPath newRoot)
     {
-        LOG.debug("Setting root to {}", root);
+        LOGGER.debug("Setting root to {}", root);
         checkArgument(newRoot.hasPrefix(root), "Attempt to weaken root path");
         root = newRoot;
     }
@@ -114,7 +114,7 @@ public class MacaroonContext
     public void setPath(FsPath desiredPath)
     {
         path = desiredPath;
-        LOG.debug("Setting path to {}", path);
+        LOGGER.debug("Setting path to {}", path);
     }
 
     public void updatePath(String directory)
@@ -184,7 +184,7 @@ public class MacaroonContext
 
     public void removeActivities(EnumSet<Activity> deniedActivities)
     {
-        LOG.debug("Denying activities: {}", deniedActivities);
+        LOGGER.debug("Denying activities: {}", deniedActivities);
         activities.removeAll(deniedActivities);
     }
 
@@ -223,7 +223,7 @@ public class MacaroonContext
 
         if (!expiry.isPresent() || newExpiry.isBefore(expiry.get())) {
             expiry = Optional.of(newExpiry);
-            LOG.debug("Updating expiry to {}", newExpiry);
+            LOGGER.debug("Updating expiry to {}", newExpiry);
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonProcessor.java
@@ -7,13 +7,11 @@ import com.github.nitram509.jmacaroons.MacaroonsVerifier;
 import com.github.nitram509.jmacaroons.NotDeSerializableException;
 import com.google.common.base.Throwables;
 import com.google.common.hash.Hashing;
-import com.google.common.io.BaseEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
 import java.net.InetAddress;
-import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Arrays;
@@ -30,7 +28,7 @@ import static org.dcache.macaroons.CaveatValues.*;
  */
 public class MacaroonProcessor
 {
-    private static final Logger LOG  = LoggerFactory.getLogger(MacaroonProcessor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MacaroonProcessor.class);
     private static final int SECRET_ID_LENGTH = 8;
     // In Base64, every 3 bytes is represented as 4 characters.
     private static final int SECRET_ID_LENGTH_BYTES = SECRET_ID_LENGTH * 3 / 4;
@@ -145,7 +143,7 @@ public class MacaroonProcessor
     public MacaroonContext expandMacaroon(String serialisedMacaroon, InetAddress clientAddress)
             throws InvalidMacaroonException
     {
-        LOG.trace("Received macaroon validate message");
+        LOGGER.trace("Received macaroon validate message");
 
         Macaroon macaroon = MacaroonsBuilder.deserialize(serialisedMacaroon);
 

--- a/modules/dcache/src/main/java/org/dcache/macaroons/ZookeeperSecretHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/ZookeeperSecretHandler.java
@@ -53,7 +53,7 @@ import org.dcache.util.FireAndForgetTask;
 public class ZookeeperSecretHandler implements SecretHandler,
         CuratorFrameworkAware, CellIdentityAware, CellLifeCycleAware
 {
-    private static final Logger LOG = LoggerFactory.getLogger(ZookeeperSecretHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperSecretHandler.class);
     private static final long INITIAL_EXPIRATION_DELAY = TimeUnit.MINUTES.toMillis(5);
     private static final Duration MINIMUM_SECRET_VALIDITY = Duration.ofMinutes(5);
 
@@ -81,7 +81,7 @@ public class ZookeeperSecretHandler implements SecretHandler,
         @Override
         public void isLeader()
         {
-            LOG.debug("Have become leader");
+            LOGGER.debug("Have become leader");
             expirationFuture = executor.scheduleWithFixedDelay(expirationTask,
                     INITIAL_EXPIRATION_DELAY, expirationPeriodUnit.toMillis(expirationPeriod),
                     TimeUnit.MILLISECONDS);
@@ -90,7 +90,7 @@ public class ZookeeperSecretHandler implements SecretHandler,
         @Override
         public void notLeader()
         {
-            LOG.debug("Have yielded leadership");
+            LOGGER.debug("Have yielded leadership");
             expirationFuture.cancel(false);
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/macaroons/ZookeeperSecretStorage.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/ZookeeperSecretStorage.java
@@ -50,7 +50,7 @@ import static org.dcache.macaroons.ZookeeperSecretHandler.ZK_MACAROONS;
  */
 public class ZookeeperSecretStorage implements PathChildrenCacheListener, CuratorFrameworkAware, CellLifeCycleAware
 {
-    private static final Logger LOG = LoggerFactory.getLogger(ZookeeperSecretStorage.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperSecretStorage.class);
     private static final String ZK_MACAROONS_SECRETS = ZKPaths.makePath(ZK_MACAROONS, "secrets");
     private static final String IDENTITY_KEY = "id:";
     private static final String SECRET_KEY = "secret:";
@@ -88,7 +88,7 @@ public class ZookeeperSecretStorage implements PathChildrenCacheListener, Curato
     @Override
     public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws IOException
     {
-        LOG.debug("Recieved event {}", event);
+        LOGGER.debug("Recieved event {}", event);
 
         ChildData child = event.getData();
 
@@ -98,7 +98,7 @@ public class ZookeeperSecretStorage implements PathChildrenCacheListener, Curato
             break;
 
         case CHILD_UPDATED:
-            LOG.error("Secret unexpectedly updated: {}", event);
+            LOGGER.error("Secret unexpectedly updated: {}", event);
             break;
 
         case CHILD_ADDED:
@@ -169,14 +169,14 @@ public class ZookeeperSecretStorage implements PathChildrenCacheListener, Curato
 
     public IdentifiedSecret put(Instant expiry, IdentifiedSecret secret) throws Exception
     {
-        LOG.debug("Adding secret {} into ZK with expire after {}", secret.getIdentifier(), expiry);
+        LOGGER.debug("Adding secret {} into ZK with expire after {}", secret.getIdentifier(), expiry);
 
         try {
             client.create().creatingParentsIfNeeded().forPath(pathFromExpiry(expiry), encodeSecret(secret));
             storage.put(expiry, secret);
             return secret;
         } catch (KeeperException.NodeExistsException e) {
-            LOG.debug("Lost put race, returning winner");
+            LOGGER.debug("Lost put race, returning winner");
             Optional<IdentifiedSecret> winner = storage.get(expiry);
             return winner.orElseThrow(() -> e);
         }
@@ -184,14 +184,14 @@ public class ZookeeperSecretStorage implements PathChildrenCacheListener, Curato
 
     private void remove(Instant expiry)
     {
-        LOG.debug("Removing secret expiring at {} from ZK", expiry);
+        LOGGER.debug("Removing secret expiring at {} from ZK", expiry);
 
         String path = pathFromExpiry(expiry);
         try {
             client.delete().forPath(path);
         } catch (Exception e) {
             Throwables.throwIfUnchecked(e);
-            LOG.error("Failed to delete path {} from ZK: {}", path, e.getMessage());
+            LOGGER.error("Failed to delete path {} from ZK: {}", path, e.getMessage());
         }
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/missingfiles/AlwaysFailMissingFileStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/missingfiles/AlwaysFailMissingFileStrategy.java
@@ -13,7 +13,7 @@ import diskCacheV111.util.FsPath;
  */
 public class AlwaysFailMissingFileStrategy implements MissingFileStrategy
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
             LoggerFactory.getLogger(AlwaysFailMissingFileStrategy.class);
 
     @Override

--- a/modules/dcache/src/main/java/org/dcache/missingfiles/MissingFileHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/missingfiles/MissingFileHandler.java
@@ -25,7 +25,7 @@ import org.dcache.missingfiles.plugins.Result;
  */
 public class MissingFileHandler implements CellMessageReceiver
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
             LoggerFactory.getLogger(RemoteMissingFileStrategy.class);
 
     private ExecutorService _executor;
@@ -34,7 +34,7 @@ public class MissingFileHandler implements CellMessageReceiver
 
     public Reply messageArrived(MissingFileMessage message)
     {
-        _log.debug("Received notice {} {}", message.getRequestedPath(),
+        LOGGER.debug("Received notice {} {}", message.getRequestedPath(),
                 message.getInternalPath());
 
         MessageReply<MissingFileMessage> reply =
@@ -126,14 +126,14 @@ public class MissingFileHandler implements CellMessageReceiver
             try {
                 result = future.get();
             } catch (CancellationException e) {
-                _log.debug("Operation was cancelled");
+                LOGGER.debug("Operation was cancelled");
                 return false;
             } catch (InterruptedException e) {
-                _log.debug("Interrupted while waiting for plugin result");
+                LOGGER.debug("Interrupted while waiting for plugin result");
                 return false;
             } catch (ExecutionException e) {
                 Throwable t = e.getCause();
-                _log.error("Plugin bug: {}", t.getMessage(),
+                LOGGER.error("Plugin bug: {}", t.getMessage(),
                         t);
                 return true;
             }

--- a/modules/dcache/src/main/java/org/dcache/missingfiles/RemoteMissingFileStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/missingfiles/RemoteMissingFileStrategy.java
@@ -19,7 +19,7 @@ import org.dcache.cells.CellStub;
  */
 public class RemoteMissingFileStrategy implements MissingFileStrategy
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
             LoggerFactory.getLogger(RemoteMissingFileStrategy.class);
 
     private CellStub _stub;
@@ -43,9 +43,9 @@ public class RemoteMissingFileStrategy implements MissingFileStrategy
             reply = _stub.sendAndWait(msg);
             return reply.getAction();
         } catch (NoRouteToCellException | CacheException e) {
-            _log.error(e.getMessage());
+            LOGGER.error(e.getMessage());
         } catch (InterruptedException e) {
-            _log.info("interrupted while waiting for advise from missing-files service");
+            LOGGER.info("interrupted while waiting for advise from missing-files service");
         }
 
         return Action.FAIL;

--- a/modules/dcache/src/main/java/org/dcache/missingfiles/plugins/PluginChain.java
+++ b/modules/dcache/src/main/java/org/dcache/missingfiles/plugins/PluginChain.java
@@ -26,7 +26,7 @@ import static com.google.common.collect.Iterables.find;
  */
 public class PluginChain implements EnvironmentAware
 {
-    private static final Logger _log = LoggerFactory.getLogger(PluginChain.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PluginChain.class);
 
     private static final ServiceLoader<PluginFactory> _factories =
             ServiceLoader.load(PluginFactory.class);
@@ -76,9 +76,9 @@ public class PluginChain implements EnvironmentAware
             PluginInstance pi = new PluginInstance(name, plugin);
             _plugins.add(pi);
         } catch(NoSuchElementException e) {
-            _log.error("Unknown plugin");
+            LOGGER.error("Unknown plugin");
         } catch(RuntimeException e) {
-            _log.error("Failed to instantiate plugin: {}", e.getMessage());
+            LOGGER.error("Failed to instantiate plugin: {}", e.getMessage());
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/LoggingDao.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/LoggingDao.java
@@ -25,7 +25,7 @@ import org.dcache.util.TimeUtils.TimeUnitFormat;
  */
 public class LoggingDao implements PinDao
 {
-    private static final Logger LOG = LoggerFactory.getLogger(LoggingDao.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingDao.class);
 
     /** Base class for wrapping either PinCriterion or PinUpdate. */
     private abstract static class LoggingWrappingBuilder<I,W extends I>
@@ -306,8 +306,8 @@ public class LoggingDao implements PinDao
     public Pin create(PinUpdate update)
     {
         LoggingPinUpdate u = (LoggingPinUpdate)update;
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Creating pin in database that{}.", u.getDescription(true));
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Creating pin in database that{}.", u.getDescription(true));
         }
         return inner.create(u.inner);
     }
@@ -316,8 +316,8 @@ public class LoggingDao implements PinDao
     public List<Pin> get(PinCriterion criterion)
     {
         LoggingPinCriterion c = (LoggingPinCriterion) criterion;
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Obtaining information about {}{}.", c.getTarget(),
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Obtaining information about {}{}.", c.getTarget(),
                     c.getDescription());
         }
         return inner.get(c.inner);
@@ -327,8 +327,8 @@ public class LoggingDao implements PinDao
     public List<Pin> get(PinCriterion criterion, int limit)
     {
         LoggingPinCriterion c = (LoggingPinCriterion) criterion;
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Obtaining information about at most {} pins{}.", limit,
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Obtaining information about at most {} pins{}.", limit,
                     c.getDescription());
         }
         return inner.get(c.inner, limit);
@@ -338,8 +338,8 @@ public class LoggingDao implements PinDao
     public Pin get(UniquePinCriterion criterion)
     {
         LoggingPinCriterion c = (LoggingPinCriterion) criterion;
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Obtaining information about {}{}.", c.getTarget(),
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Obtaining information about {}{}.", c.getTarget(),
                     c.getDescription());
         }
         return inner.get(c.innerUnique);
@@ -349,9 +349,9 @@ public class LoggingDao implements PinDao
     public int count(PinCriterion criterion)
     {
         LoggingPinCriterion c = (LoggingPinCriterion) criterion;
-        if (LOG.isDebugEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             String operation = c.isUnique() ? "Checking existance of" : "Counting";
-            LOG.debug("{} {}{}.", operation, c.getTarget(), c.getDescription());
+            LOGGER.debug("{} {}{}.", operation, c.getTarget(), c.getDescription());
         }
 
         return inner.count(c.inner);
@@ -377,8 +377,8 @@ public class LoggingDao implements PinDao
 
     private void logUpdate(LoggingPinCriterion criterion, LoggingPinUpdate update)
     {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Updating {}{} so {}{}.", criterion.getTarget(),
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Updating {}{} so {}{}.", criterion.getTarget(),
                     criterion.getDescription(), criterion.getSubjectPronoun(),
                     update.getDescription(criterion.isUnique()));
         }
@@ -388,8 +388,8 @@ public class LoggingDao implements PinDao
     public int delete(PinCriterion criterion)
     {
         LoggingPinCriterion c = (LoggingPinCriterion) criterion;
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Deleting {}{}.", c.getTarget(), c.getDescription());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Deleting {}{}.", c.getTarget(), c.getDescription());
         }
         return inner.delete(c.inner);
     }
@@ -400,9 +400,9 @@ public class LoggingDao implements PinDao
     {
         LoggingPinCriterion c = (LoggingPinCriterion) criterion;
 
-        if (LOG.isDebugEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             String id = "FOREACH-" + foreachCounter.incrementAndGet();
-            LOG.debug("Operating on {}{} as {}.", c.getTarget(),
+            LOGGER.debug("Operating on {}{} as {}.", c.getTarget(),
                     c.getDescription(), id);
             NDC.push(id);
         }
@@ -410,7 +410,7 @@ public class LoggingDao implements PinDao
         try {
             inner.foreach(c.inner, f);
         } finally {
-            if (LOG.isDebugEnabled()) {
+            if (LOGGER.isDebugEnabled()) {
                 NDC.pop();
             }
         }    }
@@ -421,10 +421,10 @@ public class LoggingDao implements PinDao
     {
         LoggingPinCriterion c = (LoggingPinCriterion) criterion;
 
-        if (LOG.isDebugEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             String limitString = " (limit: " + limit + ")";
             String id = "FOREACH-" + foreachCounter.incrementAndGet();
-            LOG.debug("Operating on {}{} as {}{}.", c.getTarget(),
+            LOGGER.debug("Operating on {}{} as {}{}.", c.getTarget(),
                     c.getDescription(), id, limitString);
             NDC.push(id);
         }
@@ -432,7 +432,7 @@ public class LoggingDao implements PinDao
         try {
             inner.foreach(c.inner, f, limit);
         } finally {
-            if (LOG.isDebugEnabled()) {
+            if (LOGGER.isDebugEnabled()) {
                 NDC.pop();
             }
         }

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/MovePinRequestProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/MovePinRequestProcessor.java
@@ -55,7 +55,7 @@ import static org.springframework.transaction.annotation.Isolation.REPEATABLE_RE
 public class MovePinRequestProcessor
     implements CellMessageReceiver
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(MovePinRequestProcessor.class);
 
     private static final long POOL_LIFETIME_MARGIN = MINUTES.toMillis(30);
@@ -241,7 +241,7 @@ public class MovePinRequestProcessor
                 _dao.delete(tmpPin);
             }
 
-            _log.info("Moved pins for {} from {} to {}", pnfsId, source, target);
+            LOGGER.info("Moved pins for {} from {} to {}", pnfsId, source, target);
         } catch (NoRouteToCellException e) {
             throw new CacheException("Failed to move pin due to communication failure: " + e.getDestinationPath(), e);
         }
@@ -281,7 +281,7 @@ public class MovePinRequestProcessor
                 message.setExpirationTime(pin.getExpirationTime());
             }
 
-            _log.info("Extended pin for {} ({})", pin.getPnfsId(), pin.getPinId());
+            LOGGER.info("Extended pin for {} ({})", pin.getPnfsId(), pin.getPinId());
 
             return message;
         } catch (NoRouteToCellException e) {

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManager.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManager.java
@@ -36,7 +36,7 @@ import static org.dcache.pinmanager.model.Pin.State.UNPINNING;
 
 public class PinManager implements CellMessageReceiver, LeaderLatchListener, CellInfoProvider
 {
-    private static final Logger _log = LoggerFactory.getLogger(PinManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PinManager.class);
     private static final long INITIAL_EXPIRATION_DELAY = SECONDS.toMillis(15);
     private static final long INITIAL_UNPIN_DELAY = SECONDS.toMillis(30);
 
@@ -135,10 +135,10 @@ public class PinManager implements CellMessageReceiver, LeaderLatchListener, Cel
                            dao.set().
                                     state(READY_TO_UNPIN));
             } catch (JDOException | DataAccessException e) {
-                _log.error("Database failure while expiring pins: {}",
+                LOGGER.error("Database failure while expiring pins: {}",
                            e.getMessage());
             } catch (RuntimeException e) {
-                _log.error("Unexpected failure while expiring pins", e);
+                LOGGER.error("Unexpected failure while expiring pins", e);
             } finally {
                 NDC.pop();
             }
@@ -163,10 +163,10 @@ public class PinManager implements CellMessageReceiver, LeaderLatchListener, Cel
                         dao.set().
                                 state(READY_TO_UNPIN));
             } catch (JDOException | DataAccessException e) {
-                _log.error("Database failure while resetting pins that previously failed to be unpinned: {}",
+                LOGGER.error("Database failure while resetting pins that previously failed to be unpinned: {}",
                         e.getMessage());
             } catch (RuntimeException e) {
-                _log.error("Unexpected failure while pins that previously failed to be unpinned", e);
+                LOGGER.error("Unexpected failure while pins that previously failed to be unpinned", e);
             } finally {
                 NDC.pop();
             }
@@ -189,10 +189,10 @@ public class PinManager implements CellMessageReceiver, LeaderLatchListener, Cel
     @Override
     public void isLeader()
     {
-        _log.info("Resetting existing intermediate pin states.");
+        LOGGER.info("Resetting existing intermediate pin states.");
         markAllExpiredPinsReadyToUnpin();
 
-        _log.info("Scheduling Expiration and Unpin tasks.");
+        LOGGER.info("Scheduling Expiration and Unpin tasks.");
         expirationFuture = executor.scheduleWithFixedDelay(
                 new FireAndForgetTask(expirationTask),
                 INITIAL_EXPIRATION_DELAY,
@@ -213,7 +213,7 @@ public class PinManager implements CellMessageReceiver, LeaderLatchListener, Cel
     @Override
     public void notLeader()
     {
-        _log.info("Cancelling Expiration, ResetFailedUnpins and Unpin tasks.");
+        LOGGER.info("Cancelling Expiration, ResetFailedUnpins and Unpin tasks.");
         expirationFuture.cancel(false);
         unpinFuture.cancel(true);
         resetFailedUnpinsFuture.cancel(true);

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinRequestProcessor.java
@@ -72,7 +72,7 @@ import static org.springframework.transaction.annotation.Isolation.REPEATABLE_RE
 public class PinRequestProcessor
     implements CellMessageReceiver
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(PinRequestProcessor.class);
 
     /**
@@ -228,7 +228,7 @@ public class PinRequestProcessor
                 RequestContainerV5.allStates :
                 RequestContainerV5.allStatesExceptStage;
         } catch (PatternSyntaxException | IOException ex) {
-            _log.error("Failed to check stage permission: {}", ex.toString());
+            LOGGER.error("Failed to check stage permission: {}", ex.toString());
         }
         return RequestContainerV5.allStatesExceptStage;
     }
@@ -256,7 +256,7 @@ public class PinRequestProcessor
             task.fail(rc, error);
             clearPin(task);
         } catch (RuntimeException e) {
-            _log.error(e.toString());
+            LOGGER.error(e.toString());
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinTask.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinTask.java
@@ -18,7 +18,7 @@ import org.dcache.vehicles.FileAttributes;
 
 public class PinTask
 {
-    private static final Logger _log = LoggerFactory.getLogger(PinTask.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PinTask.class);
 
     private final PinManagerPinMessage _request;
     private final Optional<MessageReply<PinManagerPinMessage>> _reply;
@@ -129,7 +129,7 @@ public class PinTask
     public void fail(int rc, String error)
     {
         _reply.ifPresent(r -> r.fail(_request, rc, error));
-        _log.warn("Failed to pin {}: {} [{}]", _pin.getPnfsId(), error, rc);
+        LOGGER.warn("Failed to pin {}: {} [{}]", _pin.getPnfsId(), error, rc);
     }
 
     public void success()
@@ -138,6 +138,6 @@ public class PinTask
                     _request.setPin(_pin);
                     r.reply(_request);
                 });
-        _log.info("Pinned {} on {} ({})", _pin.getPnfsId(), _pin.getPool(), _pin.getPinId());
+        LOGGER.info("Pinned {} on {} ({})", _pin.getPnfsId(), _pin.getPool(), _pin.getPinId());
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/UnpinProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/UnpinProcessor.java
@@ -43,7 +43,7 @@ import static org.dcache.pinmanager.model.Pin.State.UNPINNING;
  */
 public class UnpinProcessor implements Runnable
 {
-    private static final Logger _logger = LoggerFactory.getLogger(UnpinProcessor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnpinProcessor.class);
 
     private static final int MAX_RUNNING = 1000;
     private static final int NO_UNPIN_LIMIT_PER_RUN = -1;
@@ -73,14 +73,14 @@ public class UnpinProcessor implements Runnable
             unpin(idle, executor);
             idle.acquire(MAX_RUNNING);
         } catch (InterruptedException e) {
-            _logger.debug(e.toString());
+            LOGGER.debug(e.toString());
         } catch (JDOException | DataAccessException e) {
-            _logger.error("Database failure while unpinning: {}",
+            LOGGER.error("Database failure while unpinning: {}",
                           e.getMessage());
         } catch (RemoteConnectFailureException e) {
-            _logger.error("Remote connection failure while unpinning: {}", e.getMessage());
+            LOGGER.error("Remote connection failure while unpinning: {}", e.getMessage());
         } catch (RuntimeException e) {
-            _logger.error("Unexpected failure while unpinning", e);
+            LOGGER.error("Unexpected failure while unpinning", e);
         } finally {
             executor.shutdown();
             NDC.pop();
@@ -100,10 +100,10 @@ public class UnpinProcessor implements Runnable
     private void upin(Semaphore idle, Executor executor, Pin pin) throws InterruptedException
     {
         if (pin.getPool() == null) {
-            _logger.debug("No pool found for pin {}, pnfsid {}; no sticky flags to clear", pin.getPinId(), pin.getPnfsId());
+            LOGGER.debug("No pool found for pin {}, pnfsid {}; no sticky flags to clear", pin.getPinId(), pin.getPnfsId());
             _dao.delete(pin);
         } else {
-            _logger.debug("Clearing sticky flag for pin {}, pnfsid {} on pool {}", pin.getPinId(), pin.getPnfsId(), pin.getPool());
+            LOGGER.debug("Clearing sticky flag for pin {}, pnfsid {} on pool {}", pin.getPinId(), pin.getPnfsId(), pin.getPool());
             _dao.update(pin, _dao.set().state(UNPINNING));
             clearStickyFlag(idle, pin, executor);
         }
@@ -118,7 +118,7 @@ public class UnpinProcessor implements Runnable
     {
         PoolSelectionUnit.SelectionPool pool = _poolMonitor.getPoolSelectionUnit().getPool(pin.getPool());
         if (pool == null || !pool.isActive()) {
-            _logger.warn("Unable to clear sticky flag for pin {} on pnfsid {} because pool {} is unavailable", pin.getPinId(), pin.getPnfsId(), pin.getPool());
+            LOGGER.warn("Unable to clear sticky flag for pin {} on pnfsid {} because pool {} is unavailable", pin.getPinId(), pin.getPnfsId(), pin.getPool());
             failedToUnpin(pin);
             return;
         }
@@ -149,7 +149,7 @@ public class UnpinProcessor implements Runnable
                                          _dao.delete(pin);
                                          break;
                                      default:
-                                         _logger.warn("Failed to clear sticky flag: {} [{}]", error, rc);
+                                         LOGGER.warn("Failed to clear sticky flag: {} [{}]", error, rc);
                                          failedToUnpin(pin);
                                          break;
                                      }

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/UnpinRequestProcessor.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/UnpinRequestProcessor.java
@@ -22,7 +22,7 @@ import org.dcache.pinmanager.model.Pin;
 public class UnpinRequestProcessor
     implements CellMessageReceiver
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(UnpinRequestProcessor.class);
 
     private PinDao _dao;
@@ -71,7 +71,7 @@ public class UnpinRequestProcessor
                 message.setPinId(pin.getPinId());
                 message.setRequestId(pin.getRequestId());
 
-                _log.info("Unpinned {} ({})", pin.getPnfsId(), pin.getPinId());
+                LOGGER.info("Unpinned {} ({})", pin.getPnfsId(), pin.getPinId());
             }
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/NoCachedFilesSpaceSweeper.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/NoCachedFilesSpaceSweeper.java
@@ -27,7 +27,7 @@ public class NoCachedFilesSpaceSweeper
     extends AbstractStateChangeListener
     implements SpaceSweeperPolicy, PoolDataBeanProvider<SweeperData>
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(NoCachedFilesSpaceSweeper.class);
 
     private Repository _repository;
@@ -82,11 +82,11 @@ public class NoCachedFilesSpaceSweeper
                 if (!entry.isSticky()) {
                     _repository.setState(id, ReplicaState.REMOVED,
                             "Replica is now cache-only on pool with no-cache policy");
-                    _log.debug(entry.getPnfsId() + " removed: {}", event.getWhy());
+                    LOGGER.debug(entry.getPnfsId() + " removed: {}", event.getWhy());
                 }
             }
         } catch (InterruptedException | CacheException e) {
-            _log.warn("Failed to remove entry from repository ({}): {}",
+            LOGGER.warn("Failed to remove entry from repository ({}): {}",
                     event.getWhy(), e.getMessage() );
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/SpaceSweeper2.java
@@ -53,7 +53,7 @@ public class SpaceSweeper2
     implements Runnable, CellCommandListener, StateChangeListener, CellSetupProvider,
                 SpaceSweeperPolicy, PoolDataBeanProvider<SweeperData>
 {
-    private static final Logger _log = LoggerFactory.getLogger(SpaceSweeper2.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpaceSweeper2.class);
 
     private static final DateTimeFormatter ISO8601_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(ZoneId.systemDefault());
@@ -157,7 +157,7 @@ public class SpaceSweeper2
 
         PnfsId id = entry.getPnfsId();
         if (_queue.add(id, entry.getLastAccessTime())) {
-            _log.debug("Added {} to sweeper", id);
+            LOGGER.debug("Added {} to sweeper", id);
             /* The sweeper thread may be waiting for more files to
              * delete.
              */
@@ -171,7 +171,7 @@ public class SpaceSweeper2
     {
         PnfsId id = entry.getPnfsId();
         if (_queue.remove(id)) {
-            _log.debug("Removed {} from sweeper", id);
+            LOGGER.debug("Removed {} from sweeper", id);
             return true;
         }
         return false;
@@ -253,7 +253,7 @@ public class SpaceSweeper2
                 {
                     try {
                         long bytes = reclaim(Long.MAX_VALUE, "'sweeper purge' command");
-                        _log.info("'sweeper purge' reclaimed {} bytes.", bytes);
+                        LOGGER.info("'sweeper purge' reclaimed {} bytes.", bytes);
                     } catch (InterruptedException e) {
                     }
                 }
@@ -279,7 +279,7 @@ public class SpaceSweeper2
                 {
                     try {
                         long bytes = reclaim(bytesToFree, "'sweeper free' command");
-                        _log.info("'sweeper free {}' reclaimed {} bytes.", bytesToFree, bytes);
+                        LOGGER.info("'sweeper free {}' reclaimed {} bytes.", bytesToFree, bytes);
                     } catch (InterruptedException e) {
                     }
                 }
@@ -369,7 +369,7 @@ public class SpaceSweeper2
                 now = System.currentTimeMillis();
                 lvalue = now - lastAccess;
                 if (lvalue < 0L) {
-                    _log.warn("repository last access time for {}"
+                    LOGGER.warn("repository last access time for {}"
                                               + " is later than current "
                                               + "system time - now {}, "
                                               + "last access {}",
@@ -426,7 +426,7 @@ public class SpaceSweeper2
     private long reclaim(long amount, String why)
         throws InterruptedException
     {
-        _log.debug("Sweeper tries to reclaim {} bytes.", amount);
+        LOGGER.debug("Sweeper tries to reclaim {} bytes.", amount);
 
         /* We copy the entries into a tmp list to avoid
          * ConcurrentModificationException.
@@ -443,16 +443,16 @@ public class SpaceSweeper2
                 // Removing an open file will not free space until
                 // the file is closed, so we skip it this time around.
                 if (entry.getLinkCount() > 0) {
-                    _log.debug("File skipped by sweeper (in use): {}", entry);
+                    LOGGER.debug("File skipped by sweeper (in use): {}", entry);
                     continue;
                 }
                 if (!isRemovable(entry)) {
-                    _log.debug("File skipped by sweeper (not removable): {}", entry);
+                    LOGGER.debug("File skipped by sweeper (not removable): {}", entry);
                     continue;
                 }
 
                 long size = entry.getReplicaSize();
-                _log.debug("Sweeper removes {}.", id);
+                LOGGER.debug("Sweeper removes {}.", id);
                 _repository.setState(id, ReplicaState.REMOVED, why);
                 deleted += size;
             } catch (IllegalTransitionException | FileNotInCacheException e) {
@@ -460,7 +460,7 @@ public class SpaceSweeper2
                  * remove it ourselves.
                  */
             } catch (CacheException e) {
-                _log.error(e.getMessage());
+                LOGGER.error(e.getMessage());
             }
             if (deleted >= amount) {
                 break;
@@ -473,7 +473,7 @@ public class SpaceSweeper2
     private synchronized long getMarginalBytes()
     {
         double reclaim = _repository.getSpaceRecord().getTotalSpace() * _margin;
-        _log.debug("sweeper margin is {}, marginal space to reclaim is {} bytes.",
+        LOGGER.debug("sweeper margin is {}, marginal space to reclaim is {} bytes.",
                    _margin, reclaim);
         return (long)(reclaim);
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Job.java
@@ -14,7 +14,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -92,7 +91,7 @@ public class Job
     enum State { NEW, INITIALIZING, RUNNING, SLEEPING, PAUSED, SUSPENDED,
             STOPPING, CANCELLING, CANCELLED, FINISHED, FAILED }
 
-    private static final Logger _log = LoggerFactory.getLogger(Job.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Job.class);
 
     private final Set<PnfsId> _queued = new LinkedHashSet<>();
     private final Map<PnfsId,Long> _sizes = new HashMap<>();
@@ -160,7 +159,7 @@ public class Job
                         _lock.unlock();
                     }
                 } catch (InterruptedException e) {
-                    _log.error("Migration job was interrupted");
+                    LOGGER.error("Migration job was interrupted");
                 } finally {
                     _lock.lock();
                     try {
@@ -325,7 +324,7 @@ public class Job
                     // File was removed before we got to it - not a
                     // problem.
                 } catch (CacheException e) {
-                    _log.error("Failed to load entry: {}", e.getMessage());
+                    LOGGER.error("Failed to load entry: {}", e.getMessage());
                 }
             }
         } catch (IllegalStateException e) {
@@ -564,11 +563,11 @@ public class Job
                 } catch (FileNotInCacheException e) {
                     _sizes.remove(pnfsId);
                 } catch (CacheException e) {
-                    _log.error("Migration job failed to read entry: {}", e.getMessage());
+                    LOGGER.error("Migration job failed to read entry: {}", e.getMessage());
                     setState(State.FAILED);
                     break;
                 } catch (InterruptedException e) {
-                    _log.error("Migration job was interrupted: {}", e.getMessage());
+                    LOGGER.error("Migration job was interrupted: {}", e.getMessage());
                     setState(State.FAILED);
                     break;
                 } finally {
@@ -945,10 +944,10 @@ public class Job
         } catch (IllegalTransitionException e) {
             // File is likely about to be removed. TODO: log it
         } catch (CacheException e) {
-            _log.error("Migration job failed to update source mode: {}", e.getMessage());
+            LOGGER.error("Migration job failed to update source mode: {}", e.getMessage());
             setState(State.FAILED);
         } catch (InterruptedException e) {
-            _log.error("Migration job was interrupted");
+            LOGGER.error("Migration job was interrupted");
             setState(State.FAILED);
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModuleServer.java
@@ -60,7 +60,7 @@ public class MigrationModuleServer
     extends AbstractCellComponent
     implements CellMessageReceiver, CellInfoProvider, PoolDataBeanProvider<MigrationData>
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(MigrationModuleServer.class);
 
     private final Map<UUID, Request> _requests = new ConcurrentHashMap<>();

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/PoolListFilter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/PoolListFilter.java
@@ -17,7 +17,7 @@ import org.dcache.util.expression.Expression;
  */
 public class PoolListFilter implements RefreshablePoolList
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(PoolListFilter.class);
 
     private final Collection<Pattern> _exclude;

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/PoolListFromPoolManager.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/PoolListFromPoolManager.java
@@ -13,7 +13,7 @@ public abstract class PoolListFromPoolManager
     extends AbstractMessageCallback<PoolManagerGetPoolsMessage>
     implements RefreshablePoolList
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(PoolListFromPoolManager.class);
 
     protected ImmutableList<PoolManagerPoolInformation> _pools =
@@ -53,6 +53,6 @@ public abstract class PoolListFromPoolManager
     @Override
     public void failure(int rc, Object error)
     {
-        _log.error("Failed to query pool manager ({})", error );
+        LOGGER.error("Failed to query pool manager ({})", error );
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
@@ -41,7 +41,7 @@ import static org.dcache.util.Exceptions.messageOrClassName;
  */
 public class ChecksumChannel extends ForwardingRepositoryChannel
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
             LoggerFactory.getLogger(ChecksumChannel.class);
 
     /**
@@ -275,7 +275,7 @@ public class ChecksumChannel extends ForwardingRepositoryChannel
                             .map(Checksum::new)
                             .collect(Collectors.toSet());
                 } catch (IOException e) {
-                    _log.info("Unable to generate checksum of sparse file: {}", e.toString());
+                    LOGGER.info("Unable to generate checksum of sparse file: {}", e.toString());
                     return Collections.emptySet();
                 }
             }
@@ -340,7 +340,7 @@ public class ChecksumChannel extends ForwardingRepositoryChannel
             RangeSet<Long> overlappingRanges = _dataRangeSet.subRangeSet(writeRange);
             if (!overlappingRanges.isEmpty()) {
                 _isChecksumViable = false;
-                _log.info("On-transfer checksum aborted due to overlapping writes from client.");
+                LOGGER.info("On-transfer checksum aborted due to overlapping writes from client.");
                 return;
             }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteGsiftpTransferProtocol.java
@@ -113,7 +113,7 @@ import static org.dcache.util.Exceptions.messageOrClassName;
 public class RemoteGsiftpTransferProtocol
     implements MoverProtocol,ChecksumMover,DataBlocksRecipient
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(RemoteGsiftpTransferProtocol.class);
     //timeout after 5 minutes if credentials not delegated
     private static final int SERVER_SOCKET_TIMEOUT = 60 * 5 *1000;
@@ -182,8 +182,8 @@ public class RemoteGsiftpTransferProtocol
             ServerException, ClientException, KeyStoreException, URISyntaxException
     {
         _pnfsId = fileAttributes.getPnfsId();
-        if (_log.isDebugEnabled()) {
-            _log.debug("runIO()\n\tprotocol={},\n\tStorageInfo={},\n\tPnfsId={},\n\taccess ={}",
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("runIO()\n\tprotocol={},\n\tStorageInfo={},\n\tPnfsId={},\n\taccess ={}",
                     protocol, StorageInfos.extractFrom(fileAttributes), _pnfsId, access );
         }
         if (!(protocol instanceof RemoteGsiftpTransferProtocolInfo)) {
@@ -200,7 +200,7 @@ public class RemoteGsiftpTransferProtocol
                                 try {
                                     c.addType(t);
                                 } catch (IOException e) {
-                                    _log.warn("Unable to calculate checksum {}: {}",
+                                    LOGGER.warn("Unable to calculate checksum {}: {}",
                                             t, messageOrClassName(e));
                                 }
                             });
@@ -214,7 +214,7 @@ public class RemoteGsiftpTransferProtocol
         } else {
             gridFTPWrite(remoteGsiftpProtocolInfo);
         }
-        _log.debug(" runIO() done");
+        LOGGER.debug(" runIO() done");
     }
 
     @Override
@@ -267,7 +267,7 @@ public class RemoteGsiftpTransferProtocol
     public void gridFTPWrite(RemoteGsiftpTransferProtocolInfo protocolInfo)
         throws CacheException
     {
-        _log.debug("gridFTPWrite started");
+        LOGGER.debug("gridFTPWrite started");
 
         try {
             PnfsHandler pnfs = new PnfsHandler(_cell, PNFS_MANAGER);
@@ -277,10 +277,10 @@ public class RemoteGsiftpTransferProtocol
 
             if (!checksums.isEmpty()){
                 Checksum checksum = checksums.iterator().next();
-                _log.debug("Will use {} for transfer verification of {}", checksum, _pnfsId);
+                LOGGER.debug("Will use {} for transfer verification of {}", checksum, _pnfsId);
                 _client.setChecksum(checksum.getType().getName(), null);
             } else {
-                _log.debug("PnfsId {} does not have checksums", _pnfsId);
+                LOGGER.debug("PnfsId {} does not have checksums", _pnfsId);
             }
 
             URI dst_url =  new URI(protocolInfo.getGsiftpUrl());
@@ -306,15 +306,15 @@ public class RemoteGsiftpTransferProtocol
             GridftpClient.Checksum checksum = _client.negotiateCksm(path);
             return Optional.of(new Checksum(ChecksumType.valueOf(checksum.type), checksum.value));
         } catch (GridftpClient.ChecksumNotSupported e) {
-            _log.error("Checksum algorithm is not supported: {}", e.getMessage());
+            LOGGER.error("Checksum algorithm is not supported: {}", e.getMessage());
         } catch (IOException e) {
-            _log.error("I/O failure talking to FTP server: {}", messageOrClassName(e));
+            LOGGER.error("I/O failure talking to FTP server: {}", messageOrClassName(e));
         } catch (ServerException e) {
-            _log.error("GridFTP server failure: {}", e.getMessage());
+            LOGGER.error("GridFTP server failure: {}", e.getMessage());
         } catch (URISyntaxException e) {
-            _log.error("Invalid GridFTP URL: {}", e.getMessage());
+            LOGGER.error("Invalid GridFTP URL: {}", e.getMessage());
         } catch (ClientException e) {
-            _log.error("GridFTP client failure: {}", e.getMessage());
+            LOGGER.error("GridFTP client failure: {}", e.getMessage());
         }
         return Optional.empty();
     }
@@ -354,7 +354,7 @@ public class RemoteGsiftpTransferProtocol
         {
             if (_source) {
                 String error = "DiskDataSourceSink is source and write is called";
-                _log.error(error);
+                LOGGER.error(error);
                 throw new IllegalStateException(error);
             }
 
@@ -379,7 +379,7 @@ public class RemoteGsiftpTransferProtocol
         @Override
         public synchronized void close()
         {
-            _log.debug("DiskDataSink.close() called");
+            LOGGER.debug("DiskDataSink.close() called");
             _last_transfer_time    = System.currentTimeMillis();
         }
 
@@ -415,7 +415,7 @@ public class RemoteGsiftpTransferProtocol
         {
             if (!_source) {
                 String error = "DiskDataSourceSink is sink and read is called";
-                _log.error(error);
+                LOGGER.error(error);
                 throw new IllegalStateException(error);
             }
 
@@ -451,7 +451,7 @@ public class RemoteGsiftpTransferProtocol
                     return checksum.get();
                 }
             } catch (CacheException e) {
-                _log.warn("Failed to fetch checksum information: {}", e.getMessage());
+                LOGGER.warn("Failed to fetch checksum information: {}", e.getMessage());
             }
 
             String value = GridftpClient.getCksmValue(_fileChannel, type);

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -160,7 +160,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     private static final Set<HeaderFlags> INITIAL_REQUEST
             = EnumSet.noneOf(HeaderFlags.class);
 
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(RemoteHttpDataTransferProtocol.class);
 
     /** Maximum time to wait when establishing a connection. */
@@ -278,7 +278,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
             ProtocolInfo genericInfo, Set<? extends OpenOption> access)
             throws CacheException, IOException, InterruptedException
     {
-        _log.debug("info={}, attributes={},  access={}", genericInfo,
+        LOGGER.debug("info={}, attributes={},  access={}", genericInfo,
                 attributes, access);
         RemoteHttpDataTransferProtocolInfo info =
                 (RemoteHttpDataTransferProtocolInfo) genericInfo;
@@ -289,7 +289,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                                 try {
                                     c.addType(t);
                                 } catch (IOException e) {
-                                    _log.warn("Unable to calculate checksum {}: {}",
+                                    LOGGER.warn("Unable to calculate checksum {}: {}",
                                             t, messageOrClassName(e));
                                 }
                             });
@@ -414,13 +414,13 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     {
         HttpContext context = getContext();
         if (context == null) {
-            _log.debug("No HttpContext value");
+            LOGGER.debug("No HttpContext value");
             return Optional.empty();
         }
 
         Object conn = context.getAttribute(HttpCoreContext.HTTP_CONNECTION);
         if (conn == null) {
-            _log.debug("HTTP_CONNECTION is null");
+            LOGGER.debug("HTTP_CONNECTION is null");
             return Optional.empty();
         }
 
@@ -431,14 +431,14 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
 
         HttpInetConnection inetConn = (HttpInetConnection)conn;
         if (!inetConn.isOpen()) {
-            _log.debug("HttpConnection is no longer open");
+            LOGGER.debug("HttpConnection is no longer open");
             return Optional.empty();
         }
 
         try {
             InetAddress addr = inetConn.getRemoteAddress();
             if (addr == null) {
-                _log.debug("HttpInetConnection is not connected.");
+                LOGGER.debug("HttpInetConnection is not connected.");
                 return Optional.empty();
             }
 
@@ -446,7 +446,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
             InetSocketAddress sockAddr = new InetSocketAddress(addr, port);
             return Optional.of(sockAddr);
         } catch (ConnectionShutdownException e) {
-            _log.warn("HTTP_CONNECTION is unexpectedly unconnected");
+            LOGGER.warn("HTTP_CONNECTION is unexpectedly unconnected");
             // Perhaps a race condition here?  Hey ho.
             return Optional.empty();
         }
@@ -595,7 +595,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                             String percent = toThreeSigFig(100 * _channel.getBytesTransferred() / (double)_channel.size(), 1000);
                             message.append(" (").append(percent).append("%)");
                         } catch (IOException io) {
-                            _log.warn("failed to discover file size: {}", messageOrClassName(io));
+                            LOGGER.warn("failed to discover file size: {}", messageOrClassName(io));
                         }
                     }
                     throw new ThirdPartyTransferFailedCacheException(message.toString(), e);
@@ -707,7 +707,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                                     "HEAD Content-Length (%d) does not match file size (%d)",
                                     contentLength, fileSize);
                         } else {
-                            _log.debug("HEAD response did not contain Content-Length");
+                            LOGGER.debug("HEAD response did not contain Content-Length");
                         }
 
                         String rfc3230 = headerValue(response, "Digest");

--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
@@ -90,7 +90,7 @@ import static org.dcache.util.ByteUnit.KiB;
  */
 class Companion
 {
-    private static final Logger _log = LoggerFactory.getLogger(Companion.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Companion.class);
 
     private static final long PING_PERIOD = TimeUnit.MINUTES.toMillis(5);
     private static final int BUFFER_SIZE = KiB.toBytes(64);
@@ -335,7 +335,7 @@ class Companion
         try {
             handle.getChecksums().forEach(c -> knownChecksumTypes.add(c.getType()));
         } catch (CacheException e) {
-            _log.warn("Failed to fetch checksum information: {}", e.getMessage());
+            LOGGER.warn("Failed to fetch checksum information: {}", e.getMessage());
         }
 
         RepositoryChannel channel = handle.createChannel();
@@ -377,7 +377,7 @@ class Companion
                     /* Data is not guaranteed to be on disk. Not a fatal
                      * problem, but better generate a warning.
                      */
-                    _log.warn("Failed to synchronize file with storage device: {}",
+                    LOGGER.warn("Failed to synchronize file with storage device: {}",
                               e.getMessage());
                 }
             } finally {
@@ -600,17 +600,17 @@ class Companion
 
         if (_error != null) {
             if (_error instanceof Error) {
-                _log.error("P2P for {} failed due to a serious problem in the JVM.",
+                LOGGER.error("P2P for {} failed due to a serious problem in the JVM.",
                         _pnfsId, _error);
                 throw (Error)_error; // We should not attempt to recover from this!
             } else if (_error instanceof RuntimeException) {
-                _log.error("P2P for {} failed due to a bug.  Please report"
+                LOGGER.error("P2P for {} failed due to a bug.  Please report"
                         + " this to <support@dCache.org>", _pnfsId, _error);
             } else {
-                _log.error("P2P for {} failed: {}", _pnfsId, _error.toString());
+                LOGGER.error("P2P for {} failed: {}", _pnfsId, _error.toString());
             }
         } else {
-            _log.info("P2P for {} completed", _pnfsId);
+            LOGGER.info("P2P for {} completed", _pnfsId);
         }
 
         if (_callback != null) {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentReplicaStore.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ConsistentReplicaStore.java
@@ -45,7 +45,7 @@ import static org.dcache.util.Exceptions.messageOrClassName;
 public class ConsistentReplicaStore
     implements ReplicaStore
 {
-    private static final Logger _log = LoggerFactory.getLogger(ConsistentReplicaStore.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsistentReplicaStore.class);
 
     private final EnumSet<FileAttribute> REQUIRED_ATTRIBUTES =
             EnumSet.of(STORAGEINFO, LOCATIONS, ACCESS_LATENCY, RETENTION_POLICY, SIZE, CHECKSUM);
@@ -106,7 +106,7 @@ public class ConsistentReplicaStore
     {
         ReplicaRecord entry = _replicaStore.get(id);
         if (entry != null && isBroken(entry)) {
-            _log.warn("Recovering {}...", id);
+            LOGGER.warn("Recovering {}...", id);
 
             try {
                 /* It is safe to remove FROM_STORE/FROM_POOL replicas: We have
@@ -120,7 +120,7 @@ public class ConsistentReplicaStore
                 case DESTROYED:
                     _replicaStore.remove(id);
                     _pnfsHandler.clearCacheLocation(id);
-                    _log.info("Recovering: Removed {} because it was not fully staged.", id);
+                    LOGGER.info("Recovering: Removed {} because it was not fully staged.", id);
                     return null;
                 }
 
@@ -129,11 +129,11 @@ public class ConsistentReplicaStore
                 throw new DiskErrorCacheException("I/O error in healer: " + messageOrClassName(e), e);
             } catch (FileNotFoundCacheException e) {
                 _replicaStore.remove(id);
-                _log.warn("Recovering: Removed {} because name space entry was deleted.", id);
+                LOGGER.warn("Recovering: Removed {} because name space entry was deleted.", id);
                 return null;
             } catch (FileIsNewCacheException e) {
                 _replicaStore.remove(id);
-                _log.warn("Recovering: Removed {}: {}", id, e.getMessage());
+                LOGGER.warn("Recovering: Removed {}: {}", id, e.getMessage());
                 return null;
             } catch (TimeoutCacheException e) {
                 throw e;
@@ -143,7 +143,7 @@ public class ConsistentReplicaStore
             } catch (CacheException | NoSuchAlgorithmException e) {
                 entry.update("Failed to recover replica: " + e.getMessage(),
                         r -> r.setState(ReplicaState.BROKEN));
-                _log.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.BROKEN_FILE,
+                LOGGER.error(AlarmMarkerFactory.getMarker(PredefinedAlarm.BROKEN_FILE,
                                 id.toString(), _poolName),
                         "Marked {} bad: {}.", id, e.getMessage());
             }
@@ -169,7 +169,7 @@ public class ConsistentReplicaStore
 
            ReplicaState state = entry.getState();
 
-           _log.warn("Recovering: Fetched storage info for {} from name space.", id);
+           LOGGER.warn("Recovering: Fetched storage info for {} from name space.", id);
            FileAttributes attributesInNameSpace = _pnfsHandler.getFileAttributes(id, REQUIRED_ATTRIBUTES);
 
            /* As a special case, empty files upon client upload are deleted, except if we already managed to
@@ -219,7 +219,7 @@ public class ConsistentReplicaStore
                     AccessLatency accessLatency = attributesOnPool.getAccessLatency();
                     attributesToUpdate.setAccessLatency(accessLatency);
                     attributesInNameSpace.setAccessLatency(accessLatency);
-                    _log.warn("Recovering: Setting access latency of {} in name space to {}.",
+                    LOGGER.warn("Recovering: Setting access latency of {} in name space to {}.",
                             id, accessLatency);
                 }
 
@@ -236,20 +236,20 @@ public class ConsistentReplicaStore
                     attributesToUpdate.setRetentionPolicy(retentionPolicy);
                     attributesInNameSpace.setRetentionPolicy(retentionPolicy);
 
-                    _log.warn("Recovering: Setting retention policy of {} in name space to {}.",
+                    LOGGER.warn("Recovering: Setting retention policy of {} in name space to {}.",
                             id, retentionPolicy);
                 }
                 if (attributesInNameSpace.isUndefined(SIZE)) {
                     attributesToUpdate.setSize(length);
                     attributesInNameSpace.setSize(length);
 
-                    _log.warn("Recovering: Setting size of {} in name space to {}.", id, length);
+                    LOGGER.warn("Recovering: Setting size of {} in name space to {}.", id, length);
                 }
                 if (!additionalChecksums.isEmpty()) {
                     attributesToUpdate.setChecksums(additionalChecksums);
                     attributesInNameSpace.setChecksums(
                             Sets.newHashSet(concat(namespaceChecksums, additionalChecksums)));
-                    _log.warn("Recovering: Setting checksum of {} in name space to {}.",
+                    LOGGER.warn("Recovering: Setting checksum of {} in name space to {}.",
                             id, additionalChecksums);
                 }
             }
@@ -277,7 +277,7 @@ public class ConsistentReplicaStore
                     r.setState(targetState);
                     return null;
                 });
-                _log.warn("Recovering: Marked {} as {}.", id, targetState);
+                LOGGER.warn("Recovering: Marked {} as {}.", id, targetState);
             } else {
                 entry.update("Recovering " + state + " replica",
                         r -> r.setFileAttributes(attributesInNameSpace));

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCopyTool.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/MetaDataCopyTool.java
@@ -14,7 +14,7 @@ import diskCacheV111.util.PnfsId;
 
 public class MetaDataCopyTool
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(MetaDataCopyTool.class);
 
     static ReplicaStore createStore(Class<? extends ReplicaStore> clazz,
@@ -60,7 +60,7 @@ public class MetaDataCopyTool
             int size = ids.size();
             int count = 1;
             for (PnfsId id : ids) {
-                _log.info("Copying {} ({} of {})", id, count, size);
+                LOGGER.info("Copying {} ({} of {})", id, count, size);
                 ReplicaRecord entry = fromStore.get(id);
                 if (entry == null) {
                     System.err.println("Failed to load " + id);

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -39,7 +39,7 @@ import static org.dcache.util.Strings.toThreeSigFig;
 public class RepositoryInterpreter
     implements CellCommandListener
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
             LoggerFactory.getLogger(RepositoryInterpreter.class);
 
     private Repository _repository;
@@ -393,13 +393,13 @@ public class RepositoryInterpreter
                 } catch (IllegalTransitionException ignored) {
                     // File is transient - no problem
                 } catch (CacheException e) {
-                    _log.error("Failed to delete {}: {}", id, e.getMessage());
+                    LOGGER.error("Failed to delete {}: {}", id, e.getMessage());
                 } catch (InterruptedException e) {
-                    _log.warn("File removal was interrupted.");
+                    LOGGER.warn("File removal was interrupted.");
                     break;
                 }
             }
-            _log.info("'rep rmclass {}' removed {} files.", storageClassName, cnt);
+            LOGGER.info("'rep rmclass {}' removed {} files.", storageClassName, cnt);
             return cnt + " files removed.";
         }
     }
@@ -422,7 +422,7 @@ public class RepositoryInterpreter
         {
             CacheEntry entry = _repository.getEntry(pnfsId);
             if (isForced || entry.getState() == ReplicaState.CACHED && !entry.isSticky()) {
-                _log.warn("rep rm: removing {}", pnfsId);
+                LOGGER.warn("rep rm: removing {}", pnfsId);
                 _repository.setState(pnfsId, ReplicaState.REMOVED,
                         "'rep rm' command");
                 return "Removed " + pnfsId;

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
@@ -42,7 +42,7 @@ import static org.dcache.pool.repository.ReplicaState.*;
  */
 public class CacheRepositoryEntryImpl implements ReplicaRecord
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(CacheRepositoryEntryImpl.class);
 
     // Reusable list for the common case
@@ -96,7 +96,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
             try {
                 _size = _fileStore.getFileAttributeView(pnfsId).readAttributes().size();
             } catch (IOException e) {
-                _log.error("Failed to read file size: {}", e.toString());
+                LOGGER.error("Failed to read file size: {}", e.toString());
             }
             _state = BROKEN;
 
@@ -112,7 +112,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
                         _repository.getStorageInfoMap().put(pnfsId.toString(), storageInfo);
                     }
                 } catch (IOException e) {
-                    _log.error("Failed to set file size: {}", e.toString());
+                    LOGGER.error("Failed to set file size: {}", e.toString());
                 }
 
             } else {
@@ -145,7 +145,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
                     accessTimeInfoNew.setCreationTime(_creationTime);
                     _repository.getAccessTimeInfo().put(pnfsId.toString(), accessTimeInfoNew);
                 } catch (IOException e) {
-                    _log.error("Failed to set AccessTime size: {}", e.toString());
+                    LOGGER.error("Failed to set AccessTime size: {}", e.toString());
                 }
             }
         }
@@ -220,7 +220,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
                     .size();
 
         } catch (IOException e) {
-            _log.error("Failed to read file size: {}", e.toString());
+            LOGGER.error("Failed to read file size: {}", e.toString());
             return 0;
         }
     }
@@ -399,7 +399,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
                 // fallthrough and return broken record
             }
         } catch (ClassCastException e) {
-            _log.warn(e.toString());
+            LOGGER.warn(e.toString());
         } catch (RuntimeExceptionWrapper e) {
             /* BerkeleyDB wraps internal exceptions. We ignore class
              * cast and class not found exceptions, since they are a
@@ -409,7 +409,7 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord
                 !(e.getCause() instanceof ClassCastException)) {
                 throw e;
             }
-            _log.warn(e.toString());
+            LOGGER.warn(e.toString());
         }
         return new CacheRepositoryEntryImpl(repository, pnfsId, BROKEN, ImmutableList.of(),  fileStore);
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/ReplicaStoreDatabase.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/ReplicaStoreDatabase.java
@@ -23,7 +23,7 @@ import java.util.Properties;
  */
 public class ReplicaStoreDatabase
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger("logger.org.dcache.repository");
 
     private final Environment env;
@@ -59,7 +59,7 @@ public class ReplicaStoreDatabase
         envConfig.setExceptionListener(event -> {
             if (event.getException() instanceof EnvironmentFailureException && !env.isValid()) {
                 setFailed();
-                _log.error("Pool restart required due to Berkeley DB failure: {}", event.getException().getMessage());
+                LOGGER.error("Pool restart required due to Berkeley DB failure: {}", event.getException().getMessage());
             }
         });
 

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/file/FileMetaDataRepository.java
@@ -36,7 +36,7 @@ import static org.dcache.util.Exceptions.messageOrClassName;
 public class FileMetaDataRepository
     implements ReplicaStore
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger("logger.org.dcache.repository");
 
     private static final String DIRECTORY_NAME = "control";
@@ -91,7 +91,7 @@ public class FileMetaDataRepository
 
             Stopwatch watch = Stopwatch.createStarted();
             Set<PnfsId> files = _fileStore.index();
-            _log.info("Indexed {} entries in {} in {}.", files.size(), _fileStore, watch);
+            LOGGER.info("Indexed {} entries in {} in {}.", files.size(), _fileStore, watch);
 
             if (indexOptions.contains(IndexOption.ALLOW_REPAIR)) {
                 watch.reset().start();
@@ -105,7 +105,7 @@ public class FileMetaDataRepository
                             })
                             .collect(toList());
                 }
-                _log.info("Found {} orphaned meta data entries in {} in {}.", metaFilesToBeDeleted.size(), _metadir, watch);
+                LOGGER.info("Found {} orphaned meta data entries in {} in {}.", metaFilesToBeDeleted.size(), _metadir, watch);
 
                 for (Path name : metaFilesToBeDeleted) {
                     deleteIfExists(name);
@@ -197,7 +197,7 @@ public class FileMetaDataRepository
             Files.createFile(tmp);
             return true;
         } catch (IOException e) {
-            _log.error("Failed to touch " + tmp + ": " + messageOrClassName(e), e);
+            LOGGER.error("Failed to touch " + tmp + ": " + messageOrClassName(e), e);
             return false;
         }
     }
@@ -227,7 +227,7 @@ public class FileMetaDataRepository
         try {
             return _fileStore.getFreeSpace();
         } catch (IOException e) {
-            _log.warn("Failed to query free space: {}", e.toString());
+            LOGGER.warn("Failed to query free space: {}", e.toString());
             return 0;
         }
     }
@@ -242,7 +242,7 @@ public class FileMetaDataRepository
         try {
             return _fileStore.getTotalSpace();
         } catch (IOException e) {
-            _log.warn("Failed to query total space: {}", e.toString());
+            LOGGER.warn("Failed to query total space: {}", e.toString());
             return 0;
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v3/entry/CacheRepositoryEntryState.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v3/entry/CacheRepositoryEntryState.java
@@ -21,7 +21,7 @@ import org.dcache.pool.repository.v3.entry.state.Sticky;
 
 public class CacheRepositoryEntryState
 {
-    private static final Logger _log = LoggerFactory.getLogger(CacheRepositoryEntryState.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheRepositoryEntryState.class);
 
     private static final Pattern VERSION_PATTERN =
         Pattern.compile("#\\s+version\\s+[0-9]\\.[0-9]");
@@ -303,7 +303,7 @@ public class CacheRepositoryEntryState
 
                         break;
                     default:
-                        _log.info("Unknow number of arguments in {} [{}]", _controlFile, line);
+                        LOGGER.info("Unknow number of arguments in {} [{}]", _controlFile, line);
                         _state = ReplicaState.BROKEN;
                         return;
                     }
@@ -313,7 +313,7 @@ public class CacheRepositoryEntryState
                 }
 
                 // if none of knows states, then it's BAD state
-                _log.error("Invalid state [{}] for entry {}", line, _controlFile);
+                LOGGER.error("Invalid state [{}] for entry {}", line, _controlFile);
                 break;
             }
         }

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
@@ -47,7 +47,7 @@ class WriteHandleImpl implements ReplicaDescriptor
         OPEN, COMMITTED, CLOSED
     }
 
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger("logger.org.dcache.repository");
 
     private static final Set<OpenOption> OPEN_OPTIONS = ImmutableSet.<OpenOption>builder()
@@ -220,7 +220,7 @@ class WriteHandleImpl implements ReplicaDescriptor
                     registerFileAttributesInNameSpace();
                     namespaceUpdated = true;
                 } catch (TimeoutCacheException e) {
-                    _log.warn("Failed to update namespace: {}. Retrying in 15 s", e.getMessage());
+                    LOGGER.warn("Failed to update namespace: {}. Retrying in 15 s", e.getMessage());
                     TimeUnit.SECONDS.sleep(15);
                 }
             } while (!namespaceUpdated);
@@ -318,7 +318,7 @@ class WriteHandleImpl implements ReplicaDescriptor
                     _targetState = ReplicaState.REMOVED;
                     why = "file no longer exists in namespace";
                 } else {
-                    _log.warn("Failed to register {} after failed replica creation: {}",
+                    LOGGER.warn("Failed to register {} after failed replica creation: {}",
                             _fileAttributes, e.getMessage());
                 }
             }
@@ -329,11 +329,11 @@ class WriteHandleImpl implements ReplicaDescriptor
                 String reason = why == null ? "Transfer failed" : "Transfer failed and " + why;
                 _entry.update(reason, r -> r.setState(ReplicaState.REMOVED));
             } catch (CacheException e) {
-                _log.warn("Failed to remove replica: {}", e.getMessage());
+                LOGGER.warn("Failed to remove replica: {}", e.getMessage());
             }
         } else {
             PnfsId id = _entry.getPnfsId();
-            _log.warn(AlarmMarkerFactory.getMarker(PredefinedAlarm.BROKEN_FILE,
+            LOGGER.warn(AlarmMarkerFactory.getMarker(PredefinedAlarm.BROKEN_FILE,
                                                    id.toString(),
                                                    _repository.getPoolName()),
                       "Marking pool entry {} on {} as BROKEN",
@@ -343,7 +343,7 @@ class WriteHandleImpl implements ReplicaDescriptor
                 _entry.update("Transfer failed for " + _initialState + " replica",
                         r -> r.setState(ReplicaState.BROKEN));
             } catch (CacheException e) {
-                _log.warn("Failed to mark replica as broken: {}", e.getMessage());
+                LOGGER.warn("Failed to mark replica as broken: {}", e.getMessage());
             }
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/cells/BillingCell.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/cells/BillingCell.java
@@ -63,7 +63,7 @@ public final class BillingCell
                CellInfoProvider,
                EnvironmentAware
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(BillingCell.class);
     public static final String FORMAT_PREFIX = "billing.text.format.";
 
@@ -96,7 +96,7 @@ public final class BillingCell
     public BillingCell()
     {
         _templateGroup.registerRenderer(Date.class, new DateRenderer());
-        _templateGroup.setListener(new Slf4jSTErrorListener(_log));
+        _templateGroup.setListener(new Slf4jSTErrorListener(LOGGER));
     }
 
     @Override
@@ -192,7 +192,7 @@ public final class BillingCell
         Date now = new Date();
         String output = _formatter.format(now) + " " + msg.toString();
 
-        _log.info(output);
+        LOGGER.info(output);
 
         /*
          * Removed writing these to the billing log.  We only
@@ -208,7 +208,7 @@ public final class BillingCell
                 msg.accept(new StringTemplateInfoMessageVisitor(template));
                 return template.render();
             } catch (STException e) {
-                _log.error("Unable to render format '{}'.", format);
+                LOGGER.error("Unable to render format '{}'.", format);
             }
         }
         return "";
@@ -289,7 +289,7 @@ public final class BillingCell
                 }
             }
         } catch (RuntimeException e) {
-            _log.warn("Exception in dumpPoolStatistics : {}", e);
+            LOGGER.warn("Exception in dumpPoolStatistics : {}", e);
             try {
                 Files.delete(report);
             } catch (IOException f) {
@@ -329,7 +329,7 @@ public final class BillingCell
             try {
                 Files.createDirectories(_currentDbFile);
             } catch (IOException e) {
-                _log.error("Failed to create directory {}: {}", _currentDbFile, e.toString());
+                LOGGER.error("Failed to create directory {}: {}", _currentDbFile, e.toString());
             }
             return _fileNameFormat.format(now);
         }
@@ -352,7 +352,7 @@ public final class BillingCell
                 }
             }
         } catch (IOException e) {
-            _log.warn("Can't write billing [{}] : {}", path, e.toString());
+            LOGGER.warn("Can't write billing [{}] : {}", path, e.toString());
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/services/billing/cells/PoolStatusCollector.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/cells/PoolStatusCollector.java
@@ -25,7 +25,7 @@ import org.dcache.cells.CellStub;
  */
 public final class PoolStatusCollector extends Thread
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(PoolStatusCollector.class);
 
     private final Path _report;
@@ -55,18 +55,18 @@ public final class PoolStatusCollector extends Thread
                         pw.println(pool.getKey() + "  " + line);
                     }
                 } catch (CacheException | InterruptedException t) {
-                    _log.warn("CollectPoolStatus : {}: {}", pool.getValue(), t.toString());
+                    LOGGER.warn("CollectPoolStatus : {}: {}", pool.getValue(), t.toString());
                 }
             }
         } catch (CacheException | NoRouteToCellException | InterruptedException t) {
-            _log.warn("Exception in CollectPools status : {}", t.toString());
+            LOGGER.warn("Exception in CollectPools status : {}", t.toString());
             try {
                 Files.delete(_report);
             } catch (IOException e) {
-                _log.warn("Could not delete report {}: {}", _report, e.toString());
+                LOGGER.warn("Could not delete report {}: {}", _report, e.toString());
             }
         } catch (IOException ioe) {
-            _log.warn("Problem opening {} : {}", _report, ioe.getMessage());
+            LOGGER.warn("Problem opening {} : {}", _report, ioe.getMessage());
         }
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/services/billing/cells/receivers/BillingInfoMessageReceiver.java
+++ b/modules/dcache/src/main/java/org/dcache/services/billing/cells/receivers/BillingInfoMessageReceiver.java
@@ -88,7 +88,7 @@ import org.dcache.services.billing.db.impl.HourlyAggregateDataHandler;
  */
 public class BillingInfoMessageReceiver implements CellMessageReceiver,
                 CellCommandListener {
-    private static final Logger logger =
+    private static final Logger LOGGER =
                     LoggerFactory.getLogger(BillingInfoMessageReceiver.class);
 
     /**
@@ -158,14 +158,14 @@ public class BillingInfoMessageReceiver implements CellMessageReceiver,
              * necessary
              */
             private void log() {
-                logger.error("insert queue (last {}, current {}, change {}/minute)",
+                LOGGER.error("insert queue (last {}, current {}, change {}/minute)",
                                 insertQueueLast, insertQueueCurrent,
                                 insertQueueDelta);
-                logger.error("commits (last {}, current {}, change {}/minute)",
+                LOGGER.error("commits (last {}, current {}, change {}/minute)",
                                 commitLast, commitCurrent, commitDelta);
-                logger.error("dropped (last {}, current {}, change {}/minute)",
+                LOGGER.error("dropped (last {}, current {}, change {}/minute)",
                                 droppedLast, droppedCurrent, droppedDelta);
-                logger.error("total memory {}; free memory {}",
+                LOGGER.error("total memory {}; free memory {}",
                                 Runtime.getRuntime().totalMemory(),
                                 Runtime.getRuntime().freeMemory());
             }
@@ -180,7 +180,7 @@ public class BillingInfoMessageReceiver implements CellMessageReceiver,
                     Thread.sleep(TimeUnit.MINUTES.toMillis(1));
                 }
             } catch (InterruptedException e) {
-                logger.debug("statistics thread interrupted, "
+                LOGGER.debug("statistics thread interrupted, "
                                 + "probably due to cell shutdown");
             }
         }
@@ -225,7 +225,7 @@ public class BillingInfoMessageReceiver implements CellMessageReceiver,
             try {
                 commitStatistics.join();
             } catch (InterruptedException e) {
-                logger.trace("stopStatistics join interrupted");
+                LOGGER.trace("stopStatistics join interrupted");
             } finally {
                 commitStatistics = null;
             }

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/HttpdCommandLineInterface.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/HttpdCommandLineInterface.java
@@ -33,7 +33,7 @@ import static org.dcache.services.httpd.util.AliasEntry.AliasType;
 public class HttpdCommandLineInterface
         implements CellCommandListener
 {
-    private static final Logger logger = LoggerFactory.getLogger(HttpdCommandLineInterface.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpdCommandLineInterface.class);
 
     @Autowired
     private AutowireCapableBeanFactory beanFactory;
@@ -85,7 +85,7 @@ public class HttpdCommandLineInterface
         String type = args.argv(1);
         args.shift(2);
         AliasEntry entry = createEntry(alias, type, args);
-        logger.debug("Creating alias {}: {}", entry.getName(), entry);
+        LOGGER.debug("Creating alias {}: {}", entry.getName(), entry);
         delegator.addAlias(entry.getName(), entry);
         return entry.getStatusMessage();
     }

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/Server.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/Server.java
@@ -26,7 +26,7 @@ import javax.annotation.PreDestroy;
 
 public class Server extends org.eclipse.jetty.server.Server
 {
-    private static final Logger LOG = LoggerFactory.getLogger(Server.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Server.class);
 
     public Server(ThreadPool pool)
     {
@@ -49,7 +49,7 @@ public class Server extends org.eclipse.jetty.server.Server
         try {
             stop();
         } catch (Exception e) {
-            LOG.error("Web server shutdown failed: {}", e.toString());
+            LOGGER.error("Web server shutdown failed: {}", e.toString());
         }
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/HandlerDelegator.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/HandlerDelegator.java
@@ -32,7 +32,7 @@ import org.dcache.services.httpd.util.AliasEntry;
  * @author arossi
  */
 public class HandlerDelegator extends AbstractHandler {
-    private static final Logger logger
+    private static final Logger LOGGER
         = LoggerFactory.getLogger(HandlerDelegator.class);
     private static final Splitter PATH_SPLITTER
         = Splitter.on('/').omitEmptyStrings();
@@ -49,18 +49,18 @@ public class HandlerDelegator extends AbstractHandler {
             if (cause instanceof HttpException) {
                 printHttpException((HttpException) cause, response);
             }
-            logger.warn("Problem with {}: {}", uri, e.getMessage());
+            LOGGER.warn("Problem with {}: {}", uri, e.getMessage());
         } else if (e instanceof HttpException) {
             printHttpException((HttpException) e, response);
-            logger.warn("Problem with {}: {}", uri, e.getMessage());
+            LOGGER.warn("Problem with {}: {}", uri, e.getMessage());
         } else if (e instanceof RuntimeException) {
             printHttpException(new HttpException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                                                 "Internal problem processing request"), response);
-            logger.warn("Bug found, please report it", e);
+            LOGGER.warn("Bug found, please report it", e);
         } else {
             printHttpException(new HttpException(HttpServletResponse.SC_BAD_REQUEST,
                                                 "Bad Request : " + e), response);
-            logger.warn("Problem in HttpServiceCellHandler: {}", e.getMessage());
+            LOGGER.warn("Problem in HttpServiceCellHandler: {}", e.getMessage());
         }
     }
 
@@ -90,7 +90,7 @@ public class HandlerDelegator extends AbstractHandler {
             uri = request.getRequestURI();
             alias = extractAlias(uri);
 
-            logger.debug("handle {}, {}", uri, alias);
+            LOGGER.debug("handle {}, {}", uri, alias);
 
             entry = aliases.get(alias);
 
@@ -103,7 +103,7 @@ public class HandlerDelegator extends AbstractHandler {
                                 "Alias not found : " + alias);
             }
 
-            logger.debug("alias: {}, entry {}", alias, entry);
+            LOGGER.debug("alias: {}, entry {}", alias, entry);
 
             /*
              * Exclusion of POST is absolute.
@@ -118,16 +118,16 @@ public class HandlerDelegator extends AbstractHandler {
              */
             final String alternate = entry.getOverwrite();
             if (alternate != null) {
-                logger.debug("handle, overwritten alias: {}", alternate);
+                LOGGER.debug("handle, overwritten alias: {}", alternate);
                 final AliasEntry overwrittenEntry = aliases.get(alternate);
                 if (overwrittenEntry != null) {
                     entry = overwrittenEntry;
                 }
-                logger.debug("handle, alias {}, entry {}", alternate, entry);
+                LOGGER.debug("handle, alias {}, entry {}", alternate, entry);
             }
 
             final Handler handler = entry.getHandler();
-            logger.debug("got handler: {}", handler);
+            LOGGER.debug("got handler: {}", handler);
             if (handler != null) {
                 handler.handle(target, baseRequest, request, response);
             }
@@ -136,11 +136,11 @@ public class HandlerDelegator extends AbstractHandler {
             if (entry != null && e.getCause() instanceof OnErrorException) {
                 final String alternate = entry.getOnError();
                 if (alternate != null) {
-                    logger.debug("handle, onError alias: {}", alternate);
+                    LOGGER.debug("handle, onError alias: {}", alternate);
                     final AliasEntry overwrittenEntry = aliases.get(alternate);
                     if (overwrittenEntry != null) {
                         entry = overwrittenEntry;
-                        logger.debug("handle, alias {}, entry {}", alternate,
+                        LOGGER.debug("handle, alias {}, entry {}", alternate,
                                         entry);
                         final Handler handler = entry.getHandler();
                         if (handler != null) {
@@ -161,7 +161,7 @@ public class HandlerDelegator extends AbstractHandler {
             }
         }
 
-        logger.info("Finished");
+        LOGGER.info("Finished");
     }
 
     public AliasEntry removeAlias(String name) throws InvocationTargetException

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/RedirectHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/RedirectHandler.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  */
 public class RedirectHandler extends AbstractHandler {
 
-    private static final Logger logger
+    private static final Logger LOGGER
         = LoggerFactory.getLogger(RedirectHandler.class);
 
     private final String fromContext;
@@ -36,7 +36,7 @@ public class RedirectHandler extends AbstractHandler {
     public void handle(String target, Request baseRequest,
             HttpServletRequest request, HttpServletResponse response) throws
             IOException, ServletException {
-        logger.debug("target: {}", target);
+        LOGGER.debug("target: {}", target);
 
         if (target.contains(fromContext)) {
             StringBuilder targetUrl = new StringBuilder(target);
@@ -45,7 +45,7 @@ public class RedirectHandler extends AbstractHandler {
             = targetUrl.replace(i, i + fromContext.length(),
                                        toContext)
                        .toString();
-            logger.debug("redirected to: {}", newUrl);
+            LOGGER.debug("redirected to: {}", newUrl);
             response.sendRedirect(newUrl);
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/services/httpd/util/StandardHttpRequest.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/util/StandardHttpRequest.java
@@ -31,7 +31,7 @@ import java.util.Base64;
 public class StandardHttpRequest implements HttpRequest {
     private static final Splitter PATH_SPLITTER
         = Splitter.on('/').omitEmptyStrings();
-    private static final Logger logger
+    private static final Logger LOGGER
         = LoggerFactory.getLogger(StandardHttpRequest.class);
 
     private final OutputStream out;
@@ -146,7 +146,7 @@ public class StandardHttpRequest implements HttpRequest {
             return;
         }
         auth = new String(Base64.getDecoder().decode(st.nextToken()));
-        logger.info("Authentication : >{}<", auth);
+        LOGGER.info("Authentication : >{}<", auth);
         st = new StringTokenizer(auth, ":");
         if (st.countTokens() < 2) {
             return;

--- a/modules/dcache/src/main/java/org/dcache/services/login/MessageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/services/login/MessageHandler.java
@@ -22,7 +22,7 @@ import dmg.cells.nucleus.CellMessageReceiver;
 public class MessageHandler
     implements CellMessageReceiver
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(MessageHandler.class);
 
     private LoginStrategy _loginStrategy;
@@ -70,7 +70,7 @@ public class MessageHandler
             message.setSubject(login.getSubject());
             message.setLoginAttributes(login.getLoginAttributes());
         } catch(RuntimeException e) {
-            _log.error("Login operation failed", e);
+            LOGGER.error("Login operation failed", e);
             throw new PermissionDeniedCacheException(e.getMessage());
         } finally {
             timeoutTask.cancel(false);
@@ -87,7 +87,7 @@ public class MessageHandler
         try {
             principal = _loginStrategy.map(message.getPrincipal());
         } catch(RuntimeException e) {
-            _log.error("Map operation failed", e);
+            LOGGER.error("Map operation failed", e);
             principal = null;
         }
 
@@ -103,7 +103,7 @@ public class MessageHandler
         try {
             principals = _loginStrategy.reverseMap(message.getPrincipal());
         } catch(RuntimeException e) {
-            _log.error("ReverseMap operation failed", e);
+            LOGGER.error("ReverseMap operation failed", e);
             principals = Collections.emptySet();
         }
 

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/AnsiTerminalCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/AnsiTerminalCommand.java
@@ -49,7 +49,7 @@ import static org.fusesource.jansi.Ansi.Color.RED;
 
 public class AnsiTerminalCommand implements Command, Runnable {
 
-    private static final Logger _logger =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(AnsiTerminalCommand.class);
     private final UserAdminShell _userAdminShell;
     private ExitCallback _exitCallback;
@@ -73,7 +73,7 @@ public class AnsiTerminalCommand implements Command, Runnable {
                 _history  = new FileHistory(historyFile);
                 _history.setMaxSize(historySize);
             } catch (IOException e) {
-                _logger.warn("History creation failed: {}", e.getMessage());
+                LOGGER.warn("History creation failed: {}", e.getMessage());
             }
         }
     }
@@ -135,12 +135,12 @@ public class AnsiTerminalCommand implements Command, Runnable {
             initAdminShell();
             runAsciiMode();
         } catch (IOException e) {
-            _logger.warn(e.getMessage());
+            LOGGER.warn(e.getMessage());
         } finally {
             try {
                 cleanUp();
             } catch (IOException e) {
-                _logger.warn("Failed to shutdown console cleanly: {}", e.getMessage());
+                LOGGER.warn("Failed to shutdown console cleanly: {}", e.getMessage());
             }
             _exitCallback.onExit(0);
         }
@@ -172,7 +172,7 @@ public class AnsiTerminalCommand implements Command, Runnable {
                 } catch (SerializationException e) {
                     result =
                             "There is a bug here, please report to support@dcache.org";
-                    _logger.error("This must be a bug, please report to support@dcache.org.", e);
+                    LOGGER.error("This must be a bug, please report to support@dcache.org.", e);
                 } catch (CommandSyntaxException e) {
                     result = e;
                 } catch (CommandExitException e) {
@@ -187,14 +187,14 @@ public class AnsiTerminalCommand implements Command, Runnable {
                     result =
                             "Cell name does not exist or cell is not started: "
                             + e.getMessage();
-                    _logger.warn("The cell the command was sent to is no "
+                    LOGGER.warn("The cell the command was sent to is no "
                                  + "longer there: {}", e.getMessage());
                 } catch (RuntimeException e) {
                     result = String.format("Command '%s' triggered a bug (%s); please" +
                                            " locate this message in the log file of the admin service and" +
                                            " send an email to support@dcache.org with this line and the" +
                                            " following stack-trace", str, e);
-                    _logger.error((String) result, e);
+                    LOGGER.error((String) result, e);
                 }
             } catch (InterruptedIOException e) {
                 _console.getCursorBuffer().clear();

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacyAdminShellCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/LegacyAdminShellCommand.java
@@ -41,7 +41,7 @@ import static org.fusesource.jansi.Ansi.Color.RED;
  */
 public class LegacyAdminShellCommand implements Command, Runnable
 {
-    private static final Logger _logger =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(LegacyAdminShellCommand.class);
     private LegacyAdminShell _shell;
     private InputStream _in;
@@ -64,7 +64,7 @@ public class LegacyAdminShellCommand implements Command, Runnable
                 _history  = new FileHistory(historyFile);
                 _history.setMaxSize(historySize);
             } catch (IOException e) {
-                _logger.warn("History creation failed: {}", e.getMessage());
+                LOGGER.warn("History creation failed: {}", e.getMessage());
             }
         }
     }
@@ -118,12 +118,12 @@ public class LegacyAdminShellCommand implements Command, Runnable
             initAdminShell();
             runAsciiMode();
         } catch (IOException e) {
-            _logger.warn(e.getMessage());
+            LOGGER.warn(e.getMessage());
         } finally {
             try {
                 cleanUp();
             } catch (IOException e) {
-                _logger.warn("Failed to shutdown console cleanly: {}"
+                LOGGER.warn("Failed to shutdown console cleanly: {}"
                         , e.getMessage());
             }
             _exitCallback.onExit(0);
@@ -170,7 +170,7 @@ public class LegacyAdminShellCommand implements Command, Runnable
             } catch (SerializationException e) {
                 result =
                     "There is a bug here, please report to support@dcache.org";
-                _logger.error("This must be a bug, please report to support@dcache.org.", e);
+                LOGGER.error("This must be a bug, please report to support@dcache.org.", e);
             } catch (CommandSyntaxException e) {
                 result = e;
             } catch (CommandEvaluationException e) {
@@ -187,7 +187,7 @@ public class LegacyAdminShellCommand implements Command, Runnable
                 result =
                     "Cell name does not exist or cell is not started: "
                     + e.getMessage();
-                _logger.warn("The cell the command was sent to is no "
+                LOGGER.warn("The cell the command was sent to is no "
                         + "longer there: {}", e.getMessage());
             } catch (InterruptedException e) {
                 result = e.getMessage();
@@ -196,7 +196,7 @@ public class LegacyAdminShellCommand implements Command, Runnable
                                        " locate this message in the log file of the admin service and" +
                                        " send an email to support@dcache.org with this line and the" +
                                        " following stack-trace", str, e);
-                _logger.error((String) result, e);
+                LOGGER.error((String) result, e);
             } catch (Exception e) {
                 result = e.getMessage();
                 if(result == null) {

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/NoTerminalCommand.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/NoTerminalCommand.java
@@ -31,7 +31,7 @@ import org.dcache.util.Strings;
 
 public class NoTerminalCommand implements Command, Runnable
 {
-    private static final Logger _logger =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(NoTerminalCommand.class);
     private final UserAdminShell _userAdminShell;
     private ExitCallback _exitCallback;
@@ -82,7 +82,7 @@ public class NoTerminalCommand implements Command, Runnable
         try {
             repl();
         } catch (IOException e) {
-            _logger.warn(e.getMessage());
+            LOGGER.warn(e.getMessage());
         } finally {
             _exitCallback.onExit(0);
         }
@@ -110,7 +110,7 @@ public class NoTerminalCommand implements Command, Runnable
                 } catch (SerializationException e) {
                     error =
                             "There is a bug here, please report to support@dcache.org";
-                    _logger.error("This must be a bug, please report to support@dcache.org.", e);
+                    LOGGER.error("This must be a bug, please report to support@dcache.org.", e);
                 } catch (CommandSyntaxException e) {
                     error = e;
                 } catch (CommandEvaluationException | CommandAclException e) {
@@ -127,14 +127,14 @@ public class NoTerminalCommand implements Command, Runnable
                     error =
                             "Cell name does not exist or cell is not started: "
                             + e.getMessage();
-                    _logger.warn("The cell the command was sent to is no "
+                    LOGGER.warn("The cell the command was sent to is no "
                                  + "longer there: {}", e.getMessage());
                 } catch (RuntimeException e) {
                     error = String.format("Command '%s' triggered a bug (%s); please" +
                                            " locate this message in the log file of the admin service and" +
                                            " send an email to support@dcache.org with this line and the" +
                                            " following stack-trace", str, e);
-                    _logger.error((String) error, e);
+                    LOGGER.error((String) error, e);
                 }
             } catch (InterruptedException e) {
                 error = null;

--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/Ssh2Admin.java
@@ -74,7 +74,7 @@ import org.dcache.util.NetLoggerBuilder;
  */
 public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
 {
-    private static final Logger _log = LoggerFactory.getLogger(Ssh2Admin.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Ssh2Admin.class);
     private static final Logger _accessLog =
             LoggerFactory.getLogger("org.dcache.access.ssh2");
 
@@ -117,7 +117,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
     }
 
     public void setPort(int port) {
-        _log.debug("Ssh2 port set to: {}", port);
+        LOGGER.debug("Ssh2 port set to: {}", port);
         _port = port;
     }
 
@@ -214,7 +214,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
         configureKeyFiles();
         startServer();
 
-        _log.debug("Ssh2 Admin Interface started!");
+        LOGGER.debug("Ssh2 Admin Interface started!");
     }
 
     @Override
@@ -222,7 +222,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
         try {
             _server.stop();
         } catch (IOException e) {
-            _log.warn("SSH failure during shutdown: {}", e.getMessage());
+            LOGGER.warn("SSH failure during shutdown: {}", e.getMessage());
         }
     }
 
@@ -299,10 +299,10 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
 
                 successful = true;
             } catch (PermissionDeniedCacheException e) {
-                _log.warn("Login for {} denied: {}", userName, e.getMessage());
+                LOGGER.warn("Login for {} denied: {}", userName, e.getMessage());
             } catch (CacheException e) {
                 reason = e.toString();
-                _log.warn("Login for {} failed: {}", userName, e.toString());
+                LOGGER.warn("Login for {} failed: {}", userName, e.toString());
             }
 
             logLoginTry(userName, session, "Password", successful, reason);
@@ -328,7 +328,7 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
         public boolean authenticate(String userName, PublicKey key,
                 ServerSession session) {
 
-            _log.debug("Authentication username set to: {} publicKey: {}", userName, key);
+            LOGGER.debug("Authentication username set to: {} publicKey: {}", userName, key);
 
             String reason = null;
             boolean successful = super.authenticate(userName, key, session);
@@ -456,13 +456,13 @@ public class Ssh2Admin implements CellCommandListener, CellLifeCycleAware
                 }
                 successful = true;
             } catch (PermissionDeniedCacheException e) {
-                _log.error("Login for {} denied: {}",
+                LOGGER.error("Login for {} denied: {}",
                            Strings.nullToEmpty(userName),
                            e.getMessage());
                 reason = e.getMessage();
             } catch (CacheException e) {
                 reason = e.toString();
-                _log.error("Login for {} failed: {}",
+                LOGGER.error("Login for {} failed: {}",
                            Strings.nullToEmpty(userName),
                            e.toString());
             }

--- a/modules/dcache/src/main/java/org/dcache/services/topology/AbstractCellsTopology.java
+++ b/modules/dcache/src/main/java/org/dcache/services/topology/AbstractCellsTopology.java
@@ -27,7 +27,7 @@ import org.dcache.cells.CellStub;
 public class AbstractCellsTopology
     implements CellInfoProvider
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(AbstractCellsTopology.class);
 
     private CellStub _stub;
@@ -42,12 +42,12 @@ public class AbstractCellsTopology
     {
         List<CellTunnelInfo> tunnels = new ArrayList<>();
 
-        _log.debug("Sending topology info request to {}", address);
+        LOGGER.debug("Sending topology info request to {}", address);
         CellTunnelInfo[] infos =
             _stub.sendAndWait(new CellPath(address),
                               "getcelltunnelinfos",
                               CellTunnelInfo[].class);
-        _log.debug("Got reply from {}", address);
+        LOGGER.debug("Got reply from {}", address);
 
         for (CellTunnelInfo info: infos) {
             if (info.getRemoteCellDomainInfo() != null) {
@@ -95,7 +95,7 @@ public class AbstractCellsTopology
                     }
                 }
             } catch (NoRouteToCellException | CacheException e) {
-                _log.warn("Failed to fetch topology info from {}: {}",
+                LOGGER.warn("Failed to fetch topology info from {}: {}",
                           node.getAddress(), e.getMessage());
             }
         }

--- a/modules/dcache/src/main/java/org/dcache/space/ReservationCaches.java
+++ b/modules/dcache/src/main/java/org/dcache/space/ReservationCaches.java
@@ -116,7 +116,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 public class ReservationCaches
 {
-    private static final Logger _log = LoggerFactory.getLogger(ReservationCaches.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReservationCaches.class);
 
     public static class GetSpaceTokensKey
     {
@@ -182,7 +182,7 @@ public class ReservationCaches
                         } catch (InterruptedException e) {
                             throw new SRMInternalErrorException("Operation interrupted", e);
                         } catch (CacheException e) {
-                            _log.warn("GetSpaceTokens failed with rc={} error={}", e.getRc(), e.getMessage());
+                            LOGGER.warn("GetSpaceTokens failed with rc={} error={}", e.getRc(), e.getMessage());
                             throw new SRMException("GetSpaceTokens failed with rc=" + e.getRc() +
                                                    " error=" + e.getMessage(), e);
                         }

--- a/modules/dcache/src/main/java/org/dcache/telemetry/InstanceData.java
+++ b/modules/dcache/src/main/java/org/dcache/telemetry/InstanceData.java
@@ -34,7 +34,7 @@ public class InstanceData implements CellLifeCycleAware {
     final private String version = loadVersion();
     private OptionalLong storage;
 
-    private static final Logger _log = LoggerFactory.getLogger(InstanceData.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceData.class);
 
     @Required
     public void setPoolManagerStub(CellStub poolManagerStub) {
@@ -113,7 +113,7 @@ public class InstanceData implements CellLifeCycleAware {
                     .sum());
 
         } catch (CacheException | InterruptedException | NoRouteToCellException e) {
-            _log.error("Could not get storage information; set storage to -1.0. This was caused by: ", e);
+            LOGGER.error("Could not get storage information; set storage to -1.0. This was caused by: ", e);
         }
 
         return space;

--- a/modules/dcache/src/main/java/org/dcache/telemetry/SendData.java
+++ b/modules/dcache/src/main/java/org/dcache/telemetry/SendData.java
@@ -29,7 +29,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  */
 
 public class SendData implements CellCommandListener, CellLifeCycleAware {
-    private static final Logger _log = LoggerFactory.getLogger(SendData.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SendData.class);
 
     private ScheduledExecutorService sendDataExecutor;
     private InstanceData instanceData;
@@ -43,7 +43,7 @@ public class SendData implements CellCommandListener, CellLifeCycleAware {
         try {
             uri = URI.create(url);
         } catch (IllegalArgumentException iae) {
-            _log.error("Failed to create URL. Reason: ", iae);
+            LOGGER.error("Failed to create URL. Reason: ", iae);
             throw new RuntimeException();
         }
     }
@@ -73,7 +73,7 @@ public class SendData implements CellCommandListener, CellLifeCycleAware {
             throw new RuntimeException("Telemetry cell is configured but not enabled. Configure the enable setting " +
                     "to run telemetry cell.");
         }
-        _log.warn("Sending information about dCache-instance to {} is activated.", uri);
+        LOGGER.warn("Sending information about dCache-instance to {} is activated.", uri);
         httpClient = HttpClient.newHttpClient();
         sendDataExecutor.scheduleAtFixedRate(new FireAndForgetTask(this::sendData),
                 0, 1, TimeUnit.HOURS);
@@ -101,12 +101,12 @@ public class SendData implements CellCommandListener, CellLifeCycleAware {
             HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() != 201 && response.statusCode() != 200) {
-                _log.error("Error sending data to {}. Response: {}", uri, response);
+                LOGGER.error("Error sending data to {}. Response: {}", uri, response);
             } else {
-                _log.info("Information successfully sent to {}", uri);
+                LOGGER.info("Information successfully sent to {}", uri);
             }
         } catch (InterruptedException | IOException ioe) {
-            _log.error("Sending data to {} failed, caused by: ", uri, ioe);
+            LOGGER.error("Sending data to {} failed, caused by: ", uri, ioe);
         }
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/util/Checksums.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Checksums.java
@@ -39,7 +39,7 @@ import static org.dcache.util.ChecksumType.*;
  */
 public class Checksums
 {
-    private static final Logger _log = LoggerFactory.getLogger(Checksums.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Checksums.class);
 
     private static final Splitter.MapSplitter RFC3230_SPLITTER =
             Splitter.on(',').omitEmptyStrings().trimResults().
@@ -78,11 +78,11 @@ public class Checksums
                             return Checksum.fromBase64Value(SHA512, value);
 
                         default:
-                            _log.debug("Unsupported checksum type {}", type);
+                            LOGGER.debug("Unsupported checksum type {}", type);
                             return null;
                     }
                 } catch(IllegalArgumentException e) {
-                    _log.debug("Value \"{}\" is invalid for type {}", value,
+                    LOGGER.debug("Value \"{}\" is invalid for type {}", value,
                             type);
                     return null;
                 }
@@ -204,7 +204,7 @@ public class Checksums
 
             return checksums.values().stream().filter(Objects::nonNull).collect(Collectors.toSet());
         } catch (IllegalArgumentException e) {
-            _log.warn("Bad RFC3230 Digest value \"{}\": {}", digest, e.getMessage());
+            LOGGER.warn("Bad RFC3230 Digest value \"{}\": {}", digest, e.getMessage());
             return Collections.emptySet();
         }
     }

--- a/modules/dcache/src/main/java/org/dcache/util/NetworkInterfaceView.java
+++ b/modules/dcache/src/main/java/org/dcache/util/NetworkInterfaceView.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 public class NetworkInterfaceView implements Serializable {
     private static final long serialVersionUID = 5589652882519395824L;
-    private static final Logger _log = LoggerFactory.getLogger(NetworkInterfaceView.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NetworkInterfaceView.class);
 
     private final String _displayName;
     private final byte[] _hardwareAddress;
@@ -124,7 +124,7 @@ public class NetworkInterfaceView implements Serializable {
                 NetworkInterfaceView childView = new NetworkInterfaceView(child, this);
                 builder.add(childView);
             } catch (SocketException e) {
-                _log.debug("Unable to add child {} of interface {}: {}", child.getName(), ni.getName(), e.getMessage());
+                LOGGER.debug("Unable to add child {} of interface {}: {}", child.getName(), ni.getName(), e.getMessage());
             }
         }
 

--- a/modules/dcache/src/main/java/org/dcache/util/PingMoversTask.java
+++ b/modules/dcache/src/main/java/org/dcache/util/PingMoversTask.java
@@ -15,7 +15,7 @@ import diskCacheV111.util.CacheException;
  */
 public class PingMoversTask<T extends Transfer> implements Runnable
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(PingMoversTask.class);
 
     private final Collection<T> _transfers;
@@ -48,14 +48,14 @@ public class PingMoversTask<T extends Transfer> implements Runnable
                 try {
                     if (transfer.hasMover()) {
                         transfer.queryMoverInfo();
-                        _log.debug("Mover {}/{} is alive",
+                        LOGGER.debug("Mover {}/{} is alive",
                                    transfer.getPool(), transfer.getMoverId());
                     }
                 } catch (IllegalStateException e) {
                     // The transfer terminated before we could query it.
-                    _log.debug(e.toString());
+                    LOGGER.debug(e.toString());
                 } catch (CacheException e) {
-                    _log.info("Failed to check status of mover {}/{}: {}", transfer.getPool(), transfer.getMoverId(),
+                    LOGGER.info("Failed to check status of mover {}/{}: {}", transfer.getPool(), transfer.getMoverId(),
                               e.getMessage());
                     if (missingLastTime.contains(transfer)) {
                         transfer.finished(CacheException.TIMEOUT,

--- a/modules/dcache/src/main/java/org/dcache/util/SpringLiquibase.java
+++ b/modules/dcache/src/main/java/org/dcache/util/SpringLiquibase.java
@@ -34,7 +34,7 @@ import java.util.jar.Manifest;
 public class SpringLiquibase
     extends liquibase.integration.spring.SpringLiquibase
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(SpringLiquibase.class);
 
     private boolean _shouldUpdate = true;

--- a/modules/dcache/src/main/java/org/dcache/util/configuration/DefaultProblemConsumer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/configuration/DefaultProblemConsumer.java
@@ -29,7 +29,7 @@ import java.io.LineNumberReader;
  */
 public class DefaultProblemConsumer implements ProblemConsumer
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(DefaultProblemConsumer.class);
 
     private String _filename;
@@ -53,13 +53,13 @@ public class DefaultProblemConsumer implements ProblemConsumer
     @Override
     public void warning(String message)
     {
-        _log.warn(addContextTo(message));
+        LOGGER.warn(addContextTo(message));
     }
 
     @Override
     public void info(String message)
     {
-        _log.info(addContextTo(message));
+        LOGGER.info(addContextTo(message));
     }
 
     @Override

--- a/modules/dcache/src/main/java/org/dcache/util/list/ListDirectoryHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/util/list/ListDirectoryHandler.java
@@ -47,7 +47,7 @@ import org.dcache.vehicles.PnfsListDirectoryMessage;
 public class ListDirectoryHandler
     implements CellMessageReceiver, DirectoryListSource
 {
-    private static final Logger _log =
+    private static final Logger LOGGER =
         LoggerFactory.getLogger(ListDirectoryHandler.class);
 
     private final PnfsHandler _pnfs;
@@ -173,7 +173,7 @@ public class ListDirectoryHandler
                 if (stream != null) {
                     stream.put(reply);
                 } else {
-                    _log.warn("Received list result for an unknown request. Directory listing was possibly incomplete.");
+                    LOGGER.warn("Received list result for an unknown request. Directory listing was possibly incomplete.");
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -274,7 +274,7 @@ public class ListDirectoryHandler
                     }
                 }
             } catch (CacheException e) {
-                _log.error("Listing of {} incomplete: {}", _path, e.getMessage());
+                LOGGER.error("Listing of {} incomplete: {}", _path, e.getMessage());
                 return false;
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/modules/dcache/src/main/java/org/dcache/zookeeper/service/ZooKeeperCell.java
+++ b/modules/dcache/src/main/java/org/dcache/zookeeper/service/ZooKeeperCell.java
@@ -22,7 +22,6 @@ import org.apache.zookeeper.server.DatadirCleanupManager;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.PatchedZooKeeperServer;
 import org.apache.zookeeper.server.ServerCnxnFactory;
-import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +44,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  */
 public class ZooKeeperCell extends AbstractCell
 {
-    private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperCell.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZooKeeperCell.class);
 
     @Option(name = "data-log-dir", required = true)
     protected File dataLogDir;
@@ -164,7 +163,7 @@ public class ZooKeeperCell extends AbstractCell
             // This should be a no-op, as ZK should already have shutdown.
             shutdownLatch.await(1, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            LOG.error("ZooKeeper server failed to shutdown.");
+            LOGGER.error("ZooKeeper server failed to shutdown.");
         }
 
         if (cnxnFactory != null) {
@@ -174,7 +173,7 @@ public class ZooKeeperCell extends AbstractCell
             try {
                 txnLog.close();
             } catch (IOException e) {
-                LOG.error("Failed to close ZooKeeper transaction log: {}", e.toString());
+                LOGGER.error("Failed to close ZooKeeper transaction log: {}", e.toString());
             }
         }
         super.stopped();


### PR DESCRIPTION
Motivation:
Due to historical development and personal preferences of various
developer an instance of logger is reverences as _log, LOGGER, LOG
or log. While forcing a unified style for all variable will produce
big code reformatting, a smaller change to enforce logger name is
beneficial.

Modification:
Renaming final static logger variables to LOGGER in two modules
(dcache-core and dcache-ftp)

Result:
More unified code in respect of logger variables.
No user observable changes.

Issue: #3807
Target: master