### PR TITLE
webdav: fix NPE if client aborts transfer

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -799,8 +799,10 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
         }
 
         private IoDoorEntry describe() {
+            @Nullable
+            InetSocketAddress remoteAddress = _endpoint.getRemoteAddress();
             // This may trigger DNS lookup; however, result should be cached by JVM.
-            String client = _endpoint.getRemoteAddress().getHostName();
+            String client = remoteAddress == null ? "(disconnected)" : remoteAddress.getHostName();
             StringBuilder status = new StringBuilder();
             status.append(_direction == Direction.PULL ? "PULL from" : "PUSH to");
             status.append(' ').append(_destination.getHost());


### PR DESCRIPTION
Motivation:

Received the following stack-trace report within issue #6748, for a
dCache v7.2 instance:

    02 Aug 2022 16:51:04 (WebDAV-f01-210-127) [Frontend-atlasdcacheweb-kit] Command failed due to a bug, please contact support@dcache.org.
    dmg.util.CommandPanicException: (1) Command failed: java.lang.NullPointerException
        at dmg.util.command.AcCommandExecutor.execute(AcCommandExecutor.java:161)
        at dmg.cells.nucleus.CellAdapter.executeCommand(CellAdapter.java:209)
        at org.dcache.cells.UniversalSpringCell.executeCommand(UniversalSpringCell.java:189)
        at dmg.cells.nucleus.CellAdapter$1.doExecute(CellAdapter.java:90)
        at org.dcache.util.cli.CommandInterpreter.command(CommandInterpreter.java:117)
        at dmg.cells.nucleus.CellAdapter$1.command(CellAdapter.java:106)
        at dmg.cells.nucleus.CellAdapter.command(CellAdapter.java:195)
        at dmg.cells.nucleus.CellAdapter.executeLocalCommand(CellAdapter.java:882)
        at dmg.cells.nucleus.CellAdapter.messageArrived(CellAdapter.java:812)
        at dmg.cells.nucleus.CellNucleus$DeliverMessageTask.run(CellNucleus.java:1274)
        at org.dcache.util.BoundedExecutor$Worker.run(BoundedExecutor.java:247)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$2(CellNucleus.java:727)
        at java.base/java.lang.Thread.run(Thread.java:829)
    Caused by: java.lang.NullPointerException: null
        at org.dcache.webdav.transfer.RemoteTransferHandler$RemoteTransfer.describe(RemoteTransferHandler.java:815)
        at org.dcache.webdav.transfer.RemoteTransferHandler.lambda$addTransfers$4(RemoteTransferHandler.java:643)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.concurrent.ConcurrentHashMap$ValueSpliterator.forEachRemaining(ConcurrentHashMap.java:3605)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEachOrdered(ReferencePipeline.java:502)
        at org.dcache.webdav.transfer.RemoteTransferHandler.addTransfers(RemoteTransferHandler.java:644)
        at org.dcache.webdav.DcacheResourceFactory.ac_get_door_info(DcacheResourceFactory.java:1358)
        at jdk.internal.reflect.GeneratedMethodAccessor86.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at dmg.util.command.AcCommandExecutor.execute(AcCommandExecutor.java:138)
        ... 14 common frames omitted

Modification:

Check whether the EndPoint is connected; i.e., whether getRemoteAddress
returns a non-null value.  If the value is null, use a place-holder
value instead.

Result:

Fix a NullPointerException when reporting on active transfers if the
client has disconnected but the door has not yet cancelled the transfer.

Target: master
Requires-notes: yes
Requires-book: no
Request: 8.1
Request: 8.0
Request: 7.2
See: #6748
Patch: https://rb.dcache.org/r/13645/
Acked-by: Lea Morschel