### PR TITLE
chimera:  fix bug in resolve_path stored procedure

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-8.2.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-8.2.xml
@@ -24,4 +24,28 @@
         <rollback>
         </rollback>
     </changeSet>
+
+    <!-- Fixes bug when handling empty or root paths. -->
+    <changeSet id="34.1" author="arossi" dbms="postgresql">
+        <comment>Symlink resolution calling inumber2path(path2inumber)</comment>
+        <createProcedure>
+            CREATE OR REPLACE FUNCTION resolve_path(root bigint, path varchar) RETURNS varchar
+                AS
+            $$
+                DECLARE
+                    len int;
+                BEGIN
+                len := length(path);
+                IF len = 0 THEN
+                    path := '/';
+                ELSIF path LIKE '/%' AND len > 1 THEN
+                    path := substring(path from 2);
+                END IF;
+                return inumber2path(path2inumber(root, path));
+            END;
+            $$ LANGUAGE plpgsql;
+        </createProcedure>
+        <rollback>
+        </rollback>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Motivation:

https://rb.dcache.org/r/13908/
master@7cb0cd0c5f5c1debe97ee0ff868e5455f33fefdb

introduced symlink resolution into the namespace
restriction checks.   The base code for this
was a new stored procedure, resolve_path.

The code for that procedure however does not
deal correctly with the two edge cases,
'' and '/', and on 8.2 and 9.0 results
in the error reported below.

Modification:

Update the stored procedure in liquibase
to handle those cases properly.

Result:

No more SQL error.

Target: master
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/13946/
Requires-notes: yes
Acked-by: Tigran