### PR TITLE
frontend: fix NPE in SRR when space information is not available yet.

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
@@ -3,6 +3,8 @@ package org.dcache.restful.srr;
 import com.google.common.base.Strings;
 import diskCacheV111.poolManager.CostModule;
 import diskCacheV111.poolManager.PoolSelectionUnit;
+import diskCacheV111.pools.PoolCostInfo;
+import diskCacheV111.pools.PoolCostInfo.PoolSpaceInfo;
 import diskCacheV111.services.space.Space;
 import diskCacheV111.services.space.message.GetSpaceTokensMessage;
 import diskCacheV111.util.CacheException;
@@ -16,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.dcache.cells.CellStub;
@@ -210,14 +213,17 @@ public class SrrBuilder {
             totalSpace += pools.stream()
                   .map(PoolSelectionUnit.SelectionEntity::getName)
                   .map(costModule::getPoolCostInfo)
-                  .mapToLong(p -> p.getSpaceInfo().getTotalSpace())
+                  .filter(Objects::nonNull)
+                  .map(PoolCostInfo::getSpaceInfo)
+                  .mapToLong(PoolSpaceInfo::getTotalSpace)
                   .sum();
 
             usedSpace += pools.stream()
                   .map(PoolSelectionUnit.SelectionEntity::getName)
                   .map(costModule::getPoolCostInfo)
-                  .mapToLong(p -> p.getSpaceInfo().getTotalSpace() - p.getSpaceInfo().getFreeSpace()
-                        - p.getSpaceInfo().getRemovableSpace())
+                  .filter(Objects::nonNull)
+                  .map(PoolCostInfo::getSpaceInfo)
+                  .mapToLong(p -> p.getTotalSpace() - p.getFreeSpace() - p.getRemovableSpace())
                   .sum();
 
             Storageshare share = new Storageshare()


### PR DESCRIPTION
Motivation:

If a pool is not online, then CostModule#getPoolCostInfo will return `null`:

29 Apr 2022 17:03:32 (Frontend-gfe02) [] Uncaught exception in thread jetty-96
java.lang.NullPointerException: null
        at org.dcache.restful.srr.SrrBuilder.lambda$collectShares$3(SrrBuilder.java:213)
        at java.base/java.util.stream.ReferencePipeline$5$1.accept(ReferencePipeline.java:229)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.LongPipeline.reduce(LongPipeline.java:474)
        at java.base/java.util.stream.LongPipeline.sum(LongPipeline.java:432)
        at org.dcache.restful.srr.SrrBuilder.collectShares(SrrBuilder.java:214)
        at org.dcache.restful.srr.SrrBuilder.generate(SrrBuilder.java:122)

Modification:
filter `null values when processing space records.

Result:
NPE is fixed.

Fixes: #6629
Acked-by: Paul Millar
Target: master, 8.1, 8.0, 7.2, 7.1, 7.0, 6.2
Require-book: no
Require-notes: yes
(cherry picked from commit 1fd2e3b7a0d138e366c1189a83247a35a70b96b2)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>