### PR TITLE
skel: minor improvements to example configuration for needrestart

### DIFF
--- a/skel/doc/examples/needrestart/exclude-dcache.conf
+++ b/skel/doc/examples/needrestart/exclude-dcache.conf
@@ -1,1 +1,1 @@
-$nrconf{override_rc}{qr(^dcache@.+\.service)} = 0;
+$nrconf{override_rc}{qr(^dcache\@.+\.service$)} = 0;

--- a/skel/doc/examples/needrestart/exclude-postgresql.conf
+++ b/skel/doc/examples/needrestart/exclude-postgresql.conf
@@ -1,1 +1,1 @@
-$nrconf{override_rc}{qr(^postgresql@.+\.service)} = 0;
+$nrconf{override_rc}{qr(^postgresql\@.+\.service$)} = 0;


### PR DESCRIPTION
Modification:

Properly anchor the regular expression and escape the `@` which Perl may
interpret as variable when followed by a valid identifier.

Target: master
Requires-notes: no
Requires-book: no

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>