### PR TITLE
dcache-bulk:  fix JSON object key not found exception

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
@@ -152,17 +152,8 @@ public final class StageActivity extends PinManagerActivity {
     }
 
     private long getLifetimeInMillis(FsPath path) {
-        String ptString = null;
-
-        String key = path.toString();
-
-        if (jsonLifetimes != null && jsonLifetimes.has(key)) {
-            ptString = jsonLifetimes.getString(key);
-        }
-
-        if (ptString == null) {
-            ptString = DISK_LIFETIME.getDefaultValue();
-        }
+        String ptString = jsonLifetimes == null ? DISK_LIFETIME.getDefaultValue()
+              : jsonLifetimes.optString(path.toString(), DISK_LIFETIME.getDefaultValue());
 
         return TimeUnit.SECONDS.toMillis(Duration.parse(ptString).get(ChronoUnit.SECONDS));
     }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
@@ -154,8 +154,10 @@ public final class StageActivity extends PinManagerActivity {
     private long getLifetimeInMillis(FsPath path) {
         String ptString = null;
 
-        if (jsonLifetimes != null) {
-            ptString = jsonLifetimes.getString(path.toString());
+        String key = path.toString();
+
+        if (jsonLifetimes != null && jsonLifetimes.has(key)) {
+            ptString = jsonLifetimes.getString(key);
         }
 
         if (ptString == null) {


### PR DESCRIPTION
Motivation:

See RT #10444 "Frontend REST API when staging (uncaught exception)" Blocks completion of request.

Modification:

Since `getString` on the `JSONObject` throws an exception when the key is not found, we need to check `hasKey` first.

Result:

No more uncaught exception.

Target: master
Request: 8.2
Patch: https://rb.dcache.org/r/13915/
Bug: #10444
Requires-notes: yes
Acked-by: Lea