### PR TITLE
dcache-frontend: support VO- or user-root relative paths in requests

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
@@ -295,6 +295,10 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
         checkForRequestCancellation();
         Long id = target.getId();
         FsPath path = target.getPath();
+        if (targetPrefix != null && !path.contains(targetPrefix)) {
+            path = computeFsPath(targetPrefix, target.getPath().toString());
+        }
+
         FileAttributes attributes = target.getAttributes();
 
         if (hasBeenCancelled(id, target.getPid(), path, attributes)) {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcBulkTargetStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcBulkTargetStore.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.services.bulk.store.jdbc.rtarget;
 
 import static org.dcache.services.bulk.util.BulkRequestTarget.NON_TERMINAL;
+import static org.dcache.services.bulk.util.BulkRequestTarget.PID.DISCOVERED;
 import static org.dcache.services.bulk.util.BulkRequestTarget.State.CREATED;
 
 import java.util.List;
@@ -204,8 +205,12 @@ public final class JdbcBulkTargetStore implements BulkTargetStore {
 
     private JdbcRequestTargetUpdate prepareUpdate(BulkRequestTarget target) {
         JdbcRequestTargetUpdate update = targetDao.set().pid(target.getPid())
-              .rid(target.getRid()).pnfsid(target.getPnfsId()).path(target.getPath())
+              .rid(target.getRid()).pnfsid(target.getPnfsId())
               .type(target.getType()).state(target.getState());
+
+        if (target.getId() == null || target.getPid() == DISCOVERED) {
+            update.path(target.getPath());
+        }
 
         switch (target.getState()) {
             case COMPLETED:

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
@@ -59,6 +59,8 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.resources.bulk;
 
+import static org.dcache.restful.util.HttpServletRequests.getUserRootAwareTargetPrefix;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -222,7 +224,7 @@ public final class BulkResources {
         Subject subject = getSubject();
         Restriction restriction = getRestriction();
 
-        BulkRequest request = toBulkRequest(requestPayload);
+        BulkRequest request = toBulkRequest(requestPayload, this.request);
 
         /*
          *  Frontend sets the URL.  The backend service provides the UUID.
@@ -411,7 +413,7 @@ public final class BulkResources {
      * they are defined in the Bulk service as well.
      */
     @VisibleForTesting
-    static BulkRequest toBulkRequest(String requestPayload) {
+    static BulkRequest toBulkRequest(String requestPayload, HttpServletRequest httpServletRequest) {
         if (Strings.emptyToNull(requestPayload) == null) {
             throw new BadRequestException("empty request payload.");
         }
@@ -445,7 +447,11 @@ public final class BulkResources {
 
         string = removeEntry(map, String.class, "target_prefix", "target-prefix",
               "targetPrefix");
-        request.setTargetPrefix(string);
+        if (httpServletRequest != null) {
+            request.setTargetPrefix(getUserRootAwareTargetPrefix(httpServletRequest, string));
+        } else {
+            request.setTargetPrefix(string);
+        }
 
         string = removeEntry(map, String.class, "expand_directories", "expand-directories",
               "expandDirectories");

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
@@ -59,6 +59,7 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.resources.tape;
 
+import static org.dcache.restful.util.HttpServletRequests.getUserRootAwareTargetPrefix;
 import static org.dcache.restful.util.RequestUser.getRestriction;
 import static org.dcache.restful.util.RequestUser.getSubject;
 
@@ -171,6 +172,7 @@ public final class ReleaseResources {
          *  Frontend sets the URL.  The backend service provides the UUID.
          */
         request.setUrlPrefix(this.request.getRequestURL().toString());
+        request.setTargetPrefix(getUserRootAwareTargetPrefix(this.request, null));
 
         BulkRequestMessage message = new BulkRequestMessage(request, restriction);
         message.setSubject(subject);

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
@@ -61,6 +61,7 @@ package org.dcache.restful.resources.tape;
 
 import static org.dcache.restful.resources.bulk.BulkResources.getRestriction;
 import static org.dcache.restful.resources.bulk.BulkResources.getSubject;
+import static org.dcache.restful.util.HttpServletRequests.getUserRootAwareTargetPrefix;
 
 import com.google.common.base.Strings;
 import io.swagger.annotations.Api;
@@ -333,6 +334,7 @@ public final class StageResources {
         request.setClearOnFailure(false);
         request.setClearOnSuccess(false);
         request.setActivity("STAGE");
+        request.setTargetPrefix(getUserRootAwareTargetPrefix(this.request, null));
 
         try {
             JSONObject reqPayload = new JSONObject(requestPayload);

--- a/modules/dcache-frontend/src/test/java/org/dcache/restful/resources/bulk/BulkRequestJsonParseTest.java
+++ b/modules/dcache-frontend/src/test/java/org/dcache/restful/resources/bulk/BulkRequestJsonParseTest.java
@@ -167,6 +167,6 @@ public class BulkRequestJsonParseTest {
     }
 
     private void whenParsed() {
-        bulkRequest = toBulkRequest(requestJson);
+        bulkRequest = toBulkRequest(requestJson, null);
     }
 }

--- a/modules/dcache-frontend/src/test/java/org/dcache/restful/util/BulkRequestTargetPathTest.java
+++ b/modules/dcache-frontend/src/test/java/org/dcache/restful/util/BulkRequestTargetPathTest.java
@@ -1,0 +1,186 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.util;
+
+import static org.dcache.restful.util.HttpServletRequests.getTargetPrefixFromUserRoot;
+import static org.junit.Assert.assertEquals;
+
+import diskCacheV111.util.FsPath;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BulkRequestTargetPathTest {
+
+    String targetPrefix;
+    FsPath userRootPath;
+
+    @Test
+    public void shouldReturnRootPathWhenTargetPrefixIsNull() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix(null);
+        assertThatFullPrefixIs("/pnfs/fs/test-user");
+    }
+
+    @Test
+    public void shouldReturnRootPathWhenTargetPrefixEqualsRoot() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix("/pnfs/fs/test-user");
+        assertThatFullPrefixIs("/pnfs/fs/test-user");
+    }
+
+    @Test
+    public void shouldConcatenateNonIntersectingRootAndPrefix() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix("/experiment1/run1");
+        assertThatFullPrefixIs("/pnfs/fs/test-user/experiment1/run1");
+    }
+
+    /*
+     *  User will not be given a path whose root is above the user root.
+     */
+    @Test
+    public void shouldConcatenateRootAndPrefixWhenRootIsContainedInsidePrefix() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix("/foo/pnfs/fs/test-user/experiment1");
+        assertThatFullPrefixIs("/pnfs/fs/test-user/foo/pnfs/fs/test-user/experiment1");
+    }
+
+    @Test
+    public void shouldJoinRootAndPathAtIntersectingName() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix("/test-user/experiment1/run1");
+        assertThatFullPrefixIs("/pnfs/fs/test-user/experiment1/run1");
+    }
+
+    @Test
+    public void shouldJoinRootAndPathOverIntersectingNames() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix("/fs/test-user/experiment1/run1");
+        assertThatFullPrefixIs("/pnfs/fs/test-user/experiment1/run1");
+    }
+
+    @Test
+    public void shouldReturnPrefixWhenItHasRootPathAsPrefix() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix("/pnfs/fs/test-user/experiment1");
+        assertThatFullPrefixIs("/pnfs/fs/test-user/experiment1");
+    }
+
+    @Test
+    public void shouldReturnRootPathForRootUserWithNoPrefixExpressed() throws Exception {
+        givenUserRootPath(FsPath.ROOT.toString());
+        givenTargetPrefix(null);
+        assertThatFullPrefixIs(FsPath.ROOT.toString());
+    }
+
+    @Test
+    public void shouldReturnPrefixForRootUserWhenPrefixIsExpressed() throws Exception {
+        givenUserRootPath(FsPath.ROOT.toString());
+        givenTargetPrefix("/pnfs/fs");
+        assertThatFullPrefixIs("/pnfs/fs");
+    }
+
+    /*
+     *  Suppose a user submits a bulk-request with "/pnfs/fs" as the target-prefix, and paths
+     *  containing "/test-user/...".  These are legitimate if the user's
+     *  root is "/pnfs/fs/test-user".  So we take the user at its word as to the prefix.
+     */
+    @Test
+    public void shouldReturnShorterPrefixWhenContainedByUserRoot() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix("/pnfs/fs");
+        assertThatFullPrefixIs("/pnfs/fs");
+    }
+
+    /*
+     *  The following two tests may look like they open security holes, but they really don't.
+     *  All we are doing is determining how the paths are constructed.  If the user
+     *  shoots itself in the foot by providing a prefix for an area which it has
+     *  no permissions to read or write from, all the target paths in its request
+     *  will fail anyway.
+     */
+    @Test
+    public void shouldReturnPrefixWhenOnlyPartiallyContainedByUserRoot1() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix("/pnfs/foo");
+        assertThatFullPrefixIs("/pnfs/foo");
+    }
+
+    @Test
+    public void shouldReturnPrefixWhenOnlyPartiallyContainedByUserRoot2() throws Exception {
+        givenUserRootPath("/pnfs/fs/test-user");
+        givenTargetPrefix("/pnfs/fs/bar");
+        assertThatFullPrefixIs("/pnfs/fs/bar");
+    }
+
+    private void givenUserRootPath(String root) {
+        userRootPath = FsPath.create(root);
+    }
+
+    private void givenTargetPrefix(String targetPrefix) {
+        this.targetPrefix = targetPrefix;
+    }
+
+    private void assertThatFullPrefixIs(String fullPrefix) {
+        assertEquals(fullPrefix, getTargetPrefixFromUserRoot(userRootPath, targetPrefix));
+    }
+}


### PR DESCRIPTION
Motivation:

See https://github.com/dCache/dcache/issues/7072
dcache-frontend: add extraction of effective root
for user to include in REST API for bulk/stage.

Modification:

The frontend resources had to be modified to
use the user root derived from the login
attributes in order to determine the
`target-prefix` which would allow for
resolution of the relative paths.  In
the case of a user-provided prefix
(`/api/v1/bulk-requests`) this is done
by trying to union the root and prefix
paths; for the `TAPE` resources, we
simply set the prefix to the root
under the covers.

On the bulk end, a little be of re-engineering
was necessary to make sure the users can
retrieve paths according to their
root expectations.  Thus, if the submitted
paths are originally relative, they
will get back all relative paths, including
those discovered through recursion. If
they submitted absolute paths, they should
see those instead.  The consistency is
arrived at by allowing the initial paths
to go into the database as given, but
derived/discovered paths are stored
as absolute and then given back through
the REST API according to the prefix
that has been set.

Result:

The RESTful interface supports
paths relative to the user root
as well as absolute paths for requests
to the bulk service.

Note:  a separate solution will be necessary
for the one-off `namespace` resource operations.

Target: master
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/13937
Requires-notes: yes
Closes: #7072
Acked-by: Tigran