### PR TITLE
pool: handle multiple shutdowns of a nfs mover

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -95,12 +95,18 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
 
     /**
      * Disable access with this mover. If {@code error} is not a {@code null}, the {@link
-     * CompletionHandler#failed(Throwable, A)} method will be called.
+     * CompletionHandler#failed(Throwable, Object)} method will be called.
      *
      * @param error error to report, or {@code null} on success
      */
     void disable(Throwable error) {
-        _nfsTransferService.remove(NfsMover.this);
+
+        boolean isActive = _nfsTransferService.remove(NfsMover.this);
+        if (!isActive) {
+            _log.info("Skip disabling disposed mover: {} {} - {}", getFileAttributes().getPnfsId(), getIoMode(), getStatus());
+            return;
+        }
+
         detachSession();
         try {
             getMoverChannel().close();

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -376,10 +376,11 @@ public class NfsTransferService
      * Removes mover from the list of allowed transfers.
      *
      * @param mover
+     * @return true, if the given mover was known to this transfer service.
      */
-    public void remove(NfsMover mover) {
-        _log.debug("un-removing io handler for stateid {}", mover);
-        _activeIO.remove(mover.getStateId());
+    public boolean remove(NfsMover mover) {
+        _log.debug("un-registering io handler for stateid {}", mover);
+        return _activeIO.remove(mover.getStateId()) != null;
     }
 
     NfsMover getMoverByStateId(CompoundContext context, stateid4 stateid)


### PR DESCRIPTION
Motivation:
In a situation, when a nfs client have expired, then door and pool might
decide at the same time to kill the mover, both will get the handle of
the mover and issue `NfsMover#disable`. As a result, the under laying
file channel will be closed twice, with an error:

```
16 Feb 2022 17:30:15 (pool_write) [] Transfer failed: Abandoned mover
16 Feb 2022 17:30:15 (pool_write) [door:NFS-nairi@dCacheDomain:AAXYJQl8nyg NFS-nairi PoolAcceptFile 0000912A5649362D46BCA828F97444F795DC] Transfer failed in post
-processing. Please report this bug to support@dcache.org.
java.lang.IllegalStateException: Handle is closed
        at org.dcache.pool.repository.v5.WriteHandleImpl.close(WriteHandleImpl.java:372)
        at org.dcache.pool.classic.DefaultPostTransferService.lambda$execute$1(DefaultPostTransferService.java:110)
        at org.dcache.util.FireAndForgetTask.run(FireAndForgetTask.java:28)
        at org.dcache.util.CDCExecutorServiceDecorator$WrappedRunnable.run(CDCExecutorServiceDecorator.java:130)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.Exception: Previous, successful close.
        at org.dcache.pool.repository.v5.WriteHandleImpl.close(WriteHandleImpl.java:383)
        ... 6 common frames omitted
```

Modification:
Update `NfsTransferService#remove` toindicate that mover is already in
disposal state (or already disposed). Update `NfsMover#disable` to
ignore such movers.

```
17 Feb 2022 10:42:24 (NFS-nairi) [pool_write DoorValidateMover] Removing orphan mover: 5@PoolName=pool_write PoolAddress=pool_write@dCacheDomain for 0000FEDE0442320945D68E6A87BD03DD7C59 by localhost/0:0:0:0:0:0:0:1:40996
17 Feb 2022 10:42:24 (pool_write) [] Transfer failed: Abandoned mover
17 Feb 2022 10:42:24 (pool_write) [] Killing abandoned mover: 0000FEDE0442320945D68E6A87BD03DD7C59 IoMode=[CREATE, WRITE, READ] h={NFSv4.1/pNFS,OS=[620e16950001000300000013, seq: 2],cl=[0:0:0:0:0:0:0:1]} bytes=8388608 time/sec=487 LM=0
17 Feb 2022 10:42:24 (pool_write) [] Skip disabling disposed mover: 0000FEDE0442320945D68E6A87BD03DD7C59 [CREATE, WRITE, READ] - NFSv4.1/pNFS,OS=[620e16950001000300000013, seq: 2],cl=[0:0:0:0:0:0:0:1]

```

Result:
No stacktraces in the logs. More stable NFS error recovery.

Acked-by: Paul Millar
Acked-by: Lea Morschel
Target: master, 8.0, 7.2
Require-book: no
Require-notes: yes
(cherry picked from commit 0d97495de3c63a87ebc3d7cbc8fe614f396e89ea)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>