### PR TITLE
webdav: update representation of symbolic links in HTML page

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -1073,9 +1073,28 @@ public class DcacheResourceFactory
                                 EnumSet.of(MODIFICATION_TIME, TYPE, SIZE)));
                     }
 
+                    private FileAttributes entryAttributes(FsPath dir, DirectoryEntry entry)
+                    {
+                        FileAttributes attr = entry.getFileAttributes();
+                        switch (attr.getFileType()) {
+                        case LINK:
+                            String entryPath = dir.child(entry.getName()).toString();
+                            try {
+                                return _pnfs.getFileAttributes(entryPath, getRequiredAttributes());
+                            } catch (CacheException e) {
+                                LOGGER.debug("Symlink lookup of {} failed with {}",
+                                        entryPath, e.getMessage());
+                                return attr;
+                            }
+
+                        default:
+                            return attr;
+                        }
+                    }
+
                     @Override
                     public void print(FsPath dir, FileAttributes dirAttr, DirectoryEntry entry) {
-                        FileAttributes attr = entry.getFileAttributes();
+                        FileAttributes attr = entryAttributes(dir, entry);
                         Date mtime = new Date(attr.getModificationTime());
                         UrlPathWrapper name =
                                 UrlPathWrapper.forPath(entry.getName());
@@ -1084,9 +1103,10 @@ public class DcacheResourceFactory
                          */
                         boolean isUploading = !attr.isDefined(SIZE);
                         FileLocality locality = _poolMonitor.getFileLocality(attr, getRemoteAddr());
-                        t.addAggr("files.{name,isDirectory,mtime,size,isUploading,locality}",
+                        t.addAggr("files.{name,isDirectory,showGhosted,mtime,size,isUploading,locality}",
                                   name,
                                   attr.getFileType() == DIR,
+                                  attr.getFileType() == LINK,
                                   mtime,
                                   attr.getSizeIfPresent().map(SizeWrapper::new).orElse(null),
                                   isUploading,

--- a/skel/share/webdav/templates/html.stg
+++ b/skel/share/webdav/templates/html.stg
@@ -41,7 +41,12 @@ list(files) ::= <<
  */
 file(f) ::= <<
   <tr>
-    $if(f.isDirectory)$
+    $if(f.showGhosted)$
+    <td></td>
+    <td class="text-muted">$f.name.unencoded$</td>
+    <td></td>
+    <td></td>
+    $elseif(f.isDirectory)$
     <td class="text-muted text-center">
         <span class="glyphicon glyphicon-folder-close"></span>
     </td>


### PR DESCRIPTION
Motivation:

The WebDAV door provides a (static) HTML-rendered version of a
directory, which lists the directory's contents.

Symbolic links are currently poorly represented in this page: they
appear "unavailable".  Also sym-links that point to a directory are
shown as files.  This leads to them being shown as unavailable, clicking
on the filename doesn't work, and a download link is made available
(which results in the browser downloading a directory listing).

Modification:

If the directory listing shows a symbolic link, query the namespace for
the resolved target and use the sym-link's target attributes to render
the sym-link.

If the sym-link doesn't resolve (e.g., dangling link) then show the
entry greyed-out without any details.

Result:

Fix how sym-links are shown in the static HTML (web-browser) view from
the WebDAV door.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.1
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Closes: #6032
Patch: https://rb.dcache.org/r/13147/
Acked-by: Albert Rossi