### PR TITLE
pool: handle double remove of IdleStateHandler

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
@@ -798,7 +798,10 @@ public class HttpPoolRequestHandler extends HttpRequestHandler {
 
         if (_useZeroCopy) {
             // disable timeout manager as zero-copy can't keep idle counters in sync
-            context.channel().pipeline().remove(IdleStateHandler.class);
+            var hasIdleStateHandler = context.channel().pipeline().get(IdleStateHandler.class) != null;
+            if (hasIdleStateHandler) {
+                context.channel().pipeline().remove(IdleStateHandler.class);
+            }
             return asFileRegion(file, lowerRange, length);
         }
         return new ReusableChunkedNioFile(file, lowerRange, length, _chunkSize);


### PR DESCRIPTION
Motivation:
If http client issues two GET requests then zero-copy enabled http mover will try to remove the IdleStateHandler twice and fail  with NoSuchElementException.

Modification:
Check the presence of IdleStateHandler before removal.

Result:
No failed transfers on GET+GET

Acked-by:
Target: master, 9.1, 9.0, 8.2
Require-book: no
Require-notes: yes