### PR TITLE
webdav/transfermanager: skip PnfsManager lookup if possible

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/transferManager/TransferManagerMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/transferManager/TransferManagerMessage.java
@@ -2,8 +2,12 @@ package diskCacheV111.vehicles.transferManager;
 
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.Message;
+import javax.annotation.Nullable;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.auth.attributes.Restrictions;
+import org.dcache.vehicles.FileAttributes;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Patrick F.
@@ -33,6 +37,8 @@ public abstract class TransferManagerMessage extends Message {
     private Long credentialId;
     private Restriction restriction;
     private PnfsId pnfsId;
+    @Nullable
+    private FileAttributes attributes;
 
     public TransferManagerMessage(
           String pnfsPath,
@@ -78,6 +84,15 @@ public abstract class TransferManagerMessage extends Message {
      */
     public PnfsId getPnfsId() {
         return pnfsId;
+    }
+
+    public void setFileAttributes(FileAttributes attributes) {
+        this.attributes = requireNonNull(attributes);
+    }
+
+    @Nullable
+    public FileAttributes getFileAttributes() {
+        return attributes;
     }
 
     /**

--- a/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/PnfsHandler.java
@@ -344,6 +344,11 @@ public class PnfsHandler implements CellMessageSender {
         return request(new PnfsCreateEntryMessage(path, attributes));
     }
 
+    public PnfsCreateEntryMessage createPnfsEntry(String path,
+          FileAttributes attributes, Set<FileAttribute> queryAttributes) throws CacheException {
+        return request(new PnfsCreateEntryMessage(path, attributes, queryAttributes));
+    }
+
     public Collection<Link> find(PnfsId pnfsId) throws CacheException {
         PnfsGetParentMessage response = request(new PnfsGetParentMessage(pnfsId));
         List<PnfsId> parents = response.getParents();


### PR DESCRIPTION
Motivation:

Currently, both the WebDAV door and TransferManager will query
PnfsManager for HTTP-TPC PUSH and PULL requests.  This is unnecessary: a
single query to PnfsManager should be sufficient.

Modification:

Update TransferManagerHandler to expose the required FileAttribute
needed for push and pull requets.

Update WebDAV to query these FileAttribute when it checks the file
exists (push) or creates the file (pull).

Update TransferManagerMessage to allow the door to carry FileAttributes
(optionally).

Update TransferManagerHandler to check if the TransferManagerMessage
contains a FileAttributes object with sufficient information.  If so,
the PnfsManager query is skipped and the transfer-manager goes straight
to the pool selection step.

Result:

dCache provides marginally better performance for HTTP-TPC, which starts
to become significant when transferring many small files.

Target: master
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13358/
Acked-by: Tigran Mkrtchyan