### PR TITLE
pool: avoid exception based flow in case of nfs bad stateid error

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
@@ -45,6 +45,11 @@ public class EDSOperationREAD extends AbstractNFSv4Operation {
             int count = _args.opread.count.value;
 
             NfsMover mover = nfsTransferService.getMoverByStateId(context, _args.opread.stateid);
+            if (mover == null) {
+                res.status = nfsstat.NFSERR_BAD_STATEID;
+                _log.debug("No mover associated with given stateid: ", _args.opread.stateid);
+                return;
+            }
 
             ByteBuffer bb = BUFFERS.get();
             bb.clear().limit(count);
@@ -64,9 +69,6 @@ public class EDSOperationREAD extends AbstractNFSv4Operation {
             _log.debug("MOVER: {}@{} read, {} requested.", bytesRead, offset,
                   _args.opread.count.value);
 
-        } catch (ChimeraNFSException he) {
-            res.status = he.getStatus();
-            _log.debug(he.getMessage());
         } catch (IOException ioe) {
             _log.error("DSREAD: ", ioe);
             res.status = nfsstat.NFSERR_IO;

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationWRITE.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationWRITE.java
@@ -39,6 +39,12 @@ public class EDSOperationWRITE extends AbstractNFSv4Operation {
         try {
 
             NfsMover mover = nfsTransferService.getMoverByStateId(context, _args.opwrite.stateid);
+            if (mover == null) {
+                res.status = nfsstat.NFSERR_BAD_STATEID;
+                _log.debug("No mover associated with given stateid: ", _args.opwrite.stateid);
+                return;
+            }
+
             if (!mover.getIoMode().contains(StandardOpenOption.WRITE)) {
                 throw new PermException("an attempt to write without IO mode enabled");
             }

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -39,6 +39,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import org.dcache.auth.Subjects;
 import org.dcache.cells.CellStub;
 import org.dcache.chimera.nfsv41.common.StatsDecoratedOperationExecutor;
@@ -383,13 +384,11 @@ public class NfsTransferService
         return _activeIO.remove(mover.getStateId()) != null;
     }
 
-    NfsMover getMoverByStateId(CompoundContext context, stateid4 stateid)
-          throws ChimeraNFSException {
+    @Nullable NfsMover getMoverByStateId(CompoundContext context, stateid4 stateid) {
         NfsMover mover = _activeIO.get(stateid);
-        if (mover == null) {
-            throw new BadStateidException("No mover associated with given stateid: " + stateid);
+        if (mover != null) {
+            mover.attachSession(context.getSession());
         }
-        mover.attachSession(context.getSession());
         return mover;
     }
 


### PR DESCRIPTION
Motivation:
if a NFS client issues IO operation on a pool with stateid that has no associated mover, then BadStateidException is generated to propage the error to the under laying NFS server. Typically client doesn't recover (at least not with RHEL7 clients) from such situation and keeps retrying. As filling exceptions stack trace is CPU intensive operation exception based flows should be avoided.

Modification:
Update EDSOperationREAD and EDSOperationWRITE to return 'bad stateid' error if mo matching mover found without relaying on BadStateidException.

Result:
Less CPU load on pools in case of client accessing a file with invalid/expired state id.

Acked-by: Albert Rossi
Target: master
Require-book: no
Require-notes: no
(cherry picked from commit 0f5b88f4437f498f9c4fa8f2a4dc3fb00ec2e67a)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>