### PR TITLE
glazma: scitoken add support for additional principals

### DIFF
--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/SciTokenPlugin.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/SciTokenPlugin.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2019-2020 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2019-2021 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -43,6 +43,8 @@ import org.dcache.auth.BearerTokenCredential;
 import org.dcache.auth.ExemptFromNamespaceChecks;
 import org.dcache.auth.JwtJtiPrincipal;
 import org.dcache.auth.JwtSubPrincipal;
+import org.dcache.auth.OidcSubjectPrincipal;
+import org.dcache.auth.OpenIdGroupPrincipal;
 import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.Activity;
 import org.dcache.auth.attributes.MultiTargetedRestriction;
@@ -139,10 +141,16 @@ public class SciTokenPlugin implements GPlazmaAuthenticationPlugin {
             Optional<String> sub = token.getPayloadString("sub");
             sub.map(s -> new JwtSubPrincipal(issuer.getId(), s))
                   .ifPresent(principals::add);
+            sub.map(s -> new OidcSubjectPrincipal(s, issuer.getId()))
+                  .ifPresent(principals::add);
 
             Optional<String> jti = token.getPayloadString("jti");
             jti.map(s -> new JwtJtiPrincipal(issuer.getId(), s))
                   .ifPresent(principals::add);
+
+            token.getPayloadStringOrArray("wlcg.groups").stream()
+                  .map(OpenIdGroupPrincipal::new)
+                  .forEach(principals::add);
 
             checkAuthentication(sub.isPresent() || jti.isPresent(), "missing sub and jti claims");
 

--- a/modules/gplazma2-scitoken/src/test/java/org/dcache/gplazma/scitoken/SciTokenPluginTest.java
+++ b/modules/gplazma2-scitoken/src/test/java/org/dcache/gplazma/scitoken/SciTokenPluginTest.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2020 - 2020 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2020 - 2021 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -86,6 +86,8 @@ import org.dcache.auth.ExemptFromNamespaceChecks;
 import org.dcache.auth.GidPrincipal;
 import org.dcache.auth.JwtJtiPrincipal;
 import org.dcache.auth.JwtSubPrincipal;
+import org.dcache.auth.OidcSubjectPrincipal;
+import org.dcache.auth.OpenIdGroupPrincipal;
 import org.dcache.auth.UidPrincipal;
 import org.dcache.auth.UserNamePrincipal;
 import org.dcache.auth.attributes.Restriction;
@@ -1381,6 +1383,40 @@ public class SciTokenPluginTest {
               .issuedBy("OP1").usingKey("key1"));
 
         assertThat(identifiedPrincipals, not(hasItem(instanceOf(ExemptFromNamespaceChecks.class))));
+    }
+
+    @Test
+    public void shouldIncludeSubPrincipal() throws Exception {
+        given(aSciTokenPlugin()
+                .withProperty("gplazma.scitoken.issuer!EXAMPLE", "https://example.org/ /prefix uid:1000 gid:1000"));
+        givenThat("OP1", isAnIssuer().withURL("https://example.org/").withKey("key1", rsa256Keys()));
+
+        String sub = UUID.randomUUID().toString();
+        whenAuthenticatingWith(aJwtToken()
+                .withClaim("sub", sub)
+                .withRandomJti()
+                .withClaim("scope", "read:/")
+                .issuedBy("OP1").usingKey("key1"));
+
+        assertThat(identifiedPrincipals, hasItem(new OidcSubjectPrincipal(sub, "EXAMPLE")));
+    }
+
+    @Test
+    public void shouldIncludeWlcgGroups() throws Exception {
+        given(aSciTokenPlugin()
+                .withProperty("gplazma.scitoken.issuer!EXAMPLE", "https://example.org/ /prefix uid:1000 gid:1000"));
+        givenThat("OP1", isAnIssuer().withURL("https://example.org/").withKey("key1", rsa256Keys()));
+
+        whenAuthenticatingWith(aJwtToken()
+                .withRandomSub()
+                .withRandomJti()
+                .withArrayClaim("wlcg.groups", "/group-1", "/group-1/subgroup", "/group-2")
+                .withClaim("scope", "read:/")
+                .issuedBy("OP1").usingKey("key1"));
+
+        assertThat(identifiedPrincipals, hasItems(new OpenIdGroupPrincipal("/group-1"),
+                new OpenIdGroupPrincipal("/group-1/subgroup"),
+                new OpenIdGroupPrincipal("/group-2")));
     }
 
     private void whenAuthenticatingWith(PrincipalSetMaker maker) throws AuthenticationException {


### PR DESCRIPTION
Motivation:

In the `scitoken` plugin, the 'sub' claim is represented by a
`JwtSubPrincipal` object.  This is in contrast to the 'oidc' plugin,
that represents the same information as an `OidcSubjectPrincipal`
object.

In general, the semantics of a claim shouldn't depend on how claims are
resolved: by examining the token or by calling the user-info endpoint.
Therefore this distinction is wrong.

Additionally, dCache comes with no support for JwtSubPrincipal objects:
no code reacts to its presence; however, there is support for
OidcSubjectPrincipal objects.

The `wlcg.groups` claim provides group-membership information.  The
`oidc` plugin provides this information but the `scitoken` plugin
currently does not.  This is despite this claim being defined in the
WLCG AuthZ JWT profile, which `scitoken` aims to support.

Modification:

Add support for asserting the person's identity (the 'sub' claim) via an
`OidcSubjectPrincipal` object and group membership (the `wlcg.groups`
claim) via `OpenIdGroupPrincipal` objects.

Result:

The 'scitoken' gplazma plugin now supports extracting the 'sub' and
'wlcg.groups' claims in the same fashion as the 'oidc' plugin.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13304/
Acked-by: Tigran Mkrtchyan