### PR TITLE
webdav: fix error handling for bad paths

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -44,6 +44,7 @@ import diskCacheV111.util.FileExistsCacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.MissingResourceCacheException;
+import diskCacheV111.util.NotDirCacheException;
 import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
@@ -733,6 +734,9 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
                               .build();
                         try {
                             msg = _pnfs.createPnfsEntry(_path.toString(), attributes);
+                        } catch (FileNotFoundCacheException | NotDirCacheException e) {
+                            // Parent directory missing or parent is a file.
+                            throw new ErrorResponseException(Response.Status.SC_BAD_REQUEST, e.getMessage());
                         } catch (FileExistsCacheException e) {
                             /* REVISIT: This should be moved to PnfsManager with a
                              * flag in the PnfsCreateEntryMessage.


### PR DESCRIPTION
Motivation:

If the client makes an HTTP-TPC PULL request that targets a directory
that doesn't exist then the door returns a status:

    500 Internal problem with server

This is wrong.  The correct status code is 400 as the client make an
incorrect request.

The same incorrect response is returned if the client attempts to upload
a file using an existing file as the parent directory.

(This is somewhat obscured because the door will returns "401 Permission
denied" if the "parent" file doesn't have the 'x' bit set.)

Modification:

Update how missing-parent-directory and parent-not-a-directory errors
are reported.

Result:

The HTTP-TPC response is improved if a client attempts to pull a file
into a non-existing directory, or attempts to use an existing file as an
ancestor directory.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13244/
Acked-by: Lea Morschel
Acked-by: Svenja Meyer