### PR TITLE
skel: bump logback to 1.2.10

### DIFF
--- a/modules/logback-test-config/pom.xml
+++ b/modules/logback-test-config/pom.xml
@@ -36,7 +36,7 @@
       <dependency>
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.10</version>
       </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,9 @@
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>
 
-        <!-- Newer versions of logback suffer from bug
-	     http://jira.qos.ch/browse/LOGBACK-941. -->
-
         <!-- Remember to update modules/logback-test-config/pom.xml
              when upgrading logback. -->
-        <version.logback>1.2.3</version.logback>
+        <version.logback>1.2.10</version.logback>
         <version.logback.contrib>0.1.5</version.logback.contrib>
         <version.jackson>2.12.1</version.jackson>
         <version.jna>5.4.0</version.jna>


### PR DESCRIPTION
Use the most recent version of 1.2 with security fixes.

Target: master
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13365/
Requires-notes: no
Requires-book: no
Acked-by: Tigran
Acked-by: Lea