### PR TITLE
xrootd: throw FileNotFoundException if vomsdir doesn't exist

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/security/ProxyDelegationStore.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/security/ProxyDelegationStore.java
@@ -20,6 +20,9 @@ package org.dcache.xrootd.security;
 import static java.util.Arrays.asList;
 
 import eu.emi.security.authn.x509.X509CertChainValidatorExt;
+
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -61,7 +64,10 @@ public class ProxyDelegationStore {
               certChainValidator);
     }
 
-    public void setVomsDir(String vomsDir) {
+    public void setVomsDir(String vomsDir) throws FileNotFoundException {
+        if (!new File(vomsDir).isDirectory()) {
+            throw new FileNotFoundException("Local trust directory does not exist: " + vomsDir);
+        }
         this.vomsDir = vomsDir;
     }
 

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/spring/GplazmaAwareChannelHandlerFactoryFactoryBean.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/spring/GplazmaAwareChannelHandlerFactoryFactoryBean.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Predicates.containsPattern;
 import static com.google.common.collect.Iterables.any;
 
 import com.google.common.collect.Lists;
+
+import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.TimeUnit;
@@ -149,7 +151,7 @@ public class GplazmaAwareChannelHandlerFactoryFactoryBean
         throw new IllegalArgumentException("Authorization plugin not found: " + name);
     }
 
-    private ProxyDelegationClientFactory createProxyDelegationClientFactory(String name) {
+    private ProxyDelegationClientFactory createProxyDelegationClientFactory(String name) throws FileNotFoundException {
         for (ProxyDelegationClientFactory factory : _clientFactories) {
             if (factory instanceof GSIProxyDelegationClientFactory) {
                 ((GSIProxyDelegationClientFactory) factory)
@@ -165,7 +167,7 @@ public class GplazmaAwareChannelHandlerFactoryFactoryBean
         return null;
     }
 
-    private ProxyDelegationStore getGsiProxyDelegationProvider() {
+    private ProxyDelegationStore getGsiProxyDelegationProvider() throws FileNotFoundException {
         LOGGER.debug("get ProxyDelegationProvider called");
 
         /*


### PR DESCRIPTION
Motivation:

If /etc/grid-security/vomsdir doesn't exist, dCache throws a stacktrace when xrootd is starting.

Modification:

Check, if vomsdir is an existing directory before setting the variable and throw a FileNotFoundException if it doesn't exist.

Result:

Error logging without a stacktrace if the directory doesn't exist.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Require-notes: yes
Require-book: no
Acked-by: Al