### PR TITLE
Allow for getting Migration Information per REST.

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/migrations/MigrationInfo.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/migrations/MigrationInfo.java
@@ -1,0 +1,98 @@
+package org.dcache.restful.providers.migrations;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+
+@ApiModel(description = "Container for migration information regarding a pool.")
+public class MigrationInfo {
+    private static final long serialVersionUID = -7942464845703567335L;
+
+    @ApiModelProperty("Current state of the migration.")
+    private String state;
+
+    @ApiModelProperty("Number of queued PNFSIDs.")
+    private Integer queued;
+
+    @ApiModelProperty("Number of attempts.")
+    private Integer attempts;
+
+    @ApiModelProperty("List of target pools for the migration.")
+    private List<String> targetPools;
+
+    @ApiModelProperty("Number of completed files, bytes and a percentage (if not finished or failed). (X files; Y bytes; Z%)")
+    private String completed;
+
+    @ApiModelProperty("Number of total bytes.")
+    private Integer total;
+
+    @ApiModelProperty("Representation of the running tasks for the migration job.")
+    private String runningTasks;
+
+    @ApiModelProperty("Representation of the most recent errors for the migration job.")
+    private String mostRecentErrors;
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setQueued(int queued) {
+        this.queued = queued;
+    }
+
+    public int getQueued() {
+        return queued;
+    }
+
+    public void setAttempts(int attempts) {
+        this.attempts = attempts;
+    }
+
+    public int getAttempts() {
+        return attempts;
+    }
+
+    public void setTargetPools(List<String> targetPools) {
+        this.targetPools = targetPools;
+    }
+
+    public List<String> getTargetPools() {
+        return targetPools;
+    }
+
+    public void setCompleted(String completed) {
+        this.completed = completed;
+    }
+
+    public String getCompleted() {
+        return completed;
+    }
+
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+
+    public void setRunningTasks(String runningTasks) {
+        this.runningTasks = runningTasks;
+    }
+
+    public String getRunningTasks() {
+        return runningTasks;
+    }
+
+    public void setMostRecentErrors(String mostRecentErrors) {
+        this.mostRecentErrors = mostRecentErrors;
+    }
+
+    public String getMostRecentErrors() {
+        return mostRecentErrors;
+    }
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/migration/MigrationResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/migration/MigrationResources.java
@@ -245,10 +245,10 @@ public final class MigrationResources {
     }
 
     /**
-     * Gets migration information to a specified migration ID on a pool.
+     * Gets migration information for the specified migration job id on the specified pool.
      */
     @GET
-    @ApiOperation(value = "Gets information to a migration. (See Pool Operator Commands 'migration info')")
+    @ApiOperation(value = "Gets migration information for the specified migration job id on the specified pool. (See Pool Operator Commands 'migration info')")
     @ApiResponses({
           @ApiResponse(code = 200, message = "OK"),
           @ApiResponse(code = 400, message = "Bad request"),
@@ -342,7 +342,6 @@ public final class MigrationResources {
             throw new InternalServerErrorException(e);
         }
     }
-
 
     private static void conditionalAppendString(String cmdParam, String jsonKey, StringBuilder sb,
           JSONObject jsonPayload) {


### PR DESCRIPTION
Motivation:
Allows the status of a migration to be requested with the poolname and ID. This will most likely be necessary for projects in the KAI Cooperation.

Modification:
Makes submitMigrationCopy method to return 401 and 403 correctly.
Adds getMigrationInfo(Pool, ID) which will return a JSON Object containing the migration information (status, completion, targets, etc.).

Result:
Now we can not only start but also see the information of migrations on pools.


There are small TODOs left to do with formatting, one could discuss if a more JSON-like encoding is even necessary for these fields (see: 'running tasks' and 'most recent errors' in the JSON Response).

Signed-off-by: Lukas Mansour [lukas.mansour@desy.de](mailto:lukas.mansour@desy.de)