### PR TITLE
deb: add explicit dependency on rsyslog package

### DIFF
--- a/packages/fhs/src/main/deb/control
+++ b/packages/fhs/src/main/deb/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 7), quilt (>= 0.46-7), gzip
 Standards-Version: 3.9.0
 
 Package: @PackageName@
-Depends: ssh-client, adduser, ssl-cert
+Depends: ssh-client, adduser, ssl-cert, rsyslog
 Conflicts: dcache-server
 Architecture: all
 Suggests: ruby, libxml2-utils | xsltproc, python-psycopg2


### PR DESCRIPTION
Motivation:
The deb package requires rsyslog service, but doesn't have dependency on
it. As a result the installation on minimal system fails with an error:

```
rsyslog: unrecognized service
dpkg: error processing package dcache (--configure):
 installed dcache package post-installation script subprocess returned error exit status 1
Processing triggers for libc-bin (2.31-0ubuntu9.1) ...
Errors were encountered while processing:
 dcache
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

Modification:
add explicit dependency on rsyslog for debian package

Result:
No errors during installation

Acked-by: Lea Morschel
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit 9d2bf0c11b79da97cbe349e081ebd2b0a90337b6)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>