### PR TITLE
dcache-bulk: force admin command STAGE activity to prestore=true, as …

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -924,7 +924,7 @@ public final class BulkServiceCommands implements CellCommandListener {
             request.setDelayClear(delayClear);
             request.setExpandDirectories(Depth.valueOf(expand.toUpperCase()));
             request.setId(UUID.randomUUID().toString());
-            request.setPrestore(prestore);
+            request.setPrestore(activity.equalsIgnoreCase("STAGE") || prestore);
 
             if (arguments != null) {
                 request.setArguments(Splitter.on(',')


### PR DESCRIPTION
…with REST API

Motivation:

The WLCG requirements make prestore necessary on the STAGE activity.  That option is forced to true when submitting through the frontend RESTful resource, but is not
when the admin shell equivalent is issued.

Modification:

Make `\s bulk request submit -activity=STAGE` override the `-prestore` option to true, in conformity with the RESTful API.

Result:

Admin shell is consistent with RESTful API.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13716/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran