### PR TITLE
dcache-bulk: (version 1) handle unexpected exceptions in queue

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkJobWrapper.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkJobWrapper.java
@@ -1,0 +1,105 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.services.bulk.job;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import org.dcache.services.bulk.BulkServiceException;
+import org.dcache.services.bulk.handlers.BulkRequestCompletionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BulkJobWrapper implements Runnable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BulkJobWrapper.class);
+
+    private final BulkJob bulkJob;
+    private final BulkRequestCompletionHandler completionHandler;
+
+    public BulkJobWrapper(BulkJob bulkJob,
+          BulkRequestCompletionHandler completionHandler) {
+        this.bulkJob = bulkJob;
+        this.completionHandler = completionHandler;
+    }
+
+    @Override
+    public void run() {
+        try {
+            bulkJob.run();
+        } catch (RuntimeException e) {
+            /*
+             * Cancel the entire request here.
+             * Handle the uncaught exceptions, so as not to kill the queue thread.
+             */
+            String id = bulkJob.getKey().getRequestId();
+
+            try {
+                completionHandler.requestCancelled(id);
+            } catch (BulkServiceException ex) {
+                LOGGER.error(
+                      "attempted cancellation of request {} because of uncaught exception ({}) failed: {}.",
+                      id, e, ex.getMessage());
+            }
+
+            Thread thisThread = Thread.currentThread();
+            UncaughtExceptionHandler ueh = thisThread.getUncaughtExceptionHandler();
+            ueh.uncaughtException(thisThread, e);
+        }
+    }
+}

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/queue/BulkServiceQueue.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/queue/BulkServiceQueue.java
@@ -65,6 +65,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.TreeMultimap;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -89,6 +90,7 @@ import org.dcache.services.bulk.BulkRequestStorageException;
 import org.dcache.services.bulk.BulkServiceException;
 import org.dcache.services.bulk.handlers.BulkRequestCompletionHandler;
 import org.dcache.services.bulk.handlers.BulkSubmissionHandler;
+import org.dcache.services.bulk.job.BulkJobWrapper;
 import org.dcache.services.bulk.job.BulkJob;
 import org.dcache.services.bulk.job.BulkRequestJob;
 import org.dcache.services.bulk.job.SingleTargetJob;
@@ -409,6 +411,11 @@ public class BulkServiceQueue implements SignalAware {
                   "Problem activating request for {}: {}; aborting.", request.getId(),
                   e.toString());
             requestStore.abort(request.getId(), e);
+        } catch (RuntimeException e) {
+            requestStore.abort(request.getId(), e);
+            Thread thisThread = Thread.currentThread();
+            UncaughtExceptionHandler ueh = thisThread.getUncaughtExceptionHandler();
+            ueh.uncaughtException(thisThread, e);
         }
     }
 
@@ -443,7 +450,7 @@ public class BulkServiceQueue implements SignalAware {
         }
         LOGGER.trace("submitting job {} to executor.", job.getKey());
         runningQueue.offer(job);
-        job.setFuture(bulkJobExecutorService.submit(new FireAndForgetTask(job)));
+        job.setFuture(bulkJobExecutorService.submit(new BulkJobWrapper(job, completionHandler)));
     }
 
     private void updateReadyStats() {
@@ -475,9 +482,9 @@ public class BulkServiceQueue implements SignalAware {
                 }
             } catch (InterruptedException e) {
                 LOGGER.warn("interrupted.");
+            } finally {
+                LOGGER.trace("JobProcessor exiting...");
             }
-
-            LOGGER.trace("exiting.");
         }
 
         /*
@@ -1024,6 +1031,11 @@ public class BulkServiceQueue implements SignalAware {
                 }
             } catch (BulkServiceException e) {
                 LOGGER.error("Failed to post-process {}: {}.", job.getKey(), e.toString());
+            } catch (RuntimeException e) {
+                LOGGER.error("Failed to post-process {}", job.getKey());
+                Thread thisThread = Thread.currentThread();
+                UncaughtExceptionHandler ueh = thisThread.getUncaughtExceptionHandler();
+                ueh.uncaughtException(thisThread, e);
             }
 
             statistics.activeRequests(activeRequests());


### PR DESCRIPTION
Motivation:

See https://rb.dcache.org/r/13603/
See https://rb.dcache.org/r/13613/

This is a fix for Bulk version 1
which combines the two strategies.

Modification:

Do not wrap the jobs in the FireAndForgetTask,
but in a wrapper that catches the RuntimeException,
calls cancel on the entire request,
analogously to how version 2 cancels the entire container,
and then calls the thread's uncaught exception handler.

Similarly handle runtime exceptions in the activate
and postprocess methods of the queue.

Result:

Runtime exceptions do not kill the queue thread
and do not leave the request in a stalled state.

Request: 8.1
Request: 8.0
Request: 7.2
Request: 7.1
Request: 7.0
Patch: https://rb.dcache.org/r/13614/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran