### PR TITLE
cleaner-disk: prevent ConcurrentModificationException in cleaning run

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/DiskCleaner.java
@@ -89,11 +89,9 @@ public class DiskCleaner extends AbstractCleaner implements CellCommandListener,
 
     /**
      * runDelete Delete files on each pool from the poolList.
-     *
-     * @throws InterruptedException
      */
     @Override
-    protected void runDelete() throws InterruptedException {
+    protected void runDelete() {
         if (!_hasHaLeadership) {
             LOGGER.warn("Delete run triggered despite not having leadership. "
                   + "We assume this is a transient problem.");

--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/PoolInformationBase.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/PoolInformationBase.java
@@ -5,8 +5,7 @@ import diskCacheV111.vehicles.PoolManagerPoolUpMessage;
 import dmg.cells.nucleus.CellMessageReceiver;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.dcache.util.Args;
 
 /**
@@ -25,12 +24,12 @@ public class PoolInformationBase implements CellMessageReceiver {
     /**
      * Map of all pools currently up.
      */
-    private final Map<String, PoolInformation> _pools = new HashMap<>();
+    private final ConcurrentHashMap<String, PoolInformation> _pools = new ConcurrentHashMap<>();
 
     /**
      * Map from HSM instance name to the set of pools attached to that HSM.
      */
-    private final Map<String, Collection<PoolInformation>> _hsmToPool = new HashMap<>();
+    private final ConcurrentHashMap<String, Collection<PoolInformation>> _hsmToPool = new ConcurrentHashMap<>();
 
     /**
      *


### PR DESCRIPTION
Motivation:
Cleaner-disk cless use a shared PoolInformationBase, which contains a pools map that is updated regularly based on pools being up/down. In a regularly scheduled cleaner run, the map values are streamed over, and when it is modified at the same time, a `ConcurrentHashMap` exception will be thrown.

Modification:
Change the PoolInformationBase pools map to a thread-safe implementation.

Result:
No more `ConcurrentHashMap` exception in cleaner-disk runs due to concurrent pool status changes.

Target: master, 9.2, 9.1, 9.0, 8.2
Fixes: #7446
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/14179/
Acked-by: Tigran Mkrtchyan