### PR TITLE
pool: http-tpc fix NPE when monitoring network traffic

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -68,7 +68,6 @@ import org.dcache.vehicles.FileAttributes;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static diskCacheV111.util.ThirdPartyTransferFailedCacheException.checkThirdPartyTransferSuccessful;
 import static dmg.util.Exceptions.getMessageWithCauses;
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.dcache.namespace.FileAttribute.CHECKSUM;
 import static org.dcache.util.ByteUnit.GiB;
@@ -409,7 +408,12 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
         }
 
         try {
-            InetAddress addr = requireNonNull(inetConn.getRemoteAddress());
+            InetAddress addr = inetConn.getRemoteAddress();
+            if (addr == null) {
+                _log.debug("HttpInetConnection is not connected.");
+                return Optional.empty();
+            }
+
             int port = inetConn.getRemotePort();
             InetSocketAddress sockAddr = new InetSocketAddress(addr, port);
             return Optional.of(sockAddr);


### PR DESCRIPTION
Motivation:

A recently commited patch added support for monitoring over which TCP
connection an HTTP-TPC data transfer is taking place.  Unfortunately,
this patch contained a race condition between the HTTP client
establishing the TCP connection and the monitoring code querying over
which connection the transfer is taking place.

If the monitoring wins the race then a NullPointerException is logged.

Modification

Update code so it understands that a connection might not (yet) be
connected.

Result:

An unreleased regression is fixed.

Target: master
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/12709/
Acked-by: Lea Morschel