### PR TITLE
qos-engine: prevent NPE if pool monitor not available

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/ALRPStorageUnitQoSProvider.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/ALRPStorageUnitQoSProvider.java
@@ -298,7 +298,11 @@ public class ALRPStorageUnitQoSProvider implements QoSRequirementsProvider, Cell
         return pnfsHandler;
     }
 
-    private synchronized PoolSelectionUnit poolSelectionUnit() {
+    private synchronized PoolSelectionUnit poolSelectionUnit() throws QoSException {
+        if (poolMonitor == null) {
+            throw new QoSException("QoSRequirementsProvider: pool monitor not yet available.");
+        }
+
         return poolMonitor.getPoolSelectionUnit();
     }
 


### PR DESCRIPTION
Motivation:

Apparent race in system tests where qos-engine
does not receive the pool monitor message in
time to handle incoming cache location messages.

Modification:

Avoid reporting an NPE by throwing an explicit
exception when pool monitor is accessed but is
null.

Result:

No runtime stack trace.

Target: master
Request: 8.2
Request: 8.1
Requires-notes: no (discovered via system test)
Requires-book: no
Bug: #6777
Closes: #6777
Acked-by: Tigran