### PR TITLE
Remove dependency on GNU patch.

### DIFF
--- a/modules/srm-common/pom.xml
+++ b/modules/srm-common/pom.xml
@@ -58,11 +58,9 @@
 
       <!-- Fix up Axis auto-generated code -->
       <plugin>
-       <groupId>org.apache.maven.plugins</groupId>
-       <artifactId>maven-patch-plugin</artifactId>
-
+       <groupId>io.github.lukasmansour</groupId>
+       <artifactId>patch-maven-plugin</artifactId>
        <configuration>
-         <naturalOrderProcessing>true</naturalOrderProcessing>
          <patchDirectory>src/main/patches</patchDirectory>
          <targetDirectory>target/generated-sources/axistools/wsdl2java</targetDirectory>
        </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1218,9 +1218,9 @@
                     <version>1.4</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-patch-plugin</artifactId>
-                    <version>1.2</version>
+                    <groupId>io.github.lukasmansour</groupId>
+                    <artifactId>patch-maven-plugin</artifactId>
+                    <version>1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>


### PR DESCRIPTION
Motivation:
Replaces the maven patch plugin (which relies on GNU patch tool) with my own maven patch tool which relies on the following library instead: https://github.com/java-diff-utils/java-diff-utils

Modification:
Change the maven plugin groupId and artifactId to match with the new plugin. Otherwise the configuration is the same.

Result:
No more GNU patch tool is required to run the plugin, this should make container management in the CI pipeline easier and generally fix some building issues on platforms that don't have the GNU patch tool installed by default.

Signed-off-by: Lukas Mansour [lukas.mansour@desy.de](mailto:lukas.mansour@desy.de)

P.S. @kofemann Wort ist Wort.