### PR TITLE
common-security: revert GSI/FTP to Java SSL

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/TlsFtpInterpreterFactory.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/TlsFtpInterpreterFactory.java
@@ -24,11 +24,10 @@ import dmg.cells.nucleus.CDC;
 import eu.emi.security.authn.x509.CrlCheckingMode;
 import eu.emi.security.authn.x509.NamespaceCheckingMode;
 import eu.emi.security.authn.x509.OCSPCheckingMode;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.handler.ssl.SslContext;
 import java.io.File;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import org.dcache.ssl.CanlContextFactory;
 import org.dcache.util.Args;
@@ -80,7 +79,7 @@ public class TlsFtpInterpreterFactory extends FtpInterpreterFactory {
 
     private Optional<String> anonUser;
 
-    private SslContext sslContext;
+    private SSLContext sslContext;
 
     @Override
     public void configure(Args args) throws ConfigurationException {
@@ -98,7 +97,7 @@ public class TlsFtpInterpreterFactory extends FtpInterpreterFactory {
 
     @Override
     protected AbstractFtpDoorV1 createInterpreter() {
-        SSLEngine engine = sslContext.newEngine(ByteBufAllocator.DEFAULT);
+        SSLEngine engine = sslContext.createSSLEngine();
         engine.setNeedClientAuth(false);
 
         /* REVISIT: with FTPS, it is possible for a client to send an X.509
@@ -113,7 +112,7 @@ public class TlsFtpInterpreterFactory extends FtpInterpreterFactory {
               anonymousRoot, requireAnonEmailPassword);
     }
 
-    protected SslContext buildContext() throws Exception {
+    protected SSLContext buildContext() throws Exception {
         return CanlContextFactory.custom()
               .withCertificatePath(service_cert.toPath())
               .withKeyPath(service_key.toPath())
@@ -123,7 +122,7 @@ public class TlsFtpInterpreterFactory extends FtpInterpreterFactory {
               .withNamespaceMode(namespaceMode)
               .withLazy(false)
               .withLoggingContext(new CDC()::restore)
-              .buildWithCaching(SslContext.class)
+              .buildWithCaching(SSLContext.class)
               .call();
     }
 


### PR DESCRIPTION
Motivation:

https://github.com/dCache/dcache/issues/6195

ddd6c88 = https://rb.dcache.org/r/13044 introduced (7.2 only)
the option of switching between the Java and OpenSSL
SSL contexts/engines where possible.

The changes affected LocationManager, GFTP, HTTPS and Xroot.

While it was not possible to apply the changes everywhere,
the switch was made for GFTP, HTTPS and Xroot doors.

Now, for the latter two, a Netty pipeline is used, and
the SSLHandler is added to it.  The GFTP door uses
a "Line based" Netty-based interpreter, and it is
not immediately obvious how to wrap the engine
in a handler and add it to the pipeline there.

Unfortunately, I did not realize that simply contructing
the engine without wrapping it in the SSLHandler and
adding it to the pipeline meant that the necessary
RELEASE would never be called, leaking native memory.

It is this mistake which I believe indeed is wreaking
havoc with our GFTP doors.

Modification:

The two classes

```
modules/dcache-ftp/src/main/java/org/dcache/ftp/door/TlsFtpInterpreterFactory.java

modules/common-security/src/main/java/org/dcache/dss/ServerGsiEngineDssContextFactory.java
```

where this mistake was made have been reverted to
used the Java SSLContext.  This is the most immediate
solution until we figure out (if that is even warranted)
how to convert GFTP to OpenSSL.

Result:

Hopefully the memory leak causing OOM and other issues
will thereby be resolved.

Target: master
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13247/
Acked-by: Paul
Closes: #6195