### PR TITLE
chimera: fix error when adding new label to a file

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -1995,8 +1995,6 @@ public class FsSqlDriver {
               }, labelname);
 
     }
-
-
     /**
      * Attache a given label to  a given file system object.
      *
@@ -2025,6 +2023,7 @@ public class FsSqlDriver {
                       }, keyHolder);
                 Long label_id = (Long) keyHolder.getKeys().get("label_id");
 
+                //TODO change to WHERE NOT EXISTS
                 _jdbc.update("INSERT INTO t_labels_ref (label_id, inumber) VALUES (?,?)",
                       label_id, inode.ino());
 
@@ -2033,8 +2032,8 @@ public class FsSqlDriver {
                 Long label_id = getLabel(labelname);
 
                 int n = _jdbc.queryForObject(
-                      "SELECT count(*) FROM t_labels_ref WHERE inumber=? and label_id = label_id",
-                      Integer.class, inode.ino());
+                      "SELECT count(*) FROM t_labels_ref WHERE inumber=? and label_id = ?",
+                      Integer.class, inode.ino(),label_id);
 
                 if (n == 0) {
                     _jdbc.update("INSERT INTO t_labels_ref (label_id, inumber) VALUES (?,?)",

--- a/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
@@ -1575,6 +1575,33 @@ public class JdbcFsTest extends ChimeraTestCaseHelper {
 
     }
 
+    @Test
+    public void testAddLabelsSameFileDiffLabels() throws Exception {
+
+        FsInode dir = _fs.mkdir("/test");
+
+        FsInode inodeA = _fs.createFile(dir, "aFile");
+        FsInode inodeB = _fs.createFile(dir, "bFile");
+        FsInode inodeC = _fs.createFile(dir, "cFile");
+
+        String labelnameCat = "cat";
+        String labelnameDog = "dog";
+
+        _fs.addLabel(inodeA, labelnameCat);
+        _fs.addLabel(inodeB, labelnameCat);
+        _fs.addLabel(inodeC, labelnameDog);
+        _fs.addLabel(inodeA, labelnameDog);
+
+
+        DirectoryStreamB<ChimeraDirectoryEntry> dirStream = _rootInode.virtualDirectoryStream(
+              labelnameDog);
+
+        assertEquals("Unexpected number of labels", 2, dirStream.stream().count());
+        assertTrue("Unexpected labels",
+              _fs.getLabels(inodeA).contains("cat") && _fs.getLabels(inodeA).contains("dog"));
+
+    }
+
     @Test(expected = FileExistsChimeraFsException.class)
     public void testExclusiveCreateXattr() throws Exception {
 


### PR DESCRIPTION
Motivation

When adding a new label to a file the followig case was not working correctly, because of one of the queries was wrong:

        String labelnameCat = "cat";
        String labelnameDog = "dog";

        _fs.addLabel(inodeA, labelnameCat);
        _fs.addLabel(inodeB, labelnameCat);
        _fs.addLabel(inodeC, labelnameDog);
        _fs.addLabel(inodeA, labelnameDog);

Result

This should work  now.

Target: master, 8.0
Acked-by: Paul Millar