### PR TITLE
dcache-bulk, frontend: fix two small bugs

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkService.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkService.java
@@ -421,7 +421,8 @@ public final class BulkService implements CellLifeCycleAware, CellMessageReceive
 
     private synchronized void checkTargetCount(BulkRequest request)
           throws BulkPermissionDeniedException {
-        int listSize = request.getTarget().size();
+        List<String> targets = request.getTarget();
+        int listSize = targets == null ? 0 : targets.size();
         switch (request.getExpandDirectories()) {
             case NONE:
                 if (listSize > maxFlatTargets) {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
@@ -251,6 +251,10 @@ public final class BulkRequestHandler implements BulkSubmissionHandler,
                     case COMPLETED:
                         LOGGER.debug("already terminated: {}.", id);
                         return;
+                    case QUEUED:
+                        /* cancel all targets*/
+                        targetStore.cancelAll(id);
+                        break;
                 }
             } else {
                 throw new IllegalStateException("request status for " + id

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
@@ -142,6 +142,11 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
 
     @Override
     protected void preprocessTargets() throws InterruptedException {
+        if (request.getTarget().isEmpty()) {
+            containerState = ContainerState.STOP;
+            update(FAILED);
+            return;
+        }
         storeAll(request.getTarget());
     }
 
@@ -331,6 +336,12 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
          *  For later processing.
          */
         semaphore.release(activity.getMaxPermits());
+
+        if (targetInfo.isEmpty()) {
+            containerState = containerState.STOP;
+            update(FAILED);
+            return;
+        }
 
         /*
          *  This must be done serially to preserve sequence numbers of directories

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
@@ -114,6 +114,12 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
     protected void processFileTargets() throws InterruptedException {
         List<String> requestTargets = request.getTarget();
 
+        if (requestTargets.isEmpty()) {
+            containerState = ContainerState.STOP;
+            update(FAILED);
+            return;
+        }
+
         for (String tgt : requestTargets) {
             checkForRequestCancellation();
             FsPath path = computeFsPath(targetPrefix, tgt);

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
@@ -416,7 +416,11 @@ public final class BulkResources {
             request.setArguments(stringified);
         }
 
-        request.setTarget(extractTarget(map));
+        List<String> targets = extractTarget(map);
+        if (targets.isEmpty()) {
+            throw new BadRequestException("request contains no targets.");
+        }
+        request.setTarget(targets);
 
         String string = removeEntry(map, String.class, "activity");
         request.setActivity(string);


### PR DESCRIPTION
Motivation:

Two small bugs:
- cancel on a QUEUED request fails to move the request from CANCELLING to CANCELLED state
- if the target attribute of BulkRequest is an empty list, the request never completes.

Modification:

For QUEUED, add pre-emption of all targets up front. For empty target list, add the necessary missing empty checks.

For good measure, I have also added the 400 BadRequest error to BulkResource when the target is empty (this is in conformity with StageResource).

Result:

Both of these conditions are now handled correctly.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13788
Requires-notes: yes
Acked-by: Tigran