### PR TITLE
dcache-frontend: fix type default of RESTful pool/nearline/queues res…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/pool/PoolInfoResources.java
@@ -367,6 +367,7 @@ public final class PoolInfoResources {
     @PathParam("pool") String pool,
           @ApiParam("Select transfers of a specific type "
                 + "(flush, stage, remove).")
+          @DefaultValue("flush,stage,remove")
           @QueryParam("type") String typeList,
           @ApiParam("The number of items to skip.")
           @DefaultValue("0")
@@ -394,8 +395,7 @@ public final class PoolInfoResources {
         int count = 0;
 
         try {
-            String[] types = typeList == null ? new String[0] :
-                  typeList.split(",");
+            String[] types = typeList.split(",");
             for (String type : types) {
                 switch (type) {
                     case "flush":


### PR DESCRIPTION
…ource

Motivation:

The ``type`` parameter to ``/api/v1/pools/{pool}/nearline/queues`` takes a comma-delimited-list of "stage,flush,remove" options.  The intention of the default was to return all types, but there is no default specified.

Modification:

Specify the default.

Result:

Default option works.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13745
Acked-by: Dmitry