### PR TITLE
dcache-qos,psu:  allow getStorageUnit to resolve regex

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/ALRPStorageUnitQoSProvider.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/ALRPStorageUnitQoSProvider.java
@@ -70,7 +70,6 @@ import static org.dcache.qos.data.QoSMessageType.VALIDATE_ONLY;
 
 import com.google.common.annotations.VisibleForTesting;
 import diskCacheV111.poolManager.PoolSelectionUnit;
-import diskCacheV111.poolManager.PoolSelectionUnit.SelectionUnit;
 import diskCacheV111.poolManager.StorageUnit;
 import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
@@ -159,13 +158,12 @@ public class ALRPStorageUnitQoSProvider implements QoSRequirementsProvider, Cell
         RetentionPolicy retentionPolicy = attributes.getRetentionPolicy();
 
         String unitKey = attributes.getStorageClass() + "@" + attributes.getHsm();
-        SelectionUnit unit = poolSelectionUnit().getStorageUnit(unitKey);
-        if (!(unit instanceof StorageUnit)) {
+        StorageUnit storageUnit = poolSelectionUnit().getStorageUnit(unitKey);
+        if (storageUnit == null) {
             throw new QoSException(unitKey + " does not correspond to a storage unit; "
                   + "cannot retrieve requirements for " + descriptor.getPnfsId());
         }
 
-        StorageUnit storageUnit = (StorageUnit) unit;
         Integer required = storageUnit.getRequiredCopies();
         List<String> onlyOneCopyPer = storageUnit.getOnlyOneCopyPer();
 

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -591,65 +591,8 @@ public class PoolSelectionUnitV2
             // original code is in the else
             //
             List<Unit> list = new ArrayList<>();
-            if (_useRegex) {
-                Unit universalCoverage = null;
-                Unit classCoverage = null;
+            resolveStorageUnit(list, storeUnitName);
 
-                for (Unit unit : _units.values()) {
-                    if (unit.getType() != STORE) {
-                        continue;
-                    }
-
-                    if (unit.getName().equals("*@*")) {
-                        universalCoverage = unit;
-                    } else if (unit.getName().equals("*@" + storeUnitName)) {
-                        classCoverage = unit;
-                    } else {
-                        if (Pattern.matches(unit.getName(), storeUnitName)) {
-                            list.add(unit);
-                            break;
-                        }
-                    }
-                }
-                //
-                // If a pattern matches then use it, fail over to a class,
-                // then universal. If nothing, throw exception
-                //
-                if (list.isEmpty()) {
-                    if (classCoverage != null) {
-                        list.add(classCoverage);
-                    } else if (universalCoverage != null) {
-                        list.add(universalCoverage);
-                    } else {
-                        throw new IllegalArgumentException(
-                              "Unit not found : " + storeUnitName);
-                    }
-                }
-
-            } else {
-                Unit unit = _units.get(storeUnitName);
-                if (unit == null) {
-                    int ind = storeUnitName.lastIndexOf('@');
-                    if ((ind > 0) && (ind < (storeUnitName.length() - 1))) {
-                        String template = "*@"
-                              + storeUnitName.substring(ind + 1);
-                        if ((unit = _units.get(template)) == null) {
-
-                            if ((unit = _units.get("*@*")) == null) {
-                                LOGGER.debug("no matching storage unit found for: {}",
-                                      storeUnitName);
-                                throw new IllegalArgumentException(
-                                      "Unit not found : " + storeUnitName);
-                            }
-                        }
-                    } else {
-                        throw new IllegalArgumentException(
-                              "IllegalUnitFormat : " + storeUnitName);
-                    }
-                }
-                LOGGER.debug("matching storage unit found for: {}", storeUnitName);
-                list.add(unit);
-            }
             if (protocolUnitName != null) {
 
                 Unit unit = findProtocolUnit(protocolUnitName);
@@ -875,6 +818,65 @@ public class PoolSelectionUnitV2
             LOGGER.debug(sb.toString());
         }
         return result;
+    }
+
+    private void resolveStorageUnit(List<Unit> list, String storeUnitName) {
+        if (_useRegex) {
+            Unit universalCoverage = null;
+            Unit classCoverage = null;
+
+            for (Unit unit : _units.values()) {
+                if (unit.getType() != STORE) {
+                    continue;
+                }
+
+                if (unit.getName().equals("*@*")) {
+                    universalCoverage = unit;
+                } else if (unit.getName().equals("*@" + storeUnitName)) {
+                    classCoverage = unit;
+                } else {
+                    if (Pattern.matches(unit.getName(), storeUnitName)) {
+                        list.add(unit);
+                        break;
+                    }
+                }
+            }
+
+            if (list.isEmpty()) {
+                if (classCoverage != null) {
+                    list.add(classCoverage);
+                } else if (universalCoverage != null) {
+                    list.add(universalCoverage);
+                } else {
+                    throw new IllegalArgumentException(
+                          "Unit not found : " + storeUnitName);
+                }
+            }
+        } else {
+            Unit unit = _units.get(storeUnitName);
+            if (unit == null) {
+                int ind = storeUnitName.lastIndexOf('@');
+                if ((ind > 0) && (ind < (storeUnitName.length() - 1))) {
+                    String template = "*@"
+                          + storeUnitName.substring(ind + 1);
+                    if ((unit = _units.get(template)) == null) {
+
+                        if ((unit = _units.get("*@*")) == null) {
+                            LOGGER.debug("no matching storage unit found for: {}",
+                                  storeUnitName);
+                            throw new IllegalArgumentException(
+                                  "Unit not found : " + storeUnitName);
+                        }
+                    }
+                } else {
+                    throw new IllegalArgumentException(
+                          "IllegalUnitFormat : " + storeUnitName);
+                }
+            }
+
+            LOGGER.debug("matching storage unit found for: {}", storeUnitName);
+            list.add(unit);
+        }
     }
 
     @Override

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -940,6 +940,17 @@ public class PoolSelectionUnitV2
             if (unit != null && unit.getType() == STORE) {
                 return (StorageUnit) unit;
             }
+
+            /*
+             *  If not found, and regex is on, try to resolve it.
+             */
+            if (_useRegex) {
+                List<Unit> units = new ArrayList<>();
+                resolveStorageUnit(units, storageClass);
+                if (!units.isEmpty()) {
+                    return (StorageUnit) units.iterator().next();
+                }
+            }
         } finally {
             _psuReadLock.unlock();
         }


### PR DESCRIPTION
Motivation:

The Resilience service unpacked the PoolSelectionUnit into its own internal map and had its own storage unit resolution code.

When transposed into QoS, the decision was made that the full special processing of PSU information was no longer necessary, so QoS relies on the PoolManager code more than Resilience did.

However, an oversight of this migration occurred in not realizing the `getStorageUnit` method did not
resolve regular expressions (when that option is on) as does the `match` method, and as Resilience did on its own.

Modification:

Change the `getStorageUnit` method to attempt unit name resolution in the event that it cannot find
the literal unit name mapped.

We also make a small correction to the qos-engine
(unnecessary class cast).

Result:

QoS can now function as it should when the PSU
regex option is `on`.

Target: master
Request: 8.2
Request: 8.1
Patch: https://rb.dcache.org/r/13888/
Requires-notes: yes
Acked-by: Dmitry