### PR TITLE
Add support for OAuthProviderPrincipal; Improve support for group-based AuthN in WLCG-AuthZ JWT

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/OAuthProviderPrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/OAuthProviderPrincipal.java
@@ -1,0 +1,62 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.auth;
+
+import java.security.Principal;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A Principal that describes which OP asserted the users identity.  The value
+ * is the short-hand name for the OP.
+ */
+public class OAuthProviderPrincipal implements Principal
+{
+    private final String name;
+
+    public OAuthProviderPrincipal(String name)
+    {
+        this.name = requireNonNull(name);
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        return other instanceof OAuthProviderPrincipal
+                && ((OAuthProviderPrincipal)other).name.equals(name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return name.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "OP[" + name + "]";
+    }
+}

--- a/modules/gplazma2-multimap/src/main/java/org/dcache/gplazma/plugins/GplazmaMultiMapFile.java
+++ b/modules/gplazma2-multimap/src/main/java/org/dcache/gplazma/plugins/GplazmaMultiMapFile.java
@@ -27,6 +27,7 @@ import org.dcache.auth.FQANPrincipal;
 import org.dcache.auth.GidPrincipal;
 import org.dcache.auth.GroupNamePrincipal;
 import org.dcache.auth.GroupPrincipal;
+import org.dcache.auth.OAuthProviderPrincipal;
 import org.dcache.auth.OidcSubjectPrincipal;
 import org.dcache.auth.OpenIdGroupPrincipal;
 import org.dcache.auth.UidPrincipal;
@@ -113,7 +114,8 @@ public class GplazmaMultiMapFile {
         OIDC_GROUP("oidcgrp", OpenIdGroupPrincipal.class),
         UID("uid", UidPrincipal.class),
         USER_NAME("username", UserNamePrincipal.class),
-        ENTITLEMENT("entitlement", EntitlementPrincipal.class);
+        ENTITLEMENT("entitlement", EntitlementPrincipal.class),
+        OP("op", OAuthProviderPrincipal.class);
 
         private final String label;
         private final Class<? extends Principal> groupType;

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
@@ -51,6 +51,7 @@ import org.dcache.auth.FullNamePrincipal;
 import org.dcache.auth.GroupNamePrincipal;
 import org.dcache.auth.LoA;
 import org.dcache.auth.LoAPrincipal;
+import org.dcache.auth.OAuthProviderPrincipal;
 import org.dcache.auth.OidcSubjectPrincipal;
 import org.dcache.auth.OpenIdGroupPrincipal;
 import org.dcache.auth.UserNamePrincipal;
@@ -477,6 +478,7 @@ public class OidcAuthPlugin implements GPlazmaAuthenticationPlugin {
             if (userInfo != null && userInfo.has("sub")) {
                 LOG.debug("UserInfo from OpenId Provider: {}", userInfo);
                 Set<Principal> principals = new HashSet<>();
+                principals.add(new OAuthProviderPrincipal(ip.getName()));
                 addSub(ip, userInfo, principals);
                 addNames(userInfo, principals);
                 addEmail(userInfo, principals);

--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.apache.http.client.HttpClient;
+import org.dcache.auth.OAuthProviderPrincipal;
 import org.dcache.gplazma.AuthenticationException;
 import org.dcache.gplazma.util.JsonWebToken;
 import org.slf4j.Logger;
@@ -84,7 +85,11 @@ public class Issuer {
         }
         sb.append(".well-known/openid-configuration");
         String configEndpoint = sb.toString();
-        this.identity = ImmutableSet.copyOf(identity);
+
+        this.identity = ImmutableSet.<Principal>builder()
+                .addAll(identity)
+                .add(new OAuthProviderPrincipal(id))
+                .build();
 
         this.configuration = new HttpJsonNode(client, configEndpoint,
               Duration.ofHours(1), Duration.ofSeconds(10));

--- a/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
+++ b/modules/gplazma2-scitoken/src/main/java/org/dcache/gplazma/scitoken/Issuer.java
@@ -59,7 +59,8 @@ public class Issuer {
 
     private final String id;
     private final String endpoint;
-    private final Set<Principal> identity;
+    private final Set<Principal> userIdentity;
+    private final Principal opIdentity;
     private final FsPath prefix;
     private final Queue<String> previousJtis;
 
@@ -86,10 +87,8 @@ public class Issuer {
         sb.append(".well-known/openid-configuration");
         String configEndpoint = sb.toString();
 
-        this.identity = ImmutableSet.<Principal>builder()
-                .addAll(identity)
-                .add(new OAuthProviderPrincipal(id))
-                .build();
+        userIdentity = Set.copyOf(identity);
+        opIdentity = new OAuthProviderPrincipal(id);
 
         this.configuration = new HttpJsonNode(client, configEndpoint,
               Duration.ofHours(1), Duration.ofSeconds(10));
@@ -108,8 +107,12 @@ public class Issuer {
         return endpoint;
     }
 
-    public Set<Principal> getPrincipals() {
-        return identity;
+    public Set<Principal> getUserIdentity() {
+        return userIdentity;
+    }
+
+    public Principal getOpIdentity() {
+        return opIdentity;
     }
 
     public String getId() {


### PR DESCRIPTION
Pull-request contains two patches because the second (desired) patch (RB 13344) has a dependency on the first (RB13090).

## Add support for OAuthProviderPrincipal

    The token-based authentication gPlazma plugins (scitoken, oidc) now
    include the identity of the OP that created the token.  The multimap
    plugin is updated to support matching on this principal.

    Patch: https://rb.dcache.org/r/13090/
---
## Improve support for group-based AuthN in WLCG-AuthZ JWT

    The 'scitoken' gplazma plugin will now accept WLCG AuthZ tokens without
    direct authorisation statements.  When accepting such a token, the
    plugin refrains from adding any of the additional principals from the
    configuration property; only the principals directly from the token are
    added.

    Patch: https://rb.dcache.org/r/13344/