### PR TITLE
dcache-core: handle null/globbed values correctly in psu match

### DIFF
--- a/modules/dcache/src/test/java/diskCacheV111/poolManager/PoolSelectionUnitV2Test.java
+++ b/modules/dcache/src/test/java/diskCacheV111/poolManager/PoolSelectionUnitV2Test.java
@@ -1,18 +1,74 @@
 package diskCacheV111.poolManager;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.readAllBytes;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import diskCacheV111.pools.PoolV2Mode;
+import dmg.cells.nucleus.DelayedReply;
+import dmg.util.CommandException;
+import dmg.util.CommandExitException;
+import dmg.util.CommandInterpreter;
+import dmg.util.CommandPanicException;
+import dmg.util.CommandThrowableException;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+import org.dcache.util.Args;
 import org.junit.Before;
 import org.junit.Test;
 
 public class PoolSelectionUnitV2Test {
 
-    private PoolSelectionUnitV2 psu;
+    static final String POOLMANAGER_CONF = "org/dcache/tests/psu/poolmanager.conf";
+    static final Set<String> TAPE_POOLS = Set.of("testpool03-5", "testpool08-5", "testpool09-5",
+          "testpool04-7", "testpool04-5");
+    static final Set<String> STAGE_POOLS = Set.of("testpool08-7", "testpool09-6", "testpool09-7",
+          "testpool08-6", "testpool03-6", "testpool04-6");
+
+    PoolSelectionUnitV2 psu;
+    CommandInterpreter commandInterpreter = new CommandInterpreter();
+    File config;
+    PoolPreferenceLevel[] levels;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         psu = new PoolSelectionUnitV2();
+        commandInterpreter.addCommandListener(psu);
+        URL url = getClass().getClassLoader().getResource(POOLMANAGER_CONF);
+        config = new File(url.toURI());
+
+        psu.beforeSetup();
+        byte[] data = readAllBytes(config.toPath());
+        try {
+            executeSetup(commandInterpreter, config.getAbsolutePath(), data);
+        } finally {
+            psu.afterSetup();
+        }
+        PoolV2Mode mode = new PoolV2Mode(PoolV2Mode.ENABLED);
+
+        psu.getAllDefinedPools(false).forEach(p -> {
+            p.setPoolMode(mode);
+            p.setActive(true);
+        });
+
+        Set<String> hsmInstances = Set.of("enstore");
+
+        TAPE_POOLS.forEach(p-> {
+            psu.getPool(p).setHsmInstances(hsmInstances);
+        });
+
+        STAGE_POOLS.forEach(p-> {
+            psu.getPool(p).setHsmInstances(hsmInstances);
+        });
     }
 
     @Test
@@ -97,5 +153,289 @@ public class PoolSelectionUnitV2Test {
         psu.addToPoolGroup("group", "@foo");
 
         psu.removeFromPoolGroup("group", "@bar");
+    }
+
+    @Test
+    public void testThatReadWithSpecificValuesMatchesTapePools() {
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * 127.0.0.1 Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatReadWithProtocolDefaultMatchesTapePools() {
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * 127.0.0.1 */*");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatReadWithProtocolGlobMatchesTapePools() {
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * 127.0.0.1 *");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatReadWithNetDefaultIPv4MatchesTapePools() {
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * 0.0.0.0/0.0.0.0 Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatReadWithNetDefaultIPv6MatchesTapePools() {
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * ::/0 Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatReadWithNetGlobMatchesTapePools() {
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * * Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatReadWithAllGlobsMatchesTapePools() {
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * * *");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatWriteWithSpecificValuesMatchesTapePools() {
+        whenMatchIsCalledWith("write tape.dcache-devel-test@enstore * 127.0.0.1 Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatWriteWithProtocolDefaultMatchesTapePools() {
+        whenMatchIsCalledWith("write tape.dcache-devel-test@enstore * 127.0.0.1 */*");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatWriteWithProtocolGlobMatchesTapePools() {
+        whenMatchIsCalledWith("write tape.dcache-devel-test@enstore * 127.0.0.1 *");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatWriteWithNetDefaultIPv4MatchesTapePools() {
+        whenMatchIsCalledWith("write tape.dcache-devel-test@enstore * 0.0.0.0/0.0.0.0 Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatWriteWithNetDefaultIPv6MatchesTapePools() {
+        whenMatchIsCalledWith("write tape.dcache-devel-test@enstore * ::/0 Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatWriteWithNetGlobMatchesTapePools() {
+        whenMatchIsCalledWith("write tape.dcache-devel-test@enstore * * Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatWriteWithAllGlobsMatchesTapePools() {
+        whenMatchIsCalledWith("write tape.dcache-devel-test@enstore * * *");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatP2PWithSpecificValuesMatchesTapePools() {
+        whenMatchIsCalledWith("p2p tape.dcache-devel-test@enstore * 127.0.0.1 Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatP2PWithProtocolDefaultMatchesTapePools() {
+        whenMatchIsCalledWith("p2p tape.dcache-devel-test@enstore * 127.0.0.1 */*");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatP2PWithProtocolGlobMatchesTapePools() {
+        whenMatchIsCalledWith("p2p tape.dcache-devel-test@enstore * 127.0.0.1 *");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatP2PWithNetDefaultIPv4MatchesTapePools() {
+        whenMatchIsCalledWith("p2p tape.dcache-devel-test@enstore * 0.0.0.0/0.0.0.0 Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatP2PWithNetDefaultIPv6MatchesTapePools() {
+        whenMatchIsCalledWith("p2p tape.dcache-devel-test@enstore * ::/0 Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatP2PWithNetGlobMatchesTapePools() {
+        whenMatchIsCalledWith("p2p tape.dcache-devel-test@enstore * * Http/1");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatP2PWithAllGlobsMatchesTapePools() {
+        whenMatchIsCalledWith("p2p tape.dcache-devel-test@enstore * * *");
+        assertThatPoolsAre(TAPE_POOLS);
+    }
+
+    @Test
+    public void testThatCacheWithSpecificValuesMatchesStagePools() {
+        whenMatchIsCalledWith("cache tape.dcache-devel-test@enstore * 127.0.0.1 Http/1");
+        assertThatPoolsAre(STAGE_POOLS);
+    }
+
+    @Test
+    public void testThatCacheWithProtocolDefaultMatchesStagePools() {
+        whenMatchIsCalledWith("cache tape.dcache-devel-test@enstore * 127.0.0.1 */*");
+        assertThatPoolsAre(STAGE_POOLS);
+    }
+
+    @Test
+    public void testThatCacheWithProtocolGlobMatchesStagePools() {
+        whenMatchIsCalledWith("cache tape.dcache-devel-test@enstore * 127.0.0.1 *");
+        assertThatPoolsAre(STAGE_POOLS);
+    }
+
+    @Test
+    public void testThatCacheWithNetDefaultIPv4MatchesStagePools() {
+        whenMatchIsCalledWith("cache tape.dcache-devel-test@enstore * 0.0.0.0/0.0.0.0 Http/1");
+        assertThatPoolsAre(STAGE_POOLS);
+    }
+
+    @Test
+    public void testThatCacheWithNetDefaultIPv6MatchesStagePools() {
+        whenMatchIsCalledWith("cache tape.dcache-devel-test@enstore * ::/0 Http/1");
+        assertThatPoolsAre(STAGE_POOLS);
+    }
+
+    @Test
+    public void testThatCacheWithNetGlobMatchesTapeStage() {
+        whenMatchIsCalledWith("cache tape.dcache-devel-test@enstore * * Http/1");
+        assertThatPoolsAre(STAGE_POOLS);
+    }
+
+    @Test
+    public void testThatCacheWithAllGlobsMatchesTapePools() {
+        whenMatchIsCalledWith("cache tape.dcache-devel-test@enstore * * *");
+        assertThatPoolsAre(STAGE_POOLS);
+    }
+
+    @Test
+    public void testThatReadWithUnmappedNetIPv5DefaultFails() {
+        givenIPv4DefaultIsMissingFromConfiguration();
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * 0.0.0.0/0.0.0.0 *");
+        /*
+         *  It would be preferable here to throw an exception, but this would
+         *  require the defaults to be mapped, which would not be backward compatible.
+         */
+        assertNoPoolsReturned();
+    }
+
+    @Test
+    public void testThatReadWithUnmappedNetIPv6DefaultFails() {
+        givenIPv6DefaultIsMissingFromConfiguration();
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * ::/0 *");
+        /*
+         *  It would be preferable here to throw an exception, but this would
+         *  require the defaults to be mapped, which would not be backward compatible.
+         */
+        assertNoPoolsReturned();
+    }
+
+    @Test
+    public void testThatReadWithGlobValueFailsWhenIPv6DefaultMissing() {
+        givenIPv6DefaultIsMissingFromConfiguration();
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * * *");
+        /*
+         *  It would be preferable here to throw an exception, but this would
+         *  require the defaults to be mapped, which would not be backward compatible.
+         */
+        assertNoPoolsReturned();
+    }
+
+    @Test
+    public void testThatReadWithUnmappedProtocolDefaultFails() {
+        givenProtocolDefaultIsMissingFromConfiguration();
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * 127.0.0.1 */*");
+        /*
+         *  It would be preferable here to throw an exception, but this would
+         *  require the defaults to be mapped, which would not be backward compatible.
+         */
+        assertNoPoolsReturned();
+    }
+
+    @Test
+    public void testThatReadWithGlobValueFailsWhenProtocolDefaultMissing() {
+        givenProtocolDefaultIsMissingFromConfiguration();
+        whenMatchIsCalledWith("read tape.dcache-devel-test@enstore * 127.0.0.1 */*");
+        /*
+         *  It would be preferable here to throw an exception, but this would
+         *  require the defaults to be mapped, which would not be backward compatible.
+         */
+        assertNoPoolsReturned();
+    }
+
+    private void assertNoPoolsReturned() {
+        assertNotNull(levels);
+        assertEquals("wrong number of preference levels", 0, levels.length);
+    }
+
+    private void assertThatPoolsAre(Set<String> oracle) {
+        assertNotNull(levels);
+        assertEquals("wrong number of preference levels", 1, levels.length);
+        Set<String> pools = new HashSet();
+        pools.addAll(levels[0].getPoolList());
+        assertEquals("preference pools are incorrect.", oracle, pools);
+    }
+
+    /*
+     *  Borrowed from UniversalSpringCell
+     */
+    private void executeSetup(CommandInterpreter interpreter, String source, byte[] data)
+          throws Exception {
+        BufferedReader in = new BufferedReader(
+              new InputStreamReader(new ByteArrayInputStream(data), UTF_8));
+        int lineCount = 1;
+        for (String line = in.readLine(); line != null; line = in.readLine(), lineCount++) {
+            line = line.trim();
+            if (line.isEmpty() || line.charAt(0) == '#') {
+                continue;
+            }
+            try {
+                Serializable result = interpreter.command(new Args(line));
+                if (result instanceof DelayedReply) {
+                    ((DelayedReply) result).take();
+                }
+            } catch (InterruptedException e) {
+                throw new CommandExitException(
+                      "Error at " + source + ":" + lineCount + ": command interrupted");
+            } catch (CommandPanicException e) {
+                throw new CommandPanicException(
+                      "Error at " + source + ":" + lineCount + ": " + e.getMessage(), e);
+            } catch (CommandException e) {
+                throw new CommandThrowableException(
+                      "Error at " + source + ":" + lineCount + ": " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private void givenIPv4DefaultIsMissingFromConfiguration() {
+        psu.removeUnit("0.0.0.0/0.0.0.0", true);
+    }
+
+    private void givenIPv6DefaultIsMissingFromConfiguration() {
+        psu.removeUnit("::/0", true);
+    }
+
+    private void givenProtocolDefaultIsMissingFromConfiguration() {
+        psu.removeUnit("*/*", false);
+    }
+
+    private void whenMatchIsCalledWith(String params) {
+        Args args = new Args(params);
+        levels = (PoolPreferenceLevel[]) psu.ac_psux_match_$_5(args);
     }
 }

--- a/modules/dcache/src/test/resources/org/dcache/tests/psu/poolmanager.conf
+++ b/modules/dcache/src/test/resources/org/dcache/tests/psu/poolmanager.conf
@@ -1,0 +1,169 @@
+psu set regex on
+psu set allpoolsactive off
+
+psu create unit -store any-disk.dcache-devel-test@enstore
+psu set storage unit any-disk.dcache-devel-test@enstore -required=2
+psu create unit -store bnltest.dcache-devel-test@enstore
+psu create unit -store highavail.dcache-devel-test@enstore
+psu set storage unit highavail.dcache-devel-test@enstore -required=4 -onlyOneCopyPer=hostname
+psu create unit -store none.none@enstore
+psu create unit -store persistent-tape.dcache-devel-test@enstore
+psu set storage unit persistent-tape.dcache-devel-test@enstore -required=1
+psu create unit -store persistent.dcache-devel-test@enstore
+psu set storage unit persistent.dcache-devel-test@enstore -required=2 -onlyOneCopyPer=hostname
+psu create unit -store tape.dcache-devel-test@enstore
+psu create unit -net 0.0.0.0/0.0.0.0
+psu create unit -net ::/0
+psu create unit -protocol */*
+
+psu create ugroup any-protocol
+psu addto ugroup any-protocol */*
+
+psu create ugroup dmz
+psu addto ugroup dmz bnltest.dcache-devel-test@enstore
+
+psu create ugroup highavail
+psu addto ugroup highavail highavail.dcache-devel-test@enstore
+
+psu create ugroup internal
+psu addto ugroup internal bnltest.dcache-devel-test@enstore
+
+psu create ugroup persistent
+psu addto ugroup persistent persistent.dcache-devel-test@enstore
+
+psu create ugroup persistent-tape
+psu addto ugroup persistent-tape any-disk.dcache-devel-test@enstore
+psu addto ugroup persistent-tape persistent-tape.dcache-devel-test@enstore
+
+psu create ugroup tape
+psu addto ugroup tape any-disk.dcache-devel-test@enstore
+psu addto ugroup tape tape.dcache-devel-test@enstore
+
+psu create ugroup world-net
+psu addto ugroup world-net 0.0.0.0/0.0.0.0
+psu addto ugroup world-net ::/0
+
+psu create pool testpool03-1
+psu create pool testpool03-2
+psu create pool testpool03-3
+psu create pool testpool03-4
+psu create pool testpool03-5
+psu create pool testpool03-6
+psu create pool testpool03-7
+psu create pool testpool03-8
+psu create pool testpool04-1
+psu create pool testpool04-2
+psu create pool testpool04-3
+psu create pool testpool04-4
+psu create pool testpool04-5
+psu create pool testpool04-6
+psu create pool testpool04-7
+psu create pool testpool04-8
+psu create pool testpool05-1
+psu create pool testpool05-2
+psu create pool testpool06-1
+psu create pool testpool06-2
+psu create pool testpool07-1
+psu create pool testpool07-2
+psu create pool testpool07-3
+psu create pool testpool07-4
+psu create pool testpool08-1
+psu create pool testpool08-2
+psu create pool testpool08-3
+psu create pool testpool08-4
+psu create pool testpool08-5
+psu create pool testpool08-6
+psu create pool testpool08-7
+psu create pool testpool08-8
+psu create pool testpool09-1
+psu create pool testpool09-2
+psu create pool testpool09-3
+psu create pool testpool09-4
+psu create pool testpool09-5
+psu create pool testpool09-6
+psu create pool testpool09-7
+psu create pool testpool09-8
+
+psu create pgroup dmz-group
+psu addto pgroup dmz-group testpool04-8
+
+psu create pgroup highavail-group -resilient
+psu addto pgroup highavail-group testpool03-1
+psu addto pgroup highavail-group testpool03-2
+psu addto pgroup highavail-group testpool04-1
+psu addto pgroup highavail-group testpool04-2
+psu addto pgroup highavail-group testpool05-1
+psu addto pgroup highavail-group testpool05-2
+psu addto pgroup highavail-group testpool06-1
+psu addto pgroup highavail-group testpool06-2
+psu addto pgroup highavail-group testpool07-1
+psu addto pgroup highavail-group testpool07-2
+psu addto pgroup highavail-group testpool08-1
+psu addto pgroup highavail-group testpool08-2
+psu addto pgroup highavail-group testpool09-1
+psu addto pgroup highavail-group testpool09-2
+
+psu create pgroup internal-group
+psu addto pgroup internal-group testpool03-8
+
+psu create pgroup persistent-group -resilient
+psu addto pgroup persistent-group testpool03-3
+psu addto pgroup persistent-group testpool03-4
+psu addto pgroup persistent-group testpool04-3
+psu addto pgroup persistent-group testpool04-4
+psu addto pgroup persistent-group testpool07-3
+psu addto pgroup persistent-group testpool07-4
+psu addto pgroup persistent-group testpool08-3
+psu addto pgroup persistent-group testpool08-4
+psu addto pgroup persistent-group testpool09-3
+psu addto pgroup persistent-group testpool09-4
+
+psu create pgroup persistent-tape-group
+psu addto pgroup persistent-tape-group testpool03-8
+psu addto pgroup persistent-tape-group testpool04-8
+psu addto pgroup persistent-tape-group testpool08-8
+psu addto pgroup persistent-tape-group testpool09-8
+
+psu create pgroup stage-group
+psu addto pgroup stage-group testpool03-6
+psu addto pgroup stage-group testpool04-6
+psu addto pgroup stage-group testpool08-6
+psu addto pgroup stage-group testpool08-7
+psu addto pgroup stage-group testpool09-6
+psu addto pgroup stage-group testpool09-7
+
+psu create pgroup tape-group
+psu addto pgroup tape-group testpool03-5
+psu addto pgroup tape-group testpool04-5
+psu addto pgroup tape-group testpool04-7
+psu addto pgroup tape-group testpool08-5
+psu addto pgroup tape-group testpool09-5
+
+psu create link dmz-link any-protocol dmz world-net
+psu set link dmz-link -readpref=20 -writepref=20 -cachepref=0 -p2ppref=20 -section=shareddisk
+psu addto link dmz-link dmz-group
+
+psu create link highavail-link any-protocol highavail world-net
+psu set link highavail-link -readpref=10 -writepref=10 -cachepref=0 -p2ppref=-1 -section=default
+psu addto link highavail-link highavail-group
+
+psu create link internal-link any-protocol internal world-net
+psu set link internal-link -readpref=10 -writepref=10 -cachepref=0 -p2ppref=-1 -section=shareddisk
+psu addto link internal-link internal-group
+
+psu create link persistent-link any-protocol persistent world-net
+psu set link persistent-link -readpref=10 -writepref=10 -cachepref=0 -p2ppref=-1 -section=default
+psu addto link persistent-link persistent-group
+
+psu create link persistent-tape-link any-protocol persistent-tape world-net
+psu set link persistent-tape-link -readpref=10 -writepref=10 -cachepref=10 -p2ppref=10 -section=default
+psu addto link persistent-tape-link persistent-tape-group
+
+psu create link stage-link any-protocol tape world-net
+psu set link stage-link -readpref=0 -writepref=0 -cachepref=10 -p2ppref=-1 -section=stage
+psu addto link stage-link stage-group
+
+psu create link tape-link any-protocol tape world-net
+psu set link tape-link -readpref=10 -writepref=10 -cachepref=0 -p2ppref=10 -section=stage
+psu addto link tape-link tape-group
+


### PR DESCRIPTION
Motivation:

The ac_psu(x)_match commands permit globbed values (\*) which are supposed to stand in for the defaults for the net and protocol
units.   However, these are translated into null, which
means that unit is skipped in the match.  This produces the wrong
result set (usually empty, but in any case incomplete). The
reason for this is that a match constitutes having satisfied
a match on all the units in the link (AND).

Modfication:

Instead of null, translate the globs into the standard defaults directly, and provide for matching those defaults correctly.

Note that if the defaults are not mapped in the poolmanager configuration, then we revert to the old behavior (it would have been better to throw an IllegalArgumentException, but that would not make it backward compatible with existing configurations).

This patch also fixes another issue when matching using the CACHE I/O direction:  the HSM needs to be defined on the top-level of the FileAttributes rather than just in the StorageInfo object.

JUnit tests for correctness have been added.

Result:

We now have correct behavior -- provided the defaults are included in the PSU configuration.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13685/
Bug: #6793
Closes: #6793
Requires-notes: yes
Requires-book: no
Acked-by: Dmitry