### PR TITLE
dcache-core: prevent ocasional message ttl test failure

### DIFF
--- a/modules/dcache/src/test/java/org/dcache/cells/MessageReplyTest.java
+++ b/modules/dcache/src/test/java/org/dcache/cells/MessageReplyTest.java
@@ -85,12 +85,11 @@ public class MessageReplyTest {
 
         messageReply.deliver(endpoint, envelope);
 
-        long timeToLive = envelope.getTtl();
-        long increasedLifetime = timeToLive + TimeUnit.SECONDS.toMillis(1);
-        long newTimeToLive = increasedLifetime < timeToLive ? Long.MAX_VALUE : increasedLifetime;
+        long ttl = TimeUnit.HOURS.toMillis(1);
+        envelope.setTtl(ttl);
 
-        envelope.setTtl(newTimeToLive);
-        assertTrue(messageReply.isValidIn(timeToLive));
+        long delay = TimeUnit.MINUTES.toMillis(5);
+        assertTrue(messageReply.isValidIn(ttl - delay));
     }
 
     @Test
@@ -101,12 +100,11 @@ public class MessageReplyTest {
 
         messageReply.deliver(endpoint, envelope);
 
-        long timeToLive = envelope.getTtl();
-        long decreasedLifetime = timeToLive - TimeUnit.SECONDS.toMillis(1);
-        long newTimeToLive = decreasedLifetime < 0 ? 0 : decreasedLifetime;
+        long ttl = TimeUnit.HOURS.toMillis(1);
+        envelope.setTtl(ttl);
 
-        envelope.setTtl(newTimeToLive);
-        assertFalse(messageReply.isValidIn(timeToLive));
+        long delay = TimeUnit.MINUTES.toMillis(5);
+        assertFalse(messageReply.isValidIn(ttl + delay));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
By default a CellMessage's TTL is Long.MAX_VALUE. The unit test code in methods `shouldBeValidIfDelayIsSmallerThanTimeToLiveOfEnvelope` and `shouldBeInvalidIfDelayIsBiggerThanTimeToLiveOfEnvelope` calls setTtl(Long.MAX_VALUE) and then isValidIn(Long.MAX_VALUE). This will fail if the code takes longer than (on average) 0.5 ms from calling the CellMessage constructor to the test.

As is, this test is nonsense.

Modification:
Fix the unit tests by setting the message test lifetime to a fixed, smaller than maximal value to ensure that the test setup and execution work as intended. Test against a larger difference in both the positive and negative case.

Result:
Fix unit tests and prevent accidental MessageReplyTest test failures due to high system load.

Target: master, 8.0
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13457/
Acked-by: Paul Millar