### PR TITLE
dcache-core: fix NPE in TransferManager when no pool was selected bef…

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandlerBackup.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandlerBackup.java
@@ -10,6 +10,8 @@
 
 package diskCacheV111.services;
 
+import diskCacheV111.vehicles.Pool;
+import java.util.Optional;
 
 public class TransferManagerHandlerBackup {
 
@@ -37,7 +39,7 @@ public class TransferManagerHandlerBackup {
         id = handler.getId();
         pnfsPath = handler.getPnfsPath();
         pnfsIdString = handler.getPnfsIdString();
-        pool = handler.getPool().getName();
+        pool = Optional.ofNullable(handler.getPool()).map(Pool::getName).orElse(null);
         store = handler.getStore();
         created = handler.getCreated();
         locked = handler.getLocked();


### PR DESCRIPTION
…ore transfer is cancelled

Motivation:

Commit a11ec8d76b introduced a Pool class to glue together a pool's name and its address.
It is possible that a transfer is being cancelled before a pool was selected. While removing a transfer, previously, the TransferManager would pass the String representation of a pool into the TransferManagerHandlerBackup constructor, including null values. Now, it attempts to extract the pool name from the pool object, disregarding that it might be null.

Modification:

Make the TransferManagerHandlerBackup constructor handle the nullable Pool object correctly.

Result:

No more NullPointerExceptions due to cancelled transfers that have not been assigned a pool yet.

Target: master
Target: 7.2
Target: 7.1
Target: 7.0
Target: 6.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13292/
Acked-by: Tigran Mkrtchyan