### PR TITLE
nfs: ensure that mover always associated with an open-stateid

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -711,7 +711,7 @@ public class NFSv41Door extends AbstractCellComponent implements
                 final InetSocketAddress remote = context.getRpcCall().getTransport()
                       .getRemoteSocketAddress();
                 final NFS4ProtocolInfo protocolInfo = new NFS4ProtocolInfo(remote,
-                      new org.dcache.chimera.nfs.v4.xdr.stateid4(stateid),
+                      new org.dcache.chimera.nfs.v4.xdr.stateid4(openStateId.stateid()),
                       nfsInode.toNfsHandle()
                 );
 
@@ -800,7 +800,7 @@ public class NFSv41Door extends AbstractCellComponent implements
             layout.lo_iomode = args.loga_iomode;
             layout.lo_offset = new offset4(0);
             layout.lo_length = new length4(nfs4_prot.NFS4_UINT64_MAX);
-            layout.lo_content = layoutDriver.getLayoutContent(stateid,
+            layout.lo_content = layoutDriver.getLayoutContent(openStateId.stateid(),
                   NFSv4Defaults.NFS4_STRIPE_SIZE, new nfs_fh4(nfsInode.toNfsHandle()), devices);
 
             layoutStateId.bumpSeqid();


### PR DESCRIPTION
Motivation:
When pNFS is used in combination of locking or delegation then the NFS door will allocate mover with incorrect state id type. Thus clients, that use open-stateid will get BAD_STATE from the pools.

Modification:
Update the NFS door to ensure that layout and mover always associated with open-stateid.

Result:
correct pNFS IO operations, even if locking or delegations are used.

Acked-by: Paul Millar
Target: master, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 7d9baa5f6feef3d9c1804ee7626f8c6caf7a70f4)