### PR TITLE
dcache-bulk:  catch Exception from getSubject()

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -266,9 +266,17 @@ public final class BulkServiceCommands implements CellCommandListener {
         Optional<Subject> subject;
 
         String statusName = null;
+        /*
+         *  If there is an exception, log to pinboard (INFO) and allow the request to be
+         *  processed without subject.
+         */
         try {
             subject = store.getSubject(requestId);
-        } catch (BulkStorageException e) {
+        } catch (RuntimeException e) {
+            LOGGER.info("could not fetch Subject for {}", requestId, e);
+            subject = Optional.empty();
+        } catch (Exception e) {
+            LOGGER.info("could not fetch Subject for {}: {}.", requestId, e.toString());
             subject = Optional.empty();
         }
 


### PR DESCRIPTION
Motivation:

see GitHub #7189 https://github.com/dCache/dcache/issues/7189 `dCache 8.2.23: exception when running request ls in bulk admin`

We don't wish to stop the listing of other requests because of some unexpected exception on one of them.  In this case, it was the deserialization attendant to the fetch of the permissions.

Modification:

Catch all exceptions, not just Bulk exceptions, when asking for the subject.

Result:

RuntimeExceptions should not cause the `request ls` to fail globally.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14005
Closes: #7189
Bug: #7189
Requires-notes: yes
Acked-by: Lea