### PR TITLE
dcache-chimera: add Unix principal conversion to AccessControlContext…

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/DCacheAwareJdbcFs.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/DCacheAwareJdbcFs.java
@@ -60,6 +60,8 @@ documents or software obtained from this server.
 package org.dcache.chimera;
 
 import com.google.common.base.Throwables;
+import com.sun.security.auth.UnixNumericGroupPrincipal;
+import com.sun.security.auth.UnixNumericUserPrincipal;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileLocality;
 import diskCacheV111.util.PermissionDeniedCacheException;
@@ -76,8 +78,10 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.AccessController;
+import java.security.Principal;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +92,9 @@ import javax.security.auth.Subject;
 import javax.sql.DataSource;
 import org.apache.curator.shaded.com.google.common.collect.ImmutableMap;
 import org.dcache.acl.enums.AccessMask;
+import org.dcache.auth.GidPrincipal;
 import org.dcache.auth.Subjects;
+import org.dcache.auth.UidPrincipal;
 import org.dcache.cells.CellStub;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.pinmanager.PinManagerListPinsMessage;
@@ -222,7 +228,7 @@ public class DCacheAwareJdbcFs extends JdbcFs implements CellIdentityAware {
      */
     @Override
     public void pin(FsInode inode, long lifetime) throws ChimeraFsException {
-        Subject subject = Subject.getSubject(AccessController.getContext());
+        Subject subject = getSubjectFromContext();
         InetAddress client = Subjects.getOrigin(subject).getAddress();
         ProtocolInfo protocolInfo
               = new DCapProtocolInfo("DCap", 3, 0, new InetSocketAddress(client, 0));
@@ -254,7 +260,7 @@ public class DCacheAwareJdbcFs extends JdbcFs implements CellIdentityAware {
     public void unpin(FsInode inode) throws ChimeraFsException {
         PinManagerUnpinMessage message
               = new PinManagerUnpinMessage(new PnfsId(inode.getId()));
-        Subject subject = Subject.getSubject(AccessController.getContext());
+        Subject subject = getSubjectFromContext();
         message.setSubject(subject);
 
         try {
@@ -277,7 +283,7 @@ public class DCacheAwareJdbcFs extends JdbcFs implements CellIdentityAware {
     public List<PinInfo> listPins(FsInode inode) throws ChimeraFsException {
         PnfsId pnfsid = new PnfsId(inode.getId());
         PinManagerListPinsMessage request = new PinManagerListPinsMessage(pnfsid);
-        Subject subject = Subject.getSubject(AccessController.getContext());
+        Subject subject = getSubjectFromContext();
         request.setSubject(subject);
         try {
             return pinManagerStub.sendAndWait(request).getInfo().stream()
@@ -290,9 +296,8 @@ public class DCacheAwareJdbcFs extends JdbcFs implements CellIdentityAware {
 
     @Override
     public void remove(FsInode directory, String name, FsInode inode) throws ChimeraFsException {
-
         super.remove(directory, name, inode);
-        Subject subject = Subject.getSubject(AccessController.getContext());
+        Subject subject = getSubjectFromContext();
         DoorRequestInfoMessage infoRemove
               = new DoorRequestInfoMessage(myAddress, "remove");
 
@@ -359,5 +364,41 @@ public class DCacheAwareJdbcFs extends JdbcFs implements CellIdentityAware {
             throw new ChimeraFsException(e.getMessage(), e);
         }
         return rc;
+    }
+
+    /*
+     * Also turns Unix principals into Uid and Gid principals.
+     */
+    private static Subject getSubjectFromContext() {
+        Subject subject = Subject.getSubject(AccessController.getContext());
+
+        UnixNumericUserPrincipal userPrincipal = null;
+        List<UnixNumericGroupPrincipal> groupPrincipals = new ArrayList<>();
+
+        for (Principal principal : subject.getPrincipals()) {
+            if (principal instanceof UnixNumericUserPrincipal) {
+                userPrincipal = (UnixNumericUserPrincipal) principal;
+            } else if (principal instanceof UnixNumericGroupPrincipal) {
+                groupPrincipals.add((UnixNumericGroupPrincipal) principal);
+            }
+        }
+
+        if (userPrincipal == null) {
+            return subject;
+        }
+
+        Principal origin = Subjects.getOrigin(subject);
+
+        subject = new Subject();
+        Set<Principal> principals = subject.getPrincipals();
+        principals.add(new UidPrincipal(userPrincipal.longValue()));
+        groupPrincipals.forEach(
+              p -> principals.add(new GidPrincipal(p.longValue(), p.isPrimaryGroup())));
+        if (origin != null) {
+            principals.add(origin);
+        }
+
+        subject.setReadOnly();
+        return subject;
     }
 }


### PR DESCRIPTION
… subject

Motivation:

commit 00c29fc7703f ("pom: migrate to nfs4j-0.22.0")
was introduced in dCache v7.0.  This update contains
the nfs4j commit ed9a57837, which updates nfs4j's
oncrpc dependency to use oncrpc v3.1.0.
This new version of oncrpc introduces new principals
(UnixNumericUser/GroupPrincipal).

Unfortunately, the change was incomplete; in
particular, dot commands where a subject
is obtained from the AccessControlContext
now cause a downstream call to getUid() to
fail, since it searches for UidPrincipal.class
and throws a NoSuchElementException in its
absence.

Modification:

Add a method to convert Unix principles
to Uid/Gid Principles where the subject
is fetched from the AccessControlContext.

Result:

No more downstream errors where getUid()
was once called without problems.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13248/
Closes: #6204
Acked-by: Paul