### PR TITLE
namespace-chimera: ignore file size update on file flush

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -1088,7 +1088,10 @@ public class ChimeraNameSpaceProvider
                         }
                         break;
                     case SIZE:
-                        stat.setSize(attr.getSize());
+                        // REVISIT: pool shouldn't update the files size on flush, but this is required due to space manager accounting
+                        if (!attr.isDefined(STORAGEINFO) || !attr.getStorageInfo().isSetAddLocation()) {
+                            stat.setSize(attr.getSize());
+                        }
                         break;
                     case MODE:
                         stat.setMode(attr.getMode());

--- a/modules/dcache-chimera/src/test/java/diskCacheV111/namespace/PnfsManagerTest.java
+++ b/modules/dcache-chimera/src/test/java/diskCacheV111/namespace/PnfsManagerTest.java
@@ -503,6 +503,48 @@ public class PnfsManagerTest
     }
 
     @Test
+    public void testIgnoreFilesizeUpdateOnFlush() throws Exception {
+
+        PnfsCreateEntryMessage pnfsCreateEntryMessage = new PnfsCreateEntryMessage("/pnfs/testRoot/tapeFile",
+                FileAttributes.ofFileType(REGULAR));
+        _pnfsManager.createEntry(pnfsCreateEntryMessage);
+        assertThat("Creating entry failed", pnfsCreateEntryMessage.getReturnCode(), is(0));
+
+        // simulate pool location update
+        PnfsSetFileAttributes setFileAttributesMessage =
+                new PnfsSetFileAttributes(pnfsCreateEntryMessage.getPnfsId(),
+                        FileAttributes.of()
+                                .location("pool-foo")
+                                .size(17)
+                                .build());
+
+        _pnfsManager.setFileAttributes(setFileAttributesMessage);
+        assertThat("Setting storage info failed", setFileAttributesMessage.getReturnCode(), is(0));
+
+        StorageInfo si = pnfsCreateEntryMessage.getFileAttributes().getStorageInfo();
+        si.addLocation(new URI(OSM_URI_STEM + "?store=tape"));
+        si.isSetAddLocation(true);
+
+        setFileAttributesMessage =
+                new PnfsSetFileAttributes(pnfsCreateEntryMessage.getPnfsId(),
+                        FileAttributes.of()
+                                .size(1L)
+                                .accessLatency(NEARLINE)
+                                .retentionPolicy(CUSTODIAL)
+                                .storageInfo(si).build());
+
+        _pnfsManager.setFileAttributes(setFileAttributesMessage);
+        assertThat("Setting storage info failed", setFileAttributesMessage.getReturnCode(), is(0));
+
+        PnfsGetFileAttributes message =
+                new PnfsGetFileAttributes(pnfsCreateEntryMessage.getPnfsId(), SOME_ATTRIBUTES);
+        _pnfsManager.getFileAttributes(message);
+
+        assertEquals("failed to get storageInfo for flushed files", 0, message.getReturnCode());
+        assertThat("File size get update", message.getFileAttributes().getSize(), is(17L));
+    }
+
+    @Test
     public void testStorageInfoDup() throws Exception {
 
         PnfsCreateEntryMessage pnfsCreateEntryMessage = new PnfsCreateEntryMessage("/pnfs/testRoot/tapeFileDup",

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1106,6 +1106,7 @@ public class NearlineStorageHandler
                     throw new CacheException(2, e.getMessage(), e);
                 }
             }
+            // REVISIT: pool shouldn't update the files size on flush, but this is required due to space manager accounting
             return FileAttributes.of()
                     .accessLatency(fileAttributes.getAccessLatency())
                     .retentionPolicy(fileAttributes.getRetentionPolicy())


### PR DESCRIPTION
alternative to  65dfad74e57d704268cb56dbbbfbb521297dabdc

Motivation:
The file attributes sent by pool after flush to namespace will update
existing attributes. Though this is not required bu the namespace, the
size information on flush is used by space reservation to adjust space
allocation accounting.

Modification:
update ChimeraNameSpaceProvider when the filesize update comes with
a tape location.

Result:
less operations on db after flush

Acked-by: Lea Morschel
Acked-by: Paul Millar
Require-book: no
Require-notes: yes
(cherry picked from commit 84b45e6f119145b33003f45f6308177b7a5d2327)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>