### PR TITLE
webdav: better logging if client disconnects during proxied transfer

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/ClientDisconnectedException.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/ClientDisconnectedException.java
@@ -1,0 +1,29 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.webdav;
+
+/**
+ * Indicates that the client disconnected.  This _should_ be a subclass of IOException, but
+ * unfortunately Milton reacts rather badly to those.
+ */
+public class ClientDisconnectedException extends RuntimeException {
+    public ClientDisconnectedException(String message) {
+        super(message);
+    }
+}

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -139,6 +139,7 @@ import org.dcache.util.list.DirectoryListPrinter;
 import org.dcache.util.list.ListDirectoryHandler;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.webdav.owncloud.OwncloudClients;
+import org.eclipse.jetty.io.EofException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -682,6 +683,14 @@ public class DcacheResourceFactory
                         throw new TimeoutCacheException("Server is busy (internal timeout)");
                     }
                     transfer.relayData(inputStream);
+                } catch (EofException e) {
+                    // REVISIT: do we wish to log diagnostic/forensic details of the transfer?
+                    LOGGER.info("Proxied upload of {} failed: client disconnected", transfer.getPnfsId());
+
+                    String explanation = "Client disconnected while proxying an upload.";
+                    transfer.notifyBilling(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, explanation);
+                    transfer.killMover(explanation);
+                    throw new ClientDisconnectedException(explanation);
                 } catch (IOException e) {
                     String message = Exceptions.messageOrClassName(e);
                     transfer.notifyBilling(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,
@@ -800,6 +809,14 @@ public class DcacheResourceFactory
                   "Shutting down");
             transfer.killMover("door shutting down");
             throw e;
+        } catch (EofException e) {
+            // REVISIT: do we wish to log diagnostic/forensic details of the transfer?
+            LOGGER.info("Proxied download of {} failed: client disconnected", transfer.getPnfsId());
+
+            String explanation = "Client disconnected while proxying a download.";
+            transfer.notifyBilling(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, explanation);
+            transfer.killMover(explanation);
+            throw new ClientDisconnectedException(explanation);
         } catch (IOException e) {
             String message = Exceptions.messageOrClassName(e);
             transfer.notifyBilling(CacheException.UNEXPECTED_SYSTEM_EXCEPTION,

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheStandardFilter.java
@@ -103,6 +103,13 @@ public class DcacheStandardFilter implements Filter {
         } catch (WebDavException e) {
             LOGGER.warn("Internal server error: {}", e.toString());
             responseHandler.respondServerError(request, response, e.getMessage());
+        } catch (ClientDisconnectedException e) {
+            // Should have been logged in DcacheResourceFactory
+            LOGGER.debug("Problem transferring data: {}", e.getMessage());
+
+            // The choice of "500 Internal Server Error" is somewhat arbitrary as we expect that
+            // the client is no longer connected.
+            responseHandler.respondServerError(request, response, e.getMessage());
         } catch (RuntimeException e) {
             LOGGER.error("Internal server error", e);
             responseHandler.respondServerError(request, response, e.getMessage());


### PR DESCRIPTION
Motivation:

The WebDAV door is currently rather noisy if the client disconnects
during a proxied upload or proxied download.

While a client disconnecting during a transfer probably indicates a
problem (i.e., timeout due to dCache being too slow), the logged
messages should make this clear.

Modification:

Update WebDAV door behaviour if a client disconnects during a proxied
transfer.

The billing message now makes it clear what has happened.

The door no longer logs anything to the log file.  Instead, there is a
message logged in the pinboard.

We may wish to revise this decision; for example, by including forensic
information to help diagnose why the client disconnected.  This patch
helps prepare dCache for any such subsequent change.

The PoolMoverKillMessage reason is updated to make it clear why the
mover is being killed.

Note that there is a race condition here: the door both disconnects the
TCP connection and sends the PoolMoverKillMessage.  The pool's log
messages and billing entry will depend on which is processed first.

Result:

A client that disconnects during a proxied HTTP transfer (GET or PUT) is
no longer logged in the WebDAV door's log file; instead, it is logged in
the cell's pinboard.  The billing message is updated to make it clearer
what went wrong.

See: #6358
Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2