### PR TITLE
bootstrap: don't hide bugs in 'create' command

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
@@ -1374,8 +1374,9 @@ public class CellShell extends CommandInterpreter
                 Throwables.throwIfUnchecked(e.getCause());
                 throw new RuntimeException(e.getCause());
             } catch (ExecutionException e) {
-                Throwables.throwIfInstanceOf(e.getCause(), CommandException.class);
-                throw new CommandThrowableException(e.getCause().getMessage(), e.getCause());
+                Throwable cause = e.getCause();
+                Throwables.propagateIfPossible(cause, CommandException.class);
+                throw new CommandThrowableException(cause.getMessage(), cause);
             }
         }
     }


### PR DESCRIPTION
Motivation:

The 'create' command starts a new cell, which may involve a non-trivial
amount of logic to bring up the cell.  Currently, if this triggers a bug
then that RuntimeException is wrapped in a CommandThrowableException,
which does not indicate a bug.

Modification:

Allow a RuntimeException to propagate.  The command execution
environment will take care to write this RuntimeException in a
CommandPanicException, which indicates a bug.

Result:

Bugs in pool startup code are now logged with a corresponding
stack-trace.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13223/
Acked-by: Marina Sahakyan