### PR TITLE
gplazma: x509 do not report bad .info files as a dCache bug

### DIFF
--- a/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/util/IGTFInfo.java
+++ b/modules/gplazma2-grid/src/main/java/org/dcache/gplazma/util/IGTFInfo.java
@@ -361,13 +361,23 @@ public class IGTFInfo {
             checkMutable();
             switch (type) {
                 case POLICY:
-                    Map<String, String> pr = Splitter.on(',').trimResults().omitEmptyStrings().
-                          withKeyValueSeparator(Splitter.on('=').trimResults()).split(value);
-                    IGTFInfo.this.policyRequires = ImmutableMap.copyOf(pr);
+                    try {
+                        Map<String, String> pr = Splitter.on(',').trimResults().omitEmptyStrings().
+                              withKeyValueSeparator(Splitter.on('=').trimResults()).split(value);
+                        IGTFInfo.this.policyRequires = ImmutableMap.copyOf(pr);
+                    } catch (IllegalArgumentException e) {
+                        throw new ParserException("Invalid policy 'requires' value: \"" + value
+                            + "\": " + e.getMessage());
+                    }
                     break;
                 case TRUST_ANCHOR:
-                    IGTFInfo.this.trustAnchorRequires =
-                          ImmutableList.copyOf(Splitter.on(',').trimResults().split(value));
+                    try {
+                        IGTFInfo.this.trustAnchorRequires =
+                              ImmutableList.copyOf(Splitter.on(',').trimResults().split(value));
+                    } catch (IllegalArgumentException e) {
+                        throw new ParserException("Invalid anchor 'requires' value: \"" + value
+                            + "\": " + e.getMessage());
+                    }
                     break;
             }
         }


### PR DESCRIPTION
Motivation:

In the trust store (typically /etc/grid-security/certificates), the `.info` files contain metadata about certificate authorities, or describe a set of CAs that (together) support a particular policy.  It is possible that these files contain errors.  If so, then such errors as reported with a cryptic message, logged as a dCache bug, and may prevent users from authenticating.

Modification:

Catch the Guava library's IllegalArgumentException and throw a parsing exception instead.

Result:

dCache handles malformed `.info` policies correctly: logging the problem but continuing to allow logins.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Require-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13891/
Acked-by: Dmitry Litvintsev
Acked-by: Lea Morschel