### PR TITLE
dcache-bulk:  add admin command and query to reset all requests with …

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -1062,6 +1062,26 @@ public final class BulkServiceCommands implements CellCommandListener {
         }
     }
 
+    @Command(name = "request retry failed",
+          hint = "Retry only those requests which have failed targets.",
+          description = "Calls reset on the requests matching this criterion.")
+    class RequestRetryFailed implements Callable<String> {
+
+        @Override
+        public String call() throws Exception {
+            executor.submit(()-> {
+                try {
+                    int count = requestStore.retryFailed();
+                    LOGGER.info("{} requests with failed targets have been reset.", count);
+                } catch (BulkStorageException e) {
+                    LOGGER.error("could not reset failed: {}.", e.toString());
+                }
+            });
+
+            return "Resetting requests with failed targets.";
+        }
+    }
+
     @Command(name = "request submit",
           hint = "Launch a bulk request.",
           description = "Command-line version of the RESTful request.")

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/BulkRequestStore.java
@@ -278,6 +278,13 @@ public interface BulkRequestStore {
     void reset(String uid) throws BulkStorageException;
 
     /**
+     * Retry all requests that have FAILED targets.
+     *
+     * @throws BulkStorageException
+     */
+    int retryFailed() throws BulkStorageException;
+
+    /**
      * Store the request.
      *
      * @param subject     sending the request.


### PR DESCRIPTION
…failed targets

Motivation:

There exists an admin command to reset requests to be rerun.  The command takes various options based on
the fields in the bulk request table.   However,
it is currently not possible to rerun only the
requests with failed targets that have completed.
This may sometimes be useful to the admin.
(Note that for safety we do not automatically
do this on service restart/reload, where only
incomplete requests are reset).

Modifications:

Add the command and a few extra pieces of
support in the dao/store layers.

Result:

We can now retry completed requests which
have failed targets.

Target: master
Request: 9.2
Patch: https://rb.dcache.org/r/14117/
Requires-notes: yes
Acked-by: Tigran