### PR TITLE
admin shell: fix line termination in SshOutputStream

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/ssh2/SshOutputStream.java
+++ b/modules/dcache/src/main/java/org/dcache/services/ssh2/SshOutputStream.java
@@ -13,8 +13,8 @@ class SshOutputStream extends FilterOutputStream {
     @Override
     public void write(int c) throws IOException {
         if (c == '\n') {
-            super.write(0xa);
             super.write(0xd);
+            super.write(0xa);
         } else {
             super.write(c);
         }


### PR DESCRIPTION
Motivation:

Patch a705b0aab51e5e553b502aef885eb8df2adf6212 attempted do add
'\r\n' at the end of each line printed to console. But unfortunately
it added '\n\r' instead.

Modification:

Add '\r\n' at the end of each line printed to console

Result:

Direct command output does not contain ^M which breaks parsing
of the shell command output

Target: trunk
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2

Patch: https://rb.dcache.org/r/13434
Issue: https://github.com/dCache/dcache/issues/6215
Acked-by: Al
Acked-by: Paul
Require-notes: yes
Require-book: no