### PR TITLE
dcache-qos: fix adjuster task cloning to reset state

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/handlers/QoSAdjusterTaskHandler.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/handlers/QoSAdjusterTaskHandler.java
@@ -106,10 +106,11 @@ public final class QoSAdjusterTaskHandler implements CellMessageReceiver {
 
     public void notifyAdjustmentCompleted(QoSAdjusterTask task) {
         QoSAdjustmentStatus status;
+        Throwable error = task.getException();
 
         if (task.isCancelled()) {
             status = QoSAdjustmentStatus.CANCELLED;
-        } else if (task.getException() != null) {
+        } else if (error != null) {
             status = QoSAdjustmentStatus.FAILED;
         } else {
             status = QoSAdjustmentStatus.COMPLETED;
@@ -117,8 +118,6 @@ public final class QoSAdjusterTaskHandler implements CellMessageReceiver {
 
         PnfsId pnfsId = task.getPnfsId();
         QoSAction action = task.getAction();
-        Throwable error = task.getException();
-
         QoSAdjustmentResponse response = new QoSAdjustmentResponse();
         response.setAction(action);
         response.setPnfsId(pnfsId);

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/util/QoSAdjusterTask.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/adjuster/util/QoSAdjusterTask.java
@@ -136,8 +136,8 @@ public final class QoSAdjusterTask extends ErrorAwareTask implements Cancellable
         this.source = task.source;
         this.target = task.target;
         this.poolGroup = task.poolGroup;
-        this.status = task.status;
         this.subject = task.subject;
+        this.status = Status.INITIALIZED;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

See principally GH Issue #7190 `bulk recursive QoS change`.

The final problem solved there was the non-completion of bulk requests because the QoS Verifier would go into an infinite loop of retrying the FLUSH, since it did not see the `p2p` as failed and simply moved on to recheck the status of the file, finding no precious replica or tape location.

Modification:

The retry with a cloned object needs to reset the
state of the task to INITIALIZED.  Otherwise,
the map will see it as "DONE" (even on the
READY queue) and report it as such.  Since
the exception is not carried over on the clone,
it reports it erroneously as successful.

Result:

The adjuster no longer swallows Migration task
exceptions and the verifier will abort the
operation as it should, allowing the bulk
request to complete.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Closes: #7190
Bug: #7190
Requires-notes: yes
Acked-by: Tigran