### PR TITLE
TransferManager: log bugs with corresponding stack-trace

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -652,7 +652,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
                   errorObject);
             manager.sendMessage(new CellMessage(requestor, errorReply));
         } catch (RuntimeException e) {
-            LOGGER.error(e.toString());
+            LOGGER.error("Send message failed:", e);
             //can not do much more here!!!
         }
         //this will allow the handler to be garbage collected
@@ -695,7 +695,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
                   errorObject);
             manager.sendMessage(new CellMessage(requestor, errorReply));
         } catch (RuntimeException e) {
-            LOGGER.error(e.toString());
+            LOGGER.error("Problem when sending failure report:", e);
             //can not do much more here!!!
         }
         //this will allow the handler to be garbage collected
@@ -728,7 +728,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
             TransferCompleteMessage errorReply = new TransferCompleteMessage(transferRequest);
             manager.sendMessage(new CellMessage(requestor, errorReply));
         } catch (RuntimeException e) {
-            LOGGER.error(e.toString());
+            LOGGER.error("Failed to send transfer complete message", e);
             //can not do much more here!!!
         }
         //this will allow the handler to be garbage collected


### PR DESCRIPTION
Motivation:

There are a few places where TransferManager catches a RuntimeException
but logs this exception without any stack-trace.  A dCache admin might
not realise a log entry without a stack-trace is the result of a bug,
and so not report it.  Similarly, without a stack-trace, understanding
the bug becomes considerably harder.

Modification:

Update log entries to include a meaningful message and to log the
stack-trace.

Result:

TransferManager will now log bugs with the corresponding stack-trace,
making fixes any such bug easier.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13373/
Acked-by: Lea Morschel