### PR TITLE
gplazma: oidc add support for the 'wlcg.groups' claim

### DIFF
--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
@@ -465,6 +465,7 @@ public class OidcAuthPlugin implements GPlazmaAuthenticationPlugin
                 addNames(userInfo, principals);
                 addEmail(userInfo, principals);
                 addGroups(userInfo, principals);
+                addWlcgGroups(userInfo, principals);
                 addLoAs(userInfo, principals);
                 addEntitlements(userInfo, principals);
                 return principals;
@@ -535,6 +536,46 @@ public class OidcAuthPlugin implements GPlazmaAuthenticationPlugin
             for (JsonNode group : userInfo.get("groups")) {
                 principals.add(new OpenIdGroupPrincipal(group.asText()));
             }
+        }
+    }
+
+    /**
+     * Parse group-membership information, as described in
+     * "WLCG Common JWT Profiles" v1.0.  For details, see:
+     * https://zenodo.org/record/3460258#.YVGMLyXRaV4
+     *
+     * Here is an example:
+     * <pre>
+     * "wlcg.groups": [
+     *     "/dteam/VO-Admin",
+     *     "/dteam",
+     *     "/dteam/itcms"
+     * ],
+     * </pre>
+     * @param userInfo The JSON node describing the user.
+     * @param principals The set of principals into which any group information
+     * is to be added.
+     */
+    private void addWlcgGroups(JsonNode userInfo, Set<Principal> principals)
+    {
+        if (!userInfo.has("wlcg.groups")) {
+            return;
+        }
+
+        JsonNode groups = userInfo.get("wlcg.groups");
+        if (!groups.isArray()) {
+            LOG.debug("Ignoring malformed \"wlcg.groups\": not an array");
+            return;
+        }
+
+        for (JsonNode group : groups) {
+            if (!group.isTextual()) {
+                LOG.debug("Ignoring malformed \"wlcg.groups\" value: {}", group);
+                continue;
+            }
+            var groupName = group.asText();
+            var principal = new OpenIdGroupPrincipal(groupName);
+            principals.add(principal);
         }
     }
 


### PR DESCRIPTION
Motivation:

The "WLCG Common JWT Profiles" (v1.0) describes the 'wlcg.groups' claim
for expressing group-membership.  We are increasingly seeing this being
used as the OIDC equivalent to the group-membership expressed through
the VOMS extension.

Modification:

Add support for `wlcg.groups` claims, which must be an array of strings.
The group names are supplied as `OpenIdGroupPrincipal` objects, in
keeping with the existing support for the `groups` claim.

Result:

During the auth phase of the login process, the group membership
information contained in a 'wlcg.groups' claim from the OP is now
available as OpenIdGroupPrincipal principals.  Subsequent plugins (e.g.,
multimap) may be used to convert these principals to more directly
useful principals.

Target: master
Requires-notes: yes
Requires-book: yes
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13178/
Acked-by: Tigran Mkrtchyan
Acked-by: Albert Rossi