### PR TITLE
dcache-xroot:  demote bad login token warning to debug

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/LoginTokens.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/LoginTokens.java
@@ -17,17 +17,16 @@
  */
 package org.dcache.xrootd;
 
-import com.google.common.base.Splitter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.Splitter;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkArgument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class to handle login token.
@@ -74,7 +73,7 @@ public class LoginTokens
                     Integer.parseInt(port));
             return Optional.of(addr);
         } catch (UnknownHostException | IllegalArgumentException e) {
-            LOGGER.warn("Bad kXR_login token \"{}\": {}", token, e.getMessage()); // should be DEBUG
+            LOGGER.debug("Bad kXR_login token \"{}\": {}", token, e.getMessage());
         }
 
         return Optional.empty();


### PR DESCRIPTION
Notivation:

This error, produced by xrdcp clients with versions prior to v5.5.0:

```
15 Feb 2023 14:44:58 [xrootd-net-8] [] Bad kXR_login token
"?xrd.cc=us&xrd.tz=0&xrd.appname=lar&xrd.info=&xrd.hostname=icaruspro-57243950-0-fnpc9102.fnal.gov&xrd.rn=v5.1.0": Missing "org.dcache.door" key
```
should not show up in the pinboard.

Modification:

Demote WARN to DEBUG.

Result:

No more noise.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Patch: https://rb.dcache.org/r/13893/
Acked-by: Paul
Acked-by: Dmitry