### PR TITLE
dcache-bulk:  reset policy defaults

### DIFF
--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -57,7 +57,7 @@ bulk.request-scheduler=org.dcache.services.bulk.manager.scheduler.LeastRecentFir
 #  - incoming-request threads:              for handling requests received on the message queue
 #  - cancellation threads:                  for handling cancellation requests
 #
-bulk.limits.container-processing-threads=110
+bulk.limits.container-processing-threads=200
 bulk.limits.activity-callback-threads=50
 bulk.limits.incoming-request-threads=10
 bulk.limits.cancellation-threads=25
@@ -75,17 +75,17 @@ bulk.limits.request-cache-expiration=1
 #       The limit is in terms of the number of submitted requests
 #       which have not yet completed (but not necessarily cleared).
 #
-bulk.limits.max-requests-per-user=10
+bulk.limits.max-requests-per-user=5000
 
 #  ---- The maximum number of unexpanded targets which can appear in the bulk request list.
 #       when request expansion is set to NONE.
 #
-bulk.limits.max.targets-per-flat-request=100000
+bulk.limits.max.targets-per-flat-request=500
 
 #  ---- The maximum number of unexpanded targets which can appear in the bulk request list.
 #       when request expansion is set to TARGETS.
 #
-bulk.limits.max.targets-per-shallow-request=100
+bulk.limits.max.targets-per-shallow-request=10
 
 #  ---- The maximum number of unexpanded targets which can appear in the bulk request list.
 #       when request expansion is set to ALL.


### PR DESCRIPTION
Motivation:

At the last WLCG DOMA BDT meeting it was suggested that the normal usage pattern for STAGE requests would be 5000 requests per VO with each request containing 200 files.

We agreed we would reset the defaults on the bulk
policy properties to conform with this, since they will be a major user of this API.

Modification:

Properties have been set to default to WLCG values. Also decreased the number of targets in a shallow
request.

Also increased number of threads available for
target activities to 200.

Result:

Happier admin users.

Target: master
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/13956/
Requires-notes: yes
Acked-by: Tigran