### PR TITLE
gplazma: print selected JWT claims for failed logins

### DIFF
--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
@@ -17,6 +17,7 @@
  */
 package org.dcache.gplazma.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -144,6 +145,17 @@ public class JsonWebToken {
         return Optional.ofNullable(payload.get(key))
               .filter(JsonNode::isTextual)
               .map(JsonNode::textValue);
+    }
+
+    public Optional<String> getPayloadValueAsString(String key) {
+        return Optional.ofNullable(payload.get(key))
+              .map(n -> {
+                    try {
+                        return mapper.writeValueAsString(n);
+                    } catch (JsonProcessingException e) {
+                        return "Bad JSON: " + e;
+                    }
+                  });
     }
 
     public Map<String,JsonNode> getPayloadMap() {


### PR DESCRIPTION
Motivation:

We deliberately do not log bearer tokens.  This follows security best- practice, because log files are not always as protected as they should be (e.g., copy-n-paste into a email or problem report), and this would leak the token.

However, if an OIDC login fails and the bearer token is a JWT then there may be useful information in the JWT's payload that would help diagnose the problem.

Modification:

Update the LoginResultPrinter to identify bearer tokens that are JWT and add support for printing selected claims from the JWT's payload.

Result:

If there is a login failure involving a OIDC JWT then potentially important information is now extracted from the JWT and included in the logged login failure report.

Target: master
Request: 9.0
Request: 8.2
Require-notes: yes
Require-book: no
Patch: https://rb.dcache.org/r/13975/
Acked-by: Tigran Mkrtchyan