### PR TITLE
ftp: try harder to ensure any timer tasks are cancelled

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/AbstractFtpDoorV1.java
@@ -267,6 +267,8 @@ import org.dcache.vehicles.PnfsListDirectoryMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.util.Collections.synchronizedList;
+
 @Inherited
 @Retention(RUNTIME)
 @Target(METHOD)
@@ -372,6 +374,7 @@ public abstract class AbstractFtpDoorV1
     private EnumSet<WorkAround> _activeWorkarounds = EnumSet.noneOf(WorkAround.class);
     private String _clientInfo;
     private boolean _logAbortedTransfers;
+    private final List<TimerTask> _activeTimerTasks = synchronizedList(new ArrayList<>());
 
     private enum WorkAround {
         /* If globus-url-copy is organising a third-party copy then it will
@@ -1253,6 +1256,7 @@ public abstract class AbstractFtpDoorV1
                 _perfMarkerTask = new PerfMarkerTask(_request, getPool().getAddress(),
                       getMoverId(), _performanceMarkerPeriod / 2);
                 TIMER.schedule(_perfMarkerTask, _performanceMarkerPeriod, _performanceMarkerPeriod);
+                _activeTimerTasks.add(_perfMarkerTask);
             }
         }
 
@@ -1747,6 +1751,14 @@ public abstract class AbstractFtpDoorV1
         } finally {
             _clientConnectionHandler.close();
             _sessionAllPassive = false; // REVISIT see RFC 2428 Section 4.
+
+            // This should not be necessary; however, we have had reports of bugs that leave
+            // a TimerTask still active (e.g., https://github.com/dCache/dcache/issues/6064).
+            if (!_activeTimerTasks.isEmpty()) {
+                List<TimerTask> toBeCancelled = new ArrayList<>(_activeTimerTasks);
+                LOGGER.warn("TimerTasks still active on shutdown: {}", toBeCancelled);
+                toBeCancelled.forEach(TimerTask::cancel);
+            }
 
             if (ACCESS_LOGGER.isInfoEnabled()) {
                 NetLoggerBuilder log = new NetLoggerBuilder(INFO,
@@ -2894,9 +2906,17 @@ public abstract class AbstractFtpDoorV1
                             public void run() {
                                 reply(cct.getReply());
                             }
+
+                            @Override
+                            public boolean cancel() {
+                                boolean result = super.cancel();
+                                _activeTimerTasks.remove(this);
+                                return result;
+                            }
                         };
                         long period = TimeUnit.SECONDS.toMillis(_checksumProgressPeriod);
                         TIMER.schedule(sendProgress, period, period);
+                        _activeTimerTasks.add(sendProgress);
                     }
                     checksum = cct.calculateChecksum();
                 } finally {
@@ -4131,6 +4151,13 @@ public abstract class AbstractFtpDoorV1
         public synchronized void stop() {
             cancel();
             _stopped = true;
+        }
+
+        @Override
+        public boolean cancel() {
+            boolean result = super.cancel();
+            _activeTimerTasks.remove(this);
+            return result;
         }
 
         /**


### PR DESCRIPTION
Motivation

A recent bug-report (see #6064) indicated that a timer task was left
active after the FTP session had terminated.

Although the trigger for that bug is currently unknown, the report
highlights a weakness of the current FTP door; specifically, that the
termination of an ongoing upload's progress markers depends on correct
behaviour within the transfer itself.

Modification:

We want to avoid the overhead of creating threads therefore the Timer
instance is left global (i.e., shared across all FTP sessions).
Instead, some additional bookkeeping is added, with an additional check
on shutdown.

Result:

The FTP door should be more robust against a (currently unknown) bug
that results in the ftp session attempting to send progress queries to
the pool after that is no longer possible.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13194/
Acked-by: Marina Sahakyan