### PR TITLE
common: provide reasonable error message if path is not absolute

### DIFF
--- a/modules/common/src/main/java/diskCacheV111/util/FsPath.java
+++ b/modules/common/src/main/java/diskCacheV111/util/FsPath.java
@@ -49,7 +49,7 @@ public abstract class FsPath implements Serializable {
     }
 
     public static FsPath create(String path) {
-        checkArgument(path.startsWith("/"));
+        checkArgument(path.startsWith("/"), "Not an absolute path: %s", path);
         return ROOT.resolve(path.substring(1));
     }
 


### PR DESCRIPTION
Motivation:

The FsPath class represents an absolute path within dCache's namespace.
An attempt to create a relative path fails by throwing an
IllegalArgumentException.

Currently that IAE contains no message.  There are circumstance where
this exception may be logged without a stack-trace (where dCache using
RuntimeException to indicate non-bugs).  Therefore, it would be helpful
if the exception contains a meaningful message.

Modification:

Add an error message to the IllegalArgumentException.

Result:

There are places where dCache configuration requires an absolute path.
In some places attempting to use a relative path will yield an unhepful
'null' in the log file.  This is now fixed, so a meaningful error
message is logged instead.

Target: master
Requires-notes: yes
Requires-book: no
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13416/
Acked-by: Tigran Mkrtchyan