### PR TITLE
dcache-bulk: aborted request gets stuck in the STARTED state

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handlers/BulkRequestHandler.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handlers/BulkRequestHandler.java
@@ -73,6 +73,7 @@ import org.dcache.services.bulk.BulkRequest;
 import org.dcache.services.bulk.BulkRequestNotFoundException;
 import org.dcache.services.bulk.BulkRequestStatus;
 import org.dcache.services.bulk.BulkRequestStatus.Status;
+import org.dcache.services.bulk.BulkRequestStorageException;
 import org.dcache.services.bulk.BulkServiceException;
 import org.dcache.services.bulk.BulkStorageException;
 import org.dcache.services.bulk.job.BulkJob;
@@ -134,6 +135,11 @@ public class BulkRequestHandler implements BulkSubmissionHandler, BulkRequestCom
         queue.signal();
 
         statistics.incrementJobsAborted();
+    }
+
+    public synchronized void abortRequest(String requestId) throws BulkRequestStorageException {
+        requestStore.update(requestId, COMPLETED);
+        statistics.incrementRequestsCompleted();
     }
 
     @Override
@@ -228,7 +234,6 @@ public class BulkRequestHandler implements BulkSubmissionHandler, BulkRequestCom
             statistics.incrementJobsCompleted();
         }
     }
-
 
     @Required
     public void setCallbackExecutorService(ExecutorService service) {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handlers/BulkSubmissionHandler.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handlers/BulkSubmissionHandler.java
@@ -84,6 +84,14 @@ public interface BulkSubmissionHandler {
           throws BulkServiceException;
 
     /**
+     * Unrecoverable internal failure. Mark the request as terminated.
+     *
+     * @param requestId unique identifier
+     */
+    void abortRequest(String requestId)
+          throws BulkServiceException;
+
+    /**
      * Services request (from user) to (cancel) the request.
      *
      * @param subject   of the user.

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkRequestJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkRequestJob.java
@@ -170,6 +170,15 @@ public class BulkRequestJob extends MultipleTargetJob
 
     protected void postCompletion() {
         completionHandler.requestProcessingFinished(key.getJobId());
+
+        if (completionHandler.isRequestCompleted()) {
+            try {
+                submissionHandler.abortRequest(key.getRequestId());
+            } catch (BulkServiceException e) {
+                LOGGER.error("RequestJob, postCompletion() for {}: {}.", key.getRequestId(),
+                      e.getMessage());
+            }
+        }
     }
 
     private void handleDirectory(String target, FileAttributes attributes)


### PR DESCRIPTION
Motivation:

On FNAL production we have found that file permission or existence errors on
paths/targets at the root of the request leave the request stuck in the
STARTED state.

Modification:

The initial bulk request job needs to check for request completion after
unregistering itself from the completion handler.

Result:

Jobs which originally get stuck now complete; their failure information
contains the reason for premature completion.

(NOTE:  the 'null' DEPTH seems to appear on FNAL production [7.2], but
but I have not yet been able to reproduce it using 7.2 on the testbed.)

Target: master
Request: 8.0
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13442/
Acked-by: Tigran