### PR TITLE
dcache-qos:  improve exception reported on aborted verification

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/qos/util/CacheExceptionUtils.java
+++ b/modules/dcache/src/main/java/org/dcache/qos/util/CacheExceptionUtils.java
@@ -64,6 +64,7 @@ import static org.dcache.qos.util.CacheExceptionUtils.FailureType.NEWSOURCE;
 import static org.dcache.qos.util.CacheExceptionUtils.FailureType.NEWTARGET;
 import static org.dcache.qos.util.CacheExceptionUtils.FailureType.RETRIABLE;
 
+import com.google.common.base.Throwables;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.PnfsId;
 import java.io.Serializable;
@@ -108,7 +109,7 @@ public final class CacheExceptionUtils {
 
         if (errorObject instanceof Throwable) {
             Throwable t = (Throwable) errorObject;
-            return new CacheException(t.getMessage(), t.getCause());
+            return new CacheException(t.getMessage(), Throwables.getRootCause(t));
         }
 
         return new CacheException(String.valueOf(errorObject));


### PR DESCRIPTION
Motivation:

When the verifier aborts an operation, the
error code is always the same (10011, unexpected
system error), and the cause may not reflect
the root cause.

Modification:

Fix this so that more specific error info
is registered.

Result:

Better understanding of what went wrong.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14020/
Requires-notes: yes
Acked-by: Lea