### PR TITLE
dcache-frontend,common:  check parsing of Duration in STAGE

### DIFF
--- a/modules/common/src/main/java/org/dcache/util/TimeUtils.java
+++ b/modules/common/src/main/java/org/dcache/util/TimeUtils.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableMap;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -35,6 +36,10 @@ import org.apache.commons.math3.stat.descriptive.StatisticalSummary;
 public class TimeUtils {
 
     public static final String TIMESTAMP_FORMAT = "yyyy-MM-dd' 'HH:mm:ss.SSS";
+
+    private static final String BAD_DURATION_FORMAT_ERROR = "Duration '%s' cannot be parsed. "
+          + "Accepted duration is a text string such as 'PnDTnHnMn.nS' based on the ISO-8601 "
+          + "duration format. E.g. 'P30DT2H30M15.5S' for 30 days, 2 hours, 30 minutes, 15.5 seconds.";
 
     /**
      * <p>Compares time units such that the larger unit is
@@ -578,5 +583,14 @@ public class TimeUtils {
 
     public static Duration durationOf(long value, TimeUnit unit) {
         return Duration.of(value, unit.toChronoUnit());
+    }
+
+    public static String validateDuration(String duration) throws IllegalArgumentException {
+        try {
+            Duration.parse(duration);
+            return duration;
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(String.format(BAD_DURATION_FORMAT_ERROR, duration));
+        }
     }
 }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
@@ -106,6 +106,7 @@ import org.dcache.services.bulk.BulkRequestInfo;
 import org.dcache.services.bulk.BulkRequestMessage;
 import org.dcache.services.bulk.BulkRequestStatusMessage;
 import org.dcache.services.bulk.BulkRequestTargetInfo;
+import org.dcache.util.TimeUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -382,7 +383,8 @@ public final class StageResources {
                 String path = file.getString("path");
                 paths.add(path);
                 if (file.has("diskLifetime")) {
-                    jsonLifetimes.put(path, file.getString("diskLifetime"));
+                    jsonLifetimes.put(path,
+                          TimeUtils.validateDuration(file.getString("diskLifetime")));
                 }
                 if (file.has("targetedMetadata")) {
                     getTargetedMetadataForPath(file).ifPresent(mdata ->
@@ -395,7 +397,7 @@ public final class StageResources {
             arguments.put("diskLifetime", jsonLifetimes.toString());
             arguments.put("targetedMetadata", jsonMetadata.toString());
             request.setArguments(arguments);
-        } catch (JSONException e) {
+        } catch (JSONException | IllegalArgumentException e) {
             throw newBadRequestException(requestPayload, e);
         }
 


### PR DESCRIPTION
Motivation:

See https://github.com/dCache/dcache/issues/7414
`tape API/bulk: seem to choke on any interval other than "PND" and "PTNH"`

Modification:

Solves the first part.  Whereever `Duration.parse` is used with a REST request (Bulk, QoS), we can now return a bad request response with a detailed error message.

Result:

No mysterious silent failure.

Target: master
Request: 9.2
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14161/
Bug: #7414
Requires-notes: yes
Acked-by: Dmitry