### PR TITLE
dcache-frontend: resolve on parent of source when renaming

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -439,7 +439,7 @@ public class FileResources {
                     break;
                 case "mv":
                     String dest = (String) reqPayload.get("destination");
-                    FsPath target = pathMapper.resolve(request, path, dest);
+                    FsPath target = pathMapper.resolve(request, path.parent(), dest);
                     pnfsHandler.renameEntry(path.toString(), target.toString(), true);
                     break;
                 case "qos":


### PR DESCRIPTION
Motivation:

Use of relative path when issuing `mv` through
the RESTful `/api/v1/namespace` is broken.

Modifcation:

Call resolve with the parent of the path.

Result:

Fixes problem.

Target: master
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: yes
Closes: #6932
Patch: https://rb.dcache.org/r/13905/
Acked-by: Lea