### PR TITLE
namespace-chimera: ignore file size update on file flush

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -1087,7 +1087,10 @@ public class ChimeraNameSpaceProvider
                         }
                         break;
                     case SIZE:
-                        stat.setSize(attr.getSize());
+                        // REVISIT: pool shouldn't update the files size on flush, but this is required due to space manager accounting
+                        if (!attr.isDefined(STORAGEINFO) || !attr.getStorageInfo().isSetAddLocation()) {
+                            stat.setSize(attr.getSize());
+                        }
                         break;
                     case MODE:
                         stat.setMode(attr.getMode());

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1106,6 +1106,7 @@ public class NearlineStorageHandler
                     throw new CacheException(2, e.getMessage(), e);
                 }
             }
+            // REVISIT: pool shouldn't update the files size on flush, but this is required due to space manager accounting
             return FileAttributes.of()
                     .accessLatency(fileAttributes.getAccessLatency())
                     .retentionPolicy(fileAttributes.getRetentionPolicy())


### PR DESCRIPTION
alternative to  65dfad74e57d704268cb56dbbbfbb521297dabdc

Motivation:
The file attributes sent by pool after flush to namespace will update
existing attributes. Though this is not required bu the namespace, the
size information on flush is used by space reservation to adjust space
allocation accounting.

Modification:
update ChimeraNameSpaceProvider when the filesize update comes with
a tape location.

Result:
less operations on db after flush

Acked-by: Lea Morschel
Acked-by: Paul Millar
Require-book: no
Require-notes: yes
(cherry picked from commit 84b45e6f119145b33003f45f6308177b7a5d2327)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>