### PR TITLE
dcache-core: fix psu logging

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
+++ b/modules/dcache/src/main/java/diskCacheV111/poolManager/PoolSelectionUnitV2.java
@@ -662,8 +662,7 @@ public class PoolSelectionUnitV2
                   .stream()
                   .map(UGroup::getName).findFirst().get();
 
-            LOGGER.debug(
-                  "this IP address   belongs to {} in uGroup {} " + netUnitName + netUnitGroup);
+            LOGGER.debug("this IP address belongs to {} in uGroup {} ", netUnitName, netUnitGroup);
 
 
         } catch (UnknownHostException e) {
@@ -1158,7 +1157,7 @@ public class PoolSelectionUnitV2
                     break;
                 default:
                     throw new IllegalArgumentException(
-                          "Syntax error," + " no such mode: " + mode);
+                          "Syntax error, no such mode: " + mode);
             }
         } finally {
             wunlock();


### PR DESCRIPTION
Motivation:
Modification:

We observed faulty logging from poolmanager's psu:
`this IP address   belongs to {} in uGroup {}` ...

Result:

Logging properly includes intended fields.

Target: master, 9.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/14209/
Acked-by: Tigran Mkrtchyan