### PR TITLE
metadata: add (some) ORCIDs to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,6 +6,7 @@ authors:
     affiliation: "Deutsches Elektronen-Synchrotron DESY"
     city: "Hamburg"
     country: "Germany"
+    orcid: https://orcid.org/0000-0002-6217-8539
   - family-names: "Chitrapu"
     given-names: "Krishnaveni"
     affiliation: "National Supercomputer Center"
@@ -21,6 +22,7 @@ authors:
     affiliation: "Fermi National Accelerator Laboratory (FNAL)"
     city: "Batavia"
     country: "USA"
+    orcid: https://orcid.org/0000-0001-6733-2905
   - family-names: "Meyer"
     given-names: "Svenja"
     affiliation: "Deutsches Elektronen-Synchrotron DESY"
@@ -31,11 +33,13 @@ authors:
     affiliation: "Deutsches Elektronen-Synchrotron DESY"
     city: "Hamburg"
     country: "Germany"
+    orcid: https://orcid.org/0000-0002-3957-1279
   - family-names: "Morschel"
     given-names: "Lea"
     affiliation: "Deutsches Elektronen-Synchrotron DESY"
     city: "Hamburg"
     country: "Germany"
+    orcid: https://orcid.org/0000-0003-2825-0469
   - family-names: "Rossi"
     given-names: "Albert"
     affiliation: "Fermi National Accelerator Laboratory (FNAL)"


### PR DESCRIPTION
Motivation:

CITATION.cff provides metadata about the dCache code, including identifying the people who have contributed.  This file format supports identifying people by ORCID, although this feature is not used. Including people by a persistent identifier (such as ORCID) helps make the identification stronger and more robust.

Modification:

Add those ORCIDs that could be easily found: Tigran, Dmitry, Lea and myself.

Result:

No user- or admin observable changes.  dCache's contribution metadata is now more robust at identifying the people involved.

Target: master
Request: 9.0
Request: 8.2
Request: 8.1
Request: 8.0
Request: 7.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/13995/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel