### PR TITLE
dcache-webdav:  fix incorrect parameter value given to DcacheDirector…

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -660,7 +660,7 @@ public class DcacheResourceFactory
     private DcacheResource getResource(FsPath path, FileAttributes attributes) {
         if (attributes.getFileType() == DIR) {
             return new DcacheDirectoryResource(this, path, attributes,
-                  _includeAllAttributesForPropfind);
+                  isFetchAllAttributes());
         } else {
             return new DcacheFileResource(this, path, attributes);
         }
@@ -1138,7 +1138,7 @@ public class DcacheResourceFactory
               pnfs.createPnfsDirectory(path.toString(), REQUIRED_ATTRIBUTES);
 
         return new DcacheDirectoryResource(this, path, reply.getFileAttributes(),
-              _includeAllAttributesForPropfind);
+              isFetchAllAttributes());
     }
 
     public void move(FsPath sourcePath, PnfsId pnfsId, FsPath newPath)


### PR DESCRIPTION
…yResource constructor

Motivation:

https://rb.dcache.org/r/14085/

passes the incorrect parameter value in
to the `DcacheDirectoryResource` contstructor.
It should be `true` if this is not a `PROPFIND`
call.

Modification:

Use the `isFetchAllAttributes` method
instead of the variable set from the
property value.

Result:

Correct resource configuration in the
case it is not `PROPFIND`.

Target: master
Patch: https://rb.dcache.org/r/14088/
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes: no (fixes unreleased change)
Acked-by: Svenja