### PR TITLE
dcache-xroot,pom.xml: bump xrootd4j to 4.3.1

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -315,7 +315,8 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
             FsPath path = createFullPath(req.getPath());
 
             XrootdResponse response
-                  = conditionallyHandleThirdPartyRequest(req,
+                  = conditionallyHandleThirdPartyRequest(ctx,
+                  req,
                   loginSessionInfo,
                   opaque,
                   path,
@@ -449,21 +450,21 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
             return new RedirectResponse<>(req, host, address.getPort(),
                   opaqueString, "");
         } catch (ParseException e) {
-            return withError(req, kXR_ArgInvalid, "Path arguments do not parse");
+            return withError(ctx, req, kXR_ArgInvalid, "Path arguments do not parse");
         } catch (FileNotFoundCacheException e) {
-            return withError(req, xrootdErrorCode(e.getRc()), "No such file");
+            return withError(ctx, req, xrootdErrorCode(e.getRc()), "No such file");
         } catch (FileExistsCacheException e) {
-            return withError(req, kXR_NotAuthorized, "File already exists");
+            return withError(ctx, req, kXR_NotAuthorized, "File already exists");
         } catch (TimeoutCacheException e) {
-            return withError(req, xrootdErrorCode(e.getRc()), "Internal timeout");
+            return withError(ctx, req, xrootdErrorCode(e.getRc()), "Internal timeout");
         } catch (PermissionDeniedCacheException e) {
-            return withError(req, xrootdErrorCode(e.getRc()), e.getMessage());
+            return withError(ctx, req, xrootdErrorCode(e.getRc()), e.getMessage());
         } catch (FileIsNewCacheException e) {
-            return withError(req, xrootdErrorCode(e.getRc()), "File is locked by upload");
+            return withError(ctx, req, xrootdErrorCode(e.getRc()), "File is locked by upload");
         } catch (NotFileCacheException e) {
-            return withError(req, xrootdErrorCode(e.getRc()), "Not a file");
+            return withError(ctx, req, xrootdErrorCode(e.getRc()), "Not a file");
         } catch (CacheException e) {
-            return withError(req, xrootdErrorCode(e.getRc()),
+            return withError(ctx, req, xrootdErrorCode(e.getRc()),
                   String.format("Failed to open file (%s [%d])",
                         e.getMessage(), e.getRc()));
         } catch (InterruptedException e) {
@@ -472,9 +473,9 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
              * message will never reach the client, so saying that the
              * server shut down is okay.
              */
-            return withError(req, kXR_ServerError, "Server shutdown");
+            return withError(ctx, req, kXR_ServerError, "Server shutdown");
         } catch (XrootdException e) {
-            return withError(req, e.getError(), e.getMessage());
+            return withError(ctx, req, e.getError(), e.getMessage());
         }
     }
 
@@ -493,7 +494,8 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
      * only has been used, we allow rendezvous to take </p>
      */
     private XrootdResponse<OpenRequest>
-    conditionallyHandleThirdPartyRequest(OpenRequest req,
+    conditionallyHandleThirdPartyRequest(ChannelHandlerContext ctx,
+          OpenRequest req,
           LoginSessionInfo loginSessionInfo,
           Map<String, String> opaque,
           FsPath fsPath,
@@ -606,7 +608,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
                                 + "ERROR: {}.",
                           req, info, error);
                     _door.removeTpcPlaceholder(info.getFd());
-                    return withError(req, kXR_InvalidRequest,
+                    return withError(ctx, req, kXR_InvalidRequest,
                           "tpc rendezvous for " + tpcKey
                                 + ": " + error);
                 case CANCELLED:
@@ -616,7 +618,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
                                 + "CANCELLED: {}.",
                           req, info, error);
                     _door.removeTpcPlaceholder(info.getFd());
-                    return withError(req, kXR_InvalidRequest,
+                    return withError(ctx, req, kXR_InvalidRequest,
                           "tpc rendezvous for " + tpcKey
                                 + ": " + error);
             }
@@ -637,7 +639,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
                  * it, an error can be returned.
                  */
                 info.setStatus(Status.ERROR);
-                return withError(req, kXR_InvalidRequest,
+                return withError(ctx, req, kXR_InvalidRequest,
                       "not allowed to read file.");
             }
 
@@ -759,7 +761,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
         if (_door.removeTpcPlaceholder(fd)) {
             return withOk(msg);
         } else {
-            return withError(msg, kXR_FileNotOpen,
+            return withError(ctx, msg, kXR_FileNotOpen,
                   "Invalid file handle " + fd
                         + " for tpc source close.");
         }
@@ -1192,7 +1194,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
             }
 
             respond(_context,
-                  withError(_request, xrootdErrorCode(rc), errorMessage));
+                  withError(_context, _request, xrootdErrorCode(rc), errorMessage));
         }
 
         /**
@@ -1201,7 +1203,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
         @Override
         public void noroute(CellPath path) {
             respond(_context,
-                  withError(_request,
+                  withError(_context, _request,
                         kXR_ServerError,
                         "Could not contact PNFS Manager."));
         }
@@ -1230,7 +1232,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
         @Override
         public void timeout(String error) {
             respond(_context,
-                  withError(_request,
+                  withError(_context, _request,
                         kXR_ServerError,
                         "Timeout when trying to list directory!"));
         }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -781,13 +781,13 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler {
                 Throwable cause = e.getCause();
                 if (cause instanceof CacheException) {
                     int rc = ((CacheException) cause).getRc();
-                    respond(ctx, withError(msg,
+                    respond(ctx, withError(ctx, msg,
                           CacheExceptionMapper.xrootdErrorCode(rc),
                           cause.getMessage()));
                 } else if (cause instanceof IOException) {
-                    respond(ctx, withError(msg, kXR_IOError, cause.getMessage()));
+                    respond(ctx, withError(ctx,msg, kXR_IOError, cause.getMessage()));
                 } else {
-                    respond(ctx, withError(msg, kXR_ServerError, cause.toString()));
+                    respond(ctx, withError(ctx,msg, kXR_ServerError, cause.toString()));
                 }
             } finally {
                 removeDescriptor(fd);

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -180,11 +180,11 @@ public final class TpcWriteDescriptor extends WriteDescriptor
                       .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             } else if (error != null) {
                 userResponseCtx.writeAndFlush(
-                            new ErrorResponse<>(syncRequest, result, error))
+                            new ErrorResponse<>(userResponseCtx, syncRequest, result, error))
                       .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             } else {
                 userResponseCtx.writeAndFlush(
-                            new ErrorResponse<>(syncRequest, errno, client.getError()))
+                            new ErrorResponse<>(userResponseCtx, syncRequest, errno, client.getError()))
                       .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             }
         }
@@ -197,7 +197,7 @@ public final class TpcWriteDescriptor extends WriteDescriptor
     public synchronized XrootdResponse<StatRequest> handleStat(StatRequest msg)
           throws XrootdException {
         if (client.getError() != null) {
-            return new ErrorResponse<>(msg,
+            return new ErrorResponse<>(userResponseCtx, msg,
                   client.getErrno(),
                   client.getError());
         }
@@ -284,7 +284,7 @@ public final class TpcWriteDescriptor extends WriteDescriptor
     public synchronized XrootdResponse<SyncRequest> sync(SyncRequest syncRequest)
           throws IOException, InterruptedException {
         if (client.getError() != null) {
-            return new ErrorResponse<>(syncRequest,
+            return new ErrorResponse<>(userResponseCtx, syncRequest,
                   client.getErrno(),
                   client.getError());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.43.v20210629</version.jetty>
-        <version.xrootd4j>4.3.0</version.xrootd4j>
+        <version.xrootd4j>4.3.1</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.2</version.dcache-view>
         <version.netty>4.1.71.Final</version.netty>


### PR DESCRIPTION
For additional diagnostic logging at INFO level.

See:  https://rb.dcache.org/r/13572/
      commit master@a6d832718ff3e2e875d59d620c7fd06cb7d8a27f

Calls to withError() have been given the required
extra ChannelContext parameter.

Target: master => 4.3.1
Request: 8.1   => 4.3.1
Request: 8.0   => 4.2.7
Request: 7.2   => 4.2.7
Request: 7.1   => 4.1.8
Request: 7.0   => 4.0.13
Request: 6.2   => 4.0.13
Patch:  https://rb.dcache.org/r/13577/
Requires-notes: no
Requires-book: no
Acked-by: Lea
Acked-by: Tigran