### PR TITLE
commons,dcache:  alternative symlinks resolution on restrictions

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -1799,7 +1799,7 @@ public class FsSqlDriver {
     String resolvePath(FsInode root, String path) throws ChimeraFsException, SQLException {
         FsInode pathInode = path2inode(root, path);
         if (pathInode == null) {
-            return path;
+            return null;
         }
         return inode2path(pathInode, root);
     }

--- a/modules/common/src/main/java/org/dcache/auth/attributes/DenyActivityRestriction.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/DenyActivityRestriction.java
@@ -21,6 +21,7 @@ package org.dcache.auth.attributes;
 import com.google.common.base.Joiner;
 import diskCacheV111.util.FsPath;
 import java.util.EnumSet;
+import java.util.function.Function;
 
 /**
  * A Restriction that allows a user to perform only activity from the supplied set of activities.
@@ -88,6 +89,11 @@ public class DenyActivityRestriction implements Restriction {
         EnumSet<Activity> otherDenied = ((DenyActivityRestriction) other).denied;
 
         return otherDenied.containsAll(denied);
+    }
+
+    @Override
+    public void setPathResolver(Function<FsPath, FsPath> resolver) {
+        //NOP
     }
 
     @Override

--- a/modules/common/src/main/java/org/dcache/auth/attributes/Restriction.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/Restriction.java
@@ -19,6 +19,7 @@ package org.dcache.auth.attributes;
 
 import diskCacheV111.util.FsPath;
 import java.io.Serializable;
+import java.util.function.Function;
 
 /**
  * A Restriction provides an overlay authorisation layer where some actions of that a user would
@@ -146,6 +147,18 @@ public interface Restriction extends LoginAttribute, Serializable {
      * {@code #isRestricted} returns true.
      */
     boolean isSubsumedBy(Restriction other);
+
+    /**
+     * @param resolver function to use for resolving paths.
+     */
+    void setPathResolver(Function<FsPath, FsPath> resolver);
+
+    /**
+     * @return returns NOP resolver.  Should be overridden by implementations.
+     */
+    default Function<FsPath, FsPath> getPathResolver() {
+        return Function.identity();
+    }
 
     /**
      * Provide a short, single-line description of this restriction.


### PR DESCRIPTION
Motivation:

See GitHub #7113 Symlink behavior broken for SE-tokens https://github.com/dCache/dcache/issues/7113

commit master@7cb0cd0c5f5c1debe97ee0ff868e5455f33fefdb https://rb.dcache.org/r/13908/

introduced symlink resolution for all targets.
The assumption was that configurations (including
token scopes) would not use symlinks to express
path restrictions.

However, macaroons constitute a special case and
were not tested.  The upgrade to stable branches
incorporating that commit thus break when the
user provides a symlinked path to construct a
macaroon.

Modification:

Inject a resolver function into Restrictions
and have the restrictions resolve both their
constraints as well as target.

The PnfsManager handling of restrictions
is refitted to inject the resolver.  Note
also that the resolution method now
walks up the path tree in case the
symlink check is done on a non-existent
path.

Result:

Symlinks on both constraints and targets
are permitted; thus macaroons will also
work.

Target: master
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/13970/
Closes: #7113
Acked-by: Tigran