### PR TITLE
webdav: add 'http-tpc ls' admin command

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/TimeUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/TimeUtils.java
@@ -377,6 +377,24 @@ public class TimeUtils
      * {@code <number> <space> <units>}, where {@code <number>}
      * is an integer and {@code <units>} is defined by the value of unitFormat.
      */
+    public static StringBuilder appendDuration(StringBuilder sb, Duration duration,
+                    TimeUnitFormat unitFormat)
+    {
+        // FIXME: this method is a wrapper around the overloaded method
+        // with (long,TimeUnit) arguments.  These two methods should be
+        // rewritten so they are the other way around: the method with
+        // (long,TimeUnit) arguments should convert this to a Duration and call
+        // this method, which does the real work.
+        return appendDuration(sb, duration.toMillis(), MILLISECONDS, unitFormat);
+    }
+
+    /**
+     * Provide a short, simple human understandable string describing the
+     * supplied duration.  The duration is a non-negative value.  The output is
+     * appended to the supplied StringBuilder and has the form
+     * {@code <number> <space> <units>}, where {@code <number>}
+     * is an integer and {@code <units>} is defined by the value of unitFormat.
+     */
     public static StringBuilder appendDuration(StringBuilder sb, long duration,
                     TimeUnit units, TimeUnitFormat unitFormat)
     {

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoJobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoJobInfo.java
@@ -1,5 +1,10 @@
 package diskCacheV111.vehicles;
 
+import javax.annotation.Nullable;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
 import diskCacheV111.util.PnfsId;
 
 public class IoJobInfo extends JobInfo  {
@@ -7,18 +12,21 @@ public class IoJobInfo extends JobInfo  {
    private final long _bytesTransferred;
    private final long _transferTime;
    private final long _lastTransferred;
+   private final List<InetSocketAddress> _remoteConnections;
    private final PnfsId _pnfsId;
 
    private static final long serialVersionUID = -7987228538353684951L;
 
    public IoJobInfo(long submitTime, long startTime, String state, int id, String clientName, long clientId,
-                    PnfsId pnfsId, long bytesTransferred, long transferTime, long lastTransferred)
+                    PnfsId pnfsId, long bytesTransferred, long transferTime, long lastTransferred,
+                    @Nullable List<InetSocketAddress> remoteConnections)
    {
       super(submitTime, startTime, state, id, clientName, clientId);
       _pnfsId           = pnfsId;
       _bytesTransferred = bytesTransferred;
       _transferTime     = transferTime;
       _lastTransferred  = lastTransferred;
+      _remoteConnections = remoteConnections;
    }
    public long getTransferTime(){ return _transferTime ; }
    public long getBytesTransferred(){ return _bytesTransferred ; }
@@ -30,5 +38,15 @@ public class IoJobInfo extends JobInfo  {
              ";B=" + _bytesTransferred +
              ";T=" + _transferTime +
              ";L=" + ((System.currentTimeMillis()-_lastTransferred)/1000) + ';';
+   }
+
+   /**
+    * A list of remote TCP endpoints to which the mover is connected.  Returns
+    * null if this information is not available.
+    */
+   @Nullable
+   public List<InetSocketAddress> remoteConnections()
+   {
+       return _remoteConnections;
    }
 }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoJobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoJobInfo.java
@@ -9,6 +9,8 @@ import diskCacheV111.util.PnfsId;
 
 public class IoJobInfo extends JobInfo  {
 
+   @Nullable
+   private final Long _requestedBytes;
    private final long _bytesTransferred;
    private final long _transferTime;
    private final long _lastTransferred;
@@ -18,7 +20,7 @@ public class IoJobInfo extends JobInfo  {
    private static final long serialVersionUID = -7987228538353684951L;
 
    public IoJobInfo(long submitTime, long startTime, String state, int id, String clientName, long clientId,
-                    PnfsId pnfsId, long bytesTransferred, long transferTime, long lastTransferred,
+                    PnfsId pnfsId, long bytesTransferred, Long requestedBytes, long transferTime, long lastTransferred,
                     @Nullable List<InetSocketAddress> remoteConnections)
    {
       super(submitTime, startTime, state, id, clientName, clientId);
@@ -27,6 +29,7 @@ public class IoJobInfo extends JobInfo  {
       _transferTime     = transferTime;
       _lastTransferred  = lastTransferred;
       _remoteConnections = remoteConnections;
+      _requestedBytes = requestedBytes;
    }
    public long getTransferTime(){ return _transferTime ; }
    public long getBytesTransferred(){ return _bytesTransferred ; }
@@ -48,5 +51,15 @@ public class IoJobInfo extends JobInfo  {
    public List<InetSocketAddress> remoteConnections()
    {
        return _remoteConnections;
+   }
+
+   /**
+    * The expected number of bytes for this transfer, if known.  Returns
+    * null if the value is unknown.
+    */
+   @Nullable
+   public Long requestedBytes()
+   {
+       return _requestedBytes;
    }
 }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/transferManager/TransferStatusQueryMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/transferManager/TransferStatusQueryMessage.java
@@ -1,5 +1,7 @@
 package diskCacheV111.vehicles.transferManager;
 
+import javax.annotation.Nullable;
+
 import diskCacheV111.vehicles.IoJobInfo;
 
 /**
@@ -12,6 +14,7 @@ public class TransferStatusQueryMessage extends TransferManagerMessage
 
     private int _state;
     private IoJobInfo _info;
+    private String pool;
 
     public TransferStatusQueryMessage(long id)
     {
@@ -44,5 +47,19 @@ public class TransferStatusQueryMessage extends TransferManagerMessage
     public int getState()
     {
         return _state;
+    }
+
+    public void setPool(String name)
+    {
+        pool = name;
+    }
+
+    /**
+     * Returns the name of the pool handling this transfer, if known.
+     */
+    @Nullable
+    public String getPool()
+    {
+        return pool;
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -18,6 +18,7 @@
 package org.dcache.webdav.transfer;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.InetAddresses;
 import com.google.common.util.concurrent.ListenableFuture;
 import eu.emi.security.authn.x509.X509Credential;
 import io.milton.http.Response;
@@ -39,15 +40,18 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import diskCacheV111.services.TransferManagerHandler;
 import diskCacheV111.util.CacheException;
@@ -771,6 +775,14 @@ public class RemoteTransferHandler implements CellMessageReceiver
                 _out.println("    Stripe Status: " + info.getStatus());
             }
             _out.println("    Total Stripe Count: 1");
+            if (info != null) {
+                List<InetSocketAddress> connections = info.remoteConnections();
+                if (connections != null) {
+                    _out.println("    RemoteConnections: " + connections.stream()
+                            .map(conn -> "tcp:" + InetAddresses.toUriString(conn.getAddress()) + ":" + conn.getPort())
+                            .collect(Collectors.joining(",")));
+                }
+            }
             _out.println("End");
             _out.flush();
         }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -40,17 +40,26 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
 import java.net.URI;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import diskCacheV111.services.TransferManagerHandler;
@@ -75,8 +84,13 @@ import diskCacheV111.vehicles.transferManager.TransferCompleteMessage;
 import diskCacheV111.vehicles.transferManager.TransferFailedMessage;
 import diskCacheV111.vehicles.transferManager.TransferStatusQueryMessage;
 
+import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.util.CommandException;
+import dmg.util.CommandSyntaxException;
+import dmg.util.command.Command;
+import dmg.util.command.Option;
 
 import org.dcache.acl.enums.AccessMask;
 import org.dcache.auth.OpenIdCredential;
@@ -86,14 +100,26 @@ import org.dcache.namespace.FileAttribute;
 import org.dcache.namespace.FileType;
 import org.dcache.util.ChecksumType;
 import org.dcache.util.Checksums;
+import org.dcache.util.ColumnWriter;
+import org.dcache.util.ColumnWriter.TabulatedRow;
+import org.dcache.util.Glob;
+import org.dcache.util.NetworkUtils;
+import org.dcache.util.Strings;
 import org.dcache.util.URIs;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.webdav.transfer.CopyFilter.CredentialSource;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Comparators.emptiesFirst;
+import static com.google.common.collect.Comparators.emptiesLast;
+import static diskCacheV111.services.TransferManagerHandler.INITIAL_STATE;
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.dcache.namespace.FileAttribute.*;
 import static org.dcache.util.ByteUnit.MiB;
+import static org.dcache.util.Strings.*;
+import static org.dcache.util.TimeUtils.TimeUnitFormat.SHORT;
+import static org.dcache.util.TimeUtils.appendDuration;
 import static org.dcache.webdav.transfer.CopyFilter.CredentialSource.*;
 
 /**
@@ -119,7 +145,7 @@ import static org.dcache.webdav.transfer.CopyFilter.CredentialSource.*;
  * documented as supporting 'https' URIs, this implementation supports
  * different transports for the third-party transfer.
  */
-public class RemoteTransferHandler implements CellMessageReceiver
+public class RemoteTransferHandler implements CellMessageReceiver, CellCommandListener
 {
 
     /**
@@ -228,6 +254,312 @@ public class RemoteTransferHandler implements CellMessageReceiver
     public long getPerformanceMarkerPeroid()
     {
         return _performanceMarkerPeriod;
+    }
+
+    private enum IPFamilyMatcher {
+        IPv4 {
+            @Override
+            public boolean matches(InetAddress addr) {
+                return addr instanceof Inet4Address;
+            }
+        },
+
+        IPv6 {
+            @Override
+            public boolean matches(InetAddress addr) {
+                return addr instanceof Inet6Address;
+            }
+        };
+
+        public abstract boolean matches(InetAddress addr);
+    }
+
+    @Command(name = "http-tpc ls", hint = "list current transfers",
+            description = "Provides a summary of all currently HTTP-TPC transfers.")
+    public class HttpTpcLsCommand implements Callable<String>
+    {
+        @Option(name="t", usage="Show timing information.", category="Field options")
+        boolean showTiming;
+
+        @Option(name="n", usage="Show network related information.",
+                category="Field options")
+        boolean showNetwork;
+
+        @Option(name="l", usage="Show the local path of the transfer.",
+                category="Field options")
+        boolean showLocalPath;
+
+        @Option(name="r", usage="Show the remote path for this transfer.",
+                category="Field options")
+        boolean showRemotePath;
+
+        @Option(name="a", usage="Show all available information about"
+                + " transfers.  This is equivalent to specifying \"-t -n -l"
+                + " -r\"", category="Field options")
+        boolean showAll;
+
+        @Option(name="pool", usage="Select transfers involving a pool that"
+                + " matches this glob pattern.", category="Filter options")
+        Glob poolFilter;
+
+        @Option(name="host", usage="Select transfers involving a remote host"
+                + " that matches this glob pattern.", category="Filter options")
+        Glob hostFilter;
+
+        @Option(name="dir", usage="Select transfers with the specified"
+                + " direction.", category="Filter options")
+        Direction direction;
+
+        /*  REVISIT: we can't use an enum directly when definint the 'ip'
+            option because of a hard-coded `String#toUpperCase` on the option's
+            argument/value in AnnotatedCommandExecutor.EnumTypeConverter.  We
+            also can't use "valueSpec" because upper case letters are always
+            converted to place-holder (e.g., "IPv4" is written as "<ip>v4" in
+            the help text).
+         */
+        @Option(name="ip", usage="Select transfers using at least one"
+                + " network connection with the specified IP address family."
+                + "  Valid values are \"IPv4\" or \"IPv6\"",
+                category="Filter options")
+        String ipFamily;
+
+        @Option(name="local-path", usage="Select transfers where the local path"
+                + " matches this pattern.", category="Filter options")
+        Glob localPathFilter;
+
+        @Option(name="remote-path", usage="Select transfers where the remote"
+                + " path matches this pattern.", category="Filter options")
+        Glob remotePathFilter;
+
+        @Option(name="sort-by", usage="How to order the output.  The available"
+                + " options are described below.\n"
+                + "    \"host\" sorts remote host.\n"
+                + "    \"pool\" sorts by pool name, with any transfers not yet"
+                + " assigned to a pool are shown first.\n"
+                + "    \"lifetime\" sorts by the request's lifetime, showing"
+                + " the most recent request first.\n"
+                + "    \"running\" sorts by the time active in increasing"
+                + " order, any queued transfers are shown first.",
+                valueSpec="host|pool|lifetime|running",
+                category="Ordering options")
+        String sort;
+
+        private ColumnWriter output = new ColumnWriter();
+
+        @Override
+        public String call() throws CommandException
+        {
+            if (showAll) {
+                showTiming = true;
+                showNetwork = true;
+                showLocalPath = true;
+                showRemotePath = true;
+            }
+
+            buildHeaders();
+
+            synchronized (_transfers) {
+                _transfers.values().stream()
+                        .filter(buildFilter())
+                        .sorted(buildComparator())
+                        .forEachOrdered(this::printTransfer);
+            }
+
+            return output.toString();
+        }
+
+        private void buildHeaders()
+        {
+            output = output.header("ID").left("id");
+
+            if (showTiming) {
+                output.space().header("Lifetime").left("lifetime")
+                        .space().header("Queued").left("queued")
+                        .space().header("Running").left("running");
+            }
+
+            output.space().header("Dirn").left("direction")
+                    .space().header("Pool").left("pool");
+
+            if (showNetwork) {
+                output.space().header("IP").left("ip")
+                        .space().header("Transferred").left("transferred");
+            }
+
+            if (showLocalPath) {
+                output.space().header("Local path").left("local-path");
+            }
+
+            output.space().header("Remote host").left("host");
+
+            if (showRemotePath) {
+                output.space().header("Remote path").left("remote-path");
+            }
+        }
+
+        private Predicate<RemoteTransfer> buildFilter() throws CommandSyntaxException
+        {
+            Predicate<RemoteTransfer> p = t -> true;
+
+            if (poolFilter != null) {
+                p = p.and(t -> t._pool.map(poolFilter::matches).orElse(Boolean.FALSE));
+            }
+
+            if (hostFilter != null) {
+                p = p.and(t -> hostFilter.matches(t._destination.getHost()));
+            }
+
+            if (direction != null) {
+                p = p.and(t -> t._direction == direction);
+            }
+
+            if (ipFamily != null) {
+                IPFamilyMatcher ipMatcher = asIPFamilyMatcher(ipFamily);
+                p = p.and(t -> t._lastInfo
+                            .map(IoJobInfo::remoteConnections)
+                            .filter(Objects::nonNull)
+                            .map(a -> a.stream()
+                                    .map(InetSocketAddress::getAddress)
+                                    .anyMatch(ipMatcher::matches))
+                            .orElse(Boolean.FALSE));
+            }
+
+            if (localPathFilter != null) {
+                p = p.and(t -> localPathFilter.matches(t._path.toString()));
+            }
+
+            if (remotePathFilter != null) {
+                p = p.and(t -> remotePathFilter.matches(t._destination.getPath()));
+            }
+
+            return p;
+        }
+
+        private IPFamilyMatcher asIPFamilyMatcher(String id)
+                throws CommandSyntaxException
+        {
+            try {
+                return IPFamilyMatcher.valueOf(id);
+            } catch (IllegalArgumentException e) {
+                throw new CommandSyntaxException("Invalid 'ip' option \"" + id
+                        + "\": valid values are \"IPv4\" and \"IPv6\"");
+            }
+        }
+
+        private Comparator<RemoteTransfer> buildComparator()
+                throws CommandSyntaxException
+        {
+            if (sort == null) {
+                return Comparator.comparingLong(t -> t._id);
+            }
+
+            Comparator<RemoteTransfer> primary;
+            switch (sort) {
+            case "pool":
+                primary = Comparator.comparing(t -> t._pool,
+                        emptiesFirst(String::compareTo));
+                break;
+            case "host":
+                primary = Comparator.comparing(t -> t._destination.getHost(),
+                        Comparator.nullsLast(String::compareToIgnoreCase));
+                break;
+            case "lifetime":
+                primary = Comparator.comparing(t -> t._whenSubmitted,
+                        Comparator.reverseOrder());
+                break;
+            case "running":
+                primary = Comparator.comparing(t -> t._transferStarted,
+                        emptiesFirst(Comparator.reverseOrder()));
+                break;
+            default:
+                throw new CommandSyntaxException("Invalid 'sort-by' option"
+                        + " argument \"" + sort + "\"");
+            }
+
+            return primary.thenComparingLong(t -> t._id);
+        }
+
+        /**
+         * Return the (expected) total number of bytes that will be transferred
+         * for this operation.  Returns -1 if the value is unknown.
+         * REVISIT: consider returning OptionalLong.
+         */
+        private long expectedTotalTransferSize(RemoteTransfer transfer)
+        {
+            Long sizeFromPool = transfer._lastInfo
+                    .map(IoJobInfo::requestedBytes)
+                    .orElse(null);
+
+            if (sizeFromPool != null) {
+                return sizeFromPool;
+            }
+
+            return  transfer._direction == Direction.PUSH
+                    ? transfer._size
+                    : -1;
+        }
+
+        private void printTransfer(RemoteTransfer transfer)
+        {
+            TabulatedRow row = output.row();
+
+            row.value("id", transfer._id)
+                    .value("direction", transfer._direction)
+                    .value("host", transfer._destination.getHost())
+                    .value("pool", transfer._pool.orElse("-"));
+
+            if (showLocalPath) {
+                row.value("local-path", transfer._path.toString());
+            }
+
+            if (showRemotePath) {
+                row.value("remote-path", transfer._destination.getPath());
+            }
+
+            if (showTiming) {
+                StringBuilder lifetime = appendDuration(new StringBuilder(),
+                        Duration.between(transfer._whenSubmitted, Instant.now()),
+                        SHORT);
+                row.value("lifetime", lifetime);
+
+
+                Duration queued = Duration.between(transfer._whenSubmitted,
+                        transfer._transferStarted.orElseGet(() -> Instant.now()));
+                StringBuilder queueDescription = appendDuration(new StringBuilder(),
+                        queued, SHORT);
+                row.value("queued", queueDescription);
+
+                Optional<String> running = transfer._transferStarted
+                        .map(i -> Duration.between(i, Instant.now()))
+                        .map(d -> appendDuration(new StringBuilder(), d, SHORT))
+                        .map(Object::toString);
+                row.value("running", running.orElse("-"));
+            }
+
+            if (showNetwork) {
+                Optional<Long> transferred = transfer._lastInfo.map(IoJobInfo::getBytesTransferred);
+
+                long total = expectedTotalTransferSize(transfer);
+                Optional<String> transferDescription = total == -1
+                        ? transferred.map(Strings::humanReadableSize)
+                        : transferred.map(i -> {
+                                    String percent = toThreeSigFig(100 * i / (double)total, 1000);
+                                    return humanReadableSize(i) + " (" + percent + "%" + ")";
+                                });
+                row.value("transferred", transferDescription.orElse("-"));
+
+
+                Optional<String> ipProtocols = transfer._lastInfo
+                        .flatMap(i -> Optional.ofNullable(i.remoteConnections()))
+                        .map(l -> l.stream()
+                                .map(a -> NetworkUtils.getProtocolFamily(a.getAddress()))
+                                .distinct()
+                                .sorted()
+                                .map(f -> f == StandardProtocolFamily.INET ? "IPv4" : "IPv6")
+                                .collect(Collectors.joining(",")));
+                row.value("ip", ipProtocols.orElse("-"));
+            }
+        }
     }
 
     /**
@@ -339,14 +671,20 @@ public class RemoteTransferHandler implements CellMessageReceiver
         private final boolean _overwriteAllowed;
         private final Optional<String> _wantDigest;
         private final PnfsHandler _pnfs;
+        private final Instant _whenSubmitted = Instant.now();
         private String _problem;
         private long _id;
         private final EndPoint _endpoint = HttpConnection.getCurrentConnection().getEndPoint();
 
+        private int _lastState = INITIAL_STATE;
+        private Optional<IoJobInfo> _lastInfo = Optional.empty();
+        private Optional<Instant> _transferStarted = Optional.empty();
         private PnfsId _pnfsId;
         private boolean _finished;
         private Optional<String> _digestValue;
+        private Optional<String> _pool = Optional.empty();
         private boolean _transferReportedAsUnknown;
+        private long _size;
 
         public RemoteTransfer(OutputStream out, Subject subject, Restriction restriction,
                 FsPath path, URI destination, @Nullable Object credential,
@@ -407,6 +745,7 @@ public class RemoteTransferHandler implements CellMessageReceiver
                         if (!attributes.isDefined(SIZE)) {
                             throw new ErrorResponseException(Response.Status.SC_CONFLICT, "File upload in progress");
                         }
+                        _size = attributes.getSize();
 
                         return attributes;
                     } catch (FileNotFoundCacheException e) {
@@ -711,8 +1050,9 @@ public class RemoteTransferHandler implements CellMessageReceiver
 
             int state = TransferManagerHandler.UNKNOWN_ID;
             IoJobInfo info = null;
+            TransferStatusQueryMessage reply = null;
             try {
-                TransferStatusQueryMessage reply = CellStub.getMessage(future);
+                reply = CellStub.getMessage(future);
                 state = reply.getState();
                 info = reply.getMoverInfo();
             } catch (MissingResourceCacheException e) {
@@ -736,6 +1076,19 @@ public class RemoteTransferHandler implements CellMessageReceiver
             } catch (NoRouteToCellException | CacheException e) {
                 LOGGER.warn("Failed to fetch information for progress marker: {}",
                         e.getMessage());
+            }
+
+            _lastState = state;
+            _lastInfo = Optional.ofNullable(info);
+            if (info != null) {
+                if (!_transferStarted.isPresent() && info.getTransferTime() > 0) {
+                    Instant started = Instant.now().minus(info.getTransferTime(), MILLIS);
+                    _transferStarted = Optional.of(started);
+                }
+
+                if (!_pool.isPresent() && reply != null && reply.getPool() != null) {
+                    _pool = Optional.of(reply.getPool());
+                }
             }
 
             sendMarker(state, info);

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -800,6 +800,10 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             return message;
         }
 
+        if (pool != null) {
+            message.setPool(pool.getName());
+        }
+
         final MessageReply<TransferStatusQueryMessage> reply = new MessageReply<>();
 
         final ListenableFuture<IoJobInfo> future = manager.getPoolStub().

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
@@ -749,6 +749,7 @@ public class MoverRequestScheduler
             return new IoJobInfo(_submitTime, _startTime, _state.toString(), _id,
                                  _mover.getPathToDoor().getDestinationAddress().toString(), _mover.getClientId(),
                                  _mover.getFileAttributes().getPnfsId(), _mover.getBytesTransferred(),
+                                 _mover.getBytesExpected(),
                                  _mover.getTransferTime(), _mover.getLastTransferred(),
                                  _mover.remoteConnections());
         }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
@@ -749,7 +749,8 @@ public class MoverRequestScheduler
             return new IoJobInfo(_submitTime, _startTime, _state.toString(), _id,
                                  _mover.getPathToDoor().getDestinationAddress().toString(), _mover.getClientId(),
                                  _mover.getFileAttributes().getPnfsId(), _mover.getBytesTransferred(),
-                                 _mover.getTransferTime(), _mover.getLastTransferred());
+                                 _mover.getTransferTime(), _mover.getLastTransferred(),
+                                 _mover.remoteConnections());
         }
 
         public synchronized MoverData toMoverData()

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
@@ -18,10 +18,14 @@
 package org.dcache.pool.movers;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.security.auth.Subject;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.channels.CompletionHandler;
 import java.nio.file.OpenOption;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -178,4 +182,17 @@ public interface Mover<T extends ProtocolInfo>
      * or failed.
      */
     void close(CompletionHandler<Void, Void> completionHandler);
+
+    /**
+     * Provide a list of the IP address and port number of all currently active
+     * TCP connections.  An empty list indicates that there is current no
+     * established connections.  The mover may order the connections in some
+     * protocol-specific fashion.  A mover that is unable to provide connection
+     * information should return null.
+     */
+    @Nullable
+    default List<InetSocketAddress> remoteConnections()
+    {
+        return null;
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
@@ -195,4 +195,14 @@ public interface Mover<T extends ProtocolInfo>
     {
         return null;
     }
+
+    /**
+     * Provide the expected total number of bytes transferred for this
+     * transfer, if known.  Returns null if this value is unknown.
+     */
+    @Nullable
+    default Long getBytesExpected()
+    {
+        return null;
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocol.java
@@ -33,6 +33,16 @@ public interface MoverProtocol
     long getBytesTransferred();
 
     /**
+     * Get the number of bytes expected to be transferred, if known.  Returns
+     * null if that value is unknown.
+     */
+    @Nullable
+    default Long getBytesExpected()
+    {
+        return null;
+    }
+
+    /**
      * Get time between transfers begin and end. If Mover is sill
      * active, then current time used as end.
      *

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocol.java
@@ -1,6 +1,10 @@
 package org.dcache.pool.movers;
 
+import javax.annotation.Nullable;
+
+import java.net.InetSocketAddress;
 import java.nio.file.OpenOption;
+import java.util.List;
 import java.util.Set;
 
 import diskCacheV111.vehicles.ProtocolInfo;
@@ -42,4 +46,17 @@ public interface MoverProtocol
      * @return last access time in milliseconds.
      */
     long getLastTransferred();
+
+    /**
+     * Provide a list of the IP address and port number of all currently active
+     * TCP connections.  An empty list indicates that there is current no
+     * established connections.  The mover may order the connections in some
+     * protocol-specific fashion.  A mover that is unable to provide connection
+     * information should return null.
+     */
+    @Nullable
+    default List<InetSocketAddress> remoteConnections()
+    {
+        return null;
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
@@ -17,6 +17,9 @@
  */
 package org.dcache.pool.movers;
 
+import java.net.InetSocketAddress;
+import java.util.List;
+
 import diskCacheV111.vehicles.PoolIoFileMessage;
 import diskCacheV111.vehicles.ProtocolInfo;
 
@@ -70,5 +73,11 @@ public class MoverProtocolMover extends AbstractMover<ProtocolInfo, MoverProtoco
     protected String getStatus()
     {
         return _moverProtocol.toString();
+    }
+
+    @Override
+    public List<InetSocketAddress> remoteConnections()
+    {
+        return _moverProtocol.remoteConnections();
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
@@ -80,4 +80,10 @@ public class MoverProtocolMover extends AbstractMover<ProtocolInfo, MoverProtoco
     {
         return _moverProtocol.remoteConnections();
     }
+
+    @Override
+    public Long getBytesExpected()
+    {
+        return _moverProtocol.getBytesExpected();
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -2,6 +2,7 @@ package org.dcache.pool.movers;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpInetConnection;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -17,18 +18,23 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.ConnectionShutdownException;
 import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
 import org.apache.http.protocol.HttpRequestExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.channels.Channels;
@@ -37,7 +43,6 @@ import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +51,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.ThirdPartyTransferFailedCacheException;
@@ -65,6 +71,7 @@ import org.dcache.vehicles.FileAttributes;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static diskCacheV111.util.ThirdPartyTransferFailedCacheException.checkThirdPartyTransferSuccessful;
 import static dmg.util.Exceptions.getMessageWithCauses;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.dcache.namespace.FileAttribute.CHECKSUM;
 import static org.dcache.util.ByteUnit.GiB;
@@ -248,6 +255,9 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
 
     private CloseableHttpClient _client;
 
+    @GuardedBy("this")
+    private HttpClientContext _context;
+
     public RemoteHttpDataTransferProtocol(CellEndpoint cell)
     {
         // constructor needed by Pool mover contract.
@@ -313,6 +323,17 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                 .setRedirectStrategy(DROP_AUTHORIZATION_HEADER);
     }
 
+    private synchronized HttpClientContext storeContext(HttpClientContext context)
+    {
+        _context = context;
+        return context;
+    }
+
+    private synchronized HttpClientContext getContext()
+    {
+        return _context;
+    }
+
     private void receiveFile(final RemoteHttpDataTransferProtocolInfo info)
             throws ThirdPartyTransferFailedCacheException
     {
@@ -320,7 +341,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
 
         long deadline = System.currentTimeMillis() + GET_RETRY_DURATION;
 
-        HttpClientContext context = new HttpClientContext();
+        HttpClientContext context = storeContext(new HttpClientContext());
         try {
             try (CloseableHttpResponse response = doGet(info, context, deadline)) {
                 String rfc3230 = headerValue(response, "Digest");
@@ -387,6 +408,43 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
             } catch (IOException e) {
                 throw new ThirdPartyTransferFailedCacheException("HEAD request failed: " + messageOrClassName(e), e);
             }
+        }
+    }
+
+    private Optional<InetSocketAddress> remoteAddress()
+    {
+        HttpContext context = getContext();
+        if (context == null) {
+            _log.debug("No HttpContext value");
+            return Optional.empty();
+        }
+
+        Object conn = context.getAttribute(HttpCoreContext.HTTP_CONNECTION);
+        if (conn == null) {
+            _log.debug("HTTP_CONNECTION is null");
+            return Optional.empty();
+        }
+
+        if (!(conn instanceof HttpInetConnection)) {
+            throw new RuntimeException("HTTP_CONNECTION has unexpected type: "
+                    + conn.getClass().getCanonicalName());
+        }
+
+        HttpInetConnection inetConn = (HttpInetConnection)conn;
+        if (!inetConn.isOpen()) {
+            _log.debug("HttpConnection is no longer open");
+            return Optional.empty();
+        }
+
+        try {
+            InetAddress addr = requireNonNull(inetConn.getRemoteAddress());
+            int port = inetConn.getRemotePort();
+            InetSocketAddress sockAddr = new InetSocketAddress(addr, port);
+            return Optional.of(sockAddr);
+        } catch (ConnectionShutdownException e) {
+            _log.warn("HTTP_CONNECTION is unexpectedly unconnected");
+            // Perhaps a race condition here?  Hey ho.
+            return Optional.empty();
         }
     }
 
@@ -471,13 +529,14 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     {
         URI location = info.getUri();
         List<URI> redirections = null;
+        HttpClientContext context = storeContext(new HttpClientContext());
 
         try {
             for (int redirectionCount = 0; redirectionCount < MAX_REDIRECTIONS; redirectionCount++) {
                 HttpPut put = buildPutRequest(info, location,
                         redirectionCount > 0 ? REDIRECTED_REQUEST : INITIAL_REQUEST);
 
-                try (CloseableHttpResponse response = _client.execute(put)) {
+                try (CloseableHttpResponse response = _client.execute(put, context)) {
                     StatusLine status = response.getStatusLine();
                     switch (status.getStatusCode()) {
                     case 200: /* OK (not actually a valid response from PUT) */
@@ -616,7 +675,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
                 }
                 isFirstAttempt = false;
 
-                HttpClientContext context = new HttpClientContext();
+                HttpClientContext context = storeContext(new HttpClientContext());
                 HttpHead head = buildHeadRequest(info, deadline);
                 buildWantDigest().ifPresent(v -> head.addHeader("Want-Digest", v));
 
@@ -837,5 +896,11 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     {
         MoverChannel<RemoteHttpDataTransferProtocolInfo> channel = _channel;
         return channel == null ? 0 : channel.getTransferTime();
+    }
+
+    @Override
+    public List<InetSocketAddress> remoteConnections()
+    {
+        return remoteAddress().stream().collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
NB.  This patch requires an additional (earlier) patch, which is included in this pull request.

 webdav: add 'http-tpc ls' admin command

Motivation:

Provide admins with some idea what's happening.

Modification:

Add the 'http-tpc ls' admin command.  This provides a table of summary
information about transfers that have been submitted and are on-going.
The command includes options for selecting which fields to show,
filtering transfers on different criteria, and sorting the resulting
table in different ways.

The progress reports messages from TransferManager are updated to
optionally include the pool name, if the request has been assigned to a
pool and transfer-manager has been updated.  The command will use the
information, if available.

The IoJobInfo class is updated to optionally include the expected
transfers size. This information is optional because non-upgraded pools
will not include it and, under some circumstances, the information is
unknowable (e.g., downloading when HTTP chunked encoding is used).

Result:

The webdav admin interface has been extended to include monitoring
information about on-going transfers.  The command can optionally show
pool information if transfer-manager is update; updating
transfer-manager is not required by this change.  Percent transfer
progress for PULL requests is optionally available if pools are updated;
updating pools is not required by this change.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13150/
Acked-by: Albert Rossi