### PR TITLE
Support additional Kafka parameters for ftp and dcap.

### DIFF
--- a/skel/share/defaults/dcap.properties
+++ b/skel/share/defaults/dcap.properties
@@ -221,3 +221,6 @@ dcap.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}
 
 # Kafka topic name
 dcap.kafka.topic = ${dcache.kafka.topic}
+
+# File from which to load additional Kafka properties.
+dcap.kafka.config-file = ${dcache.kafka.config-file}

--- a/skel/share/defaults/ftp.properties
+++ b/skel/share/defaults/ftp.properties
@@ -396,3 +396,6 @@ ftp.kafka.bootstrap-servers = ${dcache.kafka.bootstrap-servers}
 
 # Kafka topic name
 ftp.kafka.topic = ${dcache.kafka.topic}
+
+# File from which to load additional Kafka properties.
+ftp.kafka.config-file = ${dcache.kafka.config-file}

--- a/skel/share/defaults/kafka.properties
+++ b/skel/share/defaults/kafka.properties
@@ -24,6 +24,10 @@ dcache.kafka.bootstrap-servers = localhost:9092
 # Kafka topic name
 dcache.kafka.topic = billing
 
+# Optional file from which to load additional Kafka properties for ftp and
+# dcap.  For other services, use dcache.kafka.configs.
+dcache.kafka.config-file =
+
 
 
 #--------------------Default Properties------------------------------

--- a/skel/share/services/dcap.batch
+++ b/skel/share/services/dcap.batch
@@ -119,6 +119,7 @@ create dmg.cells.services.login.LoginManager ${dcap.cell.name} \
              -kafka-max-block-units=${dcap.kafka.maximum-block.unit}\
              -retries-kafka=0 \
              -kafka-clientid=\"${dcap.cell.name}\" \
+             -kafka-config-file=\"${dcap.kafka.config-file}\" \
              -stageConfigurationFilePath=\"${dcap.authz.staging}\" \
              -allowAnonymousStaging=\"${dcap.authz.anonymous-staging}\" \
              -io-queue=${dcap.mover.queue} \

--- a/skel/share/services/ftp.batch
+++ b/skel/share/services/ftp.batch
@@ -94,6 +94,7 @@ create dmg.cells.services.login.LoginManager ${ftp.cell.name} \
    -billing=\"${ftp.service.billing}\" \
    -kafka=\"${ftp.enable.kafka}\" \
    -kafka-clientid=\"${ftp.cell.name}\" \
+   -kafka-config-file=\"${ftp.kafka.config-file}\" \
    -bootstrap-server-kafka=\"${ftp.kafka.bootstrap-servers}\" \
    -kafka-topic=\"${ftp.kafka.topic}\" \
    -kafka-max-block=${ftp.kafka.maximum-block}\


### PR DESCRIPTION
This is my proposal to solve #7280.  Originally I indicated that the new configuration parameters would be called `configs`, but I changed it to `config-file` due to the observable difference in how it is used.

I have only tested gsiftp, since the implementation for dcap is almost identical and I already spent most of the time getting gsiftp to work.  Though that mainly caused by a bug in globus, so I can maybe get dcap working faster if you think it's essential to also test it.  I did the test by cherry-picking the commit onto the 9.1 branch, building a deb and installing it on some experimental headnodes we're running, adding in our TLS parameters in the separate file and triggering a billing record with arccp.
