### PR TITLE
webdav: do not log  stacktrace if non-existing `well-known` is requested

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/WellKnownHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/services/httpd/handlers/WellKnownHandler.java
@@ -59,8 +59,10 @@ documents or software obtained from this server.
  */
 package org.dcache.services.httpd.handlers;
 
+import diskCacheV111.util.CacheException;
 import dmg.util.HttpRequest;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Optional;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -91,7 +93,8 @@ public class WellKnownHandler extends AbstractHandler {
             String[] tokens = proxy.getRequestTokens();
             Optional<WellKnownProducerFactory> factory = factoryProvider.getFactory(tokens[1]);
             if (factory.isEmpty()) {
-                throw new OnErrorException("No such endpoint");
+                response.sendError(HttpServletResponse.SC_NOT_FOUND, "No such endpoint");
+                return;
             }
 
             WellKnownProducer producer = factory.get().createProducer();
@@ -108,8 +111,8 @@ public class WellKnownHandler extends AbstractHandler {
                 baseRequest.setHandled(true);
             }
 
-        } catch (Exception t) {
-            throw new ServletException("WellKnownHandler", t);
+        } catch (CacheException | URISyntaxException e) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         }
     }
 


### PR DESCRIPTION
No reaouns to log a stacktrace

Fixes: #7434
Acked-by: Lea Morschel
Acked-by: Albert Rossi
Target: master, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit 05d9c4cf29447b72a122f43770e830d6a07a9c99)