### PR TITLE
dcache-bulk:  increase path col to VARCHAR 1024

### DIFF
--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/model/db.changelog-8.0.xml
@@ -392,4 +392,15 @@
             <column name="rid"/>
         </createIndex>
     </changeSet>
+
+    <!-- for 8.2 only, full path will not be necessary in 9+ -->
+    <changeSet author="arossi" id="4.1.8.2" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <columnExists tableName="request_target" columnName="path"/>
+            </and>
+        </preConditions>
+        <modifyDataType tableName="request_target" columnName="path" newDataType="varchar(1024)"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Motivation:

See

https://github.com/dCache/dcache/issues/7104#issuecomment-1490912723 and

https://rt.dcache.org/Ticket/Display.html?id=10463

https://ggus.eu/index.php?mode=ticket_info&ticket_id=161903

Modification:

For 8.2 only, increase this column to 1024 chars.

Result:

ATLAS and others will not experience failures because paths are too long.

Target: 8.2
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/13981/
Closes: #10463
Acked-by:  Tigran