### PR TITLE
dcache-qos: correction to the threshold warning

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/util/InitializerAwareCommand.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/util/InitializerAwareCommand.java
@@ -74,8 +74,7 @@ public abstract class InitializerAwareCommand implements Callable<String> {
     protected static final String REQUIRE_LIMIT =
           "The current table contains %s entries; listing them all "
                 + "could cause an out-of-memory error and "
-                + "cause the resilience system to fail and/or "
-                + "restarts; if you wish to proceed "
+                + "cause failure and/or restart; if you wish to proceed "
                 + "with this listing, reissue the command "
                 + "with the explicit option '-limit=%s'";
 


### PR DESCRIPTION
Motivation:

Admin command warning on ls in qos borrowed from
resilience, but language not adapted.

Modification:

Change the command warning output not to mention
resilience.

Result:

Less confusion.

Target: master
Request: 9.2
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14140/
Requires-notes: no
Acked-by: Tigran