### PR TITLE
loginbroker: add support for multiple protocol families

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerInfo.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginBrokerInfo.java
@@ -16,7 +16,9 @@ import java.net.ProtocolFamily;
 import java.net.StandardProtocolFamily;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import org.dcache.util.NetworkUtils.InetAddressScope;
@@ -38,7 +40,9 @@ public class LoginBrokerInfo implements Serializable {
 
     private final String _cellName;
     private final String _domainName;
-    private final String _protocolFamily;
+    @Deprecated()
+    private final String _protocolFamily;  // only for serialisation backwards-compatibility
+    private List<String> _protocolFamilies;
     private final String _protocolVersion;
     private final String _protocolEngine;
     private final String _root;
@@ -54,9 +58,10 @@ public class LoginBrokerInfo implements Serializable {
     private transient Collection<FsPath> _readFsPaths;
     private transient Collection<FsPath> _writeFsPaths;
 
+    // The first element of protocolFamilies is the preferred protocol
     public LoginBrokerInfo(String cellName,
           String domainName,
-          String protocolFamily,
+          List<String> protocolFamilies,
           String protocolVersion,
           String protocolEngine,
           String root,
@@ -70,7 +75,8 @@ public class LoginBrokerInfo implements Serializable {
         checkArgument(!addresses.isEmpty());
         _cellName = requireNonNull(cellName);
         _domainName = requireNonNull(domainName);
-        _protocolFamily = requireNonNull(protocolFamily);
+        _protocolFamilies = List.copyOf(protocolFamilies);
+        _protocolFamily = protocolFamilies.get(0);
         _protocolVersion = requireNonNull(protocolVersion);
         _protocolEngine = requireNonNull(protocolEngine);
         _root = root;
@@ -122,8 +128,23 @@ public class LoginBrokerInfo implements Serializable {
     }
 
     @Nonnull
-    public String getProtocolFamily() {
-        return _protocolFamily;
+    public String getPreferredProtocolFamily() {
+        return _protocolFamilies.get(0);
+    }
+
+    @Nonnull
+    public List<String> getProtocolFamilies() {
+        return _protocolFamilies;
+    }
+
+    public boolean supportsProtocol(String protocol) {
+        return _protocolFamilies.contains(protocol);
+    }
+
+    public boolean supportsAnyProtocol(Collection protocols) {
+        Set<String> supported = new HashSet<>(_protocolFamilies);
+        supported.retainAll(protocols);
+        return !supported.isEmpty();
     }
 
     @Nonnull
@@ -231,5 +252,9 @@ public class LoginBrokerInfo implements Serializable {
         }
         _readFsPaths = _readPaths.stream().map(FsPath::create).collect(toList());
         _writeFsPaths = _writePaths.stream().map(FsPath::create).collect(toList());
+
+        if (_protocolFamilies == null) { // backwards compatible with old doors.
+            _protocolFamilies = List.of(_protocolFamily);
+        }
     }
 }

--- a/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/login/LoginManager.java
@@ -186,7 +186,7 @@ public class LoginManager
             _loginBrokerPublisher.setCellAddress(_nucleus.getThisAddress());
             _loginBrokerPublisher.setTags(byComma.splitToList(_args.getOption("brokerTags")));
             _loginBrokerPublisher.setProtocolEngine(_loginCellFactory.getName());
-            _loginBrokerPublisher.setProtocolFamily(_args.getOption("protocolFamily", ""));
+            _loginBrokerPublisher.setProtocolFamilies(_args.getOption("protocolFamily", ""));
             _loginBrokerPublisher.setProtocolVersion(_args.getOption("protocolVersion", "1.0"));
             _loginBrokerPublisher.setUpdateTime(_args.getLongOption("brokerUpdateTime"));
             _loginBrokerPublisher.setUpdateTimeUnit(

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/doors/Door.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/doors/Door.java
@@ -20,8 +20,11 @@ public final class Door {
           "role assertion.")
     private String domainName;
 
-    @ApiModelProperty("The abbreviation of the protocol name.")
+    @ApiModelProperty("The preferred protocol name.")
     private String protocol;
+
+    @ApiModelProperty("All protocol names supported by this door.")
+    private List<String> protocols;
 
     @ApiModelProperty("The version number of the protocol.")
     private String version;
@@ -62,7 +65,8 @@ public final class Door {
         identifier = isAdmin ? info.getIdentifier() : null;
         updateTime = isAdmin ? info.getUpdateTime() : 0L;
 
-        protocol = info.getProtocolFamily();
+        protocol = info.getPreferredProtocolFamily();
+        protocols = info.getProtocolFamilies();
         version = info.getProtocolVersion();
         root = info.getRoot();
         addresses = info.getAddresses().stream()

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
@@ -241,11 +241,11 @@ public class SrrBuilder {
               .filter(i -> i.supports(InetAddressScope.GLOBAL))
               .map(d -> {
                         Storageendpoint endpoint = new Storageendpoint()
-                              .withName(id + "#" + d.getProtocolFamily() + "@" + d.getAddresses().get(0)
+                              .withName(id + "#" + d.getPreferredProtocolFamily() + "@" + d.getAddresses().get(0)
                                     .getCanonicalHostName() + "-" + d.getPort())
-                              .withInterfacetype(d.getProtocolFamily())
+                              .withInterfacetype(d.getPreferredProtocolFamily())
                               .withInterfaceversion(d.getProtocolVersion())
-                              .withEndpointurl(d.getProtocolFamily() + "://" + d.getAddresses().get(0)
+                              .withEndpointurl(d.getPreferredProtocolFamily() + "://" + d.getAddresses().get(0)
                                     .getCanonicalHostName() + ":" + d.getPort() + d.getRoot())
                               .withAssignedshares(Collections.singletonList("all"));
 

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/loginbroker/LoginBrokerMsgHandler.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/loginbroker/LoginBrokerMsgHandler.java
@@ -52,7 +52,7 @@ public class LoginBrokerMsgHandler implements CellMessageReceiver {
         StatePath pathToProtocol = pathToDoor.newChild("protocol");
 
         conditionalAddString(update, pathToProtocol, "engine", info.getProtocolEngine(), lifetime);
-        conditionalAddString(update, pathToProtocol, "family", info.getProtocolFamily(), lifetime);
+        conditionalAddString(update, pathToProtocol, "family", info.getPreferredProtocolFamily(), lifetime);
         conditionalAddString(update, pathToProtocol, "version", info.getProtocolVersion(),
               lifetime);
         conditionalAddString(update, pathToProtocol, "root", info.getRoot(), lifetime);

--- a/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
+++ b/modules/dcache-nfs/src/main/resources/org/dcache/chimera/nfsv41/door/nfsv41-common.xml
@@ -182,7 +182,7 @@
         <property name="updateThreshold" value="${nfs.loginbroker.update-threshold}"/>
         <property name="protocolEngine" value="org.dcache.chimera.nfsv41.door.NFSv41Door"/>
         <property name="protocolVersion" value="${nfs.loginbroker.version}"/>
-        <property name="protocolFamily" value="${nfs.loginbroker.family}"/>
+        <property name="protocolFamilies" value="${nfs.loginbroker.family}"/>
         <property name="address" value="#{ T(com.google.common.base.Strings).emptyToNull('${nfs.loginbroker.address}') }"/>
         <property name="port" value="${nfs.loginbroker.port}"/>
         <property name="topic" value="${nfs.loginbroker.update-topic}"/>

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -253,6 +253,8 @@ public final class Storage
           "space reservation is disabled";
     private static final String SFN_STRING = "SFN=";
 
+    private static final Set<String> FTP_URL_SCHEMATA = Set.of("ftp", "gsiftp", "gkftp");
+
     private static final LoadingCache<InetAddress, String> GET_HOST_BY_ADDR_CACHE =
           CacheBuilder.newBuilder()
                 .expireAfterWrite(10, MINUTES)
@@ -678,9 +680,8 @@ public final class Storage
 
             /* Determine path component of TURL.
              */
-            String protocol = door.getProtocolFamily();
             String transferPath = door.relativize(user.getRoot(), path);
-            if (protocol.equals("gsiftp") || protocol.equals("ftp") || protocol.equals("gkftp")) {
+            if (door.supportsAnyProtocol(FTP_URL_SCHEMATA)) {
                 /* According to RFC 1738 an FTP URL is relative to the FTP server's initial
                  * working directory, which in dCache is the user's home directory.
                  *
@@ -706,6 +707,7 @@ public final class Storage
 
             /* Compose the TURL.
              */
+            String protocol = protocols.stream().filter(door::supportsProtocol).findFirst().orElseThrow();
             URI turl = isHostAndPortNeeded(protocol)
                   ? new URI(protocol, null, selectHostName(door, scope, family), door.getPort(),
                   transferPath, null, null)
@@ -819,8 +821,8 @@ public final class Storage
 
         Collection<LoginBrokerInfo> doors = loginBrokerSource.doors();
 
-        if (!doors.stream().map(LoginBrokerInfo::getProtocolFamily)
-              .anyMatch(s -> s.equals(srmProtocol))) {
+        boolean haveSrmDoor = doors.stream().anyMatch(d -> d.supportsProtocol(srmProtocol));
+        if (!haveSrmDoor) {
             /*  We have SRM activity without (apparently) any SRM doors.  This
              *  is likely from an SrmManager starting up and attempting to
              *  continue incomplete (for srmBringOnline) or queud activity.
@@ -836,7 +838,7 @@ public final class Storage
             result = doors
                   .stream()
                   .anyMatch(i -> (port == -1 || port == i.getPort())
-                        && i.getProtocolFamily().equals(srmProtocol)
+                        && i.supportsProtocol(srmProtocol)
                         && i.getAddresses().stream()
                         .map(InetAddress::getHostAddress)
                         .anyMatch(n -> n.equalsIgnoreCase(address.getHostAddress())));
@@ -848,7 +850,7 @@ public final class Storage
                     sb.append("    ").append(i.toString()).append(" ");
                     if (port != -1 && port != i.getPort()) {
                         sb.append("mismatch on port");
-                    } else if (!i.getProtocolFamily().equals(srmProtocol)) {
+                    } else if (!i.supportsProtocol(srmProtocol)) {
                         sb.append("mismatch on family");
                     } else if (!i.getAddresses()
                           .stream()

--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srm.xml
@@ -61,7 +61,7 @@
         <property name="updateThreshold" value="${srm.loginbroker.update-threshold}"/>
         <property name="protocolEngine" value="diskCacheV111.srm.dcache.Storage"/>
         <property name="protocolVersion" value="${srm.loginbroker.version}"/>
-        <property name="protocolFamily" value="${srm.loginbroker.family}"/>
+        <property name="protocolFamilies" value="${srm.loginbroker.family}"/>
         <property name="address" value="#{ T(com.google.common.base.Strings).emptyToNull('${srm.loginbroker.address}') }"/>
         <property name="port" value="${srm.loginbroker.port}"/>
         <property name="topic" value="${srm.loginbroker.update-topic}"/>

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -372,7 +372,7 @@
       <property name="updateThreshold" value="${webdav.loginbroker.update-threshold}"/>
       <property name="protocolEngine" value="org.dcache.webdav.DcacheResourceFactory"/>
       <property name="protocolVersion" value="${webdav.loginbroker.version}"/>
-      <property name="protocolFamily" value="${webdav.loginbroker.family}"/>
+      <property name="protocolFamilies" value="${webdav.loginbroker.family}"/>
       <property name="address" value="#{ T(com.google.common.base.Strings).emptyToNull('${webdav.loginbroker.address}') }"/>
       <property name="port" value="${webdav.loginbroker.port}"/>
       <property name="topic" value="${webdav.loginbroker.update-topic}"/>

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -233,7 +233,7 @@
     <property name="updateThreshold" value="${xrootd.loginbroker.update-threshold}"/>
     <property name="protocolEngine" value="org.dcache.xrootd.door.XrootdDoor"/>
     <property name="protocolVersion" value="${xrootd.loginbroker.version}"/>
-    <property name="protocolFamily" value="${xrootd.loginbroker.family}"/>
+    <property name="protocolFamilies" value="${xrootd.loginbroker.family}"/>
     <property name="port" value="${xrootd.loginbroker.port}"/>
     <property name="address" value="#{ T(com.google.common.base.Strings).emptyToNull('${xrootd.loginbroker.address}') }"/>
     <property name="topic" value="${xrootd.loginbroker.update-topic}"/>

--- a/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
+++ b/modules/dcache/src/main/java/diskCacheV111/cells/TransferObserverV1.java
@@ -508,7 +508,7 @@ public class TransferObserverV1
             page.beginRow(null, "odd");
             page.td("cell", door.getCellName());
             page.td("domain", door.getDomainName());
-            page.td("protocol", door.getProtocolFamily());
+            page.td("protocol", door.getPreferredProtocolFamily());
             page.td("version", door.getProtocolVersion());
             page.td("host", address.getHostName());
             page.td("port", door.getPort());


### PR DESCRIPTION
Motivation:

Commit 4e8c33b3822 introduced support for TLS in the xroot door.  The
admin may choose the level of support via the 'xrootd.security.tls.mode'
configuration property.  Acceptable values are `OFF`, `OPTIONAL` and
`STRICT`, with `OFF` being the default value.

The patch introduced corresponding changes to the
`xrootd.loginbroker.family` configuration property.  There are a couple
of problems with those changes.

  1.  If `xrootd.security.tls.mode` has value `OPTIONAL` then the
      configuration property default value is `xroot,xroots`.

      Unfortunately, the `xrootd.loginbroker.family` configuration
      property is not a comma-separated list of values, but a single
      value.

  2.  The name for the xroot protocol changed from `root` to `xroot`.

      Unfortuately, there are clients that expect the door to identify
      itself with the name `root` (rather than `xroot`).  In particular,
      there are clients/users that present `root` as the protocol name
      in SRM, and so expect to get back a TURL starting `root://`.

      (See #6372)

This patch is targeting the first problem.  Once this is fixed,
resolving the second problem becomes almost trivial, as `root` may be
added as another protocol family that the door supports.

Modification:

Update LoginBrokerInfo to accept a list of "protocol families".
Backwards compatability with old doors (publishing family as a String
field member) is achieved through the `readObject` customisation of the
object deserialisation.

LoginBrokerInfo is further updated to allow querying if a particular
protocol is supported (`supportsProtocol` and `supportsAnyProtocol`).
This simplies the code using LoginBrokerInfo objects, helping keep the
code DRY.

LoginBrokerPublisher (the code in the door that builds and sends
LoginBrokerInfo objects) is updated to parse comma-separated values,
with a change in the method name to make the new semantics clear.

Code that makes use of LoginBrokerInfo objects (mostly in SrmManager)
has been updated to use the new methods: `supportsProtocol` and
`supportsAnyProtocol`.

For places where the door is described (e.g., SRR, info, Frontend), the
patch designates the first protocol as "preferred", and only this is
published.  This means we can add compatibility support in SRM (allowing
clients to specify `root`) without affecting how the doors are
published.

We may need to review this when it is decided how an xroot door that
supports both encrypted (TLS) and unencrypted should be represented in
SRR.

Result:

Fix SRM based upload or download where the client requests an
xroot-based transfer.  The SRM door will now also consider any xroot
door with `xrootd.security.tls.mode` configured to `OPTIONAL` when
building a TURL targeting either `xroot` or `xroots` protocols.

Target: master
Require-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13341/
Acked-by: Tigran Mkrtchyan