### PR TITLE
wevdav: fix redirect path

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -1556,7 +1556,7 @@ public class DcacheResourceFactory
 
             var request = ServletRequest.getRequest();
             request.setAttribute(TRANSACTION_ATTRIBUTE, getTransaction());
-            _requestPath = ServletRequest.stripToPath(request.getRequestURI());
+            _requestPath = ServletRequest.stripToPath(request.getRequestURL().toString());
         }
 
         protected ProtocolInfo createProtocolInfo(InetSocketAddress address) {


### PR DESCRIPTION
Motivation:

Commit 8a4273fa8ce478fd5dffa425728fe505b367d629 seem to have introduced regression in how redirect paths are presented.

Modification:

Pass request.getRequestURL() to call to ServletRequest.stripToPath instead of request.getRequestURI()

Result:

Observe correct path on redirect

Patch: https://rb.dcache.org/r/14130/
Target: trunk
Request: 9.2
Request: 9.1
Request: 9.0
Request: 8.2