### PR TITLE
dcache-xroot: support kXR_delete as a write request on the pool

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -399,7 +399,11 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler {
                     throw new XrootdException(kXR_FileNotOpen, "File exists.");
                 } else if (msg.isDelete() && !isWrite) {
                     throw new XrootdException(kXR_Unsupported, "File exists.");
-                } else if ((msg.isNew() || msg.isReadWrite()) && isWrite) {
+                    /*
+                     *  Some clients express only kXR_delete when then intend to write
+                     *  so we need to consider delete as a write request here.
+                     */
+                } else if ((msg.isNew() || msg.isReadWrite() || msg.isDelete()) && isWrite) {
                     boolean posc = (msg.getOptions() & kXR_posc) == kXR_posc ||
                           file.getProtocolInfo().getFlags()
                                 .contains(XrootdProtocolInfo.Flags.POSC);


### PR DESCRIPTION
Motivation:

A number of tickets, starting with GGUS #150289
"cannot stream content from ROOT to ALICE dCache instances"
report experiencing an inability to write/upload to
dCache pools because the get an error:

```
ERROR] Server responded with an error: [3004] Tried to write on read only file.
```

Apparently, some clients do not express open for write with
kXR_new or kXR_readwrite flags, but rather with the kXR_delete
flag.  E.g., instead of the xrdcp open:

```
oss.asize=1, mode: 0644, flags: kXR_new kXR_open_updt kXR_async kXR_retstat
```

one sees

```
mode: 00, flags: kXR_delete kXR_async kXR_retstat
```

While kXR_delete on the door will trigger a PoolAcceptFileMessage,
thus setting the channel mode to include write, the pool
request handler checks these flags to see what kind
of FileDescriptor to open.   In the absence of new or readwrite,
it opens a ReadDescriptor.

Modification:

Add a check for kXR_delete to the pool request open handling.

Result:

The clients sending only kXR_delete for write should no longer fail.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13259/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran
Acked-by: Lea