### PR TITLE
dcache-http: add http request header for role assertion

### DIFF
--- a/docs/UserGuide/src/main/markdown/frontend.md
+++ b/docs/UserGuide/src/main/markdown/frontend.md
@@ -2702,3 +2702,24 @@ dcache.wellknown!security-txt.uri=${dcache.paths.httpd}/security.txt
 should be configured to point to either a URL with host and port that provides
 this information, or a local path with the appropriate `security.txt` file.
 See https://securitytxt.org/ for further information.
+
+## Asserting a desired role using an http header
+
+It is now possible to assert roles without recourse to the password
+authentication plugin.
+
+For instance, with `curl`, instead of `-u user#role`, you can do the following:
+
+```
+curl  -k -L -H "Roles: admin"  --capath /etc/grid-security/certificates --cert /tmp/x509up_u`uid` --cacert /tmp/x509up_u`uid` --key /tmp/x509up_u`uid` -X  POST "https://fndcatemp2.fnal.gov:3880/api/v1/quota/user/8888" -H "accept: application/json" -H "content-type: application/json"
+```
+
+or
+
+```
+curl  -k -L -H "Roles: admin" -H "Authorization: Bearer ${TOKEN}" -X  POST "https://fndcatemp2.fnal.gov:3880/api/v1/quota/user/8888" -H "accept: application/json" -H "content-type: application/json"
+```
+
+The `Roles` header takes a comma-delimited list of available roles the user wishes to assert.
+Whether those roles are assigned, of course, depends upon whether the user has actually
+been authorized to have them.


### PR DESCRIPTION
Motivation:

In order to assert a role, one must currently
use the password login authentication scheme.
This is unacceptable not only in non-interactive
environments, but also requires a user mapping
which overrides or bypasses others that are
accessed by x509 or token authentication.

Modification:

Add a new header, `Roles`, which takes as
data a comma-delimited list of roles
the user wishes to assert for this
connection.

For the sake of backward compatibility, we
leave in place the separate extraction
of desired roles based on the `user#roles`
login (with password).

Result:

It is now possible to assert roles using
an x509 proxy or a bearer token without
recourse to a `login` stanza and password
in a config file.

I am asking for a backport in order to
(eventually) enable authorization of
QoS modifications based on a specific
`qos` role (which will need to be
there in 8.2).

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14016/
Requires-notes: yes
Requires-book: yes (included)
Acked-by: Tigran