### PR TITLE
ChimeraVfs: Check file level in addition to inode type when disallowi…

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java
@@ -359,7 +359,9 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
                 }
 
                 // allow set size only for newly created files
-                if (fsInode.type() == FsInodeType.INODE && chimeraStat.getState() != FileState.CREATED) {
+                if (fsInode.type() == FsInodeType.INODE
+                      && fsInode.getLevel() == 0 // exclude layer files
+                      && chimeraStat.getState() != FileState.CREATED) {
                     throw new PermException("Can't change size of existing file");
                 }
             }


### PR DESCRIPTION
…ng file size change

Motivation:

commit 19fa7cf2425d084c6737bbc8e3944f21d770a3f9 added a check on file
create state and FsInodeType when attempting to set file size. Unfortunately
this affects ability to modify layer files which is needed as part of
Enstore operations (e.g. tape migration)

Modification:

Add check of file level when disallowing file size update

Result:

Restored ability to mofify file levels

Patch: https://rb.dcache.org/r/13563/

Target: trunk
Request: 8.1
Request: 8.0
Request: 7.2
Acked-by: Lea, Al

Conflicts:
	modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ChimeraVfs.java