### PR TITLE
gplazma: scitoken add support for OPs that advertise keys without kid

### DIFF
--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Supplier;
 import org.apache.http.client.HttpClient;
 import org.dcache.gplazma.AuthenticationException;
@@ -141,6 +142,14 @@ public class Issuer {
         return Optional.of(url);
     }
 
+    private Optional<String> getOptionalString(JsonNode details, String key) throws BadKeyDescriptionException {
+        JsonNode value = details.get(key);
+        if (value != null && !value.isTextual()) {
+            throw new BadKeyDescriptionException("Attribute not textual " + key);
+        }
+        return Optional.ofNullable(value).map(JsonNode::asText);
+    }
+
     private Map<String, PublicKey> parseJwks() {
         JsonNode keys = jwks.get("keys");
         if (keys == null) {
@@ -155,7 +164,7 @@ public class Issuer {
         Map<String, PublicKey> publicKeys = new HashMap<>();
         for (JsonNode key : keys) {
             try {
-                String kid = getString(key, "kid");
+                String kid = getOptionalString(key, "kid").orElseGet(() -> UUID.randomUUID().toString());
                 publicKeys.put(kid, buildPublicKey(key));
             } catch (BadKeyDescriptionException e) {
                 LOGGER.warn("Bad public key: {}", e.getMessage());

--- a/modules/gplazma2-scitoken/src/test/java/org/dcache/gplazma/scitoken/SciTokenPluginTest.java
+++ b/modules/gplazma2-scitoken/src/test/java/org/dcache/gplazma/scitoken/SciTokenPluginTest.java
@@ -62,6 +62,7 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -94,6 +95,8 @@ import org.dcache.util.PrincipalSetMaker;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
+
+import static com.google.common.base.Preconditions.checkState;
 
 public class SciTokenPluginTest {
 
@@ -321,6 +324,27 @@ public class SciTokenPluginTest {
               .withClaim("scope", "read:/")
               .withClaim("exp", Instant.now().plus(10, MINUTES))
               .issuedBy("OP1").usingKey("key1"));
+
+        assertThat(identifiedPrincipals, hasItems(new UidPrincipal(1000),
+              new GidPrincipal(1000, true), new JwtSubPrincipal("EXAMPLE", sub),
+              new JwtJtiPrincipal("EXAMPLE", jti)));
+    }
+
+    @Test
+    public void shouldAcceptNonExpiredJwtWithoutKid() throws Exception {
+        given(aSciTokenPlugin().withProperty("gplazma.scitoken.issuer!EXAMPLE",
+              "https://example.org/ /prefix/path uid:1000 gid:1000"));
+        givenThat("OP1",
+              isAnIssuer().withURL("https://example.org/").withKey(rsa256Keys()));
+
+        String sub = UUID.randomUUID().toString();
+        String jti = UUID.randomUUID().toString();
+        whenAuthenticatingWith(aJwtToken()
+              .withClaim("jti", jti)
+              .withClaim("sub", sub)
+              .withClaim("scope", "read:/")
+              .withClaim("exp", Instant.now().plus(10, MINUTES))
+              .issuedBy("OP1"));
 
         assertThat(identifiedPrincipals, hasItems(new UidPrincipal(1000),
               new GidPrincipal(1000, true), new JwtSubPrincipal("EXAMPLE", sub),
@@ -1377,6 +1401,7 @@ public class SciTokenPluginTest {
     private class IssuerInfoBuilder {
 
         private final Map<String, KeyMaterial> keys = new HashMap<>();
+        private List<KeyMaterial> keysWithoutKid = new ArrayList<>();
         private String url;
         private String jwkPath = "/jwk";
         private Optional<String> jwtContents = Optional.empty();
@@ -1390,6 +1415,11 @@ public class SciTokenPluginTest {
 
         public IssuerInfoBuilder withKey(String id, KeyMaterial material) {
             keys.put(id, material);
+            return this;
+        }
+
+        public IssuerInfoBuilder withKey(KeyMaterial material) {
+            keysWithoutKid.add(material);
             return this;
         }
 
@@ -1415,7 +1445,7 @@ public class SciTokenPluginTest {
 
         public IssuerInfo build() {
             return new IssuerInfo(url, keys, configurationPath, configurationContents,
-                  jwkPath, jwtContents);
+                  jwkPath, jwtContents, keysWithoutKid);
         }
     }
 
@@ -1528,6 +1558,7 @@ public class SciTokenPluginTest {
 
         private final URI base;
         private final Map<String, KeyMaterial> keys;
+        private final List<KeyMaterial> keysWithoutKid;
         private final String keyPath;
         private final String configurationPath;
         private final Optional<String> openidConfig;
@@ -1535,17 +1566,26 @@ public class SciTokenPluginTest {
 
         public IssuerInfo(String base, Map<String, KeyMaterial> keys,
               String configurationPath, Optional<String> openidConfig,
-              String jwkPath, Optional<String> jwtContents) {
+              String jwkPath, Optional<String> jwtContents, List<KeyMaterial> keysWithoutKid) {
             this.base = URI.create(base);
             this.keys = keys;
             this.keyPath = jwkPath;
             this.configurationPath = configurationPath;
             this.openidConfig = openidConfig;
             this.jwtContents = jwtContents;
+            this.keysWithoutKid = keysWithoutKid;
         }
 
         public KeyMaterial getKey(String kid) {
             return keys.get(kid);
+        }
+
+        /**
+         * Return the single key without kid.
+         */
+        public KeyMaterial getKey() {
+            checkState(keys.isEmpty() && keysWithoutKid.size() == 1);
+            return keysWithoutKid.get(0);
         }
 
         private String buildOpenidConfiguration() {
@@ -1562,6 +1602,10 @@ public class SciTokenPluginTest {
                 ObjectNode keyInfo = keysArray.addObject();
                 keyInfo.put("kid", key.getKey());
                 key.getValue().addToJwt(keyInfo);
+            }
+            for (KeyMaterial key : keysWithoutKid) {
+                ObjectNode keyInfo = keysArray.addObject();
+                key.addToJwt(keyInfo);
             }
 
             return json.toString();
@@ -1643,10 +1687,15 @@ public class SciTokenPluginTest {
 
         private String header() {
             ObjectNode json = MAPPER.createObjectNode();
-            json.put("kid", kid);
-            KeyMaterial keys = requireNonNull(issuer.getKey(kid), "Unknown kid");
-            json.put("alg", keys.alg);
+            if (kid != null) {
+                json.put("kid", kid);
+            }
+            json.put("alg", getKey().alg);
             return json.toString();
+        }
+
+        private KeyMaterial getKey() {
+            return kid == null? issuer.getKey() : issuer.getKey(kid);
         }
 
         private String payload() {
@@ -1671,12 +1720,11 @@ public class SciTokenPluginTest {
 
         public String build() {
             requireNonNull(issuer, "Missing issuedBy() call");
-            requireNonNull(kid, "Missing usingKey() call");
             String encodedHeader = base64Encoded(header());
             String encodedPayload = base64Encoded(payload());
 
             String valueToBeSigned = encodedHeader + "." + encodedPayload;
-            String signature = issuer.getKey(kid).sign(valueToBeSigned);
+            String signature = getKey().sign(valueToBeSigned);
             return valueToBeSigned + "." + signature;
         }
     }


### PR DESCRIPTION
Motivation:

The 'kid', the key-identifier, is an optional value that the OP may use.
It allows the JWT to indicate which of several public keys should be
used to verify the signature.  Assigning kid values to public keys is
optional: an OP may publish their public keys without giving them IDs.

Currently the scitoken plugin requires that a `kid` is present, which is
wrong.

Modification:

The plugin already supports JWTs without a `kid` by trying all the
public keys the OP has published, irrespective of the OP-published kid.

Therefore, one solution is to create a (dCache internal) kid value if
the OP doesn't provide one.  This is needed to allow that the public key
may be added to the map.

Result:

The scitoken plugin now supports OPs that publish their public keys
without any corresponding ID (i.e., no `kid` value).

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13274/
Acked-by: Albert Rossi