### PR TITLE
dcache-bulk,dcache-frontend: distinguish "Not Found" from "Invalid" r…

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkService.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkService.java
@@ -81,6 +81,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.security.auth.Subject;
+import javax.ws.rs.HEAD;
 import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.auth.attributes.Restrictions;
@@ -206,6 +207,10 @@ public final class BulkService implements CellLifeCycleAware, CellMessageReceive
             try {
                 Subject subject = message.getSubject();
                 String requestId = message.getRequestId();
+                /*
+                 *  First check to see if the request corresponds to a stored one.
+                 */
+                requestStore.getKey(requestId);
                 checkRestrictions(message.getRestriction(), requestId);
                 matchActivity(message.getActivity(), requestId);
                 BulkRequestInfo status = requestStore.getRequestInfo(subject, requestId,
@@ -233,6 +238,10 @@ public final class BulkService implements CellLifeCycleAware, CellMessageReceive
             try {
                 Subject subject = message.getSubject();
                 String requestId = message.getRequestId();
+                /*
+                 *  First check to see if the request corresponds to a stored one.
+                 */
+                requestStore.getKey(requestId);
                 checkRestrictions(message.getRestriction(), requestId);
                 matchActivity(message.getActivity(), requestId);
                 List<String> targetPaths = message.getTargetPaths();
@@ -264,6 +273,10 @@ public final class BulkService implements CellLifeCycleAware, CellMessageReceive
             try {
                 String requestId = message.getRequestId();
                 Subject subject = message.getSubject();
+                /*
+                 *  First check to see if the request corresponds to a stored one.
+                 */
+                requestStore.getKey(requestId);
                 checkRestrictions(message.getRestriction(), requestId);
                 matchActivity(message.getActivity(), requestId);
                 submissionHandler.clearRequest(subject, requestId, message.isCancelIfRunning());

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkRequestStore.java
@@ -171,6 +171,13 @@ public interface BulkRequestStore {
     ListMultimap<String, String> getActiveRequestsByUser() throws BulkStorageException;
 
     /**
+     * @param uid unique id for request.
+     * @return the key (sequence number) of the request.
+     * @throws BulkStorageException
+     */
+    Long getKey(String uid) throws BulkStorageException;
+
+    /**
      * @param id unique id for request.
      * @return optional of the request.
      */

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
@@ -307,6 +307,11 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
     }
 
     @Override
+    public Long getKey(String uid) throws BulkStorageException {
+        return valid(uid).getSeqNo();
+    }
+
+    @Override
     public Optional<BulkRequest> getRequest(String id) throws BulkStorageException {
         Optional<BulkRequest> stored = Optional.empty();
         try {
@@ -798,8 +803,7 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
     private BulkRequest valid(String id) throws BulkStorageException {
         BulkRequest stored = get(id);
         if (stored == null) {
-            String error = "request id " + id + " is no longer valid!";
-            throw new BulkRequestNotFoundException(error);
+            throw new BulkRequestNotFoundException("request " + id + " not found");
         }
         return stored;
     }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
@@ -359,6 +359,7 @@ public final class BulkResources {
           @ApiResponse(code = 400, message = "Bad request"),
           @ApiResponse(code = 401, message = "Unauthorized"),
           @ApiResponse(code = 403, message = "Forbidden"),
+          @ApiResponse(code = 404, message = "Not Found"),
           @ApiResponse(code = 500, message = "Internal Server Error")
     })
     @Path("/{id}")

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
@@ -188,6 +188,7 @@ public final class StageResources {
           @ApiResponse(code = 400, message = "Bad request"),
           @ApiResponse(code = 401, message = "Unauthorized"),
           @ApiResponse(code = 403, message = "Forbidden"),
+          @ApiResponse(code = 404, message = "Not Found"),
           @ApiResponse(code = 429, message = "Too many requests"),
           @ApiResponse(code = 500, message = "Internal Server Error")
     })
@@ -313,6 +314,7 @@ public final class StageResources {
           @ApiResponse(code = 400, message = "Bad request"),
           @ApiResponse(code = 401, message = "Unauthorized"),
           @ApiResponse(code = 403, message = "Forbidden"),
+          @ApiResponse(code = 404, message = "Not Found"),
           @ApiResponse(code = 500, message = "Internal Server Error")
     })
     @Path("/{id}")


### PR DESCRIPTION
…equest

Motivation:

See https://github.com/dCache/dcache/issues/7165
REST API (Frontend): non-existent request returns 400 instead of 404

Modification:

Check existence of the request before permissions.

Result:

Correct error code is returned.

Target: master
Request: 9.0
Request: 8.2
Closes: #7165
Patch: https://rb.dcache.org/r/13984/
Requires-notes: yes
Acked-by: Tigran