### PR TITLE
nearline-storage: fix NPE on error path

### DIFF
--- a/modules/dcache-nearline-spi/src/main/java/org/dcache/pool/nearline/AbstractBlockingNearlineStorage.java
+++ b/modules/dcache-nearline-spi/src/main/java/org/dcache/pool/nearline/AbstractBlockingNearlineStorage.java
@@ -348,9 +348,9 @@ public abstract class AbstractBlockingNearlineStorage implements NearlineStorage
         }
 
         public void run() {
+            Thread currentThread = Thread.currentThread();
             try {
-                Thread thread = Thread.currentThread();
-                if (bind(thread)) {
+                if (bind(currentThread)) {
                     boolean isSuccess = false;
                     T result = null;
                     try {
@@ -386,7 +386,7 @@ public abstract class AbstractBlockingNearlineStorage implements NearlineStorage
                     }
                 }
             } catch (Throwable e) {
-                thread.getUncaughtExceptionHandler().uncaughtException(thread, e);
+                currentThread.getUncaughtExceptionHandler().uncaughtException(currentThread, e);
             }
         }
 


### PR DESCRIPTION
Motivation:
The AbstractBlockingNearlineStorage.Task#run uses thread bind-release mechanist to associate a task with a thread. Finally, a catch block is used to process uncaught exception with the bound thread. However, the `release` call between releases the bound thread, which is a source of NPE:

```
try {
  bind(); // thread = Thread.currentThread()

  ...

  release(); // thread = null;

} catch( Throwable t) {
  thread.uncaughtException(thread, e);
}
```

java.lang.NullPointerException: null
        at org.dcache.pool.nearline.AbstractBlockingNearlineStorage$Task.run(AbstractBlockingNearlineStorage.java:390)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)

Modification:
make sure that uncaughtException is executed by current thread, independent of it's binding state. Change the variable name to avoid method variable and class field name conflict.

Result:
No NPE

Ref: #6426
Acked-by: Marina Sahakyan
Target: master, 8.2, 8.1, 8.0, 7.2
Require-book: no
Require-notes: yes
(cherry picked from commit b708a6ce5362649f2b49daf1bd62a40d726abefc)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>