### PR TITLE
pool: fix open queue flag when template defined by `queue define class`

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/StorageClassContainer.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/StorageClassContainer.java
@@ -3,6 +3,7 @@ package org.dcache.pool.classic;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toCollection;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
 import diskCacheV111.pools.StorageClassFlushInfo;
 import diskCacheV111.util.CacheException;
@@ -96,7 +97,8 @@ public class StorageClassContainer
         return _pnfsIds.get(pnfsId);
     }
 
-    private synchronized StorageClassInfo defineStorageClass(String hsmName, String storageClass) {
+    @VisibleForTesting
+    synchronized StorageClassInfo defineStorageClass(String hsmName, String storageClass) {
         StorageClassInfo info =
               getStorageClassInfo(hsmName, storageClass);
         if (info == null) {
@@ -170,7 +172,7 @@ public class StorageClassContainer
             classInfo = new StorageClassInfo(_storageHandler, hsmName, storageClass);
             //
             // in case we find a template, we take the
-            // 'pending', 'expire' and 'total' parameter from it.
+            // 'pending', 'expire', 'total' and 'open' parameter from it.
             //
             StorageClassInfo tmpInfo =
                   _storageClasses.get("*@" + hsmName);
@@ -178,6 +180,7 @@ public class StorageClassContainer
                 classInfo.setExpiration(tmpInfo.getExpiration());
                 classInfo.setPending(tmpInfo.getPending());
                 classInfo.setMaxSize(tmpInfo.getMaxSize());
+                classInfo.setOpen(tmpInfo.isOpen());
             }
             _storageClasses.put(composedName, classInfo);
         }

--- a/modules/dcache/src/test/java/org/dcache/pool/classic/StorageClassContainerTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/classic/StorageClassContainerTest.java
@@ -1,0 +1,84 @@
+package org.dcache.pool.classic;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import diskCacheV111.util.CacheException;
+import java.util.concurrent.TimeUnit;
+import org.dcache.pool.nearline.NearlineStorageHandler;
+import org.dcache.pool.repository.CacheEntry;
+import org.dcache.vehicles.FileAttributes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class StorageClassContainerTest {
+
+
+    private StorageClassContainer scc;
+
+
+    @Before
+    public void setUp() throws Exception {
+
+        scc = new StorageClassContainer();
+        scc.setNearlineStorageHandler(mock(NearlineStorageHandler.class));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testTemplatePropagation() throws CacheException, InterruptedException {
+
+        var template1 = scc.defineStorageClass("osm1", "*");
+        template1.setOpen(false);
+        template1.setExpiration(TimeUnit.SECONDS.toMillis(1));
+        template1.setMaxSize(2);
+        template1.setPending(3);
+
+        var template2 = scc.defineStorageClass("osm2", "*");
+        template2.setOpen(true);
+        template2.setExpiration(TimeUnit.SECONDS.toMillis(4));
+        template2.setMaxSize(5);
+        template2.setPending(6);
+
+        var ce1 = givenCacheEntry("osm1", "test:tape");
+        scc.addCacheEntry(ce1);
+
+        var ce2 = givenCacheEntry("osm2", "test:tape");
+        scc.addCacheEntry(ce2);
+
+        StorageClassInfo sci1 = scc.getStorageClassInfo("osm1", "test:tape");
+        assertMatchTemplate(template1, sci1);
+
+        StorageClassInfo sci2 = scc.getStorageClassInfo("osm2", "test:tape");
+        assertMatchTemplate(template2, sci2);
+
+    }
+
+    private void assertMatchTemplate(StorageClassInfo template, StorageClassInfo actual) {
+        assertEquals(template.getExpiration(), actual.getExpiration());
+        assertEquals(template.getMaxSize(), actual.getMaxSize());
+        assertEquals(template.getPending(), actual.getPending());
+        assertEquals(template.isOpen(), actual.isOpen());
+    }
+
+
+    private CacheEntry givenCacheEntry(String hsm, String storageClass) {
+
+
+        var attr = FileAttributes.of()
+              .storageClass(storageClass)
+              .hsm(hsm)
+              .build();
+
+        var ce = mock(CacheEntry.class);
+        when(ce.getFileAttributes()).thenReturn(attr);
+
+        return ce;
+    }
+}

--- a/modules/dcache/src/test/java/org/dcache/pool/classic/StorageClassContainerTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/classic/StorageClassContainerTest.java
@@ -5,7 +5,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.PnfsId;
 import java.util.concurrent.TimeUnit;
+import org.dcache.chimera.InodeId;
 import org.dcache.pool.nearline.NearlineStorageHandler;
 import org.dcache.pool.repository.CacheEntry;
 import org.dcache.vehicles.FileAttributes;
@@ -70,14 +72,17 @@ public class StorageClassContainerTest {
 
     private CacheEntry givenCacheEntry(String hsm, String storageClass) {
 
+        PnfsId id = new PnfsId(InodeId.newID(0));
 
         var attr = FileAttributes.of()
               .storageClass(storageClass)
               .hsm(hsm)
+              .pnfsId(id)
               .build();
 
         var ce = mock(CacheEntry.class);
         when(ce.getFileAttributes()).thenReturn(attr);
+        when(ce.getPnfsId()).thenReturn(id);
 
         return ce;
     }


### PR DESCRIPTION
Motivation:
the a hsm class queue defined as template with

queue define class -expire=N -pending=M -total=B -open <hsmType> *

command, then we expect that any storage class that is not explicitly
defined will inherit that attributes. This not the case for `-open`
option.

Modification:
propagate 'open' flag when a storage class queue is created from a
template. Added unit test.

Result:
fixes storage class template propagation

Ticket: #10213
Acked-by: Lea Morschel
Acked-by: Paul Millar
Target: master, 7.2, 7.1, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit aeadc6cf1a1da6356361c2c41a57d3703c82a4b0)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>