### PR TITLE
util: treat broken file as unrecoverable error in Trnasfer class

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ExceptionUtils.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ExceptionUtils.java
@@ -2,6 +2,7 @@ package org.dcache.chimera.nfsv41.door;
 
 import static diskCacheV111.util.CacheException.BROKEN_ON_TAPE;
 import static diskCacheV111.util.CacheException.ERROR_IO_DISK;
+import static diskCacheV111.util.CacheException.FILE_CORRUPTED;
 import static diskCacheV111.util.CacheException.FILE_IN_CACHE;
 import static diskCacheV111.util.CacheException.FILE_NOT_FOUND;
 import static diskCacheV111.util.CacheException.NO_POOL_CONFIGURED;
@@ -71,6 +72,8 @@ public class ExceptionUtils {
         switch (e.getRc()) {
             case BROKEN_ON_TAPE:
             case ERROR_IO_DISK:
+            case FILE_IN_CACHE:
+            case FILE_CORRUPTED:
                 return new NfsIoException(e.getMessage(), e);
             case FILE_NOT_FOUND:
                 return new NoEntException(e.getMessage(), e);
@@ -83,8 +86,6 @@ public class ExceptionUtils {
                 return new NoSpcException(e.getMessage(), e);
             case TIMEOUT:
                 return new DelayException(e.getMessage(), e);
-            case FILE_IN_CACHE:
-                return new NfsIoException(e.getMessage(), e);
             default:
                 return buildNfsException(defaultException, e);
         }

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -1269,6 +1269,8 @@ public class Transfer implements Comparable<Transfer> {
                           case CacheException.FILE_IN_CACHE:
                           case CacheException.INVALID_ARGS:
                           case CacheException.FILE_NOT_FOUND:
+                          case CacheException.FILE_CORRUPTED:
+                              _log.warn("Failing request: {}", t.getMessage());
                               return immediateFailedFuture(t);
                           case CacheException.NO_POOL_CONFIGURED:
                               _log.error(t.getMessage());


### PR DESCRIPTION
Motivation:
Pools reject to serve broken files, however the Transfer treats this
situation as transient and keep trying.

Modification:
Update Transfer class to permanently fail the request if BROKEN file is
detected. Update nfs door to map broken file to IO error.

Result:

```
$ curl  -L  -k -u admin:dickerelch https://localhost:2881/public/file-1644414738
Internal problem: File is broken
$ xrdcp -f root://localhost/public/file-1644414738 /dev/null
[0B/0B][100%][==================================================][0B/s]
Run: [ERROR] Server responded with an error: [3019] Failed to open file (File is broken [10004]) (source)
cat: /mnt/public/file-1644414738: Input/output error

```

```
09 Feb 2022 15:34:18 (pool_read) [door:WebDAV-S-nairi@dCacheDomain:AAXXlrqNNaA WebDAV-S-nairi PoolDeliverFile 0000FE49FB88D32B44709F2BAB62735673A6] File is broken
09 Feb 2022 15:34:18 (WebDAV-S-nairi) [door:WebDAV-S-nairi@dCacheDomain:AAXXlrqNNaA] failing request due to : File is broken
09 Feb 2022 15:34:18 (WebDAV-S-nairi) [door:WebDAV-S-nairi@dCacheDomain:AAXXlrqNNaA] Internal server error: org.dcache.webdav.WebDavException: File is broken
09 Feb 2022 15:34:31 (pool_read) [door:Xrootd-nairi@dCacheDomain:AAXXlrtZtTA Xrootd-nairi PoolDeliverFile 0000FE49FB88D32B44709F2BAB62735673A6] File is broken
09 Feb 2022 15:34:31 (Xrootd-nairi) [door:Xrootd-nairi@dCacheDomain:AAXXlrtZtTA] failing request due to : File is broken
09 Feb 2022 15:34:47 (pool_read) [door:NFS-nairi@dCacheDomain:AAXXlrxDIwA NFS-nairi PoolDeliverFile 0000FE49FB88D32B44709F2BAB62735673A6] File is broken
09 Feb 2022 15:34:47 (NFS-nairi) [door:NFS-nairi@dCacheDomain:AAXXlrxDIwA 0000FE49FB88D32B44709F2BAB62735673A6 localhost/0:0:0:0:0:0:0:1:1018] failing request due to : File is broken
09 Feb 2022 15:34:47 (NFS-nairi) [] NFS server fault: op: READ : NFS4ERR_IO : File is broken
09 Feb 2022 15:34:47 (NFS-nairi) [] NFS server fault: op: READ : NFS4ERR_IO : File is broken
```

Acked-by: Dmitry Litvintsev
Acked-by: Paul Millar
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit adaa8bc47ee43c19753d93dd92b3a41220bdaea7)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>