### PR TITLE
cache-core: improve error message for inexistent statistics path

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/PoolStatisticsV0.java
@@ -5,6 +5,7 @@ package diskCacheV111.services;
 import static java.util.Arrays.asList;
 import static org.dcache.util.ByteUnit.BYTES;
 import static org.dcache.util.ByteUnit.KiB;
+import static org.dcache.util.Files.checkFile;
 
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
@@ -270,9 +271,9 @@ public class PoolStatisticsV0 extends CellAdapter implements CellCron.TaskRunnab
             }
 
         } else {
-            if ((!_dbBase.exists()) || (_createHtmlTree && !_htmlBase.exists())) {
-                throw new IllegalArgumentException(
-                      "Either <baseDirectory> or <htmlBase> doesn't exist");
+            checkFile(_dbBase);
+            if (_createHtmlTree) {
+                checkFile(_htmlBase);
             }
 
         }


### PR DESCRIPTION
Motivation:
The statistics domain writes files into a configurable directory, which it expects to be present. If it is not, it will throw an exception that does not make clear were the problem is coming from.

Modification:
Change the error message to give hints to the admin as to why the cell fails to start.

Result:
Hopefully easier to interpret error message in case the statistics cell fails to start due to path issues.

Target: master
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Fixes: #6603
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13546/
Acked-by: Paul Millar