### PR TITLE
rest api: add checksum parameter to namespace resource

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -150,6 +150,8 @@ public class FileResources {
           @QueryParam("xattr") boolean isXattr,
           @ApiParam("Whether to include labels.")
           @QueryParam("labels") boolean isLabels,
+          @ApiParam("Whether or not to list checksum values.")
+          @QueryParam("checksum") boolean isChecksum,
           @ApiParam("Limit number of replies in directory listing.")
           @QueryParam("limit") String limit,
           @ApiParam("Number of entries to skip in directory listing.")
@@ -159,6 +161,7 @@ public class FileResources {
               NamespaceUtils.getRequestedAttributes(isLocality,
                     isLocations,
                     isQos,
+                    isChecksum,
                     false);
         PnfsHandler handler = HandlerBuilders.roleAwarePnfsHandler(pnfsmanager);
         FsPath path = pathMapper.asDcachePath(request, requestPath, ForbiddenException::new);
@@ -168,7 +171,7 @@ public class FileResources {
             NamespaceUtils.chimeraToJsonAttributes(path.name(), fileAttributes,
                   namespaceAttributes,
                   isLocality, isLocations, isLabels,
-                  false, isXattr,
+                  false, isXattr, isChecksum,
                   request, poolMonitor);
             if (isQos) {
                 NamespaceUtils.addQoSAttributes(fileAttributes,
@@ -211,7 +214,7 @@ public class FileResources {
                           childrenAttributes,
                           entry.getFileAttributes(),
                           isLocality, isLocations, isLabels,
-                          false, isXattr,
+                          false, isXattr, isChecksum,
                           request, poolMonitor);
                     childrenAttributes.setFileName(fName);
                     if (isQos) {

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/IdResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/IdResources.java
@@ -150,6 +150,7 @@ public class IdResources {
               = NamespaceUtils.getRequestedAttributes(true,
               true,
               true,
+              true,
               true);
         JsonFileAttributes result = new JsonFileAttributes();
         PnfsHandler handler = HandlerBuilders.roleAwarePnfsHandler(pnfsmanager);
@@ -184,6 +185,7 @@ public class IdResources {
                   true,
                   true,
                   false,
+                  true,
                   request,
                   poolMonitor);
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/namespace/NamespaceUtils.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/namespace/NamespaceUtils.java
@@ -73,6 +73,8 @@ public final class NamespaceUtils {
      * @param isLocations add locations if true
      * @param isLabels    add label if true
      * @param isOptional  add optional attributes if true
+     * @param isXattr     add xattr if true
+     * @param isChecksum  add checksums if true
      * @param request     to check for client info
      * @param poolMonitor for access to remote PoolMonitor
      */
@@ -84,6 +86,7 @@ public final class NamespaceUtils {
           boolean isLabels,
           boolean isOptional,
           boolean isXattr,
+          boolean isChecksum,
           HttpServletRequest request,
           PoolMonitor poolMonitor) throws CacheException {
         json.setPnfsId(attributes.getPnfsId());
@@ -139,6 +142,12 @@ public final class NamespaceUtils {
         if (isXattr) {
             Map<String, String> xattr = attributes.getXattrs();
             json.setExtendedAttributes(xattr);
+        }
+
+        if (isChecksum) {
+            if (attributes.isDefined(FileAttribute.CHECKSUM)) {
+                json.setChecksums(attributes.getChecksums());
+            }
         }
 
         if (isLabels) {
@@ -200,10 +209,6 @@ public final class NamespaceUtils {
             json.setCacheClass(attributes.getCacheClass());
         }
 
-        if (attributes.isDefined(FileAttribute.CHECKSUM)) {
-            json.setChecksums(attributes.getChecksums());
-        }
-
         if (attributes.isDefined(FileAttribute.CHANGE_TIME)) {
             json.setCtime(attributes.getChangeTime());
         }
@@ -242,6 +247,7 @@ public final class NamespaceUtils {
     public static Set<FileAttribute> getRequestedAttributes(boolean locality,
           boolean locations,
           boolean qos,
+          boolean checksum,
           boolean optional) {
         Set<FileAttribute> attributes = new HashSet<>();
         attributes.add(FileAttribute.PNFSID);
@@ -269,11 +275,14 @@ public final class NamespaceUtils {
             attributes.add(FileAttribute.RETENTION_POLICY);
         }
 
+        if (checksum) {
+            attributes.add(FileAttribute.CHECKSUM);
+        }
+
         if (optional) {
             attributes.add(FileAttribute.ACL);
             attributes.add(FileAttribute.ACCESS_TIME);
             attributes.add(FileAttribute.CACHECLASS);
-            attributes.add(FileAttribute.CHECKSUM);
             attributes.add(FileAttribute.CHANGE_TIME);
             attributes.add(FileAttribute.OWNER_GROUP);
             attributes.add(FileAttribute.OWNER);


### PR DESCRIPTION
Motivation:

namespace rest API allows to query locality, locations, xattr, labels but not
file checksum values

Modification:

add checksum parameter to API

Result:

Ability to query file checksum values

Patch: https://rb.dcache.org/r/13414
Target: trunk
Request: 7.2
Request: 8.0

Conflicts:
	modules/dcache-frontend/src/main/java/org/dcache/restful/resources/labels/LabelsResources.java