### PR TITLE
dcache-bulk:  add id,rid index on request target table

### DIFF
--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
@@ -378,7 +378,7 @@
          (select * from request_target where rid = ? order by id limit ?)
          because otherwise the optimizer chooses to do a full table scan with
          a filter on the rid -->
-    <changeSet author="arossi" id="4.0" runInTransaction="false" dbms="postgresql">
+    <changeSet author="arossi" id="4.0" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <and>
                 <not>
@@ -386,8 +386,10 @@
                 </not>
             </and>
         </preConditions>
-        <sql splitStatements="false">
-            CREATE INDEX CONCURRENTLY idx_target_id_rid on request_target(id,rid);
-        </sql>
+        <createIndex tableName="request_target"
+          indexName="idx_target_id_rid">
+            <column name="id"/>
+            <column name="rid"/>
+        </createIndex>
     </changeSet>
 </databaseChangeLog>

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
@@ -378,7 +378,7 @@
          (select * from request_target where rid = ? order by id limit ?)
          because otherwise the optimizer chooses to do a full table scan with
          a filter on the rid -->
-    <changeSet author="arossi" id="4.0" runInTransaction="false">
+    <changeSet author="arossi" id="4.0" runInTransaction="false" dbms="postgresql">
         <preConditions onFail="MARK_RAN">
             <and>
                 <not>

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
@@ -373,4 +373,21 @@
         </insert>
         <rollback/>
     </changeSet>
+
+    <!-- necessary to support paging on target:
+         (select * from request_target where rid = ? order by id limit ?)
+         because otherwise the optimizer chooses to do a full table scan with
+         a filter on the rid -->
+    <changeSet author="arossi" id="4.0" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <not>
+                    <indexExists indexName="idx_target_id_rid"/>
+                </not>
+            </and>
+        </preConditions>
+        <sql splitStatements="false">
+            CREATE INDEX CONCURRENTLY idx_target_id_rid on request_target(id,rid);
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Motivation:

Retrieval of potentially long lists in bulk, e.g., of targets or even requests, use implicit (admin)
or explicit (REST) paging to fetch batches at
a time.  This means that they need to be ordered
sequentially and a limit applied on the database
query.

Without indexing on Y, for a query like
"SELECT ... FROM ... WHERE X=x ORDER BY Y LIMIT Z" the Postgres query optimizer elects to
do a full scan with a filter on the X
condition (without the limit, it will use a
bitmap scan on X).

Modification:

Add the necessary index (actually a composite here) on the request_target table to facilitate this query.

Result:

Significant speed-up on retrieval of target rows;
this is essential once the table grows to > 100M.

Target: master
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13781/
Acked-by: Lea