### PR TITLE
dcache-history: avoid NaN stack trace in histogram conversion

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/MathUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/MathUtils.java
@@ -78,10 +78,10 @@ public class MathUtils {
      *  convert NaN to 0.0.
      *
      * @param value the double result of the computation.
-     * @return 0.0 if the value is NaN; otherwise, the value.
+     * @return 0.0 if the value is NaN; otherwise, the value (including null).
      */
     public static Double nanToZero(Double value) {
-        return Double.isNaN(value) ? 0.0 : value;
+        return value != null && Double.isNaN(value) ? 0.0 : value;
     }
 
 }

--- a/modules/common/src/main/java/org/dcache/util/MathUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/MathUtils.java
@@ -72,4 +72,16 @@ public class MathUtils {
 
         return (a < 0) ? Long.MIN_VALUE : Long.MAX_VALUE;
     }
+
+    /**
+     *  For applications where this is appropriate (like a Histogram value),
+     *  convert NaN to 0.0.
+     *
+     * @param value the double result of the computation.
+     * @return 0.0 if the value is NaN; otherwise, the value.
+     */
+    public static Double nanToZero(Double value) {
+        return Double.isNaN(value) ? 0.0 : value;
+    }
+
 }

--- a/modules/common/src/main/java/org/dcache/util/MathUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/MathUtils.java
@@ -81,7 +81,6 @@ public class MathUtils {
      * @return 0.0 if the value is NaN; otherwise, the value (including null).
      */
     public static Double nanToZero(Double value) {
-        return value != null && Double.isNaN(value) ? 0.0 : value;
+        return value != null && Double.isNaN(value) ? (Double)0.0 : value;
     }
-
 }

--- a/modules/common/src/main/java/org/dcache/util/histograms/CountingHistogram.java
+++ b/modules/common/src/main/java/org/dcache/util/histograms/CountingHistogram.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.util.histograms;
 
 import static java.util.Objects.requireNonNull;
+import static org.dcache.util.MathUtils.nanToZero;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
@@ -126,8 +127,8 @@ public class CountingHistogram extends HistogramModel {
          */
         Double min = FastMath.min(0.0D, metadata.getMinValue().orElse(0.0D));
 
-        double maxIndex = max == null ? binCount - 1 : FastMath.floor((max - min) / binSize);
-        binWidth = (int) FastMath.ceil(maxIndex / (binCount - 1));
+        double maxIndex = max == null ? binCount - 1 : FastMath.floor(nanToZero((max - min) / binSize));
+        binWidth = (int) FastMath.ceil(nanToZero(maxIndex / (binCount - 1)));
 
         /**
          * Re-adjust size on the basis of the adjusted width.
@@ -145,7 +146,7 @@ public class CountingHistogram extends HistogramModel {
               binSize, binCount, min, max, maxIndex);
 
         for (Double d : data) {
-            ++histogram[(int) FastMath.floor((d - min) / binSize)];
+            ++histogram[(int) FastMath.floor(nanToZero((d - min) / binSize))];
         }
 
         data = new ArrayList<>();
@@ -158,7 +159,7 @@ public class CountingHistogram extends HistogramModel {
         setHighestFromLowest();
         int computedCount = (int) binSize == 0 ?
               binCount :
-              (int) FastMath.ceil((highestBin - lowestBin) / binSize) + 1;
+              (int) FastMath.ceil(nanToZero((highestBin - lowestBin) / binSize)) + 1;
 
         if (computedCount > binCount) {
             throw new RuntimeException("bin count " + binCount

--- a/modules/common/src/main/java/org/dcache/util/histograms/HistogramMetadata.java
+++ b/modules/common/src/main/java/org/dcache/util/histograms/HistogramMetadata.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.util.histograms;
 
 import static java.util.Objects.requireNonNull;
+import static org.dcache.util.MathUtils.nanToZero;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
@@ -251,8 +252,8 @@ public final class HistogramMetadata implements Serializable {
             return 0.0;
         }
 
-        double variance = (sumOfSquares / count)
-              - FastMath.pow(sum / count, 2);
+        double variance = nanToZero((sumOfSquares / count)
+              - FastMath.pow(sum / count, 2));
 
         return FastMath.sqrt(variance);
     }

--- a/modules/common/src/main/java/org/dcache/util/histograms/TimeseriesHistogram.java
+++ b/modules/common/src/main/java/org/dcache/util/histograms/TimeseriesHistogram.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.util.histograms;
 
 import static java.util.Objects.requireNonNull;
+import static org.dcache.util.MathUtils.nanToZero;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
@@ -85,12 +86,12 @@ public class TimeseriesHistogram extends HistogramModel
 
     @Override
     public void add(Double value, Long timestamp) {
-        update(value, UpdateOperation.SUM, timestamp);
+        update(nanToZero(value), UpdateOperation.SUM, timestamp);
     }
 
     @Override
     public void average(Double value, Long timestamp) {
-        update(value, UpdateOperation.AVERAGE, timestamp);
+        update(nanToZero(value), UpdateOperation.AVERAGE, timestamp);
     }
 
     @Override
@@ -147,7 +148,7 @@ public class TimeseriesHistogram extends HistogramModel
 
     @Override
     public void replace(Double value, Long timestamp) {
-        update(value, UpdateOperation.REPLACE, timestamp);
+        update(nanToZero(value), UpdateOperation.REPLACE, timestamp);
     }
 
     /**
@@ -177,7 +178,7 @@ public class TimeseriesHistogram extends HistogramModel
     }
 
     private int findTimebinIndex(long timestamp) {
-        return (int) FastMath.floor((timestamp - lowestBin) / binSize);
+        return (int) FastMath.floor(nanToZero((timestamp - lowestBin) / binSize));
     }
 
     private int rotateBuffer(int binIndex) {

--- a/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
+++ b/modules/dcache/src/main/java/org/dcache/util/collector/pools/PoolInfoCollectorUtils.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.util.collector.pools;
 
 import static org.dcache.services.history.pools.PoolListingService.ALL;
+import static org.dcache.util.MathUtils.nanToZero;
 
 import diskCacheV111.poolManager.PoolSelectionUnit;
 import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPool;
@@ -352,8 +353,8 @@ public final class PoolInfoCollectorUtils {
             double currentBinSize = h.getBinSize();
             int numBins = currentData.size();
             for (int bin = 0; bin < numBins; ++bin) {
-                int groupBin = (int) FastMath.floor(
-                      (bin * currentBinSize) / binSize);
+                int groupBin = (int) FastMath.floor(nanToZero(
+                      (bin * currentBinSize) / binSize));
                 dataArray[groupBin] += currentData.get(bin);
             }
         }


### PR DESCRIPTION
Motivation:

See GH #6978 NaN error in history service
https://github.com/dCache/dcache/issues/6978

The stack trace comes when the Gson writer
attempts to serialize a double NaN.

Modification:

While it has been difficult to reproduce
the conditions giving rise to this error,
there are a number of possible places where
NaNs can occur in the histogram pipeline.
These all involve division where either numerator
or denominator are a floating point value and they both are zero.  (a NaN can also occur from the
modulo operation if done using a floating point zero value, but there are no instances of % + fp that
I could find).

To prevent this, those places are wrapped in
a utility method that converts the
NaN to a zero.

As extra prevention, we do the same when
adding a double value to a timeseries
histogram.

Result:

The code should not generate the reported exception.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13867/
Closes: #6978
Acked-by: Dmitry