### PR TITLE
webdav: fix ASCII error response

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheSimpleResponseHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheSimpleResponseHandler.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 import static io.milton.http.Response.Status.*;
@@ -96,9 +95,11 @@ public class DcacheSimpleResponseHandler extends AbstractWrappingResponseHandler
     {
         response.setStatus(status);
         response.setContentTypeHeader(MediaType.PLAIN_TEXT_UTF_8.toString());
-        OutputStream out = response.getOutputStream();
+        byte[] messageBytes = (message + "\n").getBytes(StandardCharsets.UTF_8);
+        response.setContentLengthHeader((long)messageBytes.length);
+
         try {
-            out.write((message + "\n").getBytes(StandardCharsets.UTF_8));
+            response.getOutputStream().write(messageBytes);
         } catch (IOException e) {
             LOGGER.warn("Failed to write error response {}: {}", message, e.toString());
         }


### PR DESCRIPTION
Motivation:

Commit 5e7f0ab79a0 introduced the possibility for dCache WebDAV door to
return a non-HTML error response if the client doesn't indicate it
understands HTML (e.g., curl, rclone).

Unfortunately, the response handler failed to set the Content-Length
header, which can lead to truncated HTTP entity (i.e., truncated error
message).

Modification:

Ensure the Content-Length is set correctly.

Result:

Non-HTML error responses from the WebDAV door (for non-webbrowsers) are
no longer truncated.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13184/
Acked-by: Lea Morschel