### PR TITLE
dcache-bulk: fix handling of uncaught exceptions

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTarget.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTarget.java
@@ -301,7 +301,7 @@ public final class BulkRequestTarget {
             errorType = errorObject.getClass().getCanonicalName();
             errorMessage = errorObject.getMessage();
 
-            setState(State.FAILED);
+            setState(errorObject instanceof InterruptedException ? State.CANCELLED : State.FAILED);
         }
     }
 

--- a/skel/share/defaults/bulk.properties
+++ b/skel/share/defaults/bulk.properties
@@ -175,8 +175,10 @@ bulk.service.poolmanager.timeout=1
 bulk.service.qos=${dcache.service.qos}
 
 # ---- How long to wait for a response from qos.
+#      The default timeout is slightly longer in order to support cancellations
+#      of many requests simultaneously, especially if these requests each have many targets.
 #
-bulk.service.qos.timeout=1
+bulk.service.qos.timeout=5
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)bulk.service.qos.timeout.unit=MINUTES
 
 # ---- How long to wait for a response from the HA leader.

--- a/skel/share/defaults/qos.properties
+++ b/skel/share/defaults/qos.properties
@@ -118,9 +118,11 @@ qos.service.pinmanager.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)qos.service.pinmanager.timeout.unit=MINUTES
 
 # ---- Endpoint (cell) settings for contacting pnfs manager.
+#      Activity in the engine and verifier can be intense so a longer default timeout
+#      may at times be required.
 #
 qos.service.pnfsmanager=${dcache.service.pnfsmanager}
-qos.service.pnfsmanager.timeout=1
+qos.service.pnfsmanager.timeout=5
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)qos.service.pnfsmanager.timeout.unit=MINUTES
 
 # ---- Endpoint (cell) settings for contacting pools (destination is dynamic).
@@ -134,9 +136,11 @@ qos.service.transition.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)qos.service.transition.timeout.unit=MINUTES
 
 # ---- Main external entry point for qos.
+#      The verifier requirements requests can accumulate against the engine so a longer
+#      default timeout is indicated.
 #
 qos.service.requirements=${dcache.service.qos}
-qos.service.requirements.timeout=1
+qos.service.requirements.timeout=5
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)qos.service.requirements.timeout.unit=MINUTES
 
 # ---- Internal endpoints consumed only by other qos services.


### PR DESCRIPTION
Motivation:

See https://github.com/dCache/dcache/issues/7414
tape API/bulk: seem to choke on any interval other than "PND" and "PTNH"

The principal issue here –– properly failing the request on an unexpected exception –– is fixed.

Modification:

The update of the target state is now properly handled. The container job update is fixed so that the state is stored when the error is added.
> NOTE:  separate patches will be necessary for 9.1/9.0
> and for 8.2.

Result:

Proper completion of a request beset by an uncaught or unexpected exception.

Target: master
Request: 9.2
Patch: https://rb.dcache.org/r/14162/
Bug: #7414
Closes: #7414
Requires-notes: yes
Acked-by: Tigran