### PR TITLE
telemetry: Don't log stacktrace for caught expceptions

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/telemetry/InstanceData.java
+++ b/modules/dcache/src/main/java/org/dcache/telemetry/InstanceData.java
@@ -119,8 +119,8 @@ public class InstanceData implements CellLifeCycleAware {
 
         } catch (CacheException | InterruptedException | NoRouteToCellException e) {
             LOGGER.error(
-                  "Could not get storage information; set storage to -1.0. This was caused by: ",
-                  e);
+                  "Could not get storage information; set storage to -1.0. This was caused by: {}",
+                    e.toString());
         }
 
         return space;

--- a/modules/dcache/src/main/java/org/dcache/telemetry/SendData.java
+++ b/modules/dcache/src/main/java/org/dcache/telemetry/SendData.java
@@ -44,8 +44,8 @@ public class SendData implements CellCommandListener, CellLifeCycleAware {
     public void setUrlStr(String url) {
         try {
             uri = URI.create(url);
-        } catch (IllegalArgumentException iae) {
-            LOGGER.error("Failed to create URL. Reason: ", iae);
+        } catch (IllegalArgumentException e) {
+            LOGGER.error("Failed to create URL. Reason: {}", e.toString());
             throw new RuntimeException();
         }
     }
@@ -111,8 +111,8 @@ public class SendData implements CellCommandListener, CellLifeCycleAware {
             } else {
                 LOGGER.info("Information successfully sent to {}", uri);
             }
-        } catch (InterruptedException | IOException ioe) {
-            LOGGER.error("Sending data to {} failed, caused by: ", uri, ioe);
+        } catch (InterruptedException | IOException e) {
+            LOGGER.error("Sending data to {} failed, caused by: {}", uri, e.toString());
         }
     }
 }


### PR DESCRIPTION
Motivation:

When an exception is thrown, for example the telemetry can't connect to the collector, this is caught with a stacktrace being logged.

Modification:

Replace it with calls of getClass() and getMessage() methods on the exception object.

Result:

Instead of a stacktrace the exception class and its message is logged.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Closes: #6973
Acked-by: Tigran, Lea