### PR TITLE
dcache-gplazma: add serialVersionUID to MultiTargetedRestriction

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/attributes/MultiTargetedRestriction.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/MultiTargetedRestriction.java
@@ -35,6 +35,8 @@ import java.util.stream.Collectors;
  */
 public class MultiTargetedRestriction implements Restriction {
 
+    private static final long serialVersionUID = -4604505680192926544L;
+
     private static final EnumSet<Activity> ALLOWED_PARENT_ACTIVITIES
           = EnumSet.of(Activity.LIST, Activity.READ_METADATA);
 


### PR DESCRIPTION
Motivation:

https://github.com/dCache/dcache/issues/7279
`gPlazma incompatibiliti detween version before and after 8.2.13 #7279`

Modification:

Add the serialVersionUID.

Result:

Compatibility restored.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Bug: #7279
Closes: #7279
Requires-notes: yes
Acked-by: Tigran