### PR TITLE
gplazma: oidc add support for offline JWT validation

### DIFF
--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/PropertiesUtils.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/PropertiesUtils.java
@@ -18,6 +18,7 @@
  */
 package org.dcache.gplazma.oidc;
 
+import java.util.OptionalInt;
 import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -34,6 +35,18 @@ public class PropertiesUtils {
             String value = properties.getProperty(key);
             checkArgument(value != null, "Missing " + key + " property");
             return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Bad " + key + "value: " + e.getMessage());
+        }
+    }
+
+    public static OptionalInt asOptionalInt(Properties properties, String key) {
+        try {
+            String value = properties.getProperty(key);
+            if (value == null) {
+                return OptionalInt.empty();
+            }
+            return OptionalInt.of(Integer.parseInt(value));
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Bad " + key + "value: " + e.getMessage());
         }

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/helpers/JsonHttpClient.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/helpers/JsonHttpClient.java
@@ -72,6 +72,10 @@ public class JsonHttpClient {
         return this.doGet(url.toASCIIString(), null);
     }
 
+    public HttpClient getClient() {
+        return httpclient;
+    }
+
     private JsonNode doGet(String url, Header header) throws IOException {
         HttpGet httpGet = new HttpGet(url);
         if (header != null) {

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/BadKeyDescriptionException.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/BadKeyDescriptionException.java
@@ -1,0 +1,28 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+/**
+ * Indicates the JSON key description could not be parsed.
+ */
+public class BadKeyDescriptionException extends Exception {
+
+    public BadKeyDescriptionException(String message) {
+        super(message);
+    }
+}

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/ForwardingJsonNode.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/ForwardingJsonNode.java
@@ -1,0 +1,160 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2019 - 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A JsonNode that delegates all operations to some other JsonNode.
+ */
+public abstract class ForwardingJsonNode extends JsonNode {
+
+    protected abstract JsonNode delegate();
+
+    @Override
+    public JsonToken asToken() {
+        return delegate().asToken();
+    }
+
+    @Override
+    public JsonParser.NumberType numberType() {
+        return delegate().numberType();
+    }
+
+    @Override
+    public JsonNode get(int index) {
+        return delegate().get(index);
+    }
+
+    @Override
+    public JsonNode get(String fieldName) {
+        return delegate().get(fieldName);
+    }
+
+    @Override
+    public String asText() {
+        return delegate().asText();
+    }
+
+    @Override
+    public int asInt() {
+        return delegate().asInt();
+    }
+
+    @Override
+    public int size() {
+        return delegate().size();
+    }
+
+    @Override
+    public JsonNode findValue(String fieldName) {
+        return delegate().findValue(fieldName);
+    }
+
+    @Override
+    public JsonNode findPath(String fieldName) {
+        return delegate().findPath(fieldName);
+    }
+
+    @Override
+    public JsonNode findParent(String fieldName) {
+        return delegate().findParent(fieldName);
+    }
+
+    @Override
+    public List<JsonNode> findValues(String fieldName, List<JsonNode> foundSoFar) {
+        return delegate().findValues(fieldName, foundSoFar);
+    }
+
+    @Override
+    public List<String> findValuesAsText(String fieldName, List<String> foundSoFar) {
+        return delegate().findValuesAsText(fieldName, foundSoFar);
+    }
+
+    @Override
+    public List<JsonNode> findParents(String fieldName, List<JsonNode> foundSoFar) {
+        return delegate().findParents(fieldName, foundSoFar);
+    }
+
+    @Override
+    public JsonNode path(String fieldName) {
+        return delegate().path(fieldName);
+    }
+
+    @Override
+    public JsonNode path(int index) {
+        return delegate().path(index);
+    }
+
+    @Override
+    public JsonParser traverse() {
+        return delegate().traverse();
+    }
+
+    @Override
+    public String toString() {
+        return delegate().toString();
+    }
+
+    @Override
+    public <T extends JsonNode> T deepCopy() {
+        return delegate().deepCopy();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return delegate().equals(o);
+    }
+
+    @Override
+    protected JsonNode _at(JsonPointer jsonPointer) {
+        return null;
+    }
+
+    @Override
+    public JsonNodeType getNodeType() {
+        return delegate().getNodeType();
+    }
+
+    @Override
+    public JsonParser traverse(ObjectCodec objectCodec) {
+        return delegate().traverse(objectCodec);
+    }
+
+    @Override
+    public void serialize(JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+          throws IOException {
+        delegate().serialize(jsonGenerator, serializerProvider);
+    }
+
+    @Override
+    public void serializeWithType(JsonGenerator jsonGenerator,
+          SerializerProvider serializerProvider, TypeSerializer typeSerializer) throws IOException {
+        delegate().serializeWithType(jsonGenerator, serializerProvider, typeSerializer);
+    }
+}

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/HttpJsonNode.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/HttpJsonNode.java
@@ -1,0 +1,200 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2019 - 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+import static org.dcache.util.Exceptions.messageOrClassName;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.google.common.net.MediaType;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A JsonNode that represents a JSON document at some remote location.  If there is a network
+ * problem, or the document cannot be parsed as a JSON document then this node behaves as if it is a
+ * MissingNode.  Otherwise it behaves as the root node of the parsed document; e.g., an ObjectNode
+ * if the JSON document is a JSON Object.
+ * <p>
+ * The node is cached for a configurable period, fetching fresh results once that period has
+ * elapsed.  The caching period for successful and unsuccessful reads may be different, allowing a
+ * more aggressive querying if the document is missing.
+ * <p>
+ * Any values (e.g., JsonNode) returned by this class represent a concrete JSON document.
+ * Therefore, no network activity is triggered while navigating the cached document.
+ */
+public class HttpJsonNode extends PreparationJsonNode {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpJsonNode.class);
+
+    private final HttpClient client;
+    private final Supplier<Optional<String>> urlSupplier;
+    private final Duration cacheHit;
+    private final Duration cacheMiss;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private volatile JsonNode cached = MissingNode.getInstance();
+    private Instant nextCheck;
+
+    public HttpJsonNode(HttpClient client, URI url, Duration cacheHit, Duration cacheMiss) {
+        this(client, () -> Optional.of(url.toASCIIString()), cacheHit, cacheMiss);
+    }
+
+    public HttpJsonNode(HttpClient client, String url, Duration cacheHit, Duration cacheMiss) {
+        this(client, () -> Optional.of(url), cacheHit, cacheMiss);
+    }
+
+    /**
+     * An HttpJsonNode that never caches the result.  Each request to this node will trigger an HTTP
+     * request to fetch up-to-date information.
+     */
+    public HttpJsonNode(HttpClient client, Supplier<Optional<String>> url) {
+        this(client, url, Duration.ZERO, Duration.ZERO);
+    }
+
+    public HttpJsonNode(HttpClient client, Supplier<Optional<String>> url, Duration cacheHit,
+          Duration cacheMiss) {
+        this.client = Objects.requireNonNull(client);
+        this.urlSupplier = url;
+        this.cacheHit = cacheHit;
+        this.cacheMiss = cacheMiss;
+    }
+
+    @Override
+    protected synchronized void prepare() {
+        Instant now = Instant.now();
+        if (nextCheck == null || now.isAfter(nextCheck)) {
+            cached = fetch();
+            nextCheck = now.plus(cached.isMissingNode() ? cacheMiss : cacheHit);
+        }
+    }
+
+    private JsonNode fetch() {
+        return urlSupplier.get()
+              .flatMap(this::fetch)
+              .orElse(MissingNode.getInstance());
+    }
+
+    private Optional<JsonNode> fetch(String url) {
+        HttpGet request = new HttpGet(url);
+        request.addHeader("Accept", "application/json");
+        try {
+            HttpResponse response = client.execute(request);
+            String entity = readEntity(response);
+            return Optional.of(mapper.readValue(entity, JsonNode.class));
+        } catch (IOException e) {
+            LOGGER.error("Failed to fetch {}: {}", url, messageOrClassName(e));
+            return Optional.empty();
+        }
+    }
+
+    private static String readEntity(HttpResponse response) throws IOException {
+        Charset charset = readCharset(response);
+
+        HttpEntity entity = response.getEntity();
+
+        if (entity == null) {
+            throw new IOException("Missing entity in HTTP response");
+        }
+
+        long length = entity.getContentLength();
+        if (length > Integer.MAX_VALUE) {
+            throw new IOException("Document too big to be parsed");
+        }
+
+        ByteArrayOutputStream os =
+              (length > 0) ? new ByteArrayOutputStream((int) length) : new ByteArrayOutputStream();
+        entity.writeTo(os);
+        return os.toString(charset.name());
+    }
+
+
+    private static Charset readCharset(HttpResponse response) throws IOException {
+
+        Header contentType = response.getLastHeader("Content-Type");
+        if (contentType == null || contentType.getValue() == null) {
+            return StandardCharsets.US_ASCII;
+        }
+
+        MediaType type = MediaType.parse(contentType.getValue());
+        String baseType = type.withoutParameters().toString().toLowerCase();
+        switch (baseType) {
+            case "application/json":
+            case "application/octet-stream": // basically "unknown"
+                break;
+            default:
+                throw new IOException("Unexpected Content-Type: " + baseType);
+        }
+        return type.charset().or(StandardCharsets.US_ASCII);
+    }
+
+    @Override
+    protected JsonNode delegate() {
+        return cached;
+    }
+
+    @Override
+    protected JsonNode _at(JsonPointer jsonPointer) {
+        return cached.at(jsonPointer);
+    }
+
+    @Override
+    public JsonNodeType getNodeType() {
+        return cached.getNodeType();
+    }
+
+    @Override
+    public JsonParser traverse(ObjectCodec objectCodec) {
+        return cached.traverse();
+    }
+
+    @Override
+    public void serialize(JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+          throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serializeWithType(JsonGenerator jsonGenerator,
+          SerializerProvider serializerProvider, TypeSerializer typeSerializer) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/Issuer.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/Issuer.java
@@ -1,0 +1,193 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2019 - 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.EvictingQueue;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.KeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.apache.http.client.HttpClient;
+import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.oidc.IdentityProvider;
+import org.dcache.gplazma.util.JsonWebToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents a JWT issuer.  This is an IdentityProvider along with their signing material.
+ */
+public class Issuer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Issuer.class);
+
+    private final Queue<String> previousJtis;
+    private final IdentityProvider provider;
+    private final JsonNode configuration;
+    private final JsonNode jwks;
+
+    private Supplier<Map<String, PublicKey>> keys = MemoizeMapWithExpiry.memorize(this::parseJwks)
+          .whenEmptyFor(Duration.ofMinutes(1))
+          .whenNonEmptyFor(Duration.ofMinutes(10))
+          .build();
+
+    public Issuer(HttpClient client, IdentityProvider provider, int tokenHistory) {
+        this.provider = requireNonNull(provider);
+
+        this.configuration = new HttpJsonNode(client, provider.getConfigurationEndpoint(),
+              Duration.ofHours(1), Duration.ofSeconds(10));
+        this.jwks = new HttpJsonNode(client, this::parseConfigurationForJwksUri,
+              Duration.ofSeconds(1), Duration.ofSeconds(1));
+
+        previousJtis = tokenHistory > 0 ? EvictingQueue.create(tokenHistory) : null;
+    }
+
+    public IdentityProvider getIdentityProvider() {
+        return provider;
+    }
+
+    public String getEndpoint() {
+        return provider.getIssuerEndpoint().toASCIIString();
+    }
+
+    private Optional<String> parseConfigurationForJwksUri() {
+        JsonNode jwksNode = configuration.get("jwks_uri");
+
+        if (jwksNode == null) {
+            LOGGER.warn("configuration does not have jwks_uri");
+            return Optional.empty();
+        }
+
+        if (!jwksNode.isTextual()) {
+            LOGGER.warn("configuration has non-textual jwks_uri");
+            return Optional.empty();
+        }
+
+        String url = jwksNode.asText();
+
+        if (url.isEmpty()) {
+            LOGGER.warn("configuration has empty jwks_uri");
+            return Optional.empty();
+        }
+
+        return Optional.of(url);
+    }
+
+    private Map<String, PublicKey> parseJwks() {
+        JsonNode keys = jwks.get("keys");
+        if (keys == null) {
+            LOGGER.warn("missing keys");
+            return Collections.emptyMap();
+        }
+        if (!keys.isArray()) {
+            LOGGER.warn("keys not an array");
+            return Collections.emptyMap();
+        }
+
+        Map<String, PublicKey> publicKeys = new HashMap<>();
+        for (JsonNode key : keys) {
+            try {
+                String kid = getOptionalString(key, "kid").orElseGet(() -> UUID.randomUUID().toString());
+                publicKeys.put(kid, buildPublicKey(key));
+            } catch (BadKeyDescriptionException e) {
+                LOGGER.warn("Bad public key: {}", e.getMessage());
+            }
+        }
+        return publicKeys;
+    }
+
+    private PublicKey buildPublicKey(JsonNode details) throws BadKeyDescriptionException {
+        String kty = getString(details, "kty");
+        switch (kty) {
+            case "RSA":
+                return buildRSAPublicKey(details);
+            default:
+                throw new BadKeyDescriptionException("Unknown key type " + kty);
+        }
+    }
+
+    private String getString(JsonNode details, String key) throws BadKeyDescriptionException {
+        JsonNode target = details.get(key);
+        if (target == null) {
+            throw new BadKeyDescriptionException("Missing attribute " + key);
+        }
+        if (!target.isTextual()) {
+            throw new BadKeyDescriptionException("Attribute not textual " + key);
+        }
+        return target.asText();
+    }
+
+    private Optional<String> getOptionalString(JsonNode details, String key) throws BadKeyDescriptionException {
+        JsonNode value = details.get(key);
+        if (value != null && !value.isTextual()) {
+            throw new BadKeyDescriptionException("Attribute not textual " + key);
+        }
+        return Optional.ofNullable(value).map(JsonNode::asText);
+    }
+
+    private PublicKey buildRSAPublicKey(JsonNode details) throws BadKeyDescriptionException {
+        try {
+            byte[] e = Base64.getUrlDecoder().decode(getString(details, "e"));
+            byte[] n = Base64.getUrlDecoder().decode(getString(details, "n"));
+            KeySpec keySpec = new RSAPublicKeySpec(new BigInteger(1, n), new BigInteger(1, e));
+            return KeyFactory.getInstance("RSA").generatePublic(keySpec);
+        } catch (GeneralSecurityException e) {
+            throw new BadKeyDescriptionException("Unable to build RSA public key: " + e.toString());
+        }
+    }
+
+    public void checkIssued(JsonWebToken token) throws AuthenticationException {
+        Map<String, PublicKey> keyMap = keys.get();
+
+        String kid = token.getKeyIdentifier();
+        if (kid != null) {
+            PublicKey publicKey = keyMap.get(kid);
+            checkAuthentication(publicKey != null, "Unknown kid \"" + kid + "\"");
+            checkAuthentication(token.isSignedBy(publicKey), "Invalid signature");
+        } else {
+            checkAuthentication(keyMap.values().stream().anyMatch(token::isSignedBy),
+                  "Invalid signature");
+        }
+
+        if (previousJtis != null) {
+            Optional<String> jtiClaim = token.getPayloadString("jti");
+            if (jtiClaim.isPresent()) {
+                String jti = jtiClaim.get();
+                boolean isReplayAttack = previousJtis.contains(jti);
+                previousJtis.add(jti);
+                checkAuthentication(!isReplayAttack, "token reuse");
+            }
+        }
+    }
+}

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/MemoizeMapWithExpiry.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/MemoizeMapWithExpiry.java
@@ -1,0 +1,85 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2019 - 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Provide access to a Map, obtained from some supplier where the value is cached for a configurable
+ * duration.  The cached duration may be different depending on whether the Map is empty.
+ */
+public class MemoizeMapWithExpiry<C extends Map<?, ?>> implements Supplier<C> {
+
+    private final Supplier<C> supplier;
+    private final Duration whenNonEmpty;
+    private final Duration whenEmpty;
+
+    private C value;
+    private Instant nextCheck;
+
+    public MemoizeMapWithExpiry(Supplier<C> supplier, Duration whenNonEmpty,
+          Duration whenEmpty) {
+        this.supplier = supplier;
+        this.whenEmpty = whenEmpty;
+        this.whenNonEmpty = whenNonEmpty;
+    }
+
+    @Override
+    public synchronized C get() {
+        Instant now = Instant.now();
+        if (nextCheck == null || now.isAfter(nextCheck)) {
+            value = supplier.get();
+            Duration cacheDuration = (value == null || value.isEmpty())
+                  ? whenEmpty : whenNonEmpty;
+            nextCheck = now.plus(cacheDuration);
+        }
+        return value;
+    }
+
+    public static <C extends Map<?, ?>> Builder memorize(Supplier<C> supplier) {
+        return new Builder(supplier);
+    }
+
+    public static class Builder<C extends Map<?, ?>> {
+
+        private final Supplier<C> supplier;
+        private Duration whenNonEmpty;
+        private Duration whenEmpty;
+
+        public Builder(Supplier<C> supplier) {
+            this.supplier = supplier;
+        }
+
+        public Builder whenEmptyFor(Duration duration) {
+            whenEmpty = duration;
+            return this;
+        }
+
+        public Builder whenNonEmptyFor(Duration duration) {
+            whenNonEmpty = duration;
+            return this;
+        }
+
+        public MemoizeMapWithExpiry build() {
+            return new MemoizeMapWithExpiry(supplier, whenNonEmpty, whenEmpty);
+        }
+    }
+}

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/OfflineJwtVerification.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/OfflineJwtVerification.java
@@ -1,0 +1,106 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.http.client.HttpClient;
+import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.oidc.ExtractResult;
+import org.dcache.gplazma.oidc.IdentityProvider;
+import org.dcache.gplazma.oidc.TokenProcessor;
+import org.dcache.gplazma.oidc.UnableToProcess;
+import org.dcache.gplazma.util.JsonWebToken;
+
+import static org.dcache.gplazma.oidc.PropertiesUtils.asOptionalInt;
+import static org.dcache.gplazma.util.Preconditions.checkAuthentication;
+
+/**
+ * This class implements the offline verification of JWTs.
+ */
+public class OfflineJwtVerification implements TokenProcessor {
+
+    private final Map<String, Issuer> issuersByEndpoint;
+
+    public OfflineJwtVerification(Properties properties, HttpClient client,
+            Set<IdentityProvider> providers) {
+        this(properties, asOptionalInt(properties, "gplazma.oidc.token-history").orElse(0), client, providers);
+    }
+
+    private OfflineJwtVerification(Properties properties, int history, HttpClient client,
+            Set<IdentityProvider> providers) {
+        this(properties, providers.stream()
+                .map(p -> new Issuer(client, p, history))
+                .collect(Collectors.toList()));
+    }
+
+    @VisibleForTesting
+    OfflineJwtVerification(Properties properties, Collection<Issuer> issuers) {
+        issuersByEndpoint = issuers.stream().collect(Collectors.toMap(Issuer::getEndpoint, i -> i));
+    }
+
+    @Override
+    public ExtractResult extract(String token) throws AuthenticationException, UnableToProcess {
+        if (!JsonWebToken.isCompatibleFormat(token)) {
+            throw new UnableToProcess("token not JWT");
+        }
+
+        try {
+            var jwt = checkValid(new JsonWebToken(token));
+
+            var issuer = issuerOf(jwt);
+
+            return new ExtractResult(issuer.getIdentityProvider(), jwt.getPayloadMap());
+        } catch (IOException e) {
+            throw new UnableToProcess(e.getMessage());
+        }
+    }
+
+    private JsonWebToken checkValid(JsonWebToken token) throws AuthenticationException {
+        Instant now = Instant.now();
+
+        Optional<Instant> exp = token.getPayloadInstant("exp");
+        checkAuthentication(!exp.isPresent() || now.isBefore(exp.get()),
+              "has expired");
+
+        Optional<Instant> nbf = token.getPayloadInstant("nbf");
+        checkAuthentication(!nbf.isPresent() || now.isAfter(nbf.get()),
+              "is not yet valid");
+
+        return token;
+    }
+
+    private Issuer issuerOf(JsonWebToken token) throws AuthenticationException {
+        var issuerEndpoint = token.getPayloadString("iss")
+              .orElseThrow(() -> new AuthenticationException("Missing 'iss' in JWT"));
+
+        var issuer = issuersByEndpoint.get(issuerEndpoint);
+        checkAuthentication(issuer != null, "Untrusted issuer %s", issuerEndpoint);
+
+        issuer.checkIssued(token);
+
+        return issuer;
+    }
+}

--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/PreparationJsonNode.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/PreparationJsonNode.java
@@ -1,0 +1,139 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2019 - 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+/**
+ * A JsonNode that executes some common task before calling the delegate.
+ */
+public abstract class PreparationJsonNode extends ForwardingJsonNode {
+
+    protected abstract void prepare();
+
+    @Override
+    public JsonToken asToken() {
+        prepare();
+        return super.asToken();
+    }
+
+    @Override
+    public JsonParser.NumberType numberType() {
+        prepare();
+        return super.numberType();
+    }
+
+    @Override
+    public JsonNode get(int index) {
+        prepare();
+        return super.get(index);
+    }
+
+    @Override
+    public JsonNode get(String fieldName) {
+        prepare();
+        return super.get(fieldName);
+    }
+
+    @Override
+    public String asText() {
+        prepare();
+        return super.asText();
+    }
+
+    @Override
+    public int asInt() {
+        prepare();
+        return super.asInt();
+    }
+
+    @Override
+    public int size() {
+        prepare();
+        return super.size();
+    }
+
+    @Override
+    public JsonNode findValue(String fieldName) {
+        prepare();
+        return super.findValue(fieldName);
+    }
+
+    @Override
+    public JsonNode findPath(String fieldName) {
+        prepare();
+        return super.findPath(fieldName);
+    }
+
+    @Override
+    public JsonNode findParent(String fieldName) {
+        prepare();
+        return super.findParent(fieldName);
+    }
+
+    @Override
+    public List<JsonNode> findValues(String fieldName, List<JsonNode> foundSoFar) {
+        prepare();
+        return super.findValues(fieldName, foundSoFar);
+    }
+
+    @Override
+    public List<String> findValuesAsText(String fieldName, List<String> foundSoFar) {
+        prepare();
+        return super.findValuesAsText(fieldName, foundSoFar);
+    }
+
+    @Override
+    public List<JsonNode> findParents(String fieldName, List<JsonNode> foundSoFar) {
+        prepare();
+        return super.findParents(fieldName, foundSoFar);
+    }
+
+    @Override
+    public JsonNode path(String fieldName) {
+        prepare();
+        return super.path(fieldName);
+    }
+
+    @Override
+    public JsonNode path(int index) {
+        prepare();
+        return super.path(index);
+    }
+
+    @Override
+    public JsonParser traverse() {
+        prepare();
+        return super.traverse();
+    }
+
+    @Override
+    public String toString() {
+        prepare();
+        return super.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        prepare();
+        return super.equals(o);
+    }
+}

--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/JwtFactoryTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/JwtFactoryTest.java
@@ -55,6 +55,7 @@ public class JwtFactoryTest {
         assertTrue(JsonWebToken.isCompatibleFormat(jwt));
         JsonWebToken token = new JsonWebToken(jwt);
         assertThat(token.getKeyIdentifier(), is(nullValue()));
+        assertThat(token.getPayloadMap(), is(anEmptyMap()));
         assertTrue(token.isSignedBy(factory.publicKey()));
     }
 
@@ -68,6 +69,8 @@ public class JwtFactoryTest {
         JsonWebToken token = new JsonWebToken(jwt);
         assertThat(token.getKeyIdentifier(), is(nullValue()));
         assertThat(token.getPayloadString("sub"), isPresentAnd(equalTo("my-identity")));
+        assertThat(token.getPayloadMap(), aMapWithSize(1));
+        assertThat(token.getPayloadMap(), hasEntry("sub", jsonString("my-identity")));
         assertTrue(token.isSignedBy(factory.publicKey()));
     }
 
@@ -86,6 +89,8 @@ public class JwtFactoryTest {
         assertThat(token.getKeyIdentifier(), is(nullValue()));
         assertThat(token.getPayloadString("sub"), isPresentAnd(equalTo("my-identity")));
         assertThat(token.getPayloadInstant("exp"), isPresentAnd(equalTo(expiry)));
+        assertThat(token.getPayloadMap(), aMapWithSize(2));
+        assertThat(token.getPayloadMap(), hasEntry("sub", jsonString("my-identity")));
         assertTrue(token.isSignedBy(factory.publicKey()));
     }
 
@@ -103,6 +108,9 @@ public class JwtFactoryTest {
         assertThat(token.getKeyIdentifier(), is(nullValue()));
         assertThat(token.getPayloadString("sub"), isPresentAnd(equalTo("my-identity")));
         assertThat(token.getPayloadStringOrArray("groups"), contains("group-1", "group-2"));
+        assertThat(token.getPayloadMap(), aMapWithSize(2));
+        assertThat(token.getPayloadMap(), hasEntry("sub", jsonString("my-identity")));
+        assertThat(token.getPayloadMap(), hasEntry("groups", jsonArray("group-1", "group-2")));
         assertTrue(token.isSignedBy(factory.publicKey()));
     }
 
@@ -119,6 +127,8 @@ public class JwtFactoryTest {
         JsonWebToken token = new JsonWebToken(jwt);
         assertThat(token.getKeyIdentifier(), is(equalTo("KEY-1")));
         assertThat(token.getPayloadString("sub"), isPresentAnd(equalTo("my-identity")));
+        assertThat(token.getPayloadMap(), aMapWithSize(1));
+        assertThat(token.getPayloadMap(), hasEntry("sub", jsonString("my-identity")));
         assertTrue(token.isSignedBy(factory.publicKey()));
     }
 

--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/PropertiesUtilsTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/PropertiesUtilsTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
 
 public class PropertiesUtilsTest {
 
@@ -64,6 +65,31 @@ public class PropertiesUtilsTest {
         var properties = given(properties().with("foo", "1234"));
 
         PropertiesUtils.asInt(properties, "bar");
+    }
+
+    @Test
+    public void shouldAcceptAsPresentOptionalIntProperty() {
+        var properties = given(properties().with("foo", "42"));
+
+        var value = PropertiesUtils.asOptionalInt(properties, "foo");
+
+        assertThat(value.getAsInt(), is(equalTo(42)));
+    }
+
+    @Test
+    public void shouldAcceptAsEmptyOptionalIntProperty() {
+        var properties = given(properties());
+
+        var value = PropertiesUtils.asOptionalInt(properties, "foo");
+
+        assertFalse(value.isPresent());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void shouldRejectOptionalIntPropertyWithNonParsableValue() {
+        var properties = given(properties().with("foo", "bar"));
+
+        PropertiesUtils.asOptionalInt(properties, "foo");
     }
 
     private Properties given(PropertiesBuilder builder) {

--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/jwt/HttpJsonNodeTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/jwt/HttpJsonNodeTest.java
@@ -1,0 +1,178 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+import com.fasterxml.jackson.core.JsonParser.NumberType;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.http.client.HttpClient;
+import org.dcache.gplazma.oidc.MockHttpClientBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.dcache.gplazma.oidc.MockHttpClientBuilder.aClient;
+import static org.hamcrest.Matchers.is;
+
+public class HttpJsonNodeTest {
+    private HttpClient client;
+    private HttpJsonNode jsonNode;
+
+    @Before
+    public void setup() {
+        client = null;
+        jsonNode = null;
+    }
+
+    @Test
+    public void shouldAcceptNullResponse() throws Exception {
+        given(aClient().onGet("https://example.org/").responds().withEntity("null"));
+        given(aNode().targeting("https://example.org/").cachingFor(Duration.of(1, MINUTES)));
+
+        jsonNode.toString();
+
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.NULL));
+        verify(client).execute(any());
+    }
+
+    @Test
+    public void shouldAcceptStringResponse() throws Exception {
+        given(aClient().onGet("https://example.org/").responds().withEntity("\"Hello, world\""));
+        given(aNode().targeting("https://example.org/").cachingFor(Duration.of(1, MINUTES)));
+
+        jsonNode.toString();
+
+        verify(client).execute(any());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.STRING));
+        assertThat(jsonNode.asText(), is(equalTo("Hello, world")));
+    }
+
+    @Test
+    public void shouldAcceptNumberResponse() throws Exception {
+        given(aClient().onGet("https://example.org/").responds().withEntity("42"));
+        given(aNode().targeting("https://example.org/").cachingFor(Duration.of(1, MINUTES)));
+
+        jsonNode.toString();
+
+        verify(client).execute(any());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.NUMBER));
+        assertThat(jsonNode.numberType(), is(equalTo(NumberType.INT)));
+        assertThat(jsonNode.asInt(), is(equalTo(42)));
+    }
+
+    @Test
+    public void shouldAcceptArrayOfStringResponse() throws Exception {
+        given(aClient().onGet("https://example.org/").responds().withEntity("[\"foo\", \"bar\", \"baz\"]"));
+        given(aNode().targeting("https://example.org/").cachingFor(Duration.of(1, MINUTES)));
+
+        jsonNode.toString();
+
+        verify(client).execute(any());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.ARRAY));
+        assertThat(jsonNode.size(), equalTo(3));
+        assertThat(jsonNode.get(0).isTextual(), equalTo(true));
+        assertThat(jsonNode.get(0).textValue(), equalTo("foo"));
+        assertThat(jsonNode.get(1).isTextual(), equalTo(true));
+        assertThat(jsonNode.get(1).textValue(), equalTo("bar"));
+        assertThat(jsonNode.get(2).isTextual(), equalTo(true));
+        assertThat(jsonNode.get(2).textValue(), equalTo("baz"));
+    }
+
+    @Test
+    public void shouldAcceptJsonObjectResponse() throws Exception {
+        given(aClient().onGet("https://example.org/").responds().withEntity("{\"string-item\": \"foo\", "
+                + "\"boolean-item\": true, "
+                + "\"number-item\": 42, "
+                + "\"null-item\": null, "
+                + "\"array-item\": [\"first\", \"second\"]}"));
+        given(aNode().targeting("https://example.org/").cachingFor(Duration.of(1, MINUTES)));
+
+        jsonNode.toString();
+
+        verify(client).execute(any());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.OBJECT));
+        assertThat(jsonNode.size(), equalTo(5));
+        assertThat(jsonNode.get("string-item").isTextual(), equalTo(true));
+        assertThat(jsonNode.get("string-item").textValue(), equalTo("foo"));
+        assertThat(jsonNode.get("boolean-item").isBoolean(), equalTo(true));
+        assertThat(jsonNode.get("boolean-item").asBoolean(), equalTo(true));
+        assertThat(jsonNode.get("number-item").isNumber(), equalTo(true));
+        assertThat(jsonNode.get("number-item").asInt(), equalTo(42));
+        assertThat(jsonNode.get("null-item").isNull(), equalTo(true));
+        assertThat(jsonNode.get("array-item").isArray(), equalTo(true));
+        assertThat(jsonNode.get("array-item").size(), equalTo(2));
+        assertThat(jsonNode.get("array-item").get(0).isTextual(), equalTo(true));
+        assertThat(jsonNode.get("array-item").get(0).textValue(), equalTo("first"));
+        assertThat(jsonNode.get("array-item").get(1).isTextual(), equalTo(true));
+        assertThat(jsonNode.get("array-item").get(1).textValue(), equalTo("second"));
+    }
+
+    @Test
+    public void shouldRejectBadJson() throws Exception {
+        given(aClient().onGet("https://example.org/").responds().withEntity("{bad json}"));
+        given(aNode().targeting("https://example.org/").cachingFor(Duration.of(1, MINUTES)));
+
+        jsonNode.toString();
+
+        verify(client).execute(any());
+        assertThat(jsonNode.getNodeType(), equalTo(JsonNodeType.MISSING));
+    }
+
+    private void given(HttpJsonNodeBuilder builder) {
+        jsonNode = builder.build();
+    }
+
+    private void given(MockHttpClientBuilder builder) {
+        client = builder.build();
+    }
+
+    private HttpJsonNodeBuilder aNode() {
+        return new HttpJsonNodeBuilder();
+    }
+
+
+    /**
+     * Class to provide an HttpJsonNode using a fluent interface.
+     */
+    private class HttpJsonNodeBuilder {
+        private Supplier<Optional<String>> urlSupplier;
+        private Duration cacheHit;
+        private Duration cacheMiss;
+
+        public HttpJsonNodeBuilder targeting(String url) {
+            urlSupplier = () -> Optional.of(url);
+            return this;
+        }
+
+        public HttpJsonNodeBuilder cachingFor(Duration duration) {
+            cacheHit = duration;
+            cacheMiss = duration;
+            return this;
+        }
+
+        public HttpJsonNode build() {
+            return new HttpJsonNode(client, urlSupplier, cacheHit, cacheMiss);
+        }
+    }
+}

--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/jwt/IssuerTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/jwt/IssuerTest.java
@@ -1,0 +1,391 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.security.PublicKey;
+import java.util.Optional;
+import org.apache.http.client.HttpClient;
+import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.oidc.IdentityProvider;
+import org.dcache.gplazma.oidc.JwtFactory;
+import org.dcache.gplazma.oidc.MockHttpClientBuilder;
+import org.dcache.gplazma.oidc.MockIdentityProviderBuilder;
+import org.dcache.gplazma.util.JsonWebToken;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.BDDMockito;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.dcache.gplazma.oidc.MockHttpClientBuilder.aClient;
+import static org.dcache.gplazma.oidc.MockIdentityProviderBuilder.anIp;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class IssuerTest {
+
+    private final JwtFactory jwtFactory = new JwtFactory();
+    private final JwtFactory anotherJwtFactory = new JwtFactory();
+
+    private HttpClient client;
+    private JsonWebToken jwt;
+    private IdentityProvider identityProvider;
+    private Issuer issuer;
+
+    @Before
+    public void setup() {
+        client = null;
+        jwt = null;
+        identityProvider = null;
+        issuer = null;
+    }
+
+    @Test
+    public void shouldReturnIdentityProvider() throws Exception {
+        given(aClient());
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+
+        IdentityProvider ip = issuer.getIdentityProvider();
+
+        assertThat(ip, is(sameInstance(identityProvider)));
+    }
+
+    @Test
+    public void shouldReturnEndpoint() throws Exception {
+        given(aClient());
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+
+        String endpoint = issuer.getEndpoint();
+
+        assertThat(endpoint, is(equalTo("https://oidc.example.org/")));
+    }
+
+    @Test
+    public void shouldAcceptJwtWithoutKidWhenJkwsNoKid() throws Exception {
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + jwtFactory.describePublicKey() + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(aMockJwt().withoutKid().withoutJti().signedBy(jwtFactory.publicKey()));
+        given(anIssuer().withoutHistory());
+
+        issuer.checkIssued(jwt);
+
+        verify(jwt).isSignedBy(eq(jwtFactory.publicKey()));
+    }
+
+    @Test
+    public void shouldAcceptJwtWithoutKid() throws Exception {
+        ObjectNode description = jwtFactory.describePublicKey().put("kid", "key-1");
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(aMockJwt().withoutKid().withoutJti().signedBy(jwtFactory.publicKey()));
+        given(anIssuer().withoutHistory());
+
+        issuer.checkIssued(jwt);
+
+        verify(jwt).isSignedBy(eq(jwtFactory.publicKey()));
+    }
+
+    @Test
+    public void shouldAcceptJwtWithKid() throws Exception {
+        ObjectNode description = jwtFactory.describePublicKey().put("kid", "key-1");
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+        given(aMockJwt().withKid("key-1").withoutJti().signedBy(jwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+
+        verify(jwt).isSignedBy(eq(jwtFactory.publicKey()));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectJwtWithUnknownKid() throws Exception {
+        ObjectNode description = jwtFactory.describePublicKey().put("kid", "key-1");
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+        given(aMockJwt().withKid("unknown-key-1").withoutJti().signedBy(jwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+    }
+
+    @Test
+    public void shouldAcceptJwtFromKey1FromOpWithMultipleKeys() throws Exception {
+        ObjectNode description1 = jwtFactory.describePublicKey().put("kid", "key-1");
+        ObjectNode description2 = anotherJwtFactory.describePublicKey().put("kid", "key-2");
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description1 + "," + description2 + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+        given(aMockJwt().withKid("key-1").withoutJti().signedBy(jwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+
+        verify(jwt).isSignedBy(eq(jwtFactory.publicKey()));
+        verify(jwt, never()).isSignedBy(eq(anotherJwtFactory.publicKey()));
+    }
+
+    @Test
+    public void shouldAcceptJwtFromKey2FromOpWithMultipleKeys() throws Exception {
+        ObjectNode description1 = jwtFactory.describePublicKey().put("kid", "key-1");
+        ObjectNode description2 = anotherJwtFactory.describePublicKey().put("kid", "key-2");
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description1 + "," + description2 + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+        given(aMockJwt().withKid("key-2").withoutJti().signedBy(anotherJwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+
+        verify(jwt, never()).isSignedBy(eq(jwtFactory.publicKey()));
+        verify(jwt).isSignedBy(eq(anotherJwtFactory.publicKey()));
+    }
+
+    @Test
+    public void shouldAcceptJwtFromKey1FromOpWithMultipleKeysNoKid() throws Exception {
+        ObjectNode description1 = jwtFactory.describePublicKey();
+        ObjectNode description2 = anotherJwtFactory.describePublicKey();
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description1 + "," + description2 + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+        given(aMockJwt().withoutKid().withoutJti().signedBy(jwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+
+        verify(jwt).isSignedBy(eq(jwtFactory.publicKey()));
+
+        // NB we don't verify whether JsonWebToken.isSignedBy(anotherJwtFactory) is called as we
+        // don't want to force a particular order on trying out the public keys.
+    }
+
+    @Test
+    public void shouldAcceptJwtFromKey2FromOpWithMultipleKeysNoKid() throws Exception {
+        ObjectNode description1 = jwtFactory.describePublicKey();
+        ObjectNode description2 = anotherJwtFactory.describePublicKey();
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description1 + "," + description2 + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+        given(aMockJwt().withoutKid().withoutJti().signedBy(anotherJwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+
+        verify(jwt).isSignedBy(eq(anotherJwtFactory.publicKey()));
+
+        // NB we don't verify whether JsonWebToken.isSignedBy(jwtFactory) is called as we
+        // don't want to force a particular order on trying out the public keys.
+    }
+
+    @Test
+    public void shouldAcceptJwtWithoutJtiMultipleTimesWithoutReplayProtection() throws Exception {
+        ObjectNode description = jwtFactory.describePublicKey();
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+        given(aMockJwt().withoutKid().withoutJti().signedBy(jwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+        issuer.checkIssued(jwt);
+    }
+
+    @Test
+    public void shouldAcceptJwtWithoutJtiMultipleTimesWithReplayProtection() throws Exception {
+        ObjectNode description = jwtFactory.describePublicKey();
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withHistory(10));
+        given(aMockJwt().withoutKid().withoutJti().signedBy(jwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+        issuer.checkIssued(jwt);
+    }
+
+    @Test
+    public void shouldAcceptJwtWithJtiMultipleTimesWithoutReplayProtection() throws Exception {
+        ObjectNode description = jwtFactory.describePublicKey();
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withoutHistory());
+        given(aMockJwt().withoutKid().withJti("token-42").signedBy(jwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+        issuer.checkIssued(jwt);
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectJwtWithJtiMultipleTimesWithReplayProtection() throws Exception {
+        ObjectNode description = jwtFactory.describePublicKey();
+        given(aClient()
+            .onGet("https://oidc.example.org/.well-known/openid-configuration").responds()
+                .withEntity("{\"jwks_uri\": \"https://oidc.example.org/jwks\"}")
+            .onGet("https://oidc.example.org/jwks").responds()
+                .withEntity("{\"keys\": [" + description + "]}"));
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anIssuer().withHistory(10));
+        given(aMockJwt().withoutKid().withJti("token-42").signedBy(jwtFactory.publicKey()));
+
+        issuer.checkIssued(jwt);
+        issuer.checkIssued(jwt);
+    }
+
+    public void given(MockHttpClientBuilder builder) {
+        client = builder.build();
+    }
+
+    public void given(MockIdentityProviderBuilder builder) {
+        identityProvider = builder.build();
+    }
+
+    public void given(JsonWebTokenBuilder builder) {
+        jwt = builder.build();
+    }
+
+    public void given(IssuerBuilder builder) {
+        issuer = builder.build();
+    }
+
+    public JsonWebTokenBuilder aMockJwt() {
+        return new JsonWebTokenBuilder();
+    }
+
+    public IssuerBuilder anIssuer() {
+        return new IssuerBuilder();
+    }
+
+    /**
+     * A fluent class that builds a mock JsonWebToken object.
+     */
+    private static class JsonWebTokenBuilder {
+        private static final JsonWebToken token = mock(JsonWebToken.class);
+        private boolean hasJti;
+        private boolean hasKid;
+
+        public JsonWebTokenBuilder withKid(String kid) {
+            checkState(!hasKid);
+            BDDMockito.given(token.getKeyIdentifier()).willReturn(kid);
+            hasKid = true;
+            return this;
+        }
+
+        public JsonWebTokenBuilder withoutKid() {
+            checkState(!hasKid);
+            BDDMockito.given(token.getKeyIdentifier()).willReturn(null);
+            hasKid = true;
+            return this;
+        }
+
+        public JsonWebTokenBuilder withJti(String id) {
+            checkState(!hasJti);
+            BDDMockito.given(token.getPayloadString(eq("jti"))).willReturn(Optional.ofNullable(id));
+            hasJti = true;
+            return this;
+        }
+
+        public JsonWebTokenBuilder withoutJti() {
+            checkState(!hasJti);
+            BDDMockito.given(token.getPayloadString(eq("jti"))).willReturn(Optional.empty());
+            hasJti = true;
+            return this;
+        }
+
+        public JsonWebTokenBuilder signedBy(PublicKey key) {
+            BDDMockito.given(token.isSignedBy(eq(key))).willReturn(true);
+            return this;
+        }
+
+        public JsonWebToken build() {
+            checkState(hasJti);
+            checkState(hasKid);
+            return token;
+        }
+    }
+
+    /**
+     * A fluent class that builds a Issuer.
+     */
+    private class IssuerBuilder {
+        int history;
+        boolean hasHistory;
+
+        public IssuerBuilder withHistory(int n) {
+            checkState(!hasHistory);
+            history = n;
+            hasHistory = true;
+            return this;
+        }
+
+        public IssuerBuilder withoutHistory() {
+            checkState(!hasHistory);
+            history = 0;
+            hasHistory = true;
+            return this;
+        }
+
+        public Issuer build() {
+            checkState(hasHistory);
+            checkState(client != null);
+            checkState(identityProvider != null);
+            return new Issuer(client, identityProvider, history);
+        }
+    }
+}

--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/jwt/OfflineJwtVerificationTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/jwt/OfflineJwtVerificationTest.java
@@ -1,0 +1,306 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2022 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dcache.gplazma.oidc.jwt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.dcache.gplazma.AuthenticationException;
+import org.dcache.gplazma.oidc.ExtractResult;
+import org.dcache.gplazma.oidc.IdentityProvider;
+import org.dcache.gplazma.oidc.JwtFactory;
+import org.dcache.gplazma.oidc.MockIdentityProviderBuilder;
+import org.dcache.gplazma.oidc.UnableToProcess;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.BDDMockito;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.dcache.gplazma.oidc.MockIdentityProviderBuilder.anIp;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+
+public class OfflineJwtVerificationTest {
+
+    private final JwtFactory jwtFactory = new JwtFactory();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private OfflineJwtVerification verification;
+    private String jwt;
+    private IdentityProvider identityProvider;
+
+    @Before
+    public void setup() {
+        verification = null;
+        jwt = null;
+        identityProvider = null;
+    }
+
+    @Test(expected=UnableToProcess.class)
+    public void shouldNotProcessNonJwt() throws Exception {
+        given(anOfflineJwtVerification().withEmptyAudienceTargetProperty());
+
+        verification.extract("token-that-is-not-a-jwt");
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectTokenWithoutIss() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("sub", "paul"));
+
+        verification.extract(jwt);
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectTokenFromUntrustedOp() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("iss", "https://another-oidc.example.com/")
+            .withPayloadClaim("sub", "paul"));
+
+        verification.extract(jwt);
+    }
+
+    @Test
+    public void shouldAcceptNonExpiringTokenFromTrustedOp() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("iss", "https://oidc.example.org/")
+            .withPayloadClaim("sub", "paul"));
+
+        ExtractResult result = verification.extract(jwt);
+
+        assertThat(result.idp(), is(sameInstance(identityProvider)));
+        assertThat(result.claims(), hasEntry("iss", jsonString("https://oidc.example.org/")));
+        assertThat(result.claims(), hasEntry("sub", jsonString("paul")));
+    }
+
+    @Test
+    public void shouldAcceptNonExpiredTokenFromTrustedOp() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("iss", "https://oidc.example.org/")
+            .withPayloadClaim("exp", Instant.now().plus(5, MINUTES))
+            .withPayloadClaim("sub", "paul"));
+
+        ExtractResult result = verification.extract(jwt);
+
+        assertThat(result.idp(), is(sameInstance(identityProvider)));
+        assertThat(result.claims(), hasEntry("iss", jsonString("https://oidc.example.org/")));
+        assertThat(result.claims(), hasEntry("sub", jsonString("paul")));
+        assertThat(result.claims(), hasKey("exp"));
+    }
+
+    @Test
+    public void shouldAcceptNonExpiredUnembargoedTokenFromTrustedOp() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("iss", "https://oidc.example.org/")
+            .withPayloadClaim("nbf", Instant.now().minus(5, MINUTES))
+            .withPayloadClaim("exp", Instant.now().plus(5, MINUTES))
+            .withPayloadClaim("sub", "paul"));
+
+        ExtractResult result = verification.extract(jwt);
+
+        assertThat(result.idp(), is(sameInstance(identityProvider)));
+        assertThat(result.claims(), hasEntry("iss", jsonString("https://oidc.example.org/")));
+        assertThat(result.claims(), hasEntry("sub", jsonString("paul")));
+        assertThat(result.claims(), hasKey("nbf"));
+        assertThat(result.claims(), hasKey("exp"));
+    }
+
+    @Test
+    public void shouldAcceptUnembargoedTokenFromTrustedOp() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("iss", "https://oidc.example.org/")
+            .withPayloadClaim("nbf", Instant.now().minus(5, MINUTES))
+            .withPayloadClaim("sub", "paul"));
+
+        ExtractResult result = verification.extract(jwt);
+
+        assertThat(result.idp(), is(sameInstance(identityProvider)));
+        assertThat(result.claims(), hasEntry("iss", jsonString("https://oidc.example.org/")));
+        assertThat(result.claims(), hasEntry("sub", jsonString("paul")));
+        assertThat(result.claims(), hasKey("nbf"));
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectExpiredTokenFromTrustedOp() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("iss", "https://oidc.example.org/")
+            .withPayloadClaim("exp", Instant.now().minus(5, MINUTES))
+            .withPayloadClaim("sub", "paul"));
+
+        verification.extract(jwt);
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectExpiredUnembargoedTokenFromTrustedOp() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("iss", "https://oidc.example.org/")
+            .withPayloadClaim("nbf", Instant.now().minus(10, MINUTES))
+            .withPayloadClaim("exp", Instant.now().minus(5, MINUTES))
+            .withPayloadClaim("sub", "paul"));
+
+        verification.extract(jwt);
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectEmbargoedTokenFromTrustedOp() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("iss", "https://oidc.example.org/")
+            .withPayloadClaim("nbf", Instant.now().plus(5, MINUTES))
+            .withPayloadClaim("sub", "paul"));
+
+        verification.extract(jwt);
+    }
+
+    @Test(expected=AuthenticationException.class)
+    public void shouldRejectUnexpiredEmbargoedTokenFromTrustedOp() throws Exception {
+        given(anIp("EXAMPLE").withEndpoint("https://oidc.example.org/"));
+        given(anOfflineJwtVerification()
+            .withEmptyAudienceTargetProperty()
+            .withIssuer(anIssuer().withIp(identityProvider)));
+        given(aJwt()
+            .withPayloadClaim("iss", "https://oidc.example.org/")
+            .withPayloadClaim("nbf", Instant.now().plus(5, MINUTES))
+            .withPayloadClaim("exp", Instant.now().plus(10, MINUTES))
+            .withPayloadClaim("sub", "paul"));
+
+        verification.extract(jwt);
+    }
+
+    private JsonNode jsonString(String json) throws JsonProcessingException {
+        return mapper.readTree("\"" + json + "\"");
+    }
+
+    private void given(MockIdentityProviderBuilder builder) {
+        identityProvider = builder.build();
+    }
+
+    private void given(OfflineJwtVerificationBuilder builder) {
+        verification = builder.build();
+    }
+
+    private void given(JwtFactory.Builder builder) {
+        jwt = builder.build();
+    }
+
+    private MockIssuerBuilder anIssuer() {
+        return new MockIssuerBuilder();
+    }
+
+    private JwtFactory.Builder aJwt() {
+        return jwtFactory.aJwt();
+    }
+
+    private OfflineJwtVerificationBuilder anOfflineJwtVerification() {
+        return new OfflineJwtVerificationBuilder();
+    }
+
+    /**
+     * A fluent class to build a mock Issuer.
+     */
+    private static class MockIssuerBuilder {
+        private final Issuer issuer = mock(Issuer.class);
+        private boolean hasIp;
+
+        public MockIssuerBuilder withIp(MockIdentityProviderBuilder builder) {
+            return withIp(builder.build());
+        }
+
+        public MockIssuerBuilder withIp(IdentityProvider ip) {
+            checkState(!hasIp);
+            var endpoint = ip.getIssuerEndpoint();
+            BDDMockito.given(issuer.getIdentityProvider()).willReturn(ip);
+            BDDMockito.given(issuer.getEndpoint()).willReturn(endpoint.toASCIIString());
+            hasIp = true;
+            return this;
+        }
+
+        public Issuer build() {
+            checkState(hasIp);
+            return issuer;
+        }
+    }
+
+    /**
+     * A fluent class to build a (real) OfflineJwtVerification object.
+     */
+    private static class OfflineJwtVerificationBuilder {
+        private final Properties properties = new Properties();
+        private final List<Issuer> issuers = new ArrayList<>();
+
+        public OfflineJwtVerificationBuilder withAudienceTargetProperty(String value) {
+            properties.setProperty("gplazma.oidc.audience-targets", value);
+            return this;
+        }
+
+        public OfflineJwtVerificationBuilder withEmptyAudienceTargetProperty() {
+            properties.setProperty("gplazma.oidc.audience-targets", "");
+            return this;
+        }
+
+        public OfflineJwtVerificationBuilder withIssuer(MockIssuerBuilder builder) {
+            issuers.add(builder.build());
+            return this;
+        }
+
+        public OfflineJwtVerification build() {
+            return new OfflineJwtVerification(properties, issuers);
+        }
+    }
+}

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2019 - 2020 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2019 - 2022 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
+import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -32,6 +33,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -142,6 +144,11 @@ public class JsonWebToken {
         return Optional.ofNullable(payload.get(key))
               .filter(JsonNode::isTextual)
               .map(JsonNode::textValue);
+    }
+
+    public Map<String,JsonNode> getPayloadMap() {
+        return Streams.stream(payload.fields())
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
     }
 
     /**


### PR DESCRIPTION
Motivation:

A JSON Web Token (JWT) is a token that contains a number of claims
(key-value pairs) that are protected via a crypographically secure
signature.  By using a JWT as the access token, the OP allows the token
to carry information about the user so that the client (dCache) can
verify that information without making any HTTP requests. In other
words, it allows offline verification.

Offline is a slightly misleading term.  dCache still needs somehow to
fetch the public keys (with which to verify the signature).  This is
done via HTTP, so there is still an online aspect.  By caching the
result, dCache makes only occational requests against the OP.

Modification:

Most of the code is taken from the SciToken plugin will only a little
modification:

    The 'aud' checking is done generically, so the JWT does not need to
    do this.

    The support for SciTokens and WLCG-AuthZ is (deliberately) missing.
    That will come in later patches.

This patch copies code from the scitoken plugin, which violates DRY.  I
intend to remove the scitoken plugin once the scope support is
implemented in the oidc plugin.

Result:

The oidc plugin is now able to accept a JWT access token without
querying the user-info endpoint.  If the token is not a JWT then the
oidc plugin will call the user-info endpoint to discover the necessary
information about the user.

Target: master
Requires-notes: yes
Requires-book: no