### PR TITLE
dcache-bulk: use rate limiter to throttle semaphore release

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -183,7 +183,7 @@ public final class BulkServiceCommands implements CellCommandListener {
     /**
      * name | class | type | permits
      */
-    private static final String FORMAT_ACTIVITY = "%-20s | %100s | %7s ";
+    private static final String FORMAT_ACTIVITY = "%-20s | %100s | %7s";
 
     /**
      * name | required | description
@@ -264,8 +264,9 @@ public final class BulkServiceCommands implements CellCommandListener {
         }
     }
 
-    private static String formatActivity(Entry<String, BulkActivityProvider> entry) {
+    private static String formatActivity(Entry<String, BulkActivityProvider> entry, BulkActivityFactory factory) {
         BulkActivityProvider provider = entry.getValue();
+
         return String.format(FORMAT_ACTIVITY,
               entry.getKey(),
               provider.getActivityClass(),
@@ -544,14 +545,14 @@ public final class BulkServiceCommands implements CellCommandListener {
             Sorter sorter = new Sorter(SortOrder.valueOf(sort.toUpperCase()));
             String activities = activityFactory.getProviders().entrySet()
                   .stream()
-                  .map(BulkServiceCommands::formatActivity)
+                  .map(e -> formatActivity(e, activityFactory))
                   .sorted(sorter)
                   .collect(joining("\n"));
             if (activities == null) {
                 return "There are no mapped activities!";
             }
 
-            return String.format(FORMAT_ACTIVITY, "NAME", "CLASS", "TYPE")
+            return String.format(FORMAT_ACTIVITY, "NAME", "CLASS", "TYPE", "RATE")
                   + "\n" + activities;
         }
     }

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -205,6 +205,23 @@
         <entry key="LOG_TARGET"><bean class="${bulk.plugin!log-target.retry-policy}"/></entry>
       </map>
     </property>
+    <property name="rateLimiters">
+      <map>
+        <entry key="PIN" value="${bulk.limits.pin-manager-rate-per-second}"/>
+        <entry key="PNFS" value="${bulk.limits.pnfs-manager-rate-per-second}"/>
+        <entry key="QOS" value="${bulk.limits.qos-engine-rate-per-second}"/>
+      </map>
+    </property>
+    <property name="rateLimiterActivityIndex">
+      <map>
+        <entry key="DELETE" value="PNFS"/>
+        <entry key="PIN" value="PIN"/>
+        <entry key="STAGE" value="PIN"/>
+        <entry key="UNPIN" value="PIN"/>
+        <entry key="RELEASE" value="PIN"/>
+        <entry key="UPDATE_QOS" value="QOS"/>
+      </map>
+    </property>
   </bean>
 
   <bean id="job-factory" class="org.dcache.services.bulk.job.RequestContainerJobFactory">

--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -109,6 +109,15 @@ bulk.limits.dir-list-semaphore=20
 #
 bulk.limits.in-flight-semaphore=2000
 
+#  ---- Endpoint throttles
+#
+#       These help bulk avoid flooding the respective service (PinManager, QoSEngine, PnfsManager)
+#       with requests at a rate it cannot handle.
+#
+bulk.limits.pin-manager-rate-per-second=1000
+bulk.limits.pnfs-manager-rate-per-second=2000
+bulk.limits.qos-engine-rate-per-second=500
+
 #  ---- Interval of inactivity by the request manager consumer if not signalled
 #       internally (as for instance when a request job completes).  The consumer checks
 #       for request readiness and completion.

--- a/skel/share/services/bulk.batch
+++ b/skel/share/services/bulk.batch
@@ -26,6 +26,9 @@ check -strong bulk.limits.archiver-window
 check -strong bulk.limits.archiver-window.unit
 check -strong bulk.limits.dir-list-semaphore
 check -strong bulk.limits.in-flight-semaphore
+check -strong bulk.limits.pin-manager-rate-per-second
+check -strong bulk.limits.pnfs-manager-rate-per-second
+check -strong bulk.limits.qos-engine-rate-per-second
 check -strong bulk.service.pnfsmanager
 check -strong bulk.service.pnfsmanager.timeout
 check -strong bulk.service.pnfsmanager.timeout.unit


### PR DESCRIPTION
Motivation:

master@0b4140b454b819de55c7c412539294537ff0beb8
https://rb.dcache.org/r/14118/

restructured the container job for greater
throughput.  In order to pace execution of
calls on external services, however, two
semaphores were used.  For task execution,
the semaphore is not released until the
future of the execution completes.

This works well but has the drawback of
not allowing submission to continue to
services like PinManager if there
are max permit number of tasks waiting
for a response (e.g., in the case of
actual staging).

On the other hand, releasing the
semaphore immediately upon reception
of the future, causes calls to external
services to pile up, causing timeout errors
of various sorts.

Modification:

Relying on the thread pool size will
not work in this case because the
execution of the activity must
be asynchronous; the turnover
is extremely rapid.

Instead we adopt the solution of
a rate limiter to throttle the
semaphore release.  Each activity
is given a limiter for the
service endpoint it communicates
with.  The rates for these
(PinManager, PnfsManager, QoSEngine)
are configurable.

Result:

Performance and stability is sustained,
but throughput continues when the submitted
task activities are in a state of waiting
for future completion.

Target: master
Request: 9.2 (fixes an important issue)
Patch:  https://rb.dcache.org/r/14136/
Requires-notes: yes  (No longer blocks throughput
of new tasks when the number of tasks waiting
for completion from an external service like
PinManager reaches max available task permits.)
Acked-by: Tigran