### PR TITLE
pool: reload host certificate if changed

### DIFF
--- a/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
+++ b/modules/common-security/src/main/java/org/dcache/ssl/CanlContextFactory.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2015 - 2022 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2015 - 2023 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -315,6 +315,7 @@ public class CanlContextFactory implements SslContextFactory {
             Callable newContext = () -> {
                 PEMCredential credential
                       = new PEMCredential(keyPath.toString(), certificatePath.toString(), new char[]{});
+                LOGGER.info("Reloading host credential {} {}", certificatePath, keyPath);
                 return factory.getContext(contextType, credential);
             };
 

--- a/modules/dcache/src/main/java/org/dcache/http/AbstractSslContextFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AbstractSslContextFactory.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2021 - 2023 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,19 +17,28 @@
  */
 package org.dcache.http;
 
+import dmg.cells.nucleus.CDC;
 import eu.emi.security.authn.x509.CrlCheckingMode;
 import eu.emi.security.authn.x509.OCSPCheckingMode;
 import java.nio.file.Path;
-import org.springframework.beans.factory.FactoryBean;
+import java.util.concurrent.Callable;
+import javax.annotation.PostConstruct;
+import org.dcache.ssl.CanlContextFactory;
 import org.springframework.beans.factory.annotation.Required;
 
-abstract class AbstractSslContextFactoryBean<C> implements FactoryBean<C> {
+abstract class AbstractSslContextFactory<C> implements Callable<C> {
 
     protected Path serverCertificatePath;
     protected Path serverKeyPath;
     protected Path serverCaPath;
     protected CrlCheckingMode crlCheckingMode;
     protected OCSPCheckingMode ocspCheckingMode;
+
+    private final Class type;
+
+    protected AbstractSslContextFactory(Class<? extends Object> type) {
+        this.type = type;
+    }
 
     @Required
     public void setServerCertificatePath(Path serverCertificatePath) {
@@ -56,8 +65,24 @@ abstract class AbstractSslContextFactoryBean<C> implements FactoryBean<C> {
         this.ocspCheckingMode = ocspCheckingMode;
     }
 
+    private Callable<C> contextHolder;
+
+    @PostConstruct
+    public void init() throws Exception {
+        contextHolder = CanlContextFactory.custom()
+              .withCertificateAuthorityPath(serverCaPath)
+              .withCrlCheckingMode(crlCheckingMode)
+              .withOcspCheckingMode(ocspCheckingMode)
+              .withCertificatePath(serverCertificatePath)
+              .withKeyPath(serverKeyPath)
+              .withLazy(false)
+              .withLoggingContext(new CDC()::restore)
+              .withLoggingContext(new CDC()::restore)
+              .buildWithCaching(type);
+    }
+
     @Override
-    public boolean isSingleton() {
-        return false;
+    public C call() throws Exception {
+        return contextHolder.call();
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpTransferService.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2013-2015 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2013-2023 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -160,7 +160,7 @@ public class HttpTransferService extends NettyTransferService<HttpProtocolInfo> 
         return true;
     }
 
-    protected void addChannelHandlers(ChannelPipeline pipeline) {
+    protected void addChannelHandlers(ChannelPipeline pipeline) throws Exception {
         // construct HttpRequestDecoder as netty defaults, except configurable chunk size
         pipeline.addLast("decoder", new HttpRequestDecoder(4096, 8192, getChunkSize(), true));
         pipeline.addLast("encoder", new HttpResponseEncoder());

--- a/modules/dcache/src/main/java/org/dcache/http/HttpsTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpsTransferService.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2017-2020 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2017-2023 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -31,6 +31,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import javax.net.ssl.SSLEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,9 +42,9 @@ public class HttpsTransferService extends HttpTransferService {
 
     private static final String PROTOCOL_HTTPS = "https";
 
-    private SslContext _sslContext;
+    private Callable<SslContext> _sslContext;
 
-    public void setSslContext(SslContext sslContext) {
+    public void setSslContext(Callable<SslContext> sslContext) {
         _sslContext = sslContext;
     }
 
@@ -102,8 +103,8 @@ public class HttpsTransferService extends HttpTransferService {
     }
 
     @Override
-    protected void addChannelHandlers(ChannelPipeline pipeline) {
-        SSLEngine engine = _sslContext.newEngine(pipeline.channel().alloc());
+    protected void addChannelHandlers(ChannelPipeline pipeline) throws Exception {
+        SSLEngine engine = _sslContext.call().newEngine(pipeline.channel().alloc());
         engine.setWantClientAuth(false);
         pipeline.addLast("ssl", new SslHandler(engine));
         super.addChannelHandlers(pipeline);

--- a/modules/dcache/src/main/java/org/dcache/http/JdkSslContextFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/http/JdkSslContextFactory.java
@@ -1,0 +1,31 @@
+/* dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2023 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dcache.http;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * SslContext context which uses JDK implementation.
+ */
+public class JdkSslContextFactory extends AbstractSslContextFactory<SSLContext> {
+
+    public JdkSslContextFactory() {
+        super(SSLContext.class);
+    }
+}

--- a/modules/dcache/src/main/java/org/dcache/http/NettySslContextFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/http/NettySslContextFactory.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2021 - 2023 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -18,32 +18,15 @@
 
 package org.dcache.http;
 
-import dmg.cells.nucleus.CDC;
 import io.netty.handler.ssl.SslContext;
-import org.dcache.ssl.CanlContextFactory;
 
 /**
  * Netty SslContext context factory which uses native OpenSsl if available, but falls back to Java
  * if not.
  */
-public class NettySslContextFactoryBean extends AbstractSslContextFactoryBean<SslContext> {
+public class NettySslContextFactory extends AbstractSslContextFactory<SslContext> {
 
-    @Override
-    public SslContext getObject() throws Exception {
-        return CanlContextFactory.custom()
-              .withCertificateAuthorityPath(serverCaPath)
-              .withCrlCheckingMode(crlCheckingMode)
-              .withOcspCheckingMode(ocspCheckingMode)
-              .withCertificatePath(serverCertificatePath)
-              .withKeyPath(serverKeyPath)
-              .withLazy(false)
-              .withLoggingContext(new CDC()::restore)
-              .buildWithCaching(SslContext.class)
-              .call();
-    }
-
-    @Override
-    public Class<?> getObjectType() {
-        return SslContext.class;
+    public NettySslContextFactory() {
+        super(SslContext.class);
     }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
@@ -190,7 +189,7 @@ class Companion {
           CacheFileAvailable callback,
           boolean forceSourceMode,
           Long atime,
-          Supplier<SSLContext> getContextIfNeeded) {
+          SSLContext sslContext) {
         _fsm = new CompanionContext(this);
 
         _executor = executor;
@@ -207,7 +206,7 @@ class Companion {
               "Destination domain name is unknown.");
         _fileAttributes = requireNonNull(fileAttributes, "File attributes is missing.");
 
-        _sslContext = getContextIfNeeded.get();
+        _sslContext = sslContext;
 
         if (!_fileAttributes.isDefined(FileAttribute.PNFSID)) {
             throw new IllegalArgumentException(

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -285,14 +285,22 @@
   </bean>
 
 
-    <bean id="ssl-context-builder" class="org.dcache.http.NettySslContextFactoryBean">
-        <description>SSL Context factory</description>
+    <bean id="ssl-context-builder-parent" abstract="true" class="org.dcache.http.AbstractSslContextSupplier">
+        <description>Abstract SSL Context factory</description>
         <property name="serverCertificatePath" value="${pool.mover.https.hostcert.cert}"/>
         <property name="serverKeyPath" value="${pool.mover.https.hostcert.key}"/>
         <property name="serverCaPath" value="${pool.mover.https.capath}"/>
         <property name="crlCheckingMode" value="${pool.authn.crl-mode}"/>
         <property name="ocspCheckingMode" value="${pool.authn.ocsp-mode}"/>
     </bean>
+
+  <bean id="netty-ssl-context-builder" class="org.dcache.http.NettySslContextFactory" parent="ssl-context-builder-parent">
+    <description>SSL Context factory for Netty</description>
+  </bean>
+
+  <bean id="jdk-ssl-context-builder" class="org.dcache.http.JdkSslContextFactory" parent="ssl-context-builder-parent">
+    <description>SSL Context factory for JDK</description>
+  </bean>
 
   <bean id="migration" class="org.dcache.pool.migration.MigrationModule"
         destroy-method="cancelAll">
@@ -747,7 +755,7 @@
 
         <bean id="p2p" parent="p2p-parent">
             <description>Pool to pool transfer manager with encryption</description>
-            <property name="sslContext" ref="ssl-context-builder"/>
+            <property name="sslContext" ref="jdk-ssl-context-builder"/>
             <property name="tlsMode" value="${pool.enable.encrypted.p2p-transfers}"/>
         </bean>
 
@@ -757,7 +765,7 @@
 
         <bean id="p2p" parent="p2p-parent">
             <description>Pool to pool transfer manager with encryption</description>
-            <property name="sslContext" ref="ssl-context-builder"/>
+            <property name="sslContext" ref="jdk-ssl-context-builder"/>
             <property name="tlsMode" value="${pool.enable.encrypted.p2p-transfers}"/>
         </bean>
 
@@ -780,7 +788,7 @@
         </bean>
 
         <bean id="https-transfer-service" parent="http-transfer-service-parent" class="org.dcache.http.HttpsTransferService">
-            <property name="sslContext" ref="ssl-context-builder" />
+            <property name="sslContext" ref="netty-ssl-context-builder" />
         </bean>
     </beans>
 


### PR DESCRIPTION
Motivation:
When host certificate is changed dCache should reload the host certificate and key to avoid service reload. Unfortunately, the https mover created with a specific SslContext, thus never reloads host credential, even if the under laying factory supposed to do so.

Modification:
Update HttpsTransferService to use Callable<SslContext> instead of SslContext. Introduce JdkSslContextFactory that created JDK SSLContext that is used by p2p transfers.

Result:
Updated host certificate is available to https mover. Fixed p2p transfers over HTTPS.

Fixes: #6929, #6939
Acked-by: Paul Millar
Acked-by: Marina Sahakyan
Target: master, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit aa348d48fad1d77eab694bc1458b08012cf1fcf9) (cherry picked from commit fc604fc0b9e01c4036c8c261a86ed90a8c68ab96)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>