### PR TITLE
info: increase delay between messages

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/DataGatheringScheduler.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/DataGatheringScheduler.java
@@ -95,7 +95,7 @@ public class DataGatheringScheduler implements Runnable, EnvironmentAware, CellL
             } else {
                 // Safety!  Check we wont trigger too quickly
                 if (nextTrigger.getTime() - System.currentTimeMillis() < MINIMUM_DGA_DELAY) {
-                    LOGGER_RA.warn("DGA {} triggering too quickly ({}ms): engaging safety.",
+                    LOGGER_RA.info("DGA {} triggering too quickly ({}ms): engaging safety.",
                           _dga, nextTrigger.getTime() - System.currentTimeMillis());
                     nextTrigger = new Date(System.currentTimeMillis() + MINIMUM_DGA_DELAY);
                 }

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/SkelListBasedActivity.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/SkelListBasedActivity.java
@@ -42,7 +42,7 @@ public abstract class SkelListBasedActivity implements Schedulable {
     /**
      * Time between sending successive messages, in milliseconds
      */
-    private static final int SUCCESSIVE_MSG_DELAY = 100;
+    private static final int SUCCESSIVE_MSG_DELAY = 10000;
 
     /**
      * For how long should the resulting metrics live? (in seconds)

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/cells/CellInfoDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/cells/CellInfoDga.java
@@ -21,7 +21,7 @@ public class CellInfoDga extends SkelListBasedActivity {
      * requests of information from any domain.
      */
     private static int MIN_LIST_REFRESH_PERIOD = 120000;
-    private static int SUCC_MSG_DELAY = 100;
+    private static int SUCC_MSG_DELAY = 2000;
 
     private final CellMessageAnswerable _handler;
 

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/domain/StaticDomainDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/domain/StaticDomainDga.java
@@ -28,7 +28,7 @@ public class StaticDomainDga extends SkelListBasedActivity {
      * 100 ms between successive requests of information from any domain.
      */
     private static final int MIN_LIST_REFRESH_PERIOD = 120000;
-    private static final int SUCC_MSG_DELAY = 100;
+    private static final int SUCC_MSG_DELAY = 2000;
 
     public StaticDomainDga(StateExhibitor exhibitor, MessageSender sender,
           CellMessageAnswerable handler) {

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/routingmanager/RoutingMgrDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/routingmanager/RoutingMgrDga.java
@@ -30,7 +30,7 @@ public class RoutingMgrDga extends SkelListBasedActivity {
      * information from any domain.
      */
     private static int MIN_LIST_REFRESH_PERIOD = 300000;
-    private static int SUCC_MSG_DELAY = 100;
+    private static int SUCC_MSG_DELAY = 5000;
 
     private final CellMessageAnswerable _handler;
 


### PR DESCRIPTION
Motivation:
Commit 9317083dcb67512cb72636b4802e152db55cd7fa decreased the delay between messages sent by info dramatically. This also affects the time when a dga should next be triggered. Some time after the patch was committed, reports started popping up that were complaining about the info log being spammed by messages of the form "DGA {...} triggering too quickly", affecting classes inheriting from `SkelListBasedActivity`.

Modification:
Increase the `SUCCESSIVE_MSG_DELAY` periods again to the values they had before the mentioned commit.

Result:
Hopefully less info log spamming due to "DGA {...} triggering too quickly".

Target: master
Request: 8.1
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Fixes: #1970
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13569/
Acked-by: Albert Rossi