### PR TITLE
pool: update `NearlineStorage` to allow the `start` method to fail.

### DIFF
--- a/modules/common/src/main/java/org/dcache/alarms/PredefinedAlarm.java
+++ b/modules/common/src/main/java/org/dcache/alarms/PredefinedAlarm.java
@@ -85,7 +85,8 @@ public enum PredefinedAlarm implements Alarm {
     RESILIENCE_PM_SYNC_FAILURE,
     RESILIENCE_LOC_SYNC_ISSUE,
     RESILIENCE_PGROUP_ISSUE,
-    CLIENT_CONNECTION_REJECTED;
+    CLIENT_CONNECTION_REJECTED,
+    HSM_STARTUP_FAILED;
 
     @Override
     public String getType() {

--- a/modules/dcache-nearline-spi/src/main/java/org/dcache/pool/nearline/spi/NearlineStorage.java
+++ b/modules/dcache-nearline-spi/src/main/java/org/dcache/pool/nearline/spi/NearlineStorage.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.pool.nearline.spi;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 
@@ -34,10 +35,11 @@ import java.util.UUID;
  * used to stage or remove the file from nearline storage.
  * <p>
  * Object life-cycle: under normal operation, the {@link #configure} method is called first,
- * followed by the {@link #start} method.  After this any of the methods other than
- * {@literal start} may be called.  It is guaranteed that {@link shutdown} is called.  After
- * {@literal shutdown} returns, no further methods are called and the object will then be garbage
- * collected at some point.
+ * followed by the {@link #start} method.  After the start method returns normally, any of the
+ * methods other than {@literal start} may be called.  It is guaranteed that {@link shutdown} is
+ * called before the object is garbage collected.  After {@literal shutdown} returns, no further
+ * methods are called.  If {@literal start} throws an exception then no further methods are called
+ * and the object will be subject to garbage collection.
  * <p>
  * A configuration-testing life-cycle is used to verify the NearlineStorage configuration is
  * correct without affecting the "live" system.  Under this mode, an object is created and the
@@ -85,10 +87,11 @@ public interface NearlineStorage {
 
     /**
      * Inform the NearlineStorageProvider to start any background activity or open external
-     * resources.  This method is only called once.  If called, it is guaranteed that
+     * resources.This method is only called once.  If called, it is guaranteed that
      * {@link #shutdown} is called.
+     * @throws java.io.IOException if the NearlineStorage is unable to start.
      */
-    default void start(){}
+    default void start() throws IOException {}
 
     /**
      * Cancels all requests and initiates a shutdown of the nearline storage interface.


### PR DESCRIPTION
Motivation:

A NearlineStorage plugin may fail to start.  This possibility is
currently not supported since the `NearlineStorage#start` is not allowed
to throw an exception.

Modification:

Update the `NearlineStorage` to indicate that the `start` method may
throw an `IOException`.  The contract is updated so that, if the `start`
method throws this exception then no further methods are called and the
object is subject to garbage collection.

The HsmSet class is updated to support this new behaviour in the
following way:

  * The `hsm create` admin command, when executed through the ssh
    interface on a running system, will return an error if the
    `NearlineStorage#start` method throws an exception.  The HSM will
    not be added.  The command's error response will include the message
    from the IOException (if there was one) or the exception's class
    name otherwise.

  * During the pool startup, if `NearlineStorage#start` method throws an
    exception then dCache will continue to start but the pool will not
    have the corresponding HSM instance.  The error is logged and an
    alert is sent.

  * During the `reload` command, if the `setup` file defines a new HSM
    instance and `NearlineStorage#start` throws an exception then the
    `reload` command will complete successfully and the failing HSM is
    not added.  An error is logged and an alert is sent.

Note that when an existing HSM's configuration is modified then
`NearlineStorage#start` is _not_ called.  This can hapen with the `hsm
set` admin command or by modifying the pool's `setup` file and running
the `reload` command.

Result:

The pool is updated to support stateful NearlineStorage plugins that can
fail during initialisation.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Patch: https://rb.dcache.org/r/13227/
Acked-by: Tigran Mkrtchyan