### PR TITLE
gplazma: oidc update explicit AuthZ parsing

### DIFF
--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/profiles/WlcgProfileScopeTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/profiles/WlcgProfileScopeTest.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2020-2022 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2020-2023 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -17,8 +17,6 @@
  */
 package org.dcache.gplazma.oidc.profiles;
 
-import org.dcache.gplazma.oidc.profiles.WlcgProfileScope;
-
 import static org.dcache.auth.attributes.Activity.DOWNLOAD;
 import static org.dcache.auth.attributes.Activity.LIST;
 import static org.dcache.auth.attributes.Activity.READ_METADATA;
@@ -34,6 +32,11 @@ import org.dcache.auth.attributes.MultiTargetedRestriction.Authorisation;
 import org.junit.Test;
 
 public class WlcgProfileScopeTest {
+
+    @Test(expected=InvalidScopeException.class)
+    public void shouldRejectUnknownScope() {
+        new WlcgProfileScope("unknown-value");
+    }
 
     @Test
     public void shouldIdentifyStorageReadScope() {
@@ -56,7 +59,41 @@ public class WlcgProfileScopeTest {
     }
 
     @Test
-    public void shouldParseReadScope() {
+    public void shouldIdentifyComputeReadScope() {
+        assertTrue(WlcgProfileScope.isWlcgProfileScope("compute.read"));
+    }
+
+    @Test
+    public void shouldIdentifyComputeModifyScope() {
+        assertTrue(WlcgProfileScope.isWlcgProfileScope("compute.modify"));
+    }
+
+    @Test
+    public void shouldIdentifyComputeCreateScope() {
+        assertTrue(WlcgProfileScope.isWlcgProfileScope("compute.create"));
+    }
+
+    @Test
+    public void shouldIdentifyComputeCancelScope() {
+        assertTrue(WlcgProfileScope.isWlcgProfileScope("compute.cancel"));
+    }
+
+    @Test
+    public void shouldParseReadScopeWithoutResourcePath() {
+        WlcgProfileScope scope = new WlcgProfileScope("storage.read");
+
+        Optional<Authorisation> maybeAuth = scope.authorisation(FsPath.create("/VOs/wlcg"));
+
+        assertTrue(maybeAuth.isPresent());
+
+        Authorisation auth = maybeAuth.get();
+
+        assertThat(auth.getPath(), equalTo(FsPath.create("/VOs/wlcg")));
+        assertThat(auth.getActivity(), containsInAnyOrder(LIST, READ_METADATA, DOWNLOAD));
+    }
+
+    @Test
+    public void shouldParseReadScopeWithRootResourcePath() {
         WlcgProfileScope scope = new WlcgProfileScope("storage.read:/");
 
         Optional<Authorisation> maybeAuth = scope.authorisation(FsPath.create("/VOs/wlcg"));
@@ -67,5 +104,60 @@ public class WlcgProfileScopeTest {
 
         assertThat(auth.getPath(), equalTo(FsPath.create("/VOs/wlcg")));
         assertThat(auth.getActivity(), containsInAnyOrder(LIST, READ_METADATA, DOWNLOAD));
+    }
+
+    @Test
+    public void shouldParseReadScopeWithNonRootResourcePath() {
+        WlcgProfileScope scope = new WlcgProfileScope("storage.read:/foo");
+
+        Optional<Authorisation> maybeAuth = scope.authorisation(FsPath.create("/VOs/wlcg"));
+
+        assertTrue(maybeAuth.isPresent());
+
+        Authorisation auth = maybeAuth.get();
+
+        assertThat(auth.getPath(), equalTo(FsPath.create("/VOs/wlcg/foo")));
+        assertThat(auth.getActivity(), containsInAnyOrder(LIST, READ_METADATA, DOWNLOAD));
+    }
+
+    @Test(expected=InvalidScopeException.class)
+    public void shouldRejectReadScopeWithRelativeResourcePath() {
+        new WlcgProfileScope("storage.read:foo");
+    }
+
+    @Test
+    public void shouldParseComputeReadScope() {
+        WlcgProfileScope scope = new WlcgProfileScope("compute.read");
+
+        Optional<Authorisation> maybeAuth = scope.authorisation(FsPath.create("/VOs/wlcg"));
+
+        assertTrue(maybeAuth.isEmpty());
+    }
+
+    @Test
+    public void shouldParseComputeModifyScope() {
+        WlcgProfileScope scope = new WlcgProfileScope("compute.modify");
+
+        Optional<Authorisation> maybeAuth = scope.authorisation(FsPath.create("/VOs/wlcg"));
+
+        assertTrue(maybeAuth.isEmpty());
+    }
+
+    @Test
+    public void shouldParseComputeCreateScope() {
+        WlcgProfileScope scope = new WlcgProfileScope("compute.create");
+
+        Optional<Authorisation> maybeAuth = scope.authorisation(FsPath.create("/VOs/wlcg"));
+
+        assertTrue(maybeAuth.isEmpty());
+    }
+
+    @Test
+    public void shouldParseComputeCancelScope() {
+        WlcgProfileScope scope = new WlcgProfileScope("compute.cancel");
+
+        Optional<Authorisation> maybeAuth = scope.authorisation(FsPath.create("/VOs/wlcg"));
+
+        assertTrue(maybeAuth.isEmpty());
     }
 }


### PR DESCRIPTION
Motivation:

The WLCG JWT Profile describes how JWTs may include explicit authorisation statements in the 'scope' claim (e.g., `storage.read:/foo`).

When processing a token, the oidc gPlazma plugin decides whether the token carries explicit AuthZ statements.  If it does, then the resulting login will suspend namespace-based authorisation and fully honour the authorisation from the token.

There are a few issues with how dCache currently parses these explicit AuthZ statements.

  1.  The profile describes how the resource identifier is optional (e.g., `storage.read` is valid), but dCache scope parsing currently rejects explicit AuthZ if the resource identifier is missing.

  2.  The profile describes several explicit AuthZ statements (e.g., `compute.read`).  Currently, dCache completely ignores these statements.  However, this is not complete correct because such compute explicit AuthZ statements indicate the token (in general) is carrying explicit AuthZ.  Therefore, the presence of compute explicit AuthZ statements and a lack of any storage explicit AuthZ statements should result in dCache rejecting requests by that token.

Modification:

Update scope parsing components to relax the requirement on having a resource identifier.  An explicit AuthZ statement without a resource identifier is equivalent to adding `:/` to the statement (e.g., `storage.read` interpreted as `storage.read:/`).

Add extra valid values for the "compute.\*" explicit AuthZ statements. This are ignored by the rest of dCache, but their presence will result in dCache considering the token as one with explicit AuthZ.

Result:

dCache will now accept non-targeted explicit AuthZ statements in the scope claim (e.g., `storage.read`).  dCache will consider tokens containing compute explicit AuthZ statements but without any storage explicit AuthZ statements as tokens with explicit authorisation; the lack of any storage explicit authorisation statements will result in all requests with that token being denied.

Target: master
Requires-notes: yes
Requires-book: no
Request: 9.2
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/13996/
Acked-by: Dmitry Litvintsev