### PR TITLE
dcache-core: fix admin command completion

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/admin/HelpCompleter.java
+++ b/modules/dcache/src/main/java/diskCacheV111/admin/HelpCompleter.java
@@ -7,7 +7,7 @@ import java.util.List;
 import jline.console.completer.Completer;
 
 /**
- * Simple completor for JLine that uses the dCache help output to suggest command completions.
+ * Simple completer for JLine that uses the dCache help output to suggest command completions.
  */
 public class HelpCompleter implements Completer {
 
@@ -21,8 +21,10 @@ public class HelpCompleter implements Completer {
     }
 
     protected String scan(String line) {
-        int i = CharMatcher.anyOf("#[]<>|-").indexIn(line);
-        return (i == -1) ? line : line.substring(0, i);
+        int i = CharMatcher.anyOf("#[]<>|").indexIn(line);
+        int j = line.indexOf(" -");
+        i = i == -1 || j == -1 ? Math.max(i, j) : Math.min(i, j);
+        return (i == -1) ? line : line.substring(0, i).trim();
     }
 
     @Override

--- a/modules/dcache/src/test/java/diskCacheV111/admin/HelpCompleterTest.java
+++ b/modules/dcache/src/test/java/diskCacheV111/admin/HelpCompleterTest.java
@@ -1,0 +1,49 @@
+/*
+ * dCache - http://www.dcache.org/
+ *
+ * Copyright (C) 2023 Deutsches Elektronen-Synchrotron
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package diskCacheV111.admin;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class HelpCompleterTest {
+
+    HelpCompleter helpCompleter = new HelpCompleter("");
+
+    @Test
+    public void testScanShouldStripArgs() {
+        String line = "log set <appender> [<logger>] OFF|ERROR|WARN|INFO|DEBUG|TRACE|ALL";
+        String processed = helpCompleter.scan(line);
+        assertEquals("log set", processed);
+    }
+
+    @Test
+    public void testScanShouldStripWhitespaceSeparatedHyphen() {
+        String line = "set max diskspace -";
+        String processed = helpCompleter.scan(line);
+        assertEquals("set max diskspace", processed);
+    }
+
+    @Test
+    public void testScanShouldAcceptHyphenContainingCommand() {
+        String line = "chimera-maintenance ha show participants";
+        String processed = helpCompleter.scan(line);
+        assertEquals("chimera-maintenance ha show participants", processed);
+    }
+}


### PR DESCRIPTION
Motivation:
In the admin interface, command autocompletion strips arguments and parameters before showing them in the overview. When one such argument contains a hyphen, everything after the hyphen is stripped and not shown.

Especially zookeeper-related ha-commands such as
`\s PnfsManager chimera-maintenance ha show participants` were shortened, not auto-completed and thus only usable if they were already known.

Modification:
Make sure that we only shorten the string if the hyphen follows a whitespace. Add tests for completion shortening.

Result:
Admin commands with hyphen-containing arguments are no longer trunkated prematurely, they are now properly shown and autocompleted.

Target: master, 9.2, 9.1
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/14176/
Acked-by: Albert Rossi