### PR TITLE
dcache-bulk: fix message thread invocation of database query for stat…

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/ConcurrentRequestManager.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/ConcurrentRequestManager.java
@@ -207,7 +207,7 @@ public final class ConcurrentRequestManager implements BulkRequestManager {
                 throw new InterruptedException();
             }
 
-            updateJobStatistics(start);
+            statistics.sweepFinished(System.currentTimeMillis() - start);
 
             LOGGER.trace("doRun() completed");
         }
@@ -254,15 +254,6 @@ public final class ConcurrentRequestManager implements BulkRequestManager {
                 userRequests().values().stream().filter(this::isTerminated)
                       .forEach(requestJobs::remove);
             }
-        }
-
-        private void updateJobStatistics(long start) {
-            try {
-                statistics.activeRequests(requestStore.countActive());
-            } catch (BulkStorageException e) {
-                LOGGER.error("problem finding number of active requests: {}.", e.toString());
-            }
-            statistics.sweepFinished(System.currentTimeMillis() - start);
         }
 
         private ListMultimap<String, String> userRequests() {

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -177,6 +177,14 @@
     <property name="expiry" value="${bulk.limits.request-cache-expiration}"/>
     <property name="expiryUnit" value="${bulk.limits.request-cache-expiration.unit}"/>
     <property name="capacity" value="${bulk.limits.container-processing-threads}"/>
+    <property name="countUpdater">
+      <bean class="java.util.concurrent.ScheduledThreadPoolExecutor">
+        <constructor-arg value="1"/>
+      </bean>
+    </property>
+    <property name="updateInterval" value="${bulk.limits.counts-update-interval}"/>
+    <property name="updateIntervalUnit" value="${bulk.limits.counts-update-interval.unit}"/>
+    <property name="utils" ref="bulk-jdbc-dao-utils"/>
   </bean>
 
   <bean id="target-store" class="org.dcache.services.bulk.store.jdbc.rtarget.JdbcBulkTargetStore">
@@ -255,7 +263,8 @@
 
   <bean id="statistics" class="org.dcache.services.bulk.util.BulkServiceStatistics">
     <description>Tracks request and target states (counts), sweeper state, etc.</description>
-    <property name="targetStore" ref="target-store"/>
+    <property name="requestDao" ref="bulk-request-dao"/>
+    <property name="daoUtils" ref="bulk-jdbc-dao-utils"/>
   </bean>
 
   <bean id="request-handler" class="org.dcache.services.bulk.handler.BulkRequestHandler">

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
@@ -322,4 +322,55 @@
             CREATE INDEX CONCURRENTLY idx_request_prestore on bulk_request(prestore);
         </sql>
     </changeSet>
+
+    <changeSet author="arossi" id="3.0">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="counts_by_state"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="counts_by_state">
+            <column name="state" type="varchar(16)">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="idx_counts_state_id"/>
+            </column>
+            <column name="count" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <insert tableName="counts_by_state">
+            <column name="state" value="ACTIVE"/>
+            <column name="count" value="0"/>
+        </insert>
+        <insert tableName="counts_by_state">
+            <column name="state" value="CREATED"/>
+            <column name="count" value="0"/>
+        </insert>
+        <insert tableName="counts_by_state">
+            <column name="state" value="READY"/>
+            <column name="count" value="0"/>
+        </insert>
+        <insert tableName="counts_by_state">
+            <column name="state" value="RUNNING"/>
+            <column name="count" value="0"/>
+        </insert>
+        <insert tableName="counts_by_state">
+            <column name="state" value="CANCELLED"/>
+            <column name="count" value="0"/>
+        </insert>
+        <insert tableName="counts_by_state">
+            <column name="state" value="COMPLETED"/>
+            <column name="count" value="0"/>
+        </insert>
+        <insert tableName="counts_by_state">
+            <column name="state" value="FAILED"/>
+            <column name="count" value="0"/>
+        </insert>
+        <insert tableName="counts_by_state">
+            <column name="state" value="SKIPPED"/>
+            <column name="count" value="0"/>
+        </insert>
+        <rollback/>
+    </changeSet>
 </databaseChangeLog>

--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -100,6 +100,12 @@ bulk.limits.max.targets-per-recursive-request=10
 bulk.limits.sweep-interval=5
 (one-of?MILLISECONDS|SECONDS|MINUTES)bulk.limits.sweep-interval.unit=SECONDS
 
+#  ---- Interval between sweeps to update the request and target counts.
+#       Calls the underlying stores (database tables).
+#
+bulk.limits.counts-update-interval=1
+(one-of?MILLISECONDS|SECONDS|MINUTES)bulk.limits.counts-update-interval.unit=MINUTES
+
 # ---- Endpoint for contacting pnfs manager.
 #
 bulk.service.pnfsmanager=${dcache.service.pnfsmanager}

--- a/skel/share/services/bulk.batch
+++ b/skel/share/services/bulk.batch
@@ -20,6 +20,8 @@ check -strong bulk.limits.max.targets-per-shallow-request
 check -strong bulk.limits.max.targets-per-recursive-request
 check -strong bulk.limits.sweep-interval
 check -strong bulk.limits.sweep-interval.unit
+check -strong bulk.limits.counts-update-interval
+check -strong bulk.limits.counts-update-interval.unit
 check -strong bulk.service.pnfsmanager
 check -strong bulk.service.pnfsmanager.timeout
 check -strong bulk.service.pnfsmanager.timeout.unit


### PR DESCRIPTION
…istics

Motivation:

The bulk admin interface provides an `info` command for monitoring the current state of the service and tracking request progress. There are currently two issues, however, with the collection of these request and target statistics.

1.  The request manager calls update after each sweep, which in turn calls requestStore.activeRequests.
2.  getInfo [CellInfoProvider] similarly calls activeRequests as well as targetStore.countsByState.

Both of these call sites thus will potentially block the executing thread on a database connection.  When the respective tables fill up, count and group-by count queries can in fact become very slow.

The issue reveals itself most clearly when `getInfo` is periodically called via messaging (e.g., by the frontend or httpd collectors); since the call is done on the message thread, this potentially results in the blocking of further message processing (including other admin commands) until the db queries have completed.

Modification:

The problem has been solved by the following steps:

- Have the request manager only update the sweep time.
- Create a new table `counts_by_state` to store updated counts for both active requests and the states of a target.
- Have `getInfo` read its values from this table only.
- Offload the table updating onto a scheduled repeating task which runs the expensive queries once every so often (default = 2 minutes).

We have opted to store the values in a DB table so that the most recent counts are immediately visible upon restart.  We have avoided doing this using a trigger for reasons that are by now well known regarding Postgres autovacuum.

Of course, issuing:

```
\s bulk request ls -count
\s bulk target ls -count
```

with or without filters (`-status` or `state`, etc., respectively) will still take longer as the `bulk_request` and `request_target` tables become large.  But at least the cell will not have a very long ping/roundtrip time or be classified as unavailable.

This is a substantial change, but I believe the problem is important enough to warrant a back-port to 8.2.

Target:  master
Request: 8.2
Patch: https://rb.dcache.org/r/13766
Requires-notes: yes
Acked-by: Tigran