### PR TITLE
webdav: http-tpc do not keep retrying to cancel transfer

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -951,21 +951,13 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
                 message.setExplanation("client went away");
                 try {
                     _transferManager.sendAndWait(message);
-                } catch (MissingResourceCacheException e) {
-                    /* Tried to cancel a transfer, but the transfer-manager
-                     * reported there is no such transfer.  Either the transfer
-                     * complete message was lost or the transfer-service was
-                     * restarted.  As the client has cancelled the transfer and
-                     * there is no transfer, we have nothing further to do.
+                } catch (NoRouteToCellException | CacheException e) {
+                    /* We tried to cancel a transfer, but the transfer-manager reported some kind
+                     * of problem.  There's no guarantee that this failure is transitory, so
+                     * retrying may not help.  Instead, we just fail the transfer.
                      */
                     failure("client went away, but failed to cancel transfer: "
                           + e.getMessage());
-                } catch (NoRouteToCellException | CacheException e) {
-                    LOGGER.error("Failed to cancel transfer id={}: {}", _id, e.toString());
-
-                    // Our attempt to kill the transfer failed.  We leave the
-                    // performance markers going as they will trigger further
-                    // attempts to kill the transfer.
                 } catch (InterruptedException e) {
                     // Do nothing: this dCache domain is shutting down.
                 }


### PR DESCRIPTION
Motivation:

If a specific RemoteTransferManager cell is shutdown then any subsequent
attempt to cancel a transfer (that was ongoing when the RTM was switched
off) will fail with NoRouteToCell.

Under this failure mode, the WebDAV door will retry these attempts until
the RTM responds that the transfer has been cancelled or that there is
no such transfer.

If the RTM is switched off and never switched back on then the WebDAV
door is caught in a loop, attempting to send messages indefinitely.

Modification:

If the attempt to cancel the transfer fails then simply fail the
transfer (within the door).  Do not retry.  For PULL requests, the
failure-recovery procedure will remove the namespace entry.  For PUSH
requests, there is a risk that the transfer will continue; however,
there is (currently) not much we can do about that.

Result:

Fix a bug where the WebDAV door will continue attempting to kill a
cancelled HTTP-TPC transfer indefinitely if the corresponding
RemoteTransferManager cell has been switched off.

Target: master
Requires-notes: yes
Requires-book: no
Request: 8.1
Request: 8.0
Request: 7.2
Closes: #6748
Patch: https://rb.dcache.org/r/13646/
Acked-by: Lea Morschel