### PR TITLE
dcache-qos:  repair faulty queue refresh algorithm in verifier

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/VerifyOperationDelegate.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/VerifyOperationDelegate.java
@@ -108,7 +108,12 @@ public interface VerifyOperationDelegate extends VerifyOperationMap {
     void reload();
 
     /**
-     * Remove the operation from any in memory caches and from including any backing persistence.
+     * Repopulate memory caches, if applicable.
+     */
+    void refresh();
+
+    /**
+     * Remove the operation from any in memory caches and from any backing persistence.
      *
      * @param pnfsId of the operation.
      */

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/VerifyOperationDelegatingMap.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/VerifyOperationDelegatingMap.java
@@ -357,6 +357,8 @@ public class VerifyOperationDelegatingMap extends RunnableModule
                 submit(operation);
                 --available;
             }
+
+            delegate.refresh();
         }
     }
 
@@ -583,12 +585,8 @@ public class VerifyOperationDelegatingMap extends RunnableModule
      */
     @VisibleForTesting
     public void scan() {
-        try {
-            terminalProcessor.processTerminated();
-            readyProcessor.processReady();
-        } catch (Throwable t) {
-            t.printStackTrace();
-        }
+        terminalProcessor.processTerminated();
+        readyProcessor.processReady();
     }
 
     public void setCounters(QoSVerifierCounters counters) {


### PR DESCRIPTION
Motivation:

Discovered while investigating
RT 10479 Time-outs using QoS in dCache 8.2.23 when doing a QoS transition through namespace and bulk https://rt.dcache.org/Ticket/Display.html?id=10479

The current algorithm for refreshing the queues from the `qos_operation` table uses the total size of the in-memory queues to trigger the query. This is flawed and is susceptible to starving one or more of the queues.

Modfication:

Two changes have been made:

- the existence of any empty queue now triggers the refresh
- the refresh is run after available running slots have been filled

The second change is for efficiency.

The `delegate` API (internal) has been extended with a `refresh()` method.

Result:

Queue starvation should be avoided and operations of all message types should continue to be processed.

Target:  master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14004/
Requires-book: no
Requires-notes: yes
Acked-by: Dmitry