### PR TITLE
universal-spring-cell: allow for serialization of Optional

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/UniversalSpringCell.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllBytes;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ArrayListMultimap;
@@ -56,6 +57,7 @@ import java.util.Formatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.TreeMap;
@@ -807,7 +809,7 @@ public class UniversalSpringCell
      * Returns true if {@code clazz} is assignable to any of the classes in {@code classes}, false
      * otherwise.
      */
-    private boolean isAssignableTo(Class<?> clazz, Class<?>... classes) {
+    private static boolean isAssignableTo(Class<?> clazz, Class<?>... classes) {
         for (Class<?> aClass : classes) {
             if (aClass.isAssignableFrom(clazz)) {
                 return true;
@@ -816,7 +818,7 @@ public class UniversalSpringCell
         return false;
     }
 
-    private Object serialize(Set<Object> prune, Queue<Map.Entry<String, Object>> queue, Object o) {
+    private static Object serialize(Set<Object> prune, Queue<Map.Entry<String, Object>> queue, Object o) {
         if (o == null || PRIMITIVE_TYPES.contains(o.getClass())) {
             return o;
         } else if (isAssignableTo(o.getClass(), TERMINAL_TYPES)) {
@@ -859,6 +861,8 @@ public class UniversalSpringCell
                 values.add(serialize(prune, queue, entry));
             }
             return values;
+        } else if (o instanceof Optional) {
+            return serialize(prune, queue, ((Optional)o).orElse(null));
         } else if (prune.contains(o)) {
             return o.toString();
         } else {
@@ -891,7 +895,8 @@ public class UniversalSpringCell
      * Prunes the object tree to produce a tree even if o is a DAG or contains cycles. Using a
      * breadth-first search tends to produce friendlier results when the object graph is pruned.
      */
-    private Object serialize(Object o) {
+    @VisibleForTesting
+    public static Object serialize(Object o) {
         Set<Object> prune = Sets.newHashSet();
         Queue<Map.Entry<String, Object>> queue = new ArrayDeque<>();
         Object result = serialize(prune, queue, o);
@@ -1075,7 +1080,7 @@ public class UniversalSpringCell
     /**
      * BeanWrapper that restricts access to certain private properties that should not be exposed.
      */
-    private class RestrictedBeanWrapper extends BeanWrapperImpl {
+    private static class RestrictedBeanWrapper extends BeanWrapperImpl {
 
         private RestrictedBeanWrapper(Object object) {
             super(object);

--- a/modules/dcache/src/test/java/org/dcache/tests/poolmanager/PoolMonitorTest.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/poolmanager/PoolMonitorTest.java
@@ -3,6 +3,7 @@ package org.dcache.tests.poolmanager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.gson.GsonBuilder;
 import diskCacheV111.poolManager.CostModuleV1;
 import diskCacheV111.poolManager.PoolMonitorV5;
 import diskCacheV111.poolManager.PoolSelectionUnit;
@@ -29,6 +30,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.dcache.cells.UniversalSpringCell;
 import org.dcache.pool.classic.IoQueueManager;
 import org.dcache.poolmanager.PartitionManager;
 import org.dcache.poolmanager.PoolSelector;
@@ -139,6 +141,14 @@ public class PoolMonitorTest {
     public void testHostFilterForWrite() throws Exception {
         prepareCostModule(false);
         prepareHostExclusion().selectWritePool(0);
+    }
+
+    @Test
+    public void testGsonDeserialization() throws Exception {
+        prepareCostModule(false);
+        Object obj = UniversalSpringCell.serialize(_poolMonitor);
+        new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting()
+              .disableHtmlEscaping().create().toJson(obj);
     }
 
     private void prepareCostModule(boolean linkPerPool) throws Exception {


### PR DESCRIPTION
Motivation:

master@34561e5ebc1a8949d4c3def3d3d573fb31630a39

11953

Added the hostname to the Psu Pool class in
order to be able to support xrootd's "exclude"
semantics.

Unfortunately, this was done using an Optional<String>,
without taking into account the need (via the httpd
ProbeResponseEngine) to serialize/deserialize the
PoolManager object to support the bean api
(e.g., http://example.org:2288/api/PoolManager).

The change thus broke the bean API for the PoolManager,
though one can still obtain the beans of other
UniversalSpringCell services.

Modification:

Add recursive serialization of the Optional object
contents.

In order to add a unit test, several methods
in the UniversalSpringCell had to be made
static and the serialize method exposed
as public.

Result:

Without this patch, a call to
api/PoolManager returns 404 not found.
After, the JSON serialized object is
returned as before.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13236/
Acked-by: Dmitry