### PR TITLE
skel: added example configuration for needrestart

### DIFF
--- a/skel/doc/examples/needrestart/README.md
+++ b/skel/doc/examples/needrestart/README.md
@@ -8,7 +8,8 @@ restarted.
 
 In a production dCache-cluster this is however typically undesired.
 
-The files `exclude-dcache.conf` and `exclude-postgresql.conf` serve as examples
-how needrestart can be configured to not automatically select dCache
-respectively PostgreSQL for being restarted.
+The files `exclude-dcache.conf`, `exclude-postgresql.conf` and
+`exclude-zookeeper.conf` serve as examples how needrestart can be configured to
+not automatically select dCache, PostgreSQL, respectively ZooKeeper for being
+restarted.
 They need to be placed into `/etc/needrestart/conf.d/`.

--- a/skel/doc/examples/needrestart/exclude-zookeeper.conf
+++ b/skel/doc/examples/needrestart/exclude-zookeeper.conf
@@ -1,0 +1,1 @@
+$nrconf{override_rc}{qr(^zookeeper\.service$)} = 0;


### PR DESCRIPTION
Motivation:

Analogous to commit 8f87734ca2227c0087430230bfeaf52d56e6cb26.

Modification:

Added example configuration for needrestart for ZooKeeper and updated the
documentation.

Target: master
Requires-notes: no
Requires-book: no

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>