### PR TITLE
Use Caffeine instead of Guava for caching.

### DIFF
--- a/modules/cells/pom.xml
+++ b/modules/cells/pom.xml
@@ -73,6 +73,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/modules/cells/src/main/java/dmg/cells/services/CoreRoutingManager.java
+++ b/modules/cells/src/main/java/dmg/cells/services/CoreRoutingManager.java
@@ -23,9 +23,7 @@ import static java.util.stream.Collectors.toMap;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -329,7 +327,7 @@ public class CoreRoutingManager
                           .map(CellDomainInfo::getCellDomainName)
                           .forEach(domain -> domains.put(domain, new ArrayList<>()));
                     queueRoutes.asMap().forEach(
-                          (domain, cells) -> domains.put(domain, Lists.newArrayList(cells)));
+                          (domain, cells) -> domains.put(domain, new ArrayList<>(cells)));
                 }
                 msg.revertDirection();
                 msg.setMessageObject(new GetAllDomainsReply(domains));
@@ -504,9 +502,9 @@ public class CoreRoutingManager
     public synchronized Object ac_ls_$_0(Args args) {
         return new Object[]{
               getCellDomainName(),
-              Sets.newHashSet(localConsumers.values()),
+              new HashSet<>(localConsumers.values()),
               queueRoutes.asMap().entrySet().stream().collect(
-                    toMap(Map.Entry::getKey, e -> Sets.newHashSet(e.getValue())))
+                    toMap(Map.Entry::getKey, e -> new HashSet<>(e.getValue())))
         };
     }
 }

--- a/modules/cells/src/main/java/dmg/cells/zookeeper/CellCuratorFramework.java
+++ b/modules/cells/src/main/java/dmg/cells/zookeeper/CellCuratorFramework.java
@@ -17,9 +17,9 @@
  */
 package dmg.cells.zookeeper;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import dmg.cells.nucleus.CDC;
 import java.util.Collection;
 import java.util.List;
@@ -115,9 +115,9 @@ public class CellCuratorFramework implements CuratorFramework {
     private final BoundedExecutor executor;
 
     private final LoadingCache<Watcher, Watcher> watchers =
-          CacheBuilder.newBuilder().build(new CacheLoader<Watcher, Watcher>() {
+          Caffeine.newBuilder().build(new CacheLoader<>() {
               @Override
-              public Watcher load(Watcher watcher) throws Exception {
+              public Watcher load(Watcher watcher) {
                   CDC cdc = new CDC();
                   return event -> executor.execute(() -> {
                       try (CDC ignore = cdc.restore()) {
@@ -128,9 +128,9 @@ public class CellCuratorFramework implements CuratorFramework {
           });
 
     private final LoadingCache<CuratorWatcher, CuratorWatcher> curatorWatchers =
-          CacheBuilder.newBuilder().build(new CacheLoader<CuratorWatcher, CuratorWatcher>() {
+          Caffeine.newBuilder().build(new CacheLoader<>() {
               @Override
-              public CuratorWatcher load(CuratorWatcher watcher) throws Exception {
+              public CuratorWatcher load(CuratorWatcher watcher) {
                   CDC cdc = new CDC();
                   return event -> executor.execute(() -> {
                       try (CDC ignore = cdc.restore()) {
@@ -175,11 +175,11 @@ public class CellCuratorFramework implements CuratorFramework {
     }
 
     protected Watcher wrap(Watcher watcher) {
-        return watchers.getUnchecked(watcher);
+        return watchers.get(watcher);
     }
 
     protected CuratorWatcher wrap(CuratorWatcher watcher) {
-        return curatorWatchers.getUnchecked(watcher);
+        return curatorWatchers.get(watcher);
     }
 
     @Override

--- a/modules/chimera/pom.xml
+++ b/modules/chimera/pom.xml
@@ -27,6 +27,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -23,6 +23,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
     </dependency>

--- a/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpInterpreterFactory.java
+++ b/modules/dcache-ftp/src/main/java/org/dcache/ftp/door/FtpInterpreterFactory.java
@@ -17,7 +17,7 @@
  */
 package org.dcache.ftp.door;
 
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import diskCacheV111.doors.LineBasedInterpreter;
 import diskCacheV111.doors.NettyLineBasedInterpreterFactory;
 import diskCacheV111.services.space.Space;

--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/DoorOperationFactory.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/DoorOperationFactory.java
@@ -20,13 +20,14 @@ package org.dcache.chimera.nfsv41.door;
 import static com.google.common.base.Throwables.getRootCause;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.io.IOException;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -110,7 +111,7 @@ public class DoorOperationFactory extends MDSOperationExecutor {
         _proxyIoFactory = proxyIoFactory;
         _vfs = fs;
         _jdbcFs = jdbcFs;
-        _pathCache = CacheBuilder.newBuilder()
+        _pathCache = Caffeine.newBuilder()
               .maximumSize(512)
               .expireAfterWrite(30, TimeUnit.SECONDS)
               .softValues()
@@ -137,7 +138,7 @@ public class DoorOperationFactory extends MDSOperationExecutor {
                 _inode2path = i -> {
                     try {
                         return _pathCache.get(i);
-                    } catch (ExecutionException e) {
+                    } catch (CompletionException e) {
                         Throwable t = getRootCause(e);
                         LOG.error("Failed to get inode path {} : {}", i, t.getMessage());
                         return "inode:" + i;
@@ -157,19 +158,14 @@ public class DoorOperationFactory extends MDSOperationExecutor {
         }
 
         if (subjectMapper.isPresent()) {
-            CacheLoader<Principal, Subject> loader = new CacheLoader<Principal, Subject>() {
-                @Override
-                public Subject load(Principal key) throws Exception {
-                    Subject in = new Subject();
-                    in.getPrincipals().add(key);
-                    return subjectMapper.get().login(in);
-                }
-            };
-
-            _subjectCache = Optional.of(CacheBuilder.newBuilder()
+            _subjectCache = Optional.of(Caffeine.newBuilder()
                   .maximumSize(2048)
                   .expireAfterWrite(10, TimeUnit.MINUTES)
-                  .build(loader));
+                  .build(key -> {
+                      Subject in = new Subject();
+                      in.getPrincipals().add(key);
+                      return subjectMapper.get().login(in);
+                  }));
         } else {
             _subjectCache = Optional.empty();
         }
@@ -223,7 +219,7 @@ public class DoorOperationFactory extends MDSOperationExecutor {
                                       if (gids.length >= 16) {
                                           long uid = UnixSubjects.getUid(subject);
                                           UidPrincipal uidPrincipal = new UidPrincipal(uid);
-                                          subject = _subjectCache.get().getUnchecked(uidPrincipal);
+                                          subject = _subjectCache.get().get(uidPrincipal);
                                           context.getSubject().getPrincipals()
                                                 .addAll(subject.getPrincipals());
                                       }
@@ -459,7 +455,7 @@ public class DoorOperationFactory extends MDSOperationExecutor {
         }
     }
 
-    private class ParentPathLoader extends CacheLoader<FsInode, String> {
+    private class ParentPathLoader implements CacheLoader<FsInode, String> {
 
         @Override
         public String load(FsInode inode) throws Exception {

--- a/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
+++ b/modules/dcache-srm/src/main/java/diskCacheV111/srm/dcache/Storage.java
@@ -81,14 +81,13 @@ import static org.dcache.namespace.FileAttribute.TYPE;
 import static org.dcache.srm.SRMInvalidPathException.checkValidPath;
 import static org.dcache.util.NetworkUtils.isInetAddress;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
@@ -161,9 +160,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
@@ -201,7 +199,6 @@ import org.dcache.srm.AbstractStorageElement;
 import org.dcache.srm.CopyCallbacks;
 import org.dcache.srm.FileMetaData;
 import org.dcache.srm.RemoveFileCallback;
-import org.dcache.srm.SRMAbortedException;
 import org.dcache.srm.SRMAuthorizationException;
 import org.dcache.srm.SRMDuplicationException;
 import org.dcache.srm.SRMExceedAllocationException;
@@ -256,7 +253,7 @@ public final class Storage
     private static final Set<String> FTP_URL_SCHEMATA = Set.of("ftp", "gsiftp", "gkftp");
 
     private static final LoadingCache<InetAddress, String> GET_HOST_BY_ADDR_CACHE =
-          CacheBuilder.newBuilder()
+          Caffeine.newBuilder()
                 .expireAfterWrite(10, MINUTES)
                 .recordStats()
                 .build(new GetHostByAddressCacheLoader());
@@ -940,7 +937,7 @@ public final class Storage
                 resolvedHost = GET_HOST_BY_ADDR_CACHE.get(address);
             }
             return resolvedHost;
-        } catch (ExecutionException e) {
+        } catch (CompletionException e) {
             Throwable cause = e.getCause();
             throw new SRMInternalErrorException("Failed to resolve door: " + cause, cause);
         }
@@ -1032,7 +1029,7 @@ public final class Storage
                               "Space associated with the space token " + spaceToken
                                     + " is not enough to hold SURL."));
                     }
-                } catch (ExecutionException e) {
+                } catch (CompletionException e) {
                     return immediateFailedFuture(new SRMException(
                           "Failure while querying space reservation: " + e.getCause()
                                 .getMessage()));
@@ -2231,7 +2228,7 @@ public final class Storage
                 _log.trace("srmGetSpaceTokens returns: {}", Arrays.toString(tokens));
             }
             return Arrays.stream(tokens).mapToObj(Long::toString).toArray(String[]::new);
-        } catch (ExecutionException e) {
+        } catch (CompletionException e) {
             Throwable cause = e.getCause();
             Throwables.throwIfInstanceOf(cause, SRMException.class);
             Throwables.throwIfUnchecked(cause);
@@ -2340,7 +2337,7 @@ public final class Storage
         return dcacheUser;
     }
 
-    private static class GetHostByAddressCacheLoader extends CacheLoader<InetAddress, String> {
+    private static class GetHostByAddressCacheLoader implements CacheLoader<InetAddress, String> {
 
         @Override
         public String load(InetAddress address) throws Exception {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -27,11 +27,11 @@ import static org.dcache.util.ByteUnit.KiB;
 import static org.dcache.util.TransferRetryPolicy.tryOnce;
 import static org.dcache.webdav.InsufficientStorageException.checkStorageSufficient;
 
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -106,6 +106,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -1614,7 +1615,7 @@ public class DcacheResourceFactory
     private Optional<Space> lookupSpaceById(String id) {
         try {
             return _spaceLookupCache.get(id);
-        } catch (ExecutionException e) {
+        } catch (CompletionException e) {
             Throwable t = e.getCause();
             Throwables.throwIfUnchecked(t);
             LOGGER.warn("Failed to fetch space statistics for {}: {}", id, t.toString());
@@ -1625,7 +1626,7 @@ public class DcacheResourceFactory
     private Optional<String> lookupWriteToken(FsPath path) {
         try {
             return _writeTokenCache.get(path);
-        } catch (ExecutionException e) {
+        } catch (CompletionException e) {
             Throwable t = e.getCause();
             Throwables.throwIfUnchecked(t);
             LOGGER.warn("Failed to query for WriteToken tag on {}: {}", path, t.toString());

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CredentialServiceClient.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CredentialServiceClient.java
@@ -20,8 +20,8 @@ package org.dcache.webdav.transfer;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableMap;
 import diskCacheV111.srm.CredentialServiceAnnouncement;
 import diskCacheV111.srm.CredentialServiceRequest;
@@ -86,7 +86,7 @@ public class CredentialServiceClient
 
     private CellStub topic;
 
-    private Cache<CellAddressCore, URI> cache = CacheBuilder.newBuilder()
+    private Cache<CellAddressCore, URI> cache = Caffeine.newBuilder()
           .expireAfterWrite(70, SECONDS).build();
 
     @Required

--- a/modules/dcache/pom.xml
+++ b/modules/dcache/pom.xml
@@ -46,6 +46,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.dcache</groupId>

--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoor.java
@@ -22,7 +22,7 @@ package diskCacheV111.doors;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.dcache.util.ByteUnit.KiB;
 
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.net.InetAddresses;
 import diskCacheV111.services.space.Space;
 import dmg.cells.nucleus.CDC;

--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoorFactory.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedDoorFactory.java
@@ -19,7 +19,7 @@
 
 package diskCacheV111.doors;
 
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import diskCacheV111.services.space.Space;
@@ -138,8 +138,8 @@ public class NettyLineBasedDoorFactory extends AbstractService implements LoginC
 
         CellStub spaceManager = new CellStub(parentEndpoint, spaceManagerPath, 30_000);
         spaceDescriptionCache = ReservationCaches.buildOwnerDescriptionLookupCache(spaceManager,
-              executor);
-        spaceLookupCache = ReservationCaches.buildSpaceLookupCache(spaceManager, executor);
+              executor).synchronous();
+        spaceLookupCache = ReservationCaches.buildSpaceLookupCache(spaceManager, executor).synchronous();
 
         LoginStrategy loginStrategy = new RemoteLoginStrategy(
               new CellStub(parentEndpoint, gPlazma, 30_000));

--- a/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedInterpreterFactory.java
+++ b/modules/dcache/src/main/java/diskCacheV111/doors/NettyLineBasedInterpreterFactory.java
@@ -18,7 +18,7 @@
  */
 package diskCacheV111.doors;
 
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import diskCacheV111.services.space.Space;
 import diskCacheV111.util.ConfigurationException;
 import dmg.cells.nucleus.CellAddressCore;

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -10,13 +10,13 @@ import static org.dcache.namespace.FileAttribute.CACHECLASS;
 import static org.dcache.namespace.FileAttribute.HSM;
 import static org.dcache.namespace.FileAttribute.STORAGECLASS;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -97,7 +97,7 @@ public class PoolSelectionUnitV2
     private final Map<String, UGroup> _uGroups = new HashMap<>();
     private final Map<String, Unit> _units = new HashMap<>();
     private final Cache<String, PoolPreferenceLevel[]> cachedMatchValue =
-          CacheBuilder.newBuilder()
+          Caffeine.newBuilder()
                 .maximumSize(100000)
                 .build();
     private boolean _useRegex;

--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/RestoreRequestsReceiver.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/RestoreRequestsReceiver.java
@@ -59,10 +59,11 @@ documents or software obtained from this server.
  */
 package diskCacheV111.poolManager;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import diskCacheV111.vehicles.RestoreHandlerInfo;
 import dmg.cells.nucleus.CellMessageReceiver;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -81,7 +82,7 @@ public class RestoreRequestsReceiver implements CellMessageReceiver {
     private TimeUnit lifetimeUnit = TimeUnit.HOURS;
 
     public void initialize() {
-        restores = CacheBuilder.newBuilder()
+        restores = Caffeine.newBuilder()
               .expireAfterWrite(lifetime, lifetimeUnit)
               .build();
     }
@@ -92,7 +93,7 @@ public class RestoreRequestsReceiver implements CellMessageReceiver {
     public List<RestoreHandlerInfo> getAllRequests() {
         return restores.asMap().values()
               .stream()
-              .flatMap(list -> list.stream())
+              .flatMap(Collection::stream)
               .collect(Collectors.toList());
     }
 

--- a/modules/dcache/src/main/java/org/dcache/services/login/IdentityResolverFactory.java
+++ b/modules/dcache/src/main/java/org/dcache/services/login/IdentityResolverFactory.java
@@ -20,15 +20,15 @@ package org.dcache.services.login;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.Throwables;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import diskCacheV111.util.CacheException;
 import java.security.Principal;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import javax.security.auth.Subject;
 import org.dcache.auth.GidPrincipal;
@@ -54,10 +54,10 @@ public class IdentityResolverFactory {
 
     private final LoginStrategy loginStrategy;
 
-    private final LoadingCache<Long, Optional<String>> uidToName = CacheBuilder.newBuilder()
+    private final LoadingCache<Long, Optional<String>> uidToName = Caffeine.newBuilder()
           .maximumSize(1000)
           .expireAfterWrite(1, TimeUnit.MINUTES)
-          .build(new CacheLoader<Long, Optional<String>>() {
+          .build(new CacheLoader<>() {
               @Override
               public Optional<String> load(Long uid) throws CacheException {
                   for (Principal p : loginStrategy.reverseMap(new UidPrincipal(uid))) {
@@ -69,10 +69,10 @@ public class IdentityResolverFactory {
               }
           });
 
-    private final LoadingCache<Long, Optional<String>> gidToName = CacheBuilder.newBuilder()
+    private final LoadingCache<Long, Optional<String>> gidToName = Caffeine.newBuilder()
           .maximumSize(1000)
           .expireAfterWrite(1, TimeUnit.MINUTES)
-          .build(new CacheLoader<Long, Optional<String>>() {
+          .build(new CacheLoader<>() {
               @Override
               public Optional<String> load(Long gid) throws CacheException {
                   for (Principal p : loginStrategy.reverseMap(new GidPrincipal(gid, false))) {
@@ -195,7 +195,7 @@ public class IdentityResolverFactory {
             if (!name.isPresent()) {
                 try {
                     name = uidToName.get(uid);
-                } catch (ExecutionException e) {
+                } catch (CompletionException e) {
                     Throwable t = e.getCause();
                     Throwables.throwIfUnchecked(t);
                     LOGGER.warn("Failed to obtain username for uid {}: {}", uid,
@@ -215,7 +215,7 @@ public class IdentityResolverFactory {
             if (!name.isPresent()) {
                 try {
                     name = gidToName.get(gid);
-                } catch (ExecutionException e) {
+                } catch (CompletionException e) {
                     Throwable t = e.getCause();
                     Throwables.throwIfUnchecked(t);
                     LOGGER.warn("Failed to obtain groupname for gid {}: {}", gid,

--- a/modules/dcache/src/main/java/org/dcache/space/ReservationCaches.java
+++ b/modules/dcache/src/main/java/org/dcache/space/ReservationCaches.java
@@ -69,11 +69,9 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
+import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import diskCacheV111.services.space.Space;
 import diskCacheV111.services.space.message.GetSpaceMetaData;
 import diskCacheV111.services.space.message.GetSpaceTokens;
@@ -89,6 +87,7 @@ import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import javax.security.auth.Subject;
 import org.dcache.cells.AbstractMessageCallback;
@@ -151,18 +150,24 @@ public class ReservationCaches {
     /**
      * Builds a loading cache for looking up space tokens by owner and description.
      */
-    public static LoadingCache<GetSpaceTokensKey, long[]> buildOwnerDescriptionLookupCache(
+    public static AsyncLoadingCache<GetSpaceTokensKey, long[]> buildOwnerDescriptionLookupCache(
           CellStub spaceManager, Executor executor) {
-        return CacheBuilder.newBuilder()
-              .maximumSize(1000)
-              .expireAfterWrite(30, SECONDS)
-              .refreshAfterWrite(10, SECONDS)
-              .recordStats()
-              .build(new CacheLoader<GetSpaceTokensKey, long[]>() {
+        return Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(30, SECONDS)
+              .refreshAfterWrite(10, SECONDS).recordStats().executor(executor)
+              .buildAsync(new AsyncCacheLoader<>() {
+                  private GetSpaceTokens createRequest(GetSpaceTokensKey key) {
+                      GetSpaceTokens message = new GetSpaceTokens(key.description);
+                      message.setSubject(new Subject(true, key.principals, Collections.emptySet(),
+                            Collections.emptySet()));
+                      return message;
+                  }
+
                   @Override
-                  public long[] load(GetSpaceTokensKey key) throws Exception {
+                  public CompletableFuture<long[]> asyncLoad(GetSpaceTokensKey key,
+                        Executor executor) throws Exception {
                       try {
-                          return spaceManager.sendAndWait(createRequest(key)).getSpaceTokens();
+                          return CompletableFuture.completedFuture(
+                                spaceManager.sendAndWait(createRequest(key)).getSpaceTokens());
                       } catch (TimeoutCacheException e) {
                           throw new SRMInternalErrorException("Space manager timeout", e);
                       } catch (InterruptedException e) {
@@ -170,35 +175,30 @@ public class ReservationCaches {
                       } catch (CacheException e) {
                           LOGGER.warn("GetSpaceTokens failed with rc={} error={}", e.getRc(),
                                 e.getMessage());
-                          throw new SRMException("GetSpaceTokens failed with rc=" + e.getRc() +
-                                " error=" + e.getMessage(), e);
+                          throw new SRMException(
+                                "GetSpaceTokens failed with rc=" + e.getRc() + " error="
+                                      + e.getMessage(), e);
                       }
                   }
 
-                  private GetSpaceTokens createRequest(GetSpaceTokensKey key) {
-                      GetSpaceTokens message = new GetSpaceTokens(key.description);
-                      message.setSubject(new Subject(true, key.principals,
-                            Collections.emptySet(), Collections.emptySet()));
-                      return message;
-                  }
-
                   @Override
-                  public ListenableFuture<long[]> reload(GetSpaceTokensKey key, long[] oldValue)
-                        throws Exception {
-                      final SettableFuture<long[]> future = SettableFuture.create();
-                      CellStub.addCallback(
-                            spaceManager.send(createRequest(key)),
-                            new AbstractMessageCallback<GetSpaceTokens>() {
+                  public CompletableFuture<long[]> asyncReload(GetSpaceTokensKey key,
+                        long[] oldValue, Executor executor) {
+                      // A future we are going to complete in the Cell Callback.
+                      final CompletableFuture<long[]> future = new CompletableFuture<>();
+
+                      CellStub.addCallback(spaceManager.send(createRequest(key)),
+                            new AbstractMessageCallback<>() {
                                 @Override
                                 public void success(GetSpaceTokens message) {
-                                    future.set(message.getSpaceTokens());
+                                    future.complete(message.getSpaceTokens());
                                 }
 
                                 @Override
                                 public void failure(int rc, Object error) {
-                                    CacheException exception = CacheExceptionFactory.exceptionOf(
-                                          rc, Objects.toString(error, null));
-                                    future.setException(exception);
+                                    CacheException exception = CacheExceptionFactory.exceptionOf(rc,
+                                          Objects.toString(error, null));
+                                    future.completeExceptionally(exception);
                                 }
                             }, executor);
                       return future;
@@ -209,89 +209,99 @@ public class ReservationCaches {
     /**
      * Build a loading cache for looking up space reservations by space token.
      */
-    public static LoadingCache<String, Optional<Space>> buildSpaceLookupCache(CellStub spaceManager,
+    public static AsyncLoadingCache<String, Optional<Space>> buildSpaceLookupCache(
+          CellStub spaceManager,
           Executor executor) {
-        return CacheBuilder.newBuilder()
+        return Caffeine.newBuilder()
               .maximumSize(1000)
               .expireAfterWrite(10, MINUTES)
               .refreshAfterWrite(30, SECONDS)
               .recordStats()
-              .build(
-                    new CacheLoader<String, Optional<Space>>() {
-                        @Override
-                        public Optional<Space> load(String token)
-                              throws CacheException, NoRouteToCellException, InterruptedException {
-                            Space space =
-                                  spaceManager.sendAndWait(new GetSpaceMetaData(token))
-                                        .getSpaces()[0];
-                            return Optional.ofNullable(space);
-                        }
-
-                        @Override
-                        public ListenableFuture<Optional<Space>> reload(String token,
-                              Optional<Space> oldValue) {
-                            final SettableFuture<Optional<Space>> future = SettableFuture.create();
-                            CellStub.addCallback(
-                                  spaceManager.send(new GetSpaceMetaData(token)),
-                                  new AbstractMessageCallback<GetSpaceMetaData>() {
-                                      @Override
-                                      public void success(GetSpaceMetaData message) {
-                                          future.set(Optional.ofNullable(message.getSpaces()[0]));
-                                      }
-
-                                      @Override
-                                      public void failure(int rc, Object error) {
-                                          CacheException exception = CacheExceptionFactory.exceptionOf(
-                                                rc, Objects.toString(error, null));
-                                          future.setException(exception);
-                                      }
-                                  }, executor);
-                            return future;
-                        }
-                    });
-    }
-
-    /**
-     * Cache queries to discover if a directory has the "WriteToken" tag set.
-     */
-    public static LoadingCache<FsPath, java.util.Optional<String>> buildWriteTokenLookupCache(
-          PnfsHandler pnfs, Executor executor) {
-        return CacheBuilder.newBuilder()
-              .maximumSize(1000)
-              .expireAfterWrite(10, MINUTES)
-              .refreshAfterWrite(5, MINUTES)
-              .recordStats()
-              .build(new CacheLoader<FsPath, java.util.Optional<String>>() {
-                  private java.util.Optional<String> writeToken(FileAttributes attr) {
-                      StorageInfo info = attr.getStorageInfo();
-                      return java.util.Optional.ofNullable(info.getMap().get("writeToken"));
-                  }
-
+              .executor(executor)
+              .buildAsync(new AsyncCacheLoader<>() {
                   @Override
-                  public java.util.Optional<String> load(FsPath path)
+                  public CompletableFuture<Optional<Space>> asyncLoad(String token,
+                        Executor executor)
                         throws CacheException, NoRouteToCellException, InterruptedException {
-                      return writeToken(
-                            pnfs.getFileAttributes(path, EnumSet.of(FileAttribute.STORAGEINFO)));
+
+                      Space space = spaceManager.sendAndWait(new GetSpaceMetaData(token))
+                            .getSpaces()[0];
+
+                      return CompletableFuture.completedFuture(Optional.ofNullable(space));
                   }
 
                   @Override
-                  public ListenableFuture<java.util.Optional<String>> reload(FsPath path,
-                        java.util.Optional<String> old) {
-                      PnfsGetFileAttributes message = new PnfsGetFileAttributes(path.toString(),
-                            EnumSet.of(FileAttribute.STORAGEINFO));
-                      SettableFuture<java.util.Optional<String>> future = SettableFuture.create();
-                      CellStub.addCallback(pnfs.requestAsync(message),
-                            new AbstractMessageCallback<PnfsGetFileAttributes>() {
+                  public CompletableFuture<Optional<Space>> asyncReload(String token,
+                        Optional<Space> oldValue, Executor executor) {
+                      // A future we are going to complete in the Cell Callback.
+                      final CompletableFuture<Optional<Space>> future = new CompletableFuture<>();
+
+                      CellStub.addCallback(
+                            spaceManager.send(new GetSpaceMetaData(token)),
+                            new AbstractMessageCallback<>() {
                                 @Override
-                                public void success(PnfsGetFileAttributes message) {
-                                    future.set(writeToken(message.getFileAttributes()));
+                                public void success(GetSpaceMetaData message) {
+                                    future.complete(Optional.ofNullable(message.getSpaces()[0]));
                                 }
 
                                 @Override
                                 public void failure(int rc, Object error) {
                                     CacheException exception = CacheExceptionFactory.exceptionOf(
                                           rc, Objects.toString(error, null));
-                                    future.setException(exception);
+                                    future.completeExceptionally(exception);
+                                }
+                            }, executor);
+                      return future;
+                  }
+              });
+    }
+
+    /**
+     * Cache queries to discover if a directory has the "WriteToken" tag set.
+     */
+    public static AsyncLoadingCache<FsPath, Optional<String>> buildWriteTokenLookupCache(
+          PnfsHandler pnfs, Executor executor) {
+        return Caffeine.newBuilder()
+              .maximumSize(1000)
+              .expireAfterWrite(10, MINUTES)
+              .refreshAfterWrite(5, MINUTES)
+              .recordStats()
+              .executor(executor)
+              .buildAsync(new AsyncCacheLoader<>() {
+                  private Optional<String> writeToken(FileAttributes attr) {
+                      StorageInfo info = attr.getStorageInfo();
+                      return Optional.ofNullable(info.getMap().get("writeToken"));
+                  }
+
+                  @Override
+                  public CompletableFuture<Optional<String>> asyncLoad(FsPath path,
+                        Executor executor)
+                        throws CacheException {
+                      return CompletableFuture.completedFuture(writeToken(
+                            pnfs.getFileAttributes(path, EnumSet.of(FileAttribute.STORAGEINFO))));
+                  }
+
+                  @Override
+                  public CompletableFuture<Optional<String>> asyncReload(FsPath path,
+                        Optional<String> old, Executor executor) {
+                      // A future we are going to complete in the Cell Callback.
+                      final CompletableFuture<Optional<String>> future = new CompletableFuture<>();
+
+                      PnfsGetFileAttributes message = new PnfsGetFileAttributes(path.toString(),
+                            EnumSet.of(FileAttribute.STORAGEINFO));
+
+                      CellStub.addCallback(pnfs.requestAsync(message),
+                            new AbstractMessageCallback<>() {
+                                @Override
+                                public void success(PnfsGetFileAttributes message) {
+                                    future.complete(writeToken(message.getFileAttributes()));
+                                }
+
+                                @Override
+                                public void failure(int rc, Object error) {
+                                    CacheException exception = CacheExceptionFactory.exceptionOf(
+                                          rc, Objects.toString(error, null));
+                                    future.completeExceptionally(exception);
                                 }
                             }, executor);
                       return future;

--- a/modules/srm-server/src/main/java/org/dcache/gridsite/InMemoryCredentialDelegationStore.java
+++ b/modules/srm-server/src/main/java/org/dcache/gridsite/InMemoryCredentialDelegationStore.java
@@ -20,9 +20,9 @@ package org.dcache.gridsite;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.dcache.gridsite.Utilities.assertThat;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.RemovalListener;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalListener;
 import org.dcache.delegation.gridsite2.DelegationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,16 +48,15 @@ public class InMemoryCredentialDelegationStore implements
           InMemoryCredentialDelegationStore.class);
 
     private final RemovalListener<DelegationIdentity, CredentialDelegation>
-          LOG_REMOVALS = notification -> {
-        DelegationIdentity identity = notification.getKey();
-        switch (notification.getCause()) {
+          LOG_REMOVALS = (key, value, cause) -> {
+        switch (cause) {
             case EXPIRED:
                 LOGGER.debug("removing delegation from {}: client took" +
-                      " too long to reply", identity.getDn());
+                      " too long to reply", key.getDn());
                 break;
             case SIZE:
                 LOGGER.debug("removing delegation from {}: too many" +
-                      " on-going delegations", identity.getDn());
+                      " on-going delegations", key.getDn());
                 break;
         }
     };
@@ -86,7 +85,7 @@ public class InMemoryCredentialDelegationStore implements
 
 
     public void start() {
-        _storage = CacheBuilder.newBuilder().
+        _storage = Caffeine.newBuilder().
               maximumSize(_maxOngoing).
               expireAfterWrite(_expireAfter, MILLISECONDS).
               removalListener(LOG_REMOVALS).

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,12 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.0.0-jre</version>
+                <version>32.1.2-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>3.1.8</version>
             </dependency>
             <dependency>
                 <groupId>eu.eu-emi.security</groupId>

--- a/skel/bin/chimera
+++ b/skel/bin/chimera
@@ -6,7 +6,7 @@ lib="$(getProperty dcache.paths.share.lib)"
 . ${lib}/utils.sh
 
 classpath=$(printLimitedClassPath dcache-vehicles dcache-chimera chimera HikariCP javassist \
-    guava jline common-cli dcache-common acl-vehicles acl \
+    guava caffeine jline common-cli dcache-common acl-vehicles acl \
     slf4j-api logback-classic logback-core logback-console-config jcl-over-slf4j \
     spring-core spring-beans spring-jdbc spring-tx \
     postgresql h2 hsqldb curator-recipes)


### PR DESCRIPTION
Motivation:
Work towards #4087 

Modification:
Replace's Guava's caching with Caffeine. Caffeine is the google-supported alternative to guava's caches, that importantly uses CompletableFutures instead of ListenableFutures. Guava does not plan to ever add this support and only does bug-fixes for Guava's caches.

It's important to remember, that the 'async' terminology used in Guava/Caffeine varies from the JDK's 'async' terminology. As such some issues may arise during translation from one library to the other. But for most cases, one will see that the translation is very straight-forward. 

I recommend this for the release after 9.2.

Result:
Replaces all uses of Guava's cache with Caffeine's cache and #4087 is now feasible without having to wrap ListenableFutures in CompletableFutures. With these commits It's possible to completely remove any import on ListenableFuture, this is however not done yet in this commit.

Signed-off-by: Lukas Mansour [lukas.mansour@desy.de](mailto:lukas.mansour@desy.de)