### PR TITLE
pom.xml:  bump xrootd4j to 4.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.44.v20210927</version.jetty>
-        <version.xrootd4j>4.5.0</version.xrootd4j>
+        <version.xrootd4j>4.5.2</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.2</version.dcache-view>
         <version.netty>4.1.71.Final</version.netty>


### PR DESCRIPTION
Includes:

- xrootd4j: do not release buffer of unconsumed message in AuthenticationHandler (#13722)
- xrootd4j: correct regression in NoAuthenticationProvider also fixes loading of protocol name so that authn:none will map to unix internally (#13725)

This fix should be invisible to the user.

NOTE:  these fixes do not affect 7.2 because
the latter depends on xrootd4j 4.2, in which
the refactoring which these changes affect was
not done.

Target: master
Request: 8.2 => 4.5.2
Request: 8.1 => 4.3.4
Request: 8.0 => 4.3.4
Patch: https://rb.dcache.org/r/13724/
Requires-notes: yes
Requires-book: no
Acked-by: Lea