### PR TITLE
dcache-bulk:  manage executor and data source shutdown explicitly

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkShutdownManager.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkShutdownManager.java
@@ -1,0 +1,117 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.services.bulk.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
+
+public class BulkShutdownManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BulkShutdownManager.class);
+
+    private List<ExecutorService> executorServices;
+    private Closeable dataSource;
+
+    private long await = 10;
+    private TimeUnit awaitUnit = TimeUnit.SECONDS;
+
+    public void shutdown() {
+        executorServices.forEach(ExecutorService::shutdownNow);
+        executorServices.forEach(service -> {
+            try {
+                service.awaitTermination(await, awaitUnit);
+            } catch (InterruptedException e) {
+                LOGGER.error("awaitTermination interrupted for {}.", service);
+            }
+        });
+        try {
+            dataSource.close();
+        } catch (IOException e) {
+            LOGGER.error("error on dataSource close(): {}, cause {}.", e.getMessage(),
+                  String.valueOf(e.getCause()));
+        }
+    }
+
+    @Required
+    public void setExecutorList(List<ExecutorService> executorServices) {
+        this.executorServices = executorServices;
+    }
+
+    @Required
+    public void setDataSource(Closeable dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Required
+    public void setAwait(long await) {
+        this.await = await;
+    }
+
+    @Required
+    public void setAwaitUnit(TimeUnit awaitUnit) {
+        this.awaitUnit = awaitUnit;
+    }
+}

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -52,9 +52,7 @@
     </constructor-arg>
   </bean>
 
-  <bean id="incoming-thread-executor"
-        class="org.dcache.util.CDCExecutorServiceDecorator"
-        destroy-method="shutdownNow">
+  <bean id="incoming-thread-executor" class="org.dcache.util.CDCExecutorServiceDecorator">
     <description>Used to execute request message handling</description>
     <constructor-arg>
       <bean class="org.dcache.util.BoundedCachedExecutor">
@@ -63,9 +61,7 @@
     </constructor-arg>
   </bean>
 
-  <bean id="container-job-executor"
-    class="org.dcache.util.CDCExecutorServiceDecorator"
-    destroy-method="shutdownNow">
+  <bean id="container-job-executor" class="org.dcache.util.CDCExecutorServiceDecorator">
     <description>Used to execute jobs that are executed by a batch container.</description>
     <constructor-arg>
       <bean class="org.dcache.util.BoundedCachedExecutor">
@@ -74,9 +70,7 @@
     </constructor-arg>
   </bean>
 
-  <bean id="activity-callback-executor"
-    class="org.dcache.util.CDCExecutorServiceDecorator"
-    destroy-method="shutdownNow">
+  <bean id="activity-callback-executor" class="org.dcache.util.CDCExecutorServiceDecorator">
     <description>Used to execute the future callbacks to jobs which send and wait for replies.</description>
     <constructor-arg>
       <bean class="org.dcache.util.BoundedCachedExecutor">
@@ -85,9 +79,7 @@
     </constructor-arg>
   </bean>
 
-  <bean id="cancellation-executor"
-    class="org.dcache.util.CDCScheduledExecutorServiceDecorator"
-    destroy-method="shutdownNow">
+  <bean id="cancellation-executor" class="org.dcache.util.CDCScheduledExecutorServiceDecorator">
     <description>Used to run delayed clear requests.</description>
     <constructor-arg>
       <bean class="java.util.concurrent.ScheduledThreadPoolExecutor">
@@ -107,8 +99,23 @@
     </constructor-arg>
   </bean>
 
-  <bean id="bulk-data-source" class="com.zaxxer.hikari.HikariDataSource"
-    destroy-method="close">
+  <bean id="manager-executor"  class="org.dcache.util.CDCExecutorServiceDecorator">
+    <constructor-arg>
+      <bean class="org.dcache.util.BoundedCachedExecutor">
+        <constructor-arg value="1"/>
+      </bean>
+    </constructor-arg>
+  </bean>
+
+  <bean id="reset-executor" class="org.dcache.util.CDCExecutorServiceDecorator">
+    <constructor-arg>
+      <bean class="org.dcache.util.BoundedCachedExecutor">
+        <constructor-arg value="1"/>
+      </bean>
+    </constructor-arg>
+  </bean>
+
+  <bean id="bulk-data-source" class="com.zaxxer.hikari.HikariDataSource">
     <description>Encapsulates the bulk database connection pool and properties.</description>
     <constructor-arg>
       <bean class="com.zaxxer.hikari.HikariConfig">
@@ -293,15 +300,7 @@
     <property name="completionHandler" ref="request-handler"/>
     <property name="submissionHandler" ref="request-handler"/>
     <property name="schedulerProvider" ref="scheduler-provider"/>
-    <property name="processorExecutorService">
-      <bean class="org.dcache.util.CDCExecutorServiceDecorator" destroy-method="shutdownNow">
-        <constructor-arg>
-          <bean class="org.dcache.util.BoundedCachedExecutor">
-            <constructor-arg value="1"/>
-          </bean>
-        </constructor-arg>
-      </bean>
-    </property>
+    <property name="processorExecutorService" ref="manager-executor"/>
     <property name="maxActiveRequests" value="${bulk.limits.container-processing-threads}"/>
     <property name="timeout" value="${bulk.limits.sweep-interval}"/>
     <property name="timeoutUnit" value="${bulk.limits.sweep-interval.unit}"/>
@@ -332,14 +331,23 @@
     <property name="requestManager" ref="request-manager"/>
     <property name="submissionHandler" ref="request-handler"/>
     <property name="statistics" ref="statistics"/>
-    <property name="executor">
-      <bean class="org.dcache.util.CDCExecutorServiceDecorator" destroy-method="shutdownNow">
-        <constructor-arg>
-          <bean class="org.dcache.util.BoundedCachedExecutor">
-            <constructor-arg value="1"/>
-          </bean>
-        </constructor-arg>
-      </bean>
+    <property name="executor" ref="reset-executor"/>
+  </bean>
+
+  <bean id="shutdownManager" class="org.dcache.services.bulk.util.BulkShutdownManager" destroy-method="shutdown">
+    <property name="executorList">
+      <list>
+        <ref bean="incoming-thread-executor"/>
+        <ref bean="container-job-executor"/>
+        <ref bean="activity-callback-executor"/>
+        <ref bean="cancellation-executor"/>
+        <ref bean="delayed-clear-executor"/>
+        <ref bean="manager-executor"/>
+        <ref bean="reset-executor"/>
+      </list>
     </property>
+    <property name="dataSource" ref="bulk-data-source"/>
+    <property name="await" value="${bulk.limits.shutdown-manager-wait}"/>
+    <property name="awaitUnit" value="${bulk.limits.shutdown-manager-wait.unit}"/>
   </bean>
 </beans>

--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -106,6 +106,12 @@ bulk.limits.sweep-interval=5
 bulk.limits.counts-update-interval=1
 (one-of?MILLISECONDS|SECONDS|MINUTES)bulk.limits.counts-update-interval.unit=MINUTES
 
+#  ---- Amount of time the shutdown manager should wait for running jobs to complete
+#       before disconnecting from the data store.
+#
+bulk.limits.shutdown-manager-wait=10
+(one-of?MILLISECONDS|SECONDS|MINUTES)bulk.limits.shutdown-manager-wait.unit=SECONDS
+
 # ---- Endpoint for contacting pnfs manager.
 #
 bulk.service.pnfsmanager=${dcache.service.pnfsmanager}

--- a/skel/share/services/bulk.batch
+++ b/skel/share/services/bulk.batch
@@ -22,6 +22,8 @@ check -strong bulk.limits.sweep-interval
 check -strong bulk.limits.sweep-interval.unit
 check -strong bulk.limits.counts-update-interval
 check -strong bulk.limits.counts-update-interval.unit
+check -strong bulk.limits.shutdown-manager-wait
+check -strong bulk.limits.shutdown-manager-wait.unit
 check -strong bulk.service.pnfsmanager
 check -strong bulk.service.pnfsmanager.timeout
 check -strong bulk.service.pnfsmanager.timeout.unit


### PR DESCRIPTION
Motivation:

When shutting down the bulk service, the loss of connection to the database will raise a couple of different RuntimeExceptions for interactions which occur after the interrupt.

Modification:

Make a best-effort to shutdown all executors and wait for task completion before closing the data source connection.

We add a ShutdownManager to do this.

Result:

Stack traces from Jdbc and Hikari should not appear on shutdown if activities were in progress.

Target: master
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13795/
Acked-by: Tigran