### PR TITLE
dcache-chimera: reduce frequency of expensive cleaner inode deletion

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
@@ -168,6 +168,9 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
      * @throws InterruptedException
      */
     private void runDelete(List<String> poolList) throws InterruptedException {
+        // Expensive operation, thus triggered once per runDelete rather than per pool
+        deleteInodeEntries();
+
         boolean runAsync = _executor.getCorePoolSize() > 1;
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
@@ -182,7 +185,6 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
                           _poolsBeingCleaned.put(pool, System.currentTimeMillis());
                           try {
                               runDelete(pool);
-                              runNotification();
                           } finally {
                               _poolsBeingCleaned.remove(pool);
                               LOGGER.info("Finished deleting from pool {}", pool);
@@ -191,7 +193,6 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
                 futures.add(cf);
             } else {
                 runDelete(pool);
-                runNotification();
                 LOGGER.info("Finished deleting from pool {}", pool);
             }
         }
@@ -311,7 +312,12 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
         }
     }
 
-    private void runNotification() {
+    /**
+     * Deletes all pnfsid entries from the trash table that are of itype=2 (inode) and for which
+     * there are no other trash table entries on disk or hsm (types 0 and 1). As this is the final
+     * delete operation for a pnfsid, it also sends a delete notification for each.
+     */
+    private void deleteInodeEntries() {
         final String QUERY =
               "SELECT ipnfsid FROM t_locationinfo_trash t1 " +
                     "WHERE itype=2 AND NOT EXISTS (SELECT 1 FROM t_locationinfo_trash t2 WHERE t2.ipnfsid=t1.ipnfsid AND t2.itype <> 2)";
@@ -574,7 +580,8 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
         pw.printf("Refresh Interval: %s\n", _refreshInterval);
         pw.printf("Refresh Interval Unit: %s\n", _refreshIntervalUnit);
         pw.printf("Cleanup grace period: %s\n", TimeUtils.describe(_gracePeriod).orElse("-"));
-        pw.printf("Reply Timeout:  %d\n", _poolStub.getTimeout());
+        pw.printf("Pool reply timeout:  %d %s\n", _poolStub.getTimeout(),
+              _poolStub.getTimeoutUnit());
         pw.printf("Number of files processed at once:  %d\n", _processAtOnce);
         pw.printf("Delete notification targets:  %s\n",
               Arrays.toString(_deleteNotificationTargets));


### PR DESCRIPTION
Motivation:
Cleaner-disk is both responsible for removing disk-based entries from the trash table and inodes themselves, once all other locations for that pnfsid have been deleted from the trash table. This SQL query is nested, rather expensive and currently executed at the end of deleting from every pool.

With the introduction of parallel disk cleaning, when sites have large trash tables, the query for deleting the leftover inodes entries and sending notifications becomes increasingly slow.

Modification:
Move the query to delete inodes entries from the trash table so that it is only executed once per cleaner-disk run, rather than after finishing deleting from every pool.

Result:
Hopefully less load on the cleaner's trash table database and thus higher performance.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13847/
Acked-by: Dmitry Litvintsev
Acked-by: Tigran Mkrtchyan