### PR TITLE
dcache-chimera: make sure non-leader does not execute clean run

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/AbstractCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/AbstractCleaner.java
@@ -134,13 +134,13 @@ public abstract class AbstractCleaner implements LeaderLatchListener {
     }
 
     @Override
-    public void isLeader() {
+    public synchronized void isLeader() {
         _hasHaLeadership = true;
         scheduleCleanerTask();
     }
 
     @Override
-    public void notLeader() {
+    public synchronized void notLeader() {
         _hasHaLeadership = false;
         cancelCleanerTask();
     }

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
@@ -107,6 +107,11 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
     protected void runDelete() throws InterruptedException {
         NDC.push(CLEANER_TYPE);
         try {
+            if (!_hasHaLeadership) {
+                LOGGER.warn("Delete run triggered despite not having leadership. "
+                      + "We assume this is a transient problem.");
+                return;
+            }
             LOGGER.info("New run...");
 
             LOGGER.debug("INFO: Refresh Interval : {} {}", _refreshInterval, _refreshIntervalUnit);

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/HsmCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/HsmCleaner.java
@@ -361,6 +361,11 @@ public class HsmCleaner extends AbstractCleaner implements CellMessageReceiver, 
     protected void runDelete() throws InterruptedException {
         NDC.push(CLEANER_TYPE);
         try {
+            if (!_hasHaLeadership) {
+                LOGGER.warn("Delete run triggered despite not having leadership. "
+                      + "We assume this is a transient problem.");
+                return;
+            }
             LOGGER.info("New run...");
 
             int locationsCached = _locationsToDelete.values().stream().map(Set::size)
@@ -425,7 +430,7 @@ public class HsmCleaner extends AbstractCleaner implements CellMessageReceiver, 
     }
 
     @Override
-    public void notLeader() {
+    public synchronized void notLeader() {
         super.notLeader();
         // All not yet sent but cached requests can be cleared
         Iterator<String> keyIterator = _locationsToDelete.keySet().iterator();

--- a/modules/dcache/src/main/java/org/dcache/cells/HAServiceLeadershipManager.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/HAServiceLeadershipManager.java
@@ -102,7 +102,7 @@ public class HAServiceLeadershipManager implements CellIdentityAware, CellComman
         return zkLeaderLatch.hasLeadership();
     }
 
-    private void releaseLeadership() {
+    private synchronized void releaseLeadership() {
         try {
             zkLeaderLatch.close(LeaderLatch.CloseMode.NOTIFY_LEADER);
         } catch (Exception e) {


### PR DESCRIPTION
Motivation:
Observed a single instance of a cleaner cell having dropped leadership, but triggering a new `runDelete` nonetheless. No error was reported, but retaking, then dropping leadership again via command line was effective.

Modification:
Syncronize a few methods that could potentially result in unwanted HA role states. Ensure that a cleaner has leadership before triggering `runDelete`. If that is not the case, log a warning.

Result:
Cleaner cells that do not have leadership will more strictly enforce not triggering delete runs.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13748/
Acked-by: Albert Rossi