### PR TITLE
dcache-xroot:  improve efficiency of stat list (ls -l)

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -1053,8 +1053,18 @@ public class XrootdDoor
         }
     }
 
-    private int getFileStatusFlags(Subject subject, Restriction restriction,
+    private int getFileStatusFlagsForListing(Subject subject, Restriction restriction,
           FsPath path, FileAttributes attributes) {
+        return getFileStatusFlags(subject, restriction, path, attributes, true);
+    }
+
+    private int getFileStatusFlags(Subject subject, Restriction restriction,
+          FsPath path, FileAttributes attributes ) {
+        return getFileStatusFlags(subject, restriction, path, attributes, false);
+    }
+
+    private int getFileStatusFlags(Subject subject, Restriction restriction,
+          FsPath path, FileAttributes attributes, boolean skipPoscCheck) {
         int flags = 0;
         switch (attributes.getFileType()) {
             case DIR:
@@ -1094,7 +1104,7 @@ public class XrootdDoor
                 if (canReadFile) {
                     flags |= kXR_readable;
                 }
-                if (attributes.getStorageInfo().isCreatedOnly()) {
+                if (!skipPoscCheck && attributes.getStorageInfo().isCreatedOnly()) {
                     flags |= kXR_poscpend;
                 }
                 break;
@@ -1125,12 +1135,25 @@ public class XrootdDoor
         return getFileStatus(subject, restriction, fullPath, clientHost, attributes);
     }
 
+    public EnumSet<FileAttribute> getRequiredAttributesForFileStatusList() {
+        EnumSet<FileAttribute> requestedAttributes = EnumSet.of(TYPE, SIZE, MODIFICATION_TIME);
+        requestedAttributes.addAll(_pdp.getRequiredAttributes());
+        return requestedAttributes;
+    }
+
     public EnumSet<FileAttribute> getRequiredAttributesForFileStatus() {
         EnumSet<FileAttribute> requestedAttributes = EnumSet.of(TYPE, SIZE, MODIFICATION_TIME,
               STORAGEINFO);
         requestedAttributes.addAll(PoolMonitorV5.getRequiredAttributesForFileLocality());
         requestedAttributes.addAll(_pdp.getRequiredAttributes());
         return requestedAttributes;
+    }
+
+    public FileStatus getFileStatusForListing(Subject subject, Restriction restriction, FsPath fullPath,
+          FileAttributes attributes) {
+        int flags = getFileStatusFlagsForListing(subject, restriction, fullPath, attributes);
+        return new FileStatus(0, attributes.getSizeIfPresent().orElse(0L), flags,
+              attributes.getModificationTime() / 1000);
     }
 
     public FileStatus getFileStatus(Subject subject, Restriction restriction,

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -1106,7 +1106,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
             if (request.isDirectoryStat()) {
                 _door.listPath(fullListPath, subject, restriction,
                       new StatListCallback(request, subject, restriction, fullListPath, ctx),
-                      _door.getRequiredAttributesForFileStatus());
+                      _door.getRequiredAttributesForFileStatusList());
             } else {
                 _door.listPath(fullListPath, subject, restriction,
                       new ListCallback(request, ctx),
@@ -1342,10 +1342,10 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
         @Override
         public void success(PnfsListDirectoryMessage message) {
             message.getEntries().stream().forEach(
-                  e -> _response.add(e.getName(), _door.getFileStatus(_subject,
+                  e -> _response.add(e.getName(), _door.getFileStatusForListing(_subject,
                         _restriction,
                         _dirPath.child(e.getName()),
-                        _client, e.getFileAttributes())));
+                        e.getFileAttributes())));
             if (message.isFinal()) {
                 respond(_context, _response.buildFinal());
             } else {


### PR DESCRIPTION
Motivation:

The xroot ls command has some unnecessary overhead. First, it does not need to query file locality;
second, it does not need to know file state in
case of POSC.

It would seem proper for those attributes to be
checked by a client by issuing an individual
stat on the file.

Modification:

Fork the `getFileStatus` functionality so
that stat listing (i.e., `ls -l`) is separate
from a full stat request; in the former case,
`STORAGEINFO` is not requested and a call
to the `PoolMonitor` for file locality is
avoided.

Result:

`ls -l` returns in approximately the
same amount of time as a non-stat listing
`ls`.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14055/
Requires-notes: yes
Acked-by: Tigran