### PR TITLE
chimera: fix loop creation on directory move

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -18,6 +18,7 @@ package org.dcache.chimera;
 
 import static java.util.stream.Collectors.toList;
 import static org.dcache.chimera.FileSystemProvider.SetXattrMode;
+import static org.dcache.chimera.FileSystemProvider.StatCacheOption.NO_STAT;
 import static org.dcache.chimera.FileSystemProvider.StatCacheOption.STAT;
 
 import com.google.common.base.Strings;
@@ -50,6 +51,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.OptionalLong;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -474,7 +476,13 @@ public class FsSqlDriver {
      * @param inode
      * @return true if moved, false if source did not exist
      */
-    boolean rename(FsInode inode, FsInode srcDir, String source, FsInode destDir, String dest) {
+    boolean rename(FsInode inode, FsInode srcDir, String source, FsInode destDir, String dest) throws ChimeraFsException {
+
+        // If source is a directory check that we don't move into its own subdirectory
+        if (inode.isDirectory()) {
+            checkLoop(inode, destDir);
+        }
+
         String moveLink = "UPDATE t_dirs SET iparent=?, iname=? WHERE iparent=? AND iname=? AND ichild=?";
         int n = _jdbc.update(moveLink,
               ps -> {
@@ -574,6 +582,30 @@ public class FsSqlDriver {
             return Lists.reverse(pList).stream().collect(Collectors.joining("/", "/", ""));
         } catch (IncorrectResultSizeDataAccessException e) {
             return "";
+        }
+    }
+
+    protected void checkLoop(FsInode inode, FsInode dst) throws InvalidArgumentChimeraException {
+        if (inode.ino() == dst.ino()) {
+            throw new InvalidArgumentChimeraException("Cannot move directory into itself.");
+        }
+
+        long destInumber = dst.ino();
+        while (true) {
+            OptionalLong parent = _jdbc.query("SELECT iparent FROM t_dirs WHERE ichild=?",
+                    rs -> rs.next() ? OptionalLong.of(rs.getLong("iparent")) : OptionalLong.empty(),
+                    destInumber);
+
+            if (parent.isEmpty()) {
+                // we have reached the root of the three
+                break;
+            }
+
+            long parentIno = parent.getAsLong();
+            if (parentIno == inode.ino()) {
+                throw new InvalidArgumentChimeraException("Cannot move directory into its own subdirectory.");
+            }
+            destInumber = parentIno;
         }
     }
 

--- a/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
@@ -921,7 +921,8 @@ public class JdbcFsTest extends ChimeraTestCaseHelper {
 
     @Test(expected = FileNotFoundChimeraFsException.class)
     public void testMoveNotExists() throws Exception {
-        _fs.rename(_rootInode, _rootInode, "foo", _rootInode, "bar");
+        FsInode dummy = new FsInode(_fs, 31415);
+        _fs.rename(dummy, _rootInode, "foo", _rootInode, "bar");
     }
 
     @Test(expected = DirNotEmptyChimeraFsException.class)
@@ -1708,6 +1709,23 @@ public class JdbcFsTest extends ChimeraTestCaseHelper {
         _fs.removeXattr(inode, key);
         assertThat("inode generation must be update on xattr remote",
               _fs.stat(inode).getGeneration(), greaterThan(s0.getGeneration()));
+    }
+
+    @Test(expected = InvalidArgumentChimeraException.class)
+    public void testMvDirectoryIntoItself() throws Exception {
+
+        FsInode dir = _fs.mkdir("/dir");
+        _fs.rename(dir, _rootInode, "dir", dir, "subdir");
+    }
+
+    @Test(expected = InvalidArgumentChimeraException.class)
+    public void testMvDirectoryOwnSubtree() throws Exception {
+
+        FsInode dir = _fs.mkdir("/dir");
+        _fs.mkdir("/dir/subdir1");
+        FsInode dir2 = _fs.mkdir("/dir/subdir1/subdir2");
+
+        _fs.rename(dir, _rootInode, "dir", dir2, "subdir3");
     }
 
     private long getDirEntryCount(FsInode dir) throws IOException {


### PR DESCRIPTION
Motivation:
On directory move we must check that destination is not a subdirectory on the source directory.

Modification:
Update JdbcFs#rename to check for a potential loop creation before move. Added unit test to cover the use case.

Result:
no more loops on directory move.

Fixes: #7559
Ticket: #10608
Acked-by: Dmitry Litvintsev
Acked-by: Paul Millar
Target: master, 10.0, 9.2, 9.1, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 72da8e95921603b67384abbbfbb4edd539140514)