### PR TITLE
dcache-frontend,bulk: fix typing of argument values

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/PinJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/PinJob.java
@@ -90,10 +90,10 @@ public class PinJob extends PinManagerJob {
 
         String expire = arguments.get(LIFETIME.getName());
         String unit = arguments.get(LIFETIME_UNIT.getName());
-
+        Long value = (long)(Double.parseDouble(expire));
         long lifetime = expire == null ? defaultUnit.toMillis(defaultValue)
-              : unit == null ? defaultUnit.toMillis(Long.valueOf(expire))
-                    : TimeUnit.valueOf(unit).toMillis(Long.valueOf(expire));
+              : unit == null ? defaultUnit.toMillis(value)
+                    : TimeUnit.valueOf(unit).toMillis(value);
 
         return lifetime;
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
@@ -71,6 +71,7 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.Example;
 import io.swagger.annotations.ExampleProperty;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -368,7 +369,13 @@ public final class BulkResources {
         Map map = new Gson().fromJson(requestPayload, Map.class);
         BulkRequest request = new BulkRequest();
 
-        request.setArguments((Map<String, String>) map.remove("arguments"));
+        Map<String, Object> arguments = (Map<String, Object>) map.remove("arguments");
+        if (arguments != null) {
+            Map<String, String> stringified = new HashMap<>();
+            arguments.entrySet().stream()
+                     .forEach(e -> stringified.put(e.getKey(), String.valueOf(e.getValue())));
+            request.setArguments(stringified);
+        }
 
         String string = removeEntry(map, String.class, "activity");
         request.setActivity(string);


### PR DESCRIPTION
Motivation:

After v2 updates, the numeric lifetime value on PIN
also changed to string, provoking an error analogous
to that corrected in https://rb.dcache.org/r/13596/
master@7cc8367c9c71c7a5b9a5dddd07524e90cc01f03d.

Modification:

In the frontend, make sure all argument values are
sent to the bulk service as strings.

In the PIN activity, accept a double string format
as a legitimate time value (cast to long).

Result:

Both numeric and string values for PIN lifetime are
valid.  I also checked that skipDirs for DELETE
can be both boolean and string. All other current
arguments are required to be strings, as before.

A separate version for bulk v1 will be provided.

Target: master
Request: 8.1  (v1)
Request: 8.0  (v1)
Request: 7.2  (v1)
Request: 7.1  (v1)
Request: 7.0  (v1)
Patch:  https://rb.dcache.org/r/13601/
Requires-notes: yes
Requires-book: no
Acked-by: Dmitry