### PR TITLE
nfs: fix tag update regression

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
@@ -342,7 +342,8 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
             // OperationSETATTR have already checked for a valid open stateid
             if (stat.isDefined(Stat.StatAttribute.SIZE)) {
 
-                int type = _fs.stat(fsInode).getMode() & UnixPermission.F_TYPE;
+                var chimeraStat = fsInode.stat();
+                int type = chimeraStat.getMode() & UnixPermission.F_TYPE;
                 switch (type) {
                     case UnixPermission.S_IFREG:
                         // ok
@@ -354,7 +355,7 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
                 }
 
                 // allow set size only for newly created files
-                if (_fs.stat(fsInode).getState() != FileState.CREATED) {
+                if (fsInode.type() == FsInodeType.INODE && chimeraStat.getState() != FileState.CREATED) {
                     throw new PermException("Can't change size of existing file");
                 }
             }


### PR DESCRIPTION
Fixes: 19fa7cf2425

Motivation:
The directory tags inherit attributes from a directory to which it
tight, however, they are files, thus the file system object type have to
be adjusted. The FsInode#stat know how to do it, but
FileSystemProvider#stat doesn't.

Modification:
Update ChimeraVfs to use FsInode#stat to use the correct oject type.

Result:
the existing directory tags can be updated.

Fixes: #5955
Acked-by: Albert Rossi
Target: master, 7.2, 7.1, 7.0
Require-book: no
Require-notes: yes
(cherry picked from commit c82b804288c78a28b268f332b46b39ad2cabcb68)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>