### PR TITLE
dcache-chimera: prevent PoolInformationBase NPE

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/PoolInformationBase.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/PoolInformationBase.java
@@ -74,13 +74,18 @@ public class PoolInformationBase implements CellMessageReceiver {
      */
     public synchronized void remove(String name) {
         PoolInformation pool = _pools.remove(name);
-        if (pool != null) {
-            for (String hsm : pool.getHsmInstances()) {
-                Collection<PoolInformation> pools = _hsmToPool.get(hsm);
-                pools.remove(pool);
-                if (pools.isEmpty()) {
-                    _hsmToPool.remove(hsm);
-                }
+        if (pool == null) {
+            return;
+        }
+        Collection<String> hsms = pool.getHsmInstances();
+        if (hsms == null) {
+            return;
+        }
+        for (String hsm : hsms) {
+            Collection<PoolInformation> pools = _hsmToPool.get(hsm);
+            pools.remove(pool);
+            if (pools.isEmpty()) {
+                _hsmToPool.remove(hsm);
             }
         }
     }


### PR DESCRIPTION
Motivation:
A NPE was reported in the PoolInformationBase#remove method.

Modification:
Check if the list of hsms for a pool is null, which is since recently also the case for pools that are are configured as `lfs=precious`.

Result:
Don't throw a NullPointerException when the associated hsms for a pool are stored as `null`.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Fixes: #6879
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13797/
Acked-by: Tigran Mkrtchyan