### PR TITLE
migration: fixing sleeping state for broken  files

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsMover.java
@@ -84,7 +84,7 @@ public class NfsMover extends MoverChannelMover<NFS4ProtocolInfo, NfsMover> {
      * @throws DiskErrorCacheException
      */
     public Cancellable enable(final CompletionHandler<Void, Void> completionHandler)
-          throws DiskErrorCacheException, InterruptedIOException {
+          throws DiskErrorCacheException, InterruptedIOException, CacheException {
 
         open();
         _completionHandler = completionHandler;

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -329,7 +329,7 @@ public class NfsTransferService
     @Override
     public Cancellable executeMover(final NfsMover mover,
             final CompletionHandler<Void, Void> completionHandler)
-            throws DiskErrorCacheException, InterruptedIOException {
+            throws DiskErrorCacheException, InterruptedIOException, CacheException {
         final Cancellable cancellableMover = mover.enable(completionHandler);
         notifyDoorWithRedirect(mover);
 

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/AbstractMover.java
@@ -24,6 +24,7 @@ import com.google.common.base.Strings;
 import com.google.common.reflect.TypeToken;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
+import diskCacheV111.util.FileCorruptedCacheException;
 import diskCacheV111.vehicles.PoolAcceptFileMessage;
 import diskCacheV111.vehicles.PoolIoFileMessage;
 import diskCacheV111.vehicles.ProtocolInfo;
@@ -271,7 +272,8 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
      * @throws InterruptedIOException  if the mover was cancelled
      * @throws DiskErrorCacheException If the file could not be opened
      */
-    public RepositoryChannel openChannel() throws DiskErrorCacheException, InterruptedIOException {
+    public RepositoryChannel openChannel()
+          throws DiskErrorCacheException, InterruptedIOException, CacheException {
         RepositoryChannel channel;
         try {
             channel = _handle.createChannel();
@@ -282,7 +284,9 @@ public abstract class AbstractMover<P extends ProtocolInfo, M extends AbstractMo
             throw new DiskErrorCacheException(
                   "File could not be opened; please check the file system: "
                         + messageOrClassName(e), e);
+
         }
+
 
         synchronized (_checksumTypes) {
             _checksumChannel = channel.optionallyAs(ChecksumChannel.class).orElse(null);

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannelMover.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/MoverChannelMover.java
@@ -19,6 +19,7 @@ package org.dcache.pool.movers;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import diskCacheV111.util.CacheException;
 import diskCacheV111.util.DiskErrorCacheException;
 import diskCacheV111.vehicles.PoolIoFileMessage;
 import diskCacheV111.vehicles.ProtocolInfo;
@@ -75,7 +76,7 @@ public abstract class MoverChannelMover<P extends ProtocolInfo, M extends MoverC
      * @throws IllegalStateException   if called more than once
      */
     public synchronized MoverChannel<P> open()
-          throws DiskErrorCacheException, InterruptedIOException {
+          throws DiskErrorCacheException, InterruptedIOException, CacheException {
         checkState(_wrappedChannel == null);
         _wrappedChannel = new MoverChannel<>(this, openChannel());
         return _wrappedChannel;

--- a/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/p2p/Companion.java
@@ -327,7 +327,7 @@ class Companion {
     }
 
     private Set<Checksum> copy(String uri, ReplicaDescriptor handle)
-          throws IOException, InterruptedException {
+          throws IOException, InterruptedException, CacheException {
         RepositoryChannel channel = handle.createChannel();
         try {
             HttpGet get = new HttpGet(uri);

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/ReplicaDescriptor.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/ReplicaDescriptor.java
@@ -51,7 +51,7 @@ public interface ReplicaDescriptor extends AutoCloseable {
      * @return repository channel.
      * @throws IOException if repository channel can't be created.
      */
-    RepositoryChannel createChannel() throws IOException;
+    RepositoryChannel createChannel() throws IOException, CacheException;
 
     /**
      * Returns the file attributes of the file represented by this replica.

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReadHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReadHandleImpl.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableSet;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileCorruptedCacheException;
 import diskCacheV111.util.PnfsHandler;
 import java.io.IOException;
 import java.net.URI;
@@ -73,11 +74,12 @@ class ReadHandleImpl implements ReplicaDescriptor {
     }
 
     @Override
-    public RepositoryChannel createChannel() throws IOException {
+    public RepositoryChannel createChannel() throws IOException, CacheException {
         RepositoryChannel channel = _entry.openChannel(_openOptions);
         long fileSizeAlloc = channel.size();
         if (_fileAttributes.getSize() != fileSizeAlloc) {
-            IOException ex = new IOException("Failed to read the file, because file is Broken.");
+            FileCorruptedCacheException ex = new FileCorruptedCacheException(
+                  "Failed to read the file, because file is Broken.");
             try {
                 _entry.update("Filesystem and pool database file sizes are inconsistent",
                       r -> r.setState(ReplicaState.BROKEN));

--- a/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
+++ b/modules/dcache/src/main/smc/org/dcache/pool/migration/Task.sm
@@ -208,6 +208,14 @@ Entry
                              String.format("Pool %s failed (no route to cell)",
                                            ctxt.getTarget()));
                 }
+         copy_failure(rc: Integer, cause: Object)
+                [ rc == FILE_CORRUPTED ]
+                Failed
+                {
+                        failPermanently(rc,
+                              String.format("Pool %s failed (%s)",
+                                            ctxt.getTarget(), cause));
+                        }
         copy_failure(rc: Integer, cause: Object)
                 Failed
                 {
@@ -228,7 +236,7 @@ Entry
                 {
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
-                [ message.getReturnCode() == FILE_NOT_FOUND ]
+                [ message.getReturnCode() == FILE_NOT_FOUND || message.getReturnCode() == FILE_CORRUPTED ]
                 Failed
                 {
                         failPermanently(message.getReturnCode(),
@@ -329,7 +337,7 @@ Exit
                 {
                 }
         messageArrived(message: PoolMigrationCopyFinishedMessage)
-                [ message.getReturnCode() == FILE_NOT_FOUND ]
+                [ message.getReturnCode() == FILE_NOT_FOUND || message.getReturnCode() == FILE_CORRUPTED ]
                 Failed
                 {
                         failPermanently(message.getReturnCode(),

--- a/modules/dcache/src/test/java/org/dcache/tests/repository/RepositorySubsystemTest.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/repository/RepositorySubsystemTest.java
@@ -128,7 +128,7 @@ public class RepositorySubsystemTest
     private final CellAddressCore address = new CellAddressCore("pool", "test");
 
     private void createFile(ReplicaDescriptor descriptor, long size)
-          throws IOException {
+          throws IOException, CacheException {
         try (RepositoryChannel channel = descriptor.createChannel()) {
             channel.write(ByteBuffer.allocate((int) size));
         }
@@ -491,7 +491,7 @@ public class RepositorySubsystemTest
         };
     }
 
-    @Test(expected = IOException.class)
+    @Test(expected = CacheException.class)
     public void testFileIsBroken()
           throws IOException, IllegalTransitionException,
           CacheException, InterruptedException {


### PR DESCRIPTION
Motivation

When broken files were discovered during migration the migration module was going into sleeping state.

This was due to the fact that when broken file was detected DiscError exception was thrown and the pool was set to disabled mode.

Result

This is fixed now and migration should works correctly for both cases.

Target: master, 9.0 8.2
Patch: https://rb.dcache.org/r/13814/
Acked-by: Tigran Mkrtchyan
Requires-notes: no