### PR TITLE
dcache-xroot: add Book section on direct memory requirements for pools*

### DIFF
--- a/docs/TheBook/src/main/markdown/config.md
+++ b/docs/TheBook/src/main/markdown/config.md
@@ -125,6 +125,7 @@ Individual services:
 - [dCache as XRoot-Server](config-xrootd.md)
      - [Setting up](config-xrootd.md#setting-up)
      - [Quick tests](config-xrootd.md#quick-tests)
+     - [Pool memory requirements](config-xrootd.md#pool-memory-requirements)
      - [Xroot security](config-xrootd.md#xroot-security)
      - [Third-party transfer](config-xrootd.md#xrootd-third-party-transfer)
 


### PR DESCRIPTION
Motivation:

See https://github.com/dCache/xrootd4j/issues/138.

Recent discussions with ATLAS and KIT admins
have raised the question of memory allocation
for xrootd on the pools.

Modification:

This added section should help to clarify
the current requirements.

Result:

Documentation now offers some explicit
guidance as to pool configuration for
xrootd reqarding memory.

Target: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes  ("A section detailing how to configure pools for memory with xrootd has been added to the Book.")
Patch: https://rb.dcache.org/r/13637/
Acked-by: Lea