### PR TITLE
dcache-qos:  fix minor regressions in handling of pool info diffs

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/PoolInfoMap.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/PoolInfoMap.java
@@ -719,7 +719,7 @@ public class PoolInfoMap {
         Collection<StorageUnit> newUnits = diff.getNewUnits();
         for (StorageUnit unit : newUnits) {
             String name = unit.getName();
-            StorageUnitInfoExtractor.getPrimaryGroupsFor(name, psu)
+            StorageUnitInfoExtractor.getPoolGroupsFor(name, psu, false)
                   .stream()
                   .forEach(g -> diff.unitsAdded.put(g, name));
         }

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/handlers/PoolInfoChangeHandler.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/handlers/PoolInfoChangeHandler.java
@@ -88,6 +88,11 @@ public final class PoolInfoChangeHandler extends
         LOGGER.trace("Cancelling pool operations for removed pools {}.", diff.getOldPools());
         diff.getOldPools().stream().forEach(handler::cancelCurrentFileOpForPool);
 
+        LOGGER.trace("Cancelling pool operations for pools of removed groups {}.",
+              diff.getOldGroups());
+        diff.getOldGroups().forEach(group -> poolInfoMap.getPoolsOfGroup(group)
+              .forEach(handler::cancelCurrentFileOpForPool));
+
         LOGGER.trace("Cancelling pool operations for pools removed from groups {}.",
               diff.getPoolsRemovedFromPoolGroup());
         diff.getPoolsRemovedFromPoolGroup().keySet().stream()


### PR DESCRIPTION
Motivation:

A few minor regressions discovered during development of junit tests.  These undoubtedly occurred as a
consequence of splitting the original diff handler in resilience into separate classes for verifier
and scanner.

Modification:

- Fixed the method in PoolInfoMap which adding mappings for new units only for to primary pool groups.
- Fixed missing cancellation of operations involving pools of removed pool groups in the PoolInfoChangeHandler.

Result:

Correct behavior for pool monitor updates of the PoolInfoMap.

Target: master
Request: 8.2
Request: 8.1
Requires-book: no
Requires-notes: yes
Patch: https://rb.dcache.org/r/13744
Acked-by: Lea