### PR TITLE
dcache-frontend: add symlink resolution to /api/v1/id GET and /api/v1…

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -67,7 +67,6 @@ import org.dcache.namespace.FileType;
 import org.dcache.pinmanager.PinManagerPinMessage;
 import org.dcache.pinmanager.PinManagerUnpinMessage;
 import org.dcache.poolmanager.PoolMonitor;
-import org.dcache.qos.QoSException;
 import org.dcache.qos.QoSTransitionEngine;
 import org.dcache.qos.data.FileQoSRequirements;
 import org.dcache.qos.remote.clients.RemoteQoSRequirementsClient;
@@ -180,7 +179,7 @@ public class FileResources {
                     isChecksum,
                     isOptional);
         PnfsHandler handler = HandlerBuilders.roleAwarePnfsHandler(pnfsmanager);
-        FsPath path = pathMapper.asDcachePath(request, requestPath, ForbiddenException::new);
+        FsPath path = pathMapper.asDcachePath(request, requestPath, ForbiddenException::new, handler);
         try {
 
             FileAttributes namespaceAttributes = handler.getFileAttributes(path, attributes);
@@ -428,9 +427,8 @@ public class FileResources {
             JSONObject reqPayload = new JSONObject(requestPayload);
             String action = (String) reqPayload.get("action");
             PnfsHandler pnfsHandler = HandlerBuilders.roleAwarePnfsHandler(pnfsmanager);
-            FsPath path = pathMapper.asDcachePath(request, requestPath, ForbiddenException::new);
+            FsPath path = pathMapper.asDcachePath(request, requestPath, ForbiddenException::new, pnfsHandler);
             PnfsId pnfsId;
-            Long uid;
             switch (action) {
                 case "mkdir":
                     String name = (String) reqPayload.get("name");
@@ -601,7 +599,7 @@ public class FileResources {
     public Response deleteFileEntry(@ApiParam(value = "Path of file or directory.", required = true)
     @PathParam("path") String requestPath) throws CacheException {
         PnfsHandler handler = HandlerBuilders.roleAwarePnfsHandler(pnfsmanager);
-        FsPath path = pathMapper.asDcachePath(request, requestPath, ForbiddenException::new);
+        FsPath path = pathMapper.asDcachePath(request, requestPath, ForbiddenException::new, handler);
 
         try {
             handler.deletePnfsEntry(path.toString());

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/IdResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/IdResources.java
@@ -172,7 +172,7 @@ public class IdResources {
              * Since FileResources maps according to the effective root,
              * we should return the path in the same form here.
              */
-            result.setPath(pathMapper.asRequestPath(request, path));
+            result.setPath(pathMapper.asRequestPath(request, path, handler));
 
             String name = path.name();
             result.setFileName(name);


### PR DESCRIPTION
…/namespace

Motivation:

If the user root contains a symlink, or
the target path contains a symlink pertaining
to the user root, the following currently
fail:

`GET, POST or DELETE /api/v1/namespace`
`GET /api/v1/id`

In the former case, we see:

```
{
  "detail": No such file or directory /pnfs/fnal.gov/usr/pnfs/fs/usr/fermilab/users/arossi/volatile/data_1b",
  "title":"Not Found",
  "status":"404"
}

```
in the latter,

```
{
  "detail": "/pnfs/fnal.gov/usr is not a prefix of /pnfs/fs/usr",
  "title": "Bad Request",
  "status": "400"
}
```

This stems from the need for a special call to
the pnfs handler to resolve symlinks on path and root, as we do, for instance, in the `xroot` door.

Modification:

So as not to affect code in other areas which seems to be working, we add two methods to `pathMapper`
which have an extra parameter for passing in
a configured `PnfsHandler`.   We use the
same message as the `xroot` door does to
retrieve resolved root and path.

Result:

The above REST calls no longer fail.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14013/
Requires-notes: yes
Acked-by: Tigran
Acked-by: Dmitry