### PR TITLE
dcache-bulk: mark expanded directory skipped if activity does not app…

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
@@ -355,7 +355,7 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
                 } else if (info.attributes.getFileType() != FileType.SPECIAL) {
                     store(info.path, info.attributes);
                 }
-            } catch (CacheException e) {
+            } catch (BulkServiceException | CacheException e) {
                 LOGGER.error("storeAll {}, path {}, error {}.", rid, info.path, e.getMessage());
             }
         }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
@@ -202,7 +202,7 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
             } else if (attributes.getFileType() != FileType.SPECIAL) {
                 perform(path, attributes);
             }
-        } catch (CacheException e) {
+        } catch (BulkServiceException | CacheException e) {
             LOGGER.error("handleTarget {}, path {}, error {}.", rid, path, e.getMessage());
             register(path, Futures.immediateFailedFuture(e), attributes, e);
         }


### PR DESCRIPTION
…ly to directories

Motivation:

https://rb.dcache.org/r/13782/
master@771db06b8a52b18939a87171a480c9d7776814fc

changed behavior to store targets immediately.
This change, however, means that directories
included among the initial paths are now
stored as targets, whether they are to be
acted upon (other than by being expanded)
––for instance by deletion––or not.  In the
case that the activity (such as PIN) does
not apply to these directories, they
need to be marked as SKIPPED.  Otherwise,
the request completion logic (counting
targets in final states) will prevent
the request from completing.

Modification:

Add the check for the expanded directory
and store it as SKIPPED.

Result:

Requests terminate as they should.

Target: master
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13818/
Acked-by: Tigran