### PR TITLE
pool: Save hsm load provider to setup file

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/HsmSet.java
@@ -103,7 +103,7 @@ public class HsmSet
      * Nearline storage provides that dynamically at the runtime.
      */
     private final Map<String, NearlineStorageProvider> dynamicProviders = new ConcurrentHashMap<>();
-
+    private final Map<NearlineStorageProvider, String> dynamicProviderPath = new ConcurrentHashMap<>();
     private static final String DEFAULT_PROVIDER = "script";
 
     private final ConcurrentMap<String, HsmInfo> _newConfig = Maps.newConcurrentMap();
@@ -376,6 +376,7 @@ public class HsmSet
         return description;
     }
 
+    @AffectsSetup
     @Command(name = "hsm load provider", hint = "Load a provider from the specified directory",
           description = "Loads an external provider. The provided path should point to a directory"
                 + " containing jar files. If the directory contains a provider with a name that already"
@@ -387,7 +388,6 @@ public class HsmSet
 
         @Override
         public String call() throws CommandException {
-
             ColumnWriter writer = new ColumnWriter();
             writer.header("PROVIDER").left("provider").space();
             writer.header("DESCRIPTION").left("description");
@@ -423,6 +423,7 @@ public class HsmSet
                     continue;
                 }
 
+                dynamicProviderPath.put(p, path);
                 var old = dynamicProviders.putIfAbsent(p.getName(), p);
                 if (old == null) {
                     writer.row()
@@ -435,6 +436,7 @@ public class HsmSet
         }
     }
 
+    @AffectsSetup
     @Command(name = "hsm unload provider", hint = "Unload user provided nearline storage provider",
           description =
                 "Unloads user loaded provide. After unloading, the provider can be used anymore."
@@ -454,6 +456,7 @@ public class HsmSet
 
             var p = dynamicProviders.remove(provider);
             if (p != null) {
+                dynamicProviderPath.remove(p);
                 dynamicProviders.remove(p.getName());
                 writer.row()
                       .value("provider", p.getName())
@@ -669,8 +672,17 @@ public class HsmSet
 
     @Override
     public void printSetup(PrintWriter pw) {
-        if (!_hsm.isEmpty()) {
+        if (!dynamicProviderPath.isEmpty() || !_hsm.isEmpty()) {
             pw.println("#\n# Nearline storage\n#");
+        }
+        if (!dynamicProviders.isEmpty()) {
+            for (NearlineStorageProvider provider : dynamicProviders.values()) {
+                pw.print("hsm load provider ");
+                pw.print(dynamicProviderPath.get(provider));
+                pw.println();
+            }
+        }
+        if(!_hsm.isEmpty()) {
             for (HsmInfo info : _hsm.values()) {
                 pw.print("hsm create ");
                 pw.print(info.getType());


### PR DESCRIPTION
Motivation:
See GitHub #7251

When a hsm provider was dynamically loaded, it doesn't appear in the pools setup file after using save.

Modification:

hsm load and hsm unload are now annotated with @AffectsSetup and the load command is written to setup file if save is executed. To get the path of the provider after it is created, I added a ConcurrentHashMap with the provider object as key and the path as value.

Result:

When executing save, hsm load is written to the setup-file.

Target: master
Request: 9.1
Acked by: Tigran
Require-notes: yes
Require-book: yes