### PR TITLE
kafka: ensure that errors are logged properly

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/kafka/LoggingProducerListener.java
+++ b/modules/dcache/src/main/java/org/dcache/kafka/LoggingProducerListener.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2018 - 2022 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2018 - 2023 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -36,8 +36,6 @@ public class LoggingProducerListener<K, V> implements ProducerListener<K, V> {
     public void onError(ProducerRecord<K, V> producerRecord,
           @Nullable RecordMetadata recordMetadata, Exception exception) {
         LOGGER.error("Producer exception occurred while publishing message : {}, exception : {}",
-              producerRecord, exception);
+              producerRecord, exception.toString());
     }
-
-
 }


### PR DESCRIPTION
Motivation:
Depending on the logger the statement:

log.error("format {}", exception)

will log stacktrace instead of exception message.

Modification:
ensure, that exception is converted to a string.

Result:
better logging

Acked-by: Lea Morschel
Target: master, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit cede2bad9a16937731b35e3c37eaf74c6a896af6)