### PR TITLE
srm-server: trs -- use Optional types, add unit tests

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/taperecallscheduling/SchedulingInfoTape.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/taperecallscheduling/SchedulingInfoTape.java
@@ -18,6 +18,8 @@
 
 package org.dcache.srm.taperecallscheduling;
 
+import java.util.OptionalLong;
+
 /**
  * Bring online tape scheduling item for tracking a tape's meta-information relevant for job
  * scheduling Used for keeping track of and evaluating oldest and newest job arrival targeting the
@@ -25,23 +27,21 @@ package org.dcache.srm.taperecallscheduling;
  */
 public class SchedulingInfoTape {
 
-    private static final long NO_VALUE = -1;
-
     // scheduling info
-    private long oldestJobArrival = NO_VALUE;
-    private long newestJobArrival = NO_VALUE;
+    private OptionalLong oldestJobArrival = OptionalLong.empty();
+    private OptionalLong newestJobArrival = OptionalLong.empty();
 
     // tape capacity info
     private boolean hasTapeInfo = false;
-    private long capacity = NO_VALUE;
-    private long usedSpace = NO_VALUE;
+    private OptionalLong capacity = OptionalLong.empty();
+    private OptionalLong usedSpace = OptionalLong.empty();
 
     public boolean addTapeInfo(long capacity, long usedSpace) {
         if (hasTapeInfo) {
             return false;
         }
-        this.capacity = capacity;
-        this.usedSpace = usedSpace;
+        this.capacity = OptionalLong.of(capacity);
+        this.usedSpace = OptionalLong.of(usedSpace);
         hasTapeInfo = true;
         return true;
     }
@@ -50,21 +50,25 @@ public class SchedulingInfoTape {
         return hasTapeInfo;
     }
 
-    public long getCapacity() {
+    public OptionalLong getCapacity() {
         return capacity;
     }
 
-    public long getUsedSpace() {
+    public OptionalLong getUsedSpace() {
         return usedSpace;
     }
 
     public void resetJobArrivalTimes() {
-        this.oldestJobArrival = NO_VALUE;
-        this.newestJobArrival = NO_VALUE;
+        oldestJobArrival = OptionalLong.empty();
+        newestJobArrival = OptionalLong.empty();
     }
 
-    public Long getNewestJobArrival() {
-        return newestJobArrival == NO_VALUE ? null : newestJobArrival;
+    public OptionalLong getNewestJobArrival() {
+        return newestJobArrival;
+    }
+
+    public void setNewestJobArrival(long jobArrival) {
+        newestJobArrival = OptionalLong.of(jobArrival);
     }
 
     /**
@@ -73,29 +77,19 @@ public class SchedulingInfoTape {
      *
      * @param jobArrival
      */
-    public void setNewestJobArrival(Long jobArrival) {
-
-        if (jobArrival == null || jobArrival <= 0) {
-            this.newestJobArrival = NO_VALUE;
-
-        } else {
-            this.newestJobArrival = jobArrival;
-            if (oldestJobArrival == NO_VALUE) {
-                oldestJobArrival = jobArrival;
-            }
+    public void setNewestJobArrivalAndOldestIfNotExists(long jobArrival) {
+        setNewestJobArrival(jobArrival);
+        if (getOldestJobArrival().isEmpty()) {
+            setOldestJobArrival(jobArrival);
         }
     }
 
-    public Long getOldestJobArrival() {
-        return oldestJobArrival == NO_VALUE ? null : oldestJobArrival;
+    public OptionalLong getOldestJobArrival() {
+        return oldestJobArrival;
     }
 
-    public void setOldestJobArrival(Long jobArrival) {
-        if (jobArrival == null || jobArrival <= 0) {
-            this.oldestJobArrival = NO_VALUE;
-        } else {
-            this.oldestJobArrival = jobArrival;
-        }
+    public void setOldestJobArrival(long jobArrival) {
+        oldestJobArrival = OptionalLong.of(jobArrival);
     }
 
     @Override

--- a/modules/srm-server/src/main/java/org/dcache/srm/taperecallscheduling/SchedulingItemJob.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/taperecallscheduling/SchedulingItemJob.java
@@ -18,18 +18,18 @@
 
 package org.dcache.srm.taperecallscheduling;
 
+import java.util.OptionalLong;
+
 /**
  * Bring online job scheduling item for tracking a job's meta-information relevant for job
  * scheduling
  */
 public class SchedulingItemJob {
 
-    private static final long NO_VALUE = -1;
-
     private final long jobid;
     private final String fileid;
     private final long creationTime;
-    private long fileSize = NO_VALUE;
+    private OptionalLong fileSize = OptionalLong.empty();
     private boolean attemptedToRetrieveTapeLocationInfo = false;
 
     public SchedulingItemJob(long jobid, String fileid, long ctime) {
@@ -50,12 +50,12 @@ public class SchedulingItemJob {
         return creationTime;
     }
 
-    public Long getFileSize() {
-        return fileSize == NO_VALUE ? null : fileSize;
+    public OptionalLong getFileSize() {
+        return fileSize;
     }
 
     public void setFileSize(long fileSize) {
-        this.fileSize = fileSize <= 0 ? NO_VALUE : fileSize;
+        this.fileSize = OptionalLong.of(fileSize);
     }
 
     public boolean attemptedToRetrieveTapeLocationInfo() {

--- a/modules/srm-server/src/test/java/org/dcache/srm/scheduler/TapeRecallSchedulingStrategyTests.java
+++ b/modules/srm-server/src/test/java/org/dcache/srm/scheduler/TapeRecallSchedulingStrategyTests.java
@@ -19,8 +19,6 @@ package org.dcache.srm.scheduler;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import java.net.URI;
@@ -32,8 +30,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.dcache.srm.request.BringOnlineFileRequest;
 import org.dcache.srm.scheduler.strategy.TapeRecallSchedulingStrategy;
-import org.dcache.srm.taperecallscheduling.SchedulingInfoTape;
-import org.dcache.srm.taperecallscheduling.SchedulingItemJob;
 import org.dcache.srm.taperecallscheduling.TapeInfo;
 import org.dcache.srm.taperecallscheduling.TapeInformant;
 import org.dcache.srm.taperecallscheduling.TapeRecallSchedulingRequirementsChecker;
@@ -363,76 +359,4 @@ public class TapeRecallSchedulingStrategyTests {
 
         assertEquals(4, strategy.size());
     }
-
-    @Test
-    public void evaluatesSufficientRelativeTapeRecallVolumeCorrectly() {
-        requirementsChecker.setMinTapeRecallPercentage(80);
-
-        // initialize tape info
-        tapeInfoProvider.addTapeInfo("tapeX", new TapeInfo(100, 40));
-        tapeInfoProvider.addTapeFileInfo("/tape/fileX.txt", new TapefileInfo(40, "tapeX"));
-
-        SchedulingInfoTape sit = new SchedulingInfoTape();
-        sit.addTapeInfo(100, 40);
-
-        assertFalse(requirementsChecker.isTapeRecallVolumeSufficient(sit, 30));
-        assertTrue(requirementsChecker.isTapeRecallVolumeSufficient(sit, 40));
-        assertTrue(requirementsChecker.isTapeRecallVolumeSufficient(sit, 80));
-    }
-
-    @Test
-    public void evaluatesSufficientTapeRecallVolumeCorrectly() {
-        requirementsChecker.setMinTapeRecallPercentage(80);
-
-        // initialize tape info
-        tapeInfoProvider.addTapeInfo("tapeX", new TapeInfo(100, 100));
-        tapeInfoProvider.addTapeFileInfo("/tape/fileX.txt", new TapefileInfo(40, "tapeX"));
-
-        SchedulingInfoTape sit = new SchedulingInfoTape();
-        sit.addTapeInfo(100, 100);
-
-        assertFalse(requirementsChecker.isTapeRecallVolumeSufficient(sit, 70));
-        assertTrue(requirementsChecker.isTapeRecallVolumeSufficient(sit, 81));
-    }
-
-    @Test
-    public void assessJobExpiry() {
-        requirementsChecker.setMaxJobWaitingTime(Duration.ofSeconds(50));
-        requirementsChecker.setTapeinfolessJobWaitingTime(Duration.ofSeconds(5));
-
-        // initialize tape info
-        SchedulingItemJob job = new SchedulingItemJob(10, "/tape/file10.txt",
-              getNewCtime() - Duration.ofSeconds(50).toMillis() - 5);
-        SchedulingItemJob jobTapeinfoless = new SchedulingItemJob(10, "/tape/file10.txt",
-              getNewCtime() - Duration.ofSeconds(5).toMillis() - 5);
-
-        assertTrue(requirementsChecker.isJobExpired(job));
-        assertTrue(requirementsChecker.isTapeinfolessJobExpired(job));
-        assertTrue(requirementsChecker.isTapeinfolessJobExpired(jobTapeinfoless));
-        assertFalse(requirementsChecker.isJobExpired(jobTapeinfoless));
-    }
-
-    @Test
-    public void shouldCompareOldestTapeRequestAgeIfOneIsNotSet() {
-        SchedulingInfoTape tapeInfo1 = new SchedulingInfoTape();
-        tapeInfo1.addTapeInfo(100, 100);
-        tapeInfo1.setOldestJobArrival(getNewCtime());
-
-        SchedulingInfoTape tapeInfo2 = new SchedulingInfoTape();
-        tapeInfo2.addTapeInfo(100, 100);
-
-        assertEquals(1, requirementsChecker.compareOldestTapeRequestAge(tapeInfo1, tapeInfo2));
-    }
-
-    @Test
-    public void shouldCompareOldestTapeRequestAgeIfBothAreNotSet() {
-        SchedulingInfoTape tapeInfo1 = new SchedulingInfoTape();
-        tapeInfo1.addTapeInfo(100, 100);
-
-        SchedulingInfoTape tapeInfo2 = new SchedulingInfoTape();
-        tapeInfo2.addTapeInfo(100, 100);
-
-        assertEquals(0, requirementsChecker.compareOldestTapeRequestAge(tapeInfo1, tapeInfo2));
-    }
-
 }

--- a/modules/srm-server/src/test/java/org/dcache/srm/taperecallscheduling/TapeRecallSchedulingRequirementsCheckerTests.java
+++ b/modules/srm-server/src/test/java/org/dcache/srm/taperecallscheduling/TapeRecallSchedulingRequirementsCheckerTests.java
@@ -1,0 +1,229 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.srm.taperecallscheduling;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Duration;
+import java.util.OptionalLong;
+import org.dcache.srm.request.BringOnlineFileRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({BringOnlineFileRequest.class})
+@PowerMockIgnore({"com.sun.org.apache.xerces.*",
+      "javax.xml.*", "org.xml.*", "org.w3c.*", "jdk.xml.*"})
+public class TapeRecallSchedulingRequirementsCheckerTests {
+
+    /**
+     * time safety margin in milliseconds
+     */
+    private static final long TIME_SAFETY_MARGIN = 20;
+    TapeRecallSchedulingRequirementsChecker requirementsChecker;
+
+    private long getNewCtime() {
+        return System.currentTimeMillis() - TIME_SAFETY_MARGIN;
+    }
+
+    private long getExpiredCtime() {
+        long age =
+              requirementsChecker.maxJobWaitingTime() + SECONDS.toMillis(1) + TIME_SAFETY_MARGIN;
+        long res = System.currentTimeMillis() - age;
+        return res;
+    }
+
+    private long getExpiredTapeinfolessCtime() {
+        OptionalLong tapeinfolessTime = requirementsChecker.tapeinfolessJobWaitingTime();
+        if (tapeinfolessTime.isEmpty()) {
+            return getExpiredCtime();
+        }
+        long age = tapeinfolessTime.getAsLong() + SECONDS.toMillis(1) + TIME_SAFETY_MARGIN;
+        long res = System.currentTimeMillis() - age;
+        return res;
+    }
+
+    @Before
+    public void setup() {
+        requirementsChecker = new TapeRecallSchedulingRequirementsChecker();
+        requirementsChecker.setMaxActiveTapes(1);
+        requirementsChecker.setMinTapeRecallPercentage(80);
+        requirementsChecker.setMinNumberOfRequestsForTapeSelection(1);
+        requirementsChecker.setMinJobWaitingTime(Duration.ofMinutes(0));
+        requirementsChecker.setMaxJobWaitingTime(Duration.ofHours(1));
+    }
+
+    @Test
+    public void shouldHandleMissingTapeInfoAsInsufficientIfNotZeroPercentRequired() {
+        requirementsChecker.setMinTapeRecallPercentage(80);
+        SchedulingInfoTape sit = new SchedulingInfoTape();
+
+        assertFalse(requirementsChecker.isTapeRecallVolumeSufficient(sit, 30L));
+        assertFalse(requirementsChecker.isTapeRecallVolumeSufficient(sit, 80L));
+    }
+
+    @Test
+    public void shouldHandleMissingTapeInfoAsSufficientIfZeroPercentRequired() {
+        requirementsChecker.setMinTapeRecallPercentage(0);
+        SchedulingInfoTape sit = new SchedulingInfoTape();
+
+        assertTrue(requirementsChecker.isTapeRecallVolumeSufficient(sit, 30L));
+        assertTrue(requirementsChecker.isTapeRecallVolumeSufficient(sit, 80L));
+    }
+
+    @Test
+    public void evaluatesSufficientRelativeTapeRecallVolumeCorrectly() {
+        requirementsChecker.setMinTapeRecallPercentage(80);
+
+        SchedulingInfoTape sit = new SchedulingInfoTape();
+        sit.addTapeInfo(100, 40);
+
+        assertFalse(requirementsChecker.isTapeRecallVolumeSufficient(sit, 30L));
+        assertTrue(requirementsChecker.isTapeRecallVolumeSufficient(sit, 40L));
+        assertTrue(requirementsChecker.isTapeRecallVolumeSufficient(sit, 80L));
+    }
+
+    @Test
+    public void evaluatesSufficientTapeRecallVolumeCorrectly() {
+        requirementsChecker.setMinTapeRecallPercentage(80);
+
+        SchedulingInfoTape sit = new SchedulingInfoTape();
+        sit.addTapeInfo(100, 100);
+
+        assertFalse(requirementsChecker.isTapeRecallVolumeSufficient(sit, 70L));
+        assertTrue(requirementsChecker.isTapeRecallVolumeSufficient(sit, 81L));
+    }
+
+    @Test
+    public void testRequestCountSufficient() {
+        requirementsChecker.setMinNumberOfRequestsForTapeSelection(1);
+        assertTrue(requirementsChecker.isRequestCountSufficient(10));
+    }
+
+    @Test
+    public void testRequestCountInsufficient() {
+        requirementsChecker.setMinNumberOfRequestsForTapeSelection(100);
+        assertFalse(requirementsChecker.isRequestCountSufficient(10));
+    }
+
+    @Test
+    public void assessJobExpiry() {
+        requirementsChecker.setMaxJobWaitingTime(Duration.ofSeconds(50));
+
+        SchedulingItemJob j1 = new SchedulingItemJob(10, "/tape/file10.txt",
+              getExpiredCtime());
+        SchedulingItemJob j2 = new SchedulingItemJob(11, "/tape/file11.txt",
+              getNewCtime());
+
+        assertTrue(requirementsChecker.isJobExpired(j1));
+        assertFalse(requirementsChecker.isJobExpired(j2));
+    }
+
+    @Test
+    public void assessTapeinfolessJobExpiry() {
+        requirementsChecker.setMaxJobWaitingTime(Duration.ofSeconds(50));
+        requirementsChecker.setTapeinfolessJobWaitingTime(Duration.ofSeconds(5));
+
+        SchedulingItemJob j1 = new SchedulingItemJob(10, "/tape/file10.txt",
+              getExpiredTapeinfolessCtime());
+        SchedulingItemJob j2 = new SchedulingItemJob(11, "/tape/file11.txt",
+              getNewCtime());
+
+        assertTrue(requirementsChecker.isTapeinfolessJobExpired(j1));
+        assertFalse(requirementsChecker.isTapeinfolessJobExpired(j2));
+    }
+
+    @Test
+    public void assessTapeinfolessJobExpiryWhenDisabled() {
+        requirementsChecker.setTapeinfolessJobWaitingTime(Duration.ofSeconds(-1));
+        requirementsChecker.setMaxJobWaitingTime(Duration.ofSeconds(50));
+
+        SchedulingItemJob j1 = new SchedulingItemJob(10, "/tape/file10.txt",
+              getExpiredCtime());
+        SchedulingItemJob j2 = new SchedulingItemJob(11, "/tape/file11.txt",
+              getNewCtime());
+
+        assertTrue(requirementsChecker.isTapeinfolessJobExpired(j1));
+        assertFalse(requirementsChecker.isTapeinfolessJobExpired(j2));
+    }
+
+    @Test
+    public void returnOldestTapeJobNotExpiredWhenNoOldestForTapeExists() {
+        requirementsChecker.setMaxJobWaitingTime(Duration.ofSeconds(50));
+        SchedulingInfoTape sit = new SchedulingInfoTape();
+
+        assertFalse(requirementsChecker.isOldestTapeJobExpired(sit));
+    }
+
+    @Test
+    public void returnNewestTapeJobNotExpiredWhenNoNewestForTapeExists() {
+        requirementsChecker.setMaxJobWaitingTime(Duration.ofSeconds(50));
+        SchedulingInfoTape sit = new SchedulingInfoTape();
+
+        assertFalse(requirementsChecker.isNewestTapeJobOldEnough(sit));
+    }
+
+    @Test
+    public void returnOldestTapeJobExpired() {
+        requirementsChecker.setMaxJobWaitingTime(Duration.ofSeconds(50));
+        SchedulingInfoTape sit = new SchedulingInfoTape();
+        sit.setOldestJobArrival(getExpiredCtime());
+
+        assertTrue(requirementsChecker.isOldestTapeJobExpired(sit));
+    }
+
+    @Test
+    public void returnNewestTapeJobExpired() {
+        requirementsChecker.setMaxJobWaitingTime(Duration.ofSeconds(50));
+        SchedulingInfoTape sit = new SchedulingInfoTape();
+        sit.setNewestJobArrival(getExpiredCtime());
+
+        assertTrue(requirementsChecker.isNewestTapeJobOldEnough(sit));
+    }
+
+    @Test
+    public void shouldCompareOldestTapeRequestAgeIfOneIsNotSet() {
+        SchedulingInfoTape tapeInfo1 = new SchedulingInfoTape();
+        tapeInfo1.addTapeInfo(100, 100);
+        tapeInfo1.setOldestJobArrival(getNewCtime());
+
+        SchedulingInfoTape tapeInfo2 = new SchedulingInfoTape();
+        tapeInfo2.addTapeInfo(100, 100);
+
+        assertEquals(1, requirementsChecker.compareOldestTapeRequestAge(tapeInfo1, tapeInfo2));
+    }
+
+    @Test
+    public void shouldCompareOldestTapeRequestAgeIfBothAreNotSet() {
+        SchedulingInfoTape tapeInfo1 = new SchedulingInfoTape();
+        tapeInfo1.addTapeInfo(100, 100);
+
+        SchedulingInfoTape tapeInfo2 = new SchedulingInfoTape();
+        tapeInfo2.addTapeInfo(100, 100);
+
+        assertEquals(0, requirementsChecker.compareOldestTapeRequestAge(tapeInfo1, tapeInfo2));
+    }
+
+}


### PR DESCRIPTION
Motivation:

Objects in Java are usually nullable. To prevent NullPointerExceptions, it is desirable to use Optional types where possible.

Modification:
Result:

Use Optional types in TRS components. Add unit tests for TapeRecallSchedulingRequirementsChecker.
No user or admin observable changes.

Target: master
Target: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13237
Acked-by: Tigran Mkrtchyan