### PR TITLE
dcache-frontend: provide optional legacy qos request in namespace res…

### DIFF
--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -594,7 +594,9 @@
     <bean class="org.dcache.restful.resources.cells.CellInfoResources" scope="request"/>
     <bean class="org.dcache.restful.resources.doors.DoorsResources" scope="request"/>
     <bean class="org.dcache.restful.resources.identity.UserResource" scope="request"/>
-    <bean class="org.dcache.restful.resources.namespace.FileResources" scope="request"/>
+    <bean class="org.dcache.restful.resources.namespace.FileResources" scope="request">
+      <property name="useQosService" value="${frontend.service.namespace.use-qos-service}"/>
+    </bean>
     <bean class="org.dcache.restful.resources.labels.LabelsResources" scope="request"/>
     <bean class="org.dcache.restful.resources.namespace.IdResources" scope="request"/>
     <bean class="org.dcache.restful.resources.pool.PoolGroupInfoResources" scope="request"/>

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -451,6 +451,10 @@ frontend.service.gplazma.cache.timeout.unit = MINUTES
 # Used by the billing service for periodic collection
 frontend.service.billing.collection.timeout = 1
 
+# Whether to submit namespace qos requests to the QoSEngine or to use
+# the embedded legacy mechanism.  Defaults to the new QoSEngine.
+(one-of?true|false)frontend.service.namespace.use-qos-service= true
+
 # Geographic placement
 #
 # A comma-separated list of ISO-3166 alpha-2 codes that identify where

--- a/skel/share/services/frontend.batch
+++ b/skel/share/services/frontend.batch
@@ -37,6 +37,7 @@ check -strong frontend.service.transfers.timeout.unit
 check -strong frontend.service.cell-info.update-threads
 check -strong frontend.service.cell-info.timeout
 check -strong frontend.service.cell-info.timeout.unit
+check -strong frontend.service.namespace.use-qos-service
 check -strong frontend.service.pool-info.update-threads
 check -strong frontend.service.pool-info.maxPoolActivityListSize
 check -strong frontend.service.pool-info.timeout


### PR DESCRIPTION
…ource

Motivation:

While 8.1 added the QoSEngine and we would
like to encourage users to adopt it, there
may be a (transient) need for installations
to continue to use the embedded transition
engine that existed in the frontend for
the namespace resource.

Modification:

Add a property which optionally turns off
the newer implementation and reverts to the
legacy one.

Result:

May ease the transition for some sites.

Target: master
Request: 8.2
Request: 8.1
Patch: https://rb.dcache.org/r/13883/
Requires-notes: yes
Acked-by: Tigran