### PR TITLE
srr: limit publisched endpoints to GLOBAL scope

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.PoolMonitor;
+import org.dcache.util.NetworkUtils.InetAddressScope;
 import org.dcache.util.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -237,6 +238,7 @@ public class SrrBuilder {
 
         return loginBrokerSubscriber.doors().stream()
               .filter(doorTagFilter)
+              .filter(i -> i.supports(InetAddressScope.GLOBAL))
               .map(d -> {
                         Storageendpoint endpoint = new Storageendpoint()
                               .withName(id + "#" + d.getProtocolFamily() + "@" + d.getAddresses().get(0)


### PR DESCRIPTION
Motivation:
When SRR publishes a door, then it expected that the door is accessible
by others. Thus we should publish only globally accessible interfaces.

Modification:
Update SrrBuilder to filter doors with GLOBAL scope.

Result:
The link-local and local host interfaces are not published.

Ticket: #10249
Acked-by: Paul Millar
Target: master, 7.2, 7.1, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 9c85dab02cb294e1ed0db6d80bb266a45bde295a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>