### PR TITLE
webdav: wait for upload to complete

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -632,8 +632,27 @@ public class DcacheResourceFactory
                     PnfsHandler pnfs = roleAwarePnfsHandler();
                     Set<FileAttribute> requestedAttributes =
                           buildRequestedAttributes();
-                    FileAttributes attributes =
-                          pnfs.getFileAttributes(path.toString(), requestedAttributes);
+                    FileAttributes attributes;
+
+                    // FIXME: work around race condition between http mover completion and HEAD request by FTS
+                    // See: https://rt.dcache.org/Ticket/Display.html?id=10510
+                    int retry = 10;
+                    do {
+                        attributes = pnfs.getFileAttributes(path.toString(), requestedAttributes);
+                        if (!requestedAttributes.contains(CHECKSUM) ||
+                                (attributes.isDefined(CHECKSUM) && !attributes.getChecksums().isEmpty())) {
+                            break;
+                        }
+                        LOGGER.debug("The checksum attribute is not available yet. Waiting ... ({} attempts left)", retry);
+                        retry--;
+                        try {
+                            MILLISECONDS.sleep(500);
+                        } catch (InterruptedException e) {
+                            // Probably shutdown...
+                            break;
+                        }
+                    } while (retry > 0);
+
                     return getResource(path, attributes);
                 } catch (FileNotFoundCacheException e) {
                     if (haveRetried) {


### PR DESCRIPTION
Motivation:
Due to a race condition between file upload and file's checksum availability a quick client might see no checksum after upload.

Modification:
Update webdav door to retry the request to the namespace if checksum is not present in files attributes.

Result:

Fixes: #7467
Ticket: #10510
Acked-by: Lea Morschel
Acked-by: Paul Millar
Target: master, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit b13f6d7bfde62cf57e7fe1b1256d0b060bec15d3)