### PR TITLE
dcache-bulk: remove target error object and always convert to type + …

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -999,10 +999,9 @@ public final class BulkServiceCommands implements CellCommandListener {
 
             BulkRequestTarget target = optional.get();
             StringBuilder builder = new StringBuilder(formatTarget(target, true)).append("\n");
-            Throwable t = target.getThrowable();
-            if (t != null) {
-                builder.append("ERROR: ").append(t.getClass().getCanonicalName()).append(" : ")
-                      .append(t.getMessage()).append("\n");
+            if (target.getErrorType() != null) {
+                builder.append("ERROR[").append(target.getErrorType()).append(" : ")
+                      .append(target.getErrorMessage()).append("]\n");
             }
             return builder.toString();
         }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
@@ -63,6 +63,7 @@ import static org.dcache.services.bulk.BulkRequestStatus.CANCELLED;
 import static org.dcache.services.bulk.BulkRequestStatus.CANCELLING;
 import static org.dcache.services.bulk.BulkRequestStatus.COMPLETED;
 
+import com.google.common.base.Throwables;
 import diskCacheV111.util.FsPath;
 import java.util.List;
 import java.util.Optional;
@@ -120,10 +121,13 @@ public final class BulkRequestHandler implements BulkSubmissionHandler,
           throws BulkServiceException {
         LOGGER.trace("requestTargetAborted {}, {}, {}; calling abort on request store",
               parent, path, exception.toString());
+        Throwable root = Throwables.getRootCause(exception);
+        String errorType = root.getClass().getCanonicalName();
+        String errorMessage = root.getMessage();
         targetStore.abort(
               BulkRequestTargetBuilder.builder().rid(parent.getRid()).pid(parent.getId())
                     .activity(parent.getActivity()).path(path).attributes(attributes)
-                    .error(exception).build());
+                    .errorType(errorType).errorMessage(errorMessage).build());
         requestManager.signal();
         statistics.incrementJobsAborted();
     }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
@@ -211,7 +211,9 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
             perform(completedTarget);
         } catch (InterruptedException e) {
             LOGGER.debug("{}. retryFailed interrupted", rid);
-            targetStore.update(result.getTarget().getId(), FAILED, e);
+            targetStore.update(result.getTarget().getId(), FAILED,
+                  InterruptedException.class.getCanonicalName(),
+                  "retryFailed interrupted for " + rid);
         }
     }
 
@@ -246,7 +248,8 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
                 return;
             }
 
-            targetStore.update(completedTarget.getId(), state, completedTarget.getThrowable());
+            targetStore.update(completedTarget.getId(), state, completedTarget.getErrorType(),
+                  completedTarget.getErrorMessage());
         } catch (BulkStorageException e) {
             LOGGER.error("{} could not store target from result: {}: {}.", rid, result.getTarget(),
                   e.toString());
@@ -267,7 +270,7 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
 
         BulkRequestTarget target = readyTargets.poll();
         if (target != null) {
-            targetStore.update(target.getId(), READY, null);
+            targetStore.update(target.getId(), READY, null, null);
         }
         return Optional.ofNullable(target);
     }
@@ -310,7 +313,7 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
         BatchedResult result = new BatchedResult(target, future);
 
         try {
-            targetStore.update(target.getId(), RUNNING, error);
+            targetStore.update(target.getId(), RUNNING, null, null);
         } catch (BulkStorageException e) {
             LOGGER.error("{}, could not update target {},: {}.", rid, target, e.toString());
         }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
@@ -162,7 +162,9 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
             perform(path, attributes);
         } catch (InterruptedException e) {
             LOGGER.debug("{}. retryFailed interrupted", rid);
-            targetStore.update(result.getTarget().getId(), FAILED, e);
+            targetStore.update(result.getTarget().getId(), FAILED,
+                  InterruptedException.class.getCanonicalName(),
+                  "retryFailed interrupted for " + rid);
         }
     }
 
@@ -178,7 +180,8 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
                 return;
             }
 
-            targetStore.update(completedTarget.getId(), state, completedTarget.getThrowable());
+            targetStore.update(completedTarget.getId(), state, completedTarget.getErrorType(),
+                  completedTarget.getErrorMessage());
         } catch (BulkStorageException e) {
             LOGGER.error("{} could not store target from result: {}, {}: {}.", rid, result,
                   attributes, e.toString());

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/ConcurrentRequestManager.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/ConcurrentRequestManager.java
@@ -539,7 +539,8 @@ public final class ConcurrentRequestManager implements BulkRequestManager {
                 case CANCELLED:
                     job.update(State.CANCELLED);
                     try {
-                        targetStore.update(target.getId(), State.CANCELLED, target.getThrowable());
+                        targetStore.update(target.getId(), State.CANCELLED, target.getErrorType(),
+                              target.getErrorMessage());
                     } catch (BulkStorageException e) {
                         LOGGER.error("updateJobState", e.toString());
                     }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkTargetStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkTargetStore.java
@@ -196,8 +196,9 @@ public interface BulkTargetStore {
      *
      * @param id
      * @param state
-     * @param errorObject
+     * @param errorType
+     * @param errorMessage
      * @throws BulkStorageException
      */
-    void update(Long id, State state, Throwable errorObject) throws BulkStorageException;
+    void update(Long id, State state, String errorType, String errorMessage) throws BulkStorageException;
 }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetDao.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetDao.java
@@ -200,13 +200,7 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
         Long startedAt = timestamp == null ? null : timestamp.getTime();
 
         String errorType = rs.getString("error_type");
-        Throwable error = null;
-
-        if (errorType != null) {
-            /** this is a placeholder **/
-            error = new Throwable(
-                  "[errorType: " + errorType + "] " + rs.getString("error_message"));
-        }
+        String errorMessage = rs.getString("error_message");
 
         return BulkRequestTargetBuilder.builder()
               .id(rs.getLong("id"))
@@ -219,7 +213,7 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
               .createdAt(rs.getTimestamp("created_at").getTime())
               .startedAt(startedAt)
               .lastUpdated(rs.getTimestamp("last_updated").getTime())
-              .error(error).build();
+              .errorType(errorType).errorMessage(errorMessage).build();
     }
 
     public int update(JdbcRequestTargetCriterion criterion, JdbcRequestTargetUpdate update) {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetUpdate.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetUpdate.java
@@ -65,7 +65,6 @@ import static org.dcache.services.bulk.util.BulkRequestTarget.State.FAILED;
 import static org.dcache.services.bulk.util.BulkRequestTarget.State.RUNNING;
 
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.PnfsId;
 import java.sql.Timestamp;
@@ -112,12 +111,13 @@ public final class JdbcRequestTargetUpdate extends JdbcUpdate {
         return this;
     }
 
-    public JdbcRequestTargetUpdate errorObject(Throwable errorObject) {
-        if (errorObject != null) {
-            Throwable root = Throwables.getRootCause(errorObject);
-            set("error_type", root.getClass().getCanonicalName());
-            set("error_message", root.getMessage());
-        }
+    public JdbcRequestTargetUpdate errorType(String errorType) {
+        set("error_type", errorType);
+        return this;
+    }
+
+    public JdbcRequestTargetUpdate errorMessage(String errorMessage) {
+        set("error_message", errorMessage);
         return this;
     }
 

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTargetBuilder.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTargetBuilder.java
@@ -129,8 +129,13 @@ public final class BulkRequestTargetBuilder {
         return this;
     }
 
-    public BulkRequestTargetBuilder error(Object error) {
-        target.setErrorObject(error);
+    public BulkRequestTargetBuilder errorType(String errorType) {
+        target.setErrorType(errorType);
+        return this;
+    }
+
+    public BulkRequestTargetBuilder errorMessage(String errorMessage) {
+        target.setErrorMessage(errorMessage);
         return this;
     }
 


### PR DESCRIPTION
…message

Motivation:

While the BulkRequestTarget object has a Throwable error field, we do not store the error in serialized form in the database; rather, we store its type (canonical class name) and message; moreover, we always store the root exception metadata.

However, when deserializing a processed target from the database fields, we have to reconstruct an error for the object field as a placeholder (as a Throwable
with error type + message as message).   This
then leads to displays of target info with error type
always `Throwable` and the type name embedded into the
message.  This is rather ugly and redundant.

Modification:

Eliminate the actual Throwable object field in the BulkRequestTarget object, and always store the type and message of the root exception directly.  These are then simply pushed to the database and retrieved as such.

Result:

Economy and consistency of error metadata for bulk target information listings.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13895/
Requires-notes: yes
Acked-by: Tigran