### PR TITLE
acl: set IDENTIFIER_GROUP flag if WHO is GROUP or OWNER_GROUP

### DIFF
--- a/modules/acl-vehicles/src/main/java/org/dcache/acl/ACE.java
+++ b/modules/acl-vehicles/src/main/java/org/dcache/acl/ACE.java
@@ -60,7 +60,7 @@ public class ACE implements Serializable
      */
     public ACE(AceType type, int flags, int accessMsk, Who who, int whoID) {
         _type = type;
-        _flags = flags;
+        _flags = (who == Who.GROUP || who == Who.OWNER_GROUP) ? flags | AceFlags.IDENTIFIER_GROUP.getValue() : flags;
         _accessMsk = accessMsk;
         _who = who;
         _whoID = whoID;

--- a/modules/acl/src/test/java/org/dcache/acl/parser/ACEParserTest.java
+++ b/modules/acl/src/test/java/org/dcache/acl/parser/ACEParserTest.java
@@ -1,5 +1,7 @@
 package org.dcache.acl.parser;
 
+import org.dcache.acl.enums.AceFlags;
+import org.dcache.acl.enums.AceType;
 import org.junit.Test;
 
 import org.dcache.acl.ACE;
@@ -120,6 +122,12 @@ public class ACEParserTest {
     @Test(expected = IllegalArgumentException.class)
     public void testWrongSpecialPrincipal() {
         parseLinuxAce("D:g:SOMEONW@:w");
+    }
+
+    @Test
+    public void testImplicitGroupACE() {
+        var ace = new ACE(ACCESS_ALLOWED_ACE_TYPE, 0, AccessMask.parseInt("rwx"), Who.GROUP, 123);
+        assertTrue("Identifier group is not set", IDENTIFIER_GROUP.matches(ace.getFlags()));
     }
 
     public static int toAccessMask(AccessMask...masks) {


### PR DESCRIPTION
Motivation:
The dCache (chimera) t_acl table have two possibilities to specify the
principal as a group identifier - through `who` field, with a defined
value 1 (one), or as a bit in ACE corresponding flag. The flag is used
NFSv4 server, as required by spec. Nevertheless, when dCache admin
command (or chimera-cli) sets group ACE, the flag is not set, thus
such ACEs apply to users principals instead of groups.

Modification:
Update ACE class constructor to enforce IDENTIFIER_GROUP flag if WHO is GROUP or OWNER_GROUP.

Result:
The group ACEs apply to desired group instead of to a users with the
same numeric id.

Ticket: #10191
Acked-by:
Target: master, 7.2, 7.1, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 04d8ae96ebdeed85add4c72d18109f711c304b70)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>