### PR TITLE
pool: handle multiple shutdowns of a nfs mover (7.1)

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -95,12 +95,18 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
 
     /**
      * Disable access with this mover. If {@code error} is not a {@code null}, the {@link
-     * CompletionHandler#failed(Throwable, A)} method will be called.
+     * CompletionHandler#failed(Throwable, Object)} method will be called.
      *
      * @param error error to report, or {@code null} on success
      */
     void disable(Throwable error) {
-        _nfsTransferService.remove(NfsMover.this);
+
+        boolean isActive = _nfsTransferService.remove(NfsMover.this);
+        if (!isActive) {
+            _log.info("Skip disabling disposed mover: {} {} - {}", getFileAttributes().getPnfsId(), getIoMode(), getStatus());
+            return;
+        }
+
         detachSession();
         try {
             getMoverChannel().close();

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -376,10 +376,11 @@ public class NfsTransferService
      * Removes mover from the list of allowed transfers.
      *
      * @param mover
+     * @return true, if the given mover was known to this transfer service.
      */
-    public void remove(NfsMover mover) {
-        _log.debug("un-removing io handler for stateid {}", mover);
-        _activeIO.remove(mover.getStateId());
+    public boolean remove(NfsMover mover) {
+        _log.debug("un-registering io handler for stateid {}", mover);
+        return _activeIO.remove(mover.getStateId()) != null;
     }
 
     NfsMover getMoverByStateId(CompoundContext context, stateid4 stateid)


### PR DESCRIPTION
This is a draft to check if the fix for 7.2 and 8.0 also works for 7.1.