### PR TITLE
webdav: http-tpc move transfer finalisation off of message queue

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/BoundedExecutor.java
+++ b/modules/common/src/main/java/org/dcache/util/BoundedExecutor.java
@@ -189,6 +189,24 @@ public class BoundedExecutor extends AbstractListeningExecutorService {
         }
     }
 
+    public int getWorkQueueSize() {
+        monitor.enter();
+        try {
+            return workQueue.size();
+        } finally {
+            monitor.leave();
+        }
+    }
+
+    public int getThreadCount() {
+        monitor.enter();
+        try {
+            return threads;
+        } finally {
+            monitor.leave();
+        }
+    }
+
     private class Worker implements Runnable {
 
         private Runnable getFirstTask() {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -65,6 +65,7 @@ import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.NoRouteToCellException;
 import dmg.util.CommandException;
 import dmg.util.CommandSyntaxException;
+import dmg.util.command.Argument;
 import dmg.util.command.Command;
 import dmg.util.command.Option;
 import eu.emi.security.authn.x509.X509Credential;
@@ -96,6 +97,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import javax.annotation.PreDestroy;
 import javax.security.auth.Subject;
 import javax.servlet.ServletResponseWrapper;
 import javax.servlet.http.HttpServletResponse;
@@ -106,6 +108,8 @@ import org.dcache.auth.attributes.Restriction;
 import org.dcache.cells.CellStub;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.namespace.FileType;
+import org.dcache.util.BoundedCachedExecutor;
+import org.dcache.util.BoundedExecutor;
 import org.dcache.util.ChecksumType;
 import org.dcache.util.Checksums;
 import org.dcache.util.ColumnWriter;
@@ -122,6 +126,8 @@ import org.eclipse.jetty.server.HttpConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
+
+import static dmg.util.CommandException.checkCommand;
 
 /**
  * This class provides the basis for interactions with the remotetransfer service.  It is used by
@@ -143,6 +149,10 @@ import org.springframework.beans.factory.annotation.Required;
  */
 public class RemoteTransferHandler implements CellMessageReceiver, CellCommandListener {
 
+    private static int threadCount = 1;
+    private static synchronized int nextThreadCount() {
+        return threadCount++;
+    }
     /**
      * The different directions that the data will travel.
      */
@@ -219,6 +229,8 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
           "transferheader";
 
     private final HashMap<Long, RemoteTransfer> _transfers = new HashMap<>();
+    private final BoundedExecutor _activity =
+          new BoundedCachedExecutor(r -> new Thread(r, "transfer-finaliser-" + nextThreadCount()), 1);
 
     private long _performanceMarkerPeriod;
     private CellStub _transferManager;
@@ -243,6 +255,10 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
         return _performanceMarkerPeriod;
     }
 
+    public void setMaxConcurrentFinalisers(int count) {
+        _activity.setMaximumPoolSize(count);
+    }
+
     private enum IPFamilyMatcher {
         IPv4 {
             @Override
@@ -259,6 +275,33 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
         };
 
         public abstract boolean matches(InetAddress addr);
+    }
+
+    @Command(name = "http-tpc finaliser info", hint="query finaliser status",
+            description = "Provides information about transfer finalisation.")
+    public class HttpTpcFinaliserInfoCommand implements Callable<String> {
+        @Override
+        public String call() throws Exception {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Max threads: ").append(_activity.getMaximumPoolSize()).append('\n');
+            sb.append("Current threads: ").append(_activity.getThreadCount()).append('\n');
+            sb.append("Queued tasks: ").append(_activity.getWorkQueueSize()).append('\n');
+            return sb.toString();
+        }
+    }
+
+    @Command(name = "http-tpc finaliser max threads", hint="update finaliser max threads",
+            description = "Updates the maximum number of threads that are satisfying transfer finalisation.")
+    public class HttpTpcFinaliserMaxThreadsCommand implements Callable<String> {
+        @Argument(usage="The new maximum number of threads", metaVar="threads")
+        int maxThreads;
+
+        @Override
+        public String call() throws Exception {
+            checkCommand(maxThreads >= 1, "Number of threads must be 1 or more");
+            _activity.setMaximumPoolSize(maxThreads);
+            return "";
+        }
     }
 
     @Command(name = "http-tpc ls", hint = "list current transfers",
@@ -539,6 +582,11 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
         }
     }
 
+    @PreDestroy
+    public void stop() {
+        _activity.shutdown();
+    }
+
     /**
      * Start a transfer and block until that transfer is complete.
      *
@@ -601,7 +649,7 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
         synchronized (_transfers) {
             RemoteTransfer transfer = _transfers.get(message.getId());
             if (transfer != null) {
-                transfer.success();
+                _activity.execute(() -> transfer.success());
             }
         }
     }
@@ -610,7 +658,8 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
         synchronized (_transfers) {
             RemoteTransfer transfer = _transfers.get(message.getId());
             if (transfer != null) {
-                transfer.failure(String.valueOf(message.getErrorObject()));
+                String error = String.valueOf(message.getErrorObject());
+                _activity.execute(() -> transfer.failure(error));
             }
         }
     }

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -135,6 +135,8 @@
               value="#{T(java.util.concurrent.TimeUnit).MILLISECONDS.convert(
                      ${webdav.third-party-transfers.performance-marker-period},
                      '${webdav.third-party-transfers.performance-marker-period.unit}')}" />
+      <property name="maxConcurrentFinalisers"
+              value="${webdav.third-party-transfers.concurrent-finalisers}"/>
   </bean>
 
   <bean id="oidc-client-ids"

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -204,6 +204,21 @@ webdav.third-party-transfers.performance-marker-period.unit = SECONDS
 
 (one-of?true|false)webdav.enable.third-party.requiring-verification-by-default = true
 
+#   The number of transfers that can complete (successfully or
+#   otherwise) concurrently before the door will start to queue the
+#   results.  The HTTP-TPC client will experience some delays if the
+#   results are queued.  If the queued time exceeds twice the
+#   performance-marker-period then transfers may start to fail.
+#
+#   Setting this value too low can lead to delays if multiple
+#   transfers finish at the same time, potentially causing transfers
+#   to fail under heavy load.
+#
+#   Setting this value too high could result in the domain running out
+#   of memory under peak load.
+#
+webdav.third-party-transfers.concurrent-finalisers = 1000
+
 #  ---- TCP port for WebDAV door
 #
 #   Specifies the TCP port on which the WebDAV door accepts connections.


### PR DESCRIPTION
Motivation:

An HTTP-TPC transfer is finalised when a message is received from the
RemoteTransferHandler service or under certain failure modes that the
door detects.  In most cases, the door is notified that a transfer has
completd.

Currently, the `messageArrived` method calls the finalisation process
directly.  This means that all activity needed to "tidy up" the transfer
is done by the (single) message delivery thread.  In some cases, this
tidy-up process involves sending further messages, which can tie up the
message delivery thread for some time.

The result is a WebDAV door that, under heavy load, is very slow to
respond to in-bound messages and can result in transfers failing.  This
may even lead to a cascading effect, as cleaning up from failing
transfers is something that requires sending messages (removing the
partially transferred file), which increases the likelihood of further
transfer failures.

Modification:

Use a BoundedExecutor to processes all transfer finalisation triggered
by RemoteTransferHandler.

A configuration property is added to control the maximum number of
concurrent transfer finalisation threads running.  Admin commands are
also added to allow introspection of the current status and updating the
maximum number of threads without requiring a restart.

Result:

The HTTP-TPC support in the WebDAV door should be more robust to high
number of transfers finishing concurrently.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: probably
Patch: https://rb.dcache.org/r/13280/
Acked-by: Albert Rossi
Acked-by: Lea Morschel