### PR TITLE
storagedescriptor: fix element name to 'latestupdate'

### DIFF
--- a/skel/share/xml/xslt/storage-descriptor.xsl
+++ b/skel/share/xml/xslt/storage-descriptor.xsl
@@ -7,7 +7,7 @@
 
 
 <!--+
-    | Copyright (c) 2018, Deutsches Elektronen-Synchrotron (DESY)
+    | Copyright (c) 2018-2021, Deutsches Elektronen-Synchrotron (DESY)
     | All rights reserved.
     |
     | Redistribution and use in source and binary forms, with
@@ -46,7 +46,13 @@
 
 <!--+
     | This XSLT template converts dCache info format into WLCG
-    | Storage Descriptor format.
+    | Storage Descriptor format.  This template targets SRR v6:
+    |
+    |    https://twiki.cern.ch/twiki/pub/LCG/StorageSpaceAccounting/SRR.v6.pdf
+    |
+    | For further details, see:
+    |
+    |     https://twiki.cern.ch/twiki/bin/view/LCG/StorageSpaceAccounting
     +-->
 
 <xsl:stylesheet version="1.0"
@@ -101,7 +107,7 @@
   <xsl:apply-templates select="*" mode="online-capacity"/>
   <xsl:apply-templates select="document('&storage-descriptor.paths.tape-info;')" mode="nearline-capacity"/>
   <xsl:text>    },&#x0a;</xsl:text>
-  <xsl:value-of select="concat('    &quot;lastupdated&quot;: ',date:seconds(),',&#x0a;')"/>
+  <xsl:value-of select="concat('    &quot;latestupdate&quot;: ',date:seconds(),',&#x0a;')"/>
   <xsl:text>    "storageendpoints": [&#x0a;</xsl:text>
   <xsl:apply-templates select="/d:dCache/d:doors/d:door[d:tags/d:tag[@id='&storage-descriptor.door.tag;']][d:interfaces/d:interface/d:metric[@name='scope'] = 'global']" mode="publish-door"/>
   <xsl:text>    ],&#x0a;</xsl:text>


### PR DESCRIPTION
Motivation:

Currently, the XSLT template creates JSON with the element
'lastupdated'.  The name of this element is wrong; the correct attribute
is 'latestupdate'.

Modification:

Add reference to the spec. for future reference.

Update the field name to the correct value.

Result:

The script for generating SRR records (from the info service output) has
been updated.  The field 'lastupdated' has been adjusted to the correct
name 'latestupdate'.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: no
Closes: #6254
Patch: https://rb.dcache.org/r/13268/
Acked-by: Tigran Mkrtchyan