### PR TITLE
libs: update nfs4j to 0.24.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -802,7 +802,7 @@
         <dependency>
             <groupId>org.dcache</groupId>
             <artifactId>nfs4j-core</artifactId>
-            <version>0.24.1</version>
+            <version>0.24.3</version>
         </dependency>
         <dependency>
             <groupId>com.github.nitram509</groupId>


### PR DESCRIPTION
fixes in open-stateid handling that aims to fix issues with concurrent opens of a single file by a same client.

Changelog for nfs4j-0.24.1..nfs4j-0.24.3
    * [483494ed] [maven-release-plugin] prepare for next development iteration
    * [98033b3c] nfs4: remove state only after successful disposal
    * [6e2658ac] nfs4: bump open-stateid sequence only in FileTracker#addOpen
    * [6463ac38] [maven-release-plugin] prepare release nfs4j-0.24.2
    * [7b4981f6] [maven-release-plugin] prepare for next development iteration
    * [584e988f] nfs4: FileTracker should return a copy of stateid
    * [ed0a06a3] pom: fix version number
    * [161e69a1] [maven-release-plugin] prepare release nfs4j-0.24.3

Acked-by: Lea Morschel
Target: master, 9.0
Require-book: no
Require-notes: yes
(cherry picked from commit 33c52d61529658f0d1bdb8af6c4ea79c384164d7)