### PR TITLE
webdav: ensure URL-path request macaroon have relative "path" caveat

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonContext.java
+++ b/modules/dcache/src/main/java/org/dcache/macaroons/MacaroonContext.java
@@ -45,6 +45,9 @@ public class MacaroonContext {
 
     private FsPath root = FsPath.ROOT;
     private FsPath home = FsPath.ROOT;
+
+    // FIXME: path is a relative path (relative to root) but uses FsPath, which
+    // is intended to store only absolute paths in dCache namespace.
     private FsPath path = FsPath.ROOT;
     private String username;
     private OptionalLong maxUpload = OptionalLong.empty();
@@ -69,12 +72,18 @@ public class MacaroonContext {
         return home == FsPath.ROOT ? Optional.empty() : Optional.of(home);
     }
 
+    /**
+     * Specify the new root value.  This does NOT modify the "path" path.
+     */
     public void setRoot(FsPath newRoot) {
         LOG.debug("Setting root to {}", root);
         checkArgument(newRoot.hasPrefix(root), "Attempt to weaken root path");
         root = newRoot;
     }
 
+    /**
+     * Update the root value.  This will modify any non-/ "path" path.
+     */
     public void updateRoot(String directory) throws InvalidCaveatException {
         FsPath newRoot = root.chroot(directory);
 
@@ -101,8 +110,11 @@ public class MacaroonContext {
         return root == FsPath.ROOT ? Optional.empty() : Optional.of(root);
     }
 
-    public void setPath(FsPath desiredPath) {
-        path = desiredPath;
+    /**
+     * Note that the supplied path is interpreted as being relative to the root.
+     */
+    public void setPath(String desiredPath) {
+        path = FsPath.ROOT.chroot(desiredPath);
         LOG.debug("Setting path to {}", path);
     }
 

--- a/modules/dcache/src/test/java/org/dcache/macaroons/MacaroonContextBuilder.java
+++ b/modules/dcache/src/test/java/org/dcache/macaroons/MacaroonContextBuilder.java
@@ -60,7 +60,7 @@ public class MacaroonContextBuilder {
     }
 
     public MacaroonContextBuilder withPath(String path) {
-        context.setPath(FsPath.create(path));
+        context.setPath(path);
         return this;
     }
 


### PR DESCRIPTION
Motivation:

When requesting a macaroon, the user may supply a "path:" caveat by
making the macaroon request target a non '/' URL.

The current code resolves such a URL path to an absolute path in dCache
and adds this as a "path:" caveat.

This is wrong, as the "path:" caveat values are interpreted as relative
to the effective root (door root or user root, whichever is longer).
The result is that such macaroons cannot work if the door (or the user
making the macaroon request) has a non-/ root.

Modification:

Update the macaroon request processing machinery to include a "path:"
caveat that is relative to the effective root.

Result:

Macaroon requests with a path in the request URL and with a non-default
door root now generate correct macaroons.  WebDAV doors with '/' root
are unaffected by this problem.

Target: master
Request: 7.2
Request: 7.1
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13054/
Acked-by: Lea Morschel