### PR TITLE
dcache-xroot:  select proxy door address on basis of reachability for…

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -1190,7 +1190,7 @@ public class XrootdDoor
         factory = SSLHandlerFactory.getHandlerFactory(CLIENT_TLS, sslHandlerFactories);
         tlsSessionInfo.setClientSslHandlerFactory(factory);
         NettyXrootProxyAdapter adapter = new NettyXrootProxyAdapter(acceptGroup, socketGroup,
-              clientGroup, portRange, InetAddress.getLocalHost(), poolAddress, tlsSessionInfo,
+              clientGroup, portRange, poolAddress, tlsSessionInfo,
               proxyResponseTimeoutInSeconds, proxyTimerExecutor);
         return adapter;
     }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -507,7 +507,8 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
         InetSocketAddress redirectAddress;
 
         if (_door.isProxied()) {
-            redirectAddress = _door.createProxy(poolAddress).start();
+            redirectAddress = _door.createProxy(poolAddress)
+                  .start(transfer.getClientAddress().getAddress());
         } else {
             redirectAddress = poolAddress;
         }

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/proxy/NettyXrootProxyAdapter.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/proxy/NettyXrootProxyAdapter.java
@@ -76,6 +76,7 @@ import java.net.InetSocketAddress;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import org.dcache.util.NettyPortRange;
+import org.dcache.util.NetworkUtils;
 import org.dcache.xrootd.core.XrootdEncoder;
 import org.dcache.xrootd.core.XrootdHandshakeHandler;
 import org.dcache.xrootd.security.TLSSessionInfo;
@@ -117,7 +118,6 @@ public class NettyXrootProxyAdapter {
     private final EventLoopGroup socketGroup;
     private final EventLoopGroup clientGroup;
     private final NettyPortRange portRange;
-    private final InetAddress localAddress;
     private final InetSocketAddress poolAddress;
     private final TLSSessionInfo tlsSessionInfo;
     private final ScheduledExecutorService executorService;
@@ -126,14 +126,13 @@ public class NettyXrootProxyAdapter {
     private final int responseTimeoutInSeconds;
 
     public NettyXrootProxyAdapter(EventLoopGroup acceptGroup, EventLoopGroup socketGroup,
-          EventLoopGroup clientGroup, NettyPortRange portRange, InetAddress localAddress,
-          InetSocketAddress poolAddress, TLSSessionInfo tlsSessionInfo, int responseTimeoutInSeconds,
+          EventLoopGroup clientGroup, NettyPortRange portRange, InetSocketAddress poolAddress,
+          TLSSessionInfo tlsSessionInfo, int responseTimeoutInSeconds,
           ScheduledExecutorService executorService) {
         this.acceptGroup = acceptGroup;
         this.socketGroup = socketGroup;
         this.clientGroup = clientGroup;
         this.portRange = portRange;
-        this.localAddress = localAddress;
         this.poolAddress = poolAddress;
         this.tlsSessionInfo = tlsSessionInfo;
         this.responseTimeoutInSeconds = responseTimeoutInSeconds;
@@ -149,7 +148,7 @@ public class NettyXrootProxyAdapter {
         return responseTimeoutInSeconds;
     }
 
-    public InetSocketAddress start() throws IOException {
+    public InetSocketAddress start(InetAddress clientAddress) throws IOException {
         ServerBootstrap bootstrap = new ServerBootstrap()
               .group(acceptGroup, socketGroup)
               .channel(NioServerSocketChannel.class)
@@ -162,8 +161,15 @@ public class NettyXrootProxyAdapter {
                   }
               });
 
+        /*
+         *  On dual stack deployments like BNL's, it is possible
+         *  that only the IPv4 address is exposed to the outside.
+         *  In this case, we need to make sure the proxy is reachable.
+         */
+        InetAddress proxyAddress = NetworkUtils.getLocalAddress(clientAddress);
+
         InetSocketAddress redirectEndpoint = (InetSocketAddress) portRange.bind(bootstrap,
-              localAddress).localAddress();
+              proxyAddress).localAddress();
 
         LOGGER.info("Proxy {} started, listening on {}.", proxyId, redirectEndpoint);
 

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/proxy/ProxyRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/proxy/ProxyRequestHandler.java
@@ -110,6 +110,7 @@ public class ProxyRequestHandler extends ChannelInboundHandlerAdapter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyRequestHandler.class);
 
+    private final NettyXrootProxyAdapter adapter;
     private final String proxyId;
     private final ProxyResponseHandler responseHandler;
     private final ProxyErrorHandler errorHandler;
@@ -122,6 +123,7 @@ public class ProxyRequestHandler extends ChannelInboundHandlerAdapter {
     ProxyRequestHandler(NettyXrootProxyAdapter proxyAdapter, EventLoopGroup clientGroup,
           InetSocketAddress poolAddress, TLSSessionInfo tlsSessionInfo,
           ScheduledExecutorService executorService) throws Exception {
+        adapter = proxyAdapter;
         proxyId = proxyAdapter.getProxyId();
         this.tlsSessionInfo = tlsSessionInfo;
         ProxyResponseDecoder decoder = new ProxyResponseDecoder(proxyId);
@@ -221,6 +223,7 @@ public class ProxyRequestHandler extends ChannelInboundHandlerAdapter {
 
     void shutdown() throws InterruptedException {
         responseHandler.shutDown();
+        adapter.shutdown();
         LOGGER.debug("ProxyRequestHandler {}, shutdown.", proxyId);
     }
 


### PR DESCRIPTION
… client

Motivation:

On dual stack deployments like BNL's, it is possible that only the IPv4 address is exposed to the outside
world.   In this case, we need to make sure the proxy is
reachable.

Modification:

Instead of using the default local address, bind the proxy to a local address that respects the network of the client and is likely reachable by it.  This is done by a simple call to NetworkUtils.getLocalAddress(client).

Result:

"Special" network configurations seem to work with this change.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13696/
Closes: RT 10350
Requires-notes: yes
Requires-book: no
Acked-by: Dmitry