### PR TITLE
bulk, frontend-rest: return 404, not 403, when request id does not exist

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handlers/BulkRequestHandler.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handlers/BulkRequestHandler.java
@@ -345,12 +345,12 @@ public class BulkRequestHandler implements BulkSubmissionHandler, BulkRequestCom
           throws BulkServiceException {
         LOGGER.trace("cancelRequest {}, {}.", subject, requestId);
 
-        if (!requestStore.isRequestSubject(subject, requestId)) {
-            throw new BulkPermissionDeniedException(requestId);
-        }
-
         if (isRequestAlreadyCleared(requestId)) {
             throw new BulkRequestNotFoundException(requestId);
+        }
+
+        if (!requestStore.isRequestSubject(subject, requestId)) {
+            throw new BulkPermissionDeniedException(requestId);
         }
 
         if (isRequestActive(requestId)) {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/memory/InMemoryBulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/memory/InMemoryBulkRequestStore.java
@@ -358,10 +358,11 @@ public class InMemoryBulkRequestStore extends InMemoryStore
           BulkRequestStorageException {
         read.lock();
         try {
+            BulkRequestStatus status = getNonNullStatus(requestId);
             if (!isRequestSubject(subject, requestId)) {
                 throw new BulkPermissionDeniedException(requestId);
             }
-            return getNonNullStatus(requestId);
+            return status;
         } finally {
             read.unlock();
         }


### PR DESCRIPTION
Motivation:

See GH #6449 https://github.com/dCache/dcache/issues/6449

When GET or PATCH is issued for the bulk-request resource
(requesting the status or cancelling the request), if the
submitted id is not recognized by the service, 404 should
be returned.  Currently, we are seeing 403 (permission denied)
instead.

Modification:

The ordering of the underlying checks for existence and
then for permissions needs to be reversed.

Result:

The existence check overrides the permission check in
terms of the error return, as it logically should.

Target: master
Request: 8.0
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13430/
Closes: #6449
Acked-by: Tigran