### PR TITLE
nfs: re-send kill only for write movers

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -54,7 +54,6 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -1313,6 +1312,12 @@ public class NFSv41Door extends AbstractCellComponent implements
             deviceid4 ds = waitForRedirect(NFS_REQUEST_BLOCKING).getDeviceId();
             return new deviceid4[]{ds};
         }
+
+        @Override
+        public synchronized boolean hasMover() {
+            // for read request we don't re-send mover kill
+            return !shutdownInProgress && super.hasMover();
+        }
     }
 
     private class WriteTransfer extends NfsTransfer {
@@ -1384,6 +1389,7 @@ public class NFSv41Door extends AbstractCellComponent implements
         protected ListenableFuture<Void> _redirectFuture;
         protected AtomicReference<ChimeraNFSException> _errorHolder = new AtomicReference<>();
         private final NFS4Client _client;
+        protected boolean shutdownInProgress;
 
         NfsTransfer(PnfsHandler pnfs, NFS4Client client, NFS4State openStateId,
               Inode nfsInode, Subject ioSubject) throws ChimeraNFSException {
@@ -1552,6 +1558,8 @@ public class NFSv41Door extends AbstractCellComponent implements
 
                 _log.debug("Shutting down transfer: {}", this);
                 killMover(0, "killed by door: returning layout");
+                shutdownInProgress = true;
+
                 // wait for clean mover shutdown only for writes only
                 if (isWrite() && !waitForMover(NFS_REQUEST_BLOCKING)) {
                     throw new DelayException("Mover not stopped");


### PR DESCRIPTION
Fixes: recall write layout on close (5a001af333)

Motivation:
As client might send LAYOUTRETURN and CLOSE in the same compound,
and nfs door doesn't wait for read  movers to shutdown on LAYOUTRETURN,
the CLOSE operation on open for read file should ignore existing mover.

Modification:
Update ReadTransfer#hasMover to return true only if mover exist and no
shutdown ware triggered.

Result:
Closing on open-for-read file doesnt trigger extra layout recall.

Acked-by: Lea Morschel
Target: master, 8.1, 8.0
Require-book: no
Require-notes: no
(cherry picked from commit 5811373f402e2a5e1eaf2bc38230cf2f4afe46e8)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>