### PR TITLE
Use correct git email scope and fix build when no email present.

### DIFF
--- a/packages/system-test/src/main/bin/populate
+++ b/packages/system-test/src/main/bin/populate
@@ -115,7 +115,11 @@ EOF
         i=$(( $i + 1 ))
     done
 
-    email_address=$(git config user.email) && cat >> $ca_config <<EOF
+    # If the email address can be found from git. continue
+    # or else it will use a dummy email address. We need the section to be defined with an email address.
+    # Alternatively we can not define the section but we would need to start handling this case earlier (remove subjectAltName).
+    email_address=$(git config user.email) || email_address="$USER@dcache.example.org"
+    cat >> $ca_config <<EOF
 
 [user_alt_names]
 email = $email_address

--- a/packages/system-test/src/main/bin/populate
+++ b/packages/system-test/src/main/bin/populate
@@ -115,7 +115,7 @@ EOF
         i=$(( $i + 1 ))
     done
 
-    email_address=$(git config --global user.email) && cat >> $ca_config <<EOF
+    email_address=$(git config user.email) && cat >> $ca_config <<EOF
 
 [user_alt_names]
 email = $email_address


### PR DESCRIPTION
Motivation:
Makes the new x509 Cert Generator by @paulmillar for system-test use the repository based git scope, which should (afaik) revert to the global git scope if no repository based scope is defined.

It also because it is related to the same issue. Fixes building when an email is not present in git (for example on our CI Systems)

Modification:
Uses the git repository based email (global if none defined) and fixes openssl erroring out, when no email is present, by passing a dummy email ```$USER@dcache.example.org``` (when no email from git can be found).

Result:
The x509 Cert Generator for system-test will not force users to change the git global email address, but use the repository based one. It will also not fail building on systems that don't have a git email address defined.

For more Context:
I don't use global git scopes, because I need to make commits for private hobbies, HAW stuff and DESY releated projects, and I don't have 1 single email address that I use to sign and commit those different projects. Hence my build system was broken, because the git global scope was empty and then openssl errored out.

Alternatively, one could setup a script to check if git global scope is empty and then use the repository scope, however this is exactly want git would do when you ask for the user.email without the global scope.

Signed-off-by: Lukas Mansour [lukas.mansour@desy.de](mailto:lukas.mansour@desy.de)