### PR TITLE
skel: added example configuration for needrestart

### DIFF
--- a/skel/doc/examples/needrestart/README.md
+++ b/skel/doc/examples/needrestart/README.md
@@ -1,0 +1,14 @@
+Example Configuration For needrestart
+======================================
+[needrestart](https://github.com/liske/needrestart) is a program that detects
+which services need to be restarted after upgrades have been made.
+
+Depending on it’s configuration it selects any such services for being
+restarted.
+
+In a production dCache-cluster this is however typically undesired.
+
+The files `exclude-dcache.conf` and `exclude-postgresql.conf` serve as examples
+how needrestart can be configured to not automatically select dCache
+respectively PostgreSQL for being restarted.
+They need to be placed into `/etc/needrestart/conf.d/`.

--- a/skel/doc/examples/needrestart/exclude-dcache.conf
+++ b/skel/doc/examples/needrestart/exclude-dcache.conf
@@ -1,0 +1,1 @@
+$nrconf{override_rc}{qr(^dcache@.+\.service)} = 0;

--- a/skel/doc/examples/needrestart/exclude-postgresql.conf
+++ b/skel/doc/examples/needrestart/exclude-postgresql.conf
@@ -1,0 +1,1 @@
+$nrconf{override_rc}{qr(^postgresql@.+\.service)} = 0;


### PR DESCRIPTION
Motivation:

needrestart is “semi-default” on Debian systems (and may be used with any other
distributions as well.
It allows to detect which services need to be restarted after upgrades and, per
default, automatically selects them for being so.

For dCache and it’s dependencies like PostgreSQL, this is typically undesired on
production clusters.

Modification:

Added example configuration and documentation on how to specifically prevent
that behaviour for dCache and PostgreSQL.

Target: master
Requires-notes: no
Requires-book: no
Issue: #6194
Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>