### PR TITLE
dcache-xroot:  improve efficiency of stat list (ls -l)

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -1093,7 +1093,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
             if (request.isDirectoryStat()) {
                 _door.listPath(fullListPath, subject, restriction,
                       new StatListCallback(request, subject, restriction, fullListPath, ctx),
-                      _door.getRequiredAttributesForFileStatus());
+                      _door.getRequiredAttributesForFileStatusList());
             } else {
                 _door.listPath(fullListPath, subject, restriction,
                       new ListCallback(request, ctx),
@@ -1329,10 +1329,10 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
         @Override
         public void success(PnfsListDirectoryMessage message) {
             message.getEntries().stream().forEach(
-                  e -> _response.add(e.getName(), _door.getFileStatus(_subject,
+                  e -> _response.add(e.getName(), _door.getFileStatusForListing(_subject,
                         _restriction,
                         _dirPath.child(e.getName()),
-                        _client, e.getFileAttributes())));
+                        e.getFileAttributes())));
             if (message.isFinal()) {
                 respond(_context, _response.buildFinal());
             } else {


### PR DESCRIPTION
Motivation:

The xroot ls command has some unnecessary overhead. First, it does not need to query file locality;
second, it does not need to know file state in
case of POSC.

It would seem proper for those attributes to be
checked by a client by issuing an individual
stat on the file.

Modification:

Fork the `getFileStatus` functionality so
that stat listing (i.e., `ls -l`) is separate
from a full stat request; in the former case,
`STORAGEINFO` is not requested and a call
to the `PoolMonitor` for file locality is
avoided.

Result:

`ls -l` returns in approximately the
same amount of time as a non-stat listing
`ls`.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14055/
Requires-notes: yes
Acked-by: Tigran