### PR TITLE
dcache-xroot:  fix effective root when subject is nobody

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -1399,6 +1399,9 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
 
     private FsPath effectiveRoot() {
         LoginSessionInfo loginSessionInfo = sessionInfo();
+        if (Subjects.isNobody(loginSessionInfo.getSubject())) {
+            return _rootPath;
+        }
         FsPath userRoot = loginSessionInfo != null ? loginSessionInfo.getUserRootPath() : null;
         return userRoot != null ? userRoot : _rootPath;
     }


### PR DESCRIPTION
Motivation:

10545: Xrootd door root path weirdness in 9.2
https://rt.dcache.org/Ticket/Display.html?id=10545

The change to use `effectiveRoot` did not take
into account Subject = Nobody

Modification:

Check first for Subject = Nobody, and if
so, return the door root.

Result:

Regression eliminated, previous behavior
with anonymous read restored.

Target: master
Request: 9.2
Request: 9.1
Bug: #10545
Closes: #10545
Requires-notes: yes
Patch: https://rb.dcache.org/r/14181/
Acked-by: Tigran