### PR TITLE
dcache: NPE on removal via WebDAV and token

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/OpScopedPrincipal.java
+++ b/modules/common/src/main/java/org/dcache/auth/OpScopedPrincipal.java
@@ -49,6 +49,9 @@ public abstract class OpScopedPrincipal implements Principal, Serializable {
             return true;
         }
 
+        if (other == null) {
+            return false;
+        }
         return this.getClass().equals(other.getClass())
               && ((Principal) other).getName().equals(name);
     }


### PR DESCRIPTION
Motivation

NPE was accuring while sending kafka messages, when JwtJtiPrincipal was used.

Modification

fix the NPE error when toString was called

Target: master, 8.2 8.1 8.0 7.2 7.1 7.0
Require-book: no
Require-notes: yes
Acked-by: Paul Millar