### PR TITLE
rpm: depend on java-11-headless

### DIFF
--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -11,7 +11,7 @@ AutoReqProv: no
 
 Requires(pre): shadow-utils
 Requires: which
-Requires: java-11
+Requires: java-11-headless
 
 %{?systemd_requires}
 BuildRequires: systemd


### PR DESCRIPTION
Motivation:
As dCache is not a desktop application java-11-headless is sufficient.

Result:
less GUI related dependencies installed as transient dependency with dCache package.

Fixes: #7249
Acked-by: Lea Morschel
Target: master, 9.1
Require-book: no
Require-notes: yes
(cherry picked from commit 0edcfb12d0da74c9871281b7a823266fd359c613)