### PR TITLE
pom.xml: bump xrootd4j to next version (4.5.7, 4.4.8, 4.3.9, 4.2.13)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.44.v20210927</version.jetty>
-        <version.xrootd4j>4.5.6</version.xrootd4j>
+        <version.xrootd4j>4.5.7</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.2</version.dcache-view>
         <version.netty>4.1.92.Final</version.netty>


### PR DESCRIPTION
See:

https://rb.dcache.org/r/14010/
xrootd4j master@555a7500ccb42f6ea0a21dfe9716af6d61f36413

Fixes byte buffer leak in ZTNCredentialUtils.

Target: master (v4.5.7)
Request: 9.1   (v4.5.7)
Request: 9.0   (v4.5.7)
Request: 8.2   (v4.5.7)
Request: 8.1   (v4.3.9)
Request: 8.0   (v4.2.13)
Request: 7.2   (v4.2.13)
Patch: https://rb.dcache.org/r/14012/
Requires-notes: yes
Acked-by: Tigran