### PR TITLE
webdav: http-tpc update 'http-tpc ls' command to include state

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
@@ -7,7 +7,11 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
 
 public class JobInfo implements Serializable {
 
@@ -52,12 +56,21 @@ public class JobInfo implements Serializable {
         return _submitTime;
     }
 
+    public Instant submitted() {
+        return Instant.ofEpochMilli(_submitTime);
+    }
+
     public String getStatus() {
         return _status;
     }
 
     public long getJobId() {
         return _jobId;
+    }
+
+    public Duration queued() {
+        long queueEnd = isStarted() ? getStartTime() : System.currentTimeMillis();
+        return Duration.of(queueEnd - _submitTime, MILLIS);
     }
 
     public String toString() {

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/JobInfo.java
@@ -44,6 +44,10 @@ public class JobInfo implements Serializable {
         return _startTime;
     }
 
+    public boolean isStarted() {
+        return _startTime > 0;
+    }
+
     public long getSubmitTime() {
         return _submitTime;
     }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -315,6 +315,9 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
               category = "Field options")
         boolean showNetwork;
 
+        @Option(name = "s", usage = "Show the current status.", category = "Field options")
+        boolean showState;
+
         @Option(name = "l", usage = "Show the local path of the transfer.",
               category = "Field options")
         boolean showLocalPath;
@@ -323,9 +326,8 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
               category = "Field options")
         boolean showRemotePath;
 
-        @Option(name = "a", usage = "Show all available information about"
-              + " transfers.  This is equivalent to specifying \"-t -n -l"
-              + " -r\"", category = "Field options")
+        @Option(name = "a", usage = "Show all available information about transfers.  This is"
+                + " equivalent to specifying \"-l -n -r -s -t\".", category = "Field options")
         boolean showAll;
 
         @Option(name = "pool", usage = "Select transfers involving a pool that"
@@ -381,6 +383,7 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
             if (showAll) {
                 showTiming = true;
                 showNetwork = true;
+                showState = true;
                 showLocalPath = true;
                 showRemotePath = true;
             }
@@ -402,6 +405,10 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
                 output.space().header("Lifetime").left("lifetime")
                       .space().header("Queued").left("queued")
                       .space().header("Running").left("running");
+            }
+
+            if (showState) {
+                output.space().header("State").left("state");
             }
 
             output.space().header("Dirn").left("direction")
@@ -527,6 +534,10 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
                   .value("direction", transfer._direction)
                   .value("host", transfer._destination.getHost())
                   .value("pool", transfer._pool.orElse("-"));
+
+            if (showState) {
+                row.value("state", TransferManagerHandler.describeState(transfer._lastState));
+            }
 
             if (showLocalPath) {
                 row.value("local-path", transfer._path.toString());

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -127,6 +127,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
+import static diskCacheV111.services.TransferManagerHandler.RECEIVED_FIRST_POOL_REPLY_STATE;
 import static dmg.util.CommandException.checkCommand;
 
 /**
@@ -536,7 +537,7 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
                   .value("pool", transfer._pool.orElse("-"));
 
             if (showState) {
-                row.value("state", TransferManagerHandler.describeState(transfer._lastState));
+                row.value("state", transfer.describeLastState());
             }
 
             if (showLocalPath) {
@@ -1105,7 +1106,7 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
             _lastState = state;
             _lastInfo = Optional.ofNullable(info);
             if (info != null) {
-                if (!_transferStarted.isPresent() && info.getTransferTime() > 0) {
+                if (!_transferStarted.isPresent() && info.isStarted()) {
                     Instant started = Instant.now().minus(info.getTransferTime(), MILLIS);
                     _transferStarted = Optional.of(started);
                 }
@@ -1119,6 +1120,15 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
             checkClientConnected();
         }
 
+        private String describeLastState() {
+            return describeState(_lastState, _lastInfo.orElse((IoJobInfo)null));
+        }
+
+        private String describeState(int state, @Nullable IoJobInfo info) {
+            return state == RECEIVED_FIRST_POOL_REPLY_STATE && info != null
+                    ? info.isStarted() ? "Running" : "Queued on pool"
+                    : TransferManagerHandler.describeState(state);
+        }
 
         /**
          * Print a performance marker on the reply channel that looks something like:
@@ -1126,12 +1136,12 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
          * Perf Marker Timestamp: 1360578938 Stripe Index: 0 Stripe Bytes Transferred: 49397760
          * Total Stripe Count: 2 End
          */
-        public void sendMarker(int state, IoJobInfo info) {
+        public void sendMarker(int state, @Nullable IoJobInfo info) {
             _out.println("Perf Marker");
             _out.println("    Timestamp: " +
                   MILLISECONDS.toSeconds(System.currentTimeMillis()));
             _out.println("    State: " + state);
-            _out.println("    State description: " + TransferManagerHandler.describeState(state));
+            _out.println("    State description: " + describeState(state, info));
             _out.println("    Stripe Index: 0");
             if (info != null) {
                 _out.println("    Stripe Start Time: " +

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -404,6 +404,7 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
 
             if (showTiming) {
                 output.space().header("Lifetime").left("lifetime")
+                      .space().header("Prep").left("preparation")
                       .space().header("Queued").left("queued")
                       .space().header("Running").left("running");
             }
@@ -549,19 +550,23 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
             }
 
             if (showTiming) {
+                Instant now = Instant.now();
+
                 StringBuilder lifetime = appendDuration(new StringBuilder(),
-                      Duration.between(transfer._whenSubmitted, Instant.now()),
-                      SHORT);
+                      Duration.between(transfer._whenSubmitted, now), SHORT);
                 row.value("lifetime", lifetime);
 
-                Duration queued = Duration.between(transfer._whenSubmitted,
-                      transfer._transferStarted.orElseGet(() -> Instant.now()));
-                StringBuilder queueDescription = appendDuration(new StringBuilder(),
-                      queued, SHORT);
-                row.value("queued", queueDescription);
+                Instant moverCreatedOrNow = transfer._lastInfo.map(IoJobInfo::submitted).orElse(now);
+                Duration prep = Duration.between(transfer._whenSubmitted, moverCreatedOrNow);
+                StringBuilder prepDescription = appendDuration(new StringBuilder(), prep, SHORT);
+                row.value("preparation", prepDescription);
+
+                Optional<CharSequence> queueDescription = transfer._lastInfo.map(IoJobInfo::queued)
+                        .map(d -> appendDuration(new StringBuilder(), d, SHORT));
+                row.value("queued", queueDescription.orElse("-"));
 
                 Optional<String> running = transfer._transferStarted
-                      .map(i -> Duration.between(i, Instant.now()))
+                      .map(i -> Duration.between(i, now))
                       .map(d -> appendDuration(new StringBuilder(), d, SHORT))
                       .map(Object::toString);
                 row.value("running", running.orElse("-"));


### PR DESCRIPTION
Motivation:

Observed transfers that spend a long time (more than a second) where the
pool is not shown.  This means _probably_ means that either the
PnfsManager or PoolManager is being slow, but it's currently impossible
to tell.

Modification:

Update the command to include the possibility of showing the transfer's
state.

Result:

The WebDAV door's 'http-tpc ls' command now has the possibility to show
the current state of the transfer.  This may be useful diagnosing
transfers spending a lot of time deciding on which pool to transfer
should take place.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13293/
Acked-by: Lea Morschel