### PR TITLE
pool: mover grizzly IO buffer initialization into NfsTransferService

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/EDSOperationREAD.java
@@ -10,33 +10,17 @@ import org.dcache.nfs.v4.xdr.READ4resok;
 import org.dcache.nfs.v4.xdr.nfs_argop4;
 import org.dcache.nfs.v4.xdr.nfs_opnum4;
 import org.dcache.nfs.v4.xdr.nfs_resop4;
-import org.dcache.oncrpc4j.grizzly.GrizzlyUtils;
 import org.dcache.oncrpc4j.rpc.OncRpcException;
 import org.dcache.oncrpc4j.xdr.Xdr;
 import org.dcache.oncrpc4j.xdr.XdrEncodingStream;
 import org.dcache.pool.repository.RepositoryChannel;
-import org.dcache.util.ByteUnit;
 import org.glassfish.grizzly.Buffer;
-import org.glassfish.grizzly.memory.MemoryManager;
-import org.glassfish.grizzly.memory.PooledMemoryManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class EDSOperationREAD extends AbstractNFSv4Operation {
 
     private static final Logger _log = LoggerFactory.getLogger(EDSOperationREAD.class.getName());
-
-    // one pool with 1MB chunks (max NFS rsize)
-    private final static MemoryManager<? extends Buffer> POOLED_BUFFER_ALLOCATOR =
-          new PooledMemoryManager(
-                ByteUnit.MiB.toBytes(1), // base chunk size
-                1, // number of pools
-                2, // grow facter per pool, ignored, see above
-                GrizzlyUtils.getDefaultWorkerPoolSize(), // expected concurrency
-                PooledMemoryManager.DEFAULT_HEAP_USAGE_PERCENTAGE,
-                PooledMemoryManager.DEFAULT_PREALLOCATED_BUFFERS_PERCENTAGE,
-                true  // direct buffers
-          );
 
     private final NfsTransferService nfsTransferService;
 
@@ -57,12 +41,12 @@ public class EDSOperationREAD extends AbstractNFSv4Operation {
             NfsMover mover = nfsTransferService.getMoverByStateId(context, _args.opread.stateid);
             if (mover == null) {
                 res.status = nfsstat.NFSERR_BAD_STATEID;
-                _log.debug("No mover associated with given stateid: ", _args.opread.stateid);
+                _log.debug("No mover associated with given stateid: {}", _args.opread.stateid);
                 return;
             }
 
             RepositoryChannel fc = mover.getMoverChannel();
-            var gBuffer = POOLED_BUFFER_ALLOCATOR.allocate(count);
+            var gBuffer = nfsTransferService.getIOBufferAllocator().allocate(count);
             int bytesToRead = count;
 
             int rc = -1;


### PR DESCRIPTION
Motivation:
the grizzly IO buffers are pre-initialized on startup. However, the initialization is bound to EDSOperationREAD class, thus, effectively, during the first NFS read request.

Modification:
mover grizzly IO buffer initialization into NfsTransferService, which is initialized at pool stat.

Result:
More predicable buffer initialization

Acked-by: Lea Morschel
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit 426d7c4f7a721c61376b09c9adab4d1f75cef2c3)