### PR TITLE
bulk: let bulk propagate Subject for pin/stage

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinActivity.java
@@ -116,6 +116,7 @@ public final class PinActivity extends PinManagerActivity {
             PinManagerPinMessage message
                   = new PinManagerPinMessage(attributes, getProtocolInfo(), id,
                   lifetimeInMillis);
+            message.setSubject(subject);
             return pinManager.send(message, Long.MAX_VALUE);
         } catch (URISyntaxException | CacheException e) {
             return Futures.immediateFailedFuture(e);
@@ -133,7 +134,7 @@ public final class PinActivity extends PinManagerActivity {
             String expire = arguments.get(LIFETIME.getName());
             String unit = arguments.get(LIFETIME_UNIT.getName());
 
-            Long value = (long)(Double.parseDouble(expire));
+            Long value = (long) (Double.parseDouble(expire));
 
             lifetimeInMillis = expire == null ? defaultUnit.toMillis(defaultValue)
                   : unit == null ? defaultUnit.toMillis(value)

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinManagerActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinManagerActivity.java
@@ -132,6 +132,7 @@ abstract class PinManagerActivity extends BulkActivity<Message> implements PinMa
 
     protected PinManagerUnpinMessage unpinMessage(String id, PnfsId pnfsId) {
         PinManagerUnpinMessage message = new PinManagerUnpinMessage(pnfsId);
+        message.setSubject(subject);
         message.setRequestId(id);
         return message;
     }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
@@ -124,6 +124,7 @@ public final class StageActivity extends PinManagerActivity {
             PinManagerPinMessage message
                   = new PinManagerPinMessage(attributes, getProtocolInfo(), id,
                   getLifetimeInMillis(target));
+            message.setSubject(subject);
             return pinManager.send(message, Long.MAX_VALUE);
         } catch (URISyntaxException | CacheException e) {
             return Futures.immediateFailedFuture(e);


### PR DESCRIPTION
Motivation:
When making pin, stage or unpin requests via `PinManager`, the bulk service currently does not propagate the subject to PinManager. If it did, that information would be used by PinManager/PoolManager to enforce permissions such as if a subject is allowed to stage.

Modification:
Add the known subject to `PinManagerPinRequest` and `PinManagerUnpinMessage` messages issued by bulk.

Result:
Better enforcement of subject-based permissions.

Target: master
Request: 9.0
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13949/
Acked-by: Albert Rossi