### PR TITLE
dcache-xroot: make handling of anonymous restrictions consistent

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -96,6 +96,8 @@ import javax.security.auth.Subject;
 import org.dcache.acl.enums.AccessType;
 import org.dcache.auth.Origin;
 import org.dcache.auth.Subjects;
+import org.dcache.auth.UnionLoginStrategy;
+import org.dcache.auth.UnionLoginStrategy.AccessLevel;
 import org.dcache.auth.attributes.Activity;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.cells.CellStub;
@@ -221,6 +223,8 @@ public class XrootdDoor
     private NettyPortRange portRange;
     private int proxyResponseTimeoutInSeconds;
     private InetAddress _internalAddress;
+
+    private UnionLoginStrategy.AccessLevel anonymousUserAccess = AccessLevel.NONE;
 
     @Autowired(required = false)
     private void setKafkaTemplate(
@@ -423,6 +427,15 @@ public class XrootdDoor
                     _tpcFdIndex)),
               TPC_EVICT_DELAY, TPC_EVICT_DELAY,
               TimeUnit.MILLISECONDS);
+    }
+
+    @Required
+    public void setAnonymousAccess(AccessLevel level) {
+        anonymousUserAccess = level;
+    }
+
+    public AccessLevel getAnonymousUserAccess() {
+        return anonymousUserAccess;
     }
 
     public boolean isTriedHostsEnabled() {

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -159,7 +159,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
 
         LoginSessionInfo(LoginReply reply) {
             subject = reply.getSubject();
-            restriction = reply.getRestriction();
+            restriction = computeRestriction(reply);
             userRootPath = reply.getLoginAttributes().stream()
                   .filter(RootDirectory.class::isInstance)
                   .findFirst()
@@ -189,6 +189,21 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
 
         public boolean isLoggedIn() {
             return loggedIn;
+        }
+
+        private Restriction computeRestriction(LoginReply reply) {
+            if (!Subjects.isNobody(subject)) {
+                return reply.getRestriction();
+            }
+
+            switch(_door.getAnonymousUserAccess()) {
+                case READONLY:
+                    return Restrictions.readOnly();
+                case FULL:
+                    return Restrictions.none();
+                default:
+                    return Restrictions.denyAll();
+            }
         }
     }
 

--- a/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
+++ b/modules/dcache-xrootd/src/main/resources/org/dcache/xrootd/door/xrootd.xml
@@ -211,6 +211,7 @@
       </bean>
     </property>
     <property name="proxyResponseTimeoutInSeconds" value="${xrootd.net.proxy.response-timeout-in-secs}"/>
+    <property name="anonymousAccess" value="${xrootd.authz.anonymous-operations}"/>
   </bean>
 
   <bean id="pool-manager-handler" class="org.dcache.poolmanager.PoolManagerHandlerSubscriber">


### PR DESCRIPTION
Motivation:

The xroot door has two ways to control access:
anonymous access permissions and enabled authentication flavors.

In deployments where xroot unauthorized access is enabled as `xrootd.plugins=gplazma:ztn,gplazma:gsi,gplazma:none,authz:scitokens` (which is the default), and anonymous access is restricted to `xrootd.authz.anonymous-operations=NONE`, the door will ignore the latter one and allow anonymous read-only access to world-readable files rather than blocking all anonymous operations.

While this setting may seem contradictory, it really isn't. The presence of `gplazma:none` in the plugin chain is in order to allow for *xroot native third-party copy using tokens*; one should be able to allow for this but still block anonymous two-party access by setting the `anonymous-operations` property; the confusion arises from the fact that we did not rename `gplazma:none` to `gplazma:unix`, which is
really what we are telling the xroot client to use.

Modification:

`xrootd.authz.anonymous-operations` only currently applies within the `UnionLoginStrategy`: that is,
if the client actually tries to use a protocol
anonymously.  Note that `xrdcp` _does not do so_
(it will skip the protocol if it cannot find the
proper credentials). The property has never been
applied when using the `gplazma:none` plugin
(since a "fallback" to anonymous there is redundant).

The solution given here is simply to have the door check whether the login is anonymous, and if it
is, to enforce the property setting using the
correct restriction.

Result:

With `xrootd.authz.anonymous-operations=READONLY`, anonymous login allows world-readable files to
be read; with `xrootd.authz.anonymous-operations=NONE`, it does not allow anonymous operations.  This is
for two-party interactions.  Third-party copy
with OIDC tokens will work regardless of the
value given to this property.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13856/
Acked-by: Dmitry