### PR TITLE
nearline-storage: fix race in flushing removed file

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1203,9 +1203,14 @@ public class NearlineStorageHandler
                 try {
                     pnfs.getFileAttributes(pnfsId, EnumSet.noneOf(FileAttribute.class));
                 } catch (FileNotFoundCacheException e) {
-                    // Remove file asynchronously to prevent request cancellation from
-                    // interrupting the state update.
-                    executor.execute(() -> removeFile(pnfsId));
+                    // Remove the file after flush canceled.
+                    addCallback(new NopCompletionHandler<>() {
+                        @Override
+                        public void failed(Throwable exc, PnfsId file) {
+                            removeFile(file);
+                        }
+                    });
+
                     throw new FileNotFoundCacheException(
                           "File not found in name space during pre-flush check.", e);
                 }
@@ -1225,9 +1230,13 @@ public class NearlineStorageHandler
                 try {
                     path = pnfs.getPathByPnfsId(pnfsId);
                 } catch (FileNotFoundCacheException e) {
-                    // Remove file asynchronously to prevent request cancellation from
-                    // interrupting the state update.
-                    executor.execute(() -> removeFile(pnfsId));
+                    // Remove the file after flush canceled.
+                    addCallback(new NopCompletionHandler<>() {
+                        @Override
+                        public void failed(Throwable exc, PnfsId file) {
+                            removeFile(file);
+                        }
+                    });
                     throw new FileNotFoundCacheException(
                           "File not found in name space during pre-flush check.", e);
                 }


### PR DESCRIPTION
Motivation:
When flushing removed files pool runs the following sequence:

- activates the request
- checks file existence (which fails)
- on check failure triggers file removal
- fails flush request.

The removal of the file triggers flush cancellation if still active, which follows with failing of flush request. This happens from a different thread.

In a race situation, the failure in flush thread and fluch cancellation in file removal thread try to decrease canceled request counter twice:

```
java.lang.IllegalArgumentException: Negative number of active requests
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145)
        at org.dcache.pool.nearline.NearlineStorageHandler$QueueStat.<init>(NearlineStorageHandler.java:151)
        at org.dcache.pool.nearline.NearlineStorageHandler$AbstractRequest.incCancelFromActive(NearlineStorageHandler.java:680)
        at org.dcache.pool.nearline.NearlineStorageHandler$AbstractRequest.cancel(NearlineStorageHandler.java:583)
        at org.dcache.pool.nearline.NearlineStorageHandler$AbstractRequestContainer.cancel(NearlineStorageHandler.java:804)
        at org.dcache.pool.nearline.NearlineStorageHandler.stateChanged(NearlineStorageHandler.java:476)
        at org.dcache.pool.repository.v5.StateChangeListeners.lambda$stateChanged$0(StateChangeListeners.java:60)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

This issues can be avoid, if file removal delayed until flush request complete (exceptionally).

Modification:
bind file removal to post-execution callback.

Result:
The race condition can't be reproduced.

Fixes: #6426
Acked-by: Albert Rossi
Target: master, 8.2, 8.1, 8.0, 7.2
Require-book: no
Require-notes: yes
(cherry picked from commit 3dff15a4a1a8195f21d4fd0ccc50afa7e6ea7e57)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>