### PR TITLE
dcache-xroot,pom.xml: bump xrootd4j to 4.3.1

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -766,13 +766,13 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler {
                 Throwable cause = e.getCause();
                 if (cause instanceof CacheException) {
                     int rc = ((CacheException) cause).getRc();
-                    respond(ctx, withError(msg,
+                    respond(ctx, withError(ctx, msg,
                           CacheExceptionMapper.xrootdErrorCode(rc),
                           cause.getMessage()));
                 } else if (cause instanceof IOException) {
-                    respond(ctx, withError(msg, kXR_IOError, cause.getMessage()));
+                    respond(ctx, withError(ctx,msg, kXR_IOError, cause.getMessage()));
                 } else {
-                    respond(ctx, withError(msg, kXR_ServerError, cause.toString()));
+                    respond(ctx, withError(ctx,msg, kXR_ServerError, cause.toString()));
                 }
             } finally {
                 removeDescriptor(fd);

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/tpc/TpcWriteDescriptor.java
@@ -178,11 +178,11 @@ public final class TpcWriteDescriptor extends WriteDescriptor
                       .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             } else if (error != null) {
                 userResponseCtx.writeAndFlush(
-                            new ErrorResponse<>(syncRequest, result, error))
+                            new ErrorResponse<>(userResponseCtx, syncRequest, result, error))
                       .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             } else {
                 userResponseCtx.writeAndFlush(
-                            new ErrorResponse<>(syncRequest, errno, client.getError()))
+                            new ErrorResponse<>(userResponseCtx, syncRequest, errno, client.getError()))
                       .addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             }
         }
@@ -191,7 +191,7 @@ public final class TpcWriteDescriptor extends WriteDescriptor
     public synchronized XrootdResponse<StatRequest> handleStat(StatRequest msg)
           throws XrootdException {
         if (client.getError() != null) {
-            return new ErrorResponse<>(msg,
+            return new ErrorResponse<>(userResponseCtx, msg,
                   client.getErrno(),
                   client.getError());
         }
@@ -278,7 +278,7 @@ public final class TpcWriteDescriptor extends WriteDescriptor
     public synchronized XrootdResponse<SyncRequest> sync(SyncRequest syncRequest)
           throws IOException, InterruptedException {
         if (client.getError() != null) {
-            return new ErrorResponse<>(syncRequest,
+            return new ErrorResponse<>(userResponseCtx, syncRequest,
                   client.getErrno(),
                   client.getError());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.18.v20190429</version.jetty>
-        <version.xrootd4j>4.0.12</version.xrootd4j>
+        <version.xrootd4j>4.0.13</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>1.6.3</version.dcache-view>
         <version.netty>4.1.50.Final</version.netty>


### PR DESCRIPTION
For additional diagnostic logging at INFO level.

See:  https://rb.dcache.org/r/13572/
      commit master@a6d832718ff3e2e875d59d620c7fd06cb7d8a27f

Calls to withError() have been given the required
extra ChannelContext parameter.

Target: master => 4.3.1
Request: 8.1   => 4.3.1
Request: 8.0   => 4.2.7
Request: 7.2   => 4.2.7
Request: 7.1   => 4.1.8
Request: 7.0   => 4.0.13
Request: 6.2   => 4.0.13
Patch:  https://rb.dcache.org/r/13577/
Requires-notes: no
Requires-book: no
Acked-by: Lea
Acked-by: Tigran