### PR TITLE
dcache-bulk: pin by request id and unpin optionally by request

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkJobArgumentDescriptor.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkJobArgumentDescriptor.java
@@ -67,6 +67,7 @@ import com.google.common.base.Objects;
  * Metadata for optional argument to a bulk job.
  */
 public class BulkJobArgumentDescriptor {
+    public static final String EMPTY_DEFAULT = "empty";
 
     private final String name;
     private final String description;
@@ -90,6 +91,9 @@ public class BulkJobArgumentDescriptor {
         if (!required) {
             requireNonNull(defaultValue, "default value "
                   + "must be provided if arg is not required.");
+            if (defaultValue.equals(EMPTY_DEFAULT)) {
+                defaultValue = null;
+            }
             this.defaultValue = defaultValue;
         } else {
             this.defaultValue = null;

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/PinJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/PinJob.java
@@ -61,6 +61,7 @@ package org.dcache.services.bulk.plugins.pinmanager;
 
 import static org.dcache.services.bulk.plugins.pinmanager.PinJobProvider.LIFETIME;
 import static org.dcache.services.bulk.plugins.pinmanager.PinJobProvider.LIFETIME_UNIT;
+import static org.dcache.services.bulk.plugins.pinmanager.PinJobProvider.PIN_REQUEST_ID;
 
 import diskCacheV111.vehicles.HttpProtocolInfo;
 import diskCacheV111.vehicles.ProtocolInfo;
@@ -102,8 +103,12 @@ public class PinJob extends PinManagerJob {
     protected void doRun() {
         long lifetime = getLifetime(arguments);
         try {
+            String requestId =  arguments == null ? null : arguments.get(PIN_REQUEST_ID.getName());
+            if (requestId == null) {
+                requestId = key.getRequestId();
+            }
             PinManagerPinMessage message
-                  = new PinManagerPinMessage(attributes, getProtocolInfo(), null, lifetime);
+                  = new PinManagerPinMessage(attributes, getProtocolInfo(),requestId, lifetime);
             sendToPinManager(message);
         } catch (URISyntaxException e) {
             setError(e);

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/PinJobProvider.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/PinJobProvider.java
@@ -59,6 +59,7 @@ documents or software obtained from this server.
  */
 package org.dcache.services.bulk.plugins.pinmanager;
 
+import static org.dcache.services.bulk.job.BulkJobArgumentDescriptor.EMPTY_DEFAULT;
 import static org.dcache.services.bulk.job.MultipleTargetJob.TargetType.FILE;
 
 import com.google.common.collect.ImmutableSet;
@@ -84,6 +85,14 @@ public class PinJobProvider extends BulkJobProvider<PinJob> {
                 false,
                 "MINUTES");
 
+    static final BulkJobArgumentDescriptor PIN_REQUEST_ID
+          = new BulkJobArgumentDescriptor("id",
+          "to use for this pin.  If empty/null on PIN, the id of the current request will "
+                + "be used)",
+          "string",
+          false,
+         EMPTY_DEFAULT);
+
     public PinJobProvider() {
         super("PIN", FILE, ExpansionType.BREADTH_FIRST);
     }
@@ -100,6 +109,6 @@ public class PinJobProvider extends BulkJobProvider<PinJob> {
 
     @Override
     public Set<BulkJobArgumentDescriptor> getArguments() {
-        return ImmutableSet.of(LIFETIME, LIFETIME_UNIT);
+        return ImmutableSet.of(LIFETIME, LIFETIME_UNIT, PIN_REQUEST_ID);
     }
 }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/UnpinJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/UnpinJob.java
@@ -59,6 +59,9 @@ documents or software obtained from this server.
  */
 package org.dcache.services.bulk.plugins.pinmanager;
 
+
+import static org.dcache.services.bulk.plugins.pinmanager.UnpinJobProvider.UNPIN_REQUEST_ID;
+
 import org.dcache.pinmanager.PinManagerUnpinMessage;
 import org.dcache.services.bulk.job.BulkJobKey;
 
@@ -70,6 +73,9 @@ public class UnpinJob extends PinManagerJob {
 
     @Override
     protected void doRun() {
-        sendToPinManager(new PinManagerUnpinMessage(attributes.getPnfsId()));
+        String id = arguments == null ? null : arguments.get(UNPIN_REQUEST_ID.getName());
+        PinManagerUnpinMessage message = new PinManagerUnpinMessage(attributes.getPnfsId());
+        message.setRequestId(id);
+        sendToPinManager(message);
     }
 }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/UnpinJobProvider.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/UnpinJobProvider.java
@@ -59,9 +59,10 @@ documents or software obtained from this server.
  */
 package org.dcache.services.bulk.plugins.pinmanager;
 
+import static org.dcache.services.bulk.job.BulkJobArgumentDescriptor.EMPTY_DEFAULT;
 import static org.dcache.services.bulk.job.MultipleTargetJob.TargetType.FILE;
 
-import java.util.Collections;
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import org.dcache.services.bulk.job.BulkJobArgumentDescriptor;
 import org.dcache.services.bulk.job.BulkJobKey;
@@ -69,6 +70,14 @@ import org.dcache.services.bulk.job.BulkJobProvider;
 import org.dcache.services.bulk.job.TargetExpansionJob.ExpansionType;
 
 public class UnpinJobProvider extends BulkJobProvider<UnpinJob> {
+
+    static final BulkJobArgumentDescriptor UNPIN_REQUEST_ID
+          = new BulkJobArgumentDescriptor("id",
+          "to use for this unpin.  If empty/null, no id will be used (meaning all pins "
+                + "should be released)",
+          "string",
+          false,
+          EMPTY_DEFAULT);
 
     public UnpinJobProvider() {
         super("UNPIN", FILE, ExpansionType.BREADTH_FIRST);
@@ -86,6 +95,6 @@ public class UnpinJobProvider extends BulkJobProvider<UnpinJob> {
 
     @Override
     public Set<BulkJobArgumentDescriptor> getArguments() {
-        return Collections.EMPTY_SET;
+        return ImmutableSet.of(UNPIN_REQUEST_ID);
     }
 }


### PR DESCRIPTION
Motivation:

Currently PIN/UNPIN in the bulk service is implemented
so as to pin without a request id.   This is actually
an implementation flaw.

What should be happening is that the pin should be (by default)
made on behalf of the specific request, and UNPIN should
then (usually) be issued with respect to the original
PIN request.

Modification:

Add the id arguments to both PIN and UNPIN, with
appropriate descriptors.

If the argument is absent from the PIN request,
it defaults to the request id of the PIN target.
If it is missing from UNPIN, it is left NULL.

Result:

Request-specific pinning is enabled, but generic
unpinning is still possible.

Target: master
Request: 8.0
Patch:  https://rb.dcache.org/r/13433/
Requires-notes: yes
Requires-book: no
Acked-by: Lea