### PR TITLE
door,pool: handle multiple possible KafkaExceptions

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -1094,9 +1094,8 @@ public class DcacheResourceFactory
 
         try {
             _kafkaSender.accept(infoRemove);
-        } catch (KafkaException e) {
-            LOGGER.warn(Throwables.getRootCause(e).getMessage());
-
+        } catch (KafkaException | org.apache.kafka.common.KafkaException e) {
+            LOGGER.warn("Failed to send message to kafka: {} ", Throwables.getRootCause(e).getMessage());
         }
     }
 

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdDoor.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2014 - 2022 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2014 - 2023 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -725,9 +725,8 @@ public class XrootdDoor
 
         try {
             _kafkaSender.accept(infoRemove);
-        } catch (KafkaException e) {
-            _log.warn(Throwables.getRootCause(e).getMessage());
-
+        } catch (KafkaException | org.apache.kafka.common.KafkaException e) {
+            _log.warn("Failed to send message to kafka: {} ", Throwables.getRootCause(e).getMessage());
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -157,9 +157,8 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
 
         try {
             _kafkaSender.accept(moverInfoMessage);
-        } catch (KafkaException e) {
-            LOGGER.warn(Throwables.getRootCause(e).getMessage());
-
+        } catch (KafkaException | org.apache.kafka.common.KafkaException e) {
+            LOGGER.warn("Failed to send message to kafka: {} ", Throwables.getRootCause(e).getMessage());
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -610,9 +610,8 @@ public class PoolV4
 
                 try {
                     _kafkaSender.accept(msg);
-                } catch (KafkaException e) {
-                    LOGGER.warn(Throwables.getRootCause(e).getMessage());
-
+                } catch (KafkaException | org.apache.kafka.common.KafkaException e) {
+                    LOGGER.warn("Failed to send message to kafka: {} ", Throwables.getRootCause(e).getMessage());
                 }
             }
         }

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1174,12 +1174,10 @@ public class NearlineStorageHandler
             addFromNearlineStorage(infoMsg, storage);
 
             billingStub.notify(infoMsg);
-
             try {
                 _kafkaSender.accept(infoMsg);
-            } catch (KafkaException e) {
-                LOGGER.warn(Throwables.getRootCause(e).getMessage());
-
+            } catch (KafkaException | org.apache.kafka.common.KafkaException e) {
+                LOGGER.warn("Failed to send message to kafka: {} ", Throwables.getRootCause(e).getMessage());
             }
             flushRequests.removeAndCallback(pnfsId, cause);
         }
@@ -1395,9 +1393,8 @@ public class NearlineStorageHandler
             billingStub.notify(infoMsg);
             try {
                 _kafkaSender.accept(infoMsg);
-            } catch (KafkaException e) {
-                LOGGER.warn(Throwables.getRootCause(e).getMessage());
-
+            } catch (KafkaException | org.apache.kafka.common.KafkaException e) {
+                LOGGER.warn("Failed to send message to kafka: {} ", Throwables.getRootCause(e).getMessage());
             }
             stageRequests.removeAndCallback(pnfsId, cause);
         }

--- a/modules/dcache/src/main/java/org/dcache/util/Transfer.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Transfer.java
@@ -1187,9 +1187,8 @@ public class Transfer implements Comparable<Transfer> {
 
         try {
             _kafkaSender.accept(msg);
-        } catch (KafkaException e) {
-            _log.warn(Throwables.getRootCause(e).getMessage());
-
+        } catch (KafkaException | org.apache.kafka.common.KafkaException e) {
+            _log.warn("Failed to send message to kafka: {} ", Throwables.getRootCause(e).getMessage());
         }
     }
 


### PR DESCRIPTION
Motivation:
KafaTemplate class might throw

  org.springframework.kafka.KafkaException
as well as
  org.apache.kafka.common.KafkaException

Thus KafkaTemplate#send should be wrapped ti try-catch block that handles both.

Result:
proper handling of multiple KafkaException.

Acked-by: Lea Morschel
Target: master, 9.2, 9.1, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 2ddd74a780a209504d1b38f62be43b40b6f10422)