### PR TITLE
srm-server: fix potential NPE in trs

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/Scheduler.java
@@ -394,13 +394,13 @@ public class Scheduler <T extends Job> implements JobStateChangeAware
                             hasBeenNotified = false;
                         }
                     } catch (SRMInvalidRequestException e) {
-                        LOGGER.error("Sheduler(id={}) detected an SRM error: {}", getId(), e.toString());
+                        LOGGER.error("Scheduler(id={}) detected an SRM error: {}", getId(), e.toString());
                     } catch (RuntimeException e) {
-                        LOGGER.error("Sheduler(id=" + getId() + ") detected a bug", e);
+                        LOGGER.error("Scheduler(id=" + getId() + ") detected a bug", e);
                     }
                 }
             } catch (InterruptedException e) {
-                LOGGER.error("Sheduler(id=" + getId() +
+                LOGGER.error("Scheduler(id=" + getId() +
                         ") terminating update thread, since it caught an InterruptedException",
                         e);
             }

--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/strategy/TapeRecallSchedulingStrategy.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/strategy/TapeRecallSchedulingStrategy.java
@@ -282,12 +282,7 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
             }
 
             if (currTapeWithJobs.getValue().isEmpty()) {
-                // remove tape if there are no jobs targeting it
-                if (!tapesWithJobs.containsKey(currTapeWithJobs.getKey())) {
-                    tapes.remove(currTapeWithJobs.getKey());
-                } else {
-                    tapes.get(currTapeWithJobs.getKey()).resetJobArrivalTimes();
-                }
+                tapes.get(currTapeWithJobs.getKey()).resetJobArrivalTimes();
                 activeTapesWithJobsIterator.remove();
             } else { // update oldest job arrival time
                 tapes.get(currTapeWithJobs.getKey()).setOldestJobArrival(currTapeWithJobs.getValue().element().getCreationTime());

--- a/modules/srm-server/src/main/java/org/dcache/srm/taperecallscheduling/TapeRecallSchedulingRequirementsChecker.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/taperecallscheduling/TapeRecallSchedulingRequirementsChecker.java
@@ -184,7 +184,7 @@ public class TapeRecallSchedulingRequirementsChecker implements CellCommandListe
      * @return whether the tape's oldest jost is expired
      */
     public boolean isOldestTapeJobExpired(SchedulingInfoTape tape) {
-        if (tape.getOldestJobArrival() == NO_VALUE) {
+        if (tape == null || tape.getOldestJobArrival() == NO_VALUE) {
             return false;
         }
         long ageOfOldestJobArrival = System.currentTimeMillis() - tape.getOldestJobArrival();
@@ -198,7 +198,7 @@ public class TapeRecallSchedulingRequirementsChecker implements CellCommandListe
      */
     public boolean isNewestTapeJobOldEnough(SchedulingInfoTape tape) {
         long minWaitingTime = minJobWaitingTime();
-        if (tape.getNewestJobArrival() == NO_VALUE) {
+        if (tape == null || tape.getNewestJobArrival() == NO_VALUE) {
             return false;
         } else if (minWaitingTime == NO_VALUE) {
             return true;
@@ -220,7 +220,7 @@ public class TapeRecallSchedulingRequirementsChecker implements CellCommandListe
      */
     public boolean isTapeRecallVolumeSufficient(SchedulingInfoTape tape, long recallVolume) {
         int percentage = minTapeRecallPercentage();
-        if (!tape.hasTapeInfo()) {
+        if (tape == null || !tape.hasTapeInfo()) {
             return percentage == 0;
         }
 
@@ -240,6 +240,9 @@ public class TapeRecallSchedulingRequirementsChecker implements CellCommandListe
     }
 
     public int compareOldestTapeRequestAge(SchedulingInfoTape first, SchedulingInfoTape second) {
+        if (first == null || second == null) {
+            return 0;
+        }
         long oldestArrival = first.getOldestJobArrival();
         long otherArrival = second.getOldestJobArrival();
         if (oldestArrival == NO_VALUE && otherArrival == NO_VALUE) {


### PR DESCRIPTION
Motivation:

A race condition might lead to the tape recall scheduler trying to operate on a null tape object, leading to an exception.

Modification:
Result:

Prevent trowing a NPE by not deleting tape objects and checking for as well as handling null values appropriately.

Target: master
Target: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13188/
Acked-by: Tigran Mkrtchyan