### PR TITLE
dcache-xroot: set default TLS to OPTIONAL for pools

### DIFF
--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -452,7 +452,7 @@ pool.mover.xrootd.security.force-signing=${dcache.xrootd.security.force-signing}
 #      These properties are not linked to a common dcache property
 #      because the door and pool very likely will have different requirements.
 #
-(one-of?OFF|OPTIONAL|STRICT)pool.mover.xrootd.security.tls.mode=OFF
+(one-of?OFF|OPTIONAL|STRICT)pool.mover.xrootd.security.tls.mode=OPTIONAL
 (one-of?true|false)pool.mover.xrootd.security.tls.require-login=false
 (one-of?true|false)pool.mover.xrootd.security.tls.require-session=false
 (one-of?true|false)pool.mover.xrootd.security.tls.require-data=false


### PR DESCRIPTION
Motivation:

https://rb.dcache.org/r/13397/
master@4f561f9914ddb2d63a72b0b6fcdc5b832b03f605

changed the default value for TLS to OPTIONAL for the doors
but neglected to do similarly for the pool properties.

Modfication:

Change default to OPTIONAL on the pools as well.

Result:

Defaults for xroot TLS are uniform.

Target: master
Request: 8.0
Patch: https://rb.dcache.org/r/13432/
Requires-notes: yes
Requires-book: no (default is not specified)
Acked-by: Dmitry