### PR TITLE
dcache-qos:  propagate subject to QoS Adjuster

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/BulkActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/BulkActivity.java
@@ -93,7 +93,7 @@ public abstract class BulkActivity<R> {
 
     public static final Set<FileAttribute> MINIMALLY_REQUIRED_ATTRIBUTES
           = Collections.unmodifiableSet(EnumSet.of(FileAttribute.PNFSID, FileAttribute.TYPE,
-          FileAttribute.RETENTION_POLICY));
+          FileAttribute.OWNER_GROUP, FileAttribute.OWNER, FileAttribute.RETENTION_POLICY));
 
     private static final BulkTargetRetryPolicy DEFAULT_RETRY_POLICY = new NoRetryPolicy();
 

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/qos/UpdateQoSActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/qos/UpdateQoSActivity.java
@@ -111,7 +111,7 @@ public class UpdateQoSActivity extends BulkActivity<QoSTransitionCompletedMessag
         client.setRequirementsService(qosEngine);
         PnfsId pnfsId = target.getAttributes().getPnfsId();
         try {
-            client.fileQoSRequirementsModifiedCancelled(pnfsId);
+            client.fileQoSRequirementsModifiedCancelled(pnfsId, subject);
         } catch (QoSException e) {
             LOGGER.error("fileQoSRequirementsModifiedCancelled failed: {}, {}.", pnfsId,
                   e.getMessage());
@@ -151,7 +151,7 @@ public class UpdateQoSActivity extends BulkActivity<QoSTransitionCompletedMessag
         client.setRequirementsService(qosEngine);
 
         try {
-            client.fileQoSRequirementsModified(requirements);
+            client.fileQoSRequirementsModified(requirements, subject);
         } catch (CacheException | InterruptedException | NoRouteToCellException e) {
             return Futures.immediateFailedFuture(e);
         }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
@@ -66,6 +67,7 @@ import org.dcache.namespace.FileType;
 import org.dcache.pinmanager.PinManagerPinMessage;
 import org.dcache.pinmanager.PinManagerUnpinMessage;
 import org.dcache.poolmanager.PoolMonitor;
+import org.dcache.qos.QoSException;
 import org.dcache.qos.QoSTransitionEngine;
 import org.dcache.qos.data.FileQoSRequirements;
 import org.dcache.qos.remote.clients.RemoteQoSRequirementsClient;
@@ -444,6 +446,7 @@ public class FileResources {
                     break;
                 case "qos":
                     String targetQos = reqPayload.getString("target");
+                    Subject subject = RequestUser.isAdmin() ? Subjects.ROOT : RequestUser.getSubject();
                     if (!useQosService) {
                         new QoSTransitionEngine(poolmanager,
                               poolMonitor,
@@ -458,11 +461,11 @@ public class FileResources {
                         FileAttributes attr
                               = pnfsHandler.getFileAttributes(path.toString(),
                               NamespaceUtils.getRequestedAttributes(false, false,
-                                    true, false, false));
+                                    true, false, true));
                         FileQoSRequirements requirements = getBasicRequirements(targetQos, attr);
                         RemoteQoSRequirementsClient client = new RemoteQoSRequirementsClient();
                         client.setRequirementsService(qosEngine);
-                        client.fileQoSRequirementsModified(requirements);
+                        client.fileQoSRequirementsModified(requirements, subject);
                     }
                     break;
                 case "pin":

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/listeners/QoSVerificationListener.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/listeners/QoSVerificationListener.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.qos.listeners;
 
 import diskCacheV111.util.PnfsId;
+import javax.security.auth.Subject;
 import org.dcache.qos.QoSException;
 import org.dcache.qos.vehicles.QoSAdjustmentResponse;
 import org.dcache.qos.vehicles.QoSScannerVerificationRequest;
@@ -95,8 +96,9 @@ public interface QoSVerificationListener {
      * This is a notification to cancel and remove the verification operation for a file.
      *
      * @param pnfsId the file for which to cancel verification operation.
+     * @param subject of the request
      */
-    void fileQoSVerificationCancelled(PnfsId pnfsId) throws QoSException;
+    void fileQoSVerificationCancelled(PnfsId pnfsId, Subject subject) throws QoSException;
 
     /**
      * Scanning activity has been cancelled; this is a notification to cancel all outstanding

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/local/clients/LocalQoSRequirementsClient.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/local/clients/LocalQoSRequirementsClient.java
@@ -59,7 +59,9 @@ documents or software obtained from this server.
  */
 package org.dcache.qos.local.clients;
 
+import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
+import javax.security.auth.Subject;
 import org.dcache.qos.QoSException;
 import org.dcache.qos.data.FileQoSRequirements;
 import org.dcache.qos.data.FileQoSUpdate;
@@ -80,13 +82,13 @@ public final class LocalQoSRequirementsClient implements QoSRequirementsListener
     }
 
     @Override
-    public void fileQoSRequirementsModified(FileQoSRequirements newRequirements)
-          throws QoSException {
-        provider.handleModifiedRequirements(newRequirements);
+    public void fileQoSRequirementsModified(FileQoSRequirements newRequirements, Subject subject)
+          throws QoSException, CacheException {
+        provider.handleModifiedRequirements(newRequirements, subject);
     }
 
     @Override
-    public void fileQoSRequirementsModifiedCancelled(PnfsId pnfsid) {
+    public void fileQoSRequirementsModifiedCancelled(PnfsId pnfsid, Subject subject) {
         /*
          *   The local client is an embedded one and thus would not be used to
          *   dispatch a cancellation request.   This is a NOP.

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/local/clients/LocalQoSVerificationClient.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/local/clients/LocalQoSVerificationClient.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.qos.local.clients;
 
 import diskCacheV111.util.PnfsId;
+import javax.security.auth.Subject;
 import org.dcache.qos.QoSException;
 import org.dcache.qos.listeners.QoSVerificationListener;
 import org.dcache.qos.services.verifier.handlers.VerifyOperationHandler;
@@ -91,7 +92,7 @@ public final class LocalQoSVerificationClient implements QoSVerificationListener
     }
 
     @Override
-    public void fileQoSVerificationCancelled(PnfsId pnfsId) throws QoSException {
+    public void fileQoSVerificationCancelled(PnfsId pnfsId, Subject subject) throws QoSException {
         fileOpHandler.handleFileOperationCancelled(pnfsId);
     }
 

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/remote/clients/RemoteQoSVerificationClient.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/remote/clients/RemoteQoSVerificationClient.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.qos.remote.clients;
 
 import diskCacheV111.util.PnfsId;
+import javax.security.auth.Subject;
 import org.dcache.cells.CellStub;
 import org.dcache.qos.QoSException;
 import org.dcache.qos.listeners.QoSVerificationListener;
@@ -97,8 +98,10 @@ public final class RemoteQoSVerificationClient implements QoSVerificationListene
     }
 
     @Override
-    public void fileQoSVerificationCancelled(PnfsId pnfsId) throws QoSException {
-        verificationService.send(new QoSVerificationCancelledMessage(pnfsId));
+    public void fileQoSVerificationCancelled(PnfsId pnfsId, Subject subject) throws QoSException {
+        QoSVerificationCancelledMessage msg = new QoSVerificationCancelledMessage(pnfsId);
+        msg.setSubject(subject);
+        verificationService.send(msg);
     }
 
     public void fileQoSBatchedVerificationCancelled(String id) {

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/remote/receivers/QoSRequirementsReceiver.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/remote/receivers/QoSRequirementsReceiver.java
@@ -59,10 +59,13 @@ documents or software obtained from this server.
  */
 package org.dcache.qos.remote.receivers;
 
+import com.google.common.base.Throwables;
+import diskCacheV111.util.CacheException;
 import diskCacheV111.vehicles.Message;
 import diskCacheV111.vehicles.PnfsAddCacheLocationMessage;
 import diskCacheV111.vehicles.PnfsClearCacheLocationMessage;
 import dmg.cells.nucleus.CellMessageReceiver;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import org.dcache.cells.MessageReply;
 import org.dcache.qos.services.engine.handler.FileQoSStatusHandler;
@@ -151,12 +154,22 @@ public final class QoSRequirementsReceiver implements CellMessageReceiver, Consu
         return reply;
     }
 
+    /**
+     * Made this synchronous to support Frontend request.
+     */
     public QoSRequirementsModifiedMessage messageArrived(QoSRequirementsModifiedMessage message) {
         if (messageGuard.getStatus("QoSRequirementsModifiedMessage", message)
               == Status.DISABLED) {
+            message.setFailed(CacheException.SERVICE_UNAVAILABLE, "messages disabled");
             return message;
         }
-        fileStatusHandler.handleQoSModification(message.getRequirements());
+        try {
+            fileStatusHandler.handleQoSModification(message).get();
+        } catch (InterruptedException e) {
+            message.setFailed(CacheException.TIMEOUT, e);
+        } catch (ExecutionException e) {
+            message.setFailed(CacheException.UNEXPECTED_SYSTEM_EXCEPTION, Throwables.getRootCause(e));
+        }
         return message;
     }
 
@@ -165,7 +178,7 @@ public final class QoSRequirementsReceiver implements CellMessageReceiver, Consu
               == Status.DISABLED) {
             return;
         }
-        fileStatusHandler.handleQoSModificationCancelled(message.getPnfsId());
+        fileStatusHandler.handleQoSModificationCancelled(message.getPnfsId(), message.getSubject());
     }
 
     public void messageArrived(QoSActionCompleteMessage message) {

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/adjusters/QoSAdjuster.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/adjusters/QoSAdjuster.java
@@ -59,8 +59,13 @@ documents or software obtained from this server.
  */
 package org.dcache.qos.services.adjuster.adjusters;
 
+import static org.dcache.qos.util.QoSPermissionUtils.canModifyQos;
+
 import com.google.common.collect.ImmutableList;
+import diskCacheV111.util.PermissionDeniedCacheException;
 import diskCacheV111.util.PnfsId;
+import java.util.Optional;
+import javax.security.auth.Subject;
 import org.dcache.pool.classic.Cancellable;
 import org.dcache.pool.repository.StickyRecord;
 import org.dcache.qos.data.QoSAction;
@@ -85,12 +90,24 @@ public abstract class QoSAdjuster implements Cancellable {
     protected PnfsId pnfsId;
     protected FileAttributes attributes;
     protected QoSAction action;
+    protected Subject subject ;
     protected QoSAdjustTaskCompletionHandler completionHandler;
 
     public void adjustQoS(QoSAdjusterTask task) {
         pnfsId = task.getPnfsId();
         action = task.getAction();
         attributes = task.getAttributes();
+        subject = task.getSubject();
+
+        try {
+            checkPermissions();
+        } catch (PermissionDeniedCacheException e) {
+            /*
+             *  handler is injected by factory build
+             */
+            completionHandler.taskFailed(pnfsId, Optional.empty(), e);
+            return;
+        }
 
         /*
          *  Generate the SESSION ID.   This is used by the QoS status endpoint
@@ -104,4 +121,11 @@ public abstract class QoSAdjuster implements Cancellable {
     }
 
     protected abstract void runAdjuster(QoSAdjusterTask task);
+
+    private void checkPermissions() throws PermissionDeniedCacheException {
+        if (!canModifyQos(subject, attributes)) {
+            throw new PermissionDeniedCacheException(String.format("subject does not have "
+                  + "permission for %s on %s.", action, pnfsId));
+        }
+    }
 }

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/adjusters/ReplicaStateAdjuster.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/adjusters/ReplicaStateAdjuster.java
@@ -132,6 +132,7 @@ public final class ReplicaStateAdjuster extends QoSAdjuster {
 
         LOGGER.debug("Sending {} message to {} for {}.", action, target, pnfsId);
         ACTIVITY_LOGGER.info("Sending {} message to {} for {}.", action, target, pnfsId);
+        msg.setSubject(subject);
         future = pools.send(new CellPath(target), msg);
     }
 

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/adjusters/StagingAdjuster.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/adjusters/StagingAdjuster.java
@@ -174,6 +174,7 @@ public final class StagingAdjuster extends QoSAdjuster {
                   getProtocolInfo(),
                   QOS_PIN_REQUEST_ID,
                   QOS_PIN_TEMP_LIFETIME);
+            message.setSubject(subject);
             future = pinManager.send(message, Long.MAX_VALUE);
             future.addListener(this::handleCompletion, executorService);
             LOGGER.debug("handleStaging, sent pin manager request for {}.", pnfsId);
@@ -192,6 +193,7 @@ public final class StagingAdjuster extends QoSAdjuster {
         LOGGER.debug("handleStaging, cancelling pin {}.", pnfsId);
         ACTIVITY_LOGGER.info("handleStaging, cancelling pin {}", pnfsId);
         PinManagerUnpinMessage message = new PinManagerUnpinMessage(pnfsId);
+        message.setSubject(subject);
         pinManager.send(message, Long.MAX_VALUE);
         LOGGER.debug("handleStaging, sent pin manager request to unpin {}.", pnfsId);
     }

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/util/QoSAdjusterTask.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/util/QoSAdjusterTask.java
@@ -64,6 +64,7 @@ import diskCacheV111.vehicles.PoolManagerPoolInformation;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import javax.security.auth.Subject;
 import org.dcache.pool.classic.Cancellable;
 import org.dcache.pool.migration.PoolMigrationCopyFinishedMessage;
 import org.dcache.qos.data.FileQoSUpdate;
@@ -86,6 +87,7 @@ public final class QoSAdjusterTask extends ErrorAwareTask implements Cancellable
 
     private final PnfsId pnfsId;
     private final QoSAction type;
+    private final Subject subject;
     private final int retry;
     private final QoSAdjusterFactory factory;
     private final FileAttributes attributes;
@@ -120,13 +122,13 @@ public final class QoSAdjusterTask extends ErrorAwareTask implements Cancellable
         this.source = request.getSource();
         this.target = request.getTarget();
         this.poolGroup = request.getPoolGroup();
+        this.subject = request.getSubject();
         this.status = Status.INITIALIZED;
     }
 
     public QoSAdjusterTask(QoSAdjusterTask task, int retry) {
         this.pnfsId = task.pnfsId;
         this.type = task.type;
-        ;
         this.retry = retry;
         this.factory = task.factory;
         this.attributes = task.attributes;
@@ -135,6 +137,7 @@ public final class QoSAdjusterTask extends ErrorAwareTask implements Cancellable
         this.target = task.target;
         this.poolGroup = task.poolGroup;
         this.status = task.status;
+        this.subject = task.subject;
     }
 
     @Override
@@ -142,7 +145,6 @@ public final class QoSAdjusterTask extends ErrorAwareTask implements Cancellable
         synchronized (this) {
             status = Status.RUNNING;
             exception = null;
-            adjuster = factory.newBuilder().of(type).build();
             startTime = System.currentTimeMillis();
         }
 
@@ -154,6 +156,7 @@ public final class QoSAdjusterTask extends ErrorAwareTask implements Cancellable
                 if (isCancelled()) {
                     break;
                 }
+                adjuster = factory.newBuilder().of(type).build();
                 adjuster.adjustQoS(this);
                 break;
         }
@@ -219,6 +222,10 @@ public final class QoSAdjusterTask extends ErrorAwareTask implements Cancellable
 
     public String getSource() {
         return source;
+    }
+
+    public Subject getSubject() {
+        return subject;
     }
 
     public String getTarget() {

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/QoSRequirementsProvider.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/QoSRequirementsProvider.java
@@ -59,6 +59,8 @@ documents or software obtained from this server.
  */
 package org.dcache.qos.services.engine.provider;
 
+import diskCacheV111.util.CacheException;
+import javax.security.auth.Subject;
 import org.dcache.qos.QoSException;
 import org.dcache.qos.data.FileQoSRequirements;
 import org.dcache.qos.data.FileQoSUpdate;
@@ -80,6 +82,7 @@ public interface QoSRequirementsProvider {
      *
      * @param newRequirements in particular the number and distribution of persistent disk and tape
      *                        replicas.
+     * @param subject subject of the request.
      */
-    void handleModifiedRequirements(FileQoSRequirements newRequirements) throws QoSException;
+    void handleModifiedRequirements(FileQoSRequirements newRequirements, Subject subject) throws QoSException, CacheException;
 }

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/VerifyOperation.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/VerifyOperation.java
@@ -73,6 +73,8 @@ import diskCacheV111.util.PnfsId;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import javax.security.auth.Subject;
+import org.dcache.auth.Subjects;
 import org.dcache.qos.QoSException;
 import org.dcache.qos.data.FileQoSUpdate;
 import org.dcache.qos.data.QoSAction;
@@ -103,6 +105,7 @@ public final class VerifyOperation implements Comparable<VerifyOperation> {
     private VerifyOperationState state;
     private QoSAction previousAction;
     private QoSAction action;
+    private Subject subject;
 
     private String poolGroup;
     private String storageUnit;
@@ -240,6 +243,10 @@ public final class VerifyOperation implements Comparable<VerifyOperation> {
         return storageUnit;
     }
 
+    public Subject getSubject() {
+        return subject == null ? Subjects.ROOT : subject;
+    }
+
     public String getTarget() {
         return target;
     }
@@ -372,6 +379,10 @@ public final class VerifyOperation implements Comparable<VerifyOperation> {
 
     public void setStorageUnit(String storageUnit) {
         this.storageUnit = storageUnit;
+    }
+
+    public void setSubject(Subject subject) {
+        this.subject = subject;
     }
 
     public void setTarget(String target) {

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/db/JdbcOperationUpdate.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/db/JdbcOperationUpdate.java
@@ -42,6 +42,14 @@ public class JdbcOperationUpdate extends JdbcUpdate implements VerifyOperationUp
     }
 
     @Override
+    public VerifyOperationUpdate subject(String subject) {
+        if (subject != null) {
+            set("subject", subject);
+        }
+        return this;
+    }
+
+    @Override
     public VerifyOperationUpdate arrivalTime(long epochMillis) {
         set("arrived", epochMillis);
         return this;

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/db/VerifyOperationDao.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/db/VerifyOperationDao.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.dcache.qos.QoSException;
 import org.dcache.qos.data.QoSAction;
 import org.dcache.qos.data.QoSMessageType;
 import org.dcache.qos.services.verifier.data.VerifyOperation;
@@ -91,6 +92,8 @@ public interface VerifyOperationDao {
 
         VerifyOperationUpdate pnfsid(PnfsId pnfsId);
 
+        VerifyOperationUpdate subject(String subject);
+
         VerifyOperationUpdate arrivalTime(long epochMillis);
 
         VerifyOperationUpdate lastUpdate(long epochMillis);
@@ -141,12 +144,12 @@ public interface VerifyOperationDao {
      * Returns a field value builder based on the fields of the file operation which can change
      * while being processed.
      */
-    VerifyOperationUpdate fromOperation(VerifyOperation operation);
+    VerifyOperationUpdate fromOperation(VerifyOperation operation) throws QoSException;
 
     /**
      * Returns true if stored, false if not.
      */
-    boolean store(VerifyOperation operation);
+    boolean store(VerifyOperation operation) throws QoSException;
 
     /**
      * Returns the VerifyOperations matching a selection criterion with an upper limit on the

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/handlers/VerifyOperationHandler.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/handlers/VerifyOperationHandler.java
@@ -574,6 +574,7 @@ public class VerifyOperationHandler implements VerifyAndUpdateHandler {
         request.setPnfsId(requirements.getPnfsId());
         request.setAttributes(requirements.getAttributes());
         request.setPoolGroup(operation.getPoolGroup());
+        request.setSubject(operation.getSubject());
 
         String source = operation.getSource();
 

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/util/QoSPermissionUtils.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/util/QoSPermissionUtils.java
@@ -57,89 +57,27 @@ export control laws.  Anyone downloading information from this server is
 obligated to secure any necessary Government licenses before exporting
 documents or software obtained from this server.
  */
-package org.dcache.qos.vehicles;
+package org.dcache.qos.util;
 
-import diskCacheV111.util.PnfsId;
-import diskCacheV111.vehicles.PoolManagerPoolInformation;
-import java.io.Serializable;
 import javax.security.auth.Subject;
-import org.dcache.qos.data.QoSAction;
+
+import org.dcache.auth.Subjects;
 import org.dcache.vehicles.FileAttributes;
 
-public class QoSAdjustmentRequest implements Serializable {
+public class QoSPermissionUtils {
 
-    private static final long serialVersionUID = -561618660521542972L;
-
-    private PnfsId pnfsId;
-    private Subject subject;
-    private QoSAction action;
-    private FileAttributes attributes;
-    private PoolManagerPoolInformation targetInfo;
-    private String source;
-    private String target;
-    private String poolGroup;
-
-    public PnfsId getPnfsId() {
-        return pnfsId;
+    /**
+     * Determines if the user is allowed to modify qos.
+     * Currently the user must either be the owner of the file or be ROOT.
+     *
+     * @param subject
+     * @param attributes
+     */
+    public static boolean canModifyQos(Subject subject, FileAttributes attributes) {
+        return Subjects.isRoot(subject) || Subjects.getUid(subject) == attributes.getOwner();
     }
 
-    public void setPnfsId(PnfsId pnfsId) {
-        this.pnfsId = pnfsId;
-    }
-
-    public QoSAction getAction() {
-        return action;
-    }
-
-    public void setAction(QoSAction action) {
-        this.action = action;
-    }
-
-    public FileAttributes getAttributes() {
-        return attributes;
-    }
-
-    public void setAttributes(FileAttributes attributes) {
-        this.attributes = attributes;
-    }
-
-    public PoolManagerPoolInformation getTargetInfo() {
-        return targetInfo;
-    }
-
-    public void setTargetInfo(PoolManagerPoolInformation targetInfo) {
-        this.targetInfo = targetInfo;
-    }
-
-    public String getSource() {
-        return source;
-    }
-
-    public void setSource(String source) {
-        this.source = source;
-    }
-
-    public String getTarget() {
-        return target;
-    }
-
-    public void setTarget(String target) {
-        this.target = target;
-    }
-
-    public String getPoolGroup() {
-        return poolGroup;
-    }
-
-    public void setPoolGroup(String poolGroup) {
-        this.poolGroup = poolGroup;
-    }
-
-    public Subject getSubject() {
-        return subject;
-    }
-
-    public void setSubject(Subject subject) {
-        this.subject = subject;
+    private QoSPermissionUtils() {
+        // static class
     }
 }

--- a/modules/dcache-qos/src/main/resources/org/dcache/qos/model/db.changelog-8.0.xml
+++ b/modules/dcache-qos/src/main/resources/org/dcache/qos/model/db.changelog-8.0.xml
@@ -153,4 +153,15 @@
         </createIndex>
         <rollback/>
     </changeSet>
+
+    <changeSet author="rossi" id="6">
+    <preConditions onFail="MARK_RAN">
+        <not>
+            <columnExists tableName="qos_operation" columnName="subject"/>
+        </not>
+    </preConditions>
+        <addColumn tableName="qos_operation">
+            <column name="subject" type="varchar(4096)"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/modules/dcache-vehicles/src/main/java/org/dcache/qos/data/FileQoSUpdate.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/qos/data/FileQoSUpdate.java
@@ -64,6 +64,8 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import javax.security.auth.Subject;
+import org.dcache.auth.Subjects;
 
 /**
  * A transient encapsulation of pertinent configuration data regarding a file, synthesized from a
@@ -83,6 +85,7 @@ public final class FileQoSUpdate implements Serializable {
 
     private final PnfsId pnfsId;
     private final QoSMessageType type;
+    private Subject subject;
     private String pool;
     private String effectivePoolGroup;
     private String storageUnit;
@@ -120,6 +123,10 @@ public final class FileQoSUpdate implements Serializable {
         return pnfsId;
     }
 
+    public Subject getSubject() {
+        return subject == null ? Subjects.ROOT: subject;
+    }
+
     public QoSMessageType getMessageType() {
         return type;
     }
@@ -134,6 +141,10 @@ public final class FileQoSUpdate implements Serializable {
 
     public void setPool(String pool) {
         this.pool = pool;
+    }
+
+    public void setSubject(Subject subject) {
+        this.subject = subject;
     }
 
     public String toString() {

--- a/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/qos/QoSCancelRequirementsModifiedMessage.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/qos/QoSCancelRequirementsModifiedMessage.java
@@ -61,13 +61,15 @@ package org.dcache.vehicles.qos;
 
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.Message;
+import javax.security.auth.Subject;
 
 public class QoSCancelRequirementsModifiedMessage extends Message {
 
     private final PnfsId pnfsId;
 
-    public QoSCancelRequirementsModifiedMessage(PnfsId pnfsId) {
+    public QoSCancelRequirementsModifiedMessage(PnfsId pnfsId, Subject subject) {
         this.pnfsId = pnfsId;
+        setSubject(subject);
     }
 
     public PnfsId getPnfsId() {

--- a/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/qos/QoSRequirementsModifiedMessage.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/qos/QoSRequirementsModifiedMessage.java
@@ -60,14 +60,16 @@ documents or software obtained from this server.
 package org.dcache.vehicles.qos;
 
 import diskCacheV111.vehicles.Message;
+import javax.security.auth.Subject;
 import org.dcache.qos.data.FileQoSRequirements;
 
 public class QoSRequirementsModifiedMessage extends Message {
 
     private final FileQoSRequirements requirements;
 
-    public QoSRequirementsModifiedMessage(FileQoSRequirements requirements) {
+    public QoSRequirementsModifiedMessage(FileQoSRequirements requirements, Subject subject) {
         this.requirements = requirements;
+        setSubject(subject);
     }
 
     public FileQoSRequirements getRequirements() {

--- a/modules/dcache/src/main/java/org/dcache/qos/listeners/QoSRequirementsListener.java
+++ b/modules/dcache/src/main/java/org/dcache/qos/listeners/QoSRequirementsListener.java
@@ -62,6 +62,7 @@ package org.dcache.qos.listeners;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
 import dmg.cells.nucleus.NoRouteToCellException;
+import javax.security.auth.Subject;
 import org.dcache.qos.QoSException;
 import org.dcache.qos.data.FileQoSRequirements;
 import org.dcache.qos.data.FileQoSUpdate;
@@ -83,7 +84,7 @@ public interface QoSRequirementsListener {
      * @param newRequirements describing principally how many peristent disk and tape copies are
      *                        required.
      */
-    void fileQoSRequirementsModified(FileQoSRequirements newRequirements)
+    void fileQoSRequirementsModified(FileQoSRequirements newRequirements, Subject subject)
           throws QoSException, CacheException, NoRouteToCellException, InterruptedException;
 
     /**
@@ -91,5 +92,5 @@ public interface QoSRequirementsListener {
      *
      * @param pnfsid of the file for which the modification was requested.
      */
-    void fileQoSRequirementsModifiedCancelled(PnfsId pnfsid) throws QoSException;
+    void fileQoSRequirementsModifiedCancelled(PnfsId pnfsid, Subject subject) throws QoSException;
 }


### PR DESCRIPTION
Motivation:

Most of the QoS engine was brought over/adpated from Resilience; in the context of the latter, it was not necessary to propagate the Subject of the request in the various internal messages.

With QoS, there is an added function allowing for QoS modification; the subject is needed in this context.

Modification:

Add all the hooks to propagate the subject downstream to the actual adjustement tasks.  Also, allow the Engine to determine what to do with a QoSModify request on the basis of subject and file attributes.

Result:

Proper handling of the QoSModify requests.

Target: master
Request: 9.0
Request: 8.2
Requires-notes: yes
(cherry picked from commit 7d898c5601d30c6f8cc027e4080f3b82c2072f4b)