### PR TITLE
webdav: return empty list instead of null as an empty collection

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheDirectoryResource.java
@@ -101,15 +101,13 @@ public class DcacheDirectoryResource
             // Theoretically, we should throw NotAuthorizedException here.  The
             // problem is that Milton reacts badly to this, and aborts the whole
             // PROPFIND request, even if the affected directory is not the primary
-            // one.  Milton accepts a null response as equivalent to
-            // Collections.emptyList()
-            return null;
+            // one.
+            return Collections.emptyList();
         } catch (CacheException | InterruptedException e) {
             // We currently have no way to indicate a temporary failure for this
             // directory and throwing any kind of exception will abort the whole
-            // PROPFIND request; therefore, we return null.  Milton accepts a
-            // null response as equivalent to Collections.emptyList()
-            return null;
+            // PROPFIND request; therefore, we return an empty list.
+            return Collections.emptyList();
         }
     }
 


### PR DESCRIPTION
Motivation:
Dispite the fact, that milton library aims that 'null' and 'empty list' are equivalent, in reality, it has different behavior, which ends up with NullPointerException.

See https://github.com/miltonio/milton2/issues/184

Modification:
Update DcacheDirectoryResource#getChildren to return an empty collection instead of 'null'.

Result:
The observed NPE should disappear (no reproducer :( )

Fixes: #7035
Ticket: #10447
Acked-by: Paul Millar
Target: master, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 138b0ca4c263a5bd8776dd2ae8f05eb57ac162c1)