### PR TITLE
pool: fix rep ls formating

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/ColumnWriter.java
+++ b/modules/common/src/main/java/org/dcache/util/ColumnWriter.java
@@ -31,6 +31,7 @@ public class ColumnWriter {
     private final List<Row> rows = new ArrayList<>();
     private boolean headersAffectRowWidth;
     private String renderedHeader;
+    private boolean noheader; // switches off printing of header
 
     public enum DateStyle {
         /**
@@ -46,6 +47,11 @@ public class ColumnWriter {
 
     public ColumnWriter() {
         spaces.add(0);
+    }
+
+    public ColumnWriter suppressHeaders() {
+        noheader = true;
+        return this;
     }
 
     private void addColumn(Column column) {
@@ -162,7 +168,7 @@ public class ColumnWriter {
         }
         List<Integer> widths = calculateWidths();
         List<Integer> spaces = new ArrayList<>(this.spaces);
-        renderedHeader = renderHeader(spaces, widths);
+        renderedHeader = noheader ? "" : renderHeader(spaces, widths);
 
         StringWriter result = new StringWriter();
         try (PrintWriter out = new NoTrailingWhitespacePrintWriter(result)) {

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -339,7 +339,7 @@ public class RepositoryInterpreter
                             + ", other: " + toString.apply(c[2]);
                   });
 
-            ColumnWriter table =  new ColumnWriter()
+            ColumnWriter table = new ColumnWriter()
                   .headersInColumns()
                   .header("Storage class").left("class")
                   .space().header("Total: size").bytes("totalSize", unitsArg, BINARY).header(",")
@@ -366,7 +366,7 @@ public class RepositoryInterpreter
                             .value("totalSize", counter[0]).value("totalFiles", counter[1])
                             .value("preciousSize", counter[2]).value("preciousFiles", counter[3])
                             .value("stickySize", counter[4]).value("stickyFiles", counter[5])
-                            .value("otherSize", counter[6]).value("otherFiles",  counter[7]);
+                            .value("otherSize", counter[6]).value("otherFiles", counter[7]);
                   });
 
             return sumLine.map(s -> table + "\n\n" + s).orElse(table.toString());

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/RepositoryInterpreter.java
@@ -244,6 +244,9 @@ public class RepositoryInterpreter
         @Option(name = "binary", usage = "Return statistics in binary format instead.")
         boolean binary;
 
+        @Option(name = "noheader", usage = "Do not print table header.")
+        boolean noheader;
+
         @Override
         public Serializable execute() throws CacheException, InterruptedException {
             if (pnfsIds != null) {
@@ -336,19 +339,23 @@ public class RepositoryInterpreter
                             + ", other: " + toString.apply(c[2]);
                   });
 
-            ColumnWriter table = new ColumnWriter()
+            ColumnWriter table =  new ColumnWriter()
                   .headersInColumns()
                   .header("Storage class").left("class")
                   .space().header("Total: size").bytes("totalSize", unitsArg, BINARY).header(",")
                   .fixed(" ").space().header("files").right("totalFiles").header(";").fixed(" ")
                   .space().space().header("Precious: size").bytes("preciousSize", unitsArg, BINARY)
-                  .header(",").fixed(" ").space().header("files").right("preciousFile").header(";")
+                  .header(",").fixed(" ").space().header("files").right("preciousFiles").header(";")
                   .fixed(" ")
                   .space().space().header("Sticky: size").bytes("stickySize", unitsArg, BINARY)
-                  .header(",").fixed(" ").space().header("files").right("stickyFile").header(";")
+                  .header(",").fixed(" ").space().header("files").right("stickyFiles").header(";")
                   .fixed(" ")
                   .space().space().header("others: size").bytes("otherSize", unitsArg, BINARY)
                   .header(",").fixed(" ").space().header("files").right("otherFiles");
+
+            if (noheader) {
+                table.suppressHeaders();
+            }
 
             stats.entrySet().stream()
                   .filter(e -> !e.getKey().equals("total"))
@@ -359,7 +366,7 @@ public class RepositoryInterpreter
                             .value("totalSize", counter[0]).value("totalFiles", counter[1])
                             .value("preciousSize", counter[2]).value("preciousFiles", counter[3])
                             .value("stickySize", counter[4]).value("stickyFiles", counter[5])
-                            .value("otherSize", counter[6]).value("otherFiles", counter[7]);
+                            .value("otherSize", counter[6]).value("otherFiles",  counter[7]);
                   });
 
             return sumLine.map(s -> table + "\n\n" + s).orElse(table.toString());


### PR DESCRIPTION
Motivation:

Issue https://github.com/dCache/dcache/issues/6214 reports that
patch a8a2673ada08916132f8264a31037be4350955 ` changed rep ls -s`
output to:
  1) contain human readable size formatting
  2) added a header
  3) introduced a bug that prevents pringing of Precious and
     Sticky file counts.
(2) and (3) broke various monitoring scripts that handle
`rep ls -s` output.

Modification:

Add "-noheader" option to print `rep ls -s` reasult without header and
fix (3) by properly matching colum names.

Result:

`rep ls -s` works as expected, `rep ls -s=b -noheader` produces output
similar to what we useed to see in previous dCache releases. Scripts work.

Patch: https://rb.dcache.org/r/13333
Acked-by: Paul Millar, Tigran Mkrtchyan

Target: trunk
Request: 7.2
Request: 7.1
Request: 7.0

Require-notes: yes
Require-book: no