### PR TITLE
dcache-xroot,pom.xml: bump xrootd4j to 4.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>4.0.12</version.xrootd4j>
+        <version.xrootd4j>4.0.13</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.3</version.dcache-view>
         <version.netty>4.1.50.Final</version.netty>


### PR DESCRIPTION
    For additional diagnostic logging at INFO level.

    See:  https://rb.dcache.org/r/13572/
          commit master@a6d832718ff3e2e875d59d620c7fd06cb7d8a27f

    Target: master => 4.3.1
    Request: 8.1   => 4.3.1
    Request: 8.0   => 4.2.7
    Request: 7.2   => 4.2.7
    Request: 7.1   => 4.1.8
    Request: 7.0   => 4.0.13
    Request: 6.2   => 4.0.13
    Acked-by: Lea
    Patch:  https://rb.dcache.org/r/13577/