### PR TITLE
Revert "poolmanager: delete property for switchingon/off caching for …

### DIFF
--- a/modules/dcache/src/test/java/org/dcache/tests/poolmanager/PoolSelectionUnitTest.java
+++ b/modules/dcache/src/test/java/org/dcache/tests/poolmanager/PoolSelectionUnitTest.java
@@ -334,6 +334,8 @@ public class PoolSelectionUnitTest {
         FileAttributes fileAttributes = new FileAttributes();
         StorageInfos.injectInto(GenericStorageInfo.valueOf("*", "*"), fileAttributes);
 
+        _psu._cachingEnabeled = true;
+
         PoolPreferenceLevel[] preferenceRes1 = _psu.match(
               DirectionType.READ,  // operation
               "131.169.214.149", // net unit

--- a/skel/share/defaults/poolmanager.properties
+++ b/skel/share/defaults/poolmanager.properties
@@ -114,3 +114,11 @@ poolmanager.request-notifier.timeout=1
 (obsolete)poolmanager.cell.export = See poolmanager.cell.consume
 (forbidden)poolmanager.plugins.selection-unit =
 (forbidden)poolmanager.plugins.quota-manager =
+
+#
+# This property is used to optimise pool selection based on the idea that
+# when a request is coming the probability  that the next request for pool selection will
+# have the same selection parameters  is very high.  depending on the set up you can switch on/ and off
+# the caching of the selected pools.
+
+(one-of?true|false)poolmanager.selection.unit.cachingenabeled = false


### PR DESCRIPTION
…psu"

This reverts commit c0c11f4aa2cc9926ce5e91d63319d3a2e6254ec9.

Motivation:
Reverting this patch has been shown to fix the issue in which poolmanager will in some instances not load parts of its configuration.

Target: master, 9.2
Requires-book: no
Requires-notes: no
Addresses: RT #10575
Acked-by: Tigran Mkrtchyan