### PR TITLE
pnfsmanager: fix migration move/copy going into SLEEP mode when the f…

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraNameSpaceProvider.java
@@ -785,6 +785,8 @@ public class ChimeraNameSpaceProvider
             }
 
             return locations;
+        } catch (FileNotFoundChimeraFsException e) {
+            throw new FileNotFoundCacheException("No such file or directory: " + pnfsId, e);
         } catch (ChimeraFsException e) {
             throw new CacheException(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, e.getMessage());
         }


### PR DESCRIPTION
…ile on the pool has been deleted

Motivation

when file has been deleted on the pool the migration  move/copy command was failling  with

[localhost] (pool_write@dCacheDomain) admin > migration info 3
Command    : migration move -target=pool -- pool_res1
State      : SLEEPING
Queued     : 79
Attempts   : 24
Targets    : pool_res1
Completed  : 21 files; 3318 bytes; 21%
Total      : 15800 bytes
Concurrency: 1
Running tasks:
Most recent errors:
14:47:22 [121] 000001CE3FEBC1D742348C1C9CE3F36F14D7: Transfer to [pool_res1@local] failed (File could not be opened; please check the file system:

log:

 (PnfsManager) [qbo:GU pool_write PnfsGetCacheLocations 0000D301D9489BE64ABB88D1D17369D3754D] Exception in getCacheLocations: CacheException(rc=10011;msg=No such file or directory with PNFSID: 0000D301D9489BE64...

Modification

10011 is UNEXPECTED_SYSTEM_EXCEPTION is replaced with the correct FileNotFoundCacheException exc.

Result

This is fixed now.

Target: master, 9.0 8.2
Patch: https://rb.dcache.org/r/13922/
Acked-byi: Tigran Mkrtchyan
Requires-notes: no