### PR TITLE
 nfs: propagate `permission denied` on stage requests

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1265,7 +1265,7 @@ public class NFSv41Door extends AbstractCellComponent implements
                 }
 
                 CacheException ce = (CacheException) t;
-                if (ce.getRc() != CacheException.PERMISSION_DENIED) {
+                if (ce.getRc() != CacheException.PERMISSION_DENIED || !getOnlineFilesOnly()) {
                     throw e;
                 }
 


### PR DESCRIPTION
Motivation:
when door gets 'permission denied' from the pool manager and was requesting
an offline file, then error must be propagated to the end user.

Fixes: 9324747

Modification:
propagate `permission denied` error when door asks for off-line files.

Result:
break infinite retry loop when staging not allowed.

```
$ dccp -P -t -1 dcap://dcache-lab000//exports/data/tau.root
dc_stage fail : File not cached
System error: Resource temporarily unavailable
$ sha1sum /mnt/exports/data/tau.root
sha1sum: /mnt/exports/data/tau.root
$ dccp -d2  dcap://dcache-lab000//exports/data/tau.root /dev/null
...
$ sha1sum /mnt/exports/data/tau.root
988e0d843be7d03965b58d1d966e0386e53e9d71 /mnt/exports/data/tau.root
$
```

Acked-by: Dmitry Litvintsev
Acked-by: Lea Morschel
Acked-by: Paul Millar
Target: master, 7.2
Require-book: no
Require-notes: yes
(cherry picked from commit 9dcc7501d7cea06b3f80d372850b11822728e2dd)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>