### PR TITLE
dcache-webdav:  improve efficiency of directory listing

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -18,6 +18,7 @@ import static org.dcache.namespace.FileAttribute.OWNER_GROUP;
 import static org.dcache.namespace.FileAttribute.PNFSID;
 import static org.dcache.namespace.FileAttribute.RETENTION_POLICY;
 import static org.dcache.namespace.FileAttribute.SIZE;
+import static org.dcache.namespace.FileAttribute.STORAGEINFO;
 import static org.dcache.namespace.FileAttribute.TYPE;
 import static org.dcache.namespace.FileAttribute.XATTR;
 import static org.dcache.namespace.FileType.DIR;
@@ -166,6 +167,10 @@ public class DcacheResourceFactory
 
     public static final String TRANSACTION_ATTRIBUTE = "org.dcache.transaction";
 
+    private static final Set<FileAttribute> MINIMALLY_REQUIRED_ATTRIBUTES =
+          EnumSet.of(TYPE, PNFSID, CREATION_TIME, MODIFICATION_TIME, SIZE,
+                MODE, OWNER, OWNER_GROUP);
+
     private static final Set<FileAttribute> REQUIRED_ATTRIBUTES =
           EnumSet.of(TYPE, PNFSID, CREATION_TIME, MODIFICATION_TIME, SIZE,
                 MODE, OWNER, OWNER_GROUP, XATTR);
@@ -176,7 +181,7 @@ public class DcacheResourceFactory
     // Additional attributes needed for PROPFIND requests; e.g., to supply
     // values for properties.
     private static final Set<FileAttribute> PROPFIND_ATTRIBUTES = Sets.union(
-          EnumSet.of(CHECKSUM, ACCESS_LATENCY, RETENTION_POLICY),
+          EnumSet.of(CHECKSUM, ACCESS_LATENCY, RETENTION_POLICY, STORAGEINFO),
           PoolMonitorV5.getRequiredAttributesForFileLocality());
 
     private static final String PROTOCOL_INFO_NAME = "Http";
@@ -190,6 +195,11 @@ public class DcacheResourceFactory
 
     private static final Splitter PATH_SPLITTER =
           Splitter.on('/').omitEmptyStrings();
+
+    enum PropfindProperties {
+        PERFORMANCE,
+        CLIENT_COMPATIBLE
+    };
 
     /**
      * In progress transfers. The key of the map is the session id of the transfer.
@@ -233,6 +243,7 @@ public class DcacheResourceFactory
     private boolean _impatientClientProxied = true;
     private boolean _isOverwriteAllowed;
     private boolean _isAnonymousListingAllowed;
+    private boolean _includeAllAttributesForPropfind;
 
     private String _staticContentPath;
     private ReloadableTemplate _template;
@@ -604,9 +615,9 @@ public class DcacheResourceFactory
     public DcacheResource getResource(FsPath path) {
         checkPathAllowed(path);
 
-        String requestPath = getRequestPath();
         boolean haveRetried = false;
         Subject subject = getSubject();
+        String requestPath = getRequestPath();
 
         try {
             while (true) {
@@ -648,7 +659,8 @@ public class DcacheResourceFactory
      */
     private DcacheResource getResource(FsPath path, FileAttributes attributes) {
         if (attributes.getFileType() == DIR) {
-            return new DcacheDirectoryResource(this, path, attributes);
+            return new DcacheDirectoryResource(this, path, attributes,
+                  _includeAllAttributesForPropfind);
         } else {
             return new DcacheFileResource(this, path, attributes);
         }
@@ -917,6 +929,11 @@ public class DcacheResourceFactory
         return result;
     }
 
+    public void setDefaultPropfindProperties(PropfindProperties defaultPropfindProperties) {
+        _includeAllAttributesForPropfind =
+              defaultPropfindProperties == PropfindProperties.CLIENT_COMPATIBLE;
+    }
+
     private class FileLocalityWrapper {
 
         private final FileLocality _inner;
@@ -1120,7 +1137,8 @@ public class DcacheResourceFactory
         PnfsCreateEntryMessage reply =
               pnfs.createPnfsDirectory(path.toString(), REQUIRED_ATTRIBUTES);
 
-        return new DcacheDirectoryResource(this, path, reply.getFileAttributes());
+        return new DcacheDirectoryResource(this, path, reply.getFileAttributes(),
+              _includeAllAttributesForPropfind);
     }
 
     public void move(FsPath sourcePath, PnfsId pnfsId, FsPath newPath)
@@ -1411,13 +1429,16 @@ public class DcacheResourceFactory
     }
 
     private Set<FileAttribute> buildRequestedAttributes() {
-        Set<FileAttribute> attributes = EnumSet.copyOf(REQUIRED_ATTRIBUTES);
+        boolean all = isFetchAllAttributes();
+
+        Set<FileAttribute> attributes = all ? EnumSet.copyOf(REQUIRED_ATTRIBUTES) :
+              EnumSet.copyOf(MINIMALLY_REQUIRED_ATTRIBUTES);
 
         if (isDigestRequested()) {
             attributes.add(CHECKSUM);
         }
 
-        if (isPropfindRequest()) {
+        if (isPropfindRequest() && all) {
             // FIXME: Unfortunately, Milton parses the request body after
             // requesting the Resource, so we cannot know which additional
             // attributes are being requested; therefore, we must request all
@@ -1426,6 +1447,14 @@ public class DcacheResourceFactory
         }
 
         return attributes;
+    }
+
+    private boolean isFetchAllAttributes() {
+        if (!isPropfindRequest()) {
+            return true;
+        }
+
+        return _includeAllAttributesForPropfind;
     }
 
     /**
@@ -1485,7 +1514,7 @@ public class DcacheResourceFactory
         }
     }
 
-    private Optional<String> lookupWriteToken(FsPath path) {
+    public Optional<String> lookupWriteToken(FsPath path) {
         try {
             return _writeTokenCache.get(path);
         } catch (ExecutionException e) {
@@ -1496,14 +1525,14 @@ public class DcacheResourceFactory
         }
     }
 
-    public Space spaceForPath(FsPath path) throws SpaceException {
-        return lookupWriteToken(path)
+    public Space spaceForToken(Optional<String> maybeToken) throws SpaceException {
+        return maybeToken
               .flatMap(this::lookupSpaceById)
               .orElseThrow(() -> new SpaceException("Path not under space management"));
     }
 
-    public boolean isSpaceManaged(FsPath path) {
-        return lookupWriteToken(path)
+    public boolean isSpaceManaged(Optional<String> maybeToken) {
+        return maybeToken
               .flatMap(this::lookupSpaceById)
               .isPresent();
     }

--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -230,6 +230,7 @@
         <property name="overwriteAllowed" value="${webdav.enable.overwrite}"/>
         <property name="redirectToHttps" value="${webdav.redirect.allow-https}"/>
         <property name="poolMonitor" ref="pool-monitor"/>
+        <property name="defaultPropfindProperties" value="${webdav.default-propfind-properties}"/>
     </bean>
 
     <bean id="pool-manager-handler" class="org.dcache.poolmanager.PoolManagerHandlerSubscriber">

--- a/modules/dcache/src/main/java/org/dcache/space/ReservationCaches.java
+++ b/modules/dcache/src/main/java/org/dcache/space/ReservationCaches.java
@@ -251,6 +251,11 @@ public class ReservationCaches {
                     });
     }
 
+    public static java.util.Optional<String> writeToken(FileAttributes attr) {
+        StorageInfo info = attr.getStorageInfo();
+        return java.util.Optional.ofNullable(info.getMap().get("writeToken"));
+    }
+
     /**
      * Cache queries to discover if a directory has the "WriteToken" tag set.
      */
@@ -262,11 +267,6 @@ public class ReservationCaches {
               .refreshAfterWrite(5, MINUTES)
               .recordStats()
               .build(new CacheLoader<FsPath, java.util.Optional<String>>() {
-                  private java.util.Optional<String> writeToken(FileAttributes attr) {
-                      StorageInfo info = attr.getStorageInfo();
-                      return java.util.Optional.ofNullable(info.getMap().get("writeToken"));
-                  }
-
                   @Override
                   public java.util.Optional<String> load(FsPath path)
                         throws CacheException, NoRouteToCellException, InterruptedException {

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -763,8 +763,6 @@ webdav.allowed.client.origins =
 #
 (one-of?true|false)webdav.redirect.allow-https=true
 
-
-
 #  ---- Kafka service enabled
 #
 (one-of?true|false|${dcache.enable.kafka})webdav.enable.kafka = ${dcache.enable.kafka}
@@ -778,3 +776,34 @@ webdav.kafka.producer.bootstrap.servers =  ${dcache.kafka.bootstrap-servers}
 
 
 (prefix)webdav.kafka.producer.configs =  Configuration for Kafka Producer
+
+#  --- Default PROPFIND properties
+#
+#  The PROPFIND request allows a client to discover information
+#  (properties) of dCache content.  When making a PROPFIND request,
+#  the client normally indicates which properties are of interest.  If
+#  not specified then the WebDAV server (dCache) is free to return a
+#  default set of information.
+#
+#  Certain clients make PROPFIND requests without specifying
+#  the desired set of properties, triggering a default set of
+#  properties.  There are two problems with this: first, the
+#  clients may react badly if information is missing from this default;
+#  second, some of the required properties may have an adverse
+#  performance impact for dCache.
+#
+#  This property controls whether to support client-side requests for
+#  properties beyond a minimal set or not.
+#
+#      PERFORMANCE -- always return only a minimal set of information that does
+#                     not incur any additional overhead. (These are basically
+#                     the same as what a POSIX list request would proviode).
+#
+#      CLIENT_COMPATIBLE -- return the set of information required by
+#                     the clients.  If the client does not specify the properties,
+#                     it will get a maximal default set.
+#
+#  Because the performance impact of the latter under the most common usage scenarios
+#  could be considerable, the default is set to PERFORMANCE.
+#
+(one-of?PERFORMANCE|CLIENT_COMPATIBLE)webdav.default-propfind-properties = PERFORMANCE


### PR DESCRIPTION
Motivation:

Listing through webdav is very slow on largish
directories (see under testing).  This creates
backlog and DOS-like conditions on FNAL
production.

There were two issues:

(a) for each directory, the write-token-cache
that is maintained in webdav was being checked;
the cache loader uses the PnfsHandler to supply
that token by requesting the STORAGEINFO attribute. Hence, an extra attribute fetch for each
directory.

This is rectified by accessing an optional
write token from the storage info if it
has already been fetched.   Merged from
patch https://rb.dcache.org/r/14082/.

(b) even without fetching STORAGEINFO again
for the directories, the original fetch is
slow because it includes things like locality
and joins for non-POSIX attributes.

This is fixed by checking to see if this
is a propfind request.  If it is, only
the minimal set of (POSIX-) attributes
are requested, unless the
dCache property for propfind default
is set to CLIENT_COMPATIBLE.

Result:

Considerable speed-up (see testing).

Target:  master
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14085/
Requires-notes: yes
Acked-by: Tigran