### PR TITLE
dcache-chimera: make sure non-leader does not execute clean run

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/AbstractCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/AbstractCleaner.java
@@ -134,13 +134,13 @@ public abstract class AbstractCleaner implements LeaderLatchListener {
     }
 
     @Override
-    public void isLeader() {
+    public synchronized void isLeader() {
         _hasHaLeadership = true;
         scheduleCleanerTask();
     }
 
     @Override
-    public void notLeader() {
+    public synchronized void notLeader() {
         _hasHaLeadership = false;
         cancelCleanerTask();
     }

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
@@ -101,6 +101,11 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
      */
     @Override
     protected void runDelete() throws InterruptedException {
+        if (!_hasHaLeadership) {
+            LOGGER.warn("Delete run triggered despite not having leadership. "
+                  + "We assume this is a transient problem.");
+            return;
+        }
         try {
             LOGGER.info("*********NEW_RUN*************");
 

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/HsmCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/HsmCleaner.java
@@ -351,6 +351,13 @@ public class HsmCleaner extends AbstractCleaner implements CellMessageReceiver, 
      */
     @Override
     protected void runDelete() throws InterruptedException {
+        if (!_hasHaLeadership) {
+            LOGGER.warn("Delete run triggered despite not having leadership. "
+                  + "We assume this is a transient problem.");
+            return;
+        }
+        LOGGER.info("New run...");
+
         int locationsCached = _locationsToDelete.values().stream().map(Set::size)
               .reduce(0, Integer::sum);
         int queryLimit = _maxCachedDeleteLocations - locationsCached;
@@ -408,7 +415,7 @@ public class HsmCleaner extends AbstractCleaner implements CellMessageReceiver, 
     }
 
     @Override
-    public void notLeader() {
+    public synchronized void notLeader() {
         super.notLeader();
         // All not yet sent but cached requests can be cleared
         Iterator<String> keyIterator = _locationsToDelete.keySet().iterator();

--- a/modules/dcache/src/main/java/org/dcache/cells/HAServiceLeadershipManager.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/HAServiceLeadershipManager.java
@@ -102,7 +102,7 @@ public class HAServiceLeadershipManager implements CellIdentityAware, CellComman
         return zkLeaderLatch.hasLeadership();
     }
 
-    private void releaseLeadership() {
+    private synchronized void releaseLeadership() {
         try {
             zkLeaderLatch.close(LeaderLatch.CloseMode.NOTIFY_LEADER);
         } catch (Exception e) {


### PR DESCRIPTION
Motivation:
Observed a single instance of a cleaner cell having dropped leadership, but triggering a new `runDelete` nonetheless. No error was reported, but retaking, then dropping leadership again via command line was effective.

Modification:
Syncronize a few methods that could potentially result in unwanted HA role states. Ensure that a cleaner has leadership before triggering `runDelete`. If that is not the case, log a warning.

Result:
Cleaner cells that do not have leadership will more strictly enforce not triggering delete runs.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13748/
Acked-by: Albert Rossi