### PR TITLE
ftp: kill cell asynchronously

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
@@ -61,6 +61,7 @@ import org.dcache.services.login.IdentityResolverFactory;
 import org.dcache.space.ReservationCaches.GetSpaceTokensKey;
 import org.dcache.util.Args;
 import org.dcache.util.BoundedExecutor;
+import org.dcache.util.FireAndForgetTask;
 import org.dcache.util.SequentialExecutor;
 import org.dcache.util.Transfer;
 import org.slf4j.Logger;
@@ -264,7 +265,7 @@ public class NettyLineBasedDoor
                 }
             }
         }
-        kill();
+        executor.execute(new FireAndForgetTask(() -> kill()));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

The NettyLineBasedDoor will create a new cell that then handles the
client's input for an FTP session.  When that FTP session terminates,
that cell is killed.

Currently, it is the Netty IO thread that kills the cell.  Killing a
cell is serialised.  We have observed this tying up all the Netty IO
threads when many FTP sessions end concurrently.  The result is poor
user experience, with clients waiting many minutes for a command to be
processed.

Modification:

There is no reason why the Netty IO thread must wait until the cell kill
process has completed.

Therefore, simply kill the cell asynchronously.

Result:

The FTP door will remain responsive when many clients terminate their
FTP session concurrently.

Target: master
Requires-notes: yes
Requires-book: no
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13452/
Acked-by: Lea Morschel
Acked-by: Dmitry Litvintsev