### PR TITLE
dcache-xroot:  add missing shutdown on proxy inactive channel

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/proxy/ProxyErrorHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/proxy/ProxyErrorHandler.java
@@ -80,8 +80,9 @@ public class ProxyErrorHandler extends ChannelDuplexHandler {
         this.proxyId = proxyId;
     }
 
-    public void channelInactive(ChannelHandlerContext ctx) {
+    public void channelInactive(ChannelHandlerContext ctx) throws InterruptedException {
         LOGGER.warn("proxy {}, channel inactive event received on {}.", proxyId, ctx.channel());
+        requestHandler.shutdown();
         ctx.fireChannelInactive();
     }
 


### PR DESCRIPTION
Motivation:

RT #10432: dCache 8.2.13 xrootd proxy mode door IPV6 issue reports as side-effect error that the proxy port was staying open when client redirect was failing.

Evidently the client disconnects and the channel goes inactive.  That case was not being handled correctly.

Modification:

Add the necessary shutdown call to the error handler.

Result:

Port should be closed if client prematurely disconnects or the channel goes inactive for some other reason.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13892/
Bug:  RT #10432
Requires-notes: yes
Acked-by: Lea
Acked-by: Dmitry