### PR TITLE
dcache-bulk:  remove in memory running state counts

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkServiceStatistics.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkServiceStatistics.java
@@ -95,8 +95,7 @@ public final class BulkServiceStatistics implements CellInfoProvider {
     private final Map<String, AtomicLong> requestTypes = new TreeMap<>();
     private final Map<String, AtomicLong> userRequests = new TreeMap<>();
     private final Map<String, AtomicLong> counts
-          = Map.of(RUNNING.name(), new AtomicLong(0L),
-          CANCELLED.name(), new AtomicLong(0L),
+          = Map.of(CANCELLED.name(), new AtomicLong(0L),
           COMPLETED.name(), new AtomicLong(0L),
           FAILED.name(), new AtomicLong(0L),
           SKIPPED.name(), new AtomicLong(0L));
@@ -153,10 +152,6 @@ public final class BulkServiceStatistics implements CellInfoProvider {
 
         pw.println("---------------- REQUESTS  (current) -----------------");
         pw.println(String.format(STATS_FORMAT, "Active", activeRequests.get()));
-        pw.println();
-
-        pw.println("----------------- TARGETS  (current) -----------------");
-        pw.println(String.format(STATS_FORMAT, RUNNING.name(), counts.get(RUNNING.name())));
         pw.println();
     }
 


### PR DESCRIPTION
Motivation:

see https://rb.dcache.org/r/13994/
master@4525fc12e1adcb72f44a642b9bbfbdcd4b20a8bc

Changes were recently made to hold statistical
counts of requests and targets in memory for
the sake of efficiency.  However, running target
counts are still problematic.  This is
especially true if a request is cancelled.

Modification:

Rather than trying to rectify what is essentially
a transactional problem, the elimination of
this count in the `info` display is an easier
solution (given its limited usefulness anyway).

It should be noted that while the database
remains a modest size, calling

`target ls -count -state`

usually returns relatively quickly and
will give a more accurate indication of
target state, since it is based on
database group-by query.

Result:

The `running` count, which can be confusing
and inaccurate, is not longer displayed.

Target: master
Request: 9.1
Request: 9.0
Requires-notes: yes
Patch: https://rb.dcache.org/r/14052/
Acked-by: Tigran