### PR TITLE
dcache-frontend: protect against RuntimeError in case of denied anony…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/RequestUser.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/RequestUser.java
@@ -75,8 +75,16 @@ public class RequestUser implements ContainerRequestFilter, ContainerResponseFil
     }
 
     public static Long getSubjectUidForFileOperations(boolean isUnlimitedVisibility) {
-        return canViewFileOperations(isUnlimitedVisibility) ?
-              null : Subjects.getUid(getSubject());
+        if (canViewFileOperations(isUnlimitedVisibility)) {
+            return null;
+        }
+
+        Subject user = getSubject();
+        if (Subjects.isNobody(user)) {
+            throw new NotAuthorizedException("visibility limited to non-anonymous users.");
+        }
+
+        return Subjects.getUid(user);
     }
 
     public static void checkAuthenticated() throws NotAuthorizedException {

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -258,7 +258,7 @@ frontend.authn.ocsp-mode=${dcache.authn.ocsp-mode}
 #       billing records, and transfers which are not owned by the user
 #       and are not anonymous can only be seen by admins.
 #
-#       Setting this value to true allows all users access
+#       Setting this value to true allows all users (including anonymous users) access
 #       to this information.
 #
 (one-of?true|false)frontend.authz.unlimited-operation-visibility=false


### PR DESCRIPTION
…mous access

Motivation:

See GH https://github.com/dCache/dcache/issues/6704
"anonymous request to frontend triggers stack-trace".

Modification:

In the case of unlimitedVisibility = false, check if
subject is anonymous first, and if so, return a 401
error; otherwise, filter on the UID as per current
code.

Result:

No more stack trace and correct behavior wrt client
(i.e., anonymous access receives a 401 error).

Target: master
Request: 8.1
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Request: 6.2
Requires-notes: yes
Requires-book: no
Bug: #6704
Closes: #6704
Patch: https://rb.dcache.org/r/13597/
Acked-by: Paul