### PR TITLE
ftp: ensure cell is killed even if shutdown triggers a bug

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
@@ -257,7 +257,11 @@ public class NettyLineBasedDoor
             commandExecutor.shutdownNow();
             commandExecutor.awaitTerminationUninterruptibly();
             if (interpreter != null) {
-                interpreter.shutdown();
+                try {
+                    interpreter.shutdown();
+                } catch (RuntimeException e) {
+                    LOGGER.warn("Bug detected please report to <support@dcache.org>: ", e);
+                }
             }
         }
         kill();


### PR DESCRIPTION
Motivation:

A recent report (see #6106) indicates that if the ftp door's shutdown
sequence triggers a bug then the cell is not killed.  Although we should
fix the bug, the door should also be more robust in shutting down.

Modification:

Catch (and report) any shutdown bugs, but continue on to kill the cell.

Result:

The ftp door is more robust against bugs triggered when a client
disconnects.  The problems so far have been triggered when the client
disconnects during a transfer that is proxied.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13196/
Acked-by: Lea Morschel