### PR TITLE
gplazma: scitoken add support for OPs that advertise keys without kid

### DIFF
--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Supplier;
 import org.apache.http.client.HttpClient;
 import org.dcache.gplazma.AuthenticationException;
@@ -141,6 +142,14 @@ public class Issuer {
         return Optional.of(url);
     }
 
+    private Optional<String> getOptionalString(JsonNode details, String key) throws BadKeyDescriptionException {
+        JsonNode value = details.get(key);
+        if (value != null && !value.isTextual()) {
+            throw new BadKeyDescriptionException("Attribute not textual " + key);
+        }
+        return Optional.ofNullable(value).map(JsonNode::asText);
+    }
+
     private Map<String, PublicKey> parseJwks() {
         JsonNode keys = jwks.get("keys");
         if (keys == null) {
@@ -155,7 +164,7 @@ public class Issuer {
         Map<String, PublicKey> publicKeys = new HashMap<>();
         for (JsonNode key : keys) {
             try {
-                String kid = getString(key, "kid");
+                String kid = getOptionalString(key, "kid").orElseGet(() -> UUID.randomUUID().toString());
                 publicKeys.put(kid, buildPublicKey(key));
             } catch (BadKeyDescriptionException e) {
                 LOGGER.warn("Bad public key: {}", e.getMessage());


### PR DESCRIPTION
Motivation:

The 'kid', the key-identifier, is an optional value that the OP may use.
It allows the JWT to indicate which of several public keys should be
used to verify the signature.  Assigning kid values to public keys is
optional: an OP may publish their public keys without giving them IDs.

Currently the scitoken plugin requires that a `kid` is present, which is
wrong.

Modification:

The plugin already supports JWTs without a `kid` by trying all the
public keys the OP has published, irrespective of the OP-published kid.

Therefore, one solution is to create a (dCache internal) kid value if
the OP doesn't provide one.  This is needed to allow that the public key
may be added to the map.

Result:

The scitoken plugin now supports OPs that publish their public keys
without any corresponding ID (i.e., no `kid` value).

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13274/
Acked-by: Albert Rossi