### PR TITLE
webdav: fix parsing of urls with two slashes in the path

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -1692,7 +1692,7 @@ public class DcacheResourceFactory
 
             var request = ServletRequest.getRequest();
             request.setAttribute(TRANSACTION_ATTRIBUTE, getTransaction());
-            _requestPath = ServletRequest.stripToPath(request.getRequestURL().toString());
+            _requestPath = Requests.stripToPath(request.getRequestURL().toString());
         }
 
         protected ProtocolInfo createProtocolInfo(InetSocketAddress address) {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/Requests.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/Requests.java
@@ -23,13 +23,13 @@ import static java.util.Comparator.comparingDouble;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Multimaps;
 import com.google.common.net.MediaType;
+
 import java.util.Comparator;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collection;
 
@@ -169,7 +169,7 @@ public class Requests {
      * @return The path component of the URL.
      */
     public static String stripToPath(String uri) {
-        return stripToPath(URI.create(uri).getPath());
+        return stripToPath(URI.create(uri));
     }
 
     /**
@@ -178,7 +178,7 @@ public class Requests {
      * @param url The URL to extract path from.
      * @return The path component of the URL.
      */
-    public static String stripToPath(URL url) {
+    public static String stripToPath(URI url) {
         return Path.of(url.getPath()).normalize().toString();
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/Requests.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/Requests.java
@@ -28,6 +28,9 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
 import java.util.Collection;
 
 /**
@@ -157,5 +160,25 @@ public class Requests {
                   lastQValue);
             return 1.0f;
         }
+    }
+
+    /**
+     * Extract the normalized path element of the given URL String excluding query information.
+     *
+     * @param url The string representation of the URL.
+     * @return The path component of the URL.
+     */
+    public static String stripToPath(String uri) {
+        return stripToPath(URI.create(uri).getPath());
+    }
+
+    /**
+     * Extract the normalized path element of the given URL excluding query information.
+     *
+     * @param url The URL to extract path from.
+     * @return The path component of the URL.
+     */
+    public static String stripToPath(URL url) {
+        return Path.of(url.getPath()).normalize().toString();
     }
 }

--- a/modules/dcache-webdav/src/test/java/org/dcache/webdav/RequestsTest.java
+++ b/modules/dcache-webdav/src/test/java/org/dcache/webdav/RequestsTest.java
@@ -20,6 +20,8 @@ package org.dcache.webdav;
 
 import com.google.common.net.MediaType;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Set;
 
 import org.junit.Test;
@@ -106,5 +108,28 @@ public class RequestsTest {
                 Set.of(HTML_UTF_8, PLAIN_TEXT_UTF_8), HTML_UTF_8);
 
         assertThat(responseType, equalTo(PLAIN_TEXT_UTF_8));
+    }
+
+    @Test
+    public void shouldReturnFilePathOfUrl() throws MalformedURLException {
+        var u = new URL("https://door.domain.foo/pnfs/domain.foo/path/to/file");
+        assertThat(Requests.stripToPath(u), equalTo("/pnfs/domain.foo/path/to/file"));
+    }
+
+    @Test
+    public void shouldReturnFilePathOfUrlWithPort() throws MalformedURLException {
+        var u = new URL("https://door.domain.foo:1234/pnfs/domain.foo/path/to/file?foo=bar");
+        assertThat(Requests.stripToPath(u), equalTo("/pnfs/domain.foo/path/to/file"));
+    }
+    @Test
+    public void shouldReturnFilePathOfUrlWithPortAndExtraSlash() throws MalformedURLException {
+        var u = new URL("https://door.domain.foo:1234//pnfs/domain.foo//path/to/file");
+        assertThat(Requests.stripToPath(u), equalTo("/pnfs/domain.foo/path/to/file"));
+    }
+
+    @Test
+    public void shouldReturnFilePathOfUrlWithQuery() throws MalformedURLException {
+        var u = new URL("https://door.domain.foo:1234/pnfs/domain.foo/path/to/file?foo=bar");
+        assertThat(Requests.stripToPath(u), equalTo("/pnfs/domain.foo/path/to/file"));
     }
 }

--- a/modules/dcache-webdav/src/test/java/org/dcache/webdav/RequestsTest.java
+++ b/modules/dcache-webdav/src/test/java/org/dcache/webdav/RequestsTest.java
@@ -112,24 +112,24 @@ public class RequestsTest {
 
     @Test
     public void shouldReturnFilePathOfUrl() throws MalformedURLException {
-        var u = new URL("https://door.domain.foo/pnfs/domain.foo/path/to/file");
+        var u = new URL("https://door.domain.foo/pnfs/domain.foo/path/to/file").toString();
         assertThat(Requests.stripToPath(u), equalTo("/pnfs/domain.foo/path/to/file"));
     }
 
     @Test
     public void shouldReturnFilePathOfUrlWithPort() throws MalformedURLException {
-        var u = new URL("https://door.domain.foo:1234/pnfs/domain.foo/path/to/file?foo=bar");
+        var u = new URL("https://door.domain.foo:1234/pnfs/domain.foo/path/to/file?foo=bar").toString();
         assertThat(Requests.stripToPath(u), equalTo("/pnfs/domain.foo/path/to/file"));
     }
     @Test
     public void shouldReturnFilePathOfUrlWithPortAndExtraSlash() throws MalformedURLException {
-        var u = new URL("https://door.domain.foo:1234//pnfs/domain.foo//path/to/file");
+        var u = new URL("https://door.domain.foo:1234//pnfs/domain.foo//path/to/file").toString();
         assertThat(Requests.stripToPath(u), equalTo("/pnfs/domain.foo/path/to/file"));
     }
 
     @Test
     public void shouldReturnFilePathOfUrlWithQuery() throws MalformedURLException {
-        var u = new URL("https://door.domain.foo:1234/pnfs/domain.foo/path/to/file?foo=bar");
+        var u = new URL("https://door.domain.foo:1234/pnfs/domain.foo/path/to/file?foo=bar").toString();
         assertThat(Requests.stripToPath(u), equalTo("/pnfs/domain.foo/path/to/file"));
     }
 }


### PR DESCRIPTION
Motivation:
The surrent implementations will strip the urls like:

https://door.domain.foo:1234//pnfs/domain.foo/path/to/file

into

/domain.foo/path/to/file

Modification:

Stop using doggy ServletRequest.stripToPath in a favor of own implementation.

Result:
Correct behavior parsing of files.

Acked-by: Paul Millar
Target: master, 9.2, 9.1, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 830a8a1469c875ee199d423f38f6775cec6cdcf0)