### PR TITLE
dcache-bulk:  modify request limits to be something more reasoned

### DIFF
--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -86,12 +86,12 @@ bulk.limits.max.targets-per-flat-request=100000
 #  ---- The maximum number of unexpanded targets which can appear in the bulk request list.
 #       when request expansion is set to TARGETS.
 #
-bulk.limits.max.targets-per-shallow-request=1000
+bulk.limits.max.targets-per-shallow-request=100
 
 #  ---- The maximum number of unexpanded targets which can appear in the bulk request list.
 #       when request expansion is set to ALL.
 #
-bulk.limits.max.targets-per-recursive-request=10
+bulk.limits.max.targets-per-recursive-request=1
 
 #  ---- Interval of inactivity by the request manager consumer if not signalled
 #       internally (as for instance when a request job completes).  The consumer checks


### PR DESCRIPTION
Motivation:

The request limits which are part of the request policy settings can be modified in the admin shell without restart. Nevertheless, the default settings should make a little more sense than they do.

Modification:

This patch proposes the following:

- FLAT REQUESTS       100K targets
- SHALLOW REQUESTS    100  targets
- RECURSIVE REQUESTS  1    target

based on the idea that (a) 100K
is the practicable limit for requests
with only file paths, and (b) a guestimate
for the average number of nodes per
directory in a workable dCache installation
is 1000.  It also makes sense to limit
fully recursive requests to a single
target, as in that case we have no
way of predicting its depth and thereby
the number of potentially discovered
targets.

Result:

Limits that make a little more sense.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13813/
Requires-notes: yes
Acked-by: Lea