### PR TITLE
dcache-bulk: refine container executor model

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkRequestContainerJob.java
@@ -73,7 +73,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Range;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.NamespaceHandlerAware;
@@ -476,7 +475,7 @@ public final class BulkRequestContainerJob
                         remove();
                     }
                 }
-            }, MoreExecutors.directExecutor());
+            }, callbackExecutor);
         }
 
         /**
@@ -510,7 +509,7 @@ public final class BulkRequestContainerJob
                         remove();
                     }
                 }
-            }, MoreExecutors.directExecutor());
+            }, callbackExecutor);
         }
 
         /**
@@ -563,7 +562,7 @@ public final class BulkRequestContainerJob
             try {
                 activityFuture = activity.perform(ruid, id == null ? seqNo : id, path, attributes);
                 if (async) {
-                    activityFuture.addListener(() -> handleCompletion(), executor);
+                    activityFuture.addListener(() -> handleCompletion(), callbackExecutor);
                 }
             } catch (BulkServiceException | UnsupportedOperationException e) {
                 LOGGER.error("{}, perform failed for {}: {}", ruid, target, e.getMessage());
@@ -665,6 +664,7 @@ public final class BulkRequestContainerJob
     private SignalAware callback;
     private Thread runThread;
     private ExecutorService executor;
+    private ExecutorService callbackExecutor;
     private Semaphore dirListSemaphore;
     private Semaphore inFlightSemaphore;
 
@@ -833,6 +833,10 @@ public final class BulkRequestContainerJob
 
     public void setListHandler(ListDirectoryHandler listHandler) {
         this.listHandler = listHandler;
+    }
+
+    public void setCallbackExecutor(ExecutorService callbackExecutor) {
+        this.callbackExecutor = callbackExecutor;
     }
 
     public void setExecutor(ExecutorService executor) {

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -243,6 +243,16 @@
     <property name="submissionHandler" ref="request-handler"/>
     <property name="schedulerProvider" ref="scheduler-provider"/>
     <property name="maxActiveRequests" value="${bulk.limits.container-processing-threads}"/>
+    <property name="executor">
+      <bean class="org.dcache.util.BoundedCachedExecutor">
+        <constructor-arg value="${bulk.limits.in-flight-semaphore}"/>
+      </bean>
+    </property>
+    <property name="callbackExecutor">
+      <bean class="org.dcache.util.BoundedCachedExecutor">
+        <constructor-arg value="${bulk.db.connections.max}"/>
+      </bean>
+    </property>
     <property name="timeout" value="${bulk.limits.sweep-interval}"/>
     <property name="timeoutUnit" value="${bulk.limits.sweep-interval.unit}"/>
   </bean>


### PR DESCRIPTION
Motivation:

In https://rb.dcache.org/r/14115
master@8a5c358af45586383d87873952407c646f81f4c6

the container executor model was made more like SRM by using an unbounded cached executor.  While this brought Bulk performance in line with SRM, it also drives memory usage to be very near to physical
memory.  In JFR, after a sustained usage/submission of about 1700 requests of 10K targets each over 6
hours, one can observe this warning (see attached).

However, a totally unbounded executor is not necessary. All that is required is an executor which has enough slots to accommodate the in-flight semaphore.

Modification:

Split the pooled executor into a main and a callback executor, each initialized with max threads equal
to the in-flight semaphore value.  Use the callback executor exclusively for message/activity callbacks (instead of direct executor).

Result:

Same performance as before, but with a total memory footprint at a little more than half available
physical memory instead of being very close to it.

Target: master
Request: 9.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14118/
Acked-by: Tigran
Acked-by: Lea