### PR TITLE
pool: removing hsm with `reload` command kills pool

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
@@ -524,10 +524,15 @@ public class HsmSet
 
         /* Remove the stores that are not in the new configuration.
          */
-        Iterator<HsmInfo> iterator =
-              Maps.filterKeys(_hsm, not(in(_newConfig.keySet()))).values().iterator();
+        Iterator<Map.Entry<String,HsmInfo>> iterator = _hsm.entrySet().iterator();
         while (iterator.hasNext()) {
-            HsmInfo removed = iterator.next();
+            Map.Entry<String,HsmInfo> entry = iterator.next();
+
+            if (_newConfig.containsKey(entry.getKey())) {
+                continue;
+            }
+
+            HsmInfo removed = entry.getValue();
             removed.shutdown();
             _descriptions.remove(removed.getNearlineStorage());
             iterator.remove();


### PR DESCRIPTION
Motivation:

When an HSM is removed from the pool's setup file and the `reload`
command is used an error is reported and the configuration is not
modified.  The following stacktrace is logged:

    dmg.util.CommandPanicException: (1) Possible bug detected during setup execution and service must be restarted: java.lang.UnsupportedOperationException
            at org.dcache.cells.UniversalSpringCell.executeSetup(UniversalSpringCell.java:365)
            at org.dcache.cells.UniversalSpringCell$LocalSetupManager.load(UniversalSpringCell.java:1228)
            at org.dcache.cells.UniversalSpringCell$SetupCommandListener$ReloadCommand.call(UniversalSpringCell.java:561)
            at org.dcache.cells.UniversalSpringCell$SetupCommandListener$ReloadCommand.call(UniversalSpringCell.java:544)
            at org.dcache.util.cli.AnnotatedCommandExecutor.execute(AnnotatedCommandExecutor.java:134)
            at dmg.cells.nucleus.CellAdapter.executeCommand(CellAdapter.java:209)
            at org.dcache.cells.UniversalSpringCell.executeCommand(UniversalSpringCell.java:187)
            at dmg.cells.nucleus.CellAdapter$1.doExecute(CellAdapter.java:90)
            at org.dcache.util.cli.CommandInterpreter.command(CommandInterpreter.java:120)
            at dmg.cells.nucleus.CellAdapter$1.command(CellAdapter.java:106)
            at dmg.cells.nucleus.CellAdapter.command(CellAdapter.java:195)
            at dmg.cells.nucleus.CellAdapter.executeLocalCommand(CellAdapter.java:873)
            at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:812)
            at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1274)
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:229)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$2(CellNucleus.java:727)
            at java.base/java.lang.Thread.run(Thread.java:829)
    Caused by: java.lang.UnsupportedOperationException: null
            at com.google.common.collect.UnmodifiableIterator.remove(UnmodifiableIterator.java:46)
            at com.google.common.collect.TransformedIterator.remove(TransformedIterator.java:52)
            at org.dcache.pool.nearline.HsmSet.afterSetup(HsmSet.java:539)
            at java.base/java.lang.Iterable.forEach(Iterable.java:75)
            at org.dcache.cells.UniversalSpringCell.executeSetup(UniversalSpringCell.java:360)
            ... 18 common frames omitted

This does, indeed, kill the pool.

The problem was introduced with commit 3c0c5cd31f (committed in 2014).
The JavaDoc for `Maps.filterKeys` says that the value view's iterator
does not support the `remove` method.

Modification:

Replace the filter apprach with a simple for-each iterator, with an
if-statement adopting the role of the filter.

Result:

A bug is fixed where removing a `create hsm` statement in a pool's setup
file and running the `reload` command kills the pool.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13219/
Acked-by: Albert Rossi
Acked-by: Lea Morschel