### PR TITLE
dcache.properties: Fyx synax erorr

### DIFF
--- a/skel/share/defaults/pnfsmanager.properties
+++ b/skel/share/defaults/pnfsmanager.properties
@@ -79,7 +79,7 @@ pnfsmanager.limits.threads = ${pnfsmanager.limits.threads-per-group}
 #   of the namespace entry contained in the messagee. On massive 
 #   uploads (create entries) to a single directory we observed 
 #   performance degradation caused by undelrying db back-end
-#   synchrnization when updating mtime and link count of the target
+#   synchronization when updating mtime and link count of the target
 #   directory. This leads to all available threads being busy/hanging 
 #   processing create entry messages denying other users from 
 #   accessing the namespace. The switch below, if enabled, would cause 


### PR DESCRIPTION
Motivatoin:

Patch a59f6c1235f75a8cbec31f65da95af3b9d029c45 introduced minor typo.

Modification:

Fixed typo

Result:

dcache.properties has no typo in previously modified block

Require-notes: no
Require-book: no