### PR TITLE
pom.xml:  upgrade to xrootd4j 4.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
         <version.jetty>9.4.51.v20230217</version.jetty>
-        <version.xrootd4j>4.5.7</version.xrootd4j>
+        <version.xrootd4j>4.5.8</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
         <version.dcache-view>2.0.2</version.dcache-view>
         <version.netty>4.1.92.Final</version.netty>


### PR DESCRIPTION
see https://rb.dcache.org/r/14027/

Improves handling/logging of Ssl exceptions.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14051/
Depends-on: 14027
Acked-by: Tigran