### PR TITLE
dcache-frontend:  convert empty to null when processing TimeUnit attr…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -2,6 +2,7 @@ package org.dcache.restful.resources.namespace;
 
 import static org.dcache.restful.providers.SuccessfulResponse.successfulResponse;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Range;
 import diskCacheV111.util.AttributeExistsCacheException;
 import diskCacheV111.util.CacheException;
@@ -453,7 +454,8 @@ public class FileResources {
                     if (lifetime == null) {
                         lifetime = 0;
                     }
-                    String lifetimeUnitVal = reqPayload.optString("lifetime-unit");
+                    String lifetimeUnitVal = Strings.emptyToNull(
+                          reqPayload.optString("lifetime-unit"));
                     TimeUnit lifetimeUnit = lifetimeUnitVal == null ?
                           TimeUnit.SECONDS : TimeUnit.valueOf(lifetimeUnitVal);
                     pnfsId = pnfsHandler.getPnfsIdByPath(path.toString());


### PR DESCRIPTION
…ibute

Motivation:

With the namespace resource 'pin' action, lifetime unit should default to SECONDS.  Leaving it unexpressed results in java.lang.IllegalArgumentException: No enum constant java.util.concurrent.TimeUnit.

Modfication:

Need to apply emptyToNull to the string option.

Result:

Request for pin without lifetime unit specified works.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Patch: https://rb.dcache.org/r/13879/
Requires-notes: yes
Acked-by: Tigran