### PR TITLE
chimera/pnfsmanager: restore compatibility with Enstore - restore

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraEnstoreStorageInfoExtractor.java
@@ -1,6 +1,7 @@
 package org.dcache.chimera.namespace;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileNotFoundCacheException;
@@ -9,95 +10,22 @@ import diskCacheV111.vehicles.EnstoreStorageInfo;
 import diskCacheV111.vehicles.StorageInfo;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
 import org.dcache.chimera.ChimeraFsException;
-import org.dcache.chimera.FileState;
 import org.dcache.chimera.StorageGenericLocation;
+import org.dcache.chimera.posix.Stat;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
 
 
-public class ChimeraEnstoreStorageInfoExtractor
-      extends ChimeraHsmStorageInfoExtractor {
+public class ChimeraEnstoreStorageInfoExtractor extends ChimeraHsmStorageInfoExtractor {
 
     public ChimeraEnstoreStorageInfoExtractor(AccessLatency defaultAL,
           RetentionPolicy defaultRP) {
         super(defaultAL, defaultRP);
-    }
-
-    @Override
-    public StorageInfo getFileStorageInfo(ExtendedInode inode)
-          throws CacheException {
-        try {
-            EnstoreStorageInfo info = getDirStorageInfo(inode);
-
-            if (inode.stat().getState() == FileState.CREATED) {
-                return info;
-            }
-
-            List<String> tapeLocations = inode.getLocations(StorageGenericLocation.TAPE);
-            if (!tapeLocations.isEmpty()) {
-                info.clearKeys();
-
-                for (String location : tapeLocations) {
-                    URI uri = UriComponentsBuilder.fromUriString(location)
-                          .build(isEncoded(location)).toUri();
-                    info.addLocation(uri);
-
-                    String queryString = Strings.nullToEmpty(uri.getQuery());
-                    for (String part : queryString.split("&")) {
-                        String[] data = part.split(
-                              "="); // REVISIT what if 'part' contains multiple '='?
-                        String value = data.length == 2 ? data[1] : "";
-                        switch (data[0]) {
-                            case "bfid":
-                                info.setBitfileId(value);
-                                break;
-                            case "volume":
-                                info.setVolume(value);
-                                break;
-                            case "location_cookie":
-                                info.setLocation(value);
-                                break;
-                            case "original_name":
-                                info.setPath(value);
-                                break;
-                        }
-                    }
-                }
-            }
-
-            info.setIsNew(false);
-            return info;
-        } catch (ChimeraFsException e) {
-            throw new CacheException(e.getMessage());
-        }
-    }
-
-    @Override
-    public EnstoreStorageInfo getDirStorageInfo(ExtendedInode inode)
-          throws CacheException {
-        ExtendedInode directory = inode.isDirectory() ? inode : inode.getParent();
-
-        if (directory == null) {
-            throw new FileNotFoundCacheException("file unlinked");
-        }
-
-        List<String> groupTag = directory.getTag("storage_group");
-        String storageGroup = getFirstLine(groupTag).map(String::intern).orElse("none");
-
-        List<String> familyTag = directory.getTag("file_family");
-        String fileFamily = getFirstLine(familyTag).map(String::intern).orElse("none");
-
-        EnstoreStorageInfo info = new EnstoreStorageInfo(storageGroup, fileFamily);
-
-        directory.getTag("OSMTemplate").stream()
-              .map(StringTokenizer::new)
-              .filter(t -> t.countTokens() >= 2)
-              .forEach(t -> info.setKey(t.nextToken().intern(), t.nextToken()));
-
-        return info;
     }
 
     private static boolean isEncoded(String s) {
@@ -108,4 +36,84 @@ public class ChimeraEnstoreStorageInfoExtractor
     protected void checkFlushUpdate(StorageInfo info) throws CacheException {
         /* No checks needed: Enstore updates the namespace directly. */
     }
+
+    @Override
+    public StorageInfo getFileStorageInfo(ExtendedInode inode) throws CacheException {
+        EnstoreStorageInfo info;
+        Stat stat;
+        ExtendedInode level2 = inode.getLevel(2);
+        try {
+            List<String> locations = inode.getLocations(StorageGenericLocation.TAPE);
+            EnstoreStorageInfo parentStorageInfo = (EnstoreStorageInfo) getDirStorageInfo(inode);
+            if (locations.isEmpty()) {
+                info = parentStorageInfo;
+            } else {
+                info = new EnstoreStorageInfo(parentStorageInfo.getStorageGroup(),
+                      parentStorageInfo.getFileFamily());
+                info.setIsNew(false);
+                for (String location : locations) {
+                    UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(location);
+                    URI uri = builder.build(isEncoded(location)).toUri();
+                    info.addLocation(uri);
+                    String queryString = uri.getQuery();
+                    if (!Strings.isNullOrEmpty(queryString)) {
+                        for (String part : uri.getQuery().split("&")) {
+                            String[] data = part.split("=");
+                            String key = data[0];
+                            String value = (data.length == 2 ? data[1] : "");
+                            switch (key) {
+                                case "bfid":
+                                    info.setBitfileId(value);
+                                    break;
+                                case "volume":
+                                    info.setVolume(value);
+                                    break;
+                                case "location_cookie":
+                                    info.setLocation(value);
+                                    break;
+                                case "original_name":
+                                    info.setPath(value);
+                                    break;
+                            }
+                        }
+                    }
+                }
+            }
+            stat = inode.stat();
+            info.setIsNew((stat.getSize() == 0) && (!level2.exists()));
+        } catch (ChimeraFsException e) {
+            throw new CacheException(e.getMessage());
+        }
+        return info;
+    }
+
+    @Override
+    public StorageInfo getDirStorageInfo(ExtendedInode inode) throws CacheException {
+        ExtendedInode dirInode;
+        if (!inode.isDirectory()) {
+            dirInode = inode.getParent();
+            if (dirInode == null) {
+                throw new FileNotFoundCacheException("file unlinked");
+            }
+        } else {
+            dirInode = inode;
+        }
+        Map<String, String> hash = new HashMap<>();
+        ImmutableList<String> OSMTemplate = dirInode.getTag("OSMTemplate");
+        ImmutableList<String> group = dirInode.getTag("storage_group");
+        ImmutableList<String> family = dirInode.getTag("file_family");
+
+        for (String line : OSMTemplate) {
+            StringTokenizer st = new StringTokenizer(line);
+            if (st.countTokens() >= 2) {
+                hash.put(st.nextToken().intern(), st.nextToken());
+            }
+        }
+        String sg = getFirstLine(group).map(String::intern).orElse("none");
+        String ff = getFirstLine(family).map(String::intern).orElse("none");
+        EnstoreStorageInfo info = new EnstoreStorageInfo(sg, ff);
+        info.addKeys(hash);
+        return info;
+    }
+
 }

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -932,9 +932,14 @@ public class ChimeraNameSpaceProvider
                     break;
                 case SIZE:
                     stat = inode.statCache();
-                    if (stat.getState() != FileState.CREATED) {
-                        attributes.setSize(stat.getSize());
-                    }
+		    // REVISIT when we have another way to detect new files
+		    ExtendedInode level2 = inode.getLevel(2);
+		    boolean isNew = (stat.getSize() == 0) &&
+			!level2.exists() &&
+			inode.getLocations().isEmpty();
+		    if (!isNew) {
+			attributes.setSize(stat.getSize());
+		    }
                     break;
                 case CHANGE_TIME:
                     stat = inode.statCache();
@@ -960,20 +965,11 @@ public class ChimeraNameSpaceProvider
                     attributes.setChecksums(Sets.newHashSet(inode.getChecksums()));
                     break;
                 case LOCATIONS:
-                    stat = inode.statCache();
-                    if (stat.getState() != FileState.CREATED) {
-                        attributes.setLocations(
-                              Lists.newArrayList(inode.getLocations(StorageGenericLocation.DISK)));
-                    } else {
-                        attributes.setLocations(Collections.emptySet());
-                    }
+		    attributes.setLocations(Lists.newArrayList(inode.getLocations(StorageGenericLocation.DISK)));
                     break;
                 case FLAGS:
-                    stat = inode.statCache();
-                    if (stat.getState() != FileState.CREATED) {
-                        attributes.setFlags(Maps.newHashMap(inode.getFlags()));
-                    }
-                    break;
+		    attributes.setFlags(Maps.newHashMap(inode.getFlags()));
+		    break;
                 case SIMPLE_TYPE:
                 case TYPE:
                     attributes.setFileType(inode.getFileType());


### PR DESCRIPTION
ability to read files written directly by encp (Enstore client).

Motivation:

After upgrade to 7.2 we discovered failure to read files written
directly by encp.

Modificatoin:

Revert commits 947216b894b0a9bd6f06fe0492f039c08f1d4c41 and
a9268f3648caf745244a295d148438dec183753b

Result:

Able to read files written directly by encp. Code has been
running at Fermilab production. The revert cost 5% in performance
on write. We will try to address the performance hit asap.

Target: trunk
Request: 7.2

Patch: https://rb.dcache.org/r/13326/
Acked-by: Tigran, Paul
Require-book: no
Require-notes: yes