### PR TITLE
chimera-shell: include sym-link information in directory listing

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
@@ -432,7 +432,16 @@ public class Shell extends ShellApplication
                                          dateOf(time),
                                          entry.getName());
 
-                sb.append(s).append('\n');
+                sb.append(s);
+
+                var inode = entry.getInode();
+                if (inode.isLink()) {
+                    String target = new String(inode.readlink(),
+                            StandardCharsets.UTF_8);
+                    sb.append(" -> ").append(target);
+                }
+
+                sb.append('\n');
             }
         }
 


### PR DESCRIPTION
Motivation:

dCache supports symbolic links, but there are few places where
information about symbolic links may be discovered.

Modification:

Update directory listing in the chimera shell to include information
about any symbolic links.  The information is modelled after the
GNU/Linux 'ls -l' output when showing a symbolic link.

Result:

The 'chimera' shell will now also show the target of a symbolic link
when listing the contents of a directory using the 'ls' command.

Target: master
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13176/
Acked-by: Tigran Mkrtchyan