### PR TITLE
gplazma: switch from `user:` to `username:`

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/Subjects.java
+++ b/modules/common/src/main/java/org/dcache/auth/Subjects.java
@@ -22,8 +22,12 @@ import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosPrincipal;
 import org.dcache.util.PrincipalSetMaker;
 import org.globus.gsi.gssapi.jaas.GlobusPrincipal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Subjects {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Subjects.class);
 
     public static final String UNKNOWN = "<unknown>";
 
@@ -480,6 +484,9 @@ public class Subjects {
                     principal = new UidPrincipal(value);
                     break;
                 case "user":
+                    LOGGER.warn("Please use \"username:{}\" instead of \"{}\"", value, arg);
+                    // FALL THROUGH
+                case "username":
                     principal = new UserNamePrincipal(value);
                     break;
                 default:

--- a/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
+++ b/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
@@ -225,7 +225,7 @@ public class Gplazma2LoginStrategy
                 "the result was obtained.\n\n" +
                 "Examples:\n" +
                 "  explain login \"dn:/C=DE/O=GermanGrid/OU=DESY/CN=testUser\" fqan:/test\n" +
-                "  explain login user:testuser\n";
+                "  explain login username:testuser\n";
     public static final String hh_explain_login = "<principal> [<principal> ...] # explain the result of login";
 
     public String ac_explain_login_$_1_99(Args args) {

--- a/modules/dcache/src/main/java/org/dcache/services/login/LoginCLI.java
+++ b/modules/dcache/src/main/java/org/dcache/services/login/LoginCLI.java
@@ -41,7 +41,7 @@ public class LoginCLI
           + "    fqan      an FQAN, the first is taken as the primary FQAN\n"
           + "    kerberos  a kerberos principal (e.g. paul@EXAMPLE.ORG)\n"
           + "    name      the desired username when authentication without a password\n"
-          + "    user      the authenticated username\n";
+          + "    username  the authenticated username\n";
     public static final String hh_test_login = "<principal> [<principal> ...] # show result of login";
 
     public String ac_test_login_$_1_99(Args args) {

--- a/modules/gplazma2-banfile/src/test/java/org/dcache/gplazma/plugins/BanFilePluginTest.java
+++ b/modules/gplazma2-banfile/src/test/java/org/dcache/gplazma/plugins/BanFilePluginTest.java
@@ -61,6 +61,18 @@ public class BanFilePluginTest {
     }
 
     @Test(expected = AuthenticationException.class)
+    public void shouldFailForBannedUserWithUser() throws IOException, AuthenticationException {
+        givenConfig("ban user:bert");
+        plugin.account(Set.of(new UserNamePrincipal("bert")));
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void shouldFailForBannedUserWithUsername() throws IOException, AuthenticationException {
+        givenConfig("ban username:bert");
+        plugin.account(Set.of(new UserNamePrincipal("bert")));
+    }
+
+    @Test(expected = AuthenticationException.class)
     public void shouldFailIfAnyPrincipalIsBanned() throws IOException, AuthenticationException {
         givenConfig("ban org.dcache.auth.UserNamePrincipal:bert");
         plugin.account(Set.of(new LoginNamePrincipal("ernie"), new UserNamePrincipal("bert")));

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -506,7 +506,7 @@ gplazma.oidc.access-token-cache.expire.unit = SECONDS
 #
 #   Here is a complete example:
 #
-#       gplazma.scitoken.issuer!demo = https://demo.scitokens.org /data/demo user:demo
+#       gplazma.scitoken.issuer!demo = https://demo.scitokens.org /data/demo username:demo
 #
 #   In this example, the id 'demo' is associated with the SciToken
 #   issuer 'https://demo.scitokens.org'.  Users presenting a valid


### PR DESCRIPTION
Motivation:

The gPlazma modules are somewhat inconsistent in how to represent the
org.dcache.auth.UserNamePrincipal.  In the banfile, scitoken plugins and
the "explain login" and "test login" admin commands it's "user:paul".
In the multimap and mutator plugins it is `username:paul`.

This inconsistency may cause confusion.

Modification:

Adopt `username:` as the common prefix, as `user:` is somewhat ambiguous
as to what about the user it is referring.

Update banfile, scitoken and the two admin commands to accept either
`user:paul` or `username:paul`.  Update unit tests added to verify this
behaviour.

The a few places where the prefix `user:` is documented are also
updated.

A warning is logged if `user:` is used, encouraging admins to update
their configuration.

A future patch (targeting just master) can then remove support for the
`user:` prefix.

Result:

The banfile and scitoken plugins, and the two admin commands `test
login` and `explain login` are updated to accept the `username:` prefix
(e.g., `username:paul`).  The prefix `user:` continues to work but is
now deprecated.

Requires-notes: yes
Requires-book: no
Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Closes: #6105
Patch: https://rb.dcache.org/r/13190/
Acked-by: Tigran Mkrtchyan