### PR TITLE
qos: add flag to enable/disable role based authorization for transitions

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/ALRPStorageUnitQoSProvider.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/ALRPStorageUnitQoSProvider.java
@@ -100,6 +100,7 @@ import org.dcache.qos.data.QoSMessageType;
 import org.dcache.vehicles.FileAttributes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
 
 /**
  * Standard provisioning of (fixed) file requirements.  Uses access latency, retention policy, and
@@ -135,6 +136,11 @@ public class ALRPStorageUnitQoSProvider implements QoSRequirementsProvider, Cell
 
     private CellStub pnfsManager;
     private PoolMonitor poolMonitor;
+
+    /**
+     * Whether users require a QoS role to perform a transition.
+     */
+    private boolean enableRoles;
 
     public synchronized void messageArrived(SerializablePoolMonitor poolMonitor) {
         setPoolMonitor(poolMonitor);
@@ -305,7 +311,7 @@ public class ALRPStorageUnitQoSProvider implements QoSRequirementsProvider, Cell
             modifiedAttributes.setRetentionPolicy(REPLICA);
         }
 
-        if (canModifyQos(subject, currentAttributes)) {
+        if (canModifyQos(subject, isEnableRoles(), currentAttributes)) {
             pnfsHandler().setFileAttributes(pnfsId, modifiedAttributes);
         } else {
             throw new PermissionDeniedCacheException("User does not have permissions to set "
@@ -373,5 +379,14 @@ public class ALRPStorageUnitQoSProvider implements QoSRequirementsProvider, Cell
         LOGGER.debug("After call to namespace, {} has locations {}.", pnfsId,
               attributes.getLocations());
         return attributes;
+    }
+
+    public boolean isEnableRoles() {
+        return enableRoles;
+    }
+
+    @Required
+    public void setEnableRoles(boolean enableRoles) {
+        this.enableRoles = enableRoles;
     }
 }

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/PolicyBasedQoSProvider.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/PolicyBasedQoSProvider.java
@@ -216,7 +216,7 @@ public class PolicyBasedQoSProvider extends ALRPStorageUnitQoSProvider {
             modifiedAttributes.setQosState(newRequirements.getRequiredQoSStateIndex());
         }
 
-        if (canModifyQos(subject, currentAttributes)) {
+        if (canModifyQos(subject, isEnableRoles(), currentAttributes)) {
             pnfsHandler().setFileAttributes(pnfsId, modifiedAttributes);
         } else {
             throw new PermissionDeniedCacheException("User does not have permissions to set "

--- a/modules/dcache-qos/src/main/java/org/dcache/qos/util/QoSPermissionUtils.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/util/QoSPermissionUtils.java
@@ -78,15 +78,24 @@ public class QoSPermissionUtils {
      * do not need checking.
      *
      * @param subject of the message received.
+     * @param useRoles if true, use roles to determine if the user can modify qos.
      * @param attributes with OWNER and OWNER_GROUP defined.
      */
-    public static boolean canModifyQos(Subject subject, FileAttributes attributes) {
+    public static boolean canModifyQos(Subject subject, boolean useRoles, FileAttributes attributes) {
+
         if (subject == null) {
             /*
              * with 9.2, the subject is no longer retrieved from the database.
              * If it is missing from the message, do not authorize.
              */
             return false;
+        }
+
+        if (!useRoles) {
+            /*
+             *  If we are not using roles, then all users can modify QoS.
+             */
+            return true;
         }
 
         Set<Principal> principals = subject.getPrincipals();

--- a/modules/dcache-qos/src/main/resources/org/dcache/qos/qos-engine.xml
+++ b/modules/dcache-qos/src/main/resources/org/dcache/qos/qos-engine.xml
@@ -170,6 +170,7 @@
       <property name="pnfsManager" ref="pnfs-manager"/>
       <property name="cache" ref="policy-cache"/>
       <property name="engineDao" ref="engine-dao"/>
+      <property name="enableRoles" value="${qos.require-roles}" />
       <!-- pool monitor is received via message -->
     </bean>
 

--- a/skel/share/defaults/qos.properties
+++ b/skel/share/defaults/qos.properties
@@ -157,6 +157,12 @@ qos.service.scanner.timeout=1
 qos.service.verification.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)qos.service.verification.timeout.unit=MINUTES
 
+#
+# Whether users require a QoS role to perform a transition.
+#
+(one-of?true|false)qos.require-roles=true
+
+
 (obsolete)qos.adjuster.cell.consume=use qos-adjuster.cell.consume
 (obsolete)qos.adjuster.cell.name=use qos-adjuster.cell.name
 (obsolete)qos.db.verifier.connections.idle=use qos-verifier.db.connections.idle


### PR DESCRIPTION
Motivation:
in some deployments, when almost all users are allowed to perform QoS transitions a per-user or per-group access control makes no sense anymore and created an addition configuration overhead (for example, when user mapping comes from LDAP)

Modification:
introduce a global enable/disable switch for role based authorization

Result:
Admins have a possibility to disable RBAC

Fixes: #7498
Acked-by:
Target: master, 9.2, 10.0
Require-book: no
Require-notes: yes
(cherry picked from commit d26b9ae03141835db34d5fa813005b5163354428)