### PR TITLE
dcache-chimera: disk-cleaner, error handling in parallel pool deletes

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
@@ -175,10 +175,13 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
                 CompletableFuture<Void> cf = CompletableFuture.runAsync(
                       () -> {
                           _poolsBeingCleaned.put(pool, System.currentTimeMillis());
-                          runDelete(pool);
-                          runNotification();
-                          _poolsBeingCleaned.remove(pool);
-                          LOGGER.info("Finished deleting from pool {}", pool);
+                          try {
+                              runDelete(pool);
+                              runNotification();
+                          } finally {
+                              _poolsBeingCleaned.remove(pool);
+                              LOGGER.info("Finished deleting from pool {}", pool);
+                          }
                       }, _executor);
                 futures.add(cf);
             } else {
@@ -573,8 +576,8 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
         int threadPoolSize = _executor.getCorePoolSize();
         pw.printf("Cleaning up to %d pools in parallel\n",
               threadPoolSize == 1 ? 1 : threadPoolSize - 1);
-        pw.printf("Pools currently being cleaned: [%s]\n",
-              _poolsBeingCleaned.entrySet().stream().map(e -> e.getKey()).collect(joining(", ")));
+        pw.printf("Pools currently being cleaned: %d [%s]\n", _poolsBeingCleaned.size(),
+              String.join(", ", _poolsBeingCleaned.keySet()));
     }
 
 }


### PR DESCRIPTION
Motivation:
The disk-cleaner is able to clean several pools in parallel according to the number of threads configured. The `info` admin command returns the number of pools currently being cleaned. It has been observed that parallel delete operations that throw exceptions due to problems connecting to the database will cause pool name leaks in the reported list of pools that are actively being cleaned.

Modification:
Wrap the delete operations in `try...finally` blocks to ensure that the pool is always removed from the list of active pools.

Result:
In cases of frequent pool delete exceptions, disk-cleaner will no longer report more active pools than is currently the case.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13711/
Acked-by: Tigran Mkrtchyan