### PR TITLE
billing: fix NPE in billing from NFSv3 message

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/DoorRequestInfoMessage.java
@@ -75,13 +75,25 @@ public class DoorRequestInfoMessage extends PnfsFileInfoMessage {
     }
 
     public int getGid() {
-        long[] gids = Subjects.getGids(getSubject());
-        return (gids.length > 0) ? (int) gids[0] : -1;
+        Subject subject = getSubject();
+        if (subject != null) {
+            long[] gids = Subjects.getGids(subject);
+            if (gids.length > 0) {
+                return (int) gids[0];
+            }
+        }
+        return -1;
     }
 
     public int getUid() {
-        long[] uids = Subjects.getUids(getSubject());
-        return (uids.length > 0) ? (int) uids[0] : -1;
+        Subject subject = getSubject();
+        if (subject != null) {
+            long[] uids = Subjects.getUids(getSubject());
+            if (uids.length > 0) {
+                return (int) uids[0];
+            }
+        }
+        return -1;
     }
 
     @Override

--- a/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/DoorRequestInfoMessageTest.java
+++ b/modules/dcache-vehicles/src/test/java/diskCacheV111/vehicles/DoorRequestInfoMessageTest.java
@@ -1,0 +1,88 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package diskCacheV111.vehicles;
+
+import dmg.cells.nucleus.CellAddressCore;
+import org.dcache.auth.Subjects;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class DoorRequestInfoMessageTest {
+    @Test
+    public void shouldReturnGidOfSubject() {
+        var message = new DoorRequestInfoMessage(new CellAddressCore("myDoor@myDomain"));
+        message.setSubject(Subjects.of().username("paul").uid(100).gid(200).build());
+
+        int gid = message.getGid();
+
+        assertThat(gid, is(equalTo(200)));
+    }
+
+    @Test
+    public void shouldReturnUidOfSubject() {
+        var message = new DoorRequestInfoMessage(new CellAddressCore("myDoor@myDomain"));
+        message.setSubject(Subjects.of().username("paul").uid(100).gid(200).build());
+
+        int uid = message.getUid();
+
+        assertThat(uid, is(equalTo(100)));
+    }
+
+    @Test
+    public void shouldReturnDnAsOwnerWithDnInSubject() {
+        var message = new DoorRequestInfoMessage(new CellAddressCore("myDoor@myDomain"));
+        message.setSubject(Subjects.of().username("paul").uid(100).gid(200)
+                .dn("/C=DE/O=GermanGrid/OU=DESY/CN=Alexander Paul Millar").build());
+
+        String owner = message.getOwner();
+
+        assertThat(owner, is(equalTo("/C=DE/O=GermanGrid/OU=DESY/CN=Alexander Paul Millar")));
+    }
+
+    @Test
+    public void shouldReturnUsernameAsOwnerWithoutDnInSubject() {
+        var message = new DoorRequestInfoMessage(new CellAddressCore("myDoor@myDomain"));
+        message.setSubject(Subjects.of().username("paul").uid(100).gid(200).build());
+
+        String owner = message.getOwner();
+
+        assertThat(owner, is(equalTo("paul")));
+    }
+
+    @Test
+    public void shouldReturnDefaultValueForGidOfMissingSubject() {
+        var message = new DoorRequestInfoMessage(new CellAddressCore("myDoor@myDomain"));
+
+        int gid = message.getGid();
+
+        assertThat(gid, is(equalTo(-1)));
+    }
+
+    @Test
+    public void shouldReturnDefaultValueForUidOfMissingSubject() {
+        var message = new DoorRequestInfoMessage(new CellAddressCore("myDoor@myDomain"));
+
+        int uid = message.getUid();
+
+        assertThat(uid, is(equalTo(-1)));
+    }
+}


### PR DESCRIPTION
Motivation:

The NFSv3 door sometimes sends info messages to billing that does not
contain a subject.  This is (seemingly) valid, but triggers an
NullPointerException in billing like:

    Thread Thread[billing-0,5,billing-threads] died <NFS-dcache-node01>
    java.lang.NullPointerException: null
        at org.dcache.auth.Subjects.getUids(Subjects.java:129)
        at diskCacheV111.vehicles.DoorRequestInfoMessage.getUid(DoorRequestInfoMessage.java:83)
        at org.dcache.services.billing.text.StringTemplateInfoMessageVisitor.visit(StringTemplateInfoMessageVisitor.java:78)
        at diskCacheV111.vehicles.DoorRequestInfoMessage.accept(DoorRequestInfoMessage.java:89)
        at org.dcache.services.billing.cells.BillingCell.getFormattedMessage(BillingCell.java:202)
        at org.dcache.services.billing.cells.BillingCell.messageArrived(BillingCell.java:174)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.dcache.cells.CellMessageDispatcher$ShortReceiver.deliver(CellMessageDispatcher.java:272)
        at org.dcache.cells.CellMessageDispatcher.call(CellMessageDispatcher.java:188)
        at org.dcache.cells.AbstractCell.messageArrived(AbstractCell.java:302)
        at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:848)
        at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1274)
        at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:229)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$2(CellNucleus.java:727)
        at java.base/java.lang.Thread.run(Thread.java:829)

Modification:

Update the visitor to correctly handle the missing Subject case.

Result:

Billing will no longer throw a NullPointerException with certain
information from an NFS door serving an NFSv3 client.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Closes: #6115
Acked-by: Lea Morschel
Patch: https://rb.dcache.org/r/13193/