### PR TITLE
srr: fix "empty path annotation" warning

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
@@ -121,7 +121,6 @@ public class SrrResource {
 
     @Produces(MediaType.APPLICATION_JSON)
     @GET
-    @Path("/")
     public Response getSrr() throws InterruptedException, CacheException, NoRouteToCellException {
 
         if (!isPublic) {


### PR DESCRIPTION
Motivation:
fix annoying warning message

The (sub)resource method getSrr in org.dcache.restful.resources.srr.SrrResource contains empty path annotation.

Modification:
Remove redundant explicit resource path.

Result:
less garbage in logs.

Acked-by: Lea Morschel
Target: master, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit 6b9e1c6b9f927827bca63657e00f35a0f7fb71de)