### PR TITLE
dcache-bulk: fix type error in updateCounts

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/JdbcBulkDaoUtils.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/JdbcBulkDaoUtils.java
@@ -264,9 +264,9 @@ public final class JdbcBulkDaoUtils {
         LOGGER.trace("updateCounts {} : {}.", countActive, countsByState);
         support.getJdbcTemplate().update(UPDATE_STATE_COUNT, countActive, "ACTIVE");
         Arrays.stream(BulkRequestTarget.State.values()).forEach(state -> {
-            Long count = countsByState.get(state);
-            support.getJdbcTemplate()
-                  .update(String.format(UPDATE_STATE_COUNT, count == null ? 0L : count, state));
+            String key = state.name();
+            Long count = countsByState.get(key);
+            support.getJdbcTemplate().update(UPDATE_STATE_COUNT, count == null ? 0L : count, key);
         });
     }
 }


### PR DESCRIPTION
Motivation:

master@b6bbfccbe4795568e46fc1bb1b379adf8e2de8ea https://rb.dcache.org/r/13766/ botched the fix for sql injection in the method which inserts the updated counts.

Modification:

Fix it.

Result:

The updates appear in the table and are reported by `info()` instead of throwing an invisible error and remaining `0`.

Target: master
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13778/
Acked-by: Lea