### PR TITLE
pool: remove hidden defaults for rh/rm/sh operations

### DIFF
--- a/skel/share/services/pool.batch
+++ b/skel/share/services/pool.batch
@@ -106,10 +106,6 @@ define context PoolDefaults endDefine
    flush set interval 60
    flush set retry delay 60
 
-   rh set timeout 14400
-   st set timeout 14400
-   rm set timeout 14400
-
    mover set max active 100
    p2p set max active 10
    jtm set timeout -queue=p2p -lastAccess=0 -total=0


### PR DESCRIPTION
fixes commit 84f1da69f

Motivation:
Site commit 84f1da69f5 we have expected that the default HSM timeout values for store, restore and remove are gone. Hoever, pool.barch comes with a default setup file, that initializes this values and a pool gets default timeouts even if pools setup files doesn't defined them.

Modification:
remove obsolete defaults.

Result:
expected behaviour on pool restart.

Acked-by: Albert Rossi
Target: master, 9.1
Require-book: no
Require-notes: yes
(cherry picked from commit 6643935656c5f69210e2526a2c30bfb1dae09ddf)