### PR TITLE
dcache-xroot: upgrade xrootd4j to 4.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.43.v20210629</version.jetty>
-        <version.xrootd4j>4.2.1</version.xrootd4j>
+        <version.xrootd4j>4.2.2</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.0</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>


### PR DESCRIPTION
xrootd4j ad0dda763bbe2bbd4795e45700a76b244b0999b6
https://rb.dcache.org/r/13201/

fixed a regression introduced into the unix protocol plugin

in tags 4.2.2, 4.1.3

Stable branches below 7.1 are unaffected.

Target: master
Request: 7.2 (4.2.2)
Request: 7.1 (4.1.3)
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13218/
Acked-by: Lea