### PR TITLE
dcache-bulk: remove redundant update of request target in container s…

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/ConcurrentRequestManager.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/ConcurrentRequestManager.java
@@ -503,11 +503,8 @@ public final class ConcurrentRequestManager implements BulkRequestManager {
         try {
             if (isJobValid(job)) { /* possibly cancelled in flight */
                 job.update(State.RUNNING);
-                    targetStore.update(id, State.RUNNING, null);
                 job.getActivity().getActivityExecutor().submit(new FireAndForgetTask(job));
             }
-        } catch (BulkStorageException e) {
-            LOGGER.error("updateJobState", e.toString());
         } catch (RuntimeException e) {
             job.getTarget().setErrorObject(e);
             job.cancel();


### PR DESCRIPTION
…tart

Motivation:

The start method on the container manager is updating the state of the root job twice (`job.update`
already calls `targetStore.update`).

Modification:

Remove the redunandant call to the target store.
RuntimeException handling is left in place so
that an unexpected exception does not kill
the manager thread.

Result:

Update is called only once.

No visible change for user.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13794/
Requires-notes: no
Acked-by: Tigran