### PR TITLE
dcache-bulk: initialize/load and reset on executor thread

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkService.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkService.java
@@ -140,32 +140,7 @@ public final class BulkService implements CellLifeCycleAware, CellMessageReceive
          */
         waitForNamespace();
 
-        /*
-         * See store specifics for how reload is handled, but the minimal contract is
-         * that all incomplete requests be reset to the QUEUED state.
-         * There is no danger in a race here because the state of the
-         * requests is not checked until the request job manager is initialized
-         * and started.
-         */
-        try {
-            LOGGER.info("Loading requests into the request store/queue; "
-                  + "incomplete requests will be reset to QUEUED.");
-            requestStore.load();
-        } catch (BulkServiceException e) {
-            LOGGER.error("There was a problem reloading requests: {}.", e.toString());
-        }
-
-        try {
-            LOGGER.info("Initializing the job manager.");
-            requestManager.initialize();
-        } catch (Exception e) {
-            LOGGER.error("There was a problem initializing the job queue: {}.", e.toString());
-        }
-
-        LOGGER.info("Signalling the job manager.");
-        requestManager.signal();
-
-        LOGGER.info("Service startup completed.");
+        incomingExecutorService.execute(() -> initialize());
     }
 
     public Reply messageArrived(BulkRequestMessage message) {
@@ -470,6 +445,35 @@ public final class BulkService implements CellLifeCycleAware, CellMessageReceive
                 }
                 break;
         }
+    }
+
+    private void initialize() {
+        /*
+         * See store specifics for how reload is handled, but the minimal contract is
+         * that all incomplete requests be reset to the QUEUED state.
+         * There is no danger in a race here because the state of the
+         * requests is not checked until the request job manager is initialized
+         * and started.
+         */
+        try {
+            LOGGER.info("Loading requests into the request store/queue; "
+                  + "incomplete requests will be reset to QUEUED.");
+            requestStore.load();
+        } catch (BulkServiceException e) {
+            LOGGER.error("There was a problem reloading requests: {}.", e.toString());
+        }
+
+        try {
+            LOGGER.info("Initializing the job manager.");
+            requestManager.initialize();
+        } catch (Exception e) {
+            LOGGER.error("There was a problem initializing the job queue: {}.", e.toString());
+        }
+
+        LOGGER.info("Signalling the job manager.");
+        requestManager.signal();
+
+        LOGGER.info("Service startup completed.");
     }
 
     private void matchActivity(String activity, String requestId)

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -83,6 +83,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import javax.security.auth.Subject;
 import org.dcache.auth.Subjects;
@@ -854,13 +855,17 @@ public final class BulkServiceCommands implements CellCommandListener {
             List<String> ids = requestIds();
             StringBuilder requests = new StringBuilder();
             for (String id : ids) {
-                requestStore.reset(id);
-                requests.append("\t")
-                      .append(id)
-                      .append("\n");
+                executor.submit(()-> {
+                    try {
+                        requestStore.reset(id);
+                    } catch (BulkStorageException e) {
+                        LOGGER.error("could not reset {}: {}.", id, e.toString());
+                    }
+                });
+                requests.append("\t").append(id).append("\n");
             }
 
-            return "Reset:\n" + requests;
+            return "Resetting:\n" + requests + "\nCheck pinboard for any errors.";
         }
     }
 
@@ -1125,10 +1130,16 @@ public final class BulkServiceCommands implements CellCommandListener {
     private BulkActivityFactory activityFactory;
     private BulkTargetStore targetStore;
     private BulkServiceStatistics statistics;
+    private ExecutorService executor;
 
     @Required
     public void setActivityFactory(BulkActivityFactory activityFactory) {
         this.activityFactory = activityFactory;
+    }
+
+    @Required
+    public void setExecutor(ExecutorService executor) {
+        this.executor = executor;
     }
 
     @Required

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -332,5 +332,14 @@
     <property name="requestManager" ref="request-manager"/>
     <property name="submissionHandler" ref="request-handler"/>
     <property name="statistics" ref="statistics"/>
+    <property name="executor">
+      <bean class="org.dcache.util.CDCExecutorServiceDecorator" destroy-method="shutdownNow">
+        <constructor-arg>
+          <bean class="org.dcache.util.BoundedCachedExecutor">
+            <constructor-arg value="1"/>
+          </bean>
+        </constructor-arg>
+      </bean>
+    </property>
   </bean>
 </beans>


### PR DESCRIPTION
Motivation:

Bulk reload on restart munges the state of all the non-terminal requests, which means resetting / deleting targets.  This can take a bit of time.

Currently, this is all done on the cell startup thread, which is not optimal, because it can block access to the cell.  What needs to take place is something similar to what happens in resilience/ QoS:  an initializer executes these routines on a separate thread, and then starts the manager.  This allows for logging into the cell, and even for submission of new requests (which will be queued).

Modification:

Execute the second half of the intialization on an incoming executor thread.  Add an executor (single threaded) to the BulkServiceCommands and execute reset on that queue as well.

Result:

The bulk service only locks at the beginning until the namespace has been successfully pinged.  All reloading of previous tasks takes place under the covers.  Note that the manager still starts only after the reloading activity has completed.  Incoming requests will of course be deprioritized as their timestamps are posterior to the reloaded requests.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13787/
Requires-notes: yes
Acked-by: Tigran