### PR TITLE
nfs: enforce subject propagation on RPC level

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/DCacheAwareJdbcFs.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/DCacheAwareJdbcFs.java
@@ -302,9 +302,11 @@ public class DCacheAwareJdbcFs extends JdbcFs implements CellIdentityAware {
         infoRemove.setPnfsId(new PnfsId(inode.getId()));
         infoRemove.setFileSize(0L);
         infoRemove.setBillingPath("parent:[" + directory.getId() + "]/" + name);
-        // FIXME: in some cases subject is not set
-        infoRemove.setClient(subject == null ? "0.0.0.0"
-              : Subjects.getOrigin(subject).getAddress().getHostAddress());
+
+        infoRemove.setClient(
+              Optional.ofNullable(Subjects.getOrigin(subject)).map( p -> p.getAddress().getHostAddress()).orElse("0.0.0.0")
+        );
+
         infoRemove.setClientChain(infoRemove.getClient());
 
         billingStub.notify(infoRemove);

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -432,6 +432,7 @@ public class NFSv41Door extends AbstractCellComponent implements
               .withPort(_port)
               .withTCP()
               .withAutoPublish()
+              .withSubjectPropagation()
               .withWorkerThreadIoStrategy();
 
         if (_enableRpcsecGss) {


### PR DESCRIPTION
Motivation:
To ensure that requester subject is always available in the request
context the subject propagation on RPC level should be enabled.

Modification:
enable requester subject propagation when NFS door builds the  RPC
service.

Result:
user subject always available in the processing thread.

Acked-by: Dmitry Litvintsev
Target: master, 8.0, 7.2
Require-book: no
Require-notes: yes
(cherry picked from commit b5975f050cab553a6f30f37d4a42061e2702f6db)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>