### PR TITLE
dcache-bulk:  guard against erroneous argument names

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinActivity.java
@@ -134,11 +134,17 @@ public final class PinActivity extends PinManagerActivity {
             String expire = arguments.get(LIFETIME.getName());
             String unit = arguments.get(LIFETIME_UNIT.getName());
 
-            Long value = (long) (Double.parseDouble(expire));
-
-            lifetimeInMillis = expire == null ? defaultUnit.toMillis(defaultValue)
-                  : unit == null ? defaultUnit.toMillis(value)
-                        : TimeUnit.valueOf(unit).toMillis(value);
+            /*
+             * Guard against erroneous argument names ...
+             */
+            if (expire == null) {
+                lifetimeInMillis = unit == null ? defaultUnit.toMillis(defaultValue):
+                      TimeUnit.valueOf(unit).toMillis(defaultValue);
+            } else {
+                Long value = (long) (Double.parseDouble(expire));
+                lifetimeInMillis = unit == null ? defaultUnit.toMillis(value)
+                            : TimeUnit.valueOf(unit).toMillis(value);
+            }
         }
 
         id = arguments == null ? null : arguments.get(PIN_REQUEST_ID.getName());


### PR DESCRIPTION
Motivation:

Giving the `PIN` activity an argument it does
not recognize will provoke an NPE, e.g.,

```
20 Sep 2023 11:28:10 [pool-11-thread-1] [] Uncaught exception in thread pool-11-thread-1java.lang.NullPointerException: null
	at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1838)
	at java.base/jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
	at java.base/java.lang.Double.parseDouble(Double.java:543)
	at org.dcache.services.bulk.activity.plugin.pin.PinActivity.configure(PinActivity.java:138)
...
```

Modification:

Check for undefined lifetime property.

Result:

No more NPE/stack trace.

Target: master
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14108/
Acked-by: Lea