### PR TITLE
ftp: show file sizes for LIST output in bytes

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -4618,7 +4618,7 @@ public abstract class AbstractFtpDoorV1
               .space().right("ncount")
               .space().left("owner")
               .space().left("group")
-              .space().bytes("size", ByteUnit.Type.DECIMAL)
+              .space().bytes("size", ByteUnit.BYTES)
               .space().date("time", DateStyle.LS)
               .space().left("name");
 


### PR DESCRIPTION
Motivation:

Some clients continue to parse the output of LIST to learn information
about dCache namespace.  Those clients expect the file size to be in
bytes.

Modification:

Update LIST output to show value in bytes.

Result:

Better compatibility with legacy clients.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13228/
Acked-by: Dmitry Litvintsev