### PR TITLE
dcache-qos,frontend:  add exception to remote client method and retur…

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/qos/UpdateQoSActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/qos/UpdateQoSActivity.java
@@ -69,6 +69,7 @@ import diskCacheV111.util.FsPath;
 import diskCacheV111.util.NamespaceHandlerAware;
 import diskCacheV111.util.PnfsHandler;
 import diskCacheV111.util.PnfsId;
+import dmg.cells.nucleus.NoRouteToCellException;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -148,7 +149,12 @@ public class UpdateQoSActivity extends BulkActivity<QoSTransitionCompletedMessag
 
         RemoteQoSRequirementsClient client = new RemoteQoSRequirementsClient();
         client.setRequirementsService(qosEngine);
-        client.fileQoSRequirementsModified(requirements);
+
+        try {
+            client.fileQoSRequirementsModified(requirements);
+        } catch (CacheException | InterruptedException | NoRouteToCellException e) {
+            return Futures.immediateFailedFuture(e);
+        }
 
         return future;
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -534,6 +534,8 @@ public class FileResources {
         } catch (NoAttributeCacheException e) {
             throw new WebApplicationException(Response.status(409, "No such attribute")
                   .build());
+        } catch (NoRouteToCellException | InterruptedException e) {
+            throw new InternalServerErrorException(e.toString());
         } catch (UnsupportedOperationException |
               URISyntaxException |
               JSONException |

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/remote/receivers/QoSRequirementsReceiver.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/remote/receivers/QoSRequirementsReceiver.java
@@ -151,12 +151,13 @@ public final class QoSRequirementsReceiver implements CellMessageReceiver, Consu
         return reply;
     }
 
-    public void messageArrived(QoSRequirementsModifiedMessage message) {
+    public QoSRequirementsModifiedMessage messageArrived(QoSRequirementsModifiedMessage message) {
         if (messageGuard.getStatus("QoSRequirementsModifiedMessage", message)
               == Status.DISABLED) {
-            return;
+            return message;
         }
         fileStatusHandler.handleQoSModification(message.getRequirements());
+        return message;
     }
 
     public void messageArrived(QoSCancelRequirementsModifiedMessage message) {

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/handler/FileQoSStatusHandler.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/handler/FileQoSStatusHandler.java
@@ -67,8 +67,10 @@ import static org.dcache.qos.data.QoSMessageType.QOS_MODIFIED;
 import static org.dcache.qos.data.QoSMessageType.QOS_MODIFIED_CANCELED;
 import static org.dcache.qos.services.engine.util.QoSEngineCounters.QOS_ACTION_COMPLETED;
 
+import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
 import dmg.cells.nucleus.CellInfoProvider;
+import dmg.cells.nucleus.NoRouteToCellException;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.concurrent.ExecutorService;
@@ -167,10 +169,9 @@ public final class FileQoSStatusHandler implements CellInfoProvider, QoSActionCo
                 LOGGER.debug("handleQoSModification calling fileQoSStatusChanged for {}, {}.",
                       pnfsId, QOS_MODIFIED);
                 fileQoSStatusChanged(new FileQoSUpdate(pnfsId, null, QOS_MODIFIED));
-            } catch (QoSException e) {
+            } catch (QoSException | CacheException | NoRouteToCellException | InterruptedException e) {
                 LOGGER.error("Failed to handle QoS requirements for {}: {}.",
-                      requirements.getPnfsId(),
-                      e.toString());
+                      requirements.getPnfsId(), e.getMessage());
                 handleActionCompleted(pnfsId, VOID, e.toString());
             }
         });

--- a/modules/dcache/src/main/java/org/dcache/qos/listeners/QoSRequirementsListener.java
+++ b/modules/dcache/src/main/java/org/dcache/qos/listeners/QoSRequirementsListener.java
@@ -59,7 +59,9 @@ documents or software obtained from this server.
  */
 package org.dcache.qos.listeners;
 
+import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
+import dmg.cells.nucleus.NoRouteToCellException;
 import org.dcache.qos.QoSException;
 import org.dcache.qos.data.FileQoSRequirements;
 import org.dcache.qos.data.FileQoSUpdate;
@@ -81,7 +83,8 @@ public interface QoSRequirementsListener {
      * @param newRequirements describing principally how many peristent disk and tape copies are
      *                        required.
      */
-    void fileQoSRequirementsModified(FileQoSRequirements newRequirements) throws QoSException;
+    void fileQoSRequirementsModified(FileQoSRequirements newRequirements)
+          throws QoSException, CacheException, NoRouteToCellException, InterruptedException;
 
     /**
      * A client sends this when it wishes to cancel a modification requirement.

--- a/modules/dcache/src/main/java/org/dcache/qos/remote/clients/RemoteQoSRequirementsClient.java
+++ b/modules/dcache/src/main/java/org/dcache/qos/remote/clients/RemoteQoSRequirementsClient.java
@@ -60,7 +60,9 @@ documents or software obtained from this server.
 package org.dcache.qos.remote.clients;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
+import dmg.cells.nucleus.NoRouteToCellException;
 import java.io.Serializable;
 import java.util.concurrent.ExecutionException;
 import org.dcache.cells.CellStub;
@@ -108,11 +110,9 @@ public final class RemoteQoSRequirementsClient implements QoSRequirementsListene
     }
 
     @Override
-    public void fileQoSRequirementsModified(FileQoSRequirements newRequirements) {
-        /*
-         *  Fire and forget. The sender will need to listen for a response.
-         */
-        requirementsService.send(new QoSRequirementsModifiedMessage(newRequirements));
+    public void fileQoSRequirementsModified(FileQoSRequirements newRequirements)
+          throws CacheException, NoRouteToCellException, InterruptedException {
+        requirementsService.sendAndWait(new QoSRequirementsModifiedMessage(newRequirements));
     }
 
     @Override


### PR DESCRIPTION
…n 500 if fails

Motivation:

See GitHub issue https://github.com/dCache/dcache/issues/6914. If there are no qos services running, the namespace qos transition should fail.

Modification:

Change the send of that message to sendAndWait with message return; catch and handle the checked exceptions.

Result:

Desired behavior (returns 500 with error message when services are not reachable).

Target: master
Request: 8.2
Request: 8.1
Patch: https://rb.dcache.org/r/13810/
Requires-notes: yes
Requires-book: no
Closes: #6914
Acked-by: Tigran