### PR TITLE
pom.xml: update to latest xrootd4j bugfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.43.v20210629</version.jetty>
-        <version.xrootd4j>4.2.7</version.xrootd4j>
+        <version.xrootd4j>4.2.8</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.2</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>


### PR DESCRIPTION
See:  https://rb.dcache.org/r/13647/

Target:   8.1
Request:  8.0  [4.2.8]
Request:  7.2  [4.2.8]
Request:  7.1  [4.1.9]
Request:  7.0  [4.0.14]
Request:  6.2  [4.0.14]
Patch: https://rb.dcache.org/r/13648/
Requires-notes: yes  "Fixes potential for DOS in xrootd write."
Acked-by: Tigran