### PR TITLE
dcache-xroot:  add note about TLS and host cert/key to documentation

### DIFF
--- a/docs/TheBook/src/main/markdown/config-xrootd.md
+++ b/docs/TheBook/src/main/markdown/config-xrootd.md
@@ -546,6 +546,14 @@ stay tuned for further developments in those areas.
 >practical to make the pools require TLS by setting
 >``pool.mover.xrootd.security.tls.mode=STRICT``.
 
+> **Host cert and key**
+>
+> These are required to be there when the SSHHandlerFactory (which provides
+> TLS support) is loaded at startup.  If either pool.mover.xrootd.security.tls.mode
+> or xrootd.security.tls.mode is set to either OPTIONAL or STRICT, the host cert
+> and key will be required, or the domain will not start.  You can start pools or
+> doors without a host cert/key by setting these properties to OFF.
+
 ###  Multiple authentication protocol chaining and defaults
 
 As of 8.1, dCache now supports the chaining of authentication plugins/protocols on the door.

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -458,6 +458,10 @@ pool.mover.xrootd.security.force-signing=${dcache.xrootd.security.force-signing}
 #      These properties are not linked to a common dcache property
 #      because the door and pool very likely will have different requirements.
 #
+#      NB:  because the default is OPTIONAL, host cert/key will be required on
+#           the pool node.  If it is not there, the pool will not start.
+#           Only with this option set to OFF will pools now start without the cert/key.
+#
 (one-of?OFF|OPTIONAL|STRICT)pool.mover.xrootd.security.tls.mode=OPTIONAL
 (one-of?true|false)pool.mover.xrootd.security.tls.require-login=false
 (one-of?true|false)pool.mover.xrootd.security.tls.require-session=false

--- a/skel/share/defaults/xrootd.properties
+++ b/skel/share/defaults/xrootd.properties
@@ -371,6 +371,10 @@ xrootd.security.force-signing=${dcache.xrootd.security.force-signing}
 #      option, in which case TLS can be deactivated for the door/pool by
 #      setting mode to OFF.
 #
+#      NB: because the default is OPTIONAL, host cert/key will be required on
+#          the door node.  If it is not there, the domain will not start.
+#          Only with this option set to OFF will the domain now start without the cert/key.
+#
 (one-of?OFF|OPTIONAL|STRICT)xrootd.security.tls.mode=OPTIONAL
 (one-of?true|false)xrootd.security.tls.require-login=false
 (one-of?true|false)xrootd.security.tls.require-session=false


### PR DESCRIPTION
Motivation:

With the release of 8.2, users are finding they can't start their pools if there is no host cert/key.  This is because we changed the default TLS options.

Modification:

Add adequate warning about this in the documentation. `OFF` is the only option for TLS which does not require the presence of the host cert/key.

Result:

Users are aware.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13717/
Requires-notes: yes
Requires-book: yes (contained in patch)
Acked-by: Tigran