### PR TITLE
pom: move dcache-view to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.jetty>9.4.43.v20210629</version.jetty>
         <version.xrootd4j>4.2.1</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
-        <version.dcache-view>1.6.3</version.dcache-view>
+        <version.dcache-view>2.0.0</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
dcache-view now at v2.0.0

This has the additional admin pages + icons,
and the new quota information in user info.

Target: master
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13187/
Acked-by: Dmitry
Acked-by: Lea