### PR TITLE
pnfsmanager: fix confusing error message.

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -291,9 +291,9 @@ public class ChimeraNameSpaceProvider
           throws CacheException {
         checkArgument(assignAttributes.isUndefined(INVALID_CREATE_FILE_ATTRIBUTES),
               "Illegal assign attributes: %s", assignAttributes.getDefinedAttributes());
+        File newEntryFile = new File(path);
+        String parentPath = newEntryFile.getParent();
         try {
-            File newEntryFile = new File(path);
-            String parentPath = newEntryFile.getParent();
             if (parentPath == null) {
                 throw new FileExistsCacheException("File exists: " + path);
             }
@@ -338,9 +338,9 @@ public class ChimeraNameSpaceProvider
             }
             return fileAttributes;
         } catch (NotDirChimeraException e) {
-            throw new NotDirCacheException("Not a directory: " + path);
+            throw new NotDirCacheException("Not a directory: " + parentPath);
         } catch (FileNotFoundChimeraFsException e) {
-            throw new FileNotFoundCacheException("No such file or directory: " + path);
+            throw new FileNotFoundCacheException("No such directory: " + parentPath);
         } catch (FileExistsChimeraFsException e) {
             throw new FileExistsCacheException("File exists: " + path);
         } catch (IOException e) {


### PR DESCRIPTION
Motivation:

When creating a file, certain failure modes trigger misleading or
otherwise confusing error messages.  Here are the two specific examples.

First, when attempting to upload `/A/my-file` and `/A` is a file, the
error message is:

    Not a directory: /A/my-file

This is misleading because the problem is with `/A`, not with
`/A/my-file`.

Second, when attempting to upload `/A/my-file` and directory `/A` is
missing, the error message is:

    No such file or directory: /A/my-file

This is misleading on two counts: it is `/A` that is missing and `/A`
should be a directory and not a file.

Modification:

Update these error messages to use the parent path.  In the second case,
"file or directory" is replaced by "directory".

Result:

Attempts to create a file where the parent directory is either missing
or not a directory now provide clearer error messages.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13243/
Acked-by: Lea Morschel
Acked-by: Svenja Meyer