### PR TITLE
chimera: don't update file mtime on hard links creation

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/JdbcFs.java
@@ -367,8 +367,8 @@ public class JdbcFs implements FileSystemProvider, LeaderLatchListener {
                 }
 
                 _sqlDriver.createEntryInParent(parent, name, inode);
-                _sqlDriver.incNlink(inode);
-                _sqlDriver.incNlink(parent, 0);
+                _sqlDriver.incNlinkForFile(inode);
+                _sqlDriver.incNlinkForDir(parent, 0);
             } catch (DuplicateKeyException e) {
                 throw new FileExistsChimeraFsException(e);
             }

--- a/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/PgSQL95FsSqlDriver.java
@@ -511,9 +511,9 @@ public class PgSQL95FsSqlDriver extends FsSqlDriver {
 
 
     @Override
-    void decNlink(FsInode inode, int delta) {
+    void decNlinkForDir(FsInode inode, int delta) {
         if (delta > 0 || !enableLazyWcc) {
-            super.decNlink(inode, delta);
+            super.decNlinkForDir(inode, delta);
             return;
         }
 
@@ -525,9 +525,9 @@ public class PgSQL95FsSqlDriver extends FsSqlDriver {
     }
 
     @Override
-    void incNlink(FsInode inode, int delta) {
+    void incNlinkForDir(FsInode inode, int delta) {
         if (delta > 0 || !enableLazyWcc) {
-            super.incNlink(inode, delta);
+            super.incNlinkForDir(inode, delta);
             return;
         }
         // parent dir mtime update

--- a/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
@@ -1710,6 +1710,19 @@ public class JdbcFsTest extends ChimeraTestCaseHelper {
               _fs.stat(inode).getGeneration(), greaterThan(s0.getGeneration()));
     }
 
+    @Test
+    public void testNoMtimeUpdateForHardlinks() throws Exception {
+
+        FsInode dir = _fs.mkdir("/test");
+        FsInode inode = _fs.createFile(dir, "aFile");
+        long mtime0 = inode.stat().getMTime();
+
+        FsInode hlink = _fs.createHLink(dir, inode, "hlink");
+        long mtime1 = inode.stat().getMTime();
+
+        assertThat("file mtine shoud not be changes on hardlink creation", mtime1, is(mtime0));
+    }
+
     private long getDirEntryCount(FsInode dir) throws IOException {
         try (var s = _fs.newDirectoryStream(dir)) {
             return s.stream().count();


### PR DESCRIPTION
Motivation:
According to POSIX, file mtime should be updated only when file content has been changed, thus creating a hardlink must not modify it.

Modification:
added unit test to ensure posix behaviour. The inc/decNlink is split into two methods - one for directories, where nlink update associated with mtime update, and for files, where nlink update is independent of file modification.

Result:
improved POSIX compliance.

Fixes: #7552
Acked-by: Lea Morschel
Target: master, 10.0, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit bf4e865732f46a755219146359117f775913c406)