### PR TITLE
dcache-bulk:  add convenience admin command for state counts

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -86,6 +86,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
@@ -1142,6 +1143,28 @@ public final class BulkServiceCommands implements CellCommandListener {
         @Override
         public String call() {
             return statistics.getOwnerCounts();
+        }
+    }
+
+    @Command(name = "status counts",
+          hint = "Display counts for requests and targets in various states.",
+          description = "Runs two database queries for actual counts.")
+    class StatusCounts implements Callable<String> {
+
+        @Override
+        public String call() {
+            Map<String, Long> requests = requestStore.countsByStatus();
+            Map<String, Long> targets = targetStore.countsByState();
+
+           return new StringBuilder()
+                 .append("---------- REQUESTS ----------\n")
+                 .append(String.format(FORMAT_COUNTS + "\n", "STATUS", "COUNT"))
+                 .append(requests.entrySet().stream().map(e -> String.format(FORMAT_COUNTS,
+                       e.getKey(), e.getValue())).collect(joining("\n")))
+                 .append("\n\n---------- TARGETS -----------\n")
+                 .append(String.format(FORMAT_COUNTS + "\n", "STATE", "COUNT"))
+                 .append(targets.entrySet().stream().map(e -> String.format(FORMAT_COUNTS,
+                       e.getKey(), e.getValue())).collect(joining("\n"))).toString();
         }
     }
 

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkRequestStore.java
@@ -62,6 +62,7 @@ package org.dcache.services.bulk.store;
 import com.google.common.collect.ListMultimap;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
@@ -154,6 +155,11 @@ public interface BulkRequestStore {
      * @throws BulkStorageException
      */
     int countNonTerminated(String user) throws BulkStorageException;
+
+    /**
+     * @return a map of the combined results of target counts grouped by state.
+     */
+    Map<String, Long> countsByStatus();
 
     /**
      * @param filter optional filter on the request.

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestDao.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestDao.java
@@ -134,6 +134,10 @@ public final class JdbcBulkRequestDao extends JdbcDaoSupport {
         return utils.count(criterion, TABLE_NAME, this);
     }
 
+    public Map<String, Long> countStatus() {
+        return utils.countGrouped(where().classifier("status"), TABLE_NAME, this);
+    }
+
     /*
      * Should delete the jobs by cascading on the request id.
      */

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
@@ -298,6 +298,11 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
     }
 
     @Override
+    public Map<String, Long> countsByStatus() {
+        return requestDao.countStatus();
+    }
+
+    @Override
     public Collection<BulkRequest> find(Optional<BulkRequestFilter> requestFilter, Integer limit)
           throws BulkStorageException {
         limit = limit == null ? Integer.MAX_VALUE : limit;


### PR DESCRIPTION
Motivation:

Counts of requests and targets by state are useful to have, especially when testing and debugging, but
generally for the admin as well.  These currently
require a `ls` command with options.

More convenient would be a single command that
just delivers them.

Modification:

Added the command and a few method calls to the
underlying db utility which already exists.

Result:

Much handier retrieval of this info.

Target: master
Request: 9.2
Patch: https://rb.dcache.org/r/14116/
Requires-notes: yes
Acked-by: Tigran