### PR TITLE
core: fix macaroon behaviour with root and path

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/auth/MacaroonLoginStrategy.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/MacaroonLoginStrategy.java
@@ -67,11 +67,15 @@ public class MacaroonLoginStrategy implements LoginStrategy {
 
             LoginReply reply = new LoginReply();
 
+            FsPath root = context.getRoot().orElse(FsPath.ROOT);
             Set<LoginAttribute> attributes = reply.getLoginAttributes();
             attributes.add(new HomeDirectory(context.getHome().orElse(FsPath.ROOT)));
-            attributes.add(new RootDirectory(context.getRoot().orElse(FsPath.ROOT)));
+            attributes.add(new RootDirectory(root));
             context.getExpiry().map(Expiry::new).ifPresent(attributes::add);
-            context.getPath().map(PrefixRestriction::new).ifPresent(attributes::add);
+            context.getPath()
+                    .map(root::chroot)
+                    .map(PrefixRestriction::new)
+                    .ifPresent(attributes::add);
             context.getAllowedActivities().map(EnumSet::complementOf)
                   .map(DenyActivityRestriction::new).ifPresent(attributes::add);
             context.getMaxUpload().ifPresent(s -> attributes.add(new MaxUploadSize(s)));

--- a/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonContext.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonContext.java
@@ -110,8 +110,13 @@ public class MacaroonContext {
         path = path.chroot(directory);
     }
 
-    public Optional<FsPath> getPath() {
-        return path == FsPath.ROOT ? Optional.empty() : Optional.of(path);
+    /**
+     * The returned value is a relative path that should be resolved against
+     * the root path {@see getRoot()} to obtain the full path in dCache
+     * namespace.
+     */
+    public Optional<String> getPath() {
+        return path == FsPath.ROOT ? Optional.empty() : Optional.of(path.toString());
     }
 
     public void setUsername(String name) {

--- a/modules/dcache/src/test/java/org/dcache/macaroons/MacaroonContextTests.java
+++ b/modules/dcache/src/test/java/org/dcache/macaroons/MacaroonContextTests.java
@@ -80,7 +80,7 @@ public class MacaroonContextTests {
         _context.updateRoot("/path");
 
         assertThat(_context.getRoot(), is(equalTo(Optional.of(FsPath.create("/path")))));
-        assertThat(_context.getPath(), is(equalTo(Optional.of(FsPath.create("/subdir")))));
+        assertThat(_context.getPath(), is(equalTo(Optional.of("/subdir"))));
         assertThat(_context.getHome(), is(equalTo(Optional.of(FsPath.create("/subdir/home")))));
     }
 
@@ -99,7 +99,7 @@ public class MacaroonContextTests {
 
         _context.updatePath("/dir");
 
-        assertThat(_context.getPath(), is(equalTo(Optional.of(FsPath.create("/users/paul/dir")))));
+        assertThat(_context.getPath(), is(equalTo(Optional.of("/users/paul/dir"))));
     }
 
     @Test
@@ -108,7 +108,7 @@ public class MacaroonContextTests {
 
         _context.updatePath("dir");
 
-        assertThat(_context.getPath(), is(equalTo(Optional.of(FsPath.create("/users/paul/dir")))));
+        assertThat(_context.getPath(), is(equalTo(Optional.of("/users/paul/dir"))));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

A macaroon may contain a multiple of both "root:" and "path:" caveats.
These interact in a somewhat complex fashion.  The MacaroonContext class
takes care to process these caveats correctly.

An important aspect is that the overall resulting (or "effective")
"path" path must be interpreted as being relative to the result (or
"effective") "root" path.

The MacaroonLoginStrategy mistakenly interpreted the "path" path as an
absolute path in dCache when adding the PrefixRestriction, since this
accepts an absoluate path in dCache namespace.

This mistake is somewhat explained by MacaroonContext#getPath mistakenly
returning FsPath, which is inteded only for absolute paths in dCache's
namespace.

If there is no "root:" caveat then there is no difference and any
"path:" caveat will work as expected.  Similarly, a macaroon without a
"path:" caveat but with a "root:" caveat will also work as expected.

However, if a macaroon has both a "root:" and "path:" caveats then the
macaroon does not work as expected.

Modification:

Add JavaDoc and update return type of MacaroonContext to make clear the
semantics of the returned value.

Update unit-tests accordingly.

Update MacaroonLoginStrategy to resolve the effective "path" path
against the effective "root" path.

Result:

Macaroons created with both a "path" caveat and "root" caveat work as
expected.

Target: master
Request: 7.2
Request: 7.1
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13053/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel