### PR TITLE
frontend: add service to provide Storage resource reporting

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
@@ -1,0 +1,145 @@
+package org.dcache.restful.resources.srr;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.net.InetAddresses;
+import diskCacheV111.util.CacheException;
+import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.cells.services.login.LoginBrokerSubscriber;
+import io.swagger.annotations.Api;
+import org.dcache.cells.CellStub;
+import org.dcache.poolmanager.PoolMonitor;
+import org.dcache.restful.srr.SrrBuilder;
+import org.dcache.restful.srr.SrrRecord;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RestFul API to  provide files/folders manipulation operations.
+ */
+@Api(value = "srr")
+@Component
+@Path("/srr")
+public class SrrResource {
+
+    @Context
+    private HttpServletRequest request;
+
+    private Map<String, List<String>> pgroup2vo = new HashMap<>();
+    // info provider properties
+    private String name;
+    private String id;
+    private String architecture;
+    private String quality;
+    private String doorTag;
+
+    @Inject
+    @Named("spacemanager-stub")
+    private CellStub spaceManager;
+
+    @Inject
+    @Named("pool-monitor")
+    private PoolMonitor remotePoolMonitor;
+
+    @Inject
+    @Named("pnfs-stub")
+    private CellStub namespaceStub;
+
+    @Inject
+    @Named("login-broker-source")
+    private LoginBrokerSubscriber loginBrokerSubscriber;
+
+    private boolean spaceReservationEnabled;
+
+    public void setQuality(String quality) {
+        this.quality = quality;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setDoorTag(String doorTag) {
+        this.doorTag = doorTag;
+    }
+
+    public void setSpaceReservationEnabled(boolean spaceReservationEnabled) {
+        this.spaceReservationEnabled = spaceReservationEnabled;
+    }
+
+    public void setArchitecture(String architecture) {
+        this.architecture = architecture;
+    }
+
+    public void setGroupMapping(String mapping) {
+
+        // pgroup=qos-disk:/cms,qos-disk:/atlas
+
+        Splitter.on(',')
+                .trimResults()
+                .omitEmptyStrings()
+                .splitToList(mapping)
+                .forEach(
+                        s -> {
+                            String[] voMap = s.split(":");
+                            if (voMap.length != 2) {
+                                throw new IllegalArgumentException("Invalid format of poolgroup -> VO mapping");
+                            }
+                            pgroup2vo.computeIfAbsent(voMap[0], k -> new ArrayList<>()).add(voMap[1]);
+                        }
+
+                );
+
+    }
+
+    @Produces(MediaType.APPLICATION_JSON)
+    @GET
+    @Path("/")
+    public Response getSrr() throws InterruptedException, CacheException, NoRouteToCellException {
+
+        InetAddress remoteAddress  = InetAddresses.forString(request.getRemoteAddr());
+        if (!remoteAddress.isLoopbackAddress()) {
+            throw new ForbiddenException();
+        }
+
+        SrrRecord record = SrrBuilder.builder()
+                .withLoginBroker(loginBrokerSubscriber)
+                .withNamespace(namespaceStub)
+                .withPoolMonitor(remotePoolMonitor)
+                .withSpaceManagerStub(spaceManager)
+                .withSpaceManagerEnaled(spaceReservationEnabled)
+                .withId(id)
+                .withName(name)
+                .withQuality(quality)
+                .withArchitecture(architecture)
+                .withGroupVoMapping(pgroup2vo)
+                .withDoorTag(doorTag)
+                .generate();
+
+        return Response.ok(record)
+                .header("Link",
+                "<https://raw.githubusercontent.com/sjones-hep-ph-liv-ac-uk/json_info_system/master/srr/v4.2/schema/srrschema_4.2.json>; rel=\"describedby\"")
+                .build();
+    }
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Bandwith.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Bandwith.java
@@ -1,0 +1,76 @@
+package org.dcache.restful.srr;
+
+
+public class Bandwith {
+
+    /**
+     * (Required)
+     */
+    private String network;
+    /**
+     * (Required)
+     */
+    private String disk;
+    /**
+     * (Required)
+     */
+    private String etc;
+
+    /**
+     * (Required)
+     */
+    public String getNetwork() {
+        return network;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setNetwork(String network) {
+        this.network = network;
+    }
+
+    public Bandwith withNetwork(String network) {
+        this.network = network;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public String getDisk() {
+        return disk;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setDisk(String disk) {
+        this.disk = disk;
+    }
+
+    public Bandwith withDisk(String disk) {
+        this.disk = disk;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public String getEtc() {
+        return etc;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setEtc(String etc) {
+        this.etc = etc;
+    }
+
+    public Bandwith withEtc(String etc) {
+        this.etc = etc;
+        return this;
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Datastore.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Datastore.java
@@ -1,0 +1,250 @@
+package org.dcache.restful.srr;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Datastore {
+
+    /**
+     * (Required)
+     */
+    private String name;
+    private String id;
+    /**
+     * (Required)
+     */
+    private Datastoretype datastoretype;
+    /**
+     * (Required)
+     */
+    private Accesslatency accesslatency;
+    /**
+     * (Required)
+     */
+    private long totalsize;
+    /**
+     * (Required)
+     */
+    private String vendor;
+    /**
+     * (Required)
+     */
+    private Bandwith bandwith;
+    private String message;
+
+    /**
+     * (Required)
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Datastore withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Datastore withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public Datastoretype getDatastoretype() {
+        return datastoretype;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setDatastoretype(Datastoretype datastoretype) {
+        this.datastoretype = datastoretype;
+    }
+
+    public Datastore withDatastoretype(Datastoretype datastoretype) {
+        this.datastoretype = datastoretype;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public Accesslatency getAccesslatency() {
+        return accesslatency;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setAccesslatency(Accesslatency accesslatency) {
+        this.accesslatency = accesslatency;
+    }
+
+    public Datastore withAccesslatency(Accesslatency accesslatency) {
+        this.accesslatency = accesslatency;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public long getTotalsize() {
+        return totalsize;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setTotalsize(long totalsize) {
+        this.totalsize = totalsize;
+    }
+
+    public Datastore withTotalsize(long totalsize) {
+        this.totalsize = totalsize;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public String getVendor() {
+        return vendor;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setVendor(String vendor) {
+        this.vendor = vendor;
+    }
+
+    public Datastore withVendor(String vendor) {
+        this.vendor = vendor;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public Bandwith getBandwith() {
+        return bandwith;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setBandwith(Bandwith bandwith) {
+        this.bandwith = bandwith;
+    }
+
+    public Datastore withBandwith(Bandwith bandwith) {
+        this.bandwith = bandwith;
+        return this;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Datastore withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public enum Accesslatency {
+
+        ONLINE("online"),
+        OFFLINE("offline"),
+        NEARLINE("nearline");
+        private final String value;
+        private final static Map<String, Accesslatency> CONSTANTS = new HashMap<String, Accesslatency>();
+
+        static {
+            for (Accesslatency c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        Accesslatency(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        public String value() {
+            return this.value;
+        }
+
+        public static Accesslatency fromValue(String value) {
+            Accesslatency constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+    }
+
+    public enum Datastoretype {
+
+        DISK("disk"),
+        TAPE("tape"),
+        CLOUD("cloud");
+        private final String value;
+        private final static Map<String, Datastoretype> CONSTANTS = new HashMap<String, Datastoretype>();
+
+        static {
+            for (Datastoretype c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        Datastoretype(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        public String value() {
+            return this.value;
+        }
+
+        public static Datastoretype fromValue(String value) {
+            Datastoretype constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Lifetime.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Lifetime.java
@@ -1,0 +1,89 @@
+package org.dcache.restful.srr;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Lifetime {
+
+    private String _default;
+    private String maximum;
+    private Expiration expiration;
+
+    public String getDefault() {
+        return _default;
+    }
+
+    public void setDefault(String _default) {
+        this._default = _default;
+    }
+
+    public Lifetime withDefault(String _default) {
+        this._default = _default;
+        return this;
+    }
+
+    public String getMaximum() {
+        return maximum;
+    }
+
+    public void setMaximum(String maximum) {
+        this.maximum = maximum;
+    }
+
+    public Lifetime withMaximum(String maximum) {
+        this.maximum = maximum;
+        return this;
+    }
+
+    public Expiration getExpiration() {
+        return expiration;
+    }
+
+    public void setExpiration(Expiration expiration) {
+        this.expiration = expiration;
+    }
+
+    public Lifetime withExpiration(Expiration expiration) {
+        this.expiration = expiration;
+        return this;
+    }
+
+    public enum Expiration {
+
+        RELEASE("release"),
+        WARN("warn"),
+        NEVER("never");
+        private final String value;
+        private final static Map<String, Expiration> CONSTANTS = new HashMap<String, Expiration>();
+
+        static {
+            for (Expiration c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        Expiration(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        public String value() {
+            return this.value;
+        }
+
+        public static Expiration fromValue(String value) {
+            Expiration constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Nearline.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Nearline.java
@@ -1,0 +1,67 @@
+package org.dcache.restful.srr;
+
+
+public class Nearline {
+
+    /**
+     * (Required)
+     */
+    private Long totalsize;
+    /**
+     * (Required)
+     */
+    private Long usedsize;
+    private Long reservedsize;
+
+    /**
+     * (Required)
+     */
+    public Long getTotalsize() {
+        return totalsize;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setTotalsize(Long totalsize) {
+        this.totalsize = totalsize;
+    }
+
+    public Nearline withTotalsize(long totalsize) {
+        this.totalsize = totalsize;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public Long getUsedsize() {
+        return usedsize;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setUsedsize(Long usedsize) {
+        this.usedsize = usedsize;
+    }
+
+    public Nearline withUsedsize(long usedsize) {
+        this.usedsize = usedsize;
+        return this;
+    }
+
+    public Long getReservedsize() {
+        return reservedsize;
+    }
+
+    public void setReservedsize(Long reservedsize) {
+        this.reservedsize = reservedsize;
+    }
+
+    public Nearline withReservedsize(long reservedsize) {
+        this.reservedsize = reservedsize;
+        return this;
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Offline.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Offline.java
@@ -1,0 +1,67 @@
+package org.dcache.restful.srr;
+
+
+public class Offline {
+
+    /**
+     * (Required)
+     */
+    private Long totalsize;
+    /**
+     * (Required)
+     */
+    private Long usedsize;
+    private Long reservedsize;
+
+    /**
+     * (Required)
+     */
+    public Long getTotalsize() {
+        return totalsize;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setTotalsize(Long totalsize) {
+        this.totalsize = totalsize;
+    }
+
+    public Offline withTotalsize(long totalsize) {
+        this.totalsize = totalsize;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public Long getUsedsize() {
+        return usedsize;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setUsedsize(Long usedsize) {
+        this.usedsize = usedsize;
+    }
+
+    public Offline withUsedsize(long usedsize) {
+        this.usedsize = usedsize;
+        return this;
+    }
+
+    public Long getReservedsize() {
+        return reservedsize;
+    }
+
+    public void setReservedsize(Long reservedsize) {
+        this.reservedsize = reservedsize;
+    }
+
+    public Offline withReservedsize(long reservedsize) {
+        this.reservedsize = reservedsize;
+        return this;
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Online.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Online.java
@@ -1,0 +1,67 @@
+package org.dcache.restful.srr;
+
+
+public class Online {
+
+    /**
+     * (Required)
+     */
+    private Long totalsize;
+    /**
+     * (Required)
+     */
+    private Long usedsize;
+    private Long reservedsize;
+
+    /**
+     * (Required)
+     */
+    public Long getTotalsize() {
+        return totalsize;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setTotalsize(Long totalsize) {
+        this.totalsize = totalsize;
+    }
+
+    public Online withTotalsize(long totalsize) {
+        this.totalsize = totalsize;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public Long getUsedsize() {
+        return usedsize;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setUsedsize(Long usedsize) {
+        this.usedsize = usedsize;
+    }
+
+    public Online withUsedsize(long usedsize) {
+        this.usedsize = usedsize;
+        return this;
+    }
+
+    public Long getReservedsize() {
+        return reservedsize;
+    }
+
+    public void setReservedsize(Long reservedsize) {
+        this.reservedsize = reservedsize;
+    }
+
+    public Online withReservedsize(long reservedsize) {
+        this.reservedsize = reservedsize;
+        return this;
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
@@ -1,0 +1,246 @@
+package org.dcache.restful.srr;
+
+import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import diskCacheV111.poolManager.CostModule;
+import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.services.space.Space;
+import diskCacheV111.services.space.message.GetSpaceTokensMessage;
+import diskCacheV111.util.CacheException;
+import dmg.cells.nucleus.NoRouteToCellException;
+import dmg.cells.services.login.LoginBrokerInfo;
+import dmg.cells.services.login.LoginBrokerSubscriber;
+import org.dcache.cells.CellStub;
+import org.dcache.poolmanager.PoolMonitor;
+import org.dcache.util.Version;
+
+public class SrrBuilder {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(SrrBuilder.class);
+
+    private Map<String, List<String>> pgroup2vo;
+    // info provider properties
+    private String name;
+    private String id;
+    private String architecture;
+    private String quality;
+    private String doorTag;
+
+
+    private CellStub spaceManager;
+
+    private PoolMonitor remotePoolMonitor;
+
+    private CellStub pnfsmanager;
+
+    private LoginBrokerSubscriber loginBrokerSubscriber;
+
+    private boolean spaceReservationEnabled;
+
+    private SrrBuilder() {
+    }
+
+    public static SrrBuilder builder() {
+        return new SrrBuilder();
+    }
+
+    public SrrBuilder withLoginBroker(LoginBrokerSubscriber loginBroker) {
+        this.loginBrokerSubscriber = loginBroker;
+        return this;
+    }
+
+    public SrrBuilder withSpaceManagerStub(CellStub stub) {
+        this.spaceManager = stub;
+        return this;
+    }
+
+    public SrrBuilder withNamespace(CellStub stub) {
+        this.pnfsmanager = stub;
+        return this;
+    }
+
+    public SrrBuilder withSpaceManagerEnaled(boolean isEnabled) {
+        this.spaceReservationEnabled = isEnabled;
+        return this;
+    }
+
+    public SrrBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public SrrBuilder withPoolMonitor(PoolMonitor poolMonitor) {
+        this.remotePoolMonitor = poolMonitor;
+        return this;
+    }
+
+    public SrrBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public SrrBuilder withQuality(String quality) {
+        this.quality = quality;
+        return this;
+    }
+
+    public SrrBuilder withArchitecture(String architecture) {
+        this.architecture = architecture;
+        return this;
+    }
+
+    public SrrBuilder withGroupVoMapping(Map<String, List<String>> pgroup2vo) {
+        this.pgroup2vo = pgroup2vo;
+        return this;
+    }
+
+    public SrrBuilder withDoorTag(String doorTag) {
+        this.doorTag = doorTag;
+        return this;
+    }
+
+    public SrrRecord generate() throws InterruptedException, CacheException, NoRouteToCellException {
+
+        Online onlineCapacity = new Online()
+                .withTotalsize(totalSpace())
+                .withUsedsize(usedSpace());
+
+        List<Storageendpoint> storageendpoints = collectEndpoint();
+        List<Storageshare> storageshares = collectShares();
+
+        if (spaceReservationEnabled) {
+            List<Storageshare> spacetokens = collectSpaceTokens();
+            storageshares.addAll(spacetokens);
+            onlineCapacity.setReservedsize(collectSpaceReserved());
+        }
+
+        Storagecapacity storagecapacity = new Storagecapacity()
+                .withOnline(onlineCapacity);
+
+        Storageservice storageservice = new Storageservice()
+                .withId(id)
+                .withName(name)
+                .withImplementation("dCache")
+                .withServicetype(architecture)
+                .withQualitylevel(Storageservice.Qualitylevel.fromValue(quality))
+                .withImplementationversion(Version.of(this).getVersion())
+                .withLatestupdate(Instant.now().getEpochSecond())
+                .withStorageendpoints(storageendpoints)
+                .withStorageshares(storageshares)
+                .withStoragecapacity(storagecapacity);
+
+        SrrRecord record = new SrrRecord();
+        record.setStorageservice(storageservice);
+
+        return record;
+    }
+
+    private long totalSpace() {
+        return remotePoolMonitor.getCostModule().getPoolCostInfos().stream()
+                .mapToLong(p -> p.getSpaceInfo().getTotalSpace())
+                .sum();
+    }
+
+    private long usedSpace() {
+        return remotePoolMonitor.getCostModule().getPoolCostInfos().stream()
+                .mapToLong(p -> p.getSpaceInfo().getTotalSpace() - p.getSpaceInfo().getFreeSpace() - p.getSpaceInfo().getRemovableSpace())
+                .sum();
+    }
+
+    private List<Storageshare> collectSpaceTokens() throws CacheException, NoRouteToCellException, InterruptedException {
+
+        long now = Instant.now().getEpochSecond();
+        return spaceManager.sendAndWait(new GetSpaceTokensMessage()).getSpaceTokenSet().stream()
+                .map(space -> {
+                    Storageshare share = new Storageshare()
+                            .withName(space.getDescription())
+                            .withTotalsize(space.getSizeInBytes())
+                            .withUsedsize(space.getUsedSizeInBytes())
+                            .withTimestamp(now)
+                            .withVos(Collections.singletonList(space.getVoGroup()))
+                            .withAssignedendpoints(Collections.singletonList("all"))
+                            .withAccesslatency(Storageshare.Accesslatency.fromValue(space.getAccessLatency()))
+                            .withRetentionpolicy(Storageshare.Retentionpolicy.fromValue(space.getRetentionPolicy()));
+
+                    return share;
+                }).collect(Collectors.toList());
+    }
+
+    private long collectSpaceReserved() throws CacheException, NoRouteToCellException, InterruptedException {
+        return spaceManager.sendAndWait(new GetSpaceTokensMessage()).getSpaceTokenSet().stream()
+                .mapToLong(Space::getSizeInBytes)
+                .sum();
+    }
+
+    private List<Storageshare> collectShares() throws CacheException, NoRouteToCellException, InterruptedException {
+
+        Map<String, Storageshare> storageshares = new HashMap<>();
+        long now = Instant.now().getEpochSecond();
+
+        for (Map.Entry<String, List<String>> pgroup: pgroup2vo.entrySet()) {
+
+            String shareName = pgroup.getKey();
+
+            CostModule costModule = remotePoolMonitor.getCostModule();
+            long totalSpace = 0;
+            long usedSpace = 0;
+
+            Collection<PoolSelectionUnit.SelectionPool> pools = remotePoolMonitor.getPoolSelectionUnit().getPoolsByPoolGroup(pgroup.getKey());
+
+            totalSpace += pools.stream()
+                    .map(PoolSelectionUnit.SelectionEntity::getName)
+                    .map(costModule::getPoolCostInfo)
+                    .mapToLong(p -> p.getSpaceInfo().getTotalSpace())
+                    .sum();
+
+            usedSpace += pools.stream()
+                    .map(PoolSelectionUnit.SelectionEntity::getName)
+                    .map(costModule::getPoolCostInfo)
+                    .mapToLong(p -> p.getSpaceInfo().getTotalSpace() - p.getSpaceInfo().getFreeSpace() - p.getSpaceInfo().getRemovableSpace())
+                    .sum();
+
+            Storageshare share = new Storageshare()
+                    .withName(shareName)
+                    .withTotalsize(totalSpace)
+                    .withUsedsize(usedSpace)
+                    .withTimestamp(now)
+                    .withVos(pgroup.getValue())
+                    .withAssignedendpoints(Collections.singletonList("all"));
+            storageshares.put(shareName, share);
+        }
+        return new ArrayList<>(storageshares.values());
+    }
+
+    private List<Storageendpoint> collectEndpoint() {
+
+        Predicate<LoginBrokerInfo> doorTagFilter = Strings.emptyToNull(doorTag) == null?
+                (d) -> true : (d) -> d.getTags().contains(doorTag);
+
+        return loginBrokerSubscriber.doors().stream()
+                .filter(doorTagFilter)
+                .map(d -> {
+                    Storageendpoint endpoint = new Storageendpoint()
+                            .withName(id + "#" + d.getProtocolFamily() + "@" + d.getAddresses().get(0).getCanonicalHostName() + "-" + d.getPort())
+                            .withInterfacetype(d.getProtocolFamily())
+                            .withInterfaceversion(d.getProtocolVersion())
+                            .withEndpointurl(d.getProtocolFamily() + "://" + d.getAddresses().get(0).getCanonicalHostName() + ":" + d.getPort() + d.getRoot())
+                            .withAssignedshares(Collections.singletonList("all"));
+
+                    return endpoint;
+                }
+        ).collect(Collectors.toList());
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrRecord.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrRecord.java
@@ -1,0 +1,34 @@
+package org.dcache.restful.srr;
+
+
+/**
+ * Storage Resource Reporting Schema
+ * <p>
+ */
+public class SrrRecord {
+
+    /**
+     * (Required)
+     */
+    private Storageservice storageservice;
+
+    /**
+     * (Required)
+     */
+    public Storageservice getStorageservice() {
+        return storageservice;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setStorageservice(Storageservice storageservice) {
+        this.storageservice = storageservice;
+    }
+
+    public SrrRecord withStorageservice(Storageservice storageservice) {
+        this.storageservice = storageservice;
+        return this;
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Storagecapacity.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Storagecapacity.java
@@ -1,0 +1,58 @@
+package org.dcache.restful.srr;
+
+
+public class Storagecapacity {
+
+    /**
+     * (Required)
+     */
+    private Online online;
+    private Offline offline;
+    private Nearline nearline;
+
+    /**
+     * (Required)
+     */
+    public Online getOnline() {
+        return online;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setOnline(Online online) {
+        this.online = online;
+    }
+
+    public Storagecapacity withOnline(Online online) {
+        this.online = online;
+        return this;
+    }
+
+    public Offline getOffline() {
+        return offline;
+    }
+
+    public void setOffline(Offline offline) {
+        this.offline = offline;
+    }
+
+    public Storagecapacity withOffline(Offline offline) {
+        this.offline = offline;
+        return this;
+    }
+
+    public Nearline getNearline() {
+        return nearline;
+    }
+
+    public void setNearline(Nearline nearline) {
+        this.nearline = nearline;
+    }
+
+    public Storagecapacity withNearline(Nearline nearline) {
+        this.nearline = nearline;
+        return this;
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Storageendpoint.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Storageendpoint.java
@@ -1,0 +1,211 @@
+package org.dcache.restful.srr;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Storageendpoint {
+
+    /**
+     * (Required)
+     */
+    private String name;
+    private String id;
+    /**
+     * (Required)
+     */
+    private String endpointurl;
+    /**
+     * (Required)
+     */
+    private String interfacetype;
+    private String interfaceversion;
+    private List<String> capabilities = null;
+    private Qualitylevel qualitylevel;
+    /**
+     * (Required)
+     */
+    private List<String> assignedshares = null;
+    private String message;
+
+    /**
+     * (Required)
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Storageendpoint withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Storageendpoint withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public String getEndpointurl() {
+        return endpointurl;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setEndpointurl(String endpointurl) {
+        this.endpointurl = endpointurl;
+    }
+
+    public Storageendpoint withEndpointurl(String endpointurl) {
+        this.endpointurl = endpointurl;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public String getInterfacetype() {
+        return interfacetype;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setInterfacetype(String interfacetype) {
+        this.interfacetype = interfacetype;
+    }
+
+    public Storageendpoint withInterfacetype(String interfacetype) {
+        this.interfacetype = interfacetype;
+        return this;
+    }
+
+    public String getInterfaceversion() {
+        return interfaceversion;
+    }
+
+    public void setInterfaceversion(String interfaceversion) {
+        this.interfaceversion = interfaceversion;
+    }
+
+    public Storageendpoint withInterfaceversion(String interfaceversion) {
+        this.interfaceversion = interfaceversion;
+        return this;
+    }
+
+    public List<String> getCapabilities() {
+        return capabilities;
+    }
+
+    public void setCapabilities(List<String> capabilities) {
+        this.capabilities = capabilities;
+    }
+
+    public Storageendpoint withCapabilities(List<String> capabilities) {
+        this.capabilities = capabilities;
+        return this;
+    }
+
+    public Qualitylevel getQualitylevel() {
+        return qualitylevel;
+    }
+
+    public void setQualitylevel(Qualitylevel qualitylevel) {
+        this.qualitylevel = qualitylevel;
+    }
+
+    public Storageendpoint withQualitylevel(Qualitylevel qualitylevel) {
+        this.qualitylevel = qualitylevel;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public List<String> getAssignedshares() {
+        return assignedshares;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setAssignedshares(List<String> assignedshares) {
+        this.assignedshares = assignedshares;
+    }
+
+    public Storageendpoint withAssignedshares(List<String> assignedshares) {
+        this.assignedshares = assignedshares;
+        return this;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Storageendpoint withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public enum Qualitylevel {
+
+        DEVELOPMENT("development"),
+        TESTING("testing"),
+        PRE_PRODUCTION("pre-production"),
+        PRODUCTION("production");
+        private final String value;
+        private final static Map<String, Qualitylevel> CONSTANTS = new HashMap<String, Qualitylevel>();
+
+        static {
+            for (Qualitylevel c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        Qualitylevel(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        public String value() {
+            return this.value;
+        }
+
+        public static Qualitylevel fromValue(String value) {
+            Qualitylevel constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Storageservice.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Storageservice.java
@@ -1,0 +1,287 @@
+package org.dcache.restful.srr;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Storageservice {
+
+    private String name;
+    private String id;
+    private String servicetype;
+    /**
+     * (Required)
+     */
+    private String implementation;
+    /**
+     * (Required)
+     */
+    private String implementationversion;
+    private List<String> capabilities = null;
+    private Qualitylevel qualitylevel;
+    private String message;
+    private Long latestupdate;
+    private Long lastupdated;
+    private Storagecapacity storagecapacity;
+    /**
+     * (Required)
+     */
+    private List<Storageendpoint> storageendpoints = null;
+    /**
+     * (Required)
+     */
+    private List<Storageshare> storageshares = null;
+    private List<Datastore> datastores = null;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Storageservice withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Storageservice withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getServicetype() {
+        return servicetype;
+    }
+
+    public void setServicetype(String servicetype) {
+        this.servicetype = servicetype;
+    }
+
+    public Storageservice withServicetype(String servicetype) {
+        this.servicetype = servicetype;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public String getImplementation() {
+        return implementation;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setImplementation(String implementation) {
+        this.implementation = implementation;
+    }
+
+    public Storageservice withImplementation(String implementation) {
+        this.implementation = implementation;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public String getImplementationversion() {
+        return implementationversion;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setImplementationversion(String implementationversion) {
+        this.implementationversion = implementationversion;
+    }
+
+    public Storageservice withImplementationversion(String implementationversion) {
+        this.implementationversion = implementationversion;
+        return this;
+    }
+
+    public List<String> getCapabilities() {
+        return capabilities;
+    }
+
+    public void setCapabilities(List<String> capabilities) {
+        this.capabilities = capabilities;
+    }
+
+    public Storageservice withCapabilities(List<String> capabilities) {
+        this.capabilities = capabilities;
+        return this;
+    }
+
+    public Qualitylevel getQualitylevel() {
+        return qualitylevel;
+    }
+
+    public void setQualitylevel(Qualitylevel qualitylevel) {
+        this.qualitylevel = qualitylevel;
+    }
+
+    public Storageservice withQualitylevel(Qualitylevel qualitylevel) {
+        this.qualitylevel = qualitylevel;
+        return this;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Storageservice withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public Long getLatestupdate() {
+        return latestupdate;
+    }
+
+    public void setLatestupdate(Long latestupdate) {
+        this.latestupdate = latestupdate;
+    }
+
+    public Storageservice withLatestupdate(long latestupdate) {
+        this.latestupdate = latestupdate;
+        return this;
+    }
+
+    public Long getLastupdated() {
+        return lastupdated;
+    }
+
+    public void setLastupdated(Long lastupdated) {
+        this.lastupdated = lastupdated;
+    }
+
+    public Storageservice withLastupdated(long lastupdated) {
+        this.lastupdated = lastupdated;
+        return this;
+    }
+
+    public Storagecapacity getStoragecapacity() {
+        return storagecapacity;
+    }
+
+    public void setStoragecapacity(Storagecapacity storagecapacity) {
+        this.storagecapacity = storagecapacity;
+    }
+
+    public Storageservice withStoragecapacity(Storagecapacity storagecapacity) {
+        this.storagecapacity = storagecapacity;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public List<Storageendpoint> getStorageendpoints() {
+        return storageendpoints;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setStorageendpoints(List<Storageendpoint> storageendpoints) {
+        this.storageendpoints = storageendpoints;
+    }
+
+    public Storageservice withStorageendpoints(List<Storageendpoint> storageendpoints) {
+        this.storageendpoints = storageendpoints;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public List<Storageshare> getStorageshares() {
+        return storageshares;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setStorageshares(List<Storageshare> storageshares) {
+        this.storageshares = storageshares;
+    }
+
+    public Storageservice withStorageshares(List<Storageshare> storageshares) {
+        this.storageshares = storageshares;
+        return this;
+    }
+
+    public List<Datastore> getDatastores() {
+        return datastores;
+    }
+
+    public void setDatastores(List<Datastore> datastores) {
+        this.datastores = datastores;
+    }
+
+    public Storageservice withDatastores(List<Datastore> datastores) {
+        this.datastores = datastores;
+        return this;
+    }
+
+    public enum Qualitylevel {
+
+        @SerializedName("development") DEVELOPMENT("development"),
+        @SerializedName("testing") TESTING("testing"),
+        @SerializedName("pre-production") PRE_PRODUCTION("pre-production"),
+        @SerializedName("production") PRODUCTION("production");
+        private final String value;
+        private final static Map<String, Qualitylevel> CONSTANTS = new HashMap<String, Qualitylevel>();
+
+        static {
+            for (Qualitylevel c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        Qualitylevel(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonValue
+        public String value() {
+            return this.value;
+        }
+
+        @JsonCreator
+        public static Qualitylevel fromValue(String value) {
+            Qualitylevel constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+    }
+
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Storageshare.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/Storageshare.java
@@ -1,0 +1,418 @@
+package org.dcache.restful.srr;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.gson.annotations.SerializedName;
+import diskCacheV111.util.AccessLatency;
+import diskCacheV111.util.RetentionPolicy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Storageshare {
+
+    private String name;
+    private String id;
+    private List<String> policyrules = null;
+    private List<String> accessmode = null;
+    private Accesslatency accesslatency;
+    private Servingstate servingstate;
+    private Retentionpolicy retentionpolicy;
+    private Lifetime lifetime;
+    /**
+     * (Required)
+     */
+    private Long timestamp;
+    /**
+     * (Required)
+     */
+    private Long totalsize;
+    /**
+     * (Required)
+     */
+    private Long usedsize;
+    private Long numberoffiles;
+    private List<String> path = null;
+    private List<String> assignedendpoints = null;
+    /**
+     * (Required)
+     */
+    private List<String> vos = null;
+    private String message;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Storageshare withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Storageshare withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public List<String> getPolicyrules() {
+        return policyrules;
+    }
+
+    public void setPolicyrules(List<String> policyrules) {
+        this.policyrules = policyrules;
+    }
+
+    public Storageshare withPolicyrules(List<String> policyrules) {
+        this.policyrules = policyrules;
+        return this;
+    }
+
+    public List<String> getAccessmode() {
+        return accessmode;
+    }
+
+    public void setAccessmode(List<String> accessmode) {
+        this.accessmode = accessmode;
+    }
+
+    public Storageshare withAccessmode(List<String> accessmode) {
+        this.accessmode = accessmode;
+        return this;
+    }
+
+    public Accesslatency getAccesslatency() {
+        return accesslatency;
+    }
+
+    public void setAccesslatency(Accesslatency accesslatency) {
+        this.accesslatency = accesslatency;
+    }
+
+    public Storageshare withAccesslatency(Accesslatency accesslatency) {
+        this.accesslatency = accesslatency;
+        return this;
+    }
+
+    public Servingstate getServingstate() {
+        return servingstate;
+    }
+
+    public void setServingstate(Servingstate servingstate) {
+        this.servingstate = servingstate;
+    }
+
+    public Storageshare withServingstate(Servingstate servingstate) {
+        this.servingstate = servingstate;
+        return this;
+    }
+
+    public Retentionpolicy getRetentionpolicy() {
+        return retentionpolicy;
+    }
+
+    public void setRetentionpolicy(Retentionpolicy retentionpolicy) {
+        this.retentionpolicy = retentionpolicy;
+    }
+
+    public Storageshare withRetentionpolicy(Retentionpolicy retentionpolicy) {
+        this.retentionpolicy = retentionpolicy;
+        return this;
+    }
+
+    public Lifetime getLifetime() {
+        return lifetime;
+    }
+
+    public void setLifetime(Lifetime lifetime) {
+        this.lifetime = lifetime;
+    }
+
+    public Storageshare withLifetime(Lifetime lifetime) {
+        this.lifetime = lifetime;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Storageshare withTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public Long getTotalsize() {
+        return totalsize;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setTotalsize(Long totalsize) {
+        this.totalsize = totalsize;
+    }
+
+    public Storageshare withTotalsize(long totalsize) {
+        this.totalsize = totalsize;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public Long getUsedsize() {
+        return usedsize;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setUsedsize(Long usedsize) {
+        this.usedsize = usedsize;
+    }
+
+    public Storageshare withUsedsize(long usedsize) {
+        this.usedsize = usedsize;
+        return this;
+    }
+
+    public Long getNumberoffiles() {
+        return numberoffiles;
+    }
+
+    public void setNumberoffiles(Long numberoffiles) {
+        this.numberoffiles = numberoffiles;
+    }
+
+    public Storageshare withNumberoffiles(long numberoffiles) {
+        this.numberoffiles = numberoffiles;
+        return this;
+    }
+
+    public List<String> getPath() {
+        return path;
+    }
+
+    public void setPath(List<String> path) {
+        this.path = path;
+    }
+
+    public Storageshare withPath(List<String> path) {
+        this.path = path;
+        return this;
+    }
+
+    public List<String> getAssignedendpoints() {
+        return assignedendpoints;
+    }
+
+    public void setAssignedendpoints(List<String> assignedendpoints) {
+        this.assignedendpoints = assignedendpoints;
+    }
+
+    public Storageshare withAssignedendpoints(List<String> assignedendpoints) {
+        this.assignedendpoints = assignedendpoints;
+        return this;
+    }
+
+    /**
+     * (Required)
+     */
+    public List<String> getVos() {
+        return vos;
+    }
+
+    /**
+     * (Required)
+     */
+    public void setVos(List<String> vos) {
+        this.vos = vos;
+    }
+
+    public Storageshare withVos(List<String> vos) {
+        this.vos = vos;
+        return this;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Storageshare withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public enum Accesslatency {
+
+        @SerializedName("online") ONLINE("online"),
+        @SerializedName("offline") OFFLINE("offline"),
+        @SerializedName("nearline") NEARLINE("nearline");
+        private final String value;
+        private final static Map<String, Accesslatency> CONSTANTS = new HashMap<String, Accesslatency>();
+
+        static {
+            for (Accesslatency c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        Accesslatency(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonValue
+        public String value() {
+            return this.value;
+        }
+
+        @JsonCreator
+        public static Accesslatency fromValue(String value) {
+            Accesslatency constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+        public static Accesslatency fromValue(AccessLatency value) {
+
+            if (value.equals(AccessLatency.ONLINE)) {
+                return Accesslatency.ONLINE;
+            } else if (value.equals(AccessLatency.NEARLINE)) {
+                return Accesslatency.NEARLINE;
+            } else {
+                throw new IllegalArgumentException();
+            }
+        }
+    }
+
+    public enum Retentionpolicy {
+
+        @SerializedName("nome") NONE("none"),
+        @SerializedName("intermediate") INTERMEDIATE("intermediate"),
+        @SerializedName("replicated") REPLICATED("replicated"),
+        @SerializedName("custodial") CUSTODIAL("custodial"),
+        @SerializedName("replica") REPLICA("replica");
+        private final String value;
+        private final static Map<String, Retentionpolicy> CONSTANTS = new HashMap<String, Retentionpolicy>();
+
+        static {
+            for (Retentionpolicy c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        Retentionpolicy(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        @JsonValue
+        public String value() {
+            return this.value;
+        }
+
+        @JsonCreator
+        public static Retentionpolicy fromValue(String value) {
+            Retentionpolicy constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+        public static Retentionpolicy fromValue(RetentionPolicy value) {
+
+            if (value.equals(RetentionPolicy.CUSTODIAL)) {
+                return Retentionpolicy.CUSTODIAL;
+            } else if (value.equals(RetentionPolicy.REPLICA)) {
+                return Retentionpolicy.REPLICA;
+            } else if (value.equals(RetentionPolicy.OUTPUT)) {
+                return Retentionpolicy.INTERMEDIATE;
+            } else {
+                throw new IllegalArgumentException();
+            }
+        }
+    }
+
+    public enum Servingstate {
+
+        OPEN("open"),
+        CLOSED("closed"),
+        DRAINING("draining");
+        private final String value;
+        private final static Map<String, Servingstate> CONSTANTS = new HashMap<String, Servingstate>();
+
+        static {
+            for (Servingstate c : values()) {
+                CONSTANTS.put(c.value, c);
+            }
+        }
+
+        Servingstate(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+
+        public String value() {
+            return this.value;
+        }
+
+        public static Servingstate fromValue(String value) {
+            Servingstate constant = CONSTANTS.get(value);
+            if (constant == null) {
+                throw new IllegalArgumentException(value);
+            } else {
+                return constant;
+            }
+        }
+
+    }
+
+}

--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -572,6 +572,15 @@
 			 ${frontend.limit.events.disconnect-timeout.maximum},
 			 '${frontend.limit.events.disconnect-timeout.maximum.unit}')}" />
     </bean>
+    <bean class="org.dcache.restful.resources.srr.SrrResource" scope="request">
+        <property name="spaceReservationEnabled" value="${frontend.enable.space-reservation}"/>
+        <property name="groupMapping" value="${frontend.srr.shares}" />
+        <property name="id" value="${info-provider.se-unique-id}" />
+        <property name="name" value="${info-provider.se-name}" />
+        <property name="architecture" value="${info-provider.dcache-architecture}" />
+        <property name="quality" value="${info-provider.dcache-quality-level}" />
+        <property name="doorTag" value="${storage-descriptor.door.tag}" />
+    </bean>
 
     <beans profile="macaroons-true">
         <bean id="macaroon-processor" class="org.dcache.macaroons.MacaroonProcessor">

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -594,6 +594,15 @@ frontend.macaroons.accept-over-unencrypted-channel = ${dcache.macaroons.accept-o
 
 frontend.version.swagger-ui = @version.swagger-ui@
 
+
+# ---- Storage Resource Reporting (SRR)
+#
+# pool group to vo names mapping to report
+# Example:
+#  cms-user:/cms,default:/cms,default:/atlas
+frontend.srr.shares =
+
+
 (obsolete)frontend.dcache-view.endpoints.webapi = Use frontend.static!dcache-view.endpoints.webapi instead
 (obsolete)frontend.dcache-view.endpoints.webdav = Use frontend.static!dcache-view.endpoints.webdav instead
 (obsolete)frontend.dcache-view.org-name = Use frontend.static!dcache-view.org-name instead


### PR DESCRIPTION
Motivation:
The Storage Resource Reporting (SRR) is the successor of info-provider
that produces specific JSON output that describes doors, space
reservations and storage areas (pool groups).

Modification:
Use official json schema[1] to generate beans. Tweak generated beans to
produce expected json and work with dcache mappings. Use info provider's
properties to populate the data.

[1] https://github.com/sjones-hep-ph-liv-ac-uk/json_info_system/blob/master/srr/v4.2/schema/srrschema_4.2.json

Result:
An attempt to make WLCG deployment group happy. Available as:

http://localhost:3880/api/v1/srr

Acked-by:
Target: master, 7.1, 6.2, 6.0, 5.2
Require-book: yes
Require-notes: yes
(cherry picked from commit 343881257ec56804adad2228da3a4ed86021c593)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>