### PR TITLE
dcache-xroot:  modify mkdir to ignore dir exists on make parent option

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -768,7 +768,14 @@ public class XrootdDoor
         }
 
         if (createParents) {
-            pnfsHandler.createDirectories(path);
+            try {
+                pnfsHandler.createDirectories(path);
+            } catch (FileExistsCacheException e) {
+                /*
+                 *  The behavior of the xroot vanilla server is to ignore this error
+                 *  for createParents.
+                 */
+            }
         } else {
             pnfsHandler.createPnfsDirectory(path.toString());
         }


### PR DESCRIPTION
Motivation:

See https://github.com/dCache/dcache/issues/7256

`Possible extension for xrootd`

Modification:

Catch the file exists exception and ignore it
when the `createParents` option is true.

Result:

Result conforms to vanilla xroot server.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14031/
Closes: #7256
Requires-notes: yes
Acked-by: Dmitry
Acked-by: Tigran