### PR TITLE
pom.xml: update xrootd4j dependencies to 4.2.5/4.1.6/4.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.35.v20201120</version.jetty>
-        <version.xrootd4j>4.1.5</version.xrootd4j>
+        <version.xrootd4j>4.1.6</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.3</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>


### PR DESCRIPTION
Provides bug fix corresponding to

https://rb.dcache.org/r/13264/
master@701211c22c1d6cc5b346af6df9f382241e99c0ff

see GitHub Xroot "Session not found"
https://github.com/dCache/dcache/issues/6246

Target: master - 4.2.5
Request: 7.2   - 4.2.5
Request: 7.1   - 4.1.6
Request: 7.0   - 4.0.11
Request: 6.2   - 4.0.11
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13278/
Acked-by: Tigran
Acked-by: Lea