### PR TITLE
pom.xml:  update dcache-view to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.jetty>9.4.51.v20230217</version.jetty>
         <version.xrootd4j>4.5.8</version.xrootd4j>
         <version.jersey>2.28</version.jersey>
-        <version.dcache-view>2.0.2</version.dcache-view>
+        <version.dcache-view>2.1.0</version.dcache-view>
         <version.netty>4.1.94.Final</version.netty>
         <version.dcache>${project.version}</version.dcache>
         <version.swagger-ui>3.1.7</version.swagger-ui>


### PR DESCRIPTION
Includes modifications to use new RolePrincipal
instead of the roles plugin role, eliminating
the need for additional logins for admin privileges.

Target: master
Request: 9.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14170/
Acked-by: Tigran