### PR TITLE
webdav: don't log an error if client disconnects before response sent

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheHtmlResponseHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheHtmlResponseHandler.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.security.AccessController;
 import javax.security.auth.Subject;
+import org.eclipse.jetty.io.EofException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
@@ -137,8 +138,10 @@ public class DcacheHtmlResponseHandler extends AbstractWrappingResponseHandler {
             response.setContentTypeHeader("text/html");
             OutputStream out = response.getOutputStream();
             out.write(error.getBytes());
-        } catch (IOException ex) {
-            LOGGER.warn("exception writing content");
+        } catch (EofException e) {
+            LOGGER.debug("Client disconnected before we could reply.");
+        } catch (IOException e) {
+            LOGGER.warn("exception writing content: {}", e.toString());
         }
     }
 

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheSimpleResponseHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheSimpleResponseHandler.java
@@ -35,6 +35,7 @@ import io.milton.http.quota.StorageChecker;
 import io.milton.resource.Resource;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.eclipse.jetty.io.EofException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,6 +101,8 @@ public class DcacheSimpleResponseHandler extends AbstractWrappingResponseHandler
 
         try {
             response.getOutputStream().write(messageBytes);
+        } catch (EofException e) {
+            LOGGER.debug("Client disconnected before we could respond {}", message);
         } catch (IOException e) {
             LOGGER.warn("Failed to write error response {}: {}", message, e.toString());
         }


### PR DESCRIPTION
Motivation:

The WebDAV door can log an error if the client disconnects before the
WebDAV door has responded.

Modification:

Catch the specific error indicating that the client has disconnected.

If this happens, only log the problem at DEBUG level.

Result:

The WebDAV door cannot send the HTTP response to some HTTP request if
the client has already disconnected.  dCache no longer logs an error
that it cannot send the HTTP response.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch https://rb.dcache.org/r/13355/
Acked-by: Lea Morschel