### PR TITLE
pool,chimera: fix pool pings having a `null`-valued hsm field

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PoolManagerPoolUpMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/PoolManagerPoolUpMessage.java
@@ -1,5 +1,6 @@
 package diskCacheV111.vehicles;
 
+import com.google.common.collect.ImmutableSet;
 import diskCacheV111.pools.PoolCostInfo;
 import diskCacheV111.pools.PoolV2Mode;
 import java.io.Serializable;
@@ -16,7 +17,7 @@ public class PoolManagerPoolUpMessage extends PoolManagerMessage {
 
     private String _hostName;
     private Map<String, String> _tagMap;
-    private Set<String> _hsmInstances;
+    private Set<String> _hsmInstances = ImmutableSet.of();
     private String _message = "";
     private int _code;
 


### PR DESCRIPTION
Motivation:
Since commit 09668f4, pools don't set the `_hsmInstances` field in a PoolManagerPoolUpMessage when the pool is marked as `lfs=precious`. The field thus remains `null`-valued, which causes problems in a number of downstream cells, such as the cleaner and PoolManager.

Modification:
Set the defualt value of `_hsmInstances` to an empty collection instead of `null`.

Result:
Prevent `NullPointerException`s in the cleaner and repeating `pool restarted` messages in PoolManager due to pools reporting `null` as their connected hsm instances.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Fixes: # 6879, # 6915
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13815/
Acked-by: Dmitry Litvintsev