### PR TITLE
docs: update oidc chapter to explain trust anchors

### DIFF
--- a/docs/TheBook/src/main/markdown/config-gplazma.md
+++ b/docs/TheBook/src/main/markdown/config-gplazma.md
@@ -227,6 +227,13 @@ will use offline verification; otherwise, the token is sent to the
 userinfo endpoint.  dCache will cache the response.  This behaviour
 may be adjusted.
 
+Please note that the OIDC plugin uses Java's built-in trust store
+to verify the certificate presented by the issuer when making
+TLS-encrypted HTTP requests (https://...).  Most issuers use
+certificates issued by a CA/B-accredited certificate authority, and
+most distributions of Java provide CA/B as a default list of
+trusted certificate authorities.
+
 ##### Obtaining OIDC information
 
 The access token represents a logged in user; however, dCache needs to


### PR DESCRIPTION
Motivation:

Issue #7553 describes how it's currently undocumented that the OIDC plugin uses Java's built-in trust store.

Modification:

Document behaviour

Result:

Admins may have a better understanding of how to configure their dCache.

Target: master
Requires-notes: no
Requires-book: yes
Request: 9.2