### PR TITLE
frontend: fix problem with making SRR resources public

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
@@ -124,7 +124,7 @@ public class SrrResource {
     @Path("/")
     public Response getSrr() throws InterruptedException, CacheException, NoRouteToCellException {
 
-        if (isPublic) {
+        if (!isPublic) {
             InetAddress remoteAddress = InetAddresses.forString(request.getRemoteAddr());
             if (!remoteAddress.isLoopbackAddress()) {
                 throw new ForbiddenException();


### PR DESCRIPTION
Motivation:
Commit 3351df28ab introduced an option that allows making the SRR resources public. The patch contained a mistake, which inverts the logic of the property, so that public access is allowed when `frontend.srr.public` option is set to false, not true.

Modification:
Invert the faulty logic so that now `frontend.srr.public=true` means "allow public access" and false does not.

Result:
The SSR public access property works as intended.

Target: master
Request: 8.0, 7.2, 7.1, 7.0, 6.2
Fixes: #6181
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13488/
Acked-by: Tigran Mkrtchyan