### PR TITLE
pnfsmanager: dispatch create entry messages to threads associated wit…

### DIFF
--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -48,6 +48,7 @@
       <property name="updateQuotaIntervalUnit" value="${pnfsmanager.quota.update.interval.time.unit}"/>
       <property name="quotaSystem" ref="quota-system"/>
       <property name="quotaEnabled" value="${pnfsmanager.enable.quota}"/>
+      <property name="useParentHashOnCreate" value="${pnfsmanager.use-parent-hash-on-create}"/>
   </bean>
 
     <bean id="data-source" class="org.dcache.db.AlarmEnabledDataSource" destroy-method="close">

--- a/skel/share/defaults/pnfsmanager.properties
+++ b/skel/share/defaults/pnfsmanager.properties
@@ -71,6 +71,23 @@ pnfsmanager.plugins.storage-info-extractor=${dcache.plugins.storage-info-extract
 (deprecated)pnfsmanager.limits.threads-per-group = 12
 pnfsmanager.limits.threads = ${pnfsmanager.limits.threads-per-group}
 
+
+#  ---- Thread displatch mechanisms
+#
+#   Experimental feature. Normally message processing is dispatched
+#   to the same thread in the thread pool associated with pnfsid (or path) 
+#   of the namespace entry contained in the messagee. On massive 
+#   uploads (create entries) to a single directory we observed 
+#   performance degradation caused by undelrying db back-end
+#   synchrnization when updating mtime and link count of the target
+#   directory. This leads to all available threads being busy/hanging 
+#   processing create entry messages denying other users from 
+#   accessing the namespace. The switch below, if enabled, would cause 
+#   the create mesages to be  dispatched to a thread associated 
+#   with that entry's parent (that is the target directory).    
+#
+(one-of?true|false)pnfsmanager.use-parent-hash-on-create = false
+
 #  ---- Number of list threads
 #
 #   The PnfsManager uses dedicated threads for directory list


### PR DESCRIPTION
…h parent entries

Motivation:

Normally message processing is dispatched
to the same thread in the thread pool associated with pnfsid (or path) of the namespace entry contained in the messagee. On massive uploads (create entries) to a single directory we observed performance degradation caused by undelrying db back-end synchrnization when updating mtime and link count of the target directory. This leads to all available threads being busy/hanging processing create entry messages denying other users from accessing the namespace.

Modification:

Dispatch create entry messages to threads associated with parent

Result:

Create entry messages are dispatched to threads associated with parent (or target directory) hopefully avoiding the DOS.

Target: trunk
Request: 8.2
Patch: https://rb.dcache.org/r/13673/
Acked-by: Tigran Mkrtchyan