### PR TITLE
webdav: update representation of symbolic links in HTML page

### DIFF
--- a/skel/share/webdav/templates/html.stg
+++ b/skel/share/webdav/templates/html.stg
@@ -41,7 +41,12 @@ list(files) ::= <<
  */
 file(f) ::= <<
   <tr>
-    $if(f.isDirectory)$
+    $if(f.showGhosted)$
+    <td></td>
+    <td class="text-muted">$f.name.unencoded$</td>
+    <td></td>
+    <td></td>
+    $elseif(f.isDirectory)$
     <td class="text-muted text-center">
         <span class="glyphicon glyphicon-folder-close"></span>
     </td>


### PR DESCRIPTION
Motivation:

The WebDAV door provides a (static) HTML-rendered version of a
directory, which lists the directory's contents.

Symbolic links are currently poorly represented in this page: they
appear "unavailable".  Also sym-links that point to a directory are
shown as files.  This leads to them being shown as unavailable, clicking
on the filename doesn't work, and a download link is made available
(which results in the browser downloading a directory listing).

Modification:

If the directory listing shows a symbolic link, query the namespace for
the resolved target and use the sym-link's target attributes to render
the sym-link.

If the sym-link doesn't resolve (e.g., dangling link) then show the
entry greyed-out without any details.

Result:

Fix how sym-links are shown in the static HTML (web-browser) view from
the WebDAV door.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.1
Request: 7.0
Request: 6.2
Request: 6.1
Request: 6.0
Request: 5.2
Closes: #6032
Patch: https://rb.dcache.org/r/13147/
Acked-by: Albert Rossi