### PR TITLE
webdav: fix NPE if 'webdav.authz.allowed-paths' disallows a request

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -584,9 +584,7 @@ public class DcacheResourceFactory
      * @param path The full path
      */
     public DcacheResource getResource(FsPath path) {
-        if (!isAllowedPath(path)) {
-            return null;
-        }
+        checkPathAllowed(path);
 
         String requestPath = getRequestPath();
         boolean haveRetried = false;
@@ -1176,13 +1174,11 @@ public class DcacheResourceFactory
     /**
      * Returns true if access to path is allowed through the WebDAV door, false otherwise.
      */
-    private boolean isAllowedPath(FsPath path) {
-        for (FsPath allowedPath : _allowedPaths) {
-            if (path.hasPrefix(allowedPath)) {
-                return true;
-            }
+    private void checkPathAllowed(FsPath path) throws UnauthorizedException, ForbiddenException {
+        if (!_allowedPaths.stream().anyMatch(path::hasPrefix)) {
+            Resource denied = new DcacheResource(this, path, FileAttributes.of().build());
+            throw WebDavExceptions.permissionDenied(denied);
         }
-        return false;
     }
 
     /**

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/UnauthorizedException.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/UnauthorizedException.java
@@ -1,6 +1,7 @@
 package org.dcache.webdav;
 
 import io.milton.resource.Resource;
+import javax.annotation.Nonnull;
 
 /**
  * Corresponds to a 401 unauthorized response.
@@ -13,15 +14,15 @@ public class UnauthorizedException extends WebDavException {
 
     private static final long serialVersionUID = 392046210465227212L;
 
-    public UnauthorizedException(Resource resource) {
+    public UnauthorizedException(@Nonnull Resource resource) {
         super(resource);
     }
 
-    public UnauthorizedException(String message, Resource resource) {
+    public UnauthorizedException(String message, @Nonnull Resource resource) {
         super(message, resource);
     }
 
-    public UnauthorizedException(String message, Throwable cause, Resource resource) {
+    public UnauthorizedException(String message, Throwable cause, @Nonnull Resource resource) {
         super(message, cause, resource);
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/WebDavExceptions.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/WebDavExceptions.java
@@ -20,6 +20,7 @@ package org.dcache.webdav;
 
 import io.milton.resource.Resource;
 import java.security.AccessController;
+import javax.annotation.Nonnull;
 import javax.security.auth.Subject;
 import org.dcache.auth.Subjects;
 
@@ -35,7 +36,7 @@ public class WebDavExceptions {
      * Returns either an UnauthorizedException or a ForbiddenException depending on whether the user
      * is authenticated.
      */
-    public static WebDavException permissionDenied(Resource resource) {
+    public static WebDavException permissionDenied(@Nonnull Resource resource) {
         Subject subject = Subject.getSubject(AccessController.getContext());
         if (Subjects.isNobody(subject)) {
             return new UnauthorizedException(resource);


### PR DESCRIPTION
Motivation:

If the 'webdav.authz.allowed-paths' configuration property is set to a
non-root value then requests outside this path are rejected.

The current code achieves this by having the dCache resource factory
returning `null` for the targeted resource.

A `null` response indicates that the requested resource does not exist.

Unfortunately, for uploads, milton will walk up the path, looking for an
existing parent directory.  If the 'webdav.authz.allowed-paths'
disallows the request then dCache claims that all parent directories do
not exist (including the root directory).

This triggers the following NullPointerException in Milton:

    java.lang.NullPointerException: null
            at io.milton.http.HandlerHelper.checkAuthorisation(HandlerHelper.java:138)
            at io.milton.http.HandlerHelper.checkAuthorisation(HandlerHelper.java:117)
            at io.milton.http.http11.PutHandler.process(PutHandler.java:159)
            at org.dcache.webdav.DcacheStandardFilter.process(DcacheStandardFilter.java:50)
            at io.milton.http.FilterChain.process(FilterChain.java:46)
            at org.dcache.webdav.transfer.CopyFilter.process(CopyFilter.java:276)
            at io.milton.http.FilterChain.process(FilterChain.java:46)
            at io.milton.http.HttpManager.process(HttpManager.java:158)
            at org.dcache.webdav.MiltonHandler.handle(MiltonHandler.java:77)
            at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:59)
            at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
            at org.dcache.http.AuthenticationHandler.access$001(AuthenticationHandler.java:55)
            at org.dcache.http.AuthenticationHandler.lambda$handle$0(AuthenticationHandler.java:156)
            at java.base/java.security.AccessController.doPrivileged(Native Method)
            at java.base/javax.security.auth.Subject.doAs(Subject.java:361)
            at org.dcache.http.AuthenticationHandler.handle(AuthenticationHandler.java:153)
            at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:59)
            at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
            at org.dcache.http.AbstractLoggingHandler.handle(AbstractLoggingHandler.java:107)
            at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:59)
            at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
            at org.eclipse.jetty.rewrite.handler.RewriteHandler.handle(RewriteHandler.java:322)
            at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
            at org.eclipse.jetty.server.Server.handle(Server.java:516)
            at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)
            at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)
            at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)
            at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
            at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
            at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
            at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.onFillable(SslConnection.java:555)
            at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:410)
            at org.eclipse.jetty.io.ssl.SslConnection$2.succeeded(SslConnection.java:164)
            at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
            at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
            at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
            at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
            at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
            at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
            at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:386)
            at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
            at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
            at java.base/java.lang.Thread.run(Thread.java:829)

Modification:

Update the code so that dCache will immediately fail the request if that
request targets a path that 'webdav.authz.allowed-paths' does not allow.

Result:

Fix handling of 'webdav.authz.allowed-paths' so it no longer triggers a
NullPointerException.

Target: master
Requires-notes: yes
Requires-book: yes
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Ticket: https://rt.dcache.org/Ticket/Display.html?id=10275
Patch: https://rb.dcache.org/r/13428/
Acked-by: Tigran Mkrtchyan