### PR TITLE
pool: fix NPE on attempt by client to read from a broken replica

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -327,20 +327,15 @@ public class NfsTransferService
 
     @Override
     public Cancellable executeMover(final NfsMover mover,
-          final CompletionHandler<Void, Void> completionHandler) {
-        try {
+            final CompletionHandler<Void, Void> completionHandler)
+            throws DiskErrorCacheException, InterruptedIOException {
+        final Cancellable cancellableMover = mover.enable(completionHandler);
+        notifyDoorWithRedirect(mover);
 
-            final Cancellable cancellableMover = mover.enable(completionHandler);
-            notifyDoorWithRedirect(mover);
-
-            /* An NFS mover doesn't complete until it is cancelled (the door sends a mover kill
-             * message when the file is closed).
-             */
-            return cancellableMover;
-        } catch (DiskErrorCacheException | InterruptedIOException | RuntimeException e) {
-            completionHandler.failed(e, null);
-        }
-        return null;
+        /* An NFS mover doesn't complete until it is cancelled (the door sends a mover kill
+         * message when the file is closed).
+         */
+        return cancellableMover;
     }
 
     public void notifyDoorWithRedirect(NfsMover mover) {

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/TransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/TransferService.java
@@ -18,6 +18,7 @@
 package org.dcache.pool.classic;
 
 import java.nio.channels.CompletionHandler;
+import javax.annotation.Nonnull;
 import org.dcache.pool.movers.Mover;
 
 /**
@@ -27,6 +28,7 @@ import org.dcache.pool.movers.Mover;
  */
 public interface TransferService<M extends Mover<?>> {
 
+    @Nonnull
     Cancellable executeMover(M mover, CompletionHandler<Void, Void> completionHandler)
           throws Exception;
 


### PR DESCRIPTION
Motivation:

Reported stack-trace:

    04 Feb 2022 19:06:41 (v-stkendca1806-1) [door:NFS-enstore01@nfsDomain:AAXXOukD/Qg NFS-enstore01 PoolDeliverFile 00008FBFF2A3F3B542BCA50AD15FEEF94E90] Transfer failed due to a bug
    java.lang.NullPointerException: null
            at java.base/java.util.Objects.requireNonNull(Objects.java:221)
            at org.dcache.util.TryCatchTemplate.setCancellable(TryCatchTemplate.java:158)
            at org.dcache.util.TryCatchTemplate.execute(TryCatchTemplate.java:170)
            at org.dcache.util.TryCatchTemplate.<init>(TryCatchTemplate.java:80)
            at org.dcache.pool.movers.AbstractMover$2.<init>(AbstractMover.java:239)
            at org.dcache.pool.movers.AbstractMover.execute(AbstractMover.java:239)
            at org.dcache.pool.classic.MoverRequestScheduler$PrioritizedRequest.transfer(MoverRequestScheduler.java:792)
            at org.dcache.pool.classic.MoverRequestScheduler.sendToExecution(MoverRequestScheduler.java:527)
            at org.dcache.pool.classic.MoverRequestScheduler.getOrCreateMover(MoverRequestScheduler.java:227)
            at org.dcache.pool.classic.IoQueueManager.getOrCreateMover(IoQueueManager.java:162)
            at org.dcache.pool.classic.PoolV4.queueIoRequest(PoolV4.java:789)
            at org.dcache.pool.classic.PoolV4.ioFile(PoolV4.java:796)
            at org.dcache.pool.classic.PoolV4.messageArrived(PoolV4.java:1014)
            at jdk.internal.reflect.GeneratedMethodAccessor53.invoke(Unknown Source)
            at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.base/java.lang.reflect.Method.invoke(Method.java:566)
            at org.dcache.cells.CellMessageDispatcher$LongReceiver.deliver(CellMessageDispatcher.java:304)
            at org.dcache.cells.CellMessageDispatcher.call(CellMessageDispatcher.java:201)
            at org.dcache.cells.AbstractCell.messageArrived(AbstractCell.java:326)
            at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:890)
            at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1316)
            at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:251)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
            at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$2(CellNucleus.java:764)
            at java.base/java.lang.Thread.run(Thread.java:829)

Modification:

Document that TransferService#executeMover must not return a `null`
value.

Update NfsTransferService so that errors are handled by throwing an
exception rather than explicitly calling the completion handler.

Note that this has the same effect as calling TryCatchTemplate#failed
and doesn't require the NfsTansferService#executeMover method to return
a value.

Result:

A NullPointerException is fixed if an NFS transfer fails due to the
file's replica being marked as broken.

Target: master
Requires-notes: yes
Requires-book: no
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Closes: #6456
Patch: https://rb.dcache.org/r/13420/
Acked-by: Tigran Mkrtchyan