### PR TITLE
dcache-frontend:  improve Swagger annotations for release and archive…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ArchiveInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ArchiveInfoResources.java
@@ -126,7 +126,8 @@ public final class ArchiveInfoResources {
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces(MediaType.APPLICATION_JSON)
     public List<ArchiveInfo> getArchiveInfo(
-          @ApiParam(value = "Array of paths for which to return archive info (file locality).",
+          @ApiParam(value = "Request structure:\n\n"
+                + "**paths** - array of paths for which to return archive info (file locality).",
                 required = true)
                 String requestPayload) {
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
@@ -133,7 +133,8 @@ public final class ReleaseResources {
     @Produces(MediaType.APPLICATION_JSON)
     public Response release(
           @PathParam("id") String id,
-          @ApiParam(value = "Array of file paths to release. If any path does not belong to the "
+          @ApiParam(value = "Request structure:\n\n"
+                + "**paths** - array of paths for files to release. If any path does not belong to the "
                 + "stage request corresponding to the id, this request will fail.", required = true)
                 String requestPayload) {
 


### PR DESCRIPTION
…info

Motivation:

see https://rb.dcache.org/r/13917/
commit master@7f16ca2ca375bd1bc9b8971572897d348dd06386

Modifcation:

Do the same for `archiveinfo` and `release` payload descriptions.

Result:

Better annotations for request payload structure.

Target: master
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/13932/
Requires-notes: no
Acked-by: Tigran