### PR TITLE
Drop usage of Apache's HttpClient in dcache-webdav.

### DIFF
--- a/modules/dcache-webdav/pom.xml
+++ b/modules/dcache-webdav/pom.xml
@@ -91,10 +91,6 @@
         <groupId>org.italiangrid</groupId>
         <artifactId>voms-api-java</artifactId>
     </dependency>
-      <dependency>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-      </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CredentialServiceClient.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CredentialServiceClient.java
@@ -188,11 +188,7 @@ public class CredentialServiceClient
                         )
                 )
                 .header("Authorization", "Basic " +
-                        Base64.getEncoder().encodeToString(
-                                UTF_8.encode(
-                                        clientId + ":" + (clientSecret == null ? "null" : clientSecret)
-                                ).array()
-                        )
+                        Base64.getEncoder().encodeToString((clientId + ":" + clientSecret).getBytes(UTF_8))
                 )
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .build();

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CredentialServiceClient.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CredentialServiceClient.java
@@ -47,6 +47,7 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -171,21 +172,23 @@ public class CredentialServiceClient
 
         return HttpRequest.newBuilder()
                 .uri(URI.create(tokenEndPoint(host)))
-                .POST(HttpRequest.BodyPublishers.ofString(
-                        String.format(
-                                "grant_type=%s" +
-                                        "&audience=%s" +
-                                        "&subject_token=%s" +
-                                        "&subject_token_type=%s" +
-                                        "&scope=%s",
-                                GRANT_TYPE,
-                                clientId,
-                                token,
-                                TOKEN_TYPE,
-                                SCOPE)
-                ))
-                .header("Authorization", "Basic " + java.util.Base64.getEncoder()
-                        .encodeToString(
+                .POST(
+                        HttpRequest.BodyPublishers.ofString(
+                                String.format(
+                                        "grant_type=%s" +
+                                                "&audience=%s" +
+                                                "&subject_token=%s" +
+                                                "&subject_token_type=%s" +
+                                                "&scope=%s",
+                                        GRANT_TYPE,
+                                        clientId,
+                                        token,
+                                        TOKEN_TYPE,
+                                        SCOPE)
+                        )
+                )
+                .header("Authorization", "Basic " +
+                        Base64.getEncoder().encodeToString(
                                 UTF_8.encode(
                                         clientId + ":" + (clientSecret == null ? "null" : clientSecret)
                                 ).array()
@@ -195,9 +198,9 @@ public class CredentialServiceClient
                 .build();
     }
 
-    private JSONObject delegateOpenIdCredential(java.net.http.HttpClient client, HttpRequest post)
+    private JSONObject delegateOpenIdCredential(HttpClient client, HttpRequest post)
             throws IOException, InterruptedException {
-        HttpResponse<byte[]> response = client.send(post, java.net.http.HttpResponse.BodyHandlers.ofByteArray());
+        HttpResponse<byte[]> response = client.send(post, HttpResponse.BodyHandlers.ofByteArray());
         if (response.statusCode() == 200) {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             os.writeBytes(response.body());


### PR DESCRIPTION
Motivation:
Starts some progress on issue #5410. 

Modification:
Modify the single class in the module dcache-webdav to no longer use Apache's HttpClient but instead use the JDK HttpClient available from JDK 9 onwards.

**N.B.** No real testing environment available, assuming dCache-tests suffice, otherwise someone should test it before throwing it on prod!


Result:
The dcache-webdav has its dependency on apache-httpclient removed (please note it is still transitively available until other modules also drop their usage)

Signed-off-by: Lukas Mansour <lukas.mansour@desy.de>