### PR TITLE
CanlContextFactory: throw FileNotFound for missing ca certs dir

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteGsiftpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteGsiftpTransferService.java
@@ -25,6 +25,7 @@ import eu.emi.security.authn.x509.CrlCheckingMode;
 import eu.emi.security.authn.x509.NamespaceCheckingMode;
 import eu.emi.security.authn.x509.OCSPCheckingMode;
 import java.util.concurrent.TimeUnit;
+import java.io.IOException;
 import org.dcache.pool.movers.MoverProtocol;
 import org.dcache.pool.movers.RemoteGsiftpTransferProtocol;
 import org.dcache.ssl.CanlContextFactory;
@@ -127,7 +128,7 @@ public class RemoteGsiftpTransferService extends AbstractMoverProtocolTransferSe
         return moverProtocol;
     }
 
-    private synchronized SslContextFactory getContextFactory() {
+    private synchronized SslContextFactory getContextFactory() throws IOException {
         if (sslContextFactory == null) {
             sslContextFactory =
                   CanlContextFactory.custom()

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/AbstractFileTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/AbstractFileTransferAgent.java
@@ -1,6 +1,7 @@
 package org.dcache.srm.shell;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.axis.types.URI;
@@ -11,7 +12,7 @@ import org.apache.axis.types.URI;
 public abstract class AbstractFileTransferAgent implements FileTransferAgent {
 
     @Override
-    public void start() {
+    public void start() throws IOException {
         // Nothing needed.
     }
 
@@ -27,7 +28,7 @@ public abstract class AbstractFileTransferAgent implements FileTransferAgent {
      * Alter an option.
      */
     @Override
-    public void setOption(String key, String value) {
+    public void setOption(String key, String value)  throws IOException {
         throw new IllegalArgumentException("No such option \"" + key + "\"");
     }
 

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/AxisSrmFileSystem.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/AxisSrmFileSystem.java
@@ -26,6 +26,7 @@ import static org.dcache.srm.shell.TStatusCodes.checkSuccess;
 import com.google.common.base.Throwables;
 import eu.emi.security.authn.x509.X509Credential;
 import java.io.File;
+import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.Collections;
 import java.util.Map;
@@ -110,7 +111,7 @@ public class AxisSrmFileSystem implements SrmFileSystem {
     }
 
     @Override
-    public void start() {
+    public void start() throws IOException {
         ExtendableFileTransferAgent transferAgent = new ExtendableFileTransferAgent();
         transferAgent.setCredential(credential);
         transferAgent.start();
@@ -518,7 +519,7 @@ public class AxisSrmFileSystem implements SrmFileSystem {
     }
 
     @Override
-    public void setTransportOption(String key, String value) {
+    public void setTransportOption(String key, String value) throws IOException {
         srmAgent.setOption(key, value);
     }
 

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/ExtendableFileTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/ExtendableFileTransferAgent.java
@@ -3,6 +3,7 @@ package org.dcache.srm.shell;
 import com.google.common.collect.ImmutableMap;
 import eu.emi.security.authn.x509.X509Credential;
 import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -51,7 +52,7 @@ public class ExtendableFileTransferAgent implements FileTransferAgent, Credentia
     }
 
     @Override
-    public void setOption(String key, String value) {
+    public void setOption(String key, String value) throws IOException {
         int index = key.indexOf('.');
         if (index == -1 || index == 0 || index == key.length() - 1) {
             throw new IllegalArgumentException("Unknown key: " + key);
@@ -70,7 +71,7 @@ public class ExtendableFileTransferAgent implements FileTransferAgent, Credentia
     }
 
     @Override
-    public void start() {
+    public void start() throws IOException {
         for (FileTransferAgent agent : agents) {
             if (agent instanceof CredentialAware) {
                 ((CredentialAware) agent).setCredential(_credential);

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/FileTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/FileTransferAgent.java
@@ -1,6 +1,7 @@
 package org.dcache.srm.shell;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.apache.axis.types.URI;
@@ -14,7 +15,7 @@ public interface FileTransferAgent extends AutoCloseable {
     /**
      * Called precisely once, before download, upload or getSupportedProtocols.
      */
-    void start();
+    void start() throws IOException;
 
     /**
      * A name for this transport.  The value should be lower-case and unique in the set of
@@ -31,7 +32,7 @@ public interface FileTransferAgent extends AutoCloseable {
     /**
      * Alter an option.
      */
-    void setOption(String key, String value);
+    void setOption(String key, String value) throws IOException;
 
     /**
      * Download a file to a locally-attached storage medium (e.g., harddisk) from some remote

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/GridFTPTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/GridFTPTransferAgent.java
@@ -80,7 +80,7 @@ public class GridFTPTransferAgent extends AbstractFileTransferAgent implements C
         IF_AVAILABLE, REQUIRE, IGNORE;
     }
 
-    private void updateCanlContextFactory() {
+    private void updateCanlContextFactory() throws IOException {
         _sslContextFactory = CanlContextFactory.custom()
               .withCertificateAuthorityPath(_caPath)
               .withCrlCheckingMode(_crlChecking)
@@ -122,7 +122,7 @@ public class GridFTPTransferAgent extends AbstractFileTransferAgent implements C
     }
 
     @Override
-    public void setOption(String key, String value) {
+    public void setOption(String key, String value) throws IOException {
         switch (key) {
             case "data.connection-initiator":
                 _dataInitiator = Entity.valueOf(value);
@@ -169,7 +169,7 @@ public class GridFTPTransferAgent extends AbstractFileTransferAgent implements C
     }
 
     @Override
-    public void start() {
+    public void start() throws IOException {
         updateCanlContextFactory();
     }
 

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmFileSystem.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmFileSystem.java
@@ -19,6 +19,7 @@ package org.dcache.srm.shell;
 
 import eu.emi.security.authn.x509.X509Credential;
 import java.io.File;
+import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -40,7 +41,7 @@ import org.dcache.srm.v2_2.TSupportedTransferProtocol;
 @ParametersAreNonnullByDefault
 public interface SrmFileSystem extends AutoCloseable {
 
-    void start();
+    void start() throws IOException;
 
     void setCredential(X509Credential credential);
 
@@ -107,5 +108,5 @@ public interface SrmFileSystem extends AutoCloseable {
     @Nonnull
     Map<String, String> getTransportOptions();
 
-    void setTransportOption(String key, String value);
+    void setTransportOption(String key, String value) throws IOException;
 }

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -2557,7 +2557,7 @@ public class SrmShell extends ShellApplication {
         String value;
 
         @Override
-        public String call() {
+        public String call() throws IOException {
             fs.setTransportOption(key, value);
             return "";
         }

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmTransferAgent.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmTransferAgent.java
@@ -12,6 +12,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.File;
+import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
@@ -87,7 +88,7 @@ public class SrmTransferAgent extends AbstractFileTransferAgent {
      * Alter an option.
      */
     @Override
-    public void setOption(String key, String value) {
+    public void setOption(String key, String value) throws IOException {
         agent.setOption(key, value);
     }
 

--- a/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
+++ b/modules/srm-common/src/main/java/org/dcache/srm/client/SRMClientV2.java
@@ -247,7 +247,7 @@ public class SRMClientV2 implements ISRM {
         axis_isrm = buildStub(nextServiceURL());
     }
 
-    private static SRMServiceLocator buildServiceLocator(String caPath) {
+    private static SRMServiceLocator buildServiceLocator(String caPath) throws IOException {
         SimpleProvider provider = new SimpleProvider();
         GsiHttpClientSender sender = new GsiHttpClientSender();
         sender.setSslContextFactory(


### PR DESCRIPTION
Motivation:

See GitHub issue #5605
https://github.com/dCache/dcache/issues/5605

The correction from RuntimeError to FileNotFoundException
needs to be made similarly for the doors that support
HTTPS (frontend, webdav).

Modification:

In the CanlContextFactory, check for the CA cert directory
and throw FNF if it is not there.

Unfortunately this change also entails modifying the
signature of a number of interface and class methods
to throw IOException.

Result:

Clearer error message which does not denote a bug.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-book: no
Requires-notes: yes
Patch: https://rb.dcache.org/r/13253
Closes: #5605
Acked-by: Lea
Acked-by: Tigran