### PR TITLE
dcache-xroot:  send door address to pool as client for proxied transfers

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdTransfer.java
@@ -93,6 +93,9 @@ public class XrootdTransfer extends RedirectedTransfer<InetSocketAddress> {
     @Override
     protected ProtocolInfo getProtocolInfoForPool() {
         XrootdProtocolInfo info = createXrootdProtocolInfo();
+        if (proxiedTransfer) {
+            info.setSocketAddress(_doorAddress);
+        }
         info.setDelegatedCredential(_delegatedCredential);
         info.setRestriction(restriction);
         /*


### PR DESCRIPTION
Motivation:

https://rb.dcache.org/r/13650/
master@13e497d7b9d9964f58c81dc921c294347d2e555c

introduced, in connection with proxied transfers,
the specification of an internal address to use
in selecting and connecting to the pool.

This was an incomplete solution to the problem
of directing the proxy connection over a protected network, as demostrated by the GH issue
XRootD IPV6 on proxy mode #6875.

Modification:

Two changes needed to be made.  First, in order
not to encounter the mover failure, we have
to pass the door's address to the pool.  This
was originally not done because we wanted to
maintain the original client for billing purposes, but that information is recoverable by a join
between the `doorinfo` and `billinginfo` tables
or by finding the door `transaction` corresponding to the billing entry's `initiator`.

Second, we need to make sure that the door
address matches the internal network mask; this
is crucial in the case (such as at BNL) where
the internal network is IPv4 only but the door
is dual stack.

Result:

With this patch, BNL has reported success.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13807/
Requires-notes: yes
Closes: #6875
Acked-by: Dmitry