### PR TITLE
srm-server: log trs tape queue states when tape requests are added

### DIFF
--- a/modules/srm-server/src/main/java/org/dcache/srm/scheduler/strategy/TapeRecallSchedulingStrategy.java
+++ b/modules/srm-server/src/main/java/org/dcache/srm/scheduler/strategy/TapeRecallSchedulingStrategy.java
@@ -102,12 +102,7 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
         }
 
         if (activatedTapes) {
-            if (!tapesWithJobs.isEmpty()) {
-                LOGGER.info("Pending tapes: {}", describeTapesWithJobsMap(tapesWithJobs));
-            }
-            if (!activeTapesWithJobs.isEmpty()) {
-                LOGGER.info("Active tapes: {}", describeTapesWithJobsMap(activeTapesWithJobs));
-            }
+            logTapesWithJobsState();
         }
 
         if (immediateJobQueue.isEmpty()) {
@@ -405,6 +400,10 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
         Map<String, TapefileInfo> newTapeFileInfos = tapeInformant.getTapefileInfos(fileids);
         LOGGER.info("Retrieved tape info on {}/{} files", newTapeFileInfos.size(), fileids.size());
 
+        if (newTapeFileInfos.isEmpty()) {
+            return;
+        }
+
         Iterator<SchedulingItemJob> iterator = newJobs.iterator();
         SchedulingItemJob job;
         String fileid;
@@ -425,6 +424,8 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
             }
         }
         sortTapeRequestQueues(changedTapeQueues);
+
+        logTapesWithJobsState();
     }
 
     /**
@@ -508,6 +509,15 @@ public class TapeRecallSchedulingStrategy implements SchedulingStrategy {
               e -> sb.append("(").append(e.getKey()).append(", ").append(e.getValue().size())
                     .append(") "));
         return sb.toString();
+    }
+
+    private void logTapesWithJobsState() {
+        if (!tapesWithJobs.isEmpty()) {
+            LOGGER.info("Pending tapes: {}", describeTapesWithJobsMap(tapesWithJobs));
+        }
+        if (!activeTapesWithJobs.isEmpty()) {
+            LOGGER.info("Active tapes: {}", describeTapesWithJobsMap(activeTapesWithJobs));
+        }
     }
 
 }


### PR DESCRIPTION
Motivation:

The tape recall scheduler groups jobs by tape and activates them according to configurable criteria.
Active and pending tapes along with the number of associated jobs are of interest in order to understand the TRS state and scheduling options. This information is currently logged when a new tape is activated, which, depending on configuration, might happen a long time after jobs have been grouped by tape and are waiting for a minimum cooldown period to have passed before being selectable for activation.

Modification:

Log the pending and active tapes with associated job counts whenever a new batch of jobs is tape-associated. Refactor logging for DRYness.

Result:

Log tape queue states when new jobs are tape-associated.

Target: master
Target: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13385/
Acked-by: Tigran Mkrtchyan