### PR TITLE
pool: improve handling empty saved state by scrubber

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/ChecksumScanner.java
@@ -1,5 +1,6 @@
 package org.dcache.pool.classic;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static dmg.util.CommandException.checkCommand;
 import static java.util.Objects.requireNonNull;
 import static org.dcache.util.Exceptions.messageOrClassName;
@@ -262,8 +263,14 @@ public class ChecksumScanner
         private void initializeFromSavedState() {
             String line;
             try {
-                line = Files.readAllLines(_scrubberStateFile.toPath(), Charset.defaultCharset())
-                      .get(0);
+                line = Files.readString(_scrubberStateFile.toPath(), Charset.defaultCharset());
+                if (isNullOrEmpty(line)) {
+                    _log.error("The scrubber saved state in {} cannot be loaded as it is empty!",
+                          _scrubberStateFile.toPath());
+                    _lastStart = System.currentTimeMillis();
+                    return;
+                }
+
             } catch (NoSuchFileException e) {
                 /**
                  * ignored - start immediately and check whole pool


### PR DESCRIPTION
Motivation:
When the scrubber saved state file is empty for some reason, the scrubber throws an `IndexOutOfBoundsException` on every attempt to load the state and does not proceed with the actual scrubbing.
The exception is not helpful for an admin to understand what is happening and how to make the pool start scrubbing again.

Modification:
Log a more helpful error message and proceed to attempt scrubbing the pool, essentially recreating the missing information from scratch.

Result:
More helpful error message and scrubber behavior when a scrubber state file happens to be empty.

Target: master, 8.1, 8.0, 7.2, 7.1, 7.0, 6.2
Fixes: #6665
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13576/
Acked-by: Tigran Mkrtchyan