### PR TITLE
dcache-frontend:  check for defined arguments with namespace qos

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/FileResources.java
@@ -443,9 +443,12 @@ public class FileResources {
                     pnfsHandler.renameEntry(path.toString(), target.toString(), true);
                     break;
                 case "qos":
-                    String targetQos = reqPayload.getString("target");
-                    String qosPolicy = reqPayload.getString("policy");
-                    Integer qosState = (Integer)reqPayload.get("state");
+                    String targetQos =
+                          reqPayload.has("target") ? reqPayload.getString("target") : null;
+                    String qosPolicy =
+                          reqPayload.has("policy") ? reqPayload.getString("policy") : null;
+                    Integer qosState =
+                          reqPayload.has("state") ? (Integer) reqPayload.get("state") : null;
                     Subject subject = RequestUser.getSubject();
                     if (!useQosService) {
                         new QoSTransitionEngine(poolmanager,


### PR DESCRIPTION
Motivation:

Bug reported by `RT 10532 QoS and Bulk Set-Up in 9.2`

Modfication:

Check that the argument/attribute is defined before calling get.

Result:

No exception thrown and request is forwarded as it should be.

Target: master
Request: 9.2
Requires-notes: yes
Patch: https://rb.dcache.org/r/14172/
Refers-to: RT 10532
Acked-by: Tigran