### PR TITLE
dcache-xroot: flesh out channel inactive and exception caught

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -56,6 +56,7 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_uw;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ux;
 
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.net.InetAddresses;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FileExistsCacheException;
@@ -266,13 +267,24 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable t) {
         if (t instanceof ClosedChannelException) {
-            _log.info("Connection closed");
+            _log.info("Connection unexpectedly closed on {}, cause {}.", ctx.channel(),
+                  Throwables.getRootCause(t).toString());
         } else if (t instanceof RuntimeException || t instanceof Error) {
             Thread me = Thread.currentThread();
             me.getUncaughtExceptionHandler().uncaughtException(me, t);
         } else if (!isHealthCheck() || !(t instanceof IOException)) {
-            _log.warn(t.toString());
+            _log.warn("exception caught on {}: {}, cause {}.", ctx.channel(), t.getMessage(),
+                  Throwables.getRootCause(t).toString());
+        } else {
+            _log.info("IO exception caught during health check on {}: {}, cause {}.", ctx.channel(),
+                  t.getMessage(), Throwables.getRootCause(t).toString());
         }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        _log.info("channel inactive event received on {}.", ctx.channel());
+        ctx.fireChannelInactive();
     }
 
     /**

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -194,6 +194,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
+        _log.info("channel inactive event received on {}.", ctx.channel());
         writeLock.lock();
         try {
             /* close leftover descriptors */
@@ -221,22 +222,22 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler {
                          *  in case there is no reconnect, in which case the channel is then released.
                          */
                         _server.scheduleReconnectTimerForMover(descriptor);
-                        _log.debug("{} channeInactive, starting timer for reconnect with mover {}.",
+                        _log.debug("{} channelInactive, starting timer for reconnect with mover {}.",
                               ctx.channel(), descriptor.getChannel().getMoverUuid());
                     }
                 }
             }
         } finally {
             writeLock.unlock();
-            ;
         }
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable t) {
         if (t instanceof ClosedChannelException) {
-            _log.info("Connection {} unexpectedly closed.", ctx.channel());
+            _log.info("Connection {} unexpectedly closed.", ctx.channel());
         } else if (t instanceof Exception) {
+            _log.info("Exception on connection {}: {}.", ctx.channel(), t.toString());
             writeLock.lock();
             try {
                 for (FileDescriptor descriptor : _descriptors) {


### PR DESCRIPTION
Motivation:

More connection error tracking.

Modification:

Log exception caught and channel inactive at
INFO level in door and pool.

Result:

Perhaps more helpful in understanding errors.

Target: master
Request: 8.1
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13573/
Acked-by: Tigran
Acked-by: Lea
Requires-notes: no
Requires-book: no