### PR TITLE
dcache-qos,dcache-bulk:  allow qos update to call engine asynchronously

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/qos/UpdateQoSActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/qos/UpdateQoSActivity.java
@@ -151,7 +151,8 @@ public class UpdateQoSActivity extends BulkActivity<QoSTransitionCompletedMessag
         client.setRequirementsService(qosEngine);
 
         try {
-            client.fileQoSRequirementsModified(requirements, subject);
+            ListenableFuture asyncFuture = client.fileQoSRequirementsModifiedAsync(requirements, subject);
+            responseReceiver.setAsyncListener(pnfsId, asyncFuture);
         } catch (CacheException | InterruptedException | NoRouteToCellException e) {
             return Futures.immediateFailedFuture(e);
         }

--- a/modules/dcache/src/main/java/org/dcache/qos/listeners/QoSRequirementsListener.java
+++ b/modules/dcache/src/main/java/org/dcache/qos/listeners/QoSRequirementsListener.java
@@ -80,6 +80,7 @@ public interface QoSRequirementsListener {
 
     /**
      * A client sends this when it wishes to change a file's QoS requirements.
+     * This call is assumed to block.
      *
      * @param newRequirements describing principally how many peristent disk and tape copies are
      *                        required.

--- a/modules/dcache/src/main/java/org/dcache/qos/remote/clients/RemoteQoSRequirementsClient.java
+++ b/modules/dcache/src/main/java/org/dcache/qos/remote/clients/RemoteQoSRequirementsClient.java
@@ -127,6 +127,18 @@ public final class RemoteQoSRequirementsClient implements QoSRequirementsListene
         }
     }
 
+    /**
+     * An async version which can be used in the context of bulk processing.
+     *
+     * @param newRequirements describing principally how many persistent disk and tape copies are
+     *                        required.
+     */
+    public ListenableFuture<QoSRequirementsModifiedMessage>
+            fileQoSRequirementsModifiedAsync(FileQoSRequirements newRequirements, Subject subject)
+          throws CacheException, NoRouteToCellException, InterruptedException {
+        return requirementsService.send(new QoSRequirementsModifiedMessage(newRequirements, subject));
+    }
+
     @Override
     public void fileQoSRequirementsModifiedCancelled(PnfsId pnfsid, Subject subject) throws QoSException {
         /*


### PR DESCRIPTION
Motivation:

During testing of the rule engine extension, it was noticed that the message queue of the System cell for the QoSEngine was backing up considerably.  Inspection of the code revealed a blunder made here:

master@7d898c5601d30c6f8cc027e4080f3b82c2072f4b
`dcache-qos:  propagate subject to QoS Adjuster`

where a get() on the message future was incorrectly added to the messageArrived method of `QoSRequirementsReceiver`, nullifying the effect of passing off the work to
a different thread pool.

Modification:

This patch removes the get(), but also adds the ability to use the remote client asynchronously by making
the receiver return a Reply, and by adding an
async version of the call to the remote client.
The latter is then incorporated into the bulk
service's activity logic.

Result:

The message queue blocking is eliminated and
the bulk service communication with QoS is
more fully asynchronous.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes: yes (the wrongful message-queue blocking)
Patch: https://rb.dcache.org/r/14067
Acked-by: Lea