### PR TITLE
gplazma: oidc support 'aud' with spaces

### DIFF
--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/OidcAuthPlugin.java
@@ -75,7 +75,7 @@ public class OidcAuthPlugin implements GPlazmaAuthenticationPlugin {
         tokenProcessor = processor;
 
         String targets = properties.getProperty(OIDC_ALLOWED_AUDIENCES);
-        audienceTargets = Set.copyOf(Splitter.on(' ').trimResults().splitToList(targets));
+        audienceTargets = Set.copyOf(new Args(targets).getArguments());
     }
 
     private static IdentityProvider createIdentityProvider(String name, String description,

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -465,9 +465,13 @@ gplazma.oidc.access-token-cache.expire.unit = SECONDS
 #   describes which service is the intended recipient of this token.
 #
 #   The audience-targets configuration property takes a space
-#   separated list of possible 'aud' values.  If a token contains the
-#   'aud' claim and the 'aud' value does not match one of the
-#   audience-targets values then dCache will reject the token.
+#   separated list of possible 'aud' values.  A possible 'aud' value
+#   may be placed in double-quotes, which allows a valid audience to
+#   contain spaces.
+#
+#   If a token contains the 'aud' claim and the 'aud' value does not
+#   match one of the audience-targets values then dCache will reject
+#   the token.
 #
 gplazma.oidc.audience-targets =
 


### PR DESCRIPTION
Motivation:

OIDC tokens may contain a 'aud' claim, which limits the token to services that self-identify with that claim's value.  The oidc plugin accepts a space-separated list of 'aud' claim values that it will accept.  This is a problem because an 'aud' claim could contain a space.

Modification:

Use the Arg class to parse the 'gplazma.oidc.audience-targets' property value.  An 'aud' claim value with spaces is supported by placing the value in double-quote-marks.

Result:

The 'gplazma.oidc.audience-targets' configuratioon property now allows values to be placed in double-quote-marks.  This is to support 'aud' claim values with spaces.

Target: master
Request: 8.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13884/
Acked-by: Tigran Mkrtchyan