### PR TITLE
chimera: fix rollback of 9.1 to 9.0 db schema

### DIFF
--- a/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-9.1.xml
+++ b/modules/chimera/src/main/resources/org/dcache/chimera/changelog/changeset-9.1.xml
@@ -87,7 +87,7 @@
         <rollback>
             <sql>
                 DROP FUNCTION IF EXISTS f_create_inode95_lazy_wcc(parent bigint, name varchar, id varchar, type integer, mode integer, nlink integer, uid integer, gid int, size bigint, io integer, now timestamp);
-                DROP FUNCTION IF EXISTS CREATE f_propagate_wcc();
+                DROP FUNCTION IF EXISTS f_propagate_wcc();
                 DROP TABLE IF EXISTS t_lazy_wcc;
             </sql>
             <createProcedure>
@@ -95,7 +95,7 @@
                 DECLARE
                     newid bigint;
                 BEGIN
-                    INSERT INTO t_inodes (ipnfsid, itype, imode, iuid, igid, isize, iio, ictime, iatime, imtime, icrtime, igeneration)
+                    INSERT INTO t_inodes (ipnfsid, itype, imode, inlink, iuid, igid, isize, iio, ictime, iatime, imtime, icrtime, igeneration)
                           VALUES (id,type,mode,nlink,uid,gid,size,io,now,now,now,now,0) RETURNING inumber INTO newid;
                     INSERT INTO t_dirs (iparent, ichild, iname) VALUES (parent, newid, name) ON CONFLICT ON CONSTRAINT t_dirs_pkey DO NOTHING;
                     IF NOT FOUND THEN

--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -43,6 +43,7 @@ usage()
     echo "   database listLocks [<cell>@<domain>]..."
     echo "   database releaseLocks [<cell>@<domain>]..."
     echo "   database doc <cell>@<domain> <out-dir>"
+    echo "   database checksum <changeid> [<cell>@<domain>]..."
     echo "   dump heap [--force] <domain> <file>"
     echo "   dump threads [<domain>...]"
     echo "   dump zklog [<path>]"
@@ -908,6 +909,25 @@ case "$1" in
                             if hasManagedDatabase "$domain" "$cell"; then
                                 printf -- "-- %s: \n" "$cell@$domain"
                                 liquibase "$domain" "$cell" updateSQL
+                            fi
+                        fi
+                    done
+                done
+                ;;
+
+            checksum)
+                if [ $# -lt 1 ]; then
+                    usage
+                fi
+
+                id=$1
+                shift
+                for domain in $(getProperty dcache.domains); do
+                    for cell in $(getProperty dcache.domain.cells "$domain"); do
+                        if [ $# -eq 0 ] || matchesAny "$cell@$domain" "$@"; then
+                            if hasManagedDatabase "$domain" "$cell"; then
+                                printf -- "-- %s: \n" "$cell@$domain"
+                                liquibase "$domain" "$cell" calculateCheckSum $id
                             fi
                         fi
                     done


### PR DESCRIPTION
Motivation:
Fixes f3286f9d05

Modification:
fix rollback section of changeset

org/dcache/chimera/changelog/changeset-9.1.xml::34::tigran

Introduce `dcache checksum` command to checksum doesn't change

Result:
restored possibility to rollback namespace db to an earlier schema version

Acked-by: Dmitry Litvintsev
Target: master, 9.2, 9.1
Require-book: no
Require-notes: yes
(cherry picked from commit 8aa9e6af418d9d81bbc43631e4b668f55e84d89f)