### PR TITLE
pool: try to forcefully kill HSM process if needed

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/RunSystem.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/RunSystem.java
@@ -125,7 +125,14 @@ public class RunSystem implements Runnable {
                 }
                 if (!_processDone) {
                     say("Master : Wait 2 loop : Destroying process");
-                    _process.destroy();
+                    if (l < 2) {
+                        // SIGTERM (15)
+                        _process.destroy();
+                    } else {
+                        // SIGKILL (9)
+                        LOGGER.warn("The HSM script ignores SIGTERM (PLEASE FIX IT!). Terminating forcefully with SIGKILL.");
+                        _process.destroyForcibly();
+                    }
                 }
                 if ((l > 2) && (_stoppedReader < 2)) {
                     say("Master : Wait 2 loop : Interrupting readers");


### PR DESCRIPTION
Motivation:
When nearline interface needs to kill HSM script then `Process#destroy`
is called to interrupt the running HSM migration process. However, if
the migration script catches SIGTERM (15) and ignores it, then request
to HSM will be blocked in CANCELED state in the pool.

Modification:
If HSM script survives `Process#destroy` switch to
`Process#destroyForcibly` which sends SIGKILL (9).

Result:
less situations when expired/canceled requests stay in CANCELED.

Acked-by: Paul Millar
Target: master, 8.0, 7.2
Require-book: no
Require-notes: yes
(cherry picked from commit 982f89b0ffb5e1b6c4920c131e86fefe5d379e58)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>