### PR TITLE
webdav: fix slow listing

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -632,27 +632,8 @@ public class DcacheResourceFactory
                     PnfsHandler pnfs = roleAwarePnfsHandler();
                     Set<FileAttribute> requestedAttributes =
                           buildRequestedAttributes();
-                    FileAttributes attributes;
-
-                    // FIXME: work around race condition between http mover completion and HEAD request by FTS
-                    // See: https://rt.dcache.org/Ticket/Display.html?id=10510
-                    int retry = 10;
-                    do {
-                        attributes = pnfs.getFileAttributes(path.toString(), requestedAttributes);
-                        if (!requestedAttributes.contains(CHECKSUM) ||
-                                (attributes.isDefined(CHECKSUM) && !attributes.getChecksums().isEmpty())) {
-                            break;
-                        }
-                        LOGGER.debug("The checksum attribute is not available yet. Waiting ... ({} attempts left)", retry);
-                        retry--;
-                        try {
-                            MILLISECONDS.sleep(500);
-                        } catch (InterruptedException e) {
-                            // Probably shutdown...
-                            break;
-                        }
-                    } while (retry > 0);
-
+                    FileAttributes attributes =
+                          pnfs.getFileAttributes(path.toString(), requestedAttributes);
                     return getResource(path, attributes);
                 } catch (FileNotFoundCacheException e) {
                     if (haveRetried) {


### PR DESCRIPTION
Motivation:

Patch b13f6d7bfde62cf57e7fe1b1256d0b060bec15d3 introduced sleep/retry loop to address mover completion and checksum availability race condition. Unfortunately this patch caused sever slowdown of list operation

Modification:

Revert "webdav: wait for upload to complete"
This reverts commit b13f6d7bfde62cf57e7fe1b1256d0b060bec15d3.

Result:

WebDAV listing back to normal

Target: trunk
Request: 9.2
Issue: https://github.com/dCache/dcache/issues/7500
Patch: https://rb.dcache.org/r/14202/
Acked-by: Lea Morschel