### PR TITLE
pom: Update mongodb-driver

### DIFF
--- a/modules/dcache/pom.xml
+++ b/modules/dcache/pom.xml
@@ -313,7 +313,7 @@
     </dependency>
     <dependency>
         <groupId>org.mongodb</groupId>
-        <artifactId>mongo-java-driver</artifactId>
+        <artifactId>mongodb-driver-sync</artifactId>
     </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -864,8 +864,8 @@
             </dependency>
             <dependency>
                 <groupId>org.mongodb</groupId>
-                <artifactId>mongo-java-driver</artifactId>
-                <version>3.4.2</version>
+                <artifactId>mongodb-driver-sync</artifactId>
+                <version>4.11.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Motivation:

\#7257 happened due to conflicting dependencies with dCache using an older version of the MongoDB-Driver.

Modification:

Replace mongo-java-driver, which is not maintained anymore, with the newest version of mongo-driver-sync. Update the code to work with the new version.

Result:

The MongoDB driver is updated

Target: master
Request: 9.2, 9.1, 9.0, 8.2
Requires-notes: yes
Requires-book: no
Acked-by: Tigran