### PR TITLE
common-security: re-read server credentials on context re-creation

### DIFF
--- a/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2015 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2015 - 2022 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -312,9 +312,12 @@ public class CanlContextFactory implements SslContextFactory {
              * PEMCredential does not consistently support keyPasswd being null
              * https://github.com/eu-emi/canl-java/issues/114
              */
-            PEMCredential credential
-                  = new PEMCredential(keyPath.toString(), certificatePath.toString(), new char[]{});
-            Callable newContext = () -> factory.getContext(contextType, credential);
+            Callable newContext = () -> {
+                PEMCredential credential
+                      = new PEMCredential(keyPath.toString(), certificatePath.toString(), new char[]{});
+                return factory.getContext(contextType, credential);
+            };
+
             return (Callable<T>) memoizeWithExpiration(memoizeFromFiles(newContext,
                         keyPath,
                         certificatePath),


### PR DESCRIPTION
Motivation:
When dcache re-initializes hosts GSI due to cache expiry, the it should
re-read the host cert and key to pickup the new certificate, if update.

Modification:
re-read server credentials on context re-creation

Result:
fixes certificate reload when updated

Fixes: #6424
Acked-by: Dmitry Litvintsev
Acked-by: Albert Rossi
Acked-by: Paul Millar
Target: master, 8.0, 7.2
Require-book: no
Require-notes: yes
(cherry picked from commit 84eb4e558267cee27f89aeb0e149fe0f1b8f62e4)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>