### PR TITLE
dcache-frontend: support different attribute styles for bulk request

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/admin/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/admin/BulkServiceCommands.java
@@ -1078,26 +1078,26 @@ public class BulkServiceCommands implements CellCommandListener {
                           + "are 'BREADTH-FIRST-WALK' and 'DEPTH-FIRST-WALK')")
         String activity;
 
-        @Option(name = "expand",
+        @Option(name = "expand-directories",
               valueSpec = "NONE|TARGETS|ALL",
               usage = "NONE = do not expand directories; TARGETS = shallow expansion of "
                     + "directories (only take action on its targets with no further expansion); "
                     + "ALL = full recursion")
         String expand = "NONE";
 
-        @Option(name = "cancelOnFailure",
+        @Option(name = "cancel_on_failure",
               usage = "cancel request preemptively on first failure; default is false")
         Boolean cancelOnFailure = false;
 
-        @Option(name = "clearOnFailure",
+        @Option(name = "clear_on_failure",
               usage = "remove request from storage if any jobs failed; default is false")
         Boolean clearOnFailure = false;
 
-        @Option(name = "clearOnSuccess",
+        @Option(name = "clear_on_success",
               usage = "remove request from storage if all jobs succeeded; default is false)")
         Boolean clearOnSuccess = false;
 
-        @Option(name = "delayClear",
+        @Option(name = "delay_clear",
               usage = "wait in seconds before clearing (one of the clear options must be "
                     + "true for this to have effect); default = 0.")
         Integer delayClear = 0;

--- a/modules/dcache-frontend/src/test/java/org/dcache/restful/resources/bulk/BulkRequestJsonParseTest.java
+++ b/modules/dcache-frontend/src/test/java/org/dcache/restful/resources/bulk/BulkRequestJsonParseTest.java
@@ -1,0 +1,156 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.resources.bulk;
+
+import static org.dcache.restful.resources.bulk.BulkResources.toBulkRequest;
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.BadRequestException;
+import org.dcache.services.bulk.BulkRequest;
+import org.dcache.services.bulk.BulkRequest.Depth;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BulkRequestJsonParseTest {
+
+    static final String JSON_FORMAT = "{'activity':'%s', 'target':'%s',"
+          + "'arguments':{'lifetime':'%s','lifetime-unit':'%s'},"
+          + "'%s':'%s', '%s':'%s', '%s':'%s'}";
+
+    String requestJson;
+    BulkRequest bulkRequest;
+
+    String activity;
+    String target;
+    Integer lifetime;
+    TimeUnit lifetimeUnit;
+    Boolean clearOnSuccess;
+    Boolean clearOnFailure;
+    Depth expandDirectories;
+
+    @Before
+    public void setUp() {
+        activity = "PIN";
+        target = "/pnfs/fs/usr/test/testdir";
+        lifetime = 1;
+        lifetimeUnit = TimeUnit.MINUTES;
+        clearOnSuccess = true;
+        clearOnFailure = true;
+        expandDirectories = Depth.ALL;
+    }
+
+    @Test
+    public void shouldSucceedWithMixedAttributes() throws Exception {
+        givenJsonWithMixedAttributeStyle();
+        whenParsed();
+        assertThatRequestIsValid();
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldFailWithRedundantAttribute() throws Exception {
+        givenJsonWithAttributeDefinedTwice();
+        whenParsed();
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldFailWithUnsupportedAttribute() throws Exception {
+        givenJsonWithUnsupportedAttribute();
+        whenParsed();
+    }
+
+    private void assertThatRequestIsValid() {
+        assertEquals(activity, bulkRequest.getActivity());
+        assertEquals(target, bulkRequest.getTarget());
+        assertEquals((int) lifetime, Integer.parseInt(bulkRequest.getArguments().get("lifetime")));
+        assertEquals(lifetimeUnit,
+              TimeUnit.valueOf(bulkRequest.getArguments().get("lifetime-unit")));
+        assertEquals(clearOnFailure, bulkRequest.isClearOnFailure());
+        assertEquals(clearOnSuccess, bulkRequest.isClearOnSuccess());
+        assertEquals(expandDirectories, bulkRequest.getExpandDirectories());
+    }
+
+    private void givenJsonWithMixedAttributeStyle() {
+        requestJson = String.format(JSON_FORMAT, activity, target, lifetime, lifetimeUnit,
+              "clearOnSuccess", clearOnSuccess, "clear_on_failure", clearOnFailure,
+              "expand-directories", expandDirectories);
+    }
+
+    private void givenJsonWithAttributeDefinedTwice() {
+        /* clearOnSuccess = clear_on_success */
+        requestJson = String.format(JSON_FORMAT, activity, target, lifetime, lifetimeUnit,
+              "clearOnSuccess", clearOnSuccess, "clear_on_success", clearOnFailure,
+              "expand-directories", expandDirectories);
+    }
+
+    private void givenJsonWithUnsupportedAttribute() {
+        /* cancelOnSuccess is nonsense */
+        requestJson = String.format(JSON_FORMAT, activity, target, lifetime, lifetimeUnit,
+              "cancelOnSuccess", clearOnSuccess, "clear_on_failure", clearOnFailure,
+              "expand-directories", expandDirectories);
+    }
+
+    private void whenParsed() throws Exception {
+        bulkRequest = toBulkRequest(requestJson);
+    }
+}


### PR DESCRIPTION
Motivation:

The REST API design document for the bulk service
which, for better or worse, has become public,
is inconsistent in the way it defines
the (top level) bulk request attributes:
in most cases, snake_case is used, but
there is one case ('expand-directories')
where kebab-case is used.

What is more, the implementer (yours truly)
did not try to follow spec and let
the jackson ObjectMapper have its default
way with camelCase.   Hence, a mess.

Some users have already started to make
requests using the implemented (camelCase)
attributes, but new users who see the
published spec should not experience failures
if they observe it.

Modification:

The only way out of this is to support
all styles (camelCase, snake_case, kebab-case)
for the shared attributes, at least until
the next golden release.  Thus we have
substituted ad hoc parsing using GSON.

We have also provided a few basic JUnit
tests to make sure that stray and
doubly-defined attributes (via different
styles) are rejected.

The Swagger API has been changed to reflect
the document's usage.  We have also
done the same for the Bulk admin command.

Result:

Any combination of the three styles (used
once per request for a valid attribute)
will be accepted as
valid JSON for the Bulk Request.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13257/
Requires-notes: no
Requires-book: no
Acked-by: Tigran