### PR TITLE
gplazma-roles:  add QoS role support

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/attributes/LoginAttributes.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/LoginAttributes.java
@@ -29,8 +29,10 @@ public class LoginAttributes {
 
     public static final String ADMIN_ROLE_NAME = "admin";
     public static final String OBSERVER_ROLE_NAME = "observer";
+    public static final String QOS_ROLE_NAME = "qos";
     private static final Role ADMIN_ROLE = new Role(ADMIN_ROLE_NAME);
     private static final Role OBSERVER_ROLE = new Role(OBSERVER_ROLE_NAME);
+    private static final Role QOS_ROLE = new Role(QOS_ROLE_NAME);
 
     private LoginAttributes() {
         // prevent instantiation
@@ -61,12 +63,20 @@ public class LoginAttributes {
         return OBSERVER_ROLE;
     }
 
+    public static Role qosRole() {
+        return QOS_ROLE;
+    }
+
     public static boolean hasAdminRole(Collection<LoginAttribute> attributes) {
         return attributes.stream().anyMatch(ADMIN_ROLE::equals);
     }
 
     public static boolean hasObserverRole(Collection<LoginAttribute> attributes) {
         return attributes.stream().anyMatch(OBSERVER_ROLE::equals);
+    }
+
+    public static boolean hasQoSRole(Collection<LoginAttribute> attributes) {
+        return attributes.stream().anyMatch(QOS_ROLE::equals);
     }
 
     public static Stream<String> assertedRoles(Collection<LoginAttribute> attributes) {

--- a/modules/gplazma2-roles/src/main/java/org/dcache/gplazma/roles/RolesPlugin.java
+++ b/modules/gplazma2-roles/src/main/java/org/dcache/gplazma/roles/RolesPlugin.java
@@ -47,12 +47,17 @@ public class RolesPlugin implements GPlazmaSessionPlugin {
     @VisibleForTesting
     static final String OBSERVER_GID_PROPERTY_NAME = "gplazma.roles.observer-gid";
 
+    @VisibleForTesting
+    static final String QOS_GID_PROPERTY_NAME = "gplazma.roles.qos-gid";
+
     private final Long adminGid;
     private final Long observerGid;
+    private final Long qosGid;
 
     public RolesPlugin(Properties properties) {
         this.adminGid = getGidForRole(properties, ADMIN_GID_PROPERTY_NAME);
         this.observerGid = getGidForRole(properties, OBSERVER_GID_PROPERTY_NAME);
+        this.qosGid = getGidForRole(properties, QOS_GID_PROPERTY_NAME);
     }
 
     @Override
@@ -102,6 +107,10 @@ public class RolesPlugin implements GPlazmaSessionPlugin {
 
                   if (observerGid != null && gid == observerGid.longValue()) {
                       roles.add(LoginAttributes.observerRole());
+                  }
+
+                  if (qosGid != null && gid == qosGid.longValue()) {
+                      roles.add(LoginAttributes.qosRole());
                   }
               });
 

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -638,6 +638,12 @@ gplazma.scitoken.audience-targets =
 gplazma.roles.admin-gid= 0
 gplazma.roles.observer-gid =
 
+# ---- Users with this role are authorized to issue QOS_MODIFY requests to the qos engine.
+#      Note that any such user has these privileges but only on the tree defined by
+#      the user root.
+#
+gplazma.roles.qos-gid=
+
 #
 #
 #  -----------------------------------------------------------------------


### PR DESCRIPTION
Motivation:

We would like a way to allow non-admin users
to be authorized to request QOS_MODIFIED for
a file or set of files.

The most convenient way to do this is to
add a new role, `qos`, which does not alter
whatever user ROOT the user has from the
user's login, but which is visible to
the QoS engine and which can be checked
there.

Modfication:

Create the new role.

Result:

Necessary step to authorization of qos
modifications.

This is a new feature but needs to be
in 8.2 so we do not oblige users to
upgrade (yet) to the 9-series.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14017/
Requires-notes: yes
Acked-by: Tigran