### PR TITLE
dcache-bulk:  cancel activity future on target cancel

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkRequestContainerJob.java
@@ -380,6 +380,10 @@ public final class BulkRequestContainerJob
         }
 
         void cancel() {
+            if (activityFuture != null) {
+                activityFuture.cancel(true);
+            }
+
             if (target != null) {
                 activity.cancel(target);
             }


### PR DESCRIPTION
Motivation:

Neglected to cancel the future of the
activity of a task running inside the container
(instead of just the task future and the target
object).

Modification:

Add cancellation.

Result:

Correct cancellation semantics.

Target: master
Request: 9.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14121/
Acked-by: Dmitry