### PR TITLE
dcache-bulk:  add neglected backport of duplicate path check to 8.2

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetDao.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetDao.java
@@ -71,9 +71,11 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.namespace.FileType;
 import org.dcache.services.bulk.BulkRequest;
@@ -146,6 +148,7 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
 
     public void insertInitialTargets(BulkRequest request) {
         List<TargetPlaceholder> targets = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
         for (String target : request.getTarget()) {
             TargetPlaceholder t = new TargetPlaceholder();
             t.rid = request.getId();
@@ -158,6 +161,10 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
                 t.path = target;
                 t.state = CREATED.name();
             }
+            if (seen.contains(t.path)) {
+                continue;
+            }
+            seen.add(t.path);
             targets.add(t);
         }
         utils.insertBatch(targets, BATCH_INSERT, SETTER, this);


### PR DESCRIPTION
Motivation:

see https://github.com/dCache/dcache/issues/7064
TAPE API: Executing stage request with duplicate file paths ends up with SQL exception in the client output

The in-memory collapsing of duplicate paths
done in master was not back-ported to 8.2, but
is also necessary there.

Modification:

Add the missing code.

Result:

Duplicate paths are collapsed and no SQL error is
generated.

Target: 8.2
Pull-request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13931/
Closes: #7064
Acked-by: Dmitry