### PR TITLE
dcache-bulk: implement HA

### DIFF
--- a/docs/TheBook/src/main/markdown/cookbook-ha-with-replicable-services.md
+++ b/docs/TheBook/src/main/markdown/cookbook-ha-with-replicable-services.md
@@ -256,3 +256,19 @@ information. Requests will be load balanced over available instances of `topo`.
 This service collects nightly statistics about available pools. One can have
 multiple instances of `statistics` and each instance will collect the same
 information.
+
+### `bulk`
+
+This service processes bulk requests for pinning/unpinning, staging/releasing,
+file deletion and qos updating or manipulation.  It does not directly affect
+transfers, but is perhaps more critical than the other services in this group
+because it supports the `REST` API.
+
+Bulk is fully replicable. All instances *_must_* share the same database instance.
+The configuration should be synchronized such that all instances are configured
+the same way.
+
+Request querying is load-balanced over the physical instances, but only the
+leader instance is responsible for submission, cancelling or clearing requests,
+and only the leader actually processes them (i.e., runs the request container
+servicing the request).

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/BulkActivityFactory.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/BulkActivityFactory.java
@@ -115,6 +115,8 @@ public final class BulkActivityFactory implements CellMessageSender, Environment
     private QoSResponseReceiver qoSResponseReceiver;
     private CellEndpoint endpoint;
 
+    private boolean initialized;
+
     /**
      * Generates an instance of the plugin-specific activity to be used by the request jobs.
      *
@@ -157,13 +159,16 @@ public final class BulkActivityFactory implements CellMessageSender, Environment
     }
 
     public void initialize() {
-        ServiceLoader<BulkActivityProvider> serviceLoader
-              = ServiceLoader.load(BulkActivityProvider.class);
-        for (BulkActivityProvider provider : serviceLoader) {
-            String activity = provider.getActivity();
-            provider.setMaxPermits(maxPermits.get(activity));
-            provider.configure(environment);
-            providers.put(provider.getActivity(), provider);
+        if (!initialized) {
+            ServiceLoader<BulkActivityProvider> serviceLoader
+                  = ServiceLoader.load(BulkActivityProvider.class);
+            for (BulkActivityProvider provider : serviceLoader) {
+                String activity = provider.getActivity();
+                provider.setMaxPermits(maxPermits.get(activity));
+                provider.configure(environment);
+                providers.put(provider.getActivity(), provider);
+            }
+            initialized = true;
         }
     }
 

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/BulkRequestManager.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/BulkRequestManager.java
@@ -90,6 +90,11 @@ public interface BulkRequestManager extends SignalAware {
     void cancelTargets(String id, List<String> targetPaths);
 
     /**
+     * Should wipe out any in-memory request state.
+     */
+    void shutdown() throws Exception;
+
+    /**
      * Implementation-specific.
      */
     void initialize() throws Exception;

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkRequestStore.java
@@ -254,6 +254,11 @@ public interface BulkRequestStore {
     boolean isRequestSubject(Subject subject, String uid) throws BulkStorageException;
 
     /**
+     * Clear all entries from memory. (May be a NOP).
+     */
+    void clearCache() throws BulkStorageException;
+
+    /**
      * Load the store into memory. (May be a NOP).
      */
     void load() throws BulkStorageException;

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
@@ -114,7 +114,6 @@ import org.dcache.services.bulk.BulkRequestSummary;
 import org.dcache.services.bulk.BulkRequestTargetInfo;
 import org.dcache.services.bulk.BulkStorageException;
 import org.dcache.services.bulk.store.BulkRequestStore;
-import org.dcache.services.bulk.store.jdbc.JdbcBulkDaoUtils;
 import org.dcache.services.bulk.store.jdbc.rtarget.JdbcBulkTargetStore;
 import org.dcache.services.bulk.store.jdbc.rtarget.JdbcRequestTargetDao;
 import org.dcache.services.bulk.util.BulkRequestFilter;
@@ -160,7 +159,6 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
     private JdbcBulkRequestPermissionsDao requestPermissionsDao;
     private JdbcBulkTargetStore targetStore;
     private JdbcRequestTargetDao requestTargetDao;
-    private JdbcBulkDaoUtils utils;
     private long expiry;
     private TimeUnit expiryUnit;
     private long capacity;
@@ -473,6 +471,11 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
                     .equals(BulkRequestStore.uidGidKey(requestSubject.get()));
     }
 
+    @Override
+    public void clearCache() throws BulkStorageException {
+        requestCache.invalidateAll();
+    }
+
     /**
      * With the RDBMS implementation of the store, the following applies on restart:
      * <p>
@@ -550,11 +553,6 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
     @Required
     public void setArchiveDao(JdbcBulkArchiveDao archiveDao) {
         this.archiveDao = archiveDao;
-    }
-
-    @Required
-    public void setBulkUtils(JdbcBulkDaoUtils utils) {
-        this.utils = utils;
     }
 
     @Required

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -38,6 +38,12 @@
     <property name="timeoutUnit" value="${bulk.service.qos.timeout.unit}"/>
   </bean>
 
+  <bean id="ha-leader-stub" class="org.dcache.cells.CellStub">
+    <description>Endpoint communication stub</description>
+    <property name="timeout" value="${bulk.service.ha-leader.timeout}"/>
+    <property name="timeoutUnit" value="${bulk.service.ha-leader.timeout.unit}"/>
+  </bean>
+
   <bean id="pool-monitor" class="org.dcache.poolmanager.RemotePoolMonitor">
     <description>Maintains runtime information about all pools</description>
     <property name="poolManagerStub" ref="pool-manager-stub"/>
@@ -125,6 +131,7 @@
                 <entry key="transactionIsolation" value="TRANSACTION_READ_COMMITTED"/>
                 <entry key="minimumIdle" value="${bulk.db.connections.idle}"/>
                 <entry key="maximumPoolSize" value="${bulk.db.connections.max}"/>
+                <entry key="connectionTimeout" value="60000"/>
               </map>
             </property>
           </bean>
@@ -187,7 +194,6 @@
     <property name="capacity" value="${bulk.limits.container-processing-threads}"/>
     <property name="statistics" ref="statistics"/>
     <property name="pnfsManager" ref="pnfs-manager-stub"/>
-    <property name="bulkUtils" ref="bulk-jdbc-dao-utils"/>
   </bean>
 
   <bean id="target-store" class="org.dcache.services.bulk.store.jdbc.rtarget.JdbcBulkTargetStore">
@@ -317,6 +323,8 @@
     <property name="submissionHandler" ref="request-handler"/>
     <property name="requestManager" ref="request-manager"/>
     <property name="targetStore" ref="target-store"/>
+    <property name="leadershipManager" ref="ha-service-leadership-manager"/>
+    <property name="endpointStub" ref="ha-leader-stub"/>
   </bean>
 
   <bean id="admin-commands" class="org.dcache.services.bulk.BulkServiceCommands">
@@ -351,7 +359,7 @@
   </bean>
 
   <bean id="request-archiver" class="org.dcache.services.bulk.store.jdbc.request.JdbcBulkRequestArchiver"
-    init-method="reset" destroy-method="shutdown">
+    destroy-method="shutdown">
     <property name="requestDao" ref="bulk-request-dao"/>
     <property name="requestStore" ref="request-store"/>
     <property name="archiverScheduler">
@@ -363,5 +371,24 @@
     <property name="archiverPeriodUnit" value="${bulk.limits.archiver-period.unit}"/>
     <property name="archiverWindow" value="${bulk.limits.archiver-window}"/>
     <property name="archiverWindowUnit" value="${bulk.limits.archiver-window.unit}"/>
+  </bean>
+
+  <bean id="ha-service-leadership-manager" class="org.dcache.cells.HAServiceLeadershipManager"
+    init-method="initZkLeaderListener" destroy-method="shutdown">
+    <description>Coordinates which bulk service handles the requests</description>
+    <constructor-arg value="bulk"/>
+    <property name="leadershipListener">
+      <ref bean="leaderlistener-group"/>
+    </property>
+  </bean>
+
+  <bean id="leaderlistener-group" class="org.dcache.cells.LeadershipListenerGroup">
+    <description>Propagates leadership change notifications to managed listeners</description>
+    <property name="leaderElectionAwareComponents">
+      <set>
+        <ref bean="bulk-service"/>
+        <ref bean="request-archiver"/>
+      </set>
+    </property>
   </bean>
 </beans>

--- a/modules/dcache/src/main/java/org/dcache/cells/HAServiceLeadershipManager.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/HAServiceLeadershipManager.java
@@ -80,6 +80,10 @@ public class HAServiceLeadershipManager implements CellIdentityAware, CellComman
         this.leadershipListener = leadershipListener;
     }
 
+    public CellAddressCore getLeaderAddress() throws Exception {
+        return new CellAddressCore(zkLeaderLatch.getLeader().getId());
+    }
+
     public void shutdown() {
         if (zkLeaderLatch != null) {
             CloseableUtils.closeQuietly(zkLeaderLatch);

--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -23,7 +23,18 @@ bulk.cell.subscribe=${bulk.pool-monitor.topic},${bulk.qos-transition-topic}
 #
 #   This property indicates if this service is replicable.
 #
-(immutable)bulk.cell.replicable = false
+#   Bulk physical instances should all run over the same database instance.
+#   HA will use leader semantics to guarantee that only one of those instances
+#   is actually processing, i.e., storing, running, canceling or clearing requests.
+#   The other instances are free to query for request information or status.
+#
+#   It is the administrator's responsibility to ensure that all
+#   bulk service instances:
+#
+#       o  have a consistent dCache 'bulk' configuration,
+#       o  share the same database.
+#
+(immutable)bulk.cell.replicable = true
 
 #  ---- Global setting for directory expansion.
 #
@@ -153,6 +164,11 @@ bulk.service.qos=${dcache.service.qos}
 #
 bulk.service.qos.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)bulk.service.qos.timeout.unit=MINUTES
+
+# ---- How long to wait for a response from the HA leader.
+#
+bulk.service.ha-leader.timeout=1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)bulk.service.ha-leader.timeout.unit=MINUTES
 
 # Topic on which to expect pool monitor updates
 #

--- a/skel/share/services/bulk.batch
+++ b/skel/share/services/bulk.batch
@@ -38,6 +38,8 @@ check -strong bulk.service.poolmanager.timeout.unit
 check -strong bulk.service.qos
 check -strong bulk.service.qos.timeout
 check -strong bulk.service.qos.timeout.unit
+check -strong bulk.service.ha-leader.timeout
+check -strong bulk.service.ha-leader.timeout.unit
 check -strong bulk.pool-monitor.topic
 check -strong bulk.qos-transition-topic
 check -strong bulk.db.connections.max


### PR DESCRIPTION
Motivation:

Some users/experiments have expressed an interest
in making the Bulk service replicable.

Modification:

The necessary hooks have been added for leader/latch management.

Because of the stateful semantics of the database, all physical instances must share a single database instance.

Because of the way containers are managed in
memory, it is preferable to have all DB insert
and update activity, as well as cancellation
and clearing (which involves the cache as
well) to be done by the leader only.

Hence, `submit` (< RESTful POST), `cancel`
(< RESTful PATCH) and `clear` (< RESTful DELETE)
messages are forwarded to the leader
(whose address is obtained by injecting the
HA leadership manager into the service).

RESTful GET queries (`info`, `list`)
are serviced by all physical instances.

The `archiver` is also run exclusively
by the leader.

Result:

Bulk is replicable.

Target: master
Request: 9.2
Patch: https://rb.dcache.org/r/14111/
Requires-notes: yes
Requires-book: yes (cookbook paragraph provided)
Acked-by: Lea