### PR TITLE
dcache-qos:  fix two more regressions in the PoolOpChangeHandler

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/handlers/PoolOpChangeHandler.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/handlers/PoolOpChangeHandler.java
@@ -130,9 +130,15 @@ public final class PoolOpChangeHandler extends
         diff.getPoolsRemovedFromPoolGroup().entries()
               .forEach(e -> scanPoolRemovedFromPoolGroup(e, currentPsu));
 
-        LOGGER.trace("Scanning pool groups pointing to new units {}.",
-              diff.getNewUnits());
-        diff.getNewUnits().forEach(u -> scanPoolsWithStorageUnitModified(u.getName(), currentPsu));
+        LOGGER.trace("Scanning pool groups pointing to units added to unit groups {}.",
+              diff.getUnitsAddedToPoolGroup());
+        diff.getUnitsAddedToPoolGroup().values()
+              .forEach(u -> scanPoolsWithStorageUnitModified(u, currentPsu));
+
+        LOGGER.trace("Scanning pool groups pointing to units removed from unit groups {}.",
+              diff.getUnitsRemovedFromPoolGroup());
+        diff.getUnitsRemovedFromPoolGroup().values()
+              .forEach(u -> scanPoolsWithStorageUnitModified(u, currentPsu));
 
         LOGGER.trace("Scanning pool groups with units whose "
                     + "constraints have changed; new constraints {}.",
@@ -407,7 +413,7 @@ public final class PoolOpChangeHandler extends
         PoolV2Mode mode = psu.getPool(pool).getPoolMode();
         poolOperationMap.add(pool);
         poolOperationMap.updateStatus(pool, PoolQoSStatus.valueOf(mode));
-        scanPool(pool, addedTo, mode);
+        scanPool(pool, addedTo, null, mode);
     }
 
     /**


### PR DESCRIPTION
Motivation:

Junit test development uncovered two other reqressions in the handling of PoolMonitor diffs (updates):

- scanPoolAddedToPoolGroup calling scanPool with the wrong number of arguments
- using newUnits instead of unitsAddedToGroups to check for storage unit changes

Modification:

Fix'em.

Result:

PoolMonitor diff'ing should result in the correct calls to rescan pools in all relevant cases.

Target: master
Request: 8.2
Request: 8.1
Patch: https://rb.dcache.org/r/13734
Requires-notes: yes
Requires-book: no
Acked-by: Tigran