### PR TITLE
webdav: http-tpc don't wait if door fails transfer

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -992,7 +992,9 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
             do {
                 generateMarker();
 
-                wait(_performanceMarkerPeriod);
+                if (!_finished) {
+                    wait(_performanceMarkerPeriod);
+                }
             } while (!_finished);
 
             if (_problem == null) {


### PR DESCRIPTION
Motivation:

The door may decide to fail the transfer.  This happens if either the
client went away or if RemoteTransferManager claims (repeatedly) that
there is no such transfer.  The latter likely due to the
RemoteTransferService being restarted.

Currently, if this happens then the door will wait
_performanceMarkerPeriod (5 seconds) before informing the client.

There's no reason to delay informing the client (typically FTS).

Modification:

Don't wait to inform the client that a transfer has failed if the door
decides to fail the transfer.

Result:

dCache provides a faster respones to the HTTP-TPC client (typically FTS)
should the door decide to fail a transfer.

Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13282/
Acked-by: Albert Rossi
Acked-by: Lea Morschel