### PR TITLE
dcache-core,common: fix user having to request `sha-1`, not `sha`

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/ChecksumType.java
+++ b/modules/common/src/main/java/org/dcache/util/ChecksumType.java
@@ -23,6 +23,9 @@ public enum ChecksumType {
     SHA512(6, "SHA-512", 512);
 
     private final int type;
+    /**
+     * the Java internal algorithm name for this checksum type.
+     */
     private final String name;
     private final int bits;
 
@@ -103,7 +106,7 @@ public enum ChecksumType {
     }
 
     /**
-     * Return a dCache internal canonical name for this checksum type.
+     * Return the Java internal algorithm name for this checksum type.
      */
     public String getName() {
         return name;

--- a/modules/dcache/src/test/java/org/dcache/util/ChecksumsTests.java
+++ b/modules/dcache/src/test/java/org/dcache/util/ChecksumsTests.java
@@ -423,9 +423,15 @@ public class ChecksumsTests {
 
     @Test
     public void shouldFindSha1AsSingleEntry() {
-        Optional<ChecksumType> type = Checksums.parseWantDigest("sha-1");
+        Optional<ChecksumType> type = Checksums.parseWantDigest("sha");
         assertThat(type.isPresent(), is(equalTo(true)));
         assertThat(type.get(), is(equalTo(SHA1)));
+    }
+
+    @Test
+    public void shouldNotFindSha1Explicitly() {
+        Optional<ChecksumType> type = Checksums.parseWantDigest("sha-1");
+        assertFalse(type.isPresent());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Even though the sha-1 checksum is supported by dCache, it currently needs to be requested as "sha-1" explicitly. This is wrong, as according to RFC 3230, `sha` is the correct label for requesting and receiving `sha-1`-valued checksums.

Currently, the supported checksum types in Java are implemented as an enum with a name field that is both used to compare the name of a requested checksum and to identify the correct checksum algorithm internally.
The "Java Security Standard Algorithm Names" document lists `SHA-1` explicitly, `SHA` is not defined, which is why dCache stores and requires to be passed the former at the moment.
Modification:

When parsing a want digest header, check for the presence of one of the RFC 3230 specific algorithm names, not the ones stored in the ChecksumType enum that are used internally. Match the RFC 3230 name to a ChecksumType enum value to proceed with.

Result:

`Sha-1` checksums can and must now correctly be requested as `sha`, as defined by RFC 3230.

Target: master
Request: 8.0
Request: 7.2
Fixes: #6541
Requires-notes: yes
Requires-book: yes
Patch: https://rb.dcache.org/r/13485/
Acked-by: Paul Millar