### PR TITLE
dcache-bulk:  make sure LINK types are handled when refetched from pr…

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
@@ -166,6 +166,23 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
                 LOGGER.error("run {}, error getting next file target: {}.", rid, e.toString());
             }
         }
+
+        /*
+         *  Make sure LINK types are handled like files, since we allow them
+         *  on expansion, but also from initial targets.
+         */
+        while (true) {
+            try {
+                checkForRequestCancellation();
+                target = next(FileType.LINK);
+                if (target.isEmpty()) {
+                    break;
+                }
+                perform(target.get());
+            } catch (BulkStorageException e) {
+                LOGGER.error("run {}, error getting next file target: {}.", rid, e.toString());
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
…estored targets

Motivation:

Symlinks are handled like files (they are not followed recursively) when expanding a directory.  Symlinks are also treated implicitly when the request uses
`-prestore=false`.  However, links are not being
retrieved along with files when `-prestore=true`.
This causes the latter type of request not to
complete if there are symlinks encountered anywhere on its path tree.

Modification:

Check for `LINK` on `next()` after all `FILE`
types are processed.

Result:

Links are handled as they should be and
the requests complete.

Target: master
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13827/
Acked-by: Tigran