### PR TITLE
dcache-xroot: Allow ZTN authentication to function as fallback author…

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/spring/GplazmaAwareChannelHandlerFactoryFactoryBean.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/spring/GplazmaAwareChannelHandlerFactoryFactoryBean.java
@@ -129,20 +129,12 @@ public class GplazmaAwareChannelHandlerFactoryFactoryBean
             if (authnFactory != null) {
                 ProxyDelegationClientFactory clientFactory
                       = createProxyDelegationClientFactory(name);
-                /*
-                 *  for ztn we don't want to use the union strategy because it has
-                 *  no specific authentication strategy and we don't want to allow
-                 *  anonymous operations on the door.  We just want the user to be 'nobody'
-                 *  until further authorization, such as using tokens, takes over.
-                 */
-                LoginStrategy loginStrategy = "ztn".equals(name) ?
-                      _anonymousLoginStrategy : _loginStrategy;
                 return new LoginAuthenticationHandlerFactory(GPLAZMA_PREFIX + name,
                       name,
                       clientFactory,
                       _properties,
                       authnFactory,
-                      loginStrategy);
+                      _loginStrategy);
             }
         }
 


### PR DESCRIPTION
…ization

Motivation:

Originally, the 'ztn' protocol was conceived of as a way
of preliminarily checking the legitimacy of a client by
asking the client to produce a token and checking its
issuer.   The ztn token was not required to have a sub
or claim.  This was in distinction to the actual JWT
authorization token to be included as the authz element
on the path query.

However, for a number of different reasons, the SLAC
team has decided that the ZTN token, if desired, should
serve as a fallback authorization token, eliminating
the requirement of expressing that token in the path query.

This patch makes a modification to support this change.

Modification:

In order to check the validity of the ZTN token when
the ZTN module is loaded as plugin, it is passed to
gPlazma as a private credential.  Since it was not
being used for authentication purposes, the login
policy used by ZTN was anonymous.  This, however,
obliterated the token, once validated, from the
subject stored as login reply.

A simple change to use the UnionStrategy, like every
other authentication module, rectifies this situation.

See further the testing below for how this should now
work.

Result:

A ZTN token can now be given without further downstream
tokens expressed, and full authorization of the subject
will take place.

Target: master
Request: 8.0
Request: 7.2
Patch: https://rb.dcache.org/r/13498/
Requires-book: yes (part of patch)
Requires-notes: yes
Acked-by: Dmitry