### PR TITLE
webdav: http-tpc improve throughput with short transfers

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -87,13 +87,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -228,7 +228,7 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
     private static final String REQUEST_HEADER_TRANSFER_HEADER_PREFIX =
           "transferheader";
 
-    private final HashMap<Long, RemoteTransfer> _transfers = new HashMap<>();
+    private final Map<Long, RemoteTransfer> _transfers = new ConcurrentHashMap<>();
     private final BoundedExecutor _activity =
           new BoundedCachedExecutor(r -> new Thread(r, "transfer-finaliser-" + nextThreadCount()), 1);
 
@@ -387,12 +387,10 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
 
             buildHeaders();
 
-            synchronized (_transfers) {
-                _transfers.values().stream()
-                      .filter(buildFilter())
-                      .sorted(buildComparator())
-                      .forEachOrdered(this::printTransfer);
-            }
+            _transfers.values().stream()
+                  .filter(buildFilter())
+                  .sorted(buildComparator())
+                  .forEachOrdered(this::printTransfer);
 
             return output.toString();
         }
@@ -612,19 +610,15 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
 
         long id;
 
-        synchronized (_transfers) {
-            id = transfer.start();
-            response.setStatus(Status.SC_ACCEPTED);
-            response.setContentTypeHeader("text/perf-marker-stream");
-            _transfers.put(id, transfer);
-        }
+        response.setStatus(Status.SC_ACCEPTED);
+        response.setContentTypeHeader("text/perf-marker-stream");
+        id = transfer.start();
+        _transfers.put(id, transfer);
 
         try {
             transfer.awaitCompletion();
         } finally {
-            synchronized (_transfers) {
-                _transfers.remove(id);
-            }
+            _transfers.remove(id);
         }
 
         return Optional.ofNullable(transfer._problem);
@@ -646,21 +640,17 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
 
 
     public void messageArrived(TransferCompleteMessage message) {
-        synchronized (_transfers) {
-            RemoteTransfer transfer = _transfers.get(message.getId());
-            if (transfer != null) {
-                _activity.execute(() -> transfer.success());
-            }
+        RemoteTransfer transfer = _transfers.get(message.getId());
+        if (transfer != null) {
+            _activity.execute(() -> transfer.success());
         }
     }
 
     public void messageArrived(TransferFailedMessage message) {
-        synchronized (_transfers) {
-            RemoteTransfer transfer = _transfers.get(message.getId());
-            if (transfer != null) {
-                String error = String.valueOf(message.getErrorObject());
-                _activity.execute(() -> transfer.failure(error));
-            }
+        RemoteTransfer transfer = _transfers.get(message.getId());
+        if (transfer != null) {
+            String error = String.valueOf(message.getErrorObject());
+            _activity.execute(() -> transfer.failure(error));
         }
     }
 


### PR DESCRIPTION
Motivation:

The WebDAV door currently serialises both the processing of message
responses and creating new transfers: only one of either a new transfer
or a reply message may be processed at any time.

Although there is only the one message queue thread there are
potentially several transfers starting concurrently.  In any case,
processing a dCache-internal message is (ideally) independent of
creating a new transfer.

Modification:

Use a ConcurrentHashMap, as this provides the same thread-safe
guarantees as the current approach but without the locking contention.

Note that this approach has already been adopted on the 'master' branch
with commit 5543d223c5.

Result:

The WebDAV door should be faster at accepting new transfers and faster
at handling transfer completions when handling many small transfers.

Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13284/
Acked-by: Lea Morschel