### PR TITLE
nfsv: convert UnixNumericXxxPrincipal into dCache analogs

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/DCacheAwareJdbcFs.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/DCacheAwareJdbcFs.java
@@ -60,8 +60,6 @@ documents or software obtained from this server.
 package org.dcache.chimera;
 
 import com.google.common.base.Throwables;
-import com.sun.security.auth.UnixNumericGroupPrincipal;
-import com.sun.security.auth.UnixNumericUserPrincipal;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileLocality;
 import diskCacheV111.util.PermissionDeniedCacheException;
@@ -78,10 +76,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.AccessController;
-import java.security.Principal;
 import java.sql.SQLException;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -92,9 +88,7 @@ import javax.security.auth.Subject;
 import javax.sql.DataSource;
 import org.apache.curator.shaded.com.google.common.collect.ImmutableMap;
 import org.dcache.acl.enums.AccessMask;
-import org.dcache.auth.GidPrincipal;
 import org.dcache.auth.Subjects;
-import org.dcache.auth.UidPrincipal;
 import org.dcache.cells.CellStub;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.pinmanager.PinManagerListPinsMessage;
@@ -373,36 +367,7 @@ public class DCacheAwareJdbcFs extends JdbcFs implements CellIdentityAware {
      * Also turns Unix principals into Uid and Gid principals.
      */
     private static Subject getSubjectFromContext() {
-        Subject subject = Subject.getSubject(AccessController.getContext());
-
-        UnixNumericUserPrincipal userPrincipal = null;
-        List<UnixNumericGroupPrincipal> groupPrincipals = new ArrayList<>();
-
-        for (Principal principal : subject.getPrincipals()) {
-            if (principal instanceof UnixNumericUserPrincipal) {
-                userPrincipal = (UnixNumericUserPrincipal) principal;
-            } else if (principal instanceof UnixNumericGroupPrincipal) {
-                groupPrincipals.add((UnixNumericGroupPrincipal) principal);
-            }
-        }
-
-        if (userPrincipal == null) {
-            return subject;
-        }
-
-        Principal origin = Subjects.getOrigin(subject);
-
-        subject = new Subject();
-        Set<Principal> principals = subject.getPrincipals();
-        principals.add(new UidPrincipal(userPrincipal.longValue()));
-        groupPrincipals.forEach(
-              p -> principals.add(new GidPrincipal(p.longValue(), p.isPrimaryGroup())));
-        if (origin != null) {
-            principals.add(origin);
-        }
-
-        subject.setReadOnly();
-        return subject;
+        return Subjects.fromUnixNumericSubject(Subject.getSubject(AccessController.getContext()));
     }
 
     private String getRequestId(Subject subject) throws PermissionDeniedCacheException {

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1353,7 +1353,7 @@ public class NFSv41Door extends AbstractCellComponent implements
 
         NfsTransfer(PnfsHandler pnfs, NFS4Client client, NFS4State openStateId,
               Inode nfsInode, Subject ioSubject) throws ChimeraNFSException {
-            super(pnfs, Subjects.ROOT, Restrictions.none(), ioSubject, null);
+            super(pnfs, Subjects.ROOT, Restrictions.none(), Subjects.fromUnixNumericSubject(ioSubject), null);
 
             _nfsInode = nfsInode;
 


### PR DESCRIPTION
Motivation:
since nfs4j uses UnixNumericUserPrincipal and UnixNumericGroupPrincipal
instead of dCache analogs (due to license conflict) some services
that expect numeric ids fail with exception:

000075F58AC6438F4C718DA7EDCBA95FF53E] Message processing failed: Subject has no primary GID
Nov 11 11:00:22 hepl@dCacheDomain[20067]: java.util.NoSuchElementException: Subject has no primary GID
Nov 11 11:00:22 hepl@dCacheDomain[20067]: at org.dcache.auth.Subjects.getPrimaryGid(Subjects.java:223)

Before we update dCache to accept UnixNumericUserPrincipal and
UnixNumericGroupPrincipal this regression can be fixed by conversion
user subject to dCache compliant version.

Modification:
Introduce Subjects#fromUnixNumericSubject to procduce a copy of a
subject with dCache compliant numeric principals.

Result:
nfs writes into space reservations are possible.

Acked-by: Paul Millar
Acked-by: Albert Rossi
Target: master, 7.2, 7.1, 7.0
Require-book: no
Require-notes: yes
(cherry picked from commit 53f8154e671d7cffcc3227d1980608f599ecd66d)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>