### PR TITLE
nfs-vfs: fix access check in ChimeraVfs (fixes 19fa7cf2425)

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
@@ -496,7 +496,7 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
     @VisibleForTesting
     static boolean shouldRejectUpdates(FsInode fsInode, FileSystemProvider fs)
           throws ChimeraFsException {
-        if (!isRoot() && fsInode.type() == FsInodeType.SURI) {
+        if (fsInode.type() == FsInodeType.SURI && !isRoot()) {
             return !fs.getInodeLocations(fsInode, StorageGenericLocation.TAPE).isEmpty();
         }
         return false;


### PR DESCRIPTION
Motivation:
the change 19fa7cf2425 introduced a check `isRoot` for all files,
however, the original code was performing such check only for special
files.

Modification:
Ensure that `isRoot` check performed only if inode type is SURI.

Result:
fixes unexpected exception.

Acked-by: Lea Morschel
Acked-by: Paul Millar
Acked-by: Dmitry Litvintsev
Target: master, 7.2, 7.1, 7.0
Require-book: no
Require-notes: yes
(cherry picked from commit bfcf3a36f1a3cc109f5714ce26b64b5926b908c2)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>