### PR TITLE
webdav: don't log an error if client disconnects before response sent

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResponseHandler.java
@@ -46,6 +46,7 @@ import org.dcache.auth.attributes.LoginAttribute;
 import org.dcache.auth.attributes.RootDirectory;
 import org.dcache.http.AuthenticationHandler;
 import org.dcache.http.PathMapper;
+import org.eclipse.jetty.io.EofException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
@@ -199,8 +200,10 @@ public class DcacheResponseHandler extends AbstractWrappingResponseHandler {
             response.setContentTypeHeader("text/html");
             OutputStream out = response.getOutputStream();
             out.write(error.getBytes());
-        } catch (IOException ex) {
-            LOGGER.warn("exception writing content");
+        } catch (EofException e) {
+            LOGGER.debug("Client disconnected before we could reply.");
+        } catch (IOException e) {
+            LOGGER.warn("exception writing content: {}", e.toString());
         }
     }
 


### PR DESCRIPTION
Motivation:

The WebDAV door can log an error if the client disconnects before the
WebDAV door has responded.

Modification:

Catch the specific error indicating that the client has disconnected.

If this happens, only log the problem at DEBUG level.

Result:

The WebDAV door cannot send the HTTP response to some HTTP request if
the client has already disconnected.  dCache no longer logs an error
that it cannot send the HTTP response.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch https://rb.dcache.org/r/13355/
Acked-by: Lea Morschel