### PR TITLE
dcache-cli:  convert IllegalArgumentException to CommandException on …

### DIFF
--- a/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
+++ b/modules/common-cli/src/main/java/org/dcache/util/cli/AnnotatedCommandExecutor.java
@@ -123,15 +123,12 @@ public class AnnotatedCommandExecutor implements CommandExecutor {
             for (Handler handler : _handlers) {
                 handler.apply(command, arguments);
             }
+            return command.call();
         } catch (IllegalAccessException e) {
             throw new RuntimeException("This is a bug. Please notify " +
                   "support@dcache.org", e);
         } catch (IllegalArgumentException e) {
             throw new CommandSyntaxException(e.getMessage());
-        }
-
-        try {
-            return command.call();
         } catch (CommandException e) {
             throw e;
         } catch (RuntimeException e) {


### PR DESCRIPTION
…call()

Motivation:

See `admin shell: stop reporting command syntax errors as bugs/stack traces` https://github.com/dCache/dcache/issues/7271

Modification:

Consolidate the try-catch blocks.  This allows
catching IllegalArgumentException for both `handler.apply` and `call`.

Result:

No more false stack trace/bug output.

Note: this fix is a palliative.  There is
a potential for it to mask actual bugs deeper
in the code.  But since this is only
in the context of admin command execution,
the problem is minor.  Another GH
issue (#7361) been opened to see how
the more fundamental problem might be
addressed.

Target: master
Request: 9.2
Request: 9.1
Request: 9.0
Request: 8.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14103
Closes: #7271
Acked-by: Tigran