### PR TITLE
dcache-bulk: fix double counting of RUNNING targets

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
@@ -172,7 +172,7 @@ public final class BulkRequestHandler implements BulkSubmissionHandler,
                 });
             }
         } catch (BulkStorageException e) {
-            LOGGER.error("checkTerminated, check for cancel on failure {}: {}.", id,
+            LOGGER.warn("checkTerminated, check for cancel on failure {}: {}.", id,
                   e.toString());
         }
         return terminated;

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetDao.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetDao.java
@@ -85,7 +85,6 @@ import org.dcache.services.bulk.util.BulkRequestTarget;
 import org.dcache.services.bulk.util.BulkRequestTarget.PID;
 import org.dcache.services.bulk.util.BulkRequestTarget.State;
 import org.dcache.services.bulk.util.BulkRequestTargetBuilder;
-import org.dcache.services.bulk.util.BulkServiceStatistics;
 import org.dcache.vehicles.FileAttributes;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.ParameterizedPreparedStatementSetter;
@@ -138,7 +137,6 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
     }
 
     private JdbcBulkDaoUtils utils;
-    private BulkServiceStatistics statistics;
 
     public int count(JdbcRequestTargetCriterion criterion) {
         return utils.count(criterion, tableNameForSelect(criterion), this);
@@ -200,11 +198,6 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
         this.utils = utils;
     }
 
-    @Required
-    public void setStatistics(BulkServiceStatistics statistics) {
-        this.statistics = statistics;
-    }
-
     public BulkRequestTarget toFullRequestTarget(ResultSet rs, int row) throws SQLException {
         BulkRequestTarget target = toRequestTarget(rs, row);
         target.setRuid(rs.getString("ruid"));
@@ -251,13 +244,11 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
     }
 
     public int update(JdbcRequestTargetCriterion criterion, JdbcRequestTargetUpdate update) {
-        int count = 0;
         if (criterion.isJoined()) {
-            count = utils.update(criterion, update, TABLE_NAME, SECONDARY_TABLE_NAME, this);
-        } else
-            count = utils.update(criterion, update, TABLE_NAME, this);
-        statistics.increment(update.getStateName(), count);
-        return count;
+            return utils.update(criterion, update, TABLE_NAME, SECONDARY_TABLE_NAME, this);
+        }
+
+        return utils.update(criterion, update, TABLE_NAME, this);
     }
 
     public JdbcRequestTargetCriterion where() {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkServiceStatistics.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkServiceStatistics.java
@@ -194,14 +194,14 @@ public final class BulkServiceStatistics implements CellInfoProvider {
         }
     }
 
-    public synchronized void decrement(String targetState) {
+    public void decrement(String targetState) {
         AtomicLong counter = counts.get(targetState);
         if (counter != null) {
             counter.decrementAndGet();
         }
     }
 
-    public synchronized void decrement(String targetState, long by) {
+    public void decrement(String targetState, long by) {
         AtomicLong counter = counts.get(targetState);
         if (counter != null) {
             counter.addAndGet(-by);

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -160,7 +160,6 @@
     <description>Bulk request target data access object handler.</description>
     <property name="dataSource" ref="bulk-data-source"/>
     <property name="utils" ref="bulk-jdbc-dao-utils"/>
-    <property name="statistics" ref="statistics"/>
   </bean>
 
   <bean id="request-store" class="org.dcache.services.bulk.store.jdbc.request.JdbcBulkRequestStore"
@@ -180,6 +179,7 @@
   <bean id="target-store" class="org.dcache.services.bulk.store.jdbc.rtarget.JdbcBulkTargetStore">
     <description>RDBMS implementation of target storage interface</description>
     <property name="targetDao" ref="bulk-request-target-dao"/>
+    <property name="statistics" ref="statistics"/>
   </bean>
 
   <bean id="qos-response-receiver" class="org.dcache.services.bulk.activity.plugin.qos.QoSResponseReceiver">


### PR DESCRIPTION
Motivation:

See GH #7164
BULK: in-memory counter is not decrementing when RELEASE activity completes

Modification:

The offending call was in storeOrUpdate. Its call to the underlying update method should not increment for RUNNING.

Removed the incrementing from the dao class and distributed it properly.

Result:

Counts for RUNNING targets are now sane.

Target: master
Request: 9.0
Patch: https://rb.dcache.org/r/13986/
Closes: #7164
Requires-notes: yes
Acked-by: Tigran