### PR TITLE
dcache-bulk: increment/decrement in-memory counts exclusively in the …

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/log/LogTargetActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/log/LogTargetActivity.java
@@ -91,7 +91,7 @@ public final class LogTargetActivity extends BulkActivity<BulkRequestTarget> {
     public ListenableFuture<BulkRequestTarget> perform(String ruid, long tid, FsPath path,
           FileAttributes attributes) {
         long now = System.currentTimeMillis();
-        BulkRequestTarget t = BulkRequestTargetBuilder.builder().activity(this.getName()).id(tid)
+        BulkRequestTarget t = BulkRequestTargetBuilder.builder(null).activity(this.getName()).id(tid)
               .ruid(ruid).state(State.RUNNING).path(path).createdAt(now).attributes(attributes)
               .startedAt(now).lastUpdated(now).build();
 

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/PrestoreRequestContainerJob.java
@@ -213,7 +213,6 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
           throws BulkStorageException {
         BulkRequestTarget completedTarget = result.getTarget();
         completedTarget.resetToReady();
-        statistics.decrement(completedTarget.getState().name());
         try {
             perform(completedTarget);
         } catch (InterruptedException e) {
@@ -237,7 +236,6 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
             LOGGER.error("addInfo {}, path {}, error {}.", ruid, target.getPath(), e.getMessage());
             target.setState(FAILED);
             target.setErrorObject(e);
-            statistics.increment(FAILED.name());
             try {
                 targetStore.storeOrUpdate(target);
             } catch (BulkStorageException ex) {
@@ -254,7 +252,6 @@ public final class PrestoreRequestContainerJob extends AbstractRequestContainerJ
 
         BulkRequestTarget completedTarget = result.getTarget();
         State state = completedTarget.getState();
-        statistics.decrement(RUNNING.name());
 
         try {
             if (state == FAILED && activity.getRetryPolicy().shouldRetry(completedTarget)) {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJob.java
@@ -146,7 +146,6 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
                 LOGGER.error("problem handling target {}: {}.", tgt, e.toString());
                 tgt.setState(FAILED);
                 tgt.setErrorObject(e);
-                statistics.increment(FAILED.name());
                 try {
                     targetStore.storeOrUpdate(tgt);
                 } catch (BulkStorageException ex) {
@@ -185,7 +184,6 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
         FsPath path = completedTarget.getPath();
         PID pid = completedTarget.getPid();
         completedTarget.resetToReady();
-        statistics.decrement(completedTarget.getState().name());
         try {
             perform(id, pid, path, attributes);
         } catch (InterruptedException e) {
@@ -201,7 +199,6 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
 
         BulkRequestTarget completedTarget = result.getTarget();
         State state = completedTarget.getState();
-        statistics.decrement(RUNNING.name());
 
         try {
             if (state == FAILED && activity.getRetryPolicy().shouldRetry(completedTarget)) {
@@ -285,7 +282,6 @@ public final class RequestContainerJob extends AbstractRequestContainerJob {
                  *  returned from the database.
                  */
                 targetStore.storeOrUpdate(target);
-                statistics.increment(RUNNING.name());
             } catch (BulkStorageException e) {
                 LOGGER.error("{}, could not store target from result {}, {}, {}: {}.", ruid, result,
                       attributes, e.toString());

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJobFactory.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJobFactory.java
@@ -112,7 +112,7 @@ public final class RequestContainerJobFactory {
         FileAttributes attributes = new FileAttributes();
         attributes.setFileType(FileType.SPECIAL);
         attributes.setPnfsId(PLACEHOLDER_PNFSID);
-        BulkRequestTarget target = BulkRequestTargetBuilder.builder()
+        BulkRequestTarget target = BulkRequestTargetBuilder.builder(statistics)
               .activity(activity.getName())
               .rid(request.getId()).ruid(request.getUid()).pid(PID.ROOT).attributes(attributes)
               .path(ROOT_REQUEST_PATH).build();

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
@@ -189,7 +189,7 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
 
         Throwable root = Throwables.getRootCause(exception);
 
-        BulkRequestTarget target = BulkRequestTargetBuilder.builder().rid(request.getId())
+        BulkRequestTarget target = BulkRequestTargetBuilder.builder(statistics).rid(request.getId())
               .pid(PID.ROOT).activity(request.getActivity())
               .path(ROOT_REQUEST_PATH).attributes(attributes)
               .errorType(root.getClass().getCanonicalName())

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetDao.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcRequestTargetDao.java
@@ -85,6 +85,7 @@ import org.dcache.services.bulk.util.BulkRequestTarget;
 import org.dcache.services.bulk.util.BulkRequestTarget.PID;
 import org.dcache.services.bulk.util.BulkRequestTarget.State;
 import org.dcache.services.bulk.util.BulkRequestTargetBuilder;
+import org.dcache.services.bulk.util.BulkServiceStatistics;
 import org.dcache.vehicles.FileAttributes;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.jdbc.core.ParameterizedPreparedStatementSetter;
@@ -136,6 +137,7 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
         return criterion.isJoined() ? JOINED_SELECT : SELECT;
     }
 
+    private BulkServiceStatistics statistics;
     private JdbcBulkDaoUtils utils;
 
     public int count(JdbcRequestTargetCriterion criterion) {
@@ -194,6 +196,11 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
     }
 
     @Required
+    public void setStatistics(BulkServiceStatistics statistics) {
+        this.statistics = statistics;
+    }
+
+    @Required
     public void setUtils(JdbcBulkDaoUtils utils) {
         this.utils = utils;
     }
@@ -230,7 +237,7 @@ public final class JdbcRequestTargetDao extends JdbcDaoSupport {
 
         String errorType = rs.getString("error_type");
         String errorMessage = rs.getString("error_message");
-        return BulkRequestTargetBuilder.builder()
+        return BulkRequestTargetBuilder.builder(statistics)
               .id(rs.getLong("id"))
               .pid(PID.values()[rs.getInt("pid")])
               .rid(rs.getLong("rid"))

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTargetBuilder.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTargetBuilder.java
@@ -71,8 +71,8 @@ public final class BulkRequestTargetBuilder {
 
     private final BulkRequestTarget target;
 
-    public static BulkRequestTargetBuilder builder() {
-        return new BulkRequestTargetBuilder();
+    public static BulkRequestTargetBuilder builder(BulkServiceStatistics statistics) {
+        return new BulkRequestTargetBuilder(statistics);
     }
 
     public BulkRequestTargetBuilder id(Long id) {
@@ -149,7 +149,7 @@ public final class BulkRequestTargetBuilder {
         return target;
     }
 
-    private BulkRequestTargetBuilder() {
-        target = new BulkRequestTarget();
+    private BulkRequestTargetBuilder(BulkServiceStatistics statistics) {
+        target = new BulkRequestTarget(statistics);
     }
 }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkServiceStatistics.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkServiceStatistics.java
@@ -187,24 +187,10 @@ public final class BulkServiceStatistics implements CellInfoProvider {
         }
     }
 
-    public void increment(String targetState, long by) {
-        AtomicLong counter = counts.get(targetState);
-        if (counter != null) {
-            counter.addAndGet(by);
-        }
-    }
-
     public void decrement(String targetState) {
         AtomicLong counter = counts.get(targetState);
         if (counter != null) {
             counter.decrementAndGet();
-        }
-    }
-
-    public void decrement(String targetState, long by) {
-        AtomicLong counter = counts.get(targetState);
-        if (counter != null) {
-            counter.addAndGet(-by);
         }
     }
 

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -160,6 +160,7 @@
     <description>Bulk request target data access object handler.</description>
     <property name="dataSource" ref="bulk-data-source"/>
     <property name="utils" ref="bulk-jdbc-dao-utils"/>
+    <property name="statistics" ref="statistics"/>
   </bean>
 
   <bean id="request-store" class="org.dcache.services.bulk.store.jdbc.request.JdbcBulkRequestStore"
@@ -179,7 +180,6 @@
   <bean id="target-store" class="org.dcache.services.bulk.store.jdbc.rtarget.JdbcBulkTargetStore">
     <description>RDBMS implementation of target storage interface</description>
     <property name="targetDao" ref="bulk-request-target-dao"/>
-    <property name="statistics" ref="statistics"/>
   </bean>
 
   <bean id="qos-response-receiver" class="org.dcache.services.bulk.activity.plugin.qos.QoSResponseReceiver">


### PR DESCRIPTION
…target object

Motivation:

See again https://github.com/dCache/dcache/issues/7164 BULK: in-memory counter is not decrementing when RELEASE activity completes

The current approach to keeping in-memory counts is flawed by the fact that there is no single point at which the increment/decrement takes place, leading to inconsistencies.

Modifications:

Inject the statistics class into the in-memory BulkRequestTarget object, and do all incrementing and decrementing there. Remove all calls to the statistics class from all other classes.

Result:

It looks like the counts are finally consistent.

Target: master
Request: 9.0
Patch: https://rb.dcache.org/r/13994/
Closes: #13994
Requires-notes: yes
Acked-by: Lea