### PR TITLE
scripts: update default heap and mempry sizes

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -112,10 +112,10 @@ dcache.log.resilience.max-history=30
 (not-for-services)dcache.restart.file=${dcache.restart.dir}/.dcache-stop.${dcache.domain.name}
 
 # Java maximum heap size
-(not-for-services)dcache.java.memory.heap=512m
+(not-for-services)dcache.java.memory.heap=2048m
 
 # Java maximum direct buffer size
-(not-for-services)dcache.java.memory.direct=512m
+(not-for-services)dcache.java.memory.direct=2048m
 
 # Directory where to store heapdumps
 (not-for-services)dcache.java.oom.location=${dcache.log.dir}


### PR DESCRIPTION
Motivation:
By default dcache provides very conservative heap and direct memory sizes, namely 512m. Many sites have adjusted the heap size, but usually keep the direct memory size as-is. The recent nfs changes require the direct memory to at least 3% of the heap size. s direct memory shared by xroot mover pools have hard times to serve the data and fail with OOME.

Modification:
Bumo default heap and direct memory sizes to 2gb.

Result:
No OOME during pool operation.

Acked-by: Albert Rossi
Target: master, 9.1
Require-book: no
Require-notes: yes
(cherry picked from commit ff857831df413887b2092236e4f9d4470135cd4f)