### PR TITLE
dcache-qos:  fix scanner operation completion logic

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/data/ScanOperationMap.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/data/ScanOperationMap.java
@@ -108,17 +108,17 @@ abstract class ScanOperationMap extends RunnableModule implements CellInfoProvid
                 break;
             }
 
-            LOGGER.trace("Pool watchdog initiating scan.");
+            LOGGER.trace("calling run scans.");
             runScans();
-            LOGGER.trace("Pool watchdog scan completed.");
+            LOGGER.trace("run scans returned.");
 
             recordSweep(start, System.currentTimeMillis());
         }
 
-        LOGGER.info("Exiting pool operation consumer.");
+        LOGGER.info("Exiting operation consumer.");
         clear();
 
-        LOGGER.info("Pool operation queues cleared.");
+        LOGGER.info("operation queues cleared.");
     }
 
     public void runNow() {

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/data/SystemScanOperation.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/scanner/data/SystemScanOperation.java
@@ -87,7 +87,6 @@ public final class SystemScanOperation extends ScanOperation<SystemScanTask> {
 
     long lastUpdate;
     long lastScan;
-    long[] minMaxIndices;
 
     SystemScanTask task;
     CacheException exception;
@@ -161,10 +160,6 @@ public final class SystemScanOperation extends ScanOperation<SystemScanTask> {
         LOGGER.trace("isComplete ? {} (runningTotal {}, completed = {}).",
               isComplete, runningTotal, completed);
         return isComplete;
-    }
-
-    boolean isFinal() {
-        return to >= minMaxIndices[1];
     }
 
     boolean isQos() {


### PR DESCRIPTION
Motivation:

When system scan operations run, the operation
map fails to understand when they have all completed. This is due to a faulty way of computing the highest index of the targets processed.

Modification:

Fix the issue by implementing a `hasNext`
method which is properly global rather than
checking indices on individual operations
(which is flawed because it assumes they
run in serial order).

The patch also corrects/improves several
logging statements.

Result:

Scans are properly marked as having
completed and the end timestamps as
reported by `info` are correct.

Target: master
Request: 9.2
Patch: https://rb.dcache.org/r/14097
Requires-notes: yes (for 9.2)
Acked-by: Tigran