### PR TITLE
util/frontend: change transfer rate to double

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -606,19 +606,19 @@ public class TransferObserverV1
         page.endRow();
     }
 
-    private Long getTransferRate(TransferInfo info) {
+    private Double getTransferRate(TransferInfo info) {
         Long bytes = info.getBytesTransferred();
         if (bytes == null) {
-            return 0L;
+            return 0.0;
         }
 
         Long time = info.getTransferTime();
         if (time == null) {
-            return 0L;
+            return 0.0;
         }
 
-        long secs = time / 1000;
-        return secs > 0.0 ? BYTES.toKiB(bytes) / secs : 0L;
+        double secs = time / 1000.0;
+        return secs > 0.0 ? BYTES.toKiB((double) bytes) / secs : 0.0;
     }
 
     private String createHtmlTable(List<TransferBean> transfers) {

--- a/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/TransferInfo.java
@@ -230,17 +230,17 @@ public class TransferInfo implements Comparable<TransferInfo>, InvalidatableItem
         return subject;
     }
 
-    public Long getTransferRate() {
+    public Double getTransferRate() {
         if (bytesTransferred == null) {
-            return 0L;
+            return 0.0;
         }
 
         if (transferTime == null) {
-            return 0L;
+            return 0.0;
         }
 
-        long secs = transferTime / 1000;
-        return secs > 0.0 ? BYTES.toMiB(bytesTransferred) / secs : 0L;
+        double secs = transferTime / 1000.0;
+        return secs > 0.0 ? BYTES.toMiB((double) bytesTransferred) / secs : 0.0;
     }
 
     public Long getTransferTime() {


### PR DESCRIPTION
Motivation:

Long division of bytes transferred by seconds
yields zero for slow transfers.

See:

https://rt.dcache.org/Ticket/Display.html?id=10209

Modification:

Change to floating point division.

Result:

Clients are happier.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.0
RT: #10209
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13215/
Acked-by: Lea