### PR TITLE
nfsv: convert UnixNumericXxxPrincipal into dCache analogs

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1353,7 +1353,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         NfsTransfer(PnfsHandler pnfs, NFS4Client client, NFS4State openStateId,
               Inode nfsInode, Subject ioSubject) throws ChimeraNFSException {
-            super(pnfs, Subjects.ROOT, Restrictions.none(), ioSubject, null);
+            super(pnfs, Subjects.ROOT, Restrictions.none(), Subjects.fromUnixNumericSubject(ioSubject), null);
 
             _nfsInode = nfsInode;
 


### PR DESCRIPTION
Motivation:
since nfs4j uses UnixNumericUserPrincipal and UnixNumericGroupPrincipal
instead of dCache analogs (due to license conflict) some services
that expect numeric ids fail with exception:

000075F58AC6438F4C718DA7EDCBA95FF53E] Message processing failed: Subject has no primary GID
Nov 11 11:00:22 hepl@dCacheDomain[20067]: java.util.NoSuchElementException: Subject has no primary GID
Nov 11 11:00:22 hepl@dCacheDomain[20067]: at org.dcache.auth.Subjects.getPrimaryGid(Subjects.java:223)

Before we update dCache to accept UnixNumericUserPrincipal and
UnixNumericGroupPrincipal this regression can be fixed by conversion
user subject to dCache compliant version.

Modification:
Introduce Subjects#fromUnixNumericSubject to procduce a copy of a
subject with dCache compliant numeric principals.

Result:
nfs writes into space reservations are possible.

Acked-by: Paul Millar
Acked-by: Albert Rossi
Target: master, 7.2, 7.1, 7.0
Require-book: no
Require-notes: yes
(cherry picked from commit 53f8154e671d7cffcc3227d1980608f599ecd66d)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>