### PR TITLE
dcache-bulk: fix handling of asynchronous pin requests

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/qos/UpdateQoSJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/qos/UpdateQoSJob.java
@@ -124,6 +124,13 @@ public class UpdateQoSJob extends SingleTargetJob implements NamespaceHandlerAwa
     }
 
     @Override
+    public void pollWaiting() {
+        if (replyHandler != null) {
+            replyHandler.handlePinReply();
+        }
+    }
+
+    @Override
     protected void doRun() {
         if (arguments == null) {
             setError(new IllegalArgumentException("no target qos given."));

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/queue/BulkServiceQueue.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/queue/BulkServiceQueue.java
@@ -83,6 +83,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import org.dcache.pinmanager.PinManagerAware;
 import org.dcache.services.bulk.BulkRequest;
 import org.dcache.services.bulk.BulkRequestStorageException;
 import org.dcache.services.bulk.BulkServiceException;
@@ -523,8 +524,7 @@ public class BulkServiceQueue implements SignalAware {
      * there and passing them to post-processing.
      *
      * <p>Finally, it checks the size of the running queue for available slots, and fills these
-     * from
-     * the ready queue.
+     * from the ready queue.
      *
      * <p>The sweeper is signalled/awakened and statistics are updated.
      */
@@ -574,8 +574,7 @@ public class BulkServiceQueue implements SignalAware {
          * the ready queue.
          *
          * <p>This method runs before the processNextReady() method, so that the ready queue is
-         * already
-         * filled with all jobs currently available to run.
+         * already filled with all jobs currently available to run.
          */
         private void appendSubmitted() {
             synchronized (submitted) {
@@ -756,8 +755,7 @@ public class BulkServiceQueue implements SignalAware {
          * submitted queue.
          *
          * <p>This method runs before the appendSubmitted() method, so that the append queue also
-         * has
-         * the requests which have become available at this pass.
+         * has the requests which have become available at this pass.
          */
         private void processNextRequests() {
             LOGGER.trace("processNextRequests()");
@@ -791,8 +789,7 @@ public class BulkServiceQueue implements SignalAware {
          * so, it removes it and places it on the waiting queue.
          *
          * <p>Synchronized on the running queue only to avoid ConcurrentModificationExceptions, as
-         * that
-         * queue is only accessed on this thread.
+         * that queue is only accessed on this thread.
          */
         private void removeFromRunning() {
             synchronized (runningQueue) {
@@ -884,6 +881,9 @@ public class BulkServiceQueue implements SignalAware {
                 if (waitingQueue.isEmpty()) {
                     return Collections.EMPTY_LIST;
                 }
+
+                waitingQueue.stream().filter(PinManagerAware.class::isInstance)
+                      .map(PinManagerAware.class::cast).forEach(PinManagerAware::pollWaiting);
 
                 return findJobsToRemove(waitingQueue);
             }

--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerAware.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerAware.java
@@ -64,4 +64,6 @@ import org.dcache.cells.CellStub;
 public interface PinManagerAware {
 
     void setPinManager(CellStub pinManager);
+
+    default void pollWaiting() {}
 }

--- a/modules/dcache/src/main/java/org/dcache/qos/QoSReplyHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/qos/QoSReplyHandler.java
@@ -122,10 +122,6 @@ public abstract class QoSReplyHandler {
             migrationFuture.addListener(() -> handleMigrationReply(), executor);
         }
 
-        if (pinFuture != null) {
-            pinFuture.addListener(() -> handlePinReply(), executor);
-        }
-
         LOGGER.trace("listen called: {}.", this);
     }
 
@@ -172,9 +168,18 @@ public abstract class QoSReplyHandler {
         }
     }
 
-    private synchronized void handlePinReply() {
+    /**
+     *  Unlike handleMigrationReply, this method supports polling semantics:
+     *  it should be called from inside a loop.
+     */
+    public synchronized void handlePinReply() {
         if (pinFuture == null) {
             LOGGER.debug("No pin future set, no reply expected.");
+            return;
+        }
+
+        LOGGER.debug("poll, checking pin request future.isDone().");
+        if (!pinFuture.isDone()) {
             return;
         }
 

--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -110,10 +110,10 @@ bulk.limits.request-store-clear-threads=5
 #  ---- Interval of inactivity by the queue consumer if not signalled
 #       internally (as for instance when a job completes).
 #
-#       Given the latency (time-to-completion) of bulk operations,
-#       the queue consumer need not wake up on its own frequently.
+#       Since staging/pin completion is ascertained by polling, it makes
+#       sense not to make this interval too long.
 #
-bulk.limits.queue-sweep-interval=3
+bulk.limits.queue-sweep-interval=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)bulk.limits.queue-sweep-interval.unit=MINUTES
 
 #  ---- Requests (but not individual tasks/jobs) are stored on disk so that


### PR DESCRIPTION
Motivation:

In the future QoSEngine (in this case,
the QoSAdjuster, already committed
master@2165c59237bdeb5af2a9c20441c6feadb000bb58
https://rb.dcache.org/r/12901/
see StagingAdjuster.java), pinning
is handled using a Long.MAX_VALUE
time to live on the send, and by
polling the returned future
periodically (future.isDone().

In the Bulk methods, however,
both for PIN and QoS, the
thread executing the task actually
waits on the Future by doing
get (uninterruptably), and (in the case
of PIN) neglects to indicate indefinite
time-to-live.  This creates two issues:

(a) if the staging takes longer
(as very likely it can) than the
default time to live (5 minutes),
the Future will never get updated;
(b) threads from the pool are
idling instead of being used to
execute other tasks, leading to
lower throughput.

Modification:

Change the way Bulk handles
pin requests to be like the
QoSStagingAdjuster (polling +
indefinite time to live).

Result:

Greater throughput and reliability.

This is the first of several changes
needed to make the Bulk service robust
enough to deploy in production.
Hence we request a backport to 7.2.

Target: master
Request: 7.2
Requires-book: no
Requires-notes: yes
Patch: https://rb.dcache.org/r/13254/
Acked-by: Lea