### PR TITLE
dcache-xroot:  check that descriptor is not null before calling close

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/pool/XrootdPoolRequestHandler.java
@@ -51,6 +51,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -945,7 +946,7 @@ public class XrootdPoolRequestHandler extends AbstractXrootdRequestHandler {
 
     @GuardedBy("writeLock")
     private void removeAllDescriptorsAtomically() {
-        _descriptors.forEach(FileDescriptor::close);
+        _descriptors.stream().filter(Objects::nonNull).forEach(FileDescriptor::close);
         _descriptors.clear();
     }
 


### PR DESCRIPTION
Motivation:

```
05 Dec 2023 16:29:55 (dcache-cms199-01) [] An exception java.lang.NullPointerException
at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
at org.dcache.xrootd.pool.XrootdPoolRequestHandler.removeAllDescriptorsAtomically(XrootdPoolRequestHandler.java:948)
at org.dcache.xrootd.pool.XrootdPoolRequestHandler.exceptionCaught(XrootdPoolRequestHandler.java:277)
```

as reported on Slack channel.

Modification:

Should check for `null` before closing descriptor.

Result:

The NPE does not swallow the actual exception from `exceptionCaught`.

Target: master
Request: 9.2
Request: 9.1
Request: 9.0
Request: 8.2
Patch: https://rb.dcache.org/r/14180/
Requires-notes: yes
Acked-by: Lea
Acked-by: Tigran