### PR TITLE
dcache-bulk,dcache-frontend: distinguish "Not Found" from "Invalid" r…

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkService.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkService.java
@@ -209,6 +209,10 @@ public final class BulkService implements CellLifeCycleAware, CellMessageReceive
             try {
                 Subject subject = message.getSubject();
                 String uuid = message.getRequestUuid();
+                /*
+                 *  First check to see if the request corresponds to a stored one.
+                 */
+                requestStore.getKey(uuid);
                 checkRestrictions(message.getRestriction(), uuid);
                 matchActivity(message.getActivity(), uuid);
                 BulkRequestInfo status = requestStore.getRequestInfo(subject, uuid,
@@ -236,6 +240,10 @@ public final class BulkService implements CellLifeCycleAware, CellMessageReceive
             try {
                 Subject subject = message.getSubject();
                 String uuid = message.getRequestUuid();
+                /*
+                 *  First check to see if the request corresponds to a stored one.
+                 */
+                requestStore.getKey(uuid);
                 checkRestrictions(message.getRestriction(), uuid);
                 matchActivity(message.getActivity(), uuid);
                 List<String> targetPaths = message.getTargetPaths();
@@ -267,6 +275,10 @@ public final class BulkService implements CellLifeCycleAware, CellMessageReceive
             try {
                 String uuid = message.getRequestUuid();
                 Subject subject = message.getSubject();
+                /*
+                 *  First check to see if the request corresponds to a stored one.
+                 */
+                requestStore.getKey(uuid);
                 checkRestrictions(message.getRestriction(), uuid);
                 matchActivity(message.getActivity(), uuid);
                 submissionHandler.clearRequest(subject, uuid, message.isCancelIfRunning());

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
@@ -816,8 +816,7 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
     private BulkRequest valid(String uid) throws BulkStorageException {
         BulkRequest stored = get(uid);
         if (stored == null) {
-            String error = "request id " + uid + " is no longer valid!";
-            throw new BulkRequestNotFoundException(error);
+            throw new BulkRequestNotFoundException("request " + uid + " not found");
         }
         return stored;
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
@@ -374,6 +374,7 @@ public final class BulkResources {
           @ApiResponse(code = 400, message = "Bad request"),
           @ApiResponse(code = 401, message = "Unauthorized"),
           @ApiResponse(code = 403, message = "Forbidden"),
+          @ApiResponse(code = 404, message = "Not Found"),
           @ApiResponse(code = 500, message = "Internal Server Error")
     })
     @Path("/{id}")

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
@@ -197,6 +197,7 @@ public final class StageResources {
           @ApiResponse(code = 400, message = "Bad request"),
           @ApiResponse(code = 401, message = "Unauthorized"),
           @ApiResponse(code = 403, message = "Forbidden"),
+          @ApiResponse(code = 404, message = "Not Found"),
           @ApiResponse(code = 429, message = "Too many requests"),
           @ApiResponse(code = 500, message = "Internal Server Error")
     })
@@ -322,6 +323,7 @@ public final class StageResources {
           @ApiResponse(code = 400, message = "Bad request"),
           @ApiResponse(code = 401, message = "Unauthorized"),
           @ApiResponse(code = 403, message = "Forbidden"),
+          @ApiResponse(code = 404, message = "Not Found"),
           @ApiResponse(code = 500, message = "Internal Server Error")
     })
     @Path("/{id}")


### PR DESCRIPTION
…equest

Motivation:

See https://github.com/dCache/dcache/issues/7165
REST API (Frontend): non-existent request returns 400 instead of 404

Modification:

Check existence of the request before permissions.

Result:

Correct error code is returned.

Target: master
Request: 9.0
Request: 8.2
Closes: #7165
Patch: https://rb.dcache.org/r/13984/
Requires-notes: yes
Acked-by: Tigran