### PR TITLE
systemtest: fix support for oidc testing

### DIFF
--- a/packages/system-test/src/main/bin/populate
+++ b/packages/system-test/src/main/bin/populate
@@ -242,7 +242,11 @@ add_oidc() {
     prepend etc/gplazma.conf "auth    optional    oidc"
 
     for op in $loaded_ops; do
-        eval $(oidc-token -c $op)
+        #  The "2>&1" is a work-around for a bug in oidc-token; see:
+        #
+        #      https://github.com/indigo-dc/oidc-agent/issues/503
+        #
+        eval $(oidc-token -c $op 2>&1)
 
         prepend_layout "gplazma.oidc.provider!$op = $OIDC_ISS"
 


### PR DESCRIPTION
Motivation:

Commit 33894867365 updated the `populate` script (a script that is used by systemtest to customise the dCache deployment) in order to support testing dCache's support for OpenID-Connect.  The patch makes use of oidc-agent to achieve this; if oidc-agent is not installed or the agent has no configurations loaded then systemtest is not updated to support OpenID-Connect.

A somewhat subtle bug in the `oidc-token` command resulted in the above patch not working as intended, resulting in the `populate` script generating a broken dCache configuration.  This bug has been reported to oidc-agent team.

Modification:

Add simple work-around for the problem, along with a comment pointing to the upstream bug report.

Result:

The `populate` script now generates a valid dCache configuration if oidc-agent is installed and at least one configuration has been loaded.

Target: master
Request: 8.1
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13960/
Acked-by: Tigran Mkrtchyan