### PR TITLE
skel:  deprecate unused dcache path for bulk

### DIFF
--- a/skel/share/defaults/paths.properties
+++ b/skel/share/defaults/paths.properties
@@ -25,7 +25,7 @@ dcache.paths.lock.file=@dcache.paths.lock.file@
 dcache.paths.classes=@dcache.paths.classes@
 dcache.paths.lib=@dcache.paths.lib@
 dcache.paths.billing=@dcache.paths.billing@
-dcache.paths.bulk=@dcache.paths.bulk@
+
 dcache.paths.statistics=@dcache.paths.statistics@
 dcache.paths.zookeeper=@dcache.paths.zookeeper@
 dcache.paths.plugins=@dcache.paths.plugins@
@@ -53,3 +53,5 @@ dcache.paths.grid-security = /etc/grid-security
 
 dcache.paths.nfs=@dcache.paths.nfs@
 dcache.paths.httpd=@dcache.paths.httpd@
+
+(deprecated)dcache.paths.bulk=no longer used


### PR DESCRIPTION
Motivation:

See GH #6940 undefined dcache.paths.bulk in paths.properties

Modification:

Deprecate the unused dcache path property.

Result:

Inconsistency removed.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13859/
Closes: #6940
Requires-notes: yes
Acked-by: Tigran
Acked-by: Lea