### PR TITLE
dcache-frontend: provide optional legacy qos request in namespace res…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -65,6 +65,7 @@ import org.dcache.namespace.FileType;
 import org.dcache.pinmanager.PinManagerPinMessage;
 import org.dcache.pinmanager.PinManagerUnpinMessage;
 import org.dcache.poolmanager.PoolMonitor;
+import org.dcache.qos.QoSTransitionEngine;
 import org.dcache.qos.data.FileQoSRequirements;
 import org.dcache.qos.remote.clients.RemoteQoSRequirementsClient;
 import org.dcache.restful.providers.JsonFileAttributes;
@@ -81,6 +82,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
 import org.springframework.stereotype.Component;
 
 /**
@@ -125,6 +127,8 @@ public class FileResources {
     @Inject
     @Named("qos-engine")
     private CellStub qosEngine;
+
+    private boolean useQosService;
 
     @GET
     @ApiOperation(value = "Find metadata and optionally directory contents.",
@@ -436,17 +440,26 @@ public class FileResources {
                     break;
                 case "qos":
                     String targetQos = reqPayload.getString("target");
-                    /*
-                     *  fire and forget, does not wait for transition to complete
-                     */
-                    FileAttributes attr
-                          = pnfsHandler.getFileAttributes(path.toString(),
-                          NamespaceUtils.getRequestedAttributes(false, false,
-                                true, false, false));
-                    FileQoSRequirements requirements = getBasicRequirements(targetQos, attr);
-                    RemoteQoSRequirementsClient client = new RemoteQoSRequirementsClient();
-                    client.setRequirementsService(qosEngine);
-                    client.fileQoSRequirementsModified(requirements);
+                    if (!useQosService) {
+                        new QoSTransitionEngine(poolmanager,
+                              poolMonitor,
+                              pnfsHandler,
+                              pinmanager)
+                              .adjustQoS(path,
+                                    targetQos, request.getRemoteHost());
+                    } else {
+                        /*
+                         *  fire and forget, does not wait for transition to complete
+                         */
+                        FileAttributes attr
+                              = pnfsHandler.getFileAttributes(path.toString(),
+                              NamespaceUtils.getRequestedAttributes(false, false,
+                                    true, false, false));
+                        FileQoSRequirements requirements = getBasicRequirements(targetQos, attr);
+                        RemoteQoSRequirementsClient client = new RemoteQoSRequirementsClient();
+                        client.setRequirementsService(qosEngine);
+                        client.fileQoSRequirementsModified(requirements);
+                    }
                     break;
                 case "pin":
                     Integer lifetime = reqPayload.optInt("lifetime");
@@ -600,6 +613,11 @@ public class FileResources {
             throw new InternalServerErrorException(e);
         }
         return successfulResponse(Response.Status.OK);
+    }
+
+    @Required
+    public void setUseQosService(boolean useQosService) {
+        this.useQosService = useQosService;
     }
 
     private FileQoSRequirements getBasicRequirements(String targetQos, FileAttributes attributes) {

--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -569,7 +569,9 @@
     <bean class="org.dcache.restful.resources.cells.CellInfoResources" scope="request"/>
     <bean class="org.dcache.restful.resources.doors.DoorsResources" scope="request"/>
     <bean class="org.dcache.restful.resources.identity.UserResource" scope="request"/>
-    <bean class="org.dcache.restful.resources.namespace.FileResources" scope="request"/>
+    <bean class="org.dcache.restful.resources.namespace.FileResources" scope="request">
+      <property name="useQosService" value="${frontend.service.namespace.use-qos-service}"/>
+    </bean>
     <bean class="org.dcache.restful.resources.labels.LabelsResources" scope="request"/>
     <bean class="org.dcache.restful.resources.namespace.IdResources" scope="request"/>
     <bean class="org.dcache.restful.resources.pool.PoolGroupInfoResources" scope="request"/>

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -445,6 +445,10 @@ frontend.service.gplazma.cache.timeout.unit = MINUTES
 # Used by the billing service for periodic collection
 frontend.service.billing.collection.timeout = 1
 
+# Whether to submit namespace qos requests to the QoSEngine or to use
+# the embedded legacy mechanism.  Defaults to the new QoSEngine.
+(one-of?true|false)frontend.service.namespace.use-qos-service= true
+
 # Geographic placement
 #
 # A comma-separated list of ISO-3166 alpha-2 codes that identify where

--- a/skel/share/services/frontend.batch
+++ b/skel/share/services/frontend.batch
@@ -37,6 +37,7 @@ check -strong frontend.service.transfers.timeout.unit
 check -strong frontend.service.cell-info.update-threads
 check -strong frontend.service.cell-info.timeout
 check -strong frontend.service.cell-info.timeout.unit
+check -strong frontend.service.namespace.use-qos-service
 check -strong frontend.service.pool-info.update-threads
 check -strong frontend.service.pool-info.maxPoolActivityListSize
 check -strong frontend.service.pool-info.timeout


### PR DESCRIPTION
…ource

Motivation:

While 8.1 added the QoSEngine and we would
like to encourage users to adopt it, there
may be a (transient) need for installations
to continue to use the embedded transition
engine that existed in the frontend for
the namespace resource.

Modification:

Add a property which optionally turns off
the newer implementation and reverts to the
legacy one.

Result:

May ease the transition for some sites.

Target: master
Request: 8.2
Request: 8.1
Patch: https://rb.dcache.org/r/13883/
Requires-notes: yes
Acked-by: Tigran