### PR TITLE
gplazma2-grid: invalid IGTF policy file should fail with ParserException

### DIFF
--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/util/IGTFInfo.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/util/IGTFInfo.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2016 - 2022 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -361,7 +361,7 @@ public class IGTFInfo {
             checkMutable();
             switch (type) {
                 case POLICY:
-                    Map<String, String> pr = Splitter.on(',').trimResults().
+                    Map<String, String> pr = Splitter.on(',').trimResults().omitEmptyStrings().
                           withKeyValueSeparator(Splitter.on('=').trimResults()).split(value);
                     IGTFInfo.this.policyRequires = ImmutableMap.copyOf(pr);
                     break;

--- a/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/util/IGTFInfoTest.java
+++ b/modules/gplazma2-grid/src/test/java/org/dcache/gplazma/util/IGTFInfoTest.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2016 - 2020 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2016 - 2022 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -124,4 +124,10 @@ public class IGTFInfoTest {
         assertThat(policy.getVersion(), is(equalTo(new Version("1.78-1"))));
     }
 
+    @Test(expected = IGTFInfo.ParserException.class)
+    public void shouldFailWithParserException() throws Exception {
+        IGTFInfo.Builder builder = IGTFInfo.builder(POLICY);
+        builder.setRequires("");
+        builder.build();
+    }
 }


### PR DESCRIPTION
Motivation:
If a IGTF policy file has empty 'requires' field, then gplazma fails with IllegalArgumentException.

Modification:
make sure, that empty 'requires' are accepted, but such IGTFInfo entries are ignored.

Result:
files with invalid/unexpected policies are ignored.

Fixes: #6778
Acked-by: Paul Millar
Acked-by: Dmitry Litvintsev
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit a5369100b61e7fc3d34b1048cf00918f9b1ffe2f)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>