### PR TITLE
info: fix broken unit-test, remove redundant one

### DIFF
--- a/modules/dcache-info/src/test/java/org/dcache/services/info/base/StateMaintainerTests.java
+++ b/modules/dcache-info/src/test/java/org/dcache/services/info/base/StateMaintainerTests.java
@@ -2,7 +2,7 @@ package org.dcache.services.info.base;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.BDDMockito.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.atLeast;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
@@ -74,37 +74,27 @@ public class StateMaintainerTests {
     }
 
     @Test
-    public void shouldBeInitiallyEmptyQueueSize() throws InterruptedException {
+    public void shouldBeInitiallyEmptyQueueSize() {
         assertThat(_maintainer.countPendingUpdates(), is(0));
     }
 
     @Test(timeout = 10_000)
-    public void shouldIncrementAfterSubmittingUpdate() throws InterruptedException {
+    public void shouldIncrementAfterSubmittingUpdate() {
         Object monitor = new Object();
 
         willAnswer(a -> {
-            synchronized (monitor) {
-                monitor.wait();
+            try {
+                synchronized (monitor) {
+                    monitor.wait();
+                }
+            } catch (InterruptedException e) {
+                // finished
             }
             return null;
-        }).given(_caretaker).processUpdate(anyObject());
+        }).given(_caretaker).processUpdate(any());
 
         _maintainer.enqueueUpdate(new StateUpdate());
-
         assertThat(_maintainer.countPendingUpdates(), is(1));
-    }
-
-    @Test(timeout = 10_000)
-    public void shouldIncreaseAfterSubmittingUpdateWhenQueuedUpdate() throws InterruptedException {
-        willAnswer(i -> {
-            wait();
-            return null;
-        }).given(_caretaker).processUpdate(anyObject());
-
-        _maintainer.enqueueUpdate(new StateUpdate());
-        _maintainer.enqueueUpdate(new StateUpdate());
-
-        assertThat(_maintainer.countPendingUpdates(), is(2));
     }
 
     @Test(timeout = 10_000)


### PR DESCRIPTION
Motivation:
A unit test logs an InterruptedException from an internally used lambda. Another test tests almost the same thing but uses a faulty wait call outside of a monitor, thus throws an IllegalMonitorStateException.

Modification:
Fix the first test by catching the (expected) exception.
Remove the second faulty and redundant test case.

Result:
Tests shouldn't fail anymore.

Target: master
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13534/
Acked-by: Albert Rossi