### PR TITLE
webdav: preserve request URL in protocol info

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -1543,14 +1543,20 @@ public class DcacheResourceFactory
         protected HttpProtocolInfo.Disposition _disposition;
         private boolean _isSSL;
 
+        /**
+         * The original request path that will be passed to pool for fall-back redirect.
+         */
+        private final String _requestPath;
+
         public HttpTransfer(PnfsHandler pnfs, Subject subject,
               Restriction restriction, FsPath path) throws URISyntaxException {
             super(pnfs, subject, restriction, path);
             initializeTransfer(this, subject);
             _clientAddressForPool = getClientAddress();
 
-            ServletRequest.getRequest().setAttribute(TRANSACTION_ATTRIBUTE,
-                  getTransaction());
+            var request = ServletRequest.getRequest();
+            request.setAttribute(TRANSACTION_ATTRIBUTE, getTransaction());
+            _requestPath = ServletRequest.stripToPath(request.getRequestURI());
         }
 
         protected ProtocolInfo createProtocolInfo(InetSocketAddress address) {
@@ -1561,7 +1567,7 @@ public class DcacheResourceFactory
                         PROTOCOL_INFO_MINOR_VERSION,
                         address,
                         getCellName(), getCellDomainName(),
-                        _path.toString(),
+                        _requestPath,
                         _location,
                         _disposition,
                         _wantedChecksum);


### PR DESCRIPTION
Motivation:
When http request redirected to a pool, then new location contains the dcache internally resolved file path, which doesn't match the prefix anymore. Thus if a pool redirects a client back, then client will get 404.

Modification:
Update HttpTransfer#createProtocolInfo to use the original request path then creating ProtocolInfo

Result:
correct behaviour on redirect with prefix.

Ticket: #10446
Acked-by: Paul Millar
Target: master, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 8a4273fa8ce478fd5dffa425728fe505b367d629)