### PR TITLE
pool: improve error message on badly configured hsm instance

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
@@ -536,7 +536,11 @@ public class HsmSet
         /* Apply configuration changes
          */
         for (HsmInfo hsm : _newConfig.values()) {
-            hsm.refresh();
+            try {
+                hsm.refresh();
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Error configuring hsm \"" + hsm.getInstance() + "\": " + e.getMessage());
+            }
         }
 
         _hsm.putAll(_newConfig);


### PR DESCRIPTION
Motivation:

If an hsm is badly configured, the error message says what is wrong but
not that the problem is with an HSM configuration, nor does it say with
which hsm instance the problem lies.

Modification:

Update error message to make it clearer that the problem is with an HSM
configuration and with which HSM instance.

Result:

Slightly more informative error messages if a setup file badly
configures an HSM instance.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13199/
Acked-by: Lea Morschel