### PR TITLE
dcap: always enforce passive mode

### DIFF
--- a/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
+++ b/modules/dcache-dcap/src/main/java/diskCacheV111/doors/DCapDoorInterpreterV3.java
@@ -1688,7 +1688,6 @@ public class DCapDoorInterpreterV3
         private String _truncFile;
         private boolean _poolRequestDone;
         private String _permission;
-        private boolean _passive;
         private String _accessLatency;
         private String _retentionPolicy;
         private PoolMgrSelectReadPoolMsg.Context _readPoolSelectionContext;
@@ -1703,19 +1702,7 @@ public class DCapDoorInterpreterV3
 
             StringTokenizer st = new StringTokenizer(_vargs.argv(2), ",");
 
-            _passive = args.hasOption("passive");
-            if (_passive) {
-                _clientSocketAddress = new InetSocketAddress(_clientAddress, port);
-            } else {
-                String hostname = st.nextToken();
-
-                _clientSocketAddress = new InetSocketAddress(hostname, port);
-
-                if (_clientSocketAddress.isUnresolved()) {
-                    _log.debug("Client sent unresolvable hostname {}", hostname);
-                    throw new CacheException("Unknown host: " + hostname);
-                }
-            }
+            _clientSocketAddress = new InetSocketAddress(_clientAddress, port);
 
             _protocolInfo = new DCapProtocolInfo("DCap", 3, 0, _clientSocketAddress);
             _protocolInfo.setSessionId(_sessionId);
@@ -1734,7 +1721,6 @@ public class DCapDoorInterpreterV3
             _truncFile = args.getOpt("truncate");
             _truncate = (_truncFile != null) && _settings.isTruncateAllowed();
 
-            _protocolInfo.isPassive(_passive);
             _accessLatency = args.getOpt("access-latency");
             _retentionPolicy = args.getOpt("retention-policy");
 

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/DCapProtocolInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/DCapProtocolInfo.java
@@ -13,7 +13,9 @@ public class DCapProtocolInfo implements IpProtocolInfo {
     private long _bytesTransferred;
     private int _sessionId;
     private boolean _writeAllowed;
-    private boolean _isPassive;
+
+    // backward compatibility
+    private final boolean _isPassive = true;
     private CellPath _door;
 
     private static final long serialVersionUID = 7432555710192378884L;
@@ -99,10 +101,6 @@ public class DCapProtocolInfo implements IpProtocolInfo {
 
     public boolean isPassive() {
         return _isPassive;
-    }
-
-    public void isPassive(boolean passive) {
-        _isPassive = passive;
     }
 
     public CellPath door() {


### PR DESCRIPTION
Motivation:
The original dcap design was expecting pools to initialize data connection. However such model doesn't play well with firewalls, thus source of network setup related issues. As a result, dcap support so called passive mode, where client connects to a pool. However, client have to request such behaviour.

Modification:
Update dcap door to always start mover in a passive mode.

Result:
simple dcap behaviour.

Acked-by: Albert Rossi
Acked-by: Lea Morschel
Target: master
Require-book: yes
Require-notes: yes
(cherry picked from commit 0eb7fbb44117961527d14fc495b15e1c16d79eb7)
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>