### PR TITLE
webdav/frontend/srm/gplazma: log OIDC 'sub' and 'jti' claims

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/JwtJtiPrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/JwtJtiPrincipal.java
@@ -24,6 +24,7 @@ package org.dcache.auth;
  *
  * @since 5.1
  */
+@AuthenticationOutput
 public class JwtJtiPrincipal extends OpScopedPrincipal {
 
     private static final long serialVersionUID = 1L;

--- a/modules/common/src/main/java/org/dcache/auth/OpScopedPrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/OpScopedPrincipal.java
@@ -30,7 +30,7 @@ public abstract class OpScopedPrincipal implements Principal, Serializable {
     private final String name;
 
     public OpScopedPrincipal(String op, String sub) {
-        name = op + ":" + sub;
+        name = sub + "@" + op;
     }
 
     @Override

--- a/modules/common/src/main/java/org/dcache/auth/Subjects.java
+++ b/modules/common/src/main/java/org/dcache/auth/Subjects.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosPrincipal;
 import org.dcache.util.PrincipalSetMaker;
@@ -322,6 +323,22 @@ public class Subjects {
             }
         }
         return UNKNOWN;
+    }
+
+    /**
+     * Return a comma-separated list of principals names.  A null value is
+     * returned if the Subject has no principals of this type.
+     * @param <T> The kind of principal to examine.
+     * @param subject The subject to examine.
+     * @param type The kind of principals to examine.
+     * @return A list of principal names of this type.
+     */
+    @Nullable
+    public static <T extends Principal> String getPrincipalNames(Subject subject, Class<T> type) {
+        Set<? extends Principal> p = subject.getPrincipals(type);
+        return p.isEmpty()
+                ? null
+                : p.stream().map(Principal::getName).collect(Collectors.joining(","));
     }
 
     /**

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/SrmHandler.java
@@ -97,6 +97,9 @@ import org.apache.axis.types.URI;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.dcache.auth.JwtJtiPrincipal;
+import org.dcache.auth.OidcSubjectPrincipal;
+import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.LoginAttribute;
 import org.dcache.cells.CellStub;
 import org.dcache.cells.CuratorFrameworkAware;
@@ -913,6 +916,8 @@ public class SrmHandler implements CellInfoProvider, CuratorFrameworkAware {
                 log.add("socket.remote", Axis.getRemoteSocketAddress());
                 log.add("request.method", requestName);
                 log.add("user.dn", Axis.getDN().orElse(null));
+                log.add("user.sub", Subjects.getPrincipalNames(user, OidcSubjectPrincipal.class));
+                log.add("user.jti", Subjects.getPrincipalNames(user, JwtJtiPrincipal.class));
                 if (user != null) {
                     log.add("user.mapped", user);
                 }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/plugins/AccessLogHandler.java
@@ -109,7 +109,9 @@ import io.netty.channel.ChannelPromise;
 import java.net.InetSocketAddress;
 import java.time.Instant;
 import javax.security.auth.Subject;
+import org.dcache.auth.JwtJtiPrincipal;
 import org.dcache.auth.LoginReply;
+import org.dcache.auth.OidcSubjectPrincipal;
 import org.dcache.auth.Subjects;
 import org.dcache.util.NetLoggerBuilder;
 import org.dcache.xrootd.door.LoginEvent;
@@ -160,6 +162,8 @@ public class AccessLogHandler extends ChannelDuplexHandler {
                   "org.dcache.xrootd.login").omitNullValues();
             log.add("session", CDC.getSession());
             log.add("user.dn", Subjects.getDn(subject));
+            log.add("user.sub", Subjects.getPrincipalNames(subject, OidcSubjectPrincipal.class));
+            log.add("user.jti", Subjects.getPrincipalNames(subject, JwtJtiPrincipal.class));
             log.add("user.mapped", subject);
             log.toLogger(logger);
         }

--- a/modules/dcache/src/main/java/org/dcache/http/AbstractLoggingHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AbstractLoggingHandler.java
@@ -33,6 +33,9 @@ import javax.servlet.AsyncListener;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.dcache.auth.JwtJtiPrincipal;
+import org.dcache.auth.OidcSubjectPrincipal;
+import org.dcache.auth.Subjects;
 import org.dcache.util.NetLoggerBuilder;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
@@ -139,7 +142,14 @@ public abstract class AbstractLoggingHandler extends HandlerWrapper {
         log.add("user-agent", request.getHeader("User-Agent"));
 
         log.add("user.dn", getCertificateName(request));
-        log.add("user.mapped", getSubject(request));
+        var subject = getSubject(request);
+        log.add("user.sub", subject
+                .flatMap(s -> Optional.ofNullable(Subjects.getPrincipalNames(s, OidcSubjectPrincipal.class)))
+                .orElse(null));
+        log.add("user.jti", subject
+                .flatMap(s -> Optional.ofNullable(Subjects.getPrincipalNames(s, JwtJtiPrincipal.class)))
+                .orElse(null));
+        log.add("user.mapped", subject.orElse(null));
     }
 
     /**
@@ -199,8 +209,8 @@ public abstract class AbstractLoggingHandler extends HandlerWrapper {
         return null;
     }
 
-    private static Subject getSubject(HttpServletRequest request) {
+    private static Optional<Subject> getSubject(HttpServletRequest request) {
         Object object = request.getAttribute(DCACHE_SUBJECT_ATTRIBUTE);
-        return (object instanceof Subject) ? (Subject) object : null;
+        return Optional.ofNullable((object instanceof Subject) ? (Subject) object : null);
     }
 }


### PR DESCRIPTION
Motivation:

The 'sub' claim identifies an individual, the 'jti' claim identifies a
specific (access) token.  Both provide useful information when
diagnosing problems or providing an audit trail.

Modification:

Update access log file to log the 'sub' and 'jti' values, if either are
known.

Result:

The OIDC 'sub' (subject) and 'jti' (JWT ID) claims in the access log
file for WebDAV, frontend and SRM doors if OIDC is used.

Target: master
Request: 8.0
Request: 7.2
Requires-notes: yes
Requires-book: no
Closes: #6452
Patch: https://rb.dcache.org/r/13418/
Acked-by: Tigran Mkrtchyan