### PR TITLE
frontend: make srr resources public

### DIFF
--- a/docs/TheBook/src/main/markdown/srr.md
+++ b/docs/TheBook/src/main/markdown/srr.md
@@ -396,3 +396,67 @@ or the package._
 | storage-descriptor.door.tag | Login-provider tag. The tag that doors identify themselves with before they are published. | storage-descriptor | |
 | storage-descriptor.output.path | Output path. The location where the JSON output is written. | `/var/spool/dcache/storage-descriptor.json` or `${dcache.home}/var/spool/dcache/storage-descriptor.json` | |
 | storage-descriptor.xslt.path | XSLT path. The location of the XSLT stylesheet that transforms the info service's XML into the Storage Descriptor JSON format. | `${dcache.paths.share}`/xml/xslt/storage-descriptor.xsl | |
+
+## WLCG Storage Resource Reporting
+
+The WLCG Storage Resource Reporting (SRR) is JSON based file that describes storage resources according
+to WCLG operational team specified [format](https://raw.githubusercontent.com/sjones-hep-ph-liv-ac-uk/json_info_system/master/srr/v4.2/schema/srrschema_4.2.json).
+
+The dCache implementation is integrated into **frontend** service and exposed as REST-API. To access
+SRR reporting a frontend service must be defined, if not exist:
+
+```
+[srrDomain]
+
+[srrdDomain/frontend]
+frontend.authn.basic=true
+frontend.authn.protocol=http
+frontend.authz.anonymous-operations=READONLY
+frontend.srr.shares=user:/cms,store:/cms
+```
+
+> NOTE: By default, the access to SRR information is restricted to localhost only.
+
+If desired, the access to the srr information can be made public as with corresponding configuration:
+
+```
+frontend.srr.public=true
+```
+
+The service produces desired json output which contains `storageshares` that represented by space reservations
+and pool groups, if configured. The `frontend.srr.shares` controls which pools groups should be published, for
+example:
+
+```
+frontend.srr.shares=user:/cms,store:/cms
+```
+
+publishes pool groups user and store for VO cms and will produce output like:
+
+```json
+    "storageshares" : [ {
+      "name" : "store",
+      "timestamp" : 1601977212,
+      "totalsize" : 5973622320626816,
+      "usedsize" : 4904609242438918,
+      "assignedendpoints" : [ "all" ],
+      "vos" : [ "/cms" ]
+    }, {
+      "name" : "user",
+      "timestamp" : 1601977212,
+      "totalsize" : 4078599175816242,
+      "usedsize" : 4025729976567280,
+      "assignedendpoints" : [ "all" ],
+      "vos" : [ "/cms" ]
+    } ]
+```
+
+The WLCG SRR uses the following info-provider properties to control the generated json output:
+
+```
+info-provider.se-unique-id=
+info-provider.se-name=
+info-provider.dcache-architecture=
+nfo-provider.dcache-quality-level=
+storage-descriptor.door.tag=
+```

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
@@ -64,6 +64,11 @@ public class SrrResource {
 
     private boolean spaceReservationEnabled;
 
+    /**
+     * If false, then SRR requests are accepted only from loopback interface.
+     */
+    private boolean isPublic;
+
     public void setQuality(String quality) {
         this.quality = quality;
     }
@@ -86,6 +91,10 @@ public class SrrResource {
 
     public void setArchitecture(String architecture) {
         this.architecture = architecture;
+    }
+
+    public void setIsPublic(boolean isPublic) {
+        this.isPublic = isPublic;
     }
 
     public void setGroupMapping(String mapping) {
@@ -115,9 +124,11 @@ public class SrrResource {
     @Path("/")
     public Response getSrr() throws InterruptedException, CacheException, NoRouteToCellException {
 
-        InetAddress remoteAddress = InetAddresses.forUriString(request.getRemoteAddr());
-        if (!remoteAddress.isLoopbackAddress()) {
-            throw new ForbiddenException();
+        if (isPublic) {
+            InetAddress remoteAddress = InetAddresses.forUriString(request.getRemoteAddr());
+            if (!remoteAddress.isLoopbackAddress()) {
+                throw new ForbiddenException();
+            }
         }
 
         SrrRecord record = SrrBuilder.builder()

--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -596,6 +596,7 @@
         <property name="architecture" value="${info-provider.dcache-architecture}" />
         <property name="quality" value="${info-provider.dcache-quality-level}" />
         <property name="doorTag" value="${storage-descriptor.door.tag}" />
+        <property name="isPublic" value="${frontend.srr.public}" />
     </bean>
 
     <beans profile="macaroons-true">

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -616,6 +616,10 @@ frontend.version.swagger-ui = @version.swagger-ui@
 #  cms-user:/cms,default:/cms,default:/atlas
 frontend.srr.shares =
 
+#
+# Should SRR information be restricted to localhost only
+#
+(one-of?true|false)frontend.srr.public=false
 
 (obsolete)frontend.dcache-view.endpoints.webapi = Use frontend.static!dcache-view.endpoints.webapi instead
 (obsolete)frontend.dcache-view.endpoints.webdav = Use frontend.static!dcache-view.endpoints.webdav instead


### PR DESCRIPTION
Motivation:
The access to Storage Resource Reporting is limited to localhost only.
Turned out, that the majority of site admins want to see it pubic.

Modification:
control SRR resource restriction with

```
frontend.srr.public=true|false
```

property. The default is false, to provide backward compatibility with
existing implementation.

Result:
The srr endpoint is publicly accessible, if desired.

Fixes: #6181
Acked-by: Paul Millar
Acked-by: Lea Morschel
Target: master, 8.0, 7.2, 7.1, 7.0, 6.2
Require-book: yes
Require-notes: yes
(cherry picked from commit 3351df28abfb6aada436723c0a01af42409c0827)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>