### PR TITLE
oidc: reject storage scopes without path

### DIFF
--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/profiles/WlcgProfileScopeTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/profiles/WlcgProfileScopeTest.java
@@ -95,20 +95,6 @@ public class WlcgProfileScopeTest {
     }
 
     @Test
-    public void shouldParseReadScopeWithoutResourcePath() {
-        WlcgProfileScope scope = new WlcgProfileScope("storage.read");
-
-        Optional<Authorisation> maybeAuth = scope.authorisation(FsPath.create("/VOs/wlcg"));
-
-        assertTrue(maybeAuth.isPresent());
-
-        Authorisation auth = maybeAuth.get();
-
-        assertThat(auth.getPath(), equalTo(FsPath.create("/VOs/wlcg")));
-        assertThat(auth.getActivity(), containsInAnyOrder(LIST, READ_METADATA, DOWNLOAD));
-    }
-
-    @Test
     public void shouldParseReadScopeWithRootResourcePath() {
         WlcgProfileScope scope = new WlcgProfileScope("storage.read:/");
 

--- a/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/profiles/WlcgProfileScopeTest.java
+++ b/modules/gplazma2-oidc/src/test/java/org/dcache/gplazma/oidc/profiles/WlcgProfileScopeTest.java
@@ -58,6 +58,22 @@ public class WlcgProfileScopeTest {
         assertFalse(WlcgProfileScope.isWlcgProfileScope("storage.write:/"));
     }
 
+
+    @Test(expected = InvalidScopeException.class)
+    public void shouldRejectStorageCreateScopeWithoutPath() {
+        new WlcgProfileScope("storage.create");
+    }
+
+    @Test(expected = InvalidScopeException.class)
+    public void shouldRejectStorageReadScopeWithoutPath() {
+        new WlcgProfileScope("storage.read");
+    }
+
+    @Test(expected = InvalidScopeException.class)
+    public void shouldRejectStorageModifyScopeWithoutPath() {
+        new WlcgProfileScope("storage.modify");
+    }
+
     @Test
     public void shouldIdentifyComputeReadScope() {
         assertTrue(WlcgProfileScope.isWlcgProfileScope("compute.read"));


### PR DESCRIPTION
Fixes commit 094c1714c

Motivation:
According WLCG Common JWT Profiles document:

  For all  storage.* scopes,  $PATH MUST be specified (but may be /to authorize the entire
  resource associated with the issuer); if not specified for these scopes, the token MUST be
  rejected.

However, dCache doesn't follow this rule, thus, such scopes are accepted and path is set to '/'.

Modification:
Update WlcgProfileScope.Operation enum to indicate whatever path is required or optional for a given scope. Require path for all 'storage.*' scopes.

Result:

spec compatibility and potential security fix.

Ticket: #10523
Acked-by: Paul Millar
Acked-by: Lea Morschel
Acked-by: Dmitry Litvintsev
Target: master, 9.2, 9.1, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 83d1e77eed2de6b92055088c1aec1544da05decd)