### PR TITLE
common-security: prevent NPE on password protected cert

### DIFF
--- a/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
@@ -269,9 +269,14 @@ public class CanlContextFactory implements SslContextFactory {
 
         public Callable<SSLContext> buildWithCaching() throws IOException {
             final CanlContextFactory factory = build();
+            /*
+             * PEMCredential does not consistently support keyPasswd being null
+             * https://github.com/eu-emi/canl-java/issues/114
+             */
             Callable<SSLContext> newContext =
                   () -> factory.getContext(
-                        new PEMCredential(keyPath.toString(), certificatePath.toString(), null));
+                        new PEMCredential(keyPath.toString(), certificatePath.toString(),
+                              new char[]{}));
             return memoizeWithExpiration(memoizeFromFiles(newContext, keyPath, certificatePath),
                   credentialUpdateInterval, credentialUpdateIntervalUnit);
         }

--- a/modules/dcache/src/main/java/org/dcache/util/jetty/CanlContextFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/util/jetty/CanlContextFactory.java
@@ -186,8 +186,12 @@ public class CanlContextFactory extends SslContextFactory.Server {
         // use instance of SslContextFactory.Server as it allows non 'https' protocol schemas.
         // See: https://github.com/eclipse/jetty.project/issues/3454
         SslContextFactory factory = new SslContextFactory.Server() {
+            /*
+             * PEMCredential does not consistently support keyPasswd being null
+             * https://github.com/eu-emi/canl-java/issues/114
+             */
             private final PEMCredential serverCredential =
-                  new PEMCredential(keyPath.toString(), certificatePath.toString(), null);
+                  new PEMCredential(keyPath.toString(), certificatePath.toString(), new char[]{});
 
             @Override
             protected void doStart() throws Exception {

--- a/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
+++ b/modules/gplazma2-xacml/src/main/java/org/dcache/gplazma/plugins/XACMLPlugin.java
@@ -375,9 +375,13 @@ public final class XACMLPlugin implements GPlazmaAuthenticationPlugin {
               caDir).build();
         validator = VOMSValidators.newValidator(vomsTrustStore, certChainValidator);
 
+        /*
+         * PEMCredential does not consistently support keyPasswd being null
+         * https://github.com/eu-emi/canl-java/issues/114
+         */
         X509Credential credential = new PEMCredential(_properties.getProperty(SERVICE_KEY),
               _properties.getProperty(SERVICE_CERT),
-              null);
+              new char[]{});
         _targetServiceName = convertFromRfc2253(
               credential.getCertificate().getSubjectX500Principal().getName(), true);
         _targetServiceIssuer = convertFromRfc2253(

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/Copier.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/Copier.java
@@ -445,10 +445,18 @@ public class Copier implements Runnable {
         ) {
             X509Credential credential;
             if (configuration.isUseproxy()) {
-                credential = new PEMCredential(configuration.getX509_user_proxy(), (char[]) null);
+                /*
+                 * PEMCredential does not consistently support keyPasswd being null
+                 * https://github.com/eu-emi/canl-java/issues/114
+                 */
+                credential = new PEMCredential(configuration.getX509_user_proxy(), new char[]{});
             } else {
+                /*
+                 * PEMCredential does not consistently support keyPasswd being null
+                 * https://github.com/eu-emi/canl-java/issues/114
+                 */
                 credential = new PEMCredential(configuration.getX509_user_key(),
-                      configuration.getX509_user_cert(), null);
+                      configuration.getX509_user_cert(), new char[]{});
             }
             javaGridFtpCopy(from, to, credential, logger);
         } else {

--- a/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMClient.java
+++ b/modules/srm-client/src/main/java/gov/fnal/srm/util/SRMClient.java
@@ -163,11 +163,19 @@ public abstract class SRMClient {
                 cred = configuration.getX509_user_proxy() == null
                       ? Optional.<X509Credential>empty()
                       : Optional.of(
+                            /*
+                             * PEMCredential does not consistently support keyPasswd being null
+                             * https://github.com/eu-emi/canl-java/issues/114
+                             */
                             new PEMCredential(configuration.getX509_user_proxy(), new char[]{}));
             } else {
                 cred = configuration.getX509_user_key() == null
                       || configuration.getX509_user_cert() == null
                       ? Optional.<X509Credential>empty()
+                      /*
+                       * PEMCredential does not consistently support keyPasswd being null
+                       * https://github.com/eu-emi/canl-java/issues/114
+                       */
                       : Optional.of(new PEMCredential(configuration.getX509_user_key(),
                             configuration.getX509_user_cert(), new char[]{}));
             }

--- a/modules/srm-client/src/main/java/org/dcache/srm/DelegationShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/DelegationShell.java
@@ -133,7 +133,11 @@ public class DelegationShell extends ShellApplication {
 
     public DelegationShell(String proxyPath) throws Exception {
         _proxyPath = proxyPath;
-        _proxy = new PEMCredential(proxyPath, (char[]) null);
+        /*
+         * PEMCredential does not consistently support keyPasswd being null
+         * https://github.com/eu-emi/canl-java/issues/114
+         */
+        _proxy = new PEMCredential(proxyPath, new char[]{});
 
         HttpClientSender sender = new HttpClientSender();
         Builder contextBuilder = CanlContextFactory.custom();

--- a/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
+++ b/modules/srm-client/src/main/java/org/dcache/srm/shell/SrmShell.java
@@ -338,12 +338,20 @@ public class SrmShell extends ShellApplication {
         if (configuration.isUseproxy()) {
             credential = configuration.getX509_user_proxy() == null
                   ? null
-                  : new PEMCredential(configuration.getX509_user_proxy(), (char[]) null);
+                  /*
+                   * PEMCredential does not consistently support keyPasswd being null
+                   * https://github.com/eu-emi/canl-java/issues/114
+                   */
+                  : new PEMCredential(configuration.getX509_user_proxy(), new char[]{});
         } else {
             credential = configuration.getX509_user_key() == null
                   || configuration.getX509_user_cert() == null
                   ? null
-                  : new PEMCredential(configuration.getX509_user_proxy(), (char[]) null);
+                  /*
+                   * PEMCredential does not consistently support keyPasswd being null
+                   * https://github.com/eu-emi/canl-java/issues/114
+                   */
+                  : new PEMCredential(configuration.getX509_user_proxy(), new char[]{});
         }
 
         fs = new AxisSrmFileSystem(decorateWithMonitoringProxy(new Class<?>[]{ISRM.class},

--- a/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseRequestCredentialStorage.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/request/sql/DatabaseRequestCredentialStorage.java
@@ -274,7 +274,11 @@ public class DatabaseRequestCredentialStorage implements RequestCredentialStorag
     private X509Credential read(String fileName) {
         if (fileName != null) {
             try {
-                return new PEMCredential(fileName, (char[]) null);
+                /*
+                 * PEMCredential does not consistently support keyPasswd being null
+                 * https://github.com/eu-emi/canl-java/issues/114
+                 */
+                return new PEMCredential(fileName, new char[]{});
             } catch (IOException | KeyStoreException | CertificateException e) {
                 LOGGER.error("error reading the credentials from database: {}", e.toString());
             }


### PR DESCRIPTION
Motivation:

When attempting to use a password-protected certificate with GridFTP, a NullPointerException is logged without any further information. This is a bug and does not help discover the underlying problem.

Modification:

The CanlContextFactory attempts to get the credential by creating a new instance of PEMCredential, which expects a key password as a char array. Because it is assumed that the key is not password protected, a value of null is passed, leading to a NullPointerException later on. This is changed, for every code occurrence, to instead pass an empty char array, which will result in a more helpful error message.

Result:
A better error message is logged when attempting to use a password-protected credential:
java.io.IOException: Error decrypting private key: the password is incorrect or the PEM data is corrupted.

Target: master
Target: 7.2
Target: 7.1
Target: 7.0
Target: 6.2
Ticket: #10265
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13337/
Acked-by: Paul Millar