### PR TITLE
common: provisional fix for out of bounds error in timeseries histogram

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/histograms/HistogramMetadata.java
+++ b/modules/common/src/main/java/org/dcache/util/histograms/HistogramMetadata.java
@@ -194,7 +194,7 @@ public final class HistogramMetadata implements Serializable {
     }
 
     public void rotate(int units) {
-        units = units >= numBins ? numBins : units;
+        units = Math.min(units, numBins);
 
         long now = System.currentTimeMillis();
 

--- a/modules/common/src/main/java/org/dcache/util/histograms/TimeseriesHistogram.java
+++ b/modules/common/src/main/java/org/dcache/util/histograms/TimeseriesHistogram.java
@@ -64,6 +64,8 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import org.apache.commons.math3.util.FastMath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>Maintains a histogram data set which consists of a fixed number of
@@ -71,6 +73,7 @@ import org.apache.commons.math3.util.FastMath;
  */
 public class TimeseriesHistogram extends HistogramModel
       implements UpdatableHistogramModel {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimeseriesHistogram.class);
 
     enum UpdateOperation {
         SUM, AVERAGE, REPLACE
@@ -181,9 +184,16 @@ public class TimeseriesHistogram extends HistogramModel
     }
 
     private int rotateBuffer(int binIndex) {
-        int units = binIndex - binCount + 1;
+        /*
+         *  REVISIT
+         *
+         *  see comments under #update().
+         */
+        int count = Math.min(binCount, data.size());
 
-        int len = units >= binCount ? binIndex : units;
+        int units = binIndex - count + 1;
+
+        int len = Math.min(units, count);
 
         for (int i = 0; i < len; ++i) {
             data.remove(0);
@@ -195,7 +205,7 @@ public class TimeseriesHistogram extends HistogramModel
         lowestBin += (binSize * units);
         highestBin += (binSize * units);
 
-        return binCount - 1;
+        return count - 1;
     }
 
     /**
@@ -216,13 +226,37 @@ public class TimeseriesHistogram extends HistogramModel
             return;
         }
 
+        /*
+         *  REVISIT
+         *
+         *  RT 10420 out of bounds exception in history cell
+         *  reported an attempt to insert at an index which should be length - 1,
+         *  but which ends up being = length.
+         *
+         *  The cause for this remains currently unidentified
+         *  (the size of the data array should be invariant).
+         *
+         *  The following is provisional:  (a) if there is a difference between the
+         *  constant size (binCount) given to the histogram upon construction and the
+         *  actual list/array size, we log it here; (b) since we are inserting into
+         *  the data, we use the actual size to compute the length - 1 to avoid the
+         *  IndexOutOfBounds error.
+         */
+
+        int datasize = Math.min(binCount, data.size());
+
+        if (binCount != datasize) {
+            LOGGER.error("{}: size of data array {} less than binCount {}: {}", identifier,
+                  datasize, binCount);
+        }
+
         /**
          * Update needs to rotate the buffer here regardless of
          * what the value is.
          *
          * New slots have a null value.
          */
-        if (binIndex >= binCount) {
+        if (binIndex >= datasize) {
             binIndex = rotateBuffer(binIndex);
         }
 


### PR DESCRIPTION
Motivation:

RT 10420 out of bounds exception in history cell
reported the stack trace (below, in testing) in
their history pinboard and log.  This was occurring each time aggregation was done, and only for one
set of pool histograms, the `Queued P2P Client`.
Inspection of the pool group's .json file confirmed that for that histogram, the length of the data
array was 1 less than it should have been (576, not 577).

How this occurred is difficult to discern.  I have checked the computations done for binning and could not discover any off-by-one arithmetic errors (so far...). The constant given to the histogram upon initialization, `binCount`, should in fact always be equal to the
`data` list size.  How and when this might occur,
short of actual corruption of the .json file, I
am currently unsure.

Modification:

I have adopted a provisional fix which is not entirely satisfactory but which should guarantee that the
OutOfBoundsException does not occur.  This involves:

- checking (which should have been redundant) the actual array size against the binCount and always preferring the array size to compute the bin index.
- reporting when the inequality occurs for which histogram.

Result:

IndexOutOfBoundsException should not occur; stack trace is replaced by a logging statement.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes
Bug:  RT #10420
Patch: https://rb.dcache.org/r/13869
Acked-by: Lea