### PR TITLE
resilience: fix runtime exception triggered by side effect of logging

### DIFF
--- a/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
+++ b/modules/dcache-resilience/src/main/java/org/dcache/resilience/data/FileUpdate.java
@@ -328,9 +328,7 @@ public final class FileUpdate {
          *  having no requirement set.
          */
         if (!constraints.isResilient()) {
-            LOGGER.trace("validateForAction, storage unit was not resilient: "
-                        + "required = {}",
-                  constraints.getRequired());
+            LOGGER.trace("validateForAction, storage unit was not resilient ... ignoring");
             return false;
         }
 


### PR DESCRIPTION
fixes (e6534d4de2f54d94dd55b188e2bbf665c1bd60a7)

Motivation:
the StorageUnitConstraints#getRequired throws RuntimeException is called
on non resilient group. This guard is there to catch programmatic defects,
which it did: we should not ask for replica count if we already knew that
storage group is not resilient.

Modification:
remove extra call to replica count number in debug output for non
resilient storage group.

Result:
works as expected.

Acked-by: Albert Rossi
Acked-by: Lea Morschel
Target: master, 7.2, 7.1, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 9d3a156cdd1beeb0fc2ae00bcef55dd33fa029be)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>