### PR TITLE
srm-server: fix bug making trs unit tests more unstable

### DIFF
--- a/modules/srm-server/src/test/java/org/dcache/srm/scheduler/TapeRecallSchedulingStrategyTests.java
+++ b/modules/srm-server/src/test/java/org/dcache/srm/scheduler/TapeRecallSchedulingStrategyTests.java
@@ -52,7 +52,7 @@ public class TapeRecallSchedulingStrategyTests {
     /**
      * time safety margin in milliseconds
      */
-    private static final long TIME_SAFETY_MARGIN = 5;
+    private static final long TIME_SAFETY_MARGIN = 20;
 
     TapeRecallSchedulingStrategy strategy;
     TapeRecallSchedulingRequirementsChecker requirementsChecker;
@@ -352,7 +352,7 @@ public class TapeRecallSchedulingStrategyTests {
 
     @Test
     public void shouldOnlySelectTapesWithCooldownSinceLastJobArrival() throws Exception {
-        requirementsChecker.setMinJobWaitingTime(Duration.ofMinutes(5));
+        requirementsChecker.setMinJobWaitingTime(Duration.ofMinutes(15));
 
         tapeInfoProvider.addTapeFileInfo("/tape/file10.txt", new TapefileInfo(10, "tape1"));
         tapeInfoProvider.addTapeFileInfo("/tape/file11.txt", new TapefileInfo(10, "tape1"));


### PR DESCRIPTION
Motivation:
Commit bf8d071ed987866eedd6600d3b2fecb7e08e267b reduced the `TIME_SAFETY_MARGIN` for timestamps to 5, which leads to less stability while the opposite was intended.

Modification:
Increase `TIME_SAFETY_MARGIN` back to 20 and set the minJobWaitingTime in one tests to be even higher as a safety measure.

Result:
Correct test behaviour.

Target: master
Requires-notes: no
Requires-book: no