### PR TITLE
xrootd: fix xrootd.root regression

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -1403,7 +1403,10 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
             return _rootPath;
         }
         FsPath userRoot = loginSessionInfo != null ? loginSessionInfo.getUserRootPath() : null;
-        return userRoot != null ? userRoot : _rootPath;
+        if (userRoot == null) {
+            return  _rootPath;
+        }
+        return userRoot.contains(_rootPath.toString()) ? userRoot : _rootPath;
     }
 
     /**


### PR DESCRIPTION
Motivation:

Commit c491f2d312abcbadefcf1df2af85c5620e1e1867 has introduced handling of relative paths in xrootd with inadvertent side effect of dropping support xroot.root variable.

Modification:

Check xroot.root and user root and choose the one that is longest

Result:

The pre-9.2 behavior is restored

Ticket: https://rt.dcache.org/Ticket/Display.html?id=10545

Target: master
Request: 9.0, 9.1, 9.2
Require-notes: yes
Acked-by: Albert Rossi
Patch: https://rb.dcache.org/r/14184/