### PR TITLE
dcache-webdav: revert improve efficiency of directory listing (14085/…

### DIFF
--- a/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
+++ b/modules/dcache-webdav/src/main/resources/org/dcache/webdav/webdav.xml
@@ -230,7 +230,6 @@
         <property name="overwriteAllowed" value="${webdav.enable.overwrite}"/>
         <property name="redirectToHttps" value="${webdav.redirect.allow-https}"/>
         <property name="poolMonitor" ref="pool-monitor"/>
-        <property name="defaultPropfindProperties" value="${webdav.default-propfind-properties}"/>
     </bean>
 
     <bean id="pool-manager-handler" class="org.dcache.poolmanager.PoolManagerHandlerSubscriber">

--- a/modules/dcache/src/main/java/org/dcache/space/ReservationCaches.java
+++ b/modules/dcache/src/main/java/org/dcache/space/ReservationCaches.java
@@ -251,11 +251,6 @@ public class ReservationCaches {
                     });
     }
 
-    public static java.util.Optional<String> writeToken(FileAttributes attr) {
-        StorageInfo info = attr.getStorageInfo();
-        return java.util.Optional.ofNullable(info.getMap().get("writeToken"));
-    }
-
     /**
      * Cache queries to discover if a directory has the "WriteToken" tag set.
      */
@@ -267,6 +262,11 @@ public class ReservationCaches {
               .refreshAfterWrite(5, MINUTES)
               .recordStats()
               .build(new CacheLoader<FsPath, java.util.Optional<String>>() {
+                  private java.util.Optional<String> writeToken(FileAttributes attr) {
+                      StorageInfo info = attr.getStorageInfo();
+                      return java.util.Optional.ofNullable(info.getMap().get("writeToken"));
+                  }
+
                   @Override
                   public java.util.Optional<String> load(FsPath path)
                         throws CacheException, NoRouteToCellException, InterruptedException {

--- a/skel/share/defaults/webdav.properties
+++ b/skel/share/defaults/webdav.properties
@@ -763,6 +763,8 @@ webdav.allowed.client.origins =
 #
 (one-of?true|false)webdav.redirect.allow-https=true
 
+
+
 #  ---- Kafka service enabled
 #
 (one-of?true|false|${dcache.enable.kafka})webdav.enable.kafka = ${dcache.enable.kafka}
@@ -776,34 +778,3 @@ webdav.kafka.producer.bootstrap.servers =  ${dcache.kafka.bootstrap-servers}
 
 
 (prefix)webdav.kafka.producer.configs =  Configuration for Kafka Producer
-
-#  --- Default PROPFIND properties
-#
-#  The PROPFIND request allows a client to discover information
-#  (properties) of dCache content.  When making a PROPFIND request,
-#  the client normally indicates which properties are of interest.  If
-#  not specified then the WebDAV server (dCache) is free to return a
-#  default set of information.
-#
-#  Certain clients make PROPFIND requests without specifying
-#  the desired set of properties, triggering a default set of
-#  properties.  There are two problems with this: first, the
-#  clients may react badly if information is missing from this default;
-#  second, some of the required properties may have an adverse
-#  performance impact for dCache.
-#
-#  This property controls whether to support client-side requests for
-#  properties beyond a minimal set or not.
-#
-#      PERFORMANCE -- always return only a minimal set of information that does
-#                     not incur any additional overhead. (These are basically
-#                     the same as what a POSIX list request would proviode).
-#
-#      CLIENT_COMPATIBLE -- return the set of information required by
-#                     the clients.  If the client does not specify the properties,
-#                     it will get a maximal default set.
-#
-#  Because the performance impact of the latter under the most common usage scenarios
-#  could be considerable, the default is set to PERFORMANCE.
-#
-(one-of?PERFORMANCE|CLIENT_COMPATIBLE)webdav.default-propfind-properties = PERFORMANCE


### PR DESCRIPTION
…14088)

Motivation:

See `RT 10505: Problem with webdav PROPFIND request for dirs with symlinks` https://rt.dcache.org/Ticket/Display.html?id=10505

The problem may be more generalized than the discussion
suggests.   Since we cut off user requests when at the
`PERFORMANCE` setting, if the user wants locality, for
instance, it fails.

Modification:

We propose to commit #14082, #14086, and #14087 on top of the reverted base.  We will also add a modification to ignore quota requests when the default setting is `PERFORMANCE`.

Result:

reverts commit 3567dde692a2eef4bed63fd6ea5ea197c2f68ba4 https://rb.dcache.org/r/14088/
`dcache-webdav:  fix incorrect parameter value given to DcacheDirectoryResource constructor`

reverts commit 707000c026c6355c9bb0aae69dba7fd656825e24. https://rb.dcache.org/r/14085/
`dcache-webdav: improve efficiency of directory listing – revised` (metalink addition conflicts resolved)

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes:  absolutely
Patch:  https://rb.dcache.org/r/14101/
Acked-by: Dmitry