### PR TITLE
gplazma: scitoken validate 'wlcg.ver' claim

### DIFF
--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/SciTokenPlugin.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/SciTokenPlugin.java
@@ -131,6 +131,8 @@ public class SciTokenPlugin implements GPlazmaAuthenticationPlugin {
             JsonWebToken token = checkValid(new JsonWebToken(tokens.get(0)));
             Issuer issuer = issuerOf(token);
 
+            validateWlcgVersionClaim(token);
+
             Collection<Principal> principals = new ArrayList<>();
 
             // REVISIT consider introducing an SPI to allow plugable support for handling claims.
@@ -167,6 +169,15 @@ public class SciTokenPlugin implements GPlazmaAuthenticationPlugin {
             }
         } catch (IOException e) {
             throw new AuthenticationException(e.getMessage());
+        }
+    }
+
+    private void validateWlcgVersionClaim(JsonWebToken token) throws AuthenticationException {
+        Optional<String> wlcgVer = token.getPayloadString("wlcg.ver");
+
+        if (wlcgVer.isPresent()) {
+            String ver = wlcgVer.get();
+            checkAuthentication(ver.equals("1.0"), "Unsupported wlcg profile version %s", ver);
         }
     }
 

--- a/modules/gplazma2-scitoken/src/test/java/org/dcache/gplazma/scitoken/SciTokenPluginTest.java
+++ b/modules/gplazma2-scitoken/src/test/java/org/dcache/gplazma/scitoken/SciTokenPluginTest.java
@@ -1353,6 +1353,34 @@ public class SciTokenPluginTest {
                 new OpenIdGroupPrincipal("/group-2")));
     }
 
+    @Test
+    public void shouldAcceptTokenSupportedWlcgVer() throws Exception {
+        given(aSciTokenPlugin()
+                .withProperty("gplazma.scitoken.issuer!EXAMPLE", "https://example.org/ /prefix uid:1000 gid:1000"));
+        givenThat("OP1", isAnIssuer().withURL("https://example.org/").withKey("key1", rsa256Keys()));
+
+        whenAuthenticatingWith(aJwtToken()
+                .withRandomSub()
+                .withRandomJti()
+                .withClaim("wlcg.ver", "1.0")
+                .withClaim("scope", "read:/")
+                .issuedBy("OP1").usingKey("key1"));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectTokenWithUnsupportedWlcgVer() throws Exception {
+        given(aSciTokenPlugin()
+                .withProperty("gplazma.scitoken.issuer!EXAMPLE", "https://example.org/ /prefix uid:1000 gid:1000"));
+        givenThat("OP1", isAnIssuer().withURL("https://example.org/").withKey("key1", rsa256Keys()));
+
+        whenAuthenticatingWith(aJwtToken()
+                .withRandomSub()
+                .withRandomJti()
+                .withClaim("wlcg.ver", "2.0")
+                .withClaim("scope", "read:/")
+                .issuedBy("OP1").usingKey("key1"));
+    }
+
     private void whenAuthenticatingWith(PrincipalSetMaker maker) throws AuthenticationException {
         identifiedPrincipals.addAll(maker.build());
         plugin.authenticate(Collections.emptySet(), Collections.emptySet(),


### PR DESCRIPTION
Motivation:

The WLCG AuthZ JWT profile defines the 'wlcg.ver' claim that all tokens
must provide.  It provides a smooth upgrade path; for example, by
allowing services to support multiple profile versions.

Although the 'scitoken' plugin doesn't require 'wlcg.ver' as it also
supports SciToken tokens, it should check the value if one is present.

Modification:

Add code to validate the 'wlcg.ver' claim, if present.

Add unit tests to verify correct behaviour.

Result:

dCache will now reject WLCG-AuthZ-JWT profile tokens with a 'wlcg.ver'
claim that it does not support.  Other tokens (e.g., SciTokens) are
unaffected by this change.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13343/
Acked-by: Tigran Mkrtchyan