### PR TITLE
info: use DGA refresh rate as message timeout

### DIFF
--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/LinkgroupListDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/LinkgroupListDga.java
@@ -48,7 +48,8 @@ public class LinkgroupListDga extends SkelPeriodicActivity {
     public void trigger() {
         super.trigger();
         LOGGER.trace("Sending linkgroup list request message");
-        _mhc.sendMessage(_metricLifetime, _spacemanager, new GetLinkGroupNamesMessage());
+        _mhc.sendMessage(_metricLifetime, _spacemanager, triggerPeriod(),
+                new GetLinkGroupNamesMessage());
     }
 
 

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/ListBasedMessageDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/ListBasedMessageDga.java
@@ -69,7 +69,8 @@ public class ListBasedMessageDga extends SkelListBasedActivity {
         sb.append(" ");
         sb.append(item);
 
-        _sender.sendMessage(getMetricLifetime(), _handler, _cellPath, sb.toString());
+        _sender.sendMessage(getMetricLifetime(), _handler, _cellPath,
+                listRefreshPeriod(), sb.toString());
     }
 
     @Override

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/MessageSender.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/MessageSender.java
@@ -19,9 +19,10 @@ public interface MessageSender {
      *
      * @param ttl     how long, in seconds, resulting metrics should last
      * @param path    the destination for this request
+     * @param timeout the number of milliseconds to wait for a response.
      * @param message the vehicle to send
      */
-    void sendMessage(long ttl, CellPath path, Message message);
+    void sendMessage(long ttl, CellPath path, long timeout, Message message);
 
     /**
      * Send some arbitrary CellMessage (which includes the payload and the target Cell). The
@@ -33,9 +34,10 @@ public interface MessageSender {
      *
      * @param ttl      how long, in seconds, resulting metrics should last
      * @param handler  the object that is to receive reply message
+     * @param timeout the number of milliseconds to wait for a response.
      * @param envelope the complete message envelope to send
      */
-    void sendMessage(long ttl, CellMessageAnswerable handler,
+    void sendMessage(long ttl, CellMessageAnswerable handler, long timeout,
           CellMessage envelope);
 
     /**
@@ -49,8 +51,9 @@ public interface MessageSender {
      * @param ttl           how long, in seconds, resulting metrics should last
      * @param handler       the object that is to receive reply message
      * @param path          the destination for this request
+     * @param timeout the number of milliseconds to wait for a response.
      * @param requestString the String sent to the cell's shell
      */
     void sendMessage(long ttl, CellMessageAnswerable handler, CellPath path,
-          String requestString);
+          long timeout, String requestString);
 }

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/SingleMessageDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/SingleMessageDga.java
@@ -78,9 +78,11 @@ public class SingleMessageDga extends SkelPeriodicActivity {
         super.trigger();
 
         if (_requestMessage != null) {
-            _sender.sendMessage(metricLifetime(), null, new CellMessage(_target, _requestMessage));
+            _sender.sendMessage(metricLifetime(), null, triggerPeriod(),
+                    new CellMessage(_target, _requestMessage));
         } else {
-            _sender.sendMessage(metricLifetime(), _handler, _target, _requestString);
+            _sender.sendMessage(metricLifetime(), _handler, _target,
+                    triggerPeriod(), _requestString);
         }
     }
 

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/SkelPeriodicActivity.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/SkelPeriodicActivity.java
@@ -28,6 +28,14 @@ public class SkelPeriodicActivity implements Schedulable {
                     _period)));
     }
 
+    /**
+     * The duration between successive triggers.
+     * @return duration in milliseconds.
+     */
+    public long triggerPeriod() {
+        return TimeUnit.SECONDS.toMillis(_period);
+    }
+
     @Override
     public Date shouldNextBeTriggered() {
         return new Date(_nextTrigger.getTime());

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/cells/CellInfoDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/cells/CellInfoDga.java
@@ -52,7 +52,8 @@ public class CellInfoDga extends SkelListBasedActivity {
 
         LOGGER.info("sending message getcellinfos to System cell on domain {}", domainName);
 
-        _sender.sendMessage(getMetricLifetime(), _handler, systemCellPath, "getcellinfos");
+        _sender.sendMessage(getMetricLifetime(), _handler, systemCellPath,
+                listRefreshPeriod(), "getcellinfos");
     }
 
     /**

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/domain/StaticDomainDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/domain/StaticDomainDga.java
@@ -51,7 +51,7 @@ public class StaticDomainDga extends SkelListBasedActivity {
                   COMMAND, domain);
 
             _sender.sendMessage(getMetricLifetime(), _handler, path,
-                  COMMAND);
+                  listRefreshPeriod(), COMMAND);
         }
     }
 

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/routingmanager/RoutingMgrDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/routingmanager/RoutingMgrDga.java
@@ -66,7 +66,8 @@ public class RoutingMgrDga extends SkelListBasedActivity {
         CellPath routingMgrCellPath = new CellPath("RoutingMgr", domainName);
 
         LOGGER.info("sending message to RoutingMgr cell on domain {}", domainName);
-        _sender.sendMessage(getMetricLifetime(), _handler, routingMgrCellPath, "ls -x");
+        _sender.sendMessage(getMetricLifetime(), _handler, routingMgrCellPath,
+                listRefreshPeriod(), "ls -x");
     }
 
     /**

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/srm/LinkgroupDetailsDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/srm/LinkgroupDetailsDga.java
@@ -57,7 +57,8 @@ public class LinkgroupDetailsDga extends SkelPeriodicActivity {
 
         LOGGER.trace("Sending linkgroup details request message");
 
-        _sender.sendMessage(_metricLifetime, _spacemanager, new GetLinkGroupsMessage());
+        _sender.sendMessage(_metricLifetime, _spacemanager, triggerPeriod(),
+                new GetLinkGroupsMessage());
     }
 
 

--- a/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/srm/SrmSpaceDetailsDga.java
+++ b/modules/dcache-info/src/main/java/org/dcache/services/info/gathers/srm/SrmSpaceDetailsDga.java
@@ -56,7 +56,8 @@ public class SrmSpaceDetailsDga extends SkelPeriodicActivity {
 
         LOGGER.trace("Sending space token details request message");
 
-        _sender.sendMessage(_metricLifetime, _spacemanager, new GetSpaceTokensMessage(true));
+        _sender.sendMessage(_metricLifetime, _spacemanager, triggerPeriod(),
+                new GetSpaceTokensMessage(true));
     }
 
     @Override

--- a/modules/dcache-info/src/test/java/org/dcache/services/info/gathers/MessageHandlerChainAsMessageSenderTests.java
+++ b/modules/dcache-info/src/test/java/org/dcache/services/info/gathers/MessageHandlerChainAsMessageSenderTests.java
@@ -95,7 +95,7 @@ public class MessageHandlerChainAsMessageSenderTests {
         };
         CellMessage msg = new CellMessage(dest, obj);
 
-        _sender.sendMessage(10, new CactusCellMessageAnswerable(), msg);
+        _sender.sendMessage(10, new CactusCellMessageAnswerable(), 1000, msg);
 
         List<CellMessage> sentMsgs = _endpoint.getSentMessages();
 
@@ -112,7 +112,7 @@ public class MessageHandlerChainAsMessageSenderTests {
         CellPath dest = new CellPath("test-cell", "test-domain");
         Message vehicle = new Message();
 
-        _sender.sendMessage(10, dest, vehicle);
+        _sender.sendMessage(10, dest, 1000, vehicle);
 
         List<CellMessage> sentMsgs = _endpoint.getSentMessages();
 
@@ -129,7 +129,7 @@ public class MessageHandlerChainAsMessageSenderTests {
         CellPath dest = new CellPath("test-cell", "test-domain");
         String request = "get all data";
 
-        _sender.sendMessage(10, new CactusCellMessageAnswerable(), dest, request);
+        _sender.sendMessage(10, new CactusCellMessageAnswerable(), dest, 1000, request);
 
         List<CellMessage> sentMsgs = _endpoint.getSentMessages();
 


### PR DESCRIPTION
Motivation:

DGAs send messages to other dCache cells to discover their current status.  These messages have a hard-coded one second timeout.

Some queries are data-intensive and could take longer than one second to build the answer, resulting in no information being provided.

Modification:

DGAs already have the concept of some queries taking longer: the DGA refresh period.  This period is how long the DGA will wait, after querying a cell, before querying the cell for updated information.

Therefore, it makes sense to use this DGA refresh period as the timeout for messages send to other cells.

Result:

The info service will now wait longer for a cell to respond to a query for information.

Target: master
Requires-notes: yes
Requires-book: no
Request: 9.2
Ticket: https://rt.dcache.org/Ticket/Display.html?id=10592
Patch: https://rb.dcache.org/r/14226/
Acked-by: Tigran Mkrtchyan
Acked-by: Lea Morschel