### PR TITLE
webdav: httptpc percent-decode local path

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
@@ -387,8 +387,9 @@ public class CopyFilter implements Filter {
 
         TransferType type = TransferType.fromScheme(remote.getScheme());
 
+        var requestPath = URI.create(request.getAbsoluteUrl()).getPath();
         FsPath path = _pathMapper.asDcachePath(ServletRequest.getRequest(),
-              request.getAbsolutePath(), m -> new ErrorResponseException(Status.SC_FORBIDDEN, m));
+              requestPath, m -> new ErrorResponseException(Status.SC_FORBIDDEN, m));
 
         // Always check any client-supplied Overwrite header, to throw an error if the value is malformed.
         boolean overwriteAllowed = clientAllowsOverwrite();


### PR DESCRIPTION
Motivation:

Percent-encoding is a way of representing non-ASCII characters within a URL.  Percent-encoding is always allowed and for certain characters (a reserved character or a character with a reserved purpose used outside of that purpose) it is required.  For example, the space character is reserved and must always be escaped.

Currently, dCache will understand the local URL without expanding any percent-encoded characters.

The following curl command illustrates an HTTP-TPC request where both the source and destination URLs are precent-encoded.

```console
paul@celebrimbor:~$ curl -X COPY \
    -H "Credential: none" \
    -H "Authorization: Bearer $(oidc-token EGI-CHECKIN)" \
    -H "Source: https://prometheus.desy.de/Video/BlenderFoundation/Tears%20of%20steel.webm" \
    https://dcache-door-doma01.desy.de:2443/Users/paul/test%201.webm
```

This command will transfer the file `Tears of steel.webm` from the remote, source server (prometheus.desy.de).  Howver, dCache will store the transferred file as the file `test%201.webm` and not the desired file `test 1.webm`.

Modification:

Use Java's URI class to parse the request URL and use this to extract the target path.  This includes any required percent-encoded decoding.

Result:

dCache now supports HTTP-TPC transfers where the dCache-local path includes HTTP reserved characters.

Target: master
Request: 9.2
Closes: #7512
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/14239/
Acked-by: Tigran Mkrtchyan