### PR TITLE
pool: ensure that nfs mover completion takes place

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2013 - 2021 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2013 - 2023 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -112,11 +112,12 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
             getMoverChannel().close();
         } catch (IOException e) {
             _log.error("failed to close RAF {}", e.toString());
-        }
-        if (error == null) {
-            _completionHandler.completed(null, null);
-        } else {
-            _completionHandler.failed(error, null);
+        } finally {
+            if (error == null) {
+                _completionHandler.completed(null, null);
+            } else {
+                _completionHandler.failed(error, null);
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:
if for whatever reasons MoverChannel#close thows an unchecked exception, then NFS mover will be left in 'CANCELED' state.

Modification:
Ensure that completed or failed of mover completion is called.

Result:
reduce possibility of stacked movers in "CANCELED" state.

Acked-by: Paul Millar
Target: master, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit c4c31e989f5a9ba0056e3eb5b11a93e60e0cc2db)