### PR TITLE
frontend: update dCacheView to v2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.jetty>9.4.43.v20210629</version.jetty>
         <version.xrootd4j>4.2.5</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
-        <version.dcache-view>2.0.1</version.dcache-view>
+        <version.dcache-view>2.0.2</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Motivation:

New version of dCacheView brings some bug-fixes:

    79a9ba5ad4 [maven-release-plugin] prepare release v2.0.2
    9955337621 oidc: add support for extra fields in OIDC (implicit flow)
    1033466341 don't show login prompt for a macaroon link.
    dea5cfd0b0 [maven-release-plugin] prepare for next development iteration

Modification:

Update dCache View version from 2.0.1 to 2.0.2

Result:

dCache is now bundled with the latest version of dCacheView.  This
includes a bug-fix for sharing a non-public directory and the ability to
specify extra options for OIDC (e.g., Keycloak's IdP hinting).

Target: master
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13404/
Acked-by: Albert Rossi
Acked-by: Lea Morschel