### PR TITLE
dcache-frontend: bulk-requests POST, allow either string or boolean f…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
@@ -373,6 +373,9 @@ public final class BulkResources {
         String string = removeEntry(map, String.class, "activity");
         request.setActivity(string);
 
+        string = removeEntry(map, String.class, "target");
+        request.setTarget(string);
+
         string = removeEntry(map, String.class, "target_prefix", "target-prefix", "targetPrefix");
         request.setTargetPrefix(string);
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
@@ -370,31 +370,43 @@ public final class BulkResources {
 
         request.setArguments((Map<String, String>) map.remove("arguments"));
 
-        String value = removeEntry(map, "activity");
-        request.setActivity(value);
+        String string = removeEntry(map, String.class, "activity");
+        request.setActivity(string);
 
-        value = removeEntry(map, "target");
-        request.setTarget(value);
+        string = removeEntry(map, String.class, "target_prefix", "target-prefix", "targetPrefix");
+        request.setTargetPrefix(string);
 
-        value = removeEntry(map, "target_prefix", "target-prefix", "targetPrefix");
-        request.setTargetPrefix(value);
-
-        value = removeEntry(map, "expand_directories", "expand-directories",
+        string = removeEntry(map, String.class, "expand_directories", "expand-directories",
               "expandDirectories");
         request.setExpandDirectories(
-              value == null ? Depth.NONE : Depth.valueOf(value.toUpperCase()));
+              string == null ? Depth.NONE : Depth.valueOf(string.toUpperCase()));
 
-        value = removeEntry(map, "delay_clear", "delay-clear", "delayClear");
-        request.setDelayClear(value == null ? 0 : Integer.parseInt(value));
+        string = removeEntry(map, String.class, "delay_clear", "delay-clear", "delayClear");
+        request.setDelayClear(string == null ? 0 : Integer.parseInt(string));
 
-        value = removeEntry(map, "clear_on_success", "clear-on-success", "clearOnSuccess");
-        request.setClearOnSuccess(Boolean.valueOf(value));
+        Object value = removeEntry(map, Object.class, "clear_on_success", "clear-on-success",
+              "clearOnSuccess");
+        if (value instanceof Boolean) {
+            request.setClearOnSuccess((boolean) value);
+        } else {
+            request.setClearOnSuccess(Boolean.valueOf(String.valueOf(value)));
+        }
 
-        value = removeEntry(map, "clear_on_failure", "clear-on-failure", "clearOnFailure");
-        request.setClearOnFailure(Boolean.valueOf(value));
+        value = removeEntry(map, Object.class, "clear_on_failure", "clear-on-failure",
+              "clearOnFailure");
+        if (value instanceof Boolean) {
+            request.setClearOnFailure((boolean) value);
+        } else {
+            request.setClearOnFailure(Boolean.valueOf(String.valueOf(value)));
+        }
 
-        value = removeEntry(map, "cancel_on_failure", "cancel-on-failure", "cancelOnFailure");
-        request.setCancelOnFailure(Boolean.valueOf(value));
+        value = removeEntry(map, Object.class, "cancel_on_failure", "cancel-on-failure",
+              "cancelOnFailure");
+        if (value instanceof Boolean) {
+            request.setCancelOnFailure((boolean) value);
+        } else {
+            request.setCancelOnFailure(Boolean.valueOf(String.valueOf(value)));
+        }
 
         if (!map.isEmpty()) {
             throw new BadRequestException("unsupported arguments: " + map.keySet());
@@ -403,10 +415,10 @@ public final class BulkResources {
         return request;
     }
 
-    private static String removeEntry(Map map, String... names) {
-        String value = null;
+    private static <T> T removeEntry(Map map, Class<T> clzz, String... names) {
+        T value = null;
         for (String name : names) {
-            String v = (String) map.remove(name);
+            T v = (T) map.remove(name);
             if (value == null) {
                 value = v;
             } else if (v != null) {


### PR DESCRIPTION
…or boolean values

Motivation:

Bulk version 1, prior to #13257 master@df7627b6d1cf6802267400980b487329214f9ca2,
accepted JSON boolean values for clearOnSuccess, clearOnFailure and cancelOnFailure.
When the multiple format changes were introduced, the type was changed to a string.

While use of bulk version 1 was not extensive, it is still probably a good idea
to support a strict boolean type for these attributes (as well as the new 'prestore'
attribute).  At the same time, since we have released Bulk v2 in 8.1 with
string definitions, we should continue to accept these for backward compatibility as well.

Modification:

Allow both boolean and string values for these attributes.

Result:

Avoids potential incompatibilities with scripts and supports the more natural
boolean type expression for those fields.

Target: master
Request: 8.1 (for v1)
Request: 8.0 (for v1)
Request: 7.2 (for v1)
Patch: https://rb.dcache.org/r/13596/
Requires-book: no
Requires-notes: yes
Acked-by: Tigran