### PR TITLE
frontend: make srr resources public

### DIFF
--- a/docs/TheBook/src/main/markdown/srr.md
+++ b/docs/TheBook/src/main/markdown/srr.md
@@ -415,13 +415,12 @@ frontend.authz.anonymous-operations=READONLY
 frontend.srr.shares=user:/cms,store:/cms
 ```
 
-> NOTE: the access to SRR information is restricted to localhost only. Thus you have to put it
-somewhere, where from WLCG ops can access it, for example with a simple copy it into dcache with cron:
+> NOTE: By default, the access to SRR information is restricted to localhost only.
+
+If desired, the access to the srr information can be made public as with corresponding configuration:
 
 ```
-*/30 * * * * root rm -f /pnfs/desy.de/cms/SRR/SRR_CMS.json && \
-                    curl  http://localhost:3880/api/v1/srr > /pnfs/cms/SRR/SRR_CMS.json && \
-                    chown 40751:4075 /pnfs/cms/SRR/SRR_CMS.json
+frontend.srr.public=true
 ```
 
 The service produces desired json output which contains `storageshares` that represented by space reservations

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
@@ -64,6 +64,11 @@ public class SrrResource {
 
     private boolean spaceReservationEnabled;
 
+    /**
+     * If false, then SRR requests are accepted only from loopback interface.
+     */
+    private boolean isPublic;
+
     public void setQuality(String quality) {
         this.quality = quality;
     }
@@ -86,6 +91,10 @@ public class SrrResource {
 
     public void setArchitecture(String architecture) {
         this.architecture = architecture;
+    }
+
+    public void setIsPublic(boolean isPublic) {
+        this.isPublic = isPublic;
     }
 
     public void setGroupMapping(String mapping) {
@@ -115,9 +124,11 @@ public class SrrResource {
     @Path("/")
     public Response getSrr() throws InterruptedException, CacheException, NoRouteToCellException {
 
-        InetAddress remoteAddress = InetAddresses.forUriString(request.getRemoteAddr());
-        if (!remoteAddress.isLoopbackAddress()) {
-            throw new ForbiddenException();
+        if (isPublic) {
+            InetAddress remoteAddress = InetAddresses.forUriString(request.getRemoteAddr());
+            if (!remoteAddress.isLoopbackAddress()) {
+                throw new ForbiddenException();
+            }
         }
 
         SrrRecord record = SrrBuilder.builder()

--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -597,6 +597,7 @@
         <property name="architecture" value="${info-provider.dcache-architecture}" />
         <property name="quality" value="${info-provider.dcache-quality-level}" />
         <property name="doorTag" value="${storage-descriptor.door.tag}" />
+        <property name="isPublic" value="${frontend.srr.public}" />
     </bean>
 
     <beans profile="macaroons-true">

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -616,6 +616,10 @@ frontend.version.swagger-ui = @version.swagger-ui@
 #  cms-user:/cms,default:/cms,default:/atlas
 frontend.srr.shares =
 
+#
+# Should SRR information be restricted to localhost only
+#
+(one-of?true|false)frontend.srr.public=false
 
 (obsolete)frontend.dcache-view.endpoints.webapi = Use frontend.static!dcache-view.endpoints.webapi instead
 (obsolete)frontend.dcache-view.endpoints.webdav = Use frontend.static!dcache-view.endpoints.webdav instead


### PR DESCRIPTION
Motivation:
The access to Storage Resource Reporting is limited to localhost only.
Turned out, that the majority of site admins want to see it pubic.

Modification:
control SRR resource restriction with

```
frontend.srr.public=true|false
```

property. The default is false, to provide backward compatibility with
existing implementation.

Result:
The srr endpoint is publicly accessible, if desired.

Fixes: #6181
Acked-by: Paul Millar
Acked-by: Lea Morschel
Target: master, 8.0, 7.2, 7.1, 7.0, 6.2
Require-book: yes
Require-notes: yes
(cherry picked from commit 3351df28abfb6aada436723c0a01af42409c0827)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>