### PR TITLE
nfs4: return EACCESS when stage is not allowed

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ExceptionUtils.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/ExceptionUtils.java
@@ -19,12 +19,12 @@ import java.util.concurrent.TimeoutException;
 import org.dcache.chimera.ChimeraFsException;
 import org.dcache.chimera.FileNotFoundChimeraFsException;
 import org.dcache.nfs.ChimeraNFSException;
+import org.dcache.nfs.status.AccessException;
 import org.dcache.nfs.status.DelayException;
 import org.dcache.nfs.status.LayoutTryLaterException;
 import org.dcache.nfs.status.NfsIoException;
 import org.dcache.nfs.status.NoEntException;
 import org.dcache.nfs.status.NoSpcException;
-import org.dcache.nfs.status.PermException;
 import org.dcache.nfs.status.ServerFaultException;
 
 /**
@@ -80,7 +80,7 @@ public class ExceptionUtils {
             case NO_POOL_ONLINE:
                 return new LayoutTryLaterException(e.getMessage(), e);
             case PERMISSION_DENIED:
-                return new PermException(e.getMessage(), e);
+                return new AccessException(e.getMessage(), e);
             case NO_POOL_CONFIGURED:
             case RESOURCE:
                 return new NoSpcException(e.getMessage(), e);


### PR DESCRIPTION
Motivation:
newer kernels ignores EPERM on READ and tries the request as in case of a transient error, thus nfs client hangs forever when staging is not allowed.

Modification:
Return EACCESS (which is spec defined error on READ) to propagate stage protection decision to the calling app.

Result:
NFS client propagates stage restriction to calling application.

Acked-by: Lea Morschel
Target: master, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit ff557a0e577aed957a30ce98f0eb0afe4e6cf91c)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>