### PR TITLE
dcache-qos:  cache modify requests until processed by executor

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/VerifyOperationManager.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/verifier/data/VerifyOperationManager.java
@@ -477,6 +477,7 @@ public class VerifyOperationManager extends RunnableModule implements CellInfoPr
         VerifyOperationFilter filter = new VerifyOperationFilter();
         filter.setPnfsIds(pnfsId);
         cancel(new VerifyOperationCancelFilter(filter, remove));
+
     }
 
     public void cancelFileOpForPool(String pool, boolean onlyParent) {


### PR DESCRIPTION
Motivation:

With ingest queues servicing large
numbers of requests, as we have
for performance reasons configured as
defaults on QoS and Bulk, there is a
potential for a race between the
processing of the original modify
request and a subsequent cancellation
request, such that cancellation
may not find the request as it
is still in the executor queue.

Modification:

On both the engine and the verifier,
we cache the request pnfsid upon
arrival and remove it when processed
on a worker thread.

Should it be cancelled and still
be awaiting processing, it will
simply be eliminated from the
cache; otherwise, the full
cancellation proceeds as usual.

Result:

We do not have a trailing stream
of requests still being processed
after cancellation (from Bulk)
completes.

Target: master
Request: 9.2
Patch: https://rb.dcache.org/r/14166/
Requires-notes: yes
Acked-by: Tigran