### PR TITLE
srm-server: trs -- improve tape info fetching

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/strategy/TapeRecallSchedulingStrategy.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/strategy/TapeRecallSchedulingStrategy.java
@@ -62,7 +62,7 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
 
     private TapeRecallSchedulingRequirementsChecker requirementsChecker;
     private TapeInformant tapeInformant;
-    private long lastTapeInfoFetch = 0;
+    private long lastTapeInfoRefreshAttempt = 0;
 
     // cached tape info and scheduling queues
 
@@ -93,9 +93,7 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
 
     @Override
     public synchronized Long remove() {
-        if (System.currentTimeMillis() > lastTapeInfoFetch + MIN_TIME_BETWEEN_TAPEINFO_FETCHING) {
-            fetchTapeInfo();
-        }
+        attemptToRefreshTapeInfo();
 
         if (!tapesWithJobs.isEmpty()
               && requirementsChecker.getRemainingTapeSlots(activeTapesWithJobs.size()) > 0) {
@@ -343,14 +341,15 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
     }
 
     /**
-     * Fetches tape location information for requests and associated tapes from the
-     * 'tapeInfoProvider'.
+     * Attempts to refresh tape location information for requests and tapes if enough time has
+     * passed since the last attempt and new jobs exists.
      */
-    private void fetchTapeInfo() {
-        if (!newJobs.isEmpty()) {
+    private void attemptToRefreshTapeInfo() {
+        long current = System.currentTimeMillis();
+        if (current > lastTapeInfoRefreshAttempt + MIN_TIME_BETWEEN_TAPEINFO_FETCHING) {
             fetchAndAddTapeInfoForJobs();
             fetchAndAddInfosForTapes();
-            lastTapeInfoFetch = System.currentTimeMillis();
+            lastTapeInfoRefreshAttempt = System.currentTimeMillis();
         }
     }
 
@@ -371,7 +370,7 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
      * from 'newJobs' and added to the 'tapesWithJobs' map.
      */
     private void fetchAndAddTapeInfoForJobs() {
-        if (newJobs.size() == 0) {
+        if (newJobs.isEmpty()) {
             return;
         }
         Set<String> changedTapeQueues = new HashSet();
@@ -450,7 +449,7 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
               .filter(e -> !e.getValue().hasTapeInfo()).map(e -> e.getKey())
               .collect(Collectors.toList());
 
-        if (tapesWithoutInfo.size() == 0) {
+        if (tapesWithoutInfo.isEmpty()) {
             return;
         }
         Map<String, TapeInfo> newInfo = tapeInformant.getTapeInfos(tapesWithoutInfo);


### PR DESCRIPTION
Motivation:

When the queue is empty and a large number of requests start arriving from a bulk request, it is not ideal to directly trigger fetching tape information for the first file because the last successful fetch is sufficiently long ago.
Rather, we would like the attempt to happen regularly and the time for fetching since arrival of new requests be a bit longer on average.

Modification:

Make the tape info check happen regularly by updating the lastTapeInfoFetch on every attempt -- if there are new jobs in the queue or not.
Also move the 'sufficient time since last attempt' check into the method itself, since it it not relevant to `remove()`.
Finally, remove the condition that there need to be new jobs for attempting fetching information on tapes.

Result:

Better time distributed tape info fetching. Better handling of edge case of temporary failure to fetch tape info.

Target: master
Target: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13238/
Acked-by: Paul Millar