### PR TITLE
gplazma: configured banfile plugin should ignore non-existent ban file

### DIFF
--- a/docs/TheBook/src/main/markdown/config-gplazma.md
+++ b/docs/TheBook/src/main/markdown/config-gplazma.md
@@ -757,7 +757,7 @@ In this example the first line is a comment. Lines 2 to 5 define aliases for pri
 
 Please note that the plug-in only supports principals whose assiciated name is a single line of plain text. In programming terms this means the constructor of the principal class has to take exactly one single string parameter.
 
-For the plugin to work, the configuration file has to exist even if it is empty.
+The plugin assumes that a missing file is equivalent to a file with no contents; i.e., that no one has been banned.
 
 After modifying the banfile, you may want to update gplazma.conf to trigger a reload to activate the changes. You can test the result with the `explain login` command in the gPlazma cell.
 

--- a/docs/TheBook/src/main/markdown/install.md
+++ b/docs/TheBook/src/main/markdown/install.md
@@ -656,7 +656,7 @@ username:tester uid:1000 gid:1000,true
 username:admin uid:0 gid:0,true
 ```
 
-Additionally we create an empty banfile to make sure the ban file plugin works:
+Additionally, we create an empty banfile to make sure the ban file plugin works:
 
 ```console-root
 touch /etc/dcache/ban.conf


### PR DESCRIPTION
Motivation:

When configured, gplazma requires a banfile to be present, even if it is empty. When one does not exist, gplazma will report the following on initialization, but continue to start: `failed to create banfile: config file doesn't exist or not a file`. All subsequent login requests will fail and result in a NullPointerException.

Modification:

As a workaround, the banfile plugin, even if configured, will now ignore an inexistent ban file and not fail with a NullPointerException on every subsequent login attempt. When a banfile is added or filled at some point, it will be used for subseqent login attempts.

Eventually, failed plugins should be ignored by gplazma, or gplazma should fail when trying to load them.

Result:

Even if configured, an empty or inexistent banfile will be ignored and logins should succeed.

Target: master, 9.2, 9.1, 9.0, 8.2
Fixes: #7465
Requires-notes: yes
Requires-book: no
Acked-by: Dmitry Litvintsev, Paul Millar, Tigran Mkrtchyan, Marina Sahakyan