### PR TITLE
Remove all remaining references of Guava's Files class.

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/data/PoolOperationMap.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/data/PoolOperationMap.java
@@ -61,7 +61,6 @@ package org.dcache.qos.services.scanner.data;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import diskCacheV111.poolManager.PoolSelectionUnit;
 import diskCacheV111.poolManager.PoolSelectionUnit.SelectionPool;
 import diskCacheV111.pools.PoolV2Mode;
@@ -171,8 +170,8 @@ public class PoolOperationMap extends ScanOperationMap {
 
         Collection<String> excluded = new ArrayList<>();
 
-        try (BufferedReader fr = new BufferedReader(new FileReader(current))) {
-            excluded = Files.readLines(current, StandardCharsets.US_ASCII);
+        try (BufferedReader fr = new BufferedReader(new FileReader(current, StandardCharsets.US_ASCII))) {
+            excluded = fr.lines().collect(Collectors.toList());
             current.delete();
         } catch (FileNotFoundException e) {
             LOGGER.error("Unable to reload excluded pools file: {}", e.getMessage());


### PR DESCRIPTION
Motivation:
Closes #3808 

Modification:
Removes the last instances of com.google.common.io.Files and replaces most of them with the JDK alternative. (Also required updating one or two guava classes, like the ```TreeTraverser```)

Result:
The remaining references of Guava's ```Files``` class are removed and some small tweaks to reduce the usage of Guava were done.

Signed-off-by: Lukas Mansour [lukas.mansour@desy.de](mailto:lukas.mansour@desy.de)