### PR TITLE
pom.xml: update to next xrootd4j version (4.5.6, 4.4.7, 4.3.8, 4.2.12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.43.v20210629</version.jetty>
-        <version.xrootd4j>4.2.11</version.xrootd4j>
+        <version.xrootd4j>4.2.12</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.2</version.dcache-view>
         <version.netty>4.1.59.Final</version.netty>


### PR DESCRIPTION
see https://rb.dcache.org/r/13939/
master@e09debe9461c2f5627e2a36dad1976f3c1544b94

Update stable branches to include
support for pre-5 clients previously
forced off TLS=STRICT doors.

Target: master (v4.5.6)
Request: 9.0   (v4.5.6)
Request: 8.2   (v4.5.6)
Request: 8.1   (v4.3.8)
Request: 8.0   (v4.2.12)
Request: 7.2   (v4.2.12)
Patch: https://rb.dcache.org/r/13941/
Requires-notes: yes
Acked-by: Tigran