### PR TITLE
dcache-bulk: add count and clear to archive admin commands

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkArchiveDao.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkArchiveDao.java
@@ -132,6 +132,10 @@ public final class JdbcBulkArchiveDao extends JdbcDaoSupport {
         return utils.count(criterion, TABLE_NAME, this);
     }
 
+    public int delete(JdbcArchivedBulkRequestCriterion criterion) {
+        return utils.delete(criterion, TABLE_NAME, this);
+    }
+
     public List<BulkArchivedRequestInfo> get(JdbcArchivedBulkRequestCriterion criterion, int limit) {
        return utils.get(SELECT_INFO, criterion, limit, TABLE_NAME, this, infoRowMapper);
     }


### PR DESCRIPTION
Motivation:

Convenience (not having to run query on the database interpreter).

Modification:

Add commands to display the count instead of the
actual entry (as with requests and targets), and
also a command to clear/delete from the archive
table.

Result:

Friendlier admin interface.

Target: master
Request: 9.2
Patch: https://rb.dcache.org/r/14119/
Requires-notes: yes
Acked-by: Lea