### PR TITLE
bulk: let bulk propagate Subject for pin/stage

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/PinJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/PinJob.java
@@ -104,6 +104,7 @@ public class PinJob extends PinManagerJob {
         try {
             PinManagerPinMessage message
                   = new PinManagerPinMessage(attributes, getProtocolInfo(), null, lifetime);
+            message.setSubject(subject);
             sendToPinManager(message);
         } catch (URISyntaxException e) {
             setError(e);

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/UnpinJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/plugins/pinmanager/UnpinJob.java
@@ -70,6 +70,8 @@ public class UnpinJob extends PinManagerJob {
 
     @Override
     protected void doRun() {
-        sendToPinManager(new PinManagerUnpinMessage(attributes.getPnfsId()));
+        PinManagerUnpinMessage message = new PinManagerUnpinMessage(attributes.getPnfsId());
+        message.setSubject(subject);
+        sendToPinManager(message);
     }
 }


### PR DESCRIPTION
Motivation:
When making pin, stage or unpin requests via `PinManager`, the bulk service currently does not propagate the subject to PinManager. If it did, that information would be used by PinManager/PoolManager to enforce permissions such as if a subject is allowed to stage.

Modification:
Add the known subject to `PinManagerPinRequest` and `PinManagerUnpinMessage` messages issued by bulk.

Result:
Better enforcement of subject-based permissions.

Target: master
Request: 9.0
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13949/
Acked-by: Albert Rossi