### PR TITLE
dcacheview: upgrade to dCacheView 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.jetty>9.4.43.v20210629</version.jetty>
         <version.xrootd4j>4.2.5</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
-        <version.dcache-view>2.0.0</version.dcache-view>
+        <version.dcache-view>2.0.1</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Motivation:

Adopt improvements from v2.0.1 of dCacheView.  The highlights are:

    Many components switched to Polymer v2.

    New icons for ROOT and HDF files.

    Improved visual appearance for user profile.

    Single radio button in some admin views.

    Folder icon colour change.

Modification:

dCacheView version bumped from v2.0.0 to v2.0.1

Result:

Better user experience with dCacheView: some improved icons and other
minor visual tweaks

Target: master
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13338/
Acked-by: Marina Sahakyan