### PR TITLE
dcache-qos: add missing pool tag comparison in PoolOpChangeHandler

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/handlers/PoolOpChangeHandler.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/handlers/PoolOpChangeHandler.java
@@ -61,6 +61,7 @@ package org.dcache.qos.services.scanner.handlers;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import diskCacheV111.poolManager.CostModule;
 import diskCacheV111.poolManager.PoolSelectionUnit;
 import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPool;
 import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPoolGroup;
@@ -69,9 +70,11 @@ import diskCacheV111.poolManager.StorageUnit;
 import diskCacheV111.poolManager.StorageUnitInfoExtractor;
 import diskCacheV111.pools.PoolV2Mode;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.dcache.poolmanager.PoolInfo;
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.qos.data.PoolQoSStatus;
 import org.dcache.qos.services.scanner.data.PoolFilter;
@@ -226,6 +229,9 @@ public final class PoolOpChangeHandler extends
         LOGGER.trace("comparing pool mode");
         comparePoolMode(diff, commonPools, nextPsu);
 
+        LOGGER.trace("comparing pool tags");
+        comparePoolTags(diff, commonPools, currentPoolMonitor, nextPoolMonitor);
+
         return diff;
     }
 
@@ -312,6 +318,24 @@ public final class PoolOpChangeHandler extends
         }
     }
 
+    private void comparePoolTags(PoolOpDiff diff, Set<String> common, PoolMonitor current,
+          PoolMonitor next) {
+        CostModule currentCostModule = current.getCostModule();
+        CostModule nextCostModule = next.getCostModule();
+
+        diff.getNewPools()
+              .forEach(p -> diff.getTagsChanged().put(p, getPoolTags(p, nextCostModule)));
+
+        common.forEach(p -> {
+            Map<String, String> newTags = getPoolTags(p, nextCostModule);
+            Map<String, String> oldTags = getPoolTags(p, currentCostModule);
+            if (oldTags == null || (newTags != null
+                  && !oldTags.equals(newTags))) {
+                diff.getTagsChanged().put(p, newTags);
+            }
+        });
+    }
+
     private Set<String> compareStorageUnits(PoolOpDiff diff,
           PoolSelectionUnit currentPsu,
           PoolSelectionUnit nextPsu) {
@@ -396,6 +420,14 @@ public final class PoolOpChangeHandler extends
         Sets.difference(next, curr).forEach(diff.newGroups::add);
         Sets.difference(curr, next).forEach(diff.oldGroups::add);
         return Sets.intersection(next, curr);
+    }
+
+    private Map<String, String> getPoolTags(String pool, CostModule costModule) {
+        PoolInfo poolInfo = costModule.getPoolInfo(pool);
+        if (poolInfo == null) {
+            return null;
+        }
+        return poolInfo.getTags();
     }
 
     /**

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/handlers/PoolOpDiff.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/handlers/PoolOpDiff.java
@@ -60,7 +60,6 @@ documents or software obtained from this server.
 package org.dcache.qos.services.scanner.handlers;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import diskCacheV111.poolManager.StorageUnit;
 import diskCacheV111.pools.PoolV2Mode;
@@ -114,7 +113,7 @@ public final class PoolOpDiff {
     /*
      *  (pool, tags)
      */
-    private final Map<String, ImmutableMap<String, String>> tagsChanged
+    private final Map<String, Map<String, String>> tagsChanged
           = new HashMap<>();
 
     public Collection<String> getConstraintsChanged() {
@@ -161,7 +160,7 @@ public final class PoolOpDiff {
         return poolsRmved;
     }
 
-    public Map<String, ImmutableMap<String, String>> getTagsChanged() {
+    public Map<String, Map<String, String>> getTagsChanged() {
         return tagsChanged;
     }
 

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/PoolInfoDiff.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/PoolInfoDiff.java
@@ -60,7 +60,6 @@ documents or software obtained from this server.
 package org.dcache.qos.services.verifier.data;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPool;
 import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPoolGroup;
@@ -128,7 +127,7 @@ public final class PoolInfoDiff {
     /*
      *  (pool, tags)
      */
-    private final Map<String, ImmutableMap<String, String>> tagsChanged = new HashMap<>();
+    private final Map<String, Map<String, String>> tagsChanged = new HashMap<>();
 
     /*
      *  (pool, hsms>
@@ -201,7 +200,7 @@ public final class PoolInfoDiff {
         return readPref0;
     }
 
-    public Map<String, ImmutableMap<String, String>> getTagsChanged() {
+    public Map<String, Map<String, String>> getTagsChanged() {
         return tagsChanged;
     }
 

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/PoolInfoMap.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/PoolInfoMap.java
@@ -821,9 +821,8 @@ public class PoolInfoMap {
                 diff.getModeChanged().put(pool, newMode);
             }
 
-            ImmutableMap<String, String> newTags
-                  = getPoolTags(pool, costModule);
-            ImmutableMap<String, String> oldTags = info.getTags();
+            Map<String, String> newTags = getPoolTags(pool, costModule);
+            Map<String, String> oldTags = info.getTags();
             if (oldTags == null ||
                   (newTags != null && !oldTags.equals(newTags))) {
                 diff.getTagsChanged().put(pool, newTags);
@@ -1061,7 +1060,7 @@ public class PoolInfoMap {
      **/
     private PoolInformation setPoolInfo(String pool,
           PoolV2Mode mode,
-          ImmutableMap<String, String> tags,
+          Map<String, String> tags,
           PoolCostInfo cost) {
         PoolInformation entry = poolInfo.getOrDefault(pool, new PoolInformation(pool));
         entry.update(mode, tags, cost);

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/PoolInformation.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/PoolInformation.java
@@ -84,7 +84,7 @@ final class PoolInformation {
     private PoolQoSStatus status;
     private PoolV2Mode mode;
     private boolean excluded;
-    private ImmutableMap<String, String> tags;
+    private Map<String, String> tags;
     private PoolCostInfo costInfo;
     private long lastUpdate;
 
@@ -143,7 +143,7 @@ final class PoolInformation {
         return status;
     }
 
-    synchronized ImmutableMap<String, String> getTags() {
+    synchronized Map<String, String> getTags() {
         return tags;
     }
 


### PR DESCRIPTION
Motivation:

While writing junit tests it came to my attention that the last comparison involving pool tags which should be made by the PoolOpChangeHandler in establishing the diff between receptions of the pool monitor message was missing.

Modification:

Add the necessary code to compare the tags and trigger a scan on the respective pools.

Also converts variable and parameter types using
the tag map from PoolInfo to use the Map interface rather than ImmutableMap.

Result:

Full scan diff behavior is complete now.

Target: master
Request: 8.2
Request: 8.1
Patch: https://rb.dcache.org/r/13726/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran