### PR TITLE
libraries: upgrade version of canl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
             <dependency>
                 <groupId>eu.eu-emi.security</groupId>
                 <artifactId>canl</artifactId>
-                <version>2.5.1</version>
+                <version>2.6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.italiangrid</groupId>


### PR DESCRIPTION
Movation:

"Rolling over" is a process where a CA updates the certificate for their
root or intermediate CA certificate, but without changing their public
private key pair.

The current version of CaNL suffers from a bug where, after such a
roll-over, the users of that CA are no longer recognised.

Modification:

Latest version of canl, which fixes this problem.

Result:

Fix a bug where dCache will no longer accept certificates issued by a
trusted CA after that CA updates their CA certificate while keeping the
public/private key-pair the same.  This is typically done to change
something in CA's certificate.

Target: master
Requires-notes: yes
Requires-book: no
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13191/
Acked-by: Lea Morschel