### PR TITLE
pool: describe why migration job was cancelled

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/PoolMigrationCancelMessage.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/PoolMigrationCancelMessage.java
@@ -2,6 +2,7 @@ package org.dcache.pool.migration;
 
 import diskCacheV111.util.PnfsId;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 /**
  * MigrationModuleServer message to request that a transfer is aborted.
@@ -10,7 +11,15 @@ public class PoolMigrationCancelMessage extends PoolMigrationMessage {
 
     private static final long serialVersionUID = -7995913634698011318L;
 
-    public PoolMigrationCancelMessage(UUID uuid, String pool, PnfsId pnfsId) {
+    private final String reason;
+
+    public PoolMigrationCancelMessage(UUID uuid, String pool, PnfsId pnfsId, @Nullable String reason) {
         super(uuid, pool, pnfsId);
+        this.reason = reason;
+    }
+
+    @Nullable
+    public String getReason() {
+      return reason;
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
@@ -292,10 +292,15 @@ public class Task {
      * FSM Action
      */
     synchronized void cancelCopy() {
+        cancelCopy(_cancelReason.orElse(null));
+    }
+
+    synchronized void cancelCopy(String reason) {
         CellStub.addCallback(_parameters.pool.send(_target,
                     new PoolMigrationCancelMessage(_uuid,
                           _source,
-                          getPnfsId())),
+                          getPnfsId(),
+                          reason)),
               new Callback<>("cancel_"), _parameters.executor);
     }
 

--- a/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
+++ b/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
@@ -220,7 +220,8 @@ Entry
                 {
                         // No reply, but message could have been
                         // received anyway, so try to cancel it.
-                        cancelCopy();
+                        cancelCopy("Timeout waiting for target pool "
+                            + ctxt.getTarget());
                 }
         cancel
                 Cancelling


### PR DESCRIPTION
Motivation:

We have had reports (see #6557) where a migration job was cancelled;
however, the reason the job was cancelled is not clear.  Currently, the
pool logs only `Task was cancelled`.

Modification:

Update PoolMigrationCancelMessage to include a reason (as a simple
String), explaining the motivation behind cancelling the migration job.

The controlling job is updated to populate this explanation.  Note that
this information is already available if the task is explicitly
cancelled (i.e., outside of the FSM).

The target pool is updated to log the explanation from the
PoolMigrationCancelMessage if one is provided.

Result:

The pool now provides more information when a migration job was
cancelled.

Target: master
Request: 8.0
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13501/
Acked-by: Lea Morschel