### PR TITLE
dcache-bulk: fix bug in archiver deletion query

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestArchiver.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestArchiver.java
@@ -61,7 +61,6 @@ package org.dcache.services.bulk.store.jdbc.request;
 
 import static org.dcache.services.bulk.BulkRequestStatus.CANCELLED;
 import static org.dcache.services.bulk.BulkRequestStatus.COMPLETED;
-import static org.dcache.services.bulk.BulkRequestStatus.INCOMPLETE;
 
 import dmg.cells.nucleus.CellInfoProvider;
 import java.io.PrintWriter;
@@ -160,7 +159,7 @@ public class JdbcBulkRequestArchiver implements Runnable, CellInfoProvider, Lead
         long threshhold = System.currentTimeMillis() - archiverWindowUnit.toMillis(archiverWindow);
 
         List<String> expiredUids = requestDao.getUids(
-              requestDao.where().modifiedBefore(threshhold).status(INCOMPLETE, COMPLETED, CANCELLED),
+              requestDao.where().modifiedBefore(threshhold).status(COMPLETED, CANCELLED),
               Integer.MAX_VALUE);
 
         /*
@@ -169,9 +168,9 @@ public class JdbcBulkRequestArchiver implements Runnable, CellInfoProvider, Lead
         expiredUids.forEach(this::insert);
 
         /*
-         *  Delete all the out-of-date requests.
+         *  Delete all the out-of-date requests which are terminal.
          */
-        requestDao.delete(requestDao.where().modifiedBefore(threshhold));
+        requestDao.delete(requestDao.where().modifiedBefore(threshhold).status(COMPLETED, CANCELLED));
         lastRunCompleted = System.currentTimeMillis();
     }
 


### PR DESCRIPTION
Motivation:

The archiver should delete only requests that are
in terminal state.

State is missing as part of the actual delete query!

Also, we should not delete INCOMPLETE requests as
there is the slight possibility the archiver could be running while an initial insertion is taking
place and could slice it (as the three table
insertions are not in the same transaction).

Modification:

Add the states and remove `INCOMPLETE`.

Result:

Correct behavior which does not risk
deleting ongoing active requests.
(This was in fact observed during
testing.)

Target: master
Request: 9.2
Patch: https://rb.dcache.org/r/14141/
Requires-notes:  yes (potentially could drop requests which have not finished)
Acked-by: Tigran