### PR TITLE
srmclient: add Java-11 dependency

### DIFF
--- a/modules/srm-client/src/main/rpm/dcache-srmclient.spec
+++ b/modules/srm-client/src/main/rpm/dcache-srmclient.spec
@@ -7,6 +7,8 @@ BuildArch: noarch
 Prefix: /usr
 AutoReqProv: no
 
+Requires: java-11
+
 License: Free
 Group: Applications/System
 


### PR DESCRIPTION
Motivation:

RPM-based distributions have now agreed which capability represents the
ability to run Java bytecode of a specific version.  The dCache RPM was
updated to describe its dependency using this standard approach;
however, the srm-client was (mistakenly) ignored.

Modification:

Add a Java dependency, following what is already done with the dCache
RPM.

Results:

The RPM packaging system and related software (e.g,. yum) now
understands that the srm-client package requires java.

Target: master
Request: 7.2
Requires-notes: yes
Requires-book: no
Ticket: https://ggus.eu/?mode=ticket_info&ticket_id=153984
Ticket: https://rt.dcache.org/Ticket/Display.html?id=10193
Patch: https://rb.dcache.org/r/13200/
Acked-by: Tigran Mkrtchyan