### PR TITLE
pnfsmanager: make list scheduling behavior optional (selectable)

### DIFF
--- a/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
+++ b/modules/dcache-chimera/src/main/resources/diskCacheV111/namespace/pnfsmanager-chimera.xml
@@ -35,6 +35,7 @@
       <property name="fileAttributesRelay" value="${pnfsmanager.destination.file-attributes-notification}"/>
       <property name="logSlowThreshold" value="${pnfsmanager.limits.log-slow-threshold}"/>
       <property name="folding" value="${pnfsmanager.enable.folding}"/>
+      <property name="useParallelListing" value="${pnfsmanager.enable.parallel-listing}"/>
       <property name="directoryListLimit" value="${pnfsmanager.limits.list-chunk-size}"/>
       <property name="permissionHandler" ref="permission-handler"/>
       <property name="queueMaxSize" value="${pnfsmanager.limits.queue-length}"/>

--- a/skel/share/defaults/pnfsmanager.properties
+++ b/skel/share/defaults/pnfsmanager.properties
@@ -83,10 +83,11 @@ pnfsmanager.limits.threads = ${pnfsmanager.limits.threads-per-group}
 #   directory. This leads to all available threads being busy/hanging 
 #   processing create entry messages denying other users from 
 #   accessing the namespace. The switch below, if enabled, would cause 
-#   the create mesages to be  dispatched to a thread associated 
-#   with that entry's parent (that is the target directory).    
+#   the create mesages to be  dispatched to a thread associated
+#   with that entry's parent (that is the target directory).
 #
 (one-of?true|false)pnfsmanager.use-parent-hash-on-create = false
+
 
 #  ---- Number of list threads
 #
@@ -104,6 +105,28 @@ pnfsmanager.limits.list-threads = 2
 #   chunk.
 #
 pnfsmanager.limits.list-chunk-size = 100
+
+#  ---- Determines listing scheduling algorithm behavior
+#
+#  When set to false, PnfsManager spawns pnfsmanager.limits.list-threads
+#  threads with each thread processing a dedicated FIFO queue. Listing
+#  requests are dispactehd to these queues based on path name hashcode.
+#  So that listing of the same directory is dispatched to the same
+#  queue. If there are multiple listing requests for the same directory
+#  queued up, once first listing complete the rest will be filled from
+#  the result of just completed request (mechanism referred to as
+#  folding).
+#
+#  When set to true, the PnfsManager spawns pnfsmanager.limits.list-threads
+#  threads serving a single list processing FIFO queue. If there are multiple
+#  list requests for the same directory they will all be served simultaneously
+#  (hence "parallel-listing") provided there are sufficient active threads
+#  remaining.
+#
+
+(one-of?true|false)pnfsmanager.enable.parallel-listing = false
+
+
 
 #  ---- Threshold for when to log slow requests
 #

--- a/skel/share/services/pnfsmanager.batch
+++ b/skel/share/services/pnfsmanager.batch
@@ -9,6 +9,7 @@ check -strong pnfsmanager.enable.folding
 check -strong pnfsmanager.enable.acl
 check -strong pnfsmanager.default-retention-policy
 check -strong pnfsmanager.default-access-latency
+check -strong pnfsmanager.enable.parallel-listing
 check pnfsmanager.destination.flush-notification
 check pnfsmanager.destination.cache-notification
 check pnfsmanager.destination.cancel-upload-notification


### PR DESCRIPTION
Motivation:

Commit d7653b9a01649ad30dd29541af467b95daefe6b8 has introduced sequential listing and folding of list requests of the same directories. This works very well in the environment where there are mutliple listing requests to the same directories simultaneously. But we discovered an edge case. A site has a directory with 15M entries that is listed periodically. Since it takes a lot of time to serve 15M listing, the list requests to other directories that are dispatched to the same queue (due to modulo of hashCode clash) are backing up even though the other threads are idle.

Modification:

Added dCache property variable:

pnfsmanager.enable.parallel-listing

that allows to restore previous behavior - listing requests are dispatched to a single queue that is prrocessed by multiple parallel workers.

Result:

dCache admin can change behavior of listing scheduler.

Target: trunk
Request: 8.2, 9.2, 9.1, 9.0

Patch: https://rb.dcache.org/r/14048/
Acked-by: Tigran, Lea

Require-book: yes
Require-notes: yes