### PR TITLE
common:  modify the way the flag on isRestricted works

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/attributes/DenyActivityRestriction.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/DenyActivityRestriction.java
@@ -60,7 +60,7 @@ public class DenyActivityRestriction implements Restriction {
     }
 
     @Override
-    public boolean isRestricted(Activity activity, FsPath directory, String name, boolean skipSymlinkResolution) {
+    public boolean isRestricted(Activity activity, FsPath directory, String name, boolean skipPrefixCheck) {
         return denied.contains(activity);
     }
 

--- a/modules/common/src/main/java/org/dcache/auth/attributes/MultiTargetedRestriction.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/MultiTargetedRestriction.java
@@ -140,14 +140,13 @@ public class MultiTargetedRestriction implements Restriction {
 
     @Override
     public boolean isRestricted(Activity activity, FsPath path) {
-        return isRestricted(activity, path, getPathResolver());
+        return isRestricted(activity, path, false);
     }
 
     @Override
     public boolean isRestricted(Activity activity, FsPath directory, String child,
-          boolean skipSymlinkResolution) {
-        return isRestricted(activity, directory.child(child),
-              skipSymlinkResolution ? getIdentityResolver() : getPathResolver());
+          boolean skipPrefixCheck) {
+        return isRestricted(activity, directory.child(child), skipPrefixCheck);
     }
 
     @Override
@@ -216,19 +215,29 @@ public class MultiTargetedRestriction implements Restriction {
               .collect(Collectors.joining(", ", "MultiTargetedRestriction[", "]"));
     }
 
-    private boolean isRestricted(Activity activity, FsPath path, Function<FsPath, FsPath> resolver) {
+    private boolean isRestricted(Activity activity, FsPath path, boolean skipPrefixCheck) {
         for (Authorisation authorisation : authorisations) {
-            FsPath allowedPath = resolver.apply(authorisation.getPath());
             EnumSet<Activity> allowedActivity = authorisation.getActivity();
-            path = resolver.apply(path);
-            if (allowedActivity.contains(activity) && path.hasPrefix(allowedPath)) {
-                return false;
-            }
+            if (skipPrefixCheck) {
+                if (allowedActivity.contains(activity)) {
+                    return false;
+                }
 
-            // As a special case, certain activities are always allowed for
-            // parents of an AllowedPath.
-            if (ALLOWED_PARENT_ACTIVITIES.contains(activity) && allowedPath.hasPrefix(path)) {
-                return false;
+                if (ALLOWED_PARENT_ACTIVITIES.contains(activity)) {
+                    return false;
+                }
+            } else {
+                FsPath allowedPath = getPathResolver().apply(authorisation.getPath());
+                path = getPathResolver().apply(path);
+                if (allowedActivity.contains(activity) && path.hasPrefix(allowedPath)) {
+                    return false;
+                }
+
+                // As a special case, certain activities are always allowed for
+                // parents of an AllowedPath.
+                if (ALLOWED_PARENT_ACTIVITIES.contains(activity) && allowedPath.hasPrefix(path)) {
+                    return false;
+                }
             }
         }
 

--- a/modules/common/src/main/java/org/dcache/auth/attributes/Restrictions.java
+++ b/modules/common/src/main/java/org/dcache/auth/attributes/Restrictions.java
@@ -165,10 +165,10 @@ public class Restrictions {
         }
 
         @Override
-        public boolean isRestricted(Activity activity, FsPath directory, String name, boolean skipSymlink) {
+        public boolean isRestricted(Activity activity, FsPath directory, String name, boolean skipPrefixCheck) {
             for (Restriction r : restrictions) {
-                r.setPathResolver(skipSymlink? getIdentityResolver() : getPathResolver());
-                if (r.isRestricted(activity, directory, name)) {
+                r.setPathResolver(getPathResolver());
+                if (r.isRestricted(activity, directory, name, skipPrefixCheck)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Motivation:

see https://rb.dcache.org/r/14006/
master@9eae61bbac6749664467e92971354b9c7490965f

There was a slight misconstrual of the real
issue.  The patch stopped calling symlink
resolution but still did the prefix comparison.
This means that, for instance, paths with
a symlink in the prefix would not be visible
(in some cases effectively returning 0 results).

Modification:

Change to boolean parameter's meaning to
`skipPrefixCheck`, and do not do prefix
comparisons in that case.  This means
that children are in fact only checked
for permissions on READ_METADATA.

Result:

Identical list results returned, e.g.,
for directories specified with or without
a symlink in the prefix.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14054/
Requires-notes:  yes (alas)
Depends-on: #14006
Acked-by: Dmitry