### PR TITLE
dcache-chimera: add sha checksum commands to chimera shell

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/cli/Shell.java
@@ -1118,7 +1118,7 @@ public class Shell extends ShellApplication {
         @Argument(index = 0)
         File path;
 
-        @Argument(index = 1, valueSpec = "adler32|md5_type|md4_type")
+        @Argument(index = 1, valueSpec = "adler32|md5_type|md4_type|sha1|sha256|sha512")
         ChecksumType type;
 
         @Override
@@ -1139,7 +1139,7 @@ public class Shell extends ShellApplication {
         @Argument(index = 0)
         File path;
 
-        @Argument(index = 1, valueSpec = "adler32|md5_type|md4_type")
+        @Argument(index = 1, valueSpec = "adler32|md5_type|md4_type|sha1|sha256|sha512")
         ChecksumType type;
 
         @Argument(index = 2)
@@ -1157,13 +1157,13 @@ public class Shell extends ShellApplication {
         }
     }
 
-    @Command(name = "checksum delete", hint = "remove checkusm from file")
+    @Command(name = "checksum delete", hint = "remove checksum from file")
     public class ChecksumDeleteCommand implements Callable<Serializable> {
 
         @Argument(index = 0)
         File path;
 
-        @Argument(index = 1, valueSpec = "adler32|md5_type|md4_type")
+        @Argument(index = 1, valueSpec = "adler32|md5_type|md4_type|sha1|sha256|sha512")
         ChecksumType type;
 
         @Override


### PR DESCRIPTION
Motivation:
Since 7.2, dCache supports sha1, sha256 and sha512. The chimera shell commands have not been updated to support getting, adding and removing those types of checksums.

Modification:
Result:

Added chimera shell support for getting, adding and removing sha1, sha156 and sha512 valued checksums.

Target: master
Request: 8.0
Request: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13486/
Acked-by: Tigran Mkrtchyan