### PR TITLE
dcache-bulk:  cancel all stored targets on abort

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcBulkTargetStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/rtarget/JdbcBulkTargetStore.java
@@ -94,13 +94,15 @@ public final class JdbcBulkTargetStore implements BulkTargetStore {
               target.getErrorType(), target.getErrorMessage());
 
         /*
-         * If aborted, the target has not yet been stored ...
+         * If aborted, the placeholder target has not yet been stored ...
          */
         targetDao.insert(
               targetDao.set().pid(target.getPid()).rid(target.getRid())
                     .pnfsid(target.getPnfsId()).path(target.getPath()).type(target.getType())
                     .activity(target.getActivity()).errorType(target.getErrorType())
                     .errorMessage(target.getErrorMessage()).aborted());
+
+        cancelAll(target.getRid());
     }
 
     @Override


### PR DESCRIPTION
Motivation:

See `RT 10496: Odd errors in Bulk logs for some requests in 9.1.0`

This ticket uncovered a bug in the abort procedure.

After the transition to version 2, an additional change was made to the target storage logic where initial targets are immediately stored in the target table (see https://rb.dcache.org/r/13782/
`dcache-bulk: insert targets immediately on submit`).

This change did not modify abort to take this into account.

Modification:

Add target cancellation to the abort method.

Result:

Request is left in consistent state on abort.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14060/
Bug: #10496
Acked-by: Tigran