### PR TITLE
dcache-xroot:  do not publish link local address for door

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -439,9 +439,12 @@ public class XrootdDoor
     public Optional<InetSocketAddress> publicEndpoint() {
         return _loginBrokerInfo.flatMap(i -> {
             List<InetAddress> addresses = i.getAddresses();
-            return addresses.isEmpty()
-                  ? Optional.empty()
-                  : Optional.of(new InetSocketAddress(addresses.get(0), i.getPort()));
+            for (InetAddress addr : addresses) {
+                if (!addr.isLinkLocalAddress() && !addr.isLoopbackAddress()) {
+                    return Optional.of(new InetSocketAddress(addr, i.getPort()));
+                }
+            }
+            return Optional.empty();
         });
     }
 


### PR DESCRIPTION
Motivation:

Checksum on xrdcp is failing because the pool
is given a link local address by the door to use
to redirect the client back.

See:  LinkLocal addresses used by xroot checksum redirection (failing xroot uploads) https://github.com/dCache/dcache/issues/6884

The code introduced by https://rb.dcache.org/r/13491/ serves up the first address in the list returned
by the NetworkUtils call, but this is sometimes
the link local address.

Modification:

Explicitly exclude link local and loopback addresses from the publishable door addresses.

Result:

`xrdcp --cksum` works again.

Target: master
Request: 8.2
Closes: #6884
Requires-notes: yes
Patch: https://rb.dcache.org/r/13798/
Acked-by: Dmitry