### PR TITLE
dcache-vehicles:  fix NPE in resolve symlink message

### DIFF
--- a/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/PnfsResolveSymlinksMessage.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/PnfsResolveSymlinksMessage.java
@@ -4,6 +4,7 @@
 
 package org.dcache.vehicles;
 
+import com.google.common.base.Strings;
 import diskCacheV111.vehicles.PnfsMessage;
 
 public class PnfsResolveSymlinksMessage extends PnfsMessage {
@@ -21,6 +22,11 @@ public class PnfsResolveSymlinksMessage extends PnfsMessage {
     }
 
     public PnfsResolveSymlinksMessage(String path, String prefix) {
+        if (Strings.emptyToNull(path) == null) {
+            path = "/";
+        } else if (path.charAt(0) != '/') {
+            path = "/" + path;
+        }
         setPnfsPath(path);
         this.prefix = prefix;
         setReplyRequired(true);


### PR DESCRIPTION
Motivation:

see GH ` looking at Open Issue access the dCache namespace via Frontend in 9.1.1` #7250

See also https://rb.dcache.org/r/14013/

Not handling paths that don't begin with slash.

Modification:

Treat `null` as `/` and prepend '/' to relative paths.

Result:

Correct behavior without NPE or index out of bounds errors.

Target: master
Request: 9.1
Request: 9.0
(not backported to 8.2)
Bug: #7250
Closes: #7250
Requires-notes: yes
Acked-by: Dmitry