### PR TITLE
pom.xml: bump to xrootd4j 4.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.43.v20210629</version.jetty>
-        <version.xrootd4j>4.2.2</version.xrootd4j>
+        <version.xrootd4j>4.2.3</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.0</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>


### PR DESCRIPTION
Includes these fixes:

     unset all tls-require flags when mode is OPTIONAL
     #13229
     master@f42bf3a90ba7f61d97496e9792ceddb6b8dae81f

Target: master (v4.2.3)
Request: 7.2 (v4.2.3)
Request: 7.1 (v4.1.4)
Request: 7.0 (v4.0.10)
Request: 6.2 (v4.0.10)
Patch: https://rb.dcache.org/r/13233/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran