### PR TITLE
dcache-xrootd: Alternate fix for client write to closed checksum channel

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/FileDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/FileDescriptor.java
@@ -14,6 +14,8 @@ import org.dcache.xrootd.util.ByteBuffersProvider;
  */
 public interface FileDescriptor {
 
+    default void close() {}
+
     /**
      * Reads data from the file. Reads until the buffer is full or the end of file has been
      * reached.

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -325,7 +325,8 @@ public final class TpcWriteDescriptor extends WriteDescriptor
         write((ByteBuffersProvider) inboundReadResponse);
     }
 
-    public void shutDown() {
+    @Override
+    public void close() {
         if (client == null) {
             return;
         }
@@ -351,5 +352,7 @@ public final class TpcWriteDescriptor extends WriteDescriptor
         }
 
         client.shutDown(ctx);
+
+        super.close();
     }
 }


### PR DESCRIPTION
Motivation:

There were questions as to whether https://rb.dcache.org/r/13119/
master@3b89d2e6966ee5847e399f1b8c37f36265128d27

was the correct fix.  In particular, the proper synchronization
seemed to be in the wrong place (FileDescriptor) rather than
in the XrootdPoolRequestHandler.

Modification:

Introduce a lock which guarantees atomicity in accessing the
file descriptor when channelInactive and write handling occurs.
When channelInactive occurs, remove the write descriptor prior
to releasing the mover channel.   Throw a "File unexpectedly closed"
exception if write or sync encounters a missing descriptor.

NB: This patch relies on reverting 3b89d2e6966ee5847e399f1b8c37f36265128d27
first (done on master).

Result:

Hopefully a more "proper" fix.

Target:  master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13126
Bug: RT 10172
Requires-notes: yes
Requires-book: no
Depends-on: #13127
Acked-by: Tigran