### PR TITLE
packages: fix system test populate sed expression

### DIFF
--- a/packages/system-test/src/main/bin/populate
+++ b/packages/system-test/src/main/bin/populate
@@ -18,6 +18,10 @@ lib="$(getProperty dcache.paths.share.lib)"
 
 cd @TARGET@/dcache
 
+extract_dn() {
+  openssl x509 -in $1 -noout -subject -nameopt compat | sed -E -e 's:subject= */?:/:;s:, :/:g;s: = :=:g'
+}
+
 build_ca() {
     local host_cert_hash old_dn ca_key ca_cert ca_index trust_store ca_serial
 
@@ -134,7 +138,8 @@ EOF
     host_cert_hash=$(openssl x509 -in $ca_cert -noout -subject_hash)
     cp "$ca_cert" "$trust_store/$host_cert_hash.0"
 
-    old_dn="$(openssl x509 -in $ca_cert -noout -subject -nameopt compat | sed 's:subject= *\+/\?:/:;s:, :/:g')"
+    old_dn=$(extract_dn "$ca_cert")
+
     cat > "$trust_store/$host_cert_hash.signing_policy" <<EOF
 access_id_CA    X509    '$old_dn'
 pos_rights      globus  CA:sign
@@ -278,7 +283,7 @@ add_dn_from_file() { # $1 - X.509 pem certificate
 	return
     fi
 
-    dn=$(openssl x509 -in "$1" -subject -noout -nameopt compat | sed 's:subject= *\+/\?:/:;s:, :/:g')
+    dn=$(extract_dn "$1")
 
     rc=0
     bin/dcache kpwd dcuserlist "$username" | grep -q "Authentication Record" || rc=$?


### PR DESCRIPTION
Motivation:

On MacOS, `system-tests` fail to build with this error:

```
[INFO] --- exec:3.1.0:exec (populate) @ system-test ---
sed: 1: "s:subject= *\+/\?:/:;s: ...": RE error: repetition-operator operand invalid
```

It would seem that MacOS `sed` does not recognize an escape before `+` as meaning a literal '+'.

```
alberts-mbp:certs arossi$ sed 's:subject= *\+/\?:/:;s:, :/:g'
sed: 1: "s:subject= *\+/\?:/:;s: ...": RE error: repetition-operator operand invalid
```

See:
https://unix.stackexchange.com/questions/229476/getting-re-error-repetition-operator-operand-invalid-on-osx-sed

Modification:

This expression occurs twice in the `populate` script. Changing to:
` sed -E -e 's:subject= */?:/:;s:, :/:g;s: = :=:g'` fixes it on MacOS.  Linux also seems to accept that syntax as well. This has been factored out into a function.

Result:

MacOS runs `system-test` again.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14100/
Acked-by: Paul
Acked-by: Dmitry