### PR TITLE
webdav: http-tpc avoid resetting transfer state

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -940,12 +940,18 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
         }
 
         public synchronized void success() {
+            if (_finished) { // Transfer already registered as completed.
+                return;
+            }
             _problem = null;
             _finished = true;
             notifyAll();
         }
 
         public synchronized void failure(String explanation) {
+            if (_finished) { // Transfer already registered as completed.
+                return;
+            }
             _problem = explanation;
             _finished = true;
             notifyAll();


### PR DESCRIPTION
Motivation:

Under high contention, it's possible that a door fails a transfer while
the TransferCompleteMessage is still on the message queue. The door's
decision to fail the transfer will delete the file (for PULL requests)
but the TransferCompleteMessage, when processed, will reset the state
back to success.  The dCache reports to the client (typically FTS) that
the transfer was successful, but the file was deleted.

Thankfully, FTS is able to detect this failure mode, as it stat()s the
file after.

Modification:

Ensure that, once the transfer is marked `finished`, no further changes
to the file's state is possible.

NB. This bug was inadvertantly fixed by commit 5543d223c, so only
affects 7.2 an earlier.

Result:

A bug is fixed where HTTP-TPC PULL request can fail (under heavy load)
with the downloaded file being deleted, but dCache reports the transfer
as successful.

Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13281/
Acked-by: Albert Rossi
Acked-by: Lea Morschel