### PR TITLE
fix bash-completion

### DIFF
--- a/packages/fhs/src/main/scripts/dcache.bash-completion
+++ b/packages/fhs/src/main/scripts/dcache.bash-completion
@@ -1,4 +1,3 @@
-have dcache &&
 _dcache()
 {
   local dccmd cur prev


### PR DESCRIPTION
Target: master
Request: 9.x
Request: 8.x
Require-book: no
Require-notes: no

Fixes: 19ae273bc891 ("bash-completion: update dcache bash-completion script")