### PR TITLE
dcache-core,dcache-frontend:  add pnfsid and path options to ac psu m…

### DIFF
--- a/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/poolManager/poolmanager.xml
@@ -33,6 +33,7 @@
 
   <bean id="psu" class="diskCacheV111.poolManager.PoolSelectionUnitV2">
     <description>Pool selection unit</description>
+    <property name="pnfsHandler" ref="pnfs"/>
   </bean>
 
   <bean id="cm" class="diskCacheV111.poolManager.CostModuleV1">

--- a/modules/dcache/src/test/java/diskCacheV111/poolManager/PoolSelectionUnitV2Test.java
+++ b/modules/dcache/src/test/java/diskCacheV111/poolManager/PoolSelectionUnitV2Test.java
@@ -5,6 +5,7 @@ import static java.nio.file.Files.readAllBytes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import diskCacheV111.pools.PoolV2Mode;
@@ -436,6 +437,10 @@ public class PoolSelectionUnitV2Test {
 
     private void whenMatchIsCalledWith(String params) {
         Args args = new Args(params);
-        levels = (PoolPreferenceLevel[]) psu.ac_psux_match_$_5(args);
+        try {
+            levels = (PoolPreferenceLevel[]) psu.ac_psux_match_$_5(args);
+        } catch (Exception e) {
+            assertNull("Unexpected exception", e);
+        }
     }
 }


### PR DESCRIPTION
…atch and RESTful resource

Motivation:

See https://rb.dcache.org/r/13686
master@0d3ef24ebf6022378d2667b1764c8e3428ac0753
See https://rb.dcache.org/r/13687
master@120e4a42ebbe3bd57756def6fe47a09a9a7acef0

Modification:

Limited to adding the two new parameters, both
for the admin shell commands and the RESTful API.

All other arguments and options are left unchanged for backward compatibility.

Result:

It should be possible to use ac_psu_match
and ac_psux_match by specifying either a
pnfsId or path.

Target: 8.2
Patch: https://rb.dcache.org/r/13699/
Requires-notes: yes
Acked-by: Tigran