### PR TITLE
pool: fix pool statistic file overwrite option

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -991,7 +991,7 @@ public class PoolStatisticsV0 extends CellAdapter {
 
         try {
             // copy the raw file into the html directory
-            Files.copy(diffFile.toPath(), new File(dir, "total.drw").toPath());
+            Files.copy(diffFile.toPath(), new File(dir, "total.drw").toPath(), StandardCopyOption.REPLACE_EXISTING);
             // load the raw data file
             Map<String, Map<String, long[]>> map = new DataStore(diffFile).getMap();
             // create todays html files


### PR DESCRIPTION
fixes: 383c3cb0b3c51f891feb52b371e2dbb78e59b654

Motivation:
When copying a pool statistics files any existing files should be
overwritten.

Modification:
Enforce overwrite when coping the statistic files.

Result:
the pool statistic copied without exception.

Fixes: #6351
Acked-by: Lea Morschel
Target: master, 7.2
Require-book: no
Require-notes: yes
(cherry picked from commit 762fd9ef8c4d8b4f62b4a5ed62768ceef2af773e)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>