### PR TITLE
 webdav: add 'http-tpc ls' admin command

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/TimeUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/TimeUtils.java
@@ -377,6 +377,24 @@ public class TimeUtils
      * {@code <number> <space> <units>}, where {@code <number>}
      * is an integer and {@code <units>} is defined by the value of unitFormat.
      */
+    public static StringBuilder appendDuration(StringBuilder sb, Duration duration,
+                    TimeUnitFormat unitFormat)
+    {
+        // FIXME: this method is a wrapper around the overloaded method
+        // with (long,TimeUnit) arguments.  These two methods should be
+        // rewritten so they are the other way around: the method with
+        // (long,TimeUnit) arguments should convert this to a Duration and call
+        // this method, which does the real work.
+        return appendDuration(sb, duration.toMillis(), MILLISECONDS, unitFormat);
+    }
+
+    /**
+     * Provide a short, simple human understandable string describing the
+     * supplied duration.  The duration is a non-negative value.  The output is
+     * appended to the supplied StringBuilder and has the form
+     * {@code <number> <space> <units>}, where {@code <number>}
+     * is an integer and {@code <units>} is defined by the value of unitFormat.
+     */
     public static StringBuilder appendDuration(StringBuilder sb, long duration,
                     TimeUnit units, TimeUnitFormat unitFormat)
     {

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoJobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoJobInfo.java
@@ -1,5 +1,10 @@
 package diskCacheV111.vehicles;
 
+import javax.annotation.Nullable;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
 import diskCacheV111.util.PnfsId;
 
 public class IoJobInfo extends JobInfo  {
@@ -7,18 +12,21 @@ public class IoJobInfo extends JobInfo  {
    private final long _bytesTransferred;
    private final long _transferTime;
    private final long _lastTransferred;
+   private final List<InetSocketAddress> _remoteConnections;
    private final PnfsId _pnfsId;
 
    private static final long serialVersionUID = -7987228538353684951L;
 
    public IoJobInfo(long submitTime, long startTime, String state, int id, String clientName, long clientId,
-                    PnfsId pnfsId, long bytesTransferred, long transferTime, long lastTransferred)
+                    PnfsId pnfsId, long bytesTransferred, long transferTime, long lastTransferred,
+                    @Nullable List<InetSocketAddress> remoteConnections)
    {
       super(submitTime, startTime, state, id, clientName, clientId);
       _pnfsId           = pnfsId;
       _bytesTransferred = bytesTransferred;
       _transferTime     = transferTime;
       _lastTransferred  = lastTransferred;
+      _remoteConnections = remoteConnections;
    }
    public long getTransferTime(){ return _transferTime ; }
    public long getBytesTransferred(){ return _bytesTransferred ; }
@@ -30,5 +38,15 @@ public class IoJobInfo extends JobInfo  {
              ";B=" + _bytesTransferred +
              ";T=" + _transferTime +
              ";L=" + ((System.currentTimeMillis()-_lastTransferred)/1000) + ';';
+   }
+
+   /**
+    * A list of remote TCP endpoints to which the mover is connected.  Returns
+    * null if this information is not available.
+    */
+   @Nullable
+   public List<InetSocketAddress> remoteConnections()
+   {
+       return _remoteConnections;
    }
 }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoJobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/IoJobInfo.java
@@ -9,6 +9,8 @@ import diskCacheV111.util.PnfsId;
 
 public class IoJobInfo extends JobInfo  {
 
+   @Nullable
+   private final Long _requestedBytes;
    private final long _bytesTransferred;
    private final long _transferTime;
    private final long _lastTransferred;
@@ -18,7 +20,7 @@ public class IoJobInfo extends JobInfo  {
    private static final long serialVersionUID = -7987228538353684951L;
 
    public IoJobInfo(long submitTime, long startTime, String state, int id, String clientName, long clientId,
-                    PnfsId pnfsId, long bytesTransferred, long transferTime, long lastTransferred,
+                    PnfsId pnfsId, long bytesTransferred, Long requestedBytes, long transferTime, long lastTransferred,
                     @Nullable List<InetSocketAddress> remoteConnections)
    {
       super(submitTime, startTime, state, id, clientName, clientId);
@@ -27,6 +29,7 @@ public class IoJobInfo extends JobInfo  {
       _transferTime     = transferTime;
       _lastTransferred  = lastTransferred;
       _remoteConnections = remoteConnections;
+      _requestedBytes = requestedBytes;
    }
    public long getTransferTime(){ return _transferTime ; }
    public long getBytesTransferred(){ return _bytesTransferred ; }
@@ -48,5 +51,15 @@ public class IoJobInfo extends JobInfo  {
    public List<InetSocketAddress> remoteConnections()
    {
        return _remoteConnections;
+   }
+
+   /**
+    * The expected number of bytes for this transfer, if known.  Returns
+    * null if the value is unknown.
+    */
+   @Nullable
+   public Long requestedBytes()
+   {
+       return _requestedBytes;
    }
 }

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/transferManager/TransferStatusQueryMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/transferManager/TransferStatusQueryMessage.java
@@ -1,5 +1,7 @@
 package diskCacheV111.vehicles.transferManager;
 
+import javax.annotation.Nullable;
+
 import diskCacheV111.vehicles.IoJobInfo;
 
 /**
@@ -12,6 +14,7 @@ public class TransferStatusQueryMessage extends TransferManagerMessage
 
     private int _state;
     private IoJobInfo _info;
+    private String pool;
 
     public TransferStatusQueryMessage(long id)
     {
@@ -44,5 +47,19 @@ public class TransferStatusQueryMessage extends TransferManagerMessage
     public int getState()
     {
         return _state;
+    }
+
+    public void setPool(String name)
+    {
+        pool = name;
+    }
+
+    /**
+     * Returns the name of the pool handling this transfer, if known.
+     */
+    @Nullable
+    public String getPool()
+    {
+        return pool;
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -18,6 +18,7 @@
 package org.dcache.webdav.transfer;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.InetAddresses;
 import com.google.common.util.concurrent.ListenableFuture;
 import eu.emi.security.authn.x509.X509Credential;
 import io.milton.http.Response;
@@ -39,15 +40,18 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import diskCacheV111.services.TransferManagerHandler;
 import diskCacheV111.util.CacheException;
@@ -767,6 +771,14 @@ public class RemoteTransferHandler implements CellMessageReceiver
                 _out.println("    Stripe Status: " + info.getStatus());
             }
             _out.println("    Total Stripe Count: 1");
+            if (info != null) {
+                List<InetSocketAddress> connections = info.remoteConnections();
+                if (connections != null) {
+                    _out.println("    RemoteConnections: " + connections.stream()
+                            .map(conn -> "tcp:" + InetAddresses.toUriString(conn.getAddress()) + ":" + conn.getPort())
+                            .collect(Collectors.joining(",")));
+                }
+            }
             _out.println("End");
             _out.flush();
         }

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -800,6 +800,10 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message>
             return message;
         }
 
+        if (pool != null) {
+            message.setPool(pool.getName());
+        }
+
         final MessageReply<TransferStatusQueryMessage> reply = new MessageReply<>();
 
         final ListenableFuture<IoJobInfo> future = manager.getPoolStub().

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
@@ -749,6 +749,7 @@ public class MoverRequestScheduler
             return new IoJobInfo(_submitTime, _startTime, _state.toString(), _id,
                                  _mover.getPathToDoor().getDestinationAddress().toString(), _mover.getClientId(),
                                  _mover.getFileAttributes().getPnfsId(), _mover.getBytesTransferred(),
+                                 _mover.getBytesExpected(),
                                  _mover.getTransferTime(), _mover.getLastTransferred(),
                                  _mover.remoteConnections());
         }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
@@ -749,7 +749,8 @@ public class MoverRequestScheduler
             return new IoJobInfo(_submitTime, _startTime, _state.toString(), _id,
                                  _mover.getPathToDoor().getDestinationAddress().toString(), _mover.getClientId(),
                                  _mover.getFileAttributes().getPnfsId(), _mover.getBytesTransferred(),
-                                 _mover.getTransferTime(), _mover.getLastTransferred());
+                                 _mover.getTransferTime(), _mover.getLastTransferred(),
+                                 _mover.remoteConnections());
         }
 
         public synchronized MoverData toMoverData()

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
@@ -18,10 +18,14 @@
 package org.dcache.pool.movers;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.security.auth.Subject;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.channels.CompletionHandler;
 import java.nio.file.OpenOption;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -178,4 +182,17 @@ public interface Mover<T extends ProtocolInfo>
      * or failed.
      */
     void close(CompletionHandler<Void, Void> completionHandler);
+
+    /**
+     * Provide a list of the IP address and port number of all currently active
+     * TCP connections.  An empty list indicates that there is current no
+     * established connections.  The mover may order the connections in some
+     * protocol-specific fashion.  A mover that is unable to provide connection
+     * information should return null.
+     */
+    @Nullable
+    default List<InetSocketAddress> remoteConnections()
+    {
+        return null;
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/Mover.java
@@ -195,4 +195,14 @@ public interface Mover<T extends ProtocolInfo>
     {
         return null;
     }
+
+    /**
+     * Provide the expected total number of bytes transferred for this
+     * transfer, if known.  Returns null if this value is unknown.
+     */
+    @Nullable
+    default Long getBytesExpected()
+    {
+        return null;
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocol.java
@@ -33,6 +33,16 @@ public interface MoverProtocol
     long getBytesTransferred();
 
     /**
+     * Get the number of bytes expected to be transferred, if known.  Returns
+     * null if that value is unknown.
+     */
+    @Nullable
+    default Long getBytesExpected()
+    {
+        return null;
+    }
+
+    /**
      * Get time between transfers begin and end. If Mover is sill
      * active, then current time used as end.
      *

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocol.java
@@ -1,6 +1,10 @@
 package org.dcache.pool.movers;
 
+import javax.annotation.Nullable;
+
+import java.net.InetSocketAddress;
 import java.nio.file.OpenOption;
+import java.util.List;
 import java.util.Set;
 
 import diskCacheV111.vehicles.ProtocolInfo;
@@ -42,4 +46,17 @@ public interface MoverProtocol
      * @return last access time in milliseconds.
      */
     long getLastTransferred();
+
+    /**
+     * Provide a list of the IP address and port number of all currently active
+     * TCP connections.  An empty list indicates that there is current no
+     * established connections.  The mover may order the connections in some
+     * protocol-specific fashion.  A mover that is unable to provide connection
+     * information should return null.
+     */
+    @Nullable
+    default List<InetSocketAddress> remoteConnections()
+    {
+        return null;
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
@@ -17,6 +17,9 @@
  */
 package org.dcache.pool.movers;
 
+import java.net.InetSocketAddress;
+import java.util.List;
+
 import diskCacheV111.vehicles.PoolIoFileMessage;
 import diskCacheV111.vehicles.ProtocolInfo;
 
@@ -70,5 +73,11 @@ public class MoverProtocolMover extends AbstractMover<ProtocolInfo, MoverProtoco
     protected String getStatus()
     {
         return _moverProtocol.toString();
+    }
+
+    @Override
+    public List<InetSocketAddress> remoteConnections()
+    {
+        return _moverProtocol.remoteConnections();
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverProtocolMover.java
@@ -80,4 +80,10 @@ public class MoverProtocolMover extends AbstractMover<ProtocolInfo, MoverProtoco
     {
         return _moverProtocol.remoteConnections();
     }
+
+    @Override
+    public Long getBytesExpected()
+    {
+        return _moverProtocol.getBytesExpected();
+    }
 }


### PR DESCRIPTION
NB. This patch requires an additional (earlier) patch, which is included in this pull request.

webdav: add 'http-tpc ls' admin command

Motivation:

Provide admins with some idea what's happening.

Modification:

Add the 'http-tpc ls' admin command. This provides a table of summary
information about transfers that have been submitted and are on-going.
The command includes options for selecting which fields to show,
filtering transfers on different criteria, and sorting the resulting
table in different ways.

The progress reports messages from TransferManager are updated to
optionally include the pool name, if the request has been assigned to a
pool and transfer-manager has been updated. The command will use the
information, if available.

The IoJobInfo class is updated to optionally include the expected
transfers size. This information is optional because non-upgraded pools
will not include it and, under some circumstances, the information is
unknowable (e.g., downloading when HTTP chunked encoding is used).

Result:

The webdav admin interface has been extended to include monitoring
information about on-going transfers. The command can optionally show
pool information if transfer-manager is update; updating
transfer-manager is not required by this change. Percent transfer
progress for PULL requests is optionally available if pools are updated;
updating pools is not required by this change.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13150/
Acked-by: Albert Rossi