### PR TITLE
dcache-bulk:  adjust semaphore permits to something more reasonable

### DIFF
--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -136,11 +136,10 @@ bulk.service.poolmanager.timeout=1
 #
 bulk.service.qos=${dcache.service.qos}
 
-# ---- How long to wait for a response from the pool manager.
+# ---- How long to wait for a response from qos.
 #
 bulk.service.qos.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)bulk.service.qos.timeout.unit=MINUTES
-
 
 # Topic on which to expect pool monitor updates
 #
@@ -171,14 +170,19 @@ bulk.db.fetch-size=1000
 # ---- Activity plugin properties
 #
 #      Max permits is the number permits for the semaphore used by the request container to
-#      perform the activity on individual targets.
+#      perform the activity on individual targets.  This number is on a container-by-container
+#      basis; for instance, if the bulk.limits.container-processing-threads is set to 100,
+#      this means that the number of concurrent requests to pin manager, e.g., would be 100000.
+#      These numbers should be adjusted up or down depending on concurrency requirements
+#      so as not to generate DOS attacks on the other dCache services such as PnfsManager,
+#      PinManager or the QoSEngine.
 #
 bulk.plugin!delete.max-permits=100
-bulk.plugin!pin.max-permits=100000
-bulk.plugin!stage.max-permits=100000
-bulk.plugin!unpin.max-permits=100000
-bulk.plugin!release.max-permits=100000
-bulk.plugin!update-qos.max-permits=100000
+bulk.plugin!pin.max-permits=1000
+bulk.plugin!stage.max-permits=1000
+bulk.plugin!unpin.max-permits=1000
+bulk.plugin!release.max-permits=1000
+bulk.plugin!update-qos.max-permits=1000
 bulk.plugin!log-target.max-permits=100
 
 #  ---- Algorithm for determining what action to take on job failures.


### PR DESCRIPTION
Motivation:

The semaphore in a bulk activity is used to throttle concurrency so as not to cause a DOS on other
dCache services.

Each time a bulk request is started, the container is given a new semaphore based on the number of permits defined for the activity in question.

Unfortunately, permits are currently specified as if the obtained globally for all running jobs of that activity.  Hence, in the case of PIN, QOS, etc.,
these are unreasonable and defeat the purpose.

Modification:

Set the per-container permit values to something more reasonable.

Result:

Semaphores will have a reasonable chance of working as intended.

Target:  master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14062/
Requires-notes: yes
Acked-by: Tigran