### PR TITLE
properties: report that remote transfer manager is replicable

### DIFF
--- a/skel/share/defaults/transfermanagers.properties
+++ b/skel/share/defaults/transfermanagers.properties
@@ -29,7 +29,7 @@ transfermanagers.cell.consume = ${transfermanagers.cell.name}
 #
 #   This property indicates if this service is replicable.
 #
-(immutable)transfermanagers.cell.replicable = false
+(immutable)transfermanagers.cell.replicable = true
 
 # Timeout for pool requests
 transfermanagers.service.pool.timeout = 300


### PR DESCRIPTION
Motivation:

Commit 62de9e9759 added support for multiple RemoteTransferManager services, which allows for high-availability deployments when the WebDAV door and all RemoteTransferManager services are upgraded to support this new feature.
However, dCache still reports that RemoteTransferManager is not replicable.

Modification:
Result:

dCache now reports RemoteTransferManager as being replicable.

Target: master
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13632/
Acked-by: Paul Millar