### PR TITLE
dcache-bulk:  fix garbled request policy command output

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -129,7 +129,7 @@ public final class BulkServiceCommands implements CellCommandListener {
     /**
      * (policy configuration property:  value)
      */
-    private static final String FORMAT_REQUEST_POLICY = "%-40s : %10s";
+    private static final String FORMAT_REQUEST_POLICY = "%-40s : %10s\n";
 
     /**
      * createdAt | startedAt| completedAt | state | target
@@ -822,17 +822,17 @@ public final class BulkServiceCommands implements CellCommandListener {
             }
 
             return new StringBuilder().append(
-                        String.format(FORMAT_REQUEST_POLICY, "Maximum concurrent (active) requests\n",
+                        String.format(FORMAT_REQUEST_POLICY, "Maximum concurrent (active) requests",
                               requestManager.getMaxActiveRequests()))
-                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum requests per user\n",
+                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum requests per user",
                         service.getMaxRequestsPerUser()))
-                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum expansion depth\n",
+                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum expansion depth",
                         service.getAllowedDepth()))
-                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum flat targets\n",
+                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum flat targets",
                         service.getMaxFlatTargets()))
-                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum shallow targets\n",
+                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum shallow targets",
                         service.getMaxShallowTargets()))
-                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum recursive targets\n",
+                  .append(String.format(FORMAT_REQUEST_POLICY, "Maximum recursive targets",
                         service.getMaxRecursiveTargets())).toString();
         }
     }


### PR DESCRIPTION
dcache-bulk:  fix garbled request policy command output

Motivation:

Newline is in the wrong place in string formatting of request policy output.

Modification:

Move it to the correct position.

Result:

Correctly formatted output.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13764/
Requires-notes: yes
Requires-book: no
Acked-by: Tigran