### PR TITLE
pnfsmanager: add support for resetting gauge and counter statistics

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -53,8 +53,10 @@ import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.util.RetentionPolicy;
 import diskCacheV111.vehicles.StorageInfo;
+import dmg.cells.nucleus.CellCommandListener;
 import dmg.cells.nucleus.CellInfo;
 import dmg.cells.nucleus.CellInfoProvider;
+import dmg.util.command.Command;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -71,6 +73,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -116,7 +119,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 
 public class ChimeraNameSpaceProvider
-      implements NameSpaceProvider, CellInfoProvider {
+      implements NameSpaceProvider, CellInfoProvider, CellCommandListener {
 
     private static final int SYMLINK_MODE = 0777;
 
@@ -853,6 +856,18 @@ public class ChimeraNameSpaceProvider
         pw.println("Statistics:");
         pw.println(_gauges);
         pw.println(_counters);
+    }
+
+
+    @Command(name = "reset chimera stats", hint="reset chimera statistics", description = "Reset"
+            + " the counters and gauge statistics describing the interaction with Chimera.")
+    public class ResetStatsCommand implements Callable<String> {
+        @Override
+        public String call() {
+            _gauges.reset();
+            _counters.reset();
+            return "";
+        }
     }
 
     @Override

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -535,6 +535,46 @@ public class PnfsManagerV3
         pw.println(_foldedCounters.toString());
     }
 
+    @Command(name = "reset stats", hint="reset statistics",
+            description = "Reset the counters and gauge statistics describing PnfsManager.  These"
+                    + " statistics are shown as part of the 'info' command output.")
+    public class ResetStatsCommand implements Callable<String> {
+
+        @Option(name="target", usage="Which statistics to reset:\n"
+                + "\n"
+                + "\"calls\" is the cell message call gauges, labelled 'PnfsManagerV3'.\n"
+                + "\n"
+                + "\"folds\" is the message folding counts, labelled 'PnfsManagerV3.Folded'.\n"
+                + "\n"
+                + "\"all\" resets everything.\n"
+                + "\n"
+                + "If this option is not specified then \"all\" is assumed.",
+                values={"calls", "folds", "all"})
+        private String target;
+
+        @Override
+        public String call() throws CommandException {
+            if (target == null) {
+                target = "all";
+            }
+            switch (target) {
+            case "all":
+                _gauges.reset();
+                _foldedCounters.reset();
+                break;
+            case "calls":
+                _gauges.reset();
+                break;
+            case "folds":
+                _foldedCounters.reset();
+                break;
+            default:
+                throw new CommandException("Unknown target \"" + target + "\".");
+            }
+            return "";
+        }
+    }
+
     @Command(name = "pnfsidof",
           hint = "find the Pnfs-Id of a file",
           description = "Print the Pnfs-Id of a file given by its absolute path.")


### PR DESCRIPTION
Motivation:

PnfsManager provides statistics (both gauge and counter based) covering
how long certain operations take.

These statistics are initially zero and currently cannot be reset.

Sometimes it's useful to reset the statistics, particularly if there's
anticipated activity of interest.

Modification:

Add admin commands to support resetting the gauge and counters.

Result:

PnfsManager now has two commands to support resetting the gauge and
counter statistics available through the 'info' command.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13361/
Acked-by: Lea Morschel