### PR TITLE
dcache-bulk: insert targets immediately on submit

### DIFF
--- a/modules/common/src/main/java/org/dcache/db/JdbcUpdate.java
+++ b/modules/common/src/main/java/org/dcache/db/JdbcUpdate.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  */
 public abstract class JdbcUpdate {
 
-    final Map<String, Object> updates = new LinkedHashMap<>();
+    protected final Map<String, Object> updates = new LinkedHashMap<>();
 
     /**
      * @return the column, value pairs.

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/AbstractRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/AbstractRequestContainerJob.java
@@ -151,7 +151,7 @@ public abstract class AbstractRequestContainerJob
 
     protected volatile ContainerState containerState;
 
-    private final long pid;
+    private final Long pid;
     private final TargetType targetType;
     private final BulkRequestTarget target;
     private final Subject subject;

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
@@ -207,7 +207,7 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
             LOGGER.error("addInfo {}, path {}, error {}.", rid, path, e.getMessage());
             BulkRequestTarget t = toTarget(path, Optional.ofNullable(null), FAILED, e);
             try {
-                targetStore.store(t);
+                targetStore.storeOrUpdate(t);
             } catch (BulkStorageException ex) {
                 LOGGER.error("addInfo {}, path {}, could not store, error {}.", rid, path,
                       ex.getMessage());
@@ -312,7 +312,7 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
                 return;
             }
             BulkRequestTarget target = toTarget(path, Optional.of(attributes), CREATED, null);
-            targetStore.store(target);
+            targetStore.storeOrUpdate(target);
         } catch (BulkStorageException e) {
             LOGGER.error("{}, could not store target {}, {}: {}.", rid, path, attributes,
                   e.toString());

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
@@ -216,12 +216,6 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
             return Futures.immediateCancelledFuture();
         }
 
-        if (targetStore.exists(rid, path)) {
-            LOGGER.debug("{}, {} has already had {} performed on it; skipping.", rid, path,
-                  activity.getName());
-            return Futures.immediateFuture(null);
-        }
-
         semaphore.acquire();
 
         ListenableFuture future;
@@ -251,7 +245,7 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
         BatchedResult result = new BatchedResult(target, future);
 
         try {
-            targetStore.store(target);
+            targetStore.storeOrUpdate(target);
         } catch (BulkStorageException e) {
             LOGGER.error("{}, could not store target from result {}, {}, {}: {}.", rid, result,
                   attributes, e.toString());

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkTargetStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkTargetStore.java
@@ -184,6 +184,14 @@ public interface BulkTargetStore {
      boolean store(BulkRequestTarget target) throws BulkStorageException;
 
     /**
+     * Store or update the target if it already exists.
+     *
+     * @param target to store.
+     * @throws BulkStorageException
+     */
+    void storeOrUpdate(BulkRequestTarget target) throws BulkStorageException;
+
+    /**
      * Update the status of the target.
      *
      * @param id

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
@@ -558,6 +558,8 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
             requestPermissionsDao.insert(
                   requestPermissionsDao.set().id(request.getId()).subject(subject)
                         .restriction(restriction));
+
+            requestTargetDao.insertInitialTargets(request);
         } catch (BulkStorageException e) {
             throw new BulkStorageException("store failed for " + request.getId(), e);
         }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTarget.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTarget.java
@@ -111,7 +111,7 @@ public final class BulkRequestTarget {
         return key.split(KEY_SEPARATOR);
     }
 
-    private long id;
+    private Long id;
     private Long pid;
     private String rid;
     private FsPath path;
@@ -200,7 +200,7 @@ public final class BulkRequestTarget {
         return createdAt;
     }
 
-    public long getId() {
+    public Long getId() {
         return id;
     }
 
@@ -271,7 +271,7 @@ public final class BulkRequestTarget {
         }
     }
 
-    public void setId(long id) {
+    public void setId(Long id) {
         this.id = id;
     }
 


### PR DESCRIPTION
Motivation:

The TAPE API expects to be able to do a GET
immediately following a POST of a stage request;
the current FTS implementation fails the request
if all the paths are not returned for that GET.
The spec provides that any waiting target/path
have the SUBMITTED state.

Unfortunately, the current implementation does
not insert the target paths into the table with
their appropriate state until the request actually runs (done either before processing with `-prestore` or after it without).  This is an error,
particularly in consideration that requests may
be queued up a long time.

Modification:

Insert all explicit initial paths directly into
the table upon arrival.  To facilitate this,

- a batched version of insert is used there
- subsequent calls in the container to insert (with attribute info from the namespace) are done using upsert for uniformity with discovered paths (from recursion).

Result:

We adhere to the reasonable spec requirements.

Target: master
Request: 8.2
Requires-note:  yes
Patch: https://rb.dcache.org/r/13782/
Depends-on: #13779
Acked-by: Tigran