### PR TITLE
Motivation:

### DIFF
--- a/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
+++ b/modules/dcache-gplazma/src/main/java/org/dcache/auth/Gplazma2LoginStrategy.java
@@ -143,7 +143,8 @@ public class Gplazma2LoginStrategy implements LoginStrategy, CellCommandListener
          *  authorisation.
          */
         if (mtRestrictions.isEmpty()) {
-            userRoots.stream().map(_createPrefixRestriction).forEach(loginAttributes::add);
+            userRoots.stream().filter(p->!p.toString().equals("/"))
+                  .map(_createPrefixRestriction).forEach(loginAttributes::add);
         } else {
             handleMultiTargetedRestrictions(userRoots, mtRestrictions, loginAttributes);
         }
@@ -183,10 +184,7 @@ public class Gplazma2LoginStrategy implements LoginStrategy, CellCommandListener
                 loginAttributes.add((LoginAttribute) attr);
                 if (attr instanceof RootDirectory) {
                     RootDirectory rootDir = (RootDirectory) attr;
-                    String root = rootDir.getRoot();
-                    if (!root.equals("/")) {
-                        userRoots.add(FsPath.create(root));
-                    }
+                    userRoots.add(FsPath.create(rootDir.getRoot()));
                 }
             }
         }


### PR DESCRIPTION
https://rb.dcache.org/r/13855/
master@40dc86223b1f664f6dad5eff4ec222fae5631d3e

was intended to allow upload (for xrootd, POSC)
when there are Multitargeted Restrictions from
tokens.  However, as

https://github.com/dCache/dcache/issues/7129#issuecomment-1531658518 `Transfer with xroot using POSC fails for token with storage.modify`

indicates, there is a bug which is erroneously
excluding user roots equivalent to '/'.

Modification:

Remove the conditional excluding '/'.

Result:

POSC works with tokens when user root is '/'.

Target: master
Request: 9.0
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Closes: #7129
Requires-notes: yes
Patch: https://rb.dcache.org/r/13973/
Acked-by: Dmitry