### PR TITLE
pool: don't publish attached HSM if lfs mode is `precious`

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -1342,7 +1342,7 @@ public class PoolV4
 
             poolManagerMessage.setHostName(NetworkUtils.getCanonicalHostName());
             poolManagerMessage.setTagMap(_tags);
-            if (_hsmSet != null) {
+            if (_hasTapeBackend && (_hsmSet != null)) {
                 poolManagerMessage.setHsmInstances(new TreeSet<>(_hsmSet
                       .getHsmInstances()));
             }


### PR DESCRIPTION
Motivation:
In a setups where pools configured with HSM, but have LargeFileStore mode `precious` then hsm cleaner might send
PoolRemoveFilesFromHSMMessage, which will fail, as operations with HSM are not allowed.

Modification:
Update pools heart beat to include attached HSM information only if HSM operations are allowed, e.g. LFS is `none` or `hsm`.

Result:
The pools with disabled HSM operations are not visible to hsm cleaner.

Closes: #6733
Acked-by: Albert Rossi
Acked-by: Lea Morschel
Target: master, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 09668f444c0c3eaa0549d7cf681182ce6976ca23)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>