### PR TITLE
gplazma: fix NPE if gPlazma is rejecting all logins

### DIFF
--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResult.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/monitor/LoginResult.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.collect.Sets;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -15,6 +16,9 @@ import org.dcache.gplazma.monitor.LoginMonitor.Result;
  * This class holds a detailed report of the activity when gPlazma processes a login request.
  */
 public class LoginResult {
+
+    private static final SetDiff<Principal> EMPTY_TO_EMPTY =
+            new SetDiff(Collections.emptySet(), Collections.emptySet());
 
     private final AuthPhaseResult _authPhase = new AuthPhaseResult();
     private final MapPhaseResult _mapPhase = new MapPhaseResult();
@@ -84,6 +88,15 @@ public class LoginResult {
     }
 
     /**
+     * Store the initial set of principals, as received by gPlazma from the
+     * door.
+     * @param initial The door-supplied set of principals.
+     */
+    public void setInitialPrincipals(Set<Principal> initial) {
+        _authPhase.setPrincipals(initial, initial);
+    }
+
+    /**
      * Returns whether gPlazma finished all four phases of the login process.
      * <p>
      * This is not the same as the login being successful.  This value will return true yet the
@@ -102,7 +115,7 @@ public class LoginResult {
 
         private final List<T> _plugins = new ArrayList<>();
         private final String _name;
-        private SetDiff<Principal> _principals;
+        private SetDiff<Principal> _principals = EMPTY_TO_EMPTY;
         private Result _result;
         private boolean _hasHappened;
 


### PR DESCRIPTION
Motivation:

If gPlazma configuration is broken or a plugin has rejected its configuration then gPlazma will NOT attempt to log in a user; in particular, the AUTH phase is not attempted.

There is a bug when handling such requests.  The code that logs unsuccessful login attempts needs to know the door-supplied information (credentials and principals, if any).  This information is used to suppress logging additional failed attempts from that user.

The door-supplied principals are currently only available if the AUTH phase is attempted.  In the above case, this does not happen, resulting in a NPE, as described in issue #7490.

This bug hides a further bug, where the code for logging failed login attempts assumes that the validation error is available, even when the validation phase has not taken place.

Modification:

Minor improvements to the error message describing how a plugin failured to initialise.

As a general safety point, ensure that the principals SetDiff values are non-null by initialising them to a safe default value.

Provide an alternative route to inject the door-supplied information into the AUTH phase result.  This is a temporary solution that is low-risk for back-porting.  A better solution would involve more code-refactoring.

In addition, the failure to configure gPlazma is recorded as a validation error for the login.  Again, this is an approach to reduce the risk for back-porting.  A more general (or "correct") approach would introduce unnecessary risk when back-porting.

Result:

A bug is fixed in gPlazma that is triggered when users attempt to authenticate with broken gPlazma configuration or a gPlazma plugin's configuration is broken.

Target: master
Fixes: #7490
Requires-notes: yes
Requires-book: no
Request: 9.2
Patch: https://rb.dcache.org/r/14198/
Acked-by: Tigran Mkrtchyan