### PR TITLE
psu:fix issue for nested pgroups

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -18,6 +18,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Streams;
 import diskCacheV111.pools.PoolV2Mode;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsHandler;
@@ -306,13 +307,13 @@ public class PoolSelectionUnitV2
                       pw.println();
                   });
             pw.println();
+
             _pGroups.values().stream().sorted(comparing(PGroup::getName)).forEachOrdered(
                   group -> {
                       pw.append("psu create pgroup ").append(group.getName());
                       if (group.isPrimary()) {
                           pw.append(" -resilient");
                       }
-
                       // don't explicitly add pools into dynamic pool groups
                       if (group instanceof DynamicPGroup) {
                           pw.append(" -dynamic");
@@ -331,8 +332,27 @@ public class PoolSelectionUnitV2
                                             .append(group.getName())
                                             .append(" ")
                                             .println(pool.getName())
+
                                 );
                       }
+
+                      pw.println();
+                  });
+            //nested -pools
+            _pGroups.values().stream().sorted(comparing(PGroup::getName)).forEachOrdered(
+                  group -> {
+                      pw.println();
+                      group._pgroupList.stream().sorted(comparing(PGroup::getName))
+                            .forEachOrdered(
+                                  groupS -> {pw
+                                            .append("psu addto pgroup ")
+                                            .append(group.getName())
+                                            .append(" ")
+                                            .println("@" + groupS.getName());
+                                      LOGGER.info(groupS.getName() + " " + group.getName());
+                                  }
+                            );
+
                       pw.println();
                   });
             _links.values().stream().sorted(comparing(Link::getName)).forEachOrdered(
@@ -1737,6 +1757,7 @@ public class PoolSelectionUnitV2
                     group._poolList.values().stream().sorted(comparing(Pool::getName))
                           .forEachOrdered(
                                 pool -> sb.append("   ").append(pool.toString()).append("\n"));
+                    sb.append("nested groups  = ").append(group._pgroupList).append("\n") ;
                 }
             }
         } finally {
@@ -2218,7 +2239,6 @@ public class PoolSelectionUnitV2
     //
 
     public void addToPoolGroup(String pGroupName, String poolName) {
-
         wlock();
         try {
             PGroup group = _pGroups.get(pGroupName);


### PR DESCRIPTION
new nested pool group feature in version 8.2, was not displaying newly added pgroups

> psu create pgroup alias-pools
> psu addto pgroup alias-pools @test-pools
>
> listing the pool groups gives:
>
> psu ls -l pgroup

@test-pools was not displayed

the second problem was that, after restart the nested group was deleted, because  the getCurrentSetup() output file was not saving the newly added command, and it was not possible to add a dynamic pool

Modification

add missing part to dumpsetup()

Result

This is fixed, the, setup is correct now

psu create pool pool_read
psu create pool pool_res1
psu create pool pool_res2
psu create pool pool_res3
psu create pool pool_sm
psu create pool pool_write

psu create pgroup alias-pools

psu create pgroup default

psu create pgroup qos-disk -dynamic -tags=qos=disk

psu create pgroup resgroup -resilient
psu addto pgroup resgroup pool_res1
psu addto pgroup resgroup pool_res2
psu addto pgroup resgroup pool_res3

psu addto pgroup alias-pools @resgroup

Target: master
8.2
 Require-book: yes
 Require-notes: yes
 Patch:
 Acked-by: Tigran Mkrtchyan, Albert Rossi