### PR TITLE
dcache-qos: fix bug in storing and retrieving 'tried' value for verif…

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/db/JdbcOperationUpdate.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/db/JdbcOperationUpdate.java
@@ -111,7 +111,7 @@ public class JdbcOperationUpdate extends JdbcUpdate implements VerifyOperationUp
 
     @Override
     public VerifyOperationUpdate tried(Collection<String> tried) {
-        if (tried != null) {
+        if (tried != null && !tried.isEmpty()) {
             set("tried", tried.stream().collect(Collectors.joining(",")));
         }
         return this;

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/db/JdbcVerifyOperationDao.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/db/JdbcVerifyOperationDao.java
@@ -100,7 +100,7 @@ public class JdbcVerifyOperationDao extends JdbcDaoSupport implements VerifyOper
         operation.setTarget(rs.getString("target"));
 
         String tried = rs.getString("tried");
-        if (tried != null) {
+        if (tried != null && !tried.isEmpty()) {
             operation.setTried(Arrays.stream(tried.split(","))
                   .map(String::trim)
                   .collect(Collectors.toSet()));


### PR DESCRIPTION
…y operation

Motivation:

In its role as successor to Resilience, QoS
has always made extra replicas from a file
source that was already sticky.  With
the new policy it may now be the case
(if AL is not set on the directory)
that a file is written as volatile
but has a policy which requires
persistent disk copies.

This sequence has uncovered a bug
in storing "tried" values from
the verify operation.  In the case
of the first pass (which is to
PERSIST the current copy) it
ends up storing an empty string
instead of null, which confuses
the pool selector which tries
to choose a target for the copy.

Modification:

Simple check for empty in both
directions fixes it.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14029/
Acked-by: Tigran