### PR TITLE
dcache-core: fix admin command to query pins by state

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCLI.java
+++ b/modules/dcache/src/main/java/org/dcache/pinmanager/PinManagerCLI.java
@@ -264,6 +264,7 @@ public class PinManagerCLI
                     break;
                 case "unpin-failed":
                     criterion.state(FAILED_TO_UNPIN);
+                    break;
                 case "all":
                     criterion.stateIsNot(PINNING);
                     requirePinning = true;


### PR DESCRIPTION
Motivation:

When querying pins by state, `count pins unpin-failed` also reports the number of pins in state PINNING, which is not intended.

Modification:
Result:

When asking for `count pins unpin-failed`, only report the number of pins in state FAILED_TO_UNPIN and not PINNING.

Target: master
Target: 7.2
Target: 7.1
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13395/
Acked-by: Paul Millar