### PR TITLE
packages: fix system test populate sed expression

### DIFF
--- a/packages/system-test/src/main/bin/populate
+++ b/packages/system-test/src/main/bin/populate
@@ -108,7 +108,7 @@ dn() { # $1 - path to X.509 certificate
     #
     #     /C=DE/O=GermanGrid/OU=DESY/CN=Alexander Paul Millar
     #
-    openssl x509 -in "$1" -subject -noout -nameopt compat | sed 's:subject= *\+/\?:/:;s:, :/:g'
+    openssl x509 -in "$1" -subject -noout -nameopt compat | sed -E -e 's:subject= */?:/:;s:, :/:g;s: = :=:g'
 }
 
 if [ ! -f etc/dcache.kpwd ]; then


### PR DESCRIPTION
Motivation:

On MacOS, system-tests fail to build with this error:

[INFO] --- exec:3.1.0:exec (populate) @ system-test --- sed: 1: "s:subject= *\+/\?:/:;s: ...": RE error: repetition-operator operand invalid

It would seem that MacOS sed does not recognize an escape before + as meaning a literal '+'.

alberts-mbp:certs arossi$ sed 's:subject= *\+/\?:/:;s:, :/:g' sed: 1: "s:subject= *\+/\?:/:;s: ...": RE error: repetition-operator operand invalid

See:
https://unix.stackexchange.com/questions/229476/getting-re-error-repetition-operator-operand-invalid-on-osx-sed

Modification:

This expression occurs twice in the populate script. Changing to:
sed -E -e 's:subject= */?:/:;s:, :/:g;s: = :=:g' fixes it on MacOS.  Linux also seems to accept that syntax as well. This has been factored out into a function.

(Modification only partially applied to 8.2 where necessary).

Result:

MacOS runs system-test again.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14100/
Acked-by: Paul
Acked-by: Dmitry