### PR TITLE
rpm: don't force java-11 it java-17 is installed

### DIFF
--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -13,7 +13,7 @@ Requires(pre): shadow-utils
 Requires: which
 Requires: hostname
 Requires: procps-ng
-Requires: java-11-headless
+Requires: (java-11-headless or java-17-headless)
 
 %{?systemd_requires}
 BuildRequires: systemd


### PR DESCRIPTION
Motivation:
as dcache can run with java 17 and java 11, we should not require sited to install both. With EL8 and later rpm allows to specify both as alternative.

Modification:
Update rpm to see java 17 and java 11 as equal alternatives

Result:
java 11 will be installed as dependency if java 17 is not already present.

NOTE: after EOL for EL7, this patch can be backported to 9.2

Acked-by: Lea Morschel
Target: 10.0
Require-book: no
Require-notes: yes