### PR TITLE
dcache-frontend:  remove authz checks in Quota GET methods

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/quota/QuotaResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/quota/QuotaResources.java
@@ -62,7 +62,6 @@ package org.dcache.restful.resources.quota;
 import static diskCacheV111.util.CacheException.ATTRIBUTE_EXISTS;
 import static diskCacheV111.util.CacheException.NO_ATTRIBUTE;
 import static diskCacheV111.util.CacheException.SERVICE_UNAVAILABLE;
-import static org.dcache.restful.util.RequestUser.checkAuthenticated;
 
 import com.google.common.base.Strings;
 import diskCacheV111.util.CacheException;
@@ -140,8 +139,6 @@ public final class QuotaResources {
           + "calling user only.")
     @DefaultValue("false")
     @QueryParam("user") boolean user) {
-        checkAuthenticated();
-
         PnfsManagerGetQuotaMessage message;
 
         if (user) {
@@ -169,8 +166,6 @@ public final class QuotaResources {
           + "calling user only.")
     @DefaultValue("false")
     @QueryParam("user") boolean user) {
-        checkAuthenticated();
-
         PnfsManagerGetQuotaMessage message;
 
         /*
@@ -200,8 +195,6 @@ public final class QuotaResources {
           @ApiParam(value = "The user id to which the quota corresponds.",
                 required = true)
           @PathParam("id") int id) {
-        checkAuthenticated();
-
         return getQuotas(new PnfsManagerGetQuotaMessage(id, QuotaType.USER));
     }
 
@@ -218,8 +211,6 @@ public final class QuotaResources {
           @ApiParam(value = "The group id to which the quota corresponds.",
                 required = true)
           @PathParam("id") int id) {
-        checkAuthenticated();
-
         return getQuotas(new PnfsManagerGetQuotaMessage(id, QuotaType.GROUP));
     }
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/RequestUser.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/RequestUser.java
@@ -18,7 +18,6 @@
 package org.dcache.restful.util;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.dcache.util.Exceptions.genericCheck;
 
 import java.io.IOException;
 import java.security.AccessController;
@@ -85,11 +84,6 @@ public class RequestUser implements ContainerRequestFilter, ContainerResponseFil
         }
 
         return Subjects.getUid(user);
-    }
-
-    public static void checkAuthenticated() throws NotAuthorizedException {
-        genericCheck(!isAnonymous(), NotAuthorizedException::new,
-              "anonymous access not allowed");
     }
 
     @Override


### PR DESCRIPTION
Motivation:

All of the Frontend REST GET methods allow
anonymous read (if the global property so
allows it), except for `quota` (but see below).

The extra check is actually not necessary,
as authenticated users can see all quotas
if `frontend.authz.anonymous-operations` is
not `NONE`.

Modification:

Remove the authorization check on the `quota`
GET methods.

The `event` resources seem to constitute a
special case, so we have not altered them;
however, the method which enforces authenticated
user has been moved to that class and out of
`RequestUser`.

Result:

All of the REST GET methods now allow anonymous
users to get the data if the global property
allows (in the case of `NONE`, 401 not authorized
is returned at login).

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14014
Requires-notes: yes
Acked-by: Tigran
Acked-by: Dmitry