### PR TITLE
webdav: return 507 if insufficient space on GET request

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
@@ -45,7 +45,6 @@ import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileExistsCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
-import diskCacheV111.util.MissingResourceCacheException;
 import diskCacheV111.util.NotFileCacheException;
 import diskCacheV111.util.PermissionDeniedCacheException;
 
@@ -72,14 +71,6 @@ public class DcacheDirectoryResource
     private static final ImmutableSet<QName> QUOTA_PROPERTIES = ImmutableSet.of(QUOTA_AVAILABLE, QUOTA_USED);
 
     private static final PropertyMetaData READONLY_LONG = new PropertyMetaData(READ_ONLY, Long.class);
-
-    // FIXME update poolmanager to return the actual CacheException.
-    private static final ImmutableSet<String> FULL_POOL_MESSAGE = ImmutableSet.<String>builder()
-            .add("All pools full")
-            .add("All pools are full")
-            .add("Cost limit exceeded")
-            .add("Fallback cost exceeded")
-            .build();
 
     public DcacheDirectoryResource(DcacheResourceFactory factory,
                                    FsPath path, FileAttributes attributes)
@@ -150,20 +141,12 @@ public class DcacheDirectoryResource
             //     RFC 2616.
             //
             throw new WebDavException("Problem with transferred data: " + e.getMessage(), e, this);
-        } catch (PermissionDeniedCacheException e) {
-            throw WebDavExceptions.permissionDenied(this);
         } catch (FileExistsCacheException e) {
             throw new ConflictException(this);
         } catch (NotFileCacheException e) { // Attempt to replace directory with file
             throw new MethodNotAllowedException("Resource exists as collection", e, null);
-        } catch (MissingResourceCacheException e) {
-            if (FULL_POOL_MESSAGE.contains(e.getMessage())) {
-                throw new InsufficientStorageException(e.getMessage(), e, this);
-            } else {
-                throw new WebDavException(e.getMessage(), e, this);
-            }
         } catch (CacheException e) {
-            throw new WebDavException(e.getMessage(), e, this);
+            throw WebDavException.of(e, this);
         } catch (InterruptedException e) {
             throw new WebDavException("Transfer was interrupted", e, this);
         } catch (URISyntaxException e) {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheFileResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheFileResource.java
@@ -130,12 +130,10 @@ public class DcacheFileResource
             // an internal error exception, although this shouldn't matter as
             // the client has already disconnected.
             throw new WebDavException("Failed to send entity: client closed connection", e, this);
-        } catch (PermissionDeniedCacheException e) {
-            throw WebDavExceptions.permissionDenied(this);
         } catch (FileNotFoundCacheException | NotInTrashCacheException e) {
             throw new ForbiddenException(e.getMessage(), e, this);
         } catch (CacheException e) {
-            throw new WebDavException(e.getMessage(), e, this);
+            throw WebDavException.of(e, this);
         } catch (InterruptedException e) {
             throw new WebDavException("Transfer was interrupted", e, this);
         } catch (URISyntaxException e) {
@@ -183,9 +181,9 @@ public class DcacheFileResource
                         dispositionFor(request.getParams().get(PARAM_ACTION)));
             }
             return null;
-        } catch (PermissionDeniedCacheException e) {
-            throw WebDavExceptions.permissionDenied(e.getMessage(), e, this);
-        } catch (CacheException | InterruptedException e) {
+        } catch (CacheException e) {
+            throw WebDavException.of(e, this);
+        } catch (InterruptedException e) {
             throw new WebDavException(e.getMessage(), e, this);
         } catch (URISyntaxException e) {
             throw new WebDavException("Invalid request URI: " + e.getMessage(), e, this);

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/WebDavException.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/WebDavException.java
@@ -1,6 +1,10 @@
 package org.dcache.webdav;
 
+import com.google.common.collect.ImmutableSet;
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.PermissionDeniedCacheException;
 import io.milton.resource.Resource;
+import javax.annotation.Nonnull;
 
 /**
  * Base class for WebDAV exceptions.
@@ -16,6 +20,15 @@ import io.milton.resource.Resource;
 public class WebDavException extends RuntimeException
 {
     private static final long serialVersionUID = -1251402018582832989L;
+
+    // FIXME update poolmanager to return the actual CacheException.
+    private static final ImmutableSet<String> FULL_POOL_MESSAGE = ImmutableSet.<String>builder()
+            .add("All pools full")
+            .add("All pools are full")
+            .add("Cost limit exceeded")
+            .add("Fallback cost exceeded")
+            .build();
+
     private final Resource _resource;
 
     public WebDavException(Resource resource)
@@ -38,5 +51,33 @@ public class WebDavException extends RuntimeException
     public Resource getResource()
     {
         return _resource;
+    }
+
+    /**
+     * Provide a common translation from (dCache) CacheException to the
+     * corresponding WebDAV exceptions that are common between GET and PUT
+     * requests.
+     * @param e The CacheException received.
+     * @param resource The resource targeted by the HTTP request.
+     * @return the corresponding WebDAV exception.
+     */
+    public static WebDavException of(@Nonnull CacheException e, Resource resource)
+    {
+        if (e instanceof PermissionDeniedCacheException) {
+            return WebDavExceptions.permissionDenied(resource);
+        }
+
+        switch (e.getRc()) {
+        case 192: // Pool-to-pool required, but destination cost exceeded.
+        case 194: // Pool-to-pool required, but source cost exceeded.
+            return new InsufficientStorageException("Unable to ready file for access",
+                    e, resource);
+        }
+
+        if (FULL_POOL_MESSAGE.contains(e.getMessage())) {
+            return new InsufficientStorageException(e.getMessage(), e, resource);
+        }
+
+        return new WebDavException(e.getMessage(), e, resource);
     }
 }


### PR DESCRIPTION
Motivation:

dCache treats PoolManager reporting insufficient storage capacity on a
PUT request by returning a 507 (Insufficient Storage) HTTP status code.

PoolManager may also fail because of insufficient storage capacity on
GET requests if pool-to-pool or staging is required.  If this happens
then dCache logs the problem (in webdav) and returns the more generic
500 (Internal Server Error) status code.

Returning 507 on a GET request is allowed (and used, in practice) and
provides more information.  In addition, the logging by the door should
be consistent between GET and PUT requests.

Modification:

Factor-out a common method that describes how a CacheException is
converted to the corresponding WebDavException.

Apply this method to both GET and PUT requests.

Result:

dCache now responds with a 507 (Insufficient Storage) on GET request if
dCache must do a pool-to-pool internal-transfer or stage the file but no
pools have sufficient free capacity to support this.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Closes: #6067
Patch: https://rb.dcache.org/r/13186/
Acked-by: Tigran Mkrtchyan