### PR TITLE
dcache-frontend: improve error message for empty string or non-JSON p…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
@@ -59,6 +59,8 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.resources.bulk;
 
+import static org.dcache.restful.util.JSONUtils.newBadRequestException;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -414,8 +416,7 @@ public final class BulkResources {
         try {
             map = new Gson().fromJson(requestPayload, Map.class);
         } catch (JsonParseException e) {
-            throw new BadRequestException(
-                  String.format("badly formed json object (%s): %s.", requestPayload, e));
+            throw newBadRequestException(requestPayload, e);
         }
 
         BulkRequest request = new BulkRequest();

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ArchiveInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ArchiveInfoResources.java
@@ -59,6 +59,8 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.resources.tape;
 
+import static org.dcache.restful.util.JSONUtils.newBadRequestException;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -147,8 +149,7 @@ public final class ArchiveInfoResources {
                 paths.add(jsonArray.getString(i));
             }
         } catch (JSONException e) {
-            throw new BadRequestException(
-                  String.format("badly formed json object (%s): %s.", requestPayload, e));
+            throw newBadRequestException(requestPayload, e);
         }
 
         return archiveInfoCollector.getInfo(HandlerBuilders.roleAwarePnfsHandler(pnfsManager),

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
@@ -59,6 +59,7 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.resources.tape;
 
+import static org.dcache.restful.util.JSONUtils.newBadRequestException;
 import static org.dcache.restful.util.RequestUser.getRestriction;
 import static org.dcache.restful.util.RequestUser.getSubject;
 
@@ -154,8 +155,7 @@ public final class ReleaseResources {
                 targetPaths.add(paths.getString(i));
             }
         } catch (JSONException e) {
-            throw new BadRequestException(
-                  String.format("badly formed json object (%s): %s.", requestPayload, e));
+            throw newBadRequestException(requestPayload, e);
         }
 
         Subject subject = getSubject();

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
@@ -61,6 +61,7 @@ package org.dcache.restful.resources.tape;
 
 import static org.dcache.restful.resources.bulk.BulkResources.getRestriction;
 import static org.dcache.restful.resources.bulk.BulkResources.getSubject;
+import static org.dcache.restful.util.JSONUtils.newBadRequestException;
 
 import com.google.common.base.Strings;
 import io.swagger.annotations.Api;
@@ -198,10 +199,16 @@ public final class StageResources {
                 + "does not belong to that stage request, this request will fail.", required = true)
                 String requestPayload) {
 
-        JSONObject reqPayload = new JSONObject(requestPayload);
-        JSONArray paths = reqPayload.getJSONArray("paths");
-        if (paths == null) {
-            throw new BadRequestException("cancellation request contains no paths.");
+        JSONObject reqPayload;
+        JSONArray paths;
+        try {
+            reqPayload = new JSONObject(requestPayload);
+            paths = reqPayload.getJSONArray("paths");
+            if (paths == null) {
+                throw new BadRequestException("cancellation request contains no paths.");
+            }
+        } catch (JSONException e) {
+            throw newBadRequestException(requestPayload, e);
         }
 
         List<String> targetPaths = new ArrayList<>();
@@ -376,8 +383,7 @@ public final class StageResources {
             arguments.put("targetedMetadata", jsonMetadata.toString());
             request.setArguments(arguments);
         } catch (JSONException e) {
-            throw new BadRequestException(
-                  String.format("badly formed json object (%s): %s.", requestPayload, e));
+            throw newBadRequestException(requestPayload, e);
         }
 
         return request;

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/JSONUtils.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/JSONUtils.java
@@ -1,0 +1,80 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.util;
+
+import com.google.common.base.Strings;
+import javax.ws.rs.BadRequestException;
+
+public class JSONUtils {
+
+    public static BadRequestException newBadRequestException(String payload, Exception e) {
+        String message;
+        if (Strings.emptyToNull(payload) == null || !payload.startsWith("{")) {
+            message = String.format("a non-empty JSON object payload string is required; payload was '%s'.",
+                  payload);
+        } else {
+            message = String.format("badly formed json object '%s': %s", payload, e);
+        }
+        return new BadRequestException(message);
+    }
+
+    private JSONUtils() {
+    }
+}


### PR DESCRIPTION
…ayload

Motivation:

For POST submissions where a required payload string is omitted or is not a JSON object, a clearer error message would be preferable.

Modification:

Add a small utility method to distinguish between those cases and the case where the internals of the object are badly formed or do not parse.  This is used in the appropriate places for `stage`, `release`, `archiveinfo` and `bulk-requests`.

Result:

Better error message reporting.

Target: master
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/13930/
Requires-notes: yes
Acked-by: Tigran