### PR TITLE
dcache-xroot: update master xrootd4j to 4.3.0, and stable branches to…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>4.0.11</version.xrootd4j>
+        <version.xrootd4j>4.0.12</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.3</version.dcache-view>
         <version.netty>4.1.50.Final</version.netty>


### PR DESCRIPTION
… next minor version

The upgrade to the next stable branch includes these changes:

v4.0.12
67eccd26dfebeaed2b734f3fde713be53b7bad8b xrootd4j: set tpc info state to READY if updated when PENDING
7b7ded4550533acafe30a574698a5a35739b9919 xrootd4j: put the attn response future on the client
e2edcd07a500dee728ba5b85b15bddac922ef648 xrootd4j: add a WaitReplyResponse

v4.1.7
v4.2.6
0f1cb4b1f9c91eeaf060eae4731d4121be886372 xrootd4j: require TLS for SciToken authz

v4.3.0
fd118bd4608f29d24b69d495017dc2263770535d xrootd4j: Enable support for authentication protocol chaining
c430a651f38ade5b9dfc747b323659a951f25b4f xrootd4j: fix two small bugs in third-party client authentication handling

Target: master (4.3.0)
Request: 8.0 (4.2.6)
Request: 7.2 (4.2.6)
Request: 7.1 (4.1.7)
Request: 7.0 (4.0.12)
Request: 6.2 (4.0.12)
Requires-notes: Yes
Requires-book: no
Patch: https://rb.dcache.org/r/13544/
Acked-by: Dmitry