### PR TITLE
poolmanager: use net unit groups to identify the request

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -999,7 +999,8 @@ public class PoolSelectionUnitV2
             if (unit == null) {
                 return NO_NET;
             }
-            return unit.getCanonicalName();
+            return unit._uGroupList.isEmpty() ? unit.getName() :
+                  unit._uGroupList.keySet().stream().collect(Collectors.joining("-"));
         } finally {
             runlock();
         }


### PR DESCRIPTION
Motivation:
When a new entry is added to the RequestContainer the file pnfsid and netunit is used as an unique identity. However, despite the fact that
 two different units are a members of the same unit group, we might get
two requests created, thus two stages are triggered. For instance:

0.0.0.0/0.0.0.0 & ::/0 => world-net

00007BBC36AB359E47A383A75CFA2AB6CDEF@0.0.0.0/0.0.0.0-*/* m=1 r=1339 [pool_A] [Waiting for stage: pool_A 10.05 16:41:55] {0,} 00007BBC36AB359E47A383A75CFA2AB6CDEF@::/0 m=1 r=1339 [pool_B] [Waiting for stage: pool_B 10.05 16:43:23] {0,}

Modification:
Update PoolSelectionUnit to compose NetIdentifier from the unit groups of the net units

Result:

00007BBC36AB359E47A383A75CFA2AB6CDEF@world-net-*/* m=1 r=1339 [pool_A] [Waiting for stage: pool_A 10.05 17:11:37] {0,}

Acked-by: Dmitry Litvintsev
Target: master, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 620ec5d710ef30f8dff1057a859eb6cbf56f9603)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>