### PR TITLE
pom: update spring libs to 5.2.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
         <version.slf4j>1.7.26</version.slf4j>
         <version.milton>2.7.3.0-dcache-1</version.milton>
-        <version.spring>5.2.2.RELEASE</version.spring>
+        <version.spring>5.2.20.RELEASE</version.spring>
         <!-- Remember to sync aspectj version in dcache.properties -->
         <version.aspectj>1.9.2</version.aspectj>
         <version.smc>6.6.0</version.smc>


### PR DESCRIPTION
CVE-2022-22965

Acked-by: Lea Morschel
Target: master, 8.0, 7.2, 7.1, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 41c331d33421a2da4ed4d3caed1b9569e158d859)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>