### PR TITLE
pool: provide more information when handle is double-closed

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReadHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReadHandleImpl.java
@@ -44,6 +44,7 @@ class ReadHandleImpl implements ReplicaDescriptor {
     private final Set<? extends OpenOption> _openOptions;
     private FileAttributes _fileAttributes;
     private boolean _open;
+    private Exception _closedBy;
 
     ReadHandleImpl(PnfsHandler pnfs, ReplicaRecord entry, FileAttributes fileAttributes,
           boolean isInternalActivity) {
@@ -63,10 +64,11 @@ class ReadHandleImpl implements ReplicaDescriptor {
     @Override
     public synchronized void close() throws IllegalStateException {
         if (!_open) {
-            throw new IllegalStateException("Handle is closed");
+            throw new IllegalStateException("Handle is closed", _closedBy);
         }
         _entry.decrementLinkCount();
         _open = false;
+        _closedBy = new Exception("Previous, successful close.");
     }
 
     @Override

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
@@ -118,6 +118,7 @@ class WriteHandleImpl implements ReplicaDescriptor {
     private Long _atime;
 
     private boolean hasChannelBeenCreated;
+    private Exception _closedBy;
 
     WriteHandleImpl(ReplicaRepository repository,
           Allocator allocator,
@@ -358,7 +359,7 @@ class WriteHandleImpl implements ReplicaDescriptor {
           throws IllegalStateException {
         switch (_state) {
             case CLOSED:
-                throw new IllegalStateException("Handle is closed");
+                throw new IllegalStateException("Handle is closed", _closedBy);
 
             case OPEN:
                 fail();
@@ -369,6 +370,7 @@ class WriteHandleImpl implements ReplicaDescriptor {
                 setState(HandleState.CLOSED);
                 break;
         }
+        _closedBy = new Exception("Previous, successful close.");
     }
 
     /**


### PR DESCRIPTION
Motivation:

A handle is expected to be closed exactly once: a second close triggers
a IllegalStateException.  Such an occurance is logged with a
stack-trace.  However, that stack-trace is only helpful if the second
attempt to close the handle is in error.  If the handle was
"prematurely" closed then the logged stack-trace does not provide
sufficient information to understand what went wrong.

For more specific motivation, see #6171.

Modification:

Capture the stack-trace of the successful close using an exception.
This is then used to embellish any subsequent the ISE.

Result:

The pool now provides more information for bugs reported as
`java.lang.IllegalStateException: Handle is closed`.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13232/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel