### PR TITLE
rpm: include default rsyslog configuration

### DIFF
--- a/packages/fhs/src/main/assembly/rpm.xml
+++ b/packages/fhs/src/main/assembly/rpm.xml
@@ -17,6 +17,11 @@
         <outputDirectory>etc/logrotate.d</outputDirectory>
         <destName>dcache</destName>
       </file>
+      <file>
+          <source>src/main/scripts/dcache.rsyslog</source>
+          <outputDirectory>etc/rsyslog.d</outputDirectory>
+          <destName>30-dcache.conf</destName>
+      </file>
     </files>
     <fileSets>
         <fileSet>

--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -128,6 +128,7 @@ rm -rf "$RPM_BUILD_ROOT"
 %attr(0755,root,root) /etc/bash_completion.d/dcache
 %config(noreplace) %attr(0644,root,root) /etc/security/limits.d/92-dcache.conf
 %config(noreplace) %attr(0644,root,root) /etc/logrotate.d/dcache
+%config(noreplace) %attr(0644,root,root) /etc/rsyslog.d/30-dcache.conf
 
 %docdir /usr/share/doc/dcache
 %config(noreplace) /etc/dcache


### PR DESCRIPTION
Motivation:
Some admins still prefer to produce log files. As journalbeat can be
redirected to the rsyslog, a standard configuration will help to avoid
reinventing of a wheel. The provided configuration can be enabled by
updating /etc/systemd/journald.conf as:

ForwardToSyslog=yes

Modification:
update rpm to include pre-configured, but not enabled rsyslog file

/etc/rsyslog.d/30-dcache.conf

Result:
simplification of rsyslog configuration for dcache

Acked-by: Dmitry Litvintsev
Target: master, 7.2
Require-book: yes
Require-notes: yes
(cherry picked from commit afb3fb85451c30c15a0e024a9e5c017d6d3a09ba)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>