### PR TITLE
ftp: switch to more reasonable logging of Subject

### DIFF
--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/GssFtpDoorV1.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 import javax.security.auth.Subject;
 import org.dcache.auth.LoginNamePrincipal;
+import org.dcache.auth.Subjects;
 import org.dcache.dss.DssContext;
 import org.dcache.dss.DssContextFactory;
 import org.slf4j.Logger;
@@ -182,7 +183,7 @@ public abstract class GssFtpDoorV1 extends AbstractFtpDoorV1 {
         } else {
             if (context.isEstablished()) {
                 LOGGER.info("GssFtpDoorV1::ftp_adat: security context established with {}",
-                      subject);
+                      Subjects.toString(subject));
                 reply("235 OK");
             } else {
                 reply("335 ADAT=");


### PR DESCRIPTION
Motivation:

The `Subject#toString` method provides way too much information,
particularly for X.509 based identities, making it hard to find the
useful information.

In addition, in providing all this information, the `toString` method is
CPU intensive and requires thread serialisation.

Modification:

Update the logging to use dCache's `Subjects#toString` method.

Result:

The FTP door now provides more succinct information on pinboard, should
use less CPU and take better advantage of the available cores.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Issue: #6195
Patch: https://rb.dcache.org/r/13246/
Acked-by: Dmitry Litvintsev