### PR TITLE
Auto create table for TransferManager persistency

### DIFF
--- a/modules/dcache/src/main/resources/META-INF/persistence.xml
+++ b/modules/dcache/src/main/resources/META-INF/persistence.xml
@@ -83,7 +83,7 @@
             <property name="datanucleus.validateConstraints" value="false"/>
             <property name="datanucleus.autoCreateColumns" value="true"/>
             <property name="datanucleus.connectionPoolingType" value="None"/>
+	    <property name="datanucleus.schema.autoCreateTables" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>
-


### PR DESCRIPTION
Motivation:
-----------

For some reason (new datanucleus library?) table auto
create is required to be specifically set to true now.

Modification:
------------

Set "datanucleus.shema.autoCreateTables" to true

Result:
-------

Observed tables created, TPC transfer complete without producing
stack traces, errors or exessive stages

Patch: https://rb.dcache.org/r/13210/
Acked-by: Al Rossi

Target: master
Request: 7.1
Request: 7.2

Require-book: no
Require-notes: yes