### PR TITLE
dcache-qos,dcache-resilience:  allow db endpoint to have separately c…

### DIFF
--- a/skel/share/defaults/qos.properties
+++ b/skel/share/defaults/qos.properties
@@ -100,12 +100,12 @@ qos.db.namespace.connections.idle=1
 
 # ---- Database related settings reserved for internal use.
 #
-(immutable)qos.db.namespace.host=${chimera.db.host}
-(immutable)qos.db.namespace.name=${chimera.db.name}
-(immutable)qos.db.namespace.user=${chimera.db.user}
-(immutable)qos.db.namespace.password=${chimera.db.password}
-(immutable)qos.db.namespace.password.file=${chimera.db.password.file}
-(immutable)qos.db.namespace.url=${chimera.db.url}
+qos.db.namespace.host=${chimera.db.host}
+qos.db.namespace.name=${chimera.db.name}
+qos.db.namespace.user=${chimera.db.user}
+qos.db.namespace.password=${chimera.db.password}
+qos.db.namespace.password.file=${chimera.db.password.file}
+qos.db.namespace.url=${chimera.db.url}
 (immutable)qos.db.namespace.schema.changelog=${chimera.db.schema.changelog}
 (immutable)qos.db.namespace.schema.auto=false
 

--- a/skel/share/defaults/resilience.properties
+++ b/skel/share/defaults/resilience.properties
@@ -104,14 +104,14 @@ resilience.db.connections.idle = 1
 (prefix)resilience.db.hikari-properties = Hikari-specific properties
 
 
-# ---- Database related settings reserved for internal use.
+# ---- Database related settings.
 #
-(immutable)resilience.db.host=${chimera.db.host}
-(immutable)resilience.db.name=${chimera.db.name}
-(immutable)resilience.db.user=${chimera.db.user}
-(immutable)resilience.db.password=${chimera.db.password}
-(immutable)resilience.db.password.file=${chimera.db.password.file}
-(immutable)resilience.db.url=${chimera.db.url}
+resilience.db.host=${chimera.db.host}
+resilience.db.name=${chimera.db.name}
+resilience.db.user=${chimera.db.user}
+resilience.db.password=${chimera.db.password}
+resilience.db.password.file=${chimera.db.password.file}
+resilience.db.url=${chimera.db.url}
 (immutable)resilience.db.schema.changelog=${chimera.db.schema.changelog}
 (immutable)resilience.db.schema.auto=false
 


### PR DESCRIPTION
…onfigurable properties

Motivation:

The namespace provider used by QoS/Resilience was meant to have the same endpoint, user and password as for chimera; thus the properties were marked immutable.

However, it may be convenient for admins to be able to configure these separately from the global
properties; e.g., if they want to give read-only
access to a db replica instead of to the live
database.

Modification:

Remove the immutable qualifier from these properties.

Result:

Friendlier configuration.

Target: master
Request: 8.2
Request: 8.1
Requires-notes: yes
Patch: https://rb.dcache.org/r/13880/
Acked-by: Tigran