### PR TITLE
dcache-core,dcache-xroot,dcache-bulk,dcache-frontend:  resolve path p…

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/attributes/PrefixRestriction.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/PrefixRestriction.java
@@ -33,6 +33,7 @@ public class PrefixRestriction implements Restriction {
     private ImmutableSet<FsPath> prefixes;
 
     public PrefixRestriction(FsPath... prefixes) {
+
         this.prefixes = ImmutableSet.copyOf(prefixes);
     }
 

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/AbstractRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/AbstractRequestContainerJob.java
@@ -104,6 +104,7 @@ import org.dcache.util.list.DirectoryEntry;
 import org.dcache.util.list.DirectoryStream;
 import org.dcache.util.list.ListDirectoryHandler;
 import org.dcache.vehicles.FileAttributes;
+import org.dcache.vehicles.PnfsResolveSymlinksMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -445,7 +446,7 @@ public abstract class AbstractRequestContainerJob
     }
 
     protected List<BulkRequestTarget> getInitialTargets() {
-         return targetStore.getInitialTargets(rid, true);
+        return targetStore.getInitialTargets(rid, true);
     }
 
     protected boolean hasBeenCancelled(Long id, PID pid, FsPath path, FileAttributes attributes) {
@@ -481,6 +482,12 @@ public abstract class AbstractRequestContainerJob
         semaphore.release();
 
         checkTransitionToDirs();
+    }
+
+    protected FsPath resolvePath(String targetPath) throws CacheException {
+        PnfsResolveSymlinksMessage message = new PnfsResolveSymlinksMessage(targetPath, null);
+        message = pnfsHandler.request(message);
+        return FsPath.create(message.getResolvedPath());
     }
 
     private void checkTransitionToDirs() {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
@@ -226,22 +226,22 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
 
     private void addInfo(BulkRequestTarget target) {
         Long id = target.getId();
-        FsPath path = target.getPath();
-        if (targetPrefix != null && !path.contains(targetPrefix)) {
-            path = computeFsPath(targetPrefix, target.getPath().toString());
-        }
         try {
+            FsPath path = resolvePath(target.getPath().toString());
+            if (targetPrefix != null && !path.contains(targetPrefix)) {
+                path = computeFsPath(targetPrefix, target.getPath().toString());
+            }
             targetInfo.add(new TargetInfo(id, path, pnfsHandler.getFileAttributes(path,
                   MINIMALLY_REQUIRED_ATTRIBUTES)));
         } catch (CacheException e) {
-            LOGGER.error("addInfo {}, path {}, error {}.", ruid, path, e.getMessage());
+            LOGGER.error("addInfo {}, path {}, error {}.", ruid, target.getPath(), e.getMessage());
             target.setState(FAILED);
             target.setErrorObject(e);
             statistics.increment(FAILED.name());
             try {
                 targetStore.storeOrUpdate(target);
             } catch (BulkStorageException ex) {
-                LOGGER.error("addInfo {}, path {}, could not store, error {}.", ruid, path,
+                LOGGER.error("addInfo {}, path {}, could not store, error {}.", ruid, target.getPath(),
                       ex.getMessage());
             }
         } finally {

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
@@ -64,6 +64,7 @@ import static org.dcache.restful.util.HttpServletRequests.getUserRootAwareTarget
 import static org.dcache.restful.util.RequestUser.getRestriction;
 import static org.dcache.restful.util.RequestUser.getSubject;
 
+import diskCacheV111.util.PnfsHandler;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -75,6 +76,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
@@ -87,6 +89,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.dcache.auth.attributes.Restriction;
+import org.dcache.cells.CellStub;
+import org.dcache.restful.util.HandlerBuilders;
 import org.dcache.restful.util.bulk.BulkServiceCommunicator;
 import org.dcache.services.bulk.BulkRequest;
 import org.dcache.services.bulk.BulkRequest.Depth;
@@ -111,6 +115,10 @@ public final class ReleaseResources {
 
     @Inject
     private BulkServiceCommunicator service;
+
+    @Inject
+    @Named("pnfs-stub")
+    private CellStub pnfsmanager;
 
     /**
      * Release files belonging to a bulk STAGE request.
@@ -173,7 +181,10 @@ public final class ReleaseResources {
          *  Frontend sets the URL.  The backend service provides the UUID.
          */
         request.setUrlPrefix(this.request.getRequestURL().toString());
-        request.setTargetPrefix(getUserRootAwareTargetPrefix(this.request, null));
+
+        PnfsHandler handler = HandlerBuilders.unrestrictedPnfsHandler(pnfsmanager);
+
+        request.setTargetPrefix(getUserRootAwareTargetPrefix(this.request, null, handler));
 
         BulkRequestMessage message = new BulkRequestMessage(request, restriction);
         message.setSubject(subject);

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
@@ -65,6 +65,7 @@ import static org.dcache.restful.util.HttpServletRequests.getUserRootAwareTarget
 import static org.dcache.restful.util.JSONUtils.newBadRequestException;
 
 import com.google.common.base.Strings;
+import diskCacheV111.util.PnfsHandler;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -77,6 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
@@ -92,7 +94,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.dcache.auth.attributes.Restriction;
+import org.dcache.cells.CellStub;
 import org.dcache.restful.providers.tape.StageRequestInfo;
+import org.dcache.restful.util.HandlerBuilders;
 import org.dcache.restful.util.bulk.BulkServiceCommunicator;
 import org.dcache.services.bulk.BulkRequest;
 import org.dcache.services.bulk.BulkRequest.Depth;
@@ -124,6 +128,10 @@ public final class StageResources {
 
     @Inject
     private BulkServiceCommunicator service;
+
+    @Inject
+    @Named("pnfs-stub")
+    private CellStub pnfsmanager;
 
     private String[] supportedSitenames;
 
@@ -341,7 +349,9 @@ public final class StageResources {
         request.setClearOnFailure(false);
         request.setClearOnSuccess(false);
         request.setActivity("STAGE");
-        request.setTargetPrefix(getUserRootAwareTargetPrefix(this.request, null));
+
+        PnfsHandler handler = HandlerBuilders.unrestrictedPnfsHandler(pnfsmanager);
+        request.setTargetPrefix(getUserRootAwareTargetPrefix(this.request, null, handler));
 
         try {
             JSONObject reqPayload = new JSONObject(requestPayload);

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/HandlerBuilders.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/HandlerBuilders.java
@@ -45,4 +45,11 @@ public class HandlerBuilders {
 
         return handler;
     }
+
+    public static PnfsHandler unrestrictedPnfsHandler(CellStub pnfsManager) {
+        PnfsHandler handler = pnfsHandler(pnfsManager);
+        handler.setSubject(Subjects.ROOT);
+        handler.setRestriction(Restrictions.none());
+        return handler;
+    }
 }

--- a/modules/dcache-frontend/src/test/java/org/dcache/restful/resources/bulk/BulkRequestJsonParseTest.java
+++ b/modules/dcache-frontend/src/test/java/org/dcache/restful/resources/bulk/BulkRequestJsonParseTest.java
@@ -62,11 +62,16 @@ package org.dcache.restful.resources.bulk;
 import static org.dcache.restful.resources.bulk.BulkResources.toBulkRequest;
 import static org.junit.Assert.assertEquals;
 
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.PnfsHandler;
+import diskCacheV111.vehicles.PnfsMessage;
+import dmg.cells.nucleus.CellPath;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.BadRequestException;
 import org.dcache.services.bulk.BulkRequest;
 import org.dcache.services.bulk.BulkRequest.Depth;
+import org.dcache.vehicles.PnfsResolveSymlinksMessage;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -91,6 +96,10 @@ public class BulkRequestJsonParseTest {
     Boolean clearOnFailure;
     Depth expandDirectories;
 
+    PnfsHandler handler;
+
+    PnfsResolveSymlinksMessage message;
+
     @Before
     public void setUp() {
         activity = "PIN";
@@ -101,6 +110,12 @@ public class BulkRequestJsonParseTest {
         clearOnSuccess = true;
         clearOnFailure = true;
         expandDirectories = Depth.ALL;
+        handler = new PnfsHandler(new CellPath()) {
+            public <T extends PnfsMessage> T request(T msg)
+                  throws CacheException {
+                return msg;
+            }
+        };
     }
 
     @Test
@@ -167,6 +182,6 @@ public class BulkRequestJsonParseTest {
     }
 
     private void whenParsed() {
-        bulkRequest = toBulkRequest(requestJson, null);
+        bulkRequest = toBulkRequest(requestJson, null, handler);
     }
 }

--- a/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/PnfsResolveSymlinksMessage.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/PnfsResolveSymlinksMessage.java
@@ -1,0 +1,49 @@
+/*
+ * $Id: PnfsRenameMessage.java,v 1.2 2005-02-21 15:49:33 tigran Exp $
+ */
+
+package org.dcache.vehicles;
+
+import diskCacheV111.vehicles.PnfsMessage;
+
+public class PnfsResolveSymlinksMessage extends PnfsMessage {
+
+    private static final long serialVersionUID = 5670471419391898275L;
+
+    private final String prefix;
+
+    private String resolvedPrefix;
+
+    private String resolvedPath;
+
+    public PnfsResolveSymlinksMessage(String path) {
+        this(path, null);
+    }
+
+    public PnfsResolveSymlinksMessage(String path, String prefix) {
+        setPnfsPath(path);
+        this.prefix = prefix;
+        setReplyRequired(true);
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getResolvedPath() {
+        return resolvedPath;
+    }
+
+    public void setResolvedPath(String resolvedPath) {
+        this.resolvedPath = resolvedPath;
+        setSucceeded();
+    }
+
+    public String getResolvedPrefix() {
+        return resolvedPrefix;
+    }
+
+    public void setResolvedPrefix(String resolvedPrefix) {
+        this.resolvedPrefix = resolvedPrefix;
+    }
+}

--- a/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
+++ b/modules/dcache/src/main/java/diskCacheV111/namespace/PnfsManagerV3.java
@@ -145,6 +145,7 @@ import org.dcache.vehicles.PnfsCreateSymLinkMessage;
 import org.dcache.vehicles.PnfsGetFileAttributes;
 import org.dcache.vehicles.PnfsListDirectoryMessage;
 import org.dcache.vehicles.PnfsRemoveChecksumMessage;
+import org.dcache.vehicles.PnfsResolveSymlinksMessage;
 import org.dcache.vehicles.PnfsSetFileAttributes;
 import org.dcache.vehicles.quota.PnfsManagerGetQuotaMessage;
 import org.dcache.vehicles.quota.PnfsManagerQuotaMessage;
@@ -2676,6 +2677,8 @@ public class PnfsManagerV3
             removeExtendedAttributes((PnfsRemoveExtendedAttributesMessage) pnfsMessage);
         } else if (pnfsMessage instanceof PnfsRemoveLabelsMessage) {
             removeLabel((PnfsRemoveLabelsMessage) pnfsMessage);
+        } else if (pnfsMessage instanceof PnfsResolveSymlinksMessage) {
+            resolveSymlinks((PnfsResolveSymlinksMessage) pnfsMessage);
         } else {
             LOGGER.warn("Unexpected message class [{}] from source [{}]",
                   pnfsMessage.getClass(), message.getSourcePath());
@@ -3328,6 +3331,17 @@ public class PnfsManagerV3
                   "Restriction " + restriction + " denied activity " + activity + " on "
                         + resolvedPath);
         }
+    }
+
+    private void resolveSymlinks(PnfsResolveSymlinksMessage message) {
+        String prefix = message.getPrefix();
+        String path   = message.getPnfsPath();
+        if (Strings.emptyToNull(prefix) != null) {
+            message.setResolvedPrefix(resolveSymlinks(prefix).toString());
+        }
+
+        message.setResolvedPath(resolveSymlinks(path).toString());
+        message.setSucceeded();
     }
 
     private FsPath resolveSymlinks(String target) {


### PR DESCRIPTION
…refixes and paths for symlinks

Motivation:

https://rb.dcache.org/r/13937/
master@51594993ee1ac88d8b8ad350788f5153e0665b98

and

https://rb.dcache.org/r/13923/
master@c491f2d312abcbadefcf1df2af85c5620e1e1867

introduced support for relative paths in
the Frontend/Bulk requests and in the
xroot door, respectively.

It did not consider, however, the case when
path prefixes may themselves involve
symlinks.  This could happen either
by a symlink in the configured prefix
from the door or user root, on in the
prefix part of the actual target.

Modification:

Since https://rb.dcache.org/r/13908/
we have the stored procedure and PnfsManager
support for resolving symlinks.  This
patch adds a PnfsMessage and uses the
PnfsHandler to ask for resolution of the
symlinks in the Frontend and xroot doors;
in addition, symlink resolution is done
on the paths of the initial targets
given to the Bulk service when they
are processed.

Result:

The support for both absolute and relative
paths does not fail if there are symlinks
affecting the path prefix.

Target: master
Request 9.0 (partial -- for frontend)
Patch: https://rb.dcache.org/r/13971/
Requires-notes: yes (for 9.0)
Acked-by: Tigran