### PR TITLE
webdav: respect xattrs for COPY request

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/Xattrs.java
+++ b/modules/common/src/main/java/org/dcache/util/Xattrs.java
@@ -50,26 +50,27 @@ public final class Xattrs {
     }
 
     /**
-     * Extract extended attributes from the given {@code params} {@link Map}.
+     * Extract extended attributes from the given {@code params} {@link Map}. This method expected
+     * the params map ar value returned by {@link ServletRequest#getParameterMap}
      *
      * @param params The map to extract attributes from.
      * @return a key-value map with extended attributes.
      * @throws NullPointerException if params is {@code null}
      */
-    public static Map<String, String> from(Map<String, String> params) {
+    public static Map<String, String> from(Map<String, String[]> params) {
 
         requireNonNull(params, "Params must be provided");
 
         return params.entrySet()
               .stream()
               .filter(e -> e.getKey().startsWith(XATTR_PREFIX))
-              .collect(toMap(Xattrs::getName, Map.Entry::getValue));
+              .collect(toMap(Xattrs::getName, e -> e.getValue()[0]));
     }
 
     /**
      * Convert a URL query key-value pair to the corresponding extended attribute name.
      */
-    private static String getName(Map.Entry<String, String> entry) {
+    private static String getName(Map.Entry<String, ?> entry) {
         return entry.getKey().substring(XATTR_PREFIX.length());
     }
 }

--- a/modules/common/src/test/java/org/dcache/util/XattrsTest.java
+++ b/modules/common/src/test/java/org/dcache/util/XattrsTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
 
-import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -76,7 +75,7 @@ public class XattrsTest {
 
     @Test
     public void testMapXattrEmpty() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, String[]> params = new HashMap<>();
 
         Map<String, String> xattrs = Xattrs.from(params);
         assertThat(xattrs, anEmptyMap());
@@ -84,8 +83,8 @@ public class XattrsTest {
 
     @Test
     public void testMapXattrSingleValue() {
-        Map<String, String> params = ImmutableMap.of(
-              "xattr.key1", "value1"
+        Map<String, String[]> params = Map.of(
+              "xattr.key1", new String[]{"value1"}
         );
 
         Map<String, String> xattrs = Xattrs.from(params);
@@ -95,9 +94,9 @@ public class XattrsTest {
 
     @Test
     public void testMapXattrMutipleValue() {
-        Map<String, String> params = ImmutableMap.of(
-              "xattr.key1", "value1",
-              "xattr.key2", "value2"
+        Map<String, String[]> params = Map.of(
+              "xattr.key1", new String[] {"value1"},
+              "xattr.key2", new String[] {"value2"}
         );
 
         Map<String, String> xattrs = Xattrs.from(params);
@@ -108,9 +107,20 @@ public class XattrsTest {
 
     @Test
     public void testMapXattrIgnoreOthers() {
-        Map<String, String> params = ImmutableMap.of(
-              "xattr.key1", "value1",
-              "key2", "value2"
+        Map<String, String[]> params = Map.of(
+              "xattr.key1", new String[] {"value1"},
+              "key2", new String[] {"value2"}
+        );
+
+        Map<String, String> xattrs = Xattrs.from(params);
+        assertThat(xattrs, aMapWithSize(1));
+        assertThat(xattrs, hasEntry("key1", "value1"));
+    }
+
+    @Test
+    public void testMapXattrFirstValueWins() {
+        Map<String, String[]> params = Map.of(
+              "xattr.key1", new String[] {"value1", "value2"}
         );
 
         Map<String, String> xattrs = Xattrs.from(params);
@@ -120,6 +130,6 @@ public class XattrsTest {
 
     @Test(expected = NullPointerException.class)
     public void testMapXattrNullArg() {
-        Xattrs.from((Map<String, String>) null);
+        Xattrs.from((Map<String, String[]>) null);
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -67,7 +67,6 @@ import dmg.cells.nucleus.CellInfoProvider;
 import dmg.cells.nucleus.CellMessageReceiver;
 import dmg.cells.nucleus.CellPath;
 import dmg.cells.services.login.LoginManagerChildrenInfo;
-import io.milton.http.FileItem;
 import io.milton.http.HttpManager;
 import io.milton.http.Request;
 import io.milton.http.ResourceFactory;
@@ -100,7 +99,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1348,14 +1346,7 @@ public class DcacheResourceFactory
      * Returns request params.
      */
     private static Map<String, String> getXattrsFromRequest() {
-        Map<String, String> m = new HashMap<>();
-        Map<String, FileItem> files = new HashMap<>();
-        try {
-            HttpManager.request().parseRequestParameters(m, files);
-        } catch (Exception e) {
-            throw new RuntimeException();
-        }
-        return Xattrs.from(m);
+        return Xattrs.from(ServletRequest.getRequest().getParameterMap());
     }
 
     /**

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -138,6 +138,7 @@ import org.dcache.util.LineIndentingPrintWriter;
 import org.dcache.util.NetworkUtils;
 import org.dcache.util.Strings;
 import org.dcache.util.URIs;
+import org.dcache.util.Xattrs;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.webdav.transfer.CopyFilter.CredentialSource;
 import org.eclipse.jetty.http.HttpFields;
@@ -858,6 +859,10 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
                               .fileType(FileType.REGULAR)
                               .xattr("xdg.origin.url", _destination.toASCIIString())
                               .build();
+
+                        Xattrs.from(ServletRequest.getRequest().getParameterMap())
+                              .forEach(attributes::updateXattr);
+
                         try {
                             msg = _pnfs.createPnfsEntry(_path.toString(), attributes,
                                     TransferManagerHandler.ATTRIBUTES_FOR_PULL);


### PR DESCRIPTION
Motivation:
if http copy is triggered by FTS, then webdav door ignores the provided xattrs.

Modification:
Update RemoteTransferHandler to populate file attributes with xattrs from the request params. Update Xatts#from(Map params) to accept Map<String, String[]> as returned by ServletRequest#getParameterMap. Update DcacheResourceFactory to use updated Xatts#from.

Result:
File transferred with http-tpc preserve extended attributes provided by FTS

Acked-by: Albert Rossi
Target: master, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 6ad477bdc5a8c541e78cbc145fa2b0ad971c5e0c)