### PR TITLE
webdav: http-tpc provide status information in 'info' admin command

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/ColumnWriter.java
+++ b/modules/common/src/main/java/org/dcache/util/ColumnWriter.java
@@ -212,19 +212,27 @@ public class ColumnWriter {
         if (rows.isEmpty()) {
             return "";
         }
+        StringWriter result = new StringWriter();
+        try (PrintWriter out = new NoTrailingWhitespacePrintWriter(result)) {
+            printTo(out, endOfLine);
+        }
+        return result.toString();
+    }
+
+    public void printTo(PrintWriter out) {
+        printTo(out, "\n");
+    }
+
+    private void printTo(PrintWriter out, String endOfLine) {
         List<Integer> widths = calculateWidths();
         List<Integer> spaces = new ArrayList<>(this.spaces);
         renderedHeader = renderHeader(spaces, widths);
 
-        StringWriter result = new StringWriter();
-        try (PrintWriter out = new NoTrailingWhitespacePrintWriter(result)) {
-            Row previousRow = null;
-            for (Row row : rows) {
-                row.render(previousRow, columns, spaces, widths, out, endOfLine);
-                previousRow = row;
-            }
+        Row previousRow = null;
+        for (Row row : rows) {
+            row.render(previousRow, columns, spaces, widths, out, endOfLine);
+            previousRow = row;
         }
-        return result.toString();
     }
 
     private void printHeader(PrintWriter out, String endOfLine) {

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -127,7 +127,7 @@
   </bean>
 
   <bean id="remote-transfer-handler" class="org.dcache.webdav.transfer.RemoteTransferHandler">
-      <description>Coordinate transfers</description>
+      <description>HTTP-TPC transfers</description>
 
       <property name="pnfsStub" ref="pnfs-stub"/>
       <property name="transferManagerStub" ref="transfer-manager-stub"/>


### PR DESCRIPTION
Motivation:

HTTP-TPC is part of the resposibilities of the WebDAV door; therefore,
it makes sense to provide static (configuration) and current status
information through the 'info' admin command.

Modification:

Make RemoteTransferManager a CellInfoProvider, so it may provide
information to the `info` admin command.

Move the information currently available via the `http-tpc finalise
info` command into the `info` command.

Add summary information on the number of transfers in each state, and
the overall number of transfers.

Update the Spring bean description, as this is included in the `info`
admin command output.

Update PrintWriter to support printing a table to an existing
PrintWriter.  This allows for easier indentation.

Result:

The admin now has access to summary of HTTP-TPC transfers and
configuration information via the WebDAV door's `info` admin
command.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13316/
Acked-by: Tigran Mkrtchyan