### PR TITLE
nfs: remove failed to start read transfers

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -737,14 +737,8 @@ public class NFSv41Door extends AbstractCellComponent implements
                     transfer.setKafkaSender(_kafkaSender);
 
                     final NfsTransfer t = transfer;
-                    openStateId.addDisposeListener(state -> {
-                        if (t.isWrite()) {
-                            /* write request keep in the message map to
-                             * avoid re-creates and trigger errors.
-                             */
-                            _transfers.remove(openStateId.stateid());
-                        }
-                    });
+                    /* clean dead transfers associated with open. */
+                    openStateId.addDisposeListener(state -> _transfers.remove(openStateId.stateid()));
                     _transfers.put(openStateId.stateid(), transfer);
                 } else {
                     // keep debug context in sync


### PR DESCRIPTION
Motivation:
When on LAYOUTGET door returns an error back to the client, then, as operation have failed, client will not issue LAYOUT_RETURN. Thus such transfers will stay in the door like:

 2023-04-24T13:47:53.59+02:00 : 00000...FCC : ReadTransfer null@N/A, ....

Modification:
As all layout (active transfer) related termination processes are done before open state invalidation, the stateid<->transfer mapping can be safely removed on open state disposal.

Result:
no layout leftovers

Acked-by: Albert Rossi
Target: master, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 9a2291cfa489f7a76b947b81de8193e7df38b3fa)