### PR TITLE
dcache-xroot:  return kXR_ItExists error code when file exists

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/CacheExceptionMapper.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/CacheExceptionMapper.java
@@ -51,6 +51,7 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ChkSumErr;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_FSError;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_FileLocked;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_IOError;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ItExists;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_NotAuthorized;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_NotFile;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_NotFound;
@@ -91,9 +92,11 @@ public class CacheExceptionMapper {
             case FILE_CORRUPTED:
                 return kXR_ChkSumErr;
 
+            case FILE_EXISTS:
+                return kXR_ItExists;
+
             case FILE_NOT_IN_REPOSITORY:
             case FILE_NOT_ONLINE:
-            case FILE_EXISTS:
             case FILE_PRECIOUS:
             case FILE_NOT_STORED:
             case FILESIZE_UNKNOWN:

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -25,7 +25,7 @@ import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ArgInvalid;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ArgMissing;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_FileNotOpen;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_InvalidRequest;
-import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_NotAuthorized;
+import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ItExists;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_Qcksum;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_Qconfig;
 import static org.dcache.xrootd.protocol.XrootdProtocol.kXR_ServerError;
@@ -488,7 +488,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
         } catch (FileNotFoundCacheException e) {
             return withError(ctx, req, xrootdErrorCode(e.getRc()), "No such file");
         } catch (FileExistsCacheException e) {
-            return withError(ctx, req, kXR_NotAuthorized, "File already exists");
+            return withError(ctx, req, kXR_ItExists, "File already exists");
         } catch (TimeoutCacheException e) {
             return withError(ctx, req, xrootdErrorCode(e.getRc()), "Internal timeout");
         } catch (PermissionDeniedCacheException e) {


### PR DESCRIPTION
Motivation:

From v4 to v5, there were some changes in
the xrootd protocol affecting error codes.
One of these was the addition of kXR_ItExists.

It was not immediately apparent that the
code that we were returning (kXR_unsupported
in 2014, then kXR_NotAuthorized) would
cause some clients to react differently;
but in any case, the neglect to change
this has provoked potential data loss
with gfal, which aggressively removes
the file/directory and tries to overwrite
in this situation when doing `copy`.

Modification:

Make sure that when a file exists we
return kXR_ItExists.

Result:

Aggressive clients should be blocked
from pre-emptive removal.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Patch: https://rb.dcache.org/r/13873
Requires-notes: yes
Acked-by: Dmitry