### PR TITLE
pom.xml:  update to next xrood4j version (4.5.4, 4.4.5, 4.3.6, 4.2.10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.44.v20210927</version.jetty>
-        <version.xrootd4j>4.5.3</version.xrootd4j>
+        <version.xrootd4j>4.5.4</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.2</version.dcache-view>
         <version.netty>4.1.71.Final</version.netty>


### PR DESCRIPTION
see https://rb.dcache.org/r/13851/
commit master@6551be9ae6f1b26a8638f2faf6d4414e67d4e197

Update stable branches to include bug fix to
maintain the difference between STRICT and OPTIONAL for xrootd.security.tls.mode (STRICT was not forcing the client to go to TLS the way it was intended).

Target: master (v4.5.4)
Request: 8.2   (v4.5.4)
Request: 8.1   (v4.3.6v)
Request: 8.0   (v4.2.10)
Request: 7.2   (v4.2.10)
Patch: https://rb.dcache.org/r/13852/
Requires-notes: yes
Acked-by: Tigran