### PR TITLE
srm-server: Fix NullPointerException in SRM TRS

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/taperecallscheduling/TapeRecallSchedulingRequirementsChecker.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/taperecallscheduling/TapeRecallSchedulingRequirementsChecker.java
@@ -252,13 +252,13 @@ public class TapeRecallSchedulingRequirementsChecker implements CellCommandListe
         if (first == null || second == null) {
             return 0;
         }
-        long oldestArrival = first.getOldestJobArrival();
-        long otherArrival = second.getOldestJobArrival();
-        if (oldestArrival == NO_VALUE && otherArrival == NO_VALUE) {
+        Long oldestArrival = first.getOldestJobArrival();
+        Long otherArrival = second.getOldestJobArrival();
+        if (oldestArrival == null && otherArrival == null) {
             return 0;
-        } else if (oldestArrival == NO_VALUE && otherArrival != NO_VALUE) {
+        } else if (oldestArrival == null && otherArrival != null) {
             return -1;
-        } else if (oldestArrival != NO_VALUE && otherArrival == NO_VALUE) {
+        } else if (oldestArrival != null && otherArrival == null) {
             return 1;
         }
         return Long.compare(oldestArrival, otherArrival);

--- a/modules/srm-server/src/test/java/org/dcache/srm/scheduler/TapeRecallSchedulingStrategyTests.java
+++ b/modules/srm-server/src/test/java/org/dcache/srm/scheduler/TapeRecallSchedulingStrategyTests.java
@@ -412,4 +412,27 @@ public class TapeRecallSchedulingStrategyTests {
         assertFalse(requirementsChecker.isJobExpired(jobTapeinfoless));
     }
 
+    @Test
+    public void shouldCompareOldestTapeRequestAgeIfOneIsNotSet() {
+        SchedulingInfoTape tapeInfo1 = new SchedulingInfoTape();
+        tapeInfo1.addTapeInfo(100, 100);
+        tapeInfo1.setOldestJobArrival(getNewCtime());
+
+        SchedulingInfoTape tapeInfo2 = new SchedulingInfoTape();
+        tapeInfo2.addTapeInfo(100, 100);
+
+        assertEquals(1, requirementsChecker.compareOldestTapeRequestAge(tapeInfo1, tapeInfo2));
+    }
+
+    @Test
+    public void shouldCompareOldestTapeRequestAgeIfBothAreNotSet() {
+        SchedulingInfoTape tapeInfo1 = new SchedulingInfoTape();
+        tapeInfo1.addTapeInfo(100, 100);
+
+        SchedulingInfoTape tapeInfo2 = new SchedulingInfoTape();
+        tapeInfo2.addTapeInfo(100, 100);
+
+        assertEquals(0, requirementsChecker.compareOldestTapeRequestAge(tapeInfo1, tapeInfo2));
+    }
+
 }


### PR DESCRIPTION
Motivation:

Observation of occasional temporary NullPointerException spams in the SrmManager logs under high load.

Modification:

When a tape object happens to not have a value in its oldestJobArrival field and is queried, it returns null. The TapeRecallSchedulingRequirementsChecker assumed to be receiving a magic number instead in its compareOldestTapeRequestAge method.
Changed code to test for null instead; handle inexitent values appropriately.
Add unit tests.

Result:

Prevent throwing a NullPointerException when a tape with expired requests does not have an oldest request age value.

Target: master
Target: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13230/
Acked-by: Paul Millar