### PR TITLE
pool: only send new URLs when flushing file

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/GenericStorageInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/GenericStorageInfo.java
@@ -168,6 +168,11 @@ public class GenericStorageInfo
     }
 
     @Override
+    public void clearLocations() {
+        _locations.clear();
+    }
+
+    @Override
     @Deprecated
     public void setBitfileId(String bitfileId) {
         _bitfileId = bitfileId;

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/StorageInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/StorageInfo.java
@@ -64,6 +64,11 @@ public interface StorageInfo
     List<URI> locations();
 
     /**
+     * Remove all known locations.
+     */
+    void clearLocations();
+
+    /**
      * add a new location for the file
      *
      * @param newLocation

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1054,6 +1054,7 @@ public class NearlineStorageHandler
               throws CacheException {
             FileAttributes fileAttributes = descriptor.getFileAttributes();
             StorageInfo storageInfo = fileAttributes.getStorageInfo().clone();
+            storageInfo.clearLocations(); // avoid sending potentially stale tape locations.
             storageInfo.isSetAddLocation(true);
             for (URI uri : uris) {
                 try {


### PR DESCRIPTION
Motivation:

The pool may know about the tape locations of file replicas stored on
that pool.  This information is created when the file's replica was
created.  This information is, in effect, a snapshot of the information
stored in the namespace.  The pool-stored information becomes incorrect
if the tape location information in the namespace changes.

On a successful flush, the pool notifies the namespace of all tape
locations that it knows about, not just the location(s) for the created
by the flush operation.

This risks updating the namespace with out-of-date information.

Modification:

Ensure that the namespace is notified with only the tape location(s)
from the flush operation.  Any existing tape information that the pool
knows about is not sent to the namespace.

Result:

Fix a problem where a file's tape location that used to exist in the
namespace and was subsequently removed can reappear if the file made
precious and flushed to tape.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13403/
Acked-by: Tigran Mkrtchyan
Acked-by: Dmitry Litvintsev