### PR TITLE
dcache-xroot: bump dependency to next xrootd4j release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>4.0.8</version.xrootd4j>
+        <version.xrootd4j>4.0.9</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.3</version.dcache-view>
         <version.netty>4.1.50.Final</version.netty>


### PR DESCRIPTION
master => 4.2.1
7.1    => 4.1.2
7.0    => 4.0.9
6.2    => 4.0.9
6.1    => 3.5.11
6.0    => 3.5.11
5.2    => 3.5.11

Includes https://rb.dcache.org/r/13124/ xrootd4j: improve handling of TPC read requests
(request exact number of bytes on last read)

Acked-by: Lea
Requires-notes: yes
Requires-book: no