### PR TITLE
system-test: increase direct memory

### DIFF
--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -3,7 +3,6 @@ system-test.home=${dcache.home}
 dcache.broker.scheme=none
 dcache.pid.dir=/tmp
 dcache.java.memory.heap=1024m
-dcache.java.memory.direct=256m
 dcache.enable.space-reservation=true
 dcache.net.listen=127.0.0.1
 pool.mover.http.port.min = 20000


### PR DESCRIPTION
Motivation:
Commit ff857831df increased the direct memory for the default config file as required for NFS, but a similar change is necessary for system-test.

Modification:
Remove the small default direct memory value for system-test.

Result:
NFS on system-test works again.

Target: master, 9.2, 9.1
Requires-notes: yes
Requires-book: no
Acked-by: Tigran Mkrtchyan