### PR TITLE
dcache-bulk: fix thread executor injection

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJobFactory.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/RequestContainerJobFactory.java
@@ -80,6 +80,7 @@ import org.dcache.services.bulk.util.BulkRequestTarget;
 import org.dcache.services.bulk.util.BulkRequestTarget.PID;
 import org.dcache.services.bulk.util.BulkRequestTargetBuilder;
 import org.dcache.services.bulk.util.BulkServiceStatistics;
+import org.dcache.util.BoundedCachedExecutor;
 import org.dcache.util.list.ListDirectoryHandler;
 import org.dcache.vehicles.FileAttributes;
 import org.slf4j.Logger;
@@ -102,6 +103,9 @@ public final class RequestContainerJobFactory {
     private BulkServiceStatistics statistics;
     private Semaphore dirListSemaphore;
     private Semaphore inFlightSemaphore;
+    private BoundedCachedExecutor taskExecutor;
+    private BoundedCachedExecutor callbackExecutor;
+    private BoundedCachedExecutor listExecutor;
 
     public BulkRequestContainerJob createRequestJob(BulkRequest request)
           throws BulkServiceException {
@@ -132,6 +136,9 @@ public final class RequestContainerJobFactory {
         containerJob.setListHandler(listHandler);
         containerJob.setDirListSemaphore(dirListSemaphore);
         containerJob.setInFlightSemaphore(inFlightSemaphore);
+        containerJob.setExecutor(taskExecutor);
+        containerJob.setListExecutor(listExecutor);
+        containerJob.setCallbackExecutor(callbackExecutor);
         containerJob.initialize();
         return containerJob;
     }
@@ -150,8 +157,18 @@ public final class RequestContainerJobFactory {
     }
 
     @Required
+    public void setCallbackExecutor(BoundedCachedExecutor callbackExecutor) {
+        this.callbackExecutor = callbackExecutor;
+    }
+
+    @Required
     public void setListHandler(ListDirectoryHandler listHandler) {
         this.listHandler = listHandler;
+    }
+
+    @Required
+    public void setListExecutor(BoundedCachedExecutor listExecutor) {
+        this.listExecutor = listExecutor;
     }
 
     @Required
@@ -182,6 +199,11 @@ public final class RequestContainerJobFactory {
     @Required
     public void setTargetStore(BulkTargetStore targetStore) {
         this.targetStore = targetStore;
+    }
+
+    @Required
+    public void setTaskExecutor(BoundedCachedExecutor taskExecutor) {
+        this.taskExecutor = taskExecutor;
     }
 
     BulkActivity create(BulkRequest request) throws BulkServiceException {

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -67,13 +67,21 @@
     </constructor-arg>
   </bean>
 
-  <bean id="container-job-executor" class="org.dcache.util.CDCExecutorServiceDecorator">
+  <bean id="container-job-executor" class="org.dcache.util.BoundedCachedExecutor">
     <description>Used to execute jobs that are executed by a batch container.</description>
-    <constructor-arg>
-      <bean class="org.dcache.util.BoundedCachedExecutor">
-        <constructor-arg value="${bulk.limits.container-processing-threads}"/>
-      </bean>
-    </constructor-arg>
+    <constructor-arg value="${bulk.limits.container-processing-threads}"/>
+  </bean>
+
+  <bean id="task-executor" class="org.dcache.util.BoundedCachedExecutor">
+    <constructor-arg value="${bulk.limits.in-flight-semaphore}"/>
+  </bean>
+
+  <bean id="callback-executor" class="org.dcache.util.BoundedCachedExecutor">
+    <constructor-arg value="${bulk.db.connections.max}"/>
+  </bean>
+
+  <bean id="dir-list-executor" class="org.dcache.util.BoundedCachedExecutor">
+    <constructor-arg value="${bulk.limits.dir-list-semaphore}"/>
   </bean>
 
   <bean id="cancellation-executor" class="org.dcache.util.CDCScheduledExecutorServiceDecorator">
@@ -209,6 +217,9 @@
     <property name="statistics" ref="statistics"/>
     <property name="dirListSemaphore" value="${bulk.limits.dir-list-semaphore}"/>
     <property name="inFlightSemaphore" value="${bulk.limits.in-flight-semaphore}"/>
+    <property name="taskExecutor" ref="task-executor"/>
+    <property name="callbackExecutor" ref="callback-executor"/>
+    <property name="listExecutor" ref="dir-list-executor"/>
   </bean>
 
   <bean id="statistics" class="org.dcache.services.bulk.util.BulkServiceStatistics">
@@ -243,21 +254,7 @@
     <property name="submissionHandler" ref="request-handler"/>
     <property name="schedulerProvider" ref="scheduler-provider"/>
     <property name="maxActiveRequests" value="${bulk.limits.container-processing-threads}"/>
-    <property name="executor">
-      <bean class="org.dcache.util.BoundedCachedExecutor">
-        <constructor-arg value="${bulk.limits.in-flight-semaphore}"/>
-      </bean>
-    </property>
-    <property name="callbackExecutor">
-      <bean class="org.dcache.util.BoundedCachedExecutor">
-        <constructor-arg value="${bulk.db.connections.max}"/>
-      </bean>
-    </property>
-    <property name="listExecutor" >
-      <bean class="org.dcache.util.BoundedCachedExecutor">
-        <constructor-arg value="${bulk.limits.dir-list-semaphore}"/>
-      </bean>
-    </property>
+    <property name="containerExecutor" ref="container-job-executor"/>
     <property name="timeout" value="${bulk.limits.sweep-interval}"/>
     <property name="timeoutUnit" value="${bulk.limits.sweep-interval.unit}"/>
   </bean>
@@ -299,6 +296,9 @@
       <list>
         <ref bean="incoming-thread-executor"/>
         <ref bean="container-job-executor"/>
+        <ref bean="task-executor"/>
+        <ref bean="callback-executor"/>
+        <ref bean="dir-list-executor"/>
         <ref bean="cancellation-executor"/>
       </list>
     </property>

--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -69,7 +69,7 @@ bulk.request-scheduler=org.dcache.services.bulk.manager.scheduler.LeastRecentFir
 #
 bulk.limits.container-processing-threads=100
 bulk.limits.incoming-request-threads=10
-bulk.limits.cancellation-threads=10
+bulk.limits.cancellation-threads=${bulk.limits.container-processing-threads}
 
 #  ---- Expiration of the cache serving to front the request storage.
 #


### PR DESCRIPTION
Motivation:

Recent changes to the job container implementation inadvertently scrambled thread pool injection
such that one of the executors (intended to run
the main container jobs) never gets used (the
container job is executed by the same thread
pool as its own tasks).

Modification:

Fix the injection.  For the sake of consistency,
all the thread pools are injected into the
container by the job factory rather than
the manager.

Result:

Container jobs run on their own thread pool,
as intended.

Target: master
Request: 9.2
Requires-notes:  no (this is largely invisible)
Patch: https://rb.dcache.org/r/14135
Acked-by: Tigran