### PR TITLE
pom.xml: update to next xrood4j version (4.5.5, 4.3.7, 4.2.11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.43.v20210629</version.jetty>
-        <version.xrootd4j>4.2.10</version.xrootd4j>
+        <version.xrootd4j>4.2.11</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.2</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>


### PR DESCRIPTION
see https://rb.dcache.org/r/13925/
master@88922f059e81e780fc1d038a47d7878ae0ea1c77

Update stable branches to include bug fix
to the TPC client behavior so that it
establishes of a secure connection
to its source when the source TLS
setting is STRICT.

Target: master (v4.5.5)
Request: 9.0   (v4.5.5)
Request: 8.2   (v4.5.5)
Request: 8.1   (v4.3.7)
Request: 8.0   (v4.2.11)
Request: 7.2   (v4.2.11)
Patch: https://rb.dcache.org/r/13928/
Requires-notes: yes
Acked-by: Lea