### PR TITLE
qos: comment out property description

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -83,7 +83,7 @@ dcache.log.zookeeper.max-history=30
 # How many days to keep resilience logs
 dcache.log.resilience.max-history=30
 
-How many days to keep resilience logs
+# How many days to keep resilience logs
 dcache.log.qos.max-history=30
 
 # Host on which the remote log server will run


### PR DESCRIPTION
Motivation:
Lines in property files should be commented out descriptions or properties/values.

Modification:
Result:
Comment out property description, prevent `PropertySetterException`.

Target: master
Request: 9.2
Addressed RT 10537
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/14178/
Acked-by: Tigran Mkrtchyan