### PR TITLE
gplazma: oidc increase cache duration for OP public key material

### DIFF
--- a/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/Issuer.java
+++ b/modules/gplazma2-oidc/src/main/java/org/dcache/gplazma/oidc/jwt/Issuer.java
@@ -62,9 +62,11 @@ public class Issuer {
     private final HttpClient client;
     private final boolean offlineSuppressed;
 
+    // Recommendation for six hours comes from this document:
+    //     https://doi.org/10.5281/zenodo.3460258
     private final Supplier<Map<String, PublicKey>> keys = MemoizeMapWithExpiry.memorize(this::readJwksDocument)
           .whenEmptyFor(Duration.ofMinutes(1))
-          .whenNonEmptyFor(Duration.ofMinutes(10))
+          .whenNonEmptyFor(Duration.ofHours(6))
           .build();
 
     public Issuer(HttpClient client, IdentityProvider provider, int tokenHistory) {


### PR DESCRIPTION
Motivation:

Under current use, validating a JWT requires dCache to have the corresponding public key from the OP's public key store.  These public keys change rather slowly, allowing dCache to cache the public keys.

The caching period is a trade-off: a short period allows dCache to react quickly to revoked (and removed) public keys while a longer peroid allows dCache to continue processing JWTs if there is a problem with the OP.

Currently dCache caches the public keys for ten minutes.  This is too short, with examples of OPs suffering outages of at least this duration.

Modification:

Increase the caching period to six hours, as recommended by WLCG JWT profile.

Result:

dCache should continue to accept JWTs for longer, if there is a problem with the OP.

Target: master
Patch: https://rb.dcache.org/r/14102/
Acked-by: Dmitry Litvintsev
Requires-book: no
Requires-notes: yes
Request: 9.2
Request: 9.1
Request: 9.0
Request: 8.2