### PR TITLE
libs: update to spring-5.3.x

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/ForwardingApplicationContext.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/ForwardingApplicationContext.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2001 - 2017 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2001 - 2022 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -97,6 +97,16 @@ public class ForwardingApplicationContext implements ApplicationContext {
     }
 
     @Override
+    public <T> ObjectProvider<T> getBeanProvider(Class<T> aClass, boolean b) {
+        return inner.getBeanProvider(aClass, b);
+    }
+
+    @Override
+    public <T> ObjectProvider<T> getBeanProvider(ResolvableType resolvableType, boolean b) {
+        return inner.getBeanProvider(resolvableType, b);
+    }
+
+    @Override
     public String[] getBeanNamesForType(ResolvableType rt) {
         return inner.getBeanNamesForType(rt);
     }
@@ -142,6 +152,12 @@ public class ForwardingApplicationContext implements ApplicationContext {
     public <A extends Annotation> A findAnnotationOnBean(String string, Class<A> type)
           throws NoSuchBeanDefinitionException {
         return inner.findAnnotationOnBean(string, type);
+    }
+
+    @Override
+    public <A extends Annotation> A findAnnotationOnBean(String s, Class<A> aClass, boolean b)
+          throws NoSuchBeanDefinitionException {
+        return null;
     }
 
     @Override

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/SpringWebServletHandler.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/SpringWebServletHandler.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2001 - 2017 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2001 - 2022 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -19,10 +19,14 @@ package org.dcache.restful.util;
 
 import static org.springframework.web.context.WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE;
 
+import java.lang.annotation.Annotation;
 import javax.servlet.ServletContext;
 import org.eclipse.jetty.servlet.ServletHandler;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.ResolvableType;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -59,6 +63,22 @@ public class SpringWebServletHandler extends ServletHandler implements Applicati
         @Override
         public ServletContext getServletContext() {
             return SpringWebServletHandler.this.getServletContext();
+        }
+
+        @Override
+        public <T> ObjectProvider<T> getBeanProvider(Class<T> aClass, boolean b) {
+            return SpringWebServletHandler.this.context.getBeanProvider(aClass, b);
+        }
+
+        @Override
+        public <T> ObjectProvider<T> getBeanProvider(ResolvableType resolvableType, boolean b) {
+            return SpringWebServletHandler.this.context.getBeanProvider(resolvableType, b);
+        }
+
+        @Override
+        public <A extends Annotation> A findAnnotationOnBean(String s, Class<A> aClass, boolean b)
+              throws NoSuchBeanDefinitionException {
+            return SpringWebServletHandler.this.context.findAnnotationOnBean(s, aClass, b);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
         <version.slf4j>1.7.32</version.slf4j>
         <version.milton>2.7.3.0-dcache-1</version.milton>
-        <version.spring>5.2.22.RELEASE</version.spring>
+        <version.spring>5.3.22</version.spring>
         <!-- Remember to sync aspectj version in dcache.properties -->
         <version.aspectj>1.9.2</version.aspectj>
         <version.smc>6.6.0</version.smc>


### PR DESCRIPTION
Motivation:
Keep external library up-to-date. pre-requisite for Java17 migration.

Modification:
Bump the library version, adjust API changes.

Result:
java17 compatible version of spring.

Acked-by:
Target: master
Require-book: no
Require-notes: yes