### PR TITLE
srm-server: trs don't cache tape names forever

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/strategy/TapeRecallSchedulingStrategy.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/strategy/TapeRecallSchedulingStrategy.java
@@ -318,7 +318,12 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
             }
 
             if (currTapeWithJobs.getValue().isEmpty()) {
-                tapes.get(currTapeWithJobs.getKey()).resetJobArrivalTimes();
+                if (tapesWithJobs.containsKey(currTapeWithJobs.getKey())) {
+                    tapes.get(currTapeWithJobs.getKey()).resetJobArrivalTimes();
+                } else {
+                    // remove tape if there are no jobs targeting it
+                    tapes.remove(currTapeWithJobs.getKey());
+                }
                 activeTapesWithJobsIterator.remove();
             } else { // update oldest job arrival time
                 tapes.get(currTapeWithJobs.getKey())


### PR DESCRIPTION
Motivation:

In search of the cause of a  transient NullPointerException that is now fixed, one suspicion was that a job might be assigned a null tape object because it was removed immediately before. Even though a null value should not happen and was then checked for as well as handled correctly, commit 1c258108c301da2925abfa61a28fda2ad72c595f prevented tape names/objects, which were loaded once in the past (since the last restart), to be removed when there are no jobs left targeting it.

The tape informant caches tape-targeting-job and tape information. It can be cleared via admin interface and will reload requested information when trs requests arrive.
When new jobs arrive in the scheduler and are associated with tape information by the tape informant, they are also associated with an existing tape info object. If such an object does not exist yet, a new one is created which is flagged as not having tape capacity and usage data. The tape informant will then be tasked to try to fetch information on these tapes.

When such a tape object is never removed from the scheduler after there are no jobs left that target it, the tape informant will never be tasked to reload this tape's information, even though it could have changed in the meantime. The tape informant bean will also not log or show as many (or any) cached tape infos in the admin interface, which may be confusing.

Modification:

Revert trs to original behaviour of removing tape objects for which there are no associated jobs anymore. They will be created again if new jobs arrive.

Result:

Remove tape object if no jobs are targeting it. Changed tape information can be loaded when it is created again.

Target: master
Target: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13298/
Acked-by: Paul Millar