### PR TITLE
dcache-frontend:  add filtering and sorting on owner, group and path …

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/restores/RestoreInfo.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/restores/RestoreInfo.java
@@ -72,11 +72,17 @@ public class RestoreInfo implements Comparable<RestoreInfo>, InvalidatableItem, 
     @ApiModelProperty("Identifies the transfer.")
     private String key;
 
-    @ApiModelProperty("PNFS-ID of staged file.")
+    @ApiModelProperty("PnfsId of staged file.")
     private PnfsId pnfsId;
 
     @ApiModelProperty("Path of staged file.")
     private String path;
+
+    @ApiModelProperty("Owner of the staged file.")
+    private String owner;
+
+    @ApiModelProperty("Owner group of the staged file.")
+    private String ownerGroup;
 
     @ApiModelProperty("Net identifier of the staging host.")
     private String subnet;
@@ -145,6 +151,14 @@ public class RestoreInfo implements Comparable<RestoreInfo>, InvalidatableItem, 
         return key;
     }
 
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getOwnerGroup() {
+        return ownerGroup;
+    }
+
     public String getPath() {
         return path;
     }
@@ -197,6 +211,14 @@ public class RestoreInfo implements Comparable<RestoreInfo>, InvalidatableItem, 
 
     public void setKey(String key) {
         this.key = key;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public void setOwnerGroup(String ownerGroup) {
+        this.ownerGroup = ownerGroup;
     }
 
     public void setPath(String path) {

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/restores/RestoreResources.java
@@ -136,8 +136,14 @@ public final class RestoreResources {
           @QueryParam("offset") Integer offset,
           @ApiParam("The maximum number of restores to return.")
           @QueryParam("limit") Integer limit,
-          @ApiParam("Select only restores that affect this PNFS-ID.")
+          @ApiParam("Select only restores that affect this pnfsId.")
           @QueryParam("pnfsid") String pnfsid,
+          @ApiParam("Select only restores that affect this path.")
+          @QueryParam("path") String path,
+          @ApiParam("Select only restores that affect this owner.")
+          @QueryParam("owner") String owner,
+          @ApiParam("Select only restores that affect this group.")
+          @QueryParam("group") String group,
           @ApiParam("Select only restores triggered by clients from this subnet.")
           @QueryParam("subnet") String subnet,
           @ApiParam("Select only restores on this pool.")
@@ -152,14 +158,8 @@ public final class RestoreResources {
                 throw new ForbiddenException("Restores can only be accessed by admin users.");
             }
 
-            return service.get(token,
-                  offset,
-                  limit,
-                  pnfsid,
-                  subnet,
-                  pool,
-                  status,
-                  sort);
+            return service.get(token, offset, limit, pnfsid, path, owner, group, subnet, pool,
+                  status, sort);
         } catch (CacheException e) {
             LOGGER.warn(Exceptions.meaningfulMessage(e));
             throw new InternalServerErrorException(e);

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/restores/RestoresInfoService.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/restores/RestoresInfoService.java
@@ -75,6 +75,9 @@ public interface RestoresInfoService {
      * @param offset Return items beginning at this index.
      * @param limit  Return at most this number of items.
      * @param pnfsid Filter on pnfsid.
+     * @param path Filter on path.
+     * @param owner Filter on owner.
+     * @param group Filter on group.
      * @param subnet Filter on subnet.
      * @param pool   Filter on pool.
      * @param status Filter on status.
@@ -85,6 +88,9 @@ public interface RestoresInfoService {
           Integer offset,
           Integer limit,
           String pnfsid,
+          String path,
+          String owner,
+          String group,
           String subnet,
           String pool,
           String status,

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/restores/RestoreCollector.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/restores/RestoreCollector.java
@@ -62,13 +62,17 @@ package org.dcache.restful.util.restores;
 import diskCacheV111.poolManager.RestoreRequestsReceiver;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsHandler;
+import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.RestoreHandlerInfo;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.dcache.auth.Subjects;
 import org.dcache.cells.CellStub;
+import org.dcache.namespace.FileAttribute;
 import org.dcache.restful.providers.restores.RestoreInfo;
 import org.dcache.util.collector.CellMessagingCollector;
+import org.dcache.vehicles.FileAttributes;
 import org.springframework.beans.factory.annotation.Required;
 
 /**
@@ -76,6 +80,9 @@ import org.springframework.beans.factory.annotation.Required;
  */
 public class RestoreCollector extends
       CellMessagingCollector<List<RestoreHandlerInfo>> {
+
+    private static final Set<FileAttribute> REQUIRED = Set.of(FileAttribute.OWNER,
+          FileAttribute.OWNER_GROUP);
 
     private RestoreRequestsReceiver receiver;
     private CellStub pnfsStub;
@@ -96,8 +103,12 @@ public class RestoreCollector extends
         super.initialize(timeout, timeUnit);
     }
 
-    public void setPath(RestoreInfo info) throws CacheException {
-        info.setPath(pnfsHandler.getPathByPnfsId(info.getPnfsId()).toString());
+    public void setNamespaceInfo(RestoreInfo info) throws CacheException {
+        PnfsId pnfsId = info.getPnfsId();
+        info.setPath(pnfsHandler.getPathByPnfsId(pnfsId).toString());
+        FileAttributes attributes = pnfsHandler.getFileAttributes(pnfsId, REQUIRED);
+        info.setOwner(String.valueOf(attributes.getOwner()));
+        info.setOwnerGroup(String.valueOf(attributes.getGroup()));
     }
 
     @Required


### PR DESCRIPTION
…to restore info API

Motivation:

It is more probable that users will want to see which of their own files are still staging.  They likely will not have the pnfsids.

Modfication:

It is now possible to filter and sort the results of the RESTful API call GET /restores by path, owner and group.

(NOTE: filtering, as per other RESTful admin commands, means String.contains(), so it is possible to match directories as well).

Result:

More useful filtering and sorting to the general user.

NOTE:  This resource is protected by the `frontend.authz.unlimited-operation-visibility` property, which means that proprietary information can be optionally protected by limiting it to those with admin privileges.

A patch which modifies the dCacheView admin page to provide filtering and sorting on these attributes/parameters follows.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13692/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran