### PR TITLE
cells: fix error reporting on tunnel disconnect

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/network/LocationManagerConnector.java
+++ b/modules/cells/src/main/java/dmg/cells/network/LocationManagerConnector.java
@@ -2,10 +2,12 @@ package dmg.cells.network;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.base.Throwables;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Uninterruptibles;
 import dmg.cells.nucleus.CellAdapter;
 import dmg.util.DummyStreamEngine;
+import dmg.util.Exceptions;
 import dmg.util.StreamEngine;
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -103,12 +105,12 @@ public class LocationManagerConnector
                 } catch (InterruptedIOException | ClosedByInterruptException e) {
                     throw e;
                 } catch (ExecutionException | IOException e) {
+                    String error = Exceptions.meaningfulMessage(Throwables.getRootCause(e));
                     _log.warn(AlarmMarkerFactory.getMarker(PredefinedAlarm.LOCATION_MANAGER_FAILURE,
                                 name,
                                 _domain,
-                                e.getMessage()),
-                          "Failed to connect to " + _domain + ": "
-                                + e.getMessage());
+                                    error),
+                          "Failed to connect to " + _domain + ": " + e);
                 }
 
                 _status = "Sleeping";


### PR DESCRIPTION
Motivation:
is a tunnel between two domain fails with an IOException without error message, then alarm logic silently fails as:

 java.lang.IllegalArgumentException: A marker name cannot be null
 at org.slf4j.helpers.BasicMarker.<init>(BasicMarker.java:47)
 at org.slf4j.helpers.BasicMarkerFactory.getDetachedMarker(BasicMarkerFactory.java:96)
 at org.dcache.alarms.AlarmMarkerFactory.getMarker(AlarmMarkerFactory.java:102)
 at java.base/java.lang.Thread.run(Thread.java:833)
 at dmg.cells.network.LocationManagerConnector.run(LocationManagerConnector.java:121)
 at dmg.cells.nucleus.CellNucleus.lambda$wrapLoggingContext$2(CellNucleus.java:725)

Modification:
Make sure that alarm gets meaning full error message, even if original exceptions returns null on getMessage.

Result:
tunnel successfully reconnects on network errors.

Related-issue: #7519
Acked-by: Paul Millar
Target: master, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit 48e5cafb6830c70cb0fadeb937ea0c5b981abb59)