### PR TITLE
dcache script: redirect deprecation warning to stderr

### DIFF
--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -222,7 +222,7 @@ deprecationWarning()
             fi
         fi
     fi
-}
+} 1>&2
 
 # Dumps the heap. Terminates the script in case of failure.
 dumpHeap() # $1=force, $2=live, $3=file, $4=pid, $5=error


### PR DESCRIPTION
Motivation:
Admins complain that deprecation warning printed by
dcache command to stdout breaks scripts that they have.

Modification:
Direct deprecation warning to stderr

Result:
Ability to redirect stderr to /dev/null for instance.

Patch: https://rb.dcache.org/r/13529/
Target: trunk
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Acked-by: Albert Rossi