### PR TITLE
dcache-chimera: fix cleaner batch delete exception

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
@@ -216,6 +216,10 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
      * @param filelist file list for this pool
      */
     void removeFiles(final String poolname, final List<String> filelist) {
+        if(filelist == null || filelist.isEmpty()) {
+            LOGGER.info("Unexpected empty delete file list.");
+            return;
+        }
         _db.batchUpdate(
               "DELETE FROM t_locationinfo_trash WHERE ilocation=? AND ipnfsid=? AND itype=1",
               new BatchPreparedStatementSetter() {
@@ -249,14 +253,14 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
                   CellStub.get(_poolStub.send(new CellPath(poolName),
                         new PoolRemoveFilesMessage(poolName, removeList)));
             if (msg.getReturnCode() == 0) {
-                removeFiles(poolName, removeList);
+                removeFiles(poolName, List.copyOf(removeList));
                 return removeList.size();
             } else if (msg.getReturnCode() == 1 && msg.getErrorObject() instanceof String[]) {
                 Set<String> notRemoved =
                       new HashSet<>(Arrays.asList((String[]) msg.getErrorObject()));
                 List<String> removed = new ArrayList<>(removeList);
                 removed.removeAll(notRemoved);
-                removeFiles(poolName, removed);
+                removeFiles(poolName, List.copyOf(removed));
                 return removed.size();
             } else {
                 throw CacheExceptionFactory.exceptionOf(msg);
@@ -406,7 +410,7 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
           hint = "clean this file (file will be deleted from DISK)")
     public class CleanFileCommand implements Callable<String> {
 
-        @Argument(usage = "pnfsid of the file to clean")
+        @Argument(required = true, usage = "pnfsid of the file to clean")
         String pnfsid;
 
         @Override


### PR DESCRIPTION
Motivation:
Deleting files by DiskCleaner is done via a database batch update, which throws the following exception when the list happens to be empty: `java.util.concurrent.CompletionException: org.springframework.jdbc.BadSqlGrammarException: PreparedStatementCallback; bad SQL grammar [DELETE FROM t_locationinfo_trash WHERE ilocation=? AND ipnfsid=? AND itype=1]; nested exception is java.sql.SQLException: statement is not in batch mode`.

Modification:
Pass an immutable delete file list copy to the batch delete method to make sure that it is not modified in the meantime. Check that the list is not empty in the batch delete method.

Result:
Reduced likelihood of `SQLException: statement is not in batch mode` in DiskCleaner.

Target: master
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Fixes: #6496
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13455/
Acked-by: Tigran Mkrtchyan