### PR TITLE
bootstrap: fix two problems with how bugs are reported on startup

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
+++ b/modules/cells/src/main/java/dmg/cells/nucleus/CellShell.java
@@ -2042,13 +2042,14 @@ public class CellShell extends CommandInterpreter
                 } else {
                     Throwable error = (Throwable) answer;
 
-                    if (error instanceof CommandPanicException) {
-                        _log.error("Bug detected in dCache; please report this " +
-                              "to <support@dcache.org> with the following " +
-                              "information.", error);
-                    }
-
                     if (_doOnError != ErrorAction.CONTINUE) {
+                        if (error instanceof CommandPanicException) {
+                            Throwable cause = error.getCause();
+                            _log.error("Bug detected in dCache; please report this " +
+                                  "to <support@dcache.org> with the following " +
+                                  "information.", cause != null ? cause : error);
+                        }
+
                         String msg =
                               String.format("%s: line %d: %s", source, no,
                                     error.getMessage());


### PR DESCRIPTION
Motivation:

Two problems:

 1. If there is a bug when executing a batch script and when onError is
    set to continue the the stacktrace is printed twice.

 2. The printed stack-trace is for the wrapping CommandPanicException,
    rather than the underlying problem.  In almost all cases, the
    stack-trace of the CommandPanicException isn't of interest, only
    that of the underlying bug.

Modification:

Move the CommandPanicException test into the block handling onError !=
CONTINUE.

Update show the CommandPanicException's cause, if there is one;
otherwise, show the CommandPanicException.

Result:

Avoid printing a stack-trace twice if a bug is triggered during startup
and omit unnecessary information.

Target: master
Require-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13222/
Acked-by: Marina Sahakyan