### PR TITLE
Handle IPv6 address when running HTTP(s) TPC with gridsite delegation

### DIFF
--- a/modules/dcache-srm/src/main/java/org/dcache/gridsite/DelegationHandler.java
+++ b/modules/dcache-srm/src/main/java/org/dcache/gridsite/DelegationHandler.java
@@ -84,7 +84,7 @@ public class DelegationHandler implements Delegation {
                   () -> new DelegationException("User supplied no certificate."));
             subject.getPublicCredentials().add(cf.generateCertPath(asList(chain)));
             subject.getPrincipals()
-                  .add(new Origin(InetAddresses.forString(Axis.getRemoteAddress())));
+                  .add(new Origin(InetAddresses.forUriString(Axis.getRemoteAddress())));
             return loginStrategy.login(subject).getSubject();
         } catch (CertificateException e) {
             throw new DelegationException("Failed to process certificate chain.");


### PR DESCRIPTION
Motivation:
-----------

Running TPC HTTP(s) transfers with gridsite delegation against
hosts on dual stack noticed this exception:
java.lang.IllegalArgumentException: '[xxxx:xx:x:xx:xxx:xxx:fe03:7377]'
is not an IP string literal. This is due to upgrade to newer
jetty library

Modification:
------------

Change InetAddresses.forString -> InetAddresses.forUriString

Result:
-------

No errors seen when doin HTTP(s) TPC with gridsite delegation

Patch: https://rb.dcache.org/r/13208/
Acked-by: Al Rossi, Paul Millar

Request: 7.1
Request: 7.2