### PR TITLE
dcache-bulk,dcache-frontend:  fix bug in tape/stage and in argument e…

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
@@ -133,8 +133,14 @@ public final class StageActivity extends PinManagerActivity {
     @Override
     protected void configure(Map<String, String> arguments) {
         if (arguments != null) {
-            jsonLifetimes = new JSONObject(arguments.get("diskLifetime"));
-            jsonMetadata = new JSONObject(arguments.get("targetedMetadata"));
+            String value = arguments.get("diskLifetime");
+            if (value != null) {
+                jsonLifetimes = new JSONObject(value);
+            }
+            value = arguments.get("targetedMetadata");
+            if (value != null) {
+                jsonMetadata = new JSONObject(value);
+            }
         }
     }
 

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestDao.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestDao.java
@@ -60,14 +60,16 @@ documents or software obtained from this server.
 package org.dcache.services.bulk.store.jdbc.request;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.dcache.services.bulk.BulkRequest;
 import org.dcache.services.bulk.BulkRequest.Depth;
@@ -76,6 +78,7 @@ import org.dcache.services.bulk.BulkRequestStatus;
 import org.dcache.services.bulk.BulkRequestStatusInfo;
 import org.dcache.services.bulk.BulkStorageException;
 import org.dcache.services.bulk.store.jdbc.JdbcBulkDaoUtils;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
@@ -163,7 +166,13 @@ public final class JdbcBulkRequestDao extends JdbcDaoSupport {
         request.setDelayClear(rs.getInt("delay_clear"));
         String args = rs.getString("arguments");
         if (Strings.emptyToNull(args) != null) {
-            request.setArguments(Splitter.on(",").withKeyValueSeparator(":").split(args));
+            JSONObject argObj = new JSONObject("{" + args + "}");
+            Map<String, String> arguments = new HashMap<>();
+            for (Iterator<String> keys = argObj.keys(); keys.hasNext();) {
+                String key = keys.next();
+                arguments.put(key, String.valueOf(argObj.get(key)));
+            }
+            request.setArguments(arguments);
         }
         BulkRequestStatusInfo statusInfo = new BulkRequestStatusInfo();
         statusInfo.setUser(rs.getString("owner"));

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
@@ -368,6 +368,7 @@ public final class StageResources {
             Map<String, String> arguments = new HashMap<>();
             arguments.put("diskLifetime", jsonLifetimes.toString());
             arguments.put("targetedMetadata", jsonMetadata.toString());
+            request.setArguments(arguments);
         } catch (JSONException e) {
             throw new BadRequestException(
                   String.format("badly formed json object (%s): %s.", requestPayload, e));


### PR DESCRIPTION
…xtraction from DB

Motivation:

See RT 10426 Inconsistencies in Pin Lifetime between dCache-like pinning https://rt.dcache.org/Ticket/Display.html?id=10426

It was noted that the diskLifetime value was always default for /tape/stage, unlike for /bulk-requests with -activity=PIN.

It turns out the fundamental problem was that the frontend resource was neglecting to set the map of arguments on the request.

Once this was done, however, a second problem was discovered. The serialized value in the database was not being parsed back
into the correct JSON string.   This has to do with the fact
that that arguments is a <String, String> map, but the
stringified value was now being used to store a JSON object
string instead of a simple value, meaning that it contains
the same delimiters as the top level map does (: and ,).

Modification:

Adding a surrounding '{' '}' to the value fetched from the database and parsing it as a JSONObject solved the problem.

Result:

The frontend resource now adds the arguments map as it should.

Target: master
Request: 8.2
Bug: #10426
Requires-notes: yes
Patch: https://rb.dcache.org/r/13877/
Acked-by: Dmitry