### PR TITLE
dcache,chimera: resolve symlink before applying Restriction

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FileSystemProvider.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FileSystemProvider.java
@@ -570,4 +570,11 @@ public interface FileSystemProvider extends Closeable {
      */
     void removeXattr(FsInode inode, String attr) throws ChimeraFsException;
 
+    /**
+     * Returns the path with symlinks resolved.
+     *
+     * @param path to resolve.
+     * @return resolved path.
+     */
+    String resolvePath(String path) throws ChimeraFsException;
 }

--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -1786,6 +1786,25 @@ public class FsSqlDriver {
     }
 
     /**
+     * Should return the actual absolute path with all symlinks followed.
+     *
+     * This base implementation composes inode2path(path2inode).
+     *
+     * @param root node from which to begin path three walk.
+     * @param path to check for symlinks.
+     * @return path with all symlinks resolved; if does not exist, return the original path.
+     * @throws ChimeraFsException
+     * @throws SQLException
+     */
+    String resolvePath(FsInode root, String path) throws ChimeraFsException, SQLException {
+        FsInode pathInode = path2inode(root, path);
+        if (pathInode == null) {
+            return path;
+        }
+        return inode2path(pathInode, root);
+    }
+
+    /**
      * creates an instance of org.dcache.chimera.&lt;dialect&gt;FsSqlDriver or default driver, if
      * specific driver not available
      *

--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -1572,6 +1572,15 @@ public class JdbcFs implements FileSystemProvider {
         throw new ChimeraFsException(NOT_IMPL);
     }
 
+    @Override
+    public String resolvePath(String path) throws ChimeraFsException {
+        try {
+            return _sqlDriver.resolvePath(new RootInode(this, _sqlDriver.getRootInumber()), path);
+        } catch (SQLException e) {
+            throw new ChimeraFsException(e.getMessage(), e);
+        }
+    }
+
     private interface FallibleTransactionCallback<T> {
 
         T doInTransaction(TransactionStatus status) throws ChimeraFsException;

--- a/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
@@ -270,6 +270,22 @@ public class PgSQL95FsSqlDriver extends FsSqlDriver {
     }
 
     @Override
+    String resolvePath(FsInode root, String path) {
+        String normalizedPath = normalizePath(path);
+        return _jdbc.query("SELECT * FROM resolve_path(?, ?)",
+              ps -> {
+                  ps.setLong(1, root.ino());
+                  ps.setString(2, normalizedPath);
+              },
+              rs -> {
+                  if (rs.next()) {
+                      return rs.getString(1);
+                  }
+                  return null;
+              });
+    }
+
+    @Override
     void copyAcl(FsInode source, FsInode inode, RsType type, EnumSet<AceFlags> mask,
           EnumSet<AceFlags> flags) {
         int msk = mask.stream().mapToInt(AceFlags::getValue).reduce(0, (a, b) -> a | b);

--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changelog-master.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changelog-master.xml
@@ -24,5 +24,5 @@
     <include file="org/dcache/chimera/changelog/changeset-6.2.xml"/>
     <include file="org/dcache/chimera/changelog/changeset-7.1.xml"/>
     <include file="org/dcache/chimera/changelog/changeset-7.2.xml"/>
-
+    <include file="org/dcache/chimera/changelog/changeset-8.2.xml"/>
 </databaseChangeLog>

--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-8.2.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-8.2.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- For safety in backporting, we introduce a separate procedure rather
+         than trying to integrate/modify an existing one. -->
+    <changeSet id="34" author="arossi" dbms="postgresql">
+        <comment>Symlink resolution calling inumber2path(path2inumber)</comment>
+        <createProcedure>
+            CREATE OR REPLACE FUNCTION resolve_path(root bigint, path varchar) RETURNS varchar
+                AS
+            $$
+                BEGIN
+                IF path LIKE '/%' THEN
+                    path := substring(path from 2);
+                END IF;
+                return inumber2path(path2inumber(root, path));
+            END;
+            $$ LANGUAGE plpgsql;
+        </createProcedure>
+        <rollback>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -1924,4 +1924,20 @@ public class ChimeraNameSpaceProvider
         }
 
     }
+
+    @Override
+    public String resolveSymlinks(Subject subject, String path) throws CacheException {
+        try {
+            /*
+             *  All calls to this method are done by the PnfsManager itself as ROOT.
+             */
+            if (!Subjects.ROOT.equals(subject)) {
+                throw new PermissionDeniedCacheException("Subject not allowed to call this method.");
+            }
+            return _fs.resolvePath(path);
+        } catch (ChimeraFsException e) {
+            throw new CacheException("Failed to resolve symlinks for " + path
+                  + ": " + Exceptions.messageOrClassName(e), e);
+        }
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/ForwardingNameSpaceProvider.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/ForwardingNameSpaceProvider.java
@@ -219,4 +219,9 @@ public abstract class ForwardingNameSpaceProvider implements NameSpaceProvider {
         delegate().removeLabel(subject, path, name);
 
     }
+
+    @Override
+    public String resolveSymlinks(Subject subject, String path) throws CacheException {
+        return delegate().resolveSymlinks(subject, path);
+    }
 }

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/NameSpaceProvider.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/NameSpaceProvider.java
@@ -443,5 +443,13 @@ public interface NameSpaceProvider {
     void listVirtualDirectory(Subject subject, String path, Range<Integer> range,
                          Set<FileAttribute> attrs, ListHandler handler)  throws  CacheException;
 
-
+    /**
+     * Resolves symlinks in the given path.
+     *
+     * @param subject user making the request.
+     * @param path full path to be resolved.
+     * @return path with symlinks resolved.
+     * @throws CacheException
+     */
+    String resolveSymlinks(Subject subject, String path) throws CacheException;
 }

--- a/modules/dcache/src/main/java/org/dcache/auth/RemoteNameSpaceProvider.java
+++ b/modules/dcache/src/main/java/org/dcache/auth/RemoteNameSpaceProvider.java
@@ -302,7 +302,6 @@ public class RemoteNameSpaceProvider implements NameSpaceProvider {
         _pnfs.request(message);
     }
 
-
     /**
      * Remove a label attribute from a file.
      *
@@ -318,6 +317,10 @@ public class RemoteNameSpaceProvider implements NameSpaceProvider {
         message.setSubject(subject);
         message.setRestriction(Restrictions.none());
         _pnfs.request(message);
+    }
 
+    @Override
+    public String resolveSymlinks(Subject subject, String path) throws CacheException {
+        throw new UnsupportedOperationException("For internal use only.");
     }
 }


### PR DESCRIPTION
Motivation:

When PnfsManager determines permissions based on
Restrictions, it should compare the prefixes or
scope claims to the actual path after all
symlinks have been resolved.

Modification:

Define and implement the necessary internal
APIs to support a single-call path resolution;
for Postgres, implement the driver method
as referencing a stored procedure.

Make the necessary changes to PnfsManager to
resolve symlinks before using the Restriction's
`isRestricted()`.

Result:

Application of restrictions is correct in
that the ownership and scope of the resolved
link is examined.

Target: master
Request: 8.2  (should this be backported further?)
Requires-notes: yes
Patch: https://rb.dcache.org/r/13908/
Acked-by: Dmitry
Acked-by: Tigran