### PR TITLE
pool: don't treat an empty file as a sparse file

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/ChecksumChannel.java
@@ -254,8 +254,8 @@ public class ChecksumChannel extends ForwardingRepositoryChannel {
         synchronized (_dataRangeSet) {
             synchronized (_digests) {
                 try {
-
-                    if (_dataRangeSet.asRanges().size() != 1 || _nextChecksumOffset == 0) {
+                    if (_dataRangeSet.asRanges().size() > 1
+                            || (_dataRangeSet.asRanges().size() == 1 && _nextChecksumOffset == 0)) {
                         feedZerosToDigesterForRangeGaps();
                     }
 

--- a/modules/dcache/src/test/java/org/dcache/pool/movers/ChecksumChannelTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/movers/ChecksumChannelTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import org.dcache.pool.repository.FileRepositoryChannel;
 import org.dcache.pool.repository.FileStore;
@@ -40,12 +41,15 @@ import org.junit.Test;
 
 public class ChecksumChannelTest {
 
+    private static final Checksum EMPTY_MD5_CHECKSUM = new Checksum(ChecksumType.MD5_TYPE,
+          "d41d8cd98f00b204e9800998ecf8427e");
 
     private ChecksumChannel chksumChannel;
 
     private final byte[] data = "\0Just\0A\0Short\0TestString\0To\0Verify\0\0Checksumming\0\0Works\12".getBytes(
           StandardCharsets.ISO_8859_1); // \12 is a octal 10, linefeed
     private final Checksum expectedChecksum = ChecksumType.MD5_TYPE.calculate(data);
+
     private int blocksize = 2;
     private int blockcount = data.length / blocksize;
     private ByteBuffer[] buffers = new ByteBuffer[blockcount];
@@ -316,6 +320,13 @@ public class ChecksumChannelTest {
         }
 
         assertThat(chksumChannel.getChecksums(), contains(expectedChecksum));
+    }
+
+    @Test
+    public void shouldNotFillUpRangeGapsWithZeroLengthFile() throws IOException {
+        chksumChannel.close();
+        Set<Checksum> results = chksumChannel.getChecksums();
+        assertThat(results, contains(EMPTY_MD5_CHECKSUM));
     }
 
     private Map<Long, ByteBuffer> getNonZeroBlocksFromByteArray(byte[] bytes) {


### PR DESCRIPTION
Motivation:

The checksum calculation currently treats an empty file as a sparse file
and attempts to fill in the missing gaps.  Sparse file handling is
currently broken, so such attempts will fail.

See #6655.

Modification:

Do not consider an empty file as sparse.

Result:

A bug is fixed where the checksum calculation would fail for empty
files.

Target: master
Requires-notes: yes
Requires-book: no
Request: 8.1
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Patch: https://rb.dcache.org/r/13564/
Acked-by: Lea Morschel