### PR TITLE
chimera: fix loop creation on directory move

### DIFF
--- a/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
@@ -995,7 +995,8 @@ public class JdbcFsTest extends ChimeraTestCaseHelper {
 
     @Test(expected = FileNotFoundChimeraFsException.class)
     public void testMoveNotExists() throws Exception {
-        _fs.rename(_rootInode, _rootInode, "foo", _rootInode, "bar");
+        FsInode dummy = new FsInode(_fs, 31415);
+        _fs.rename(dummy, _rootInode, "foo", _rootInode, "bar");
     }
 
     @Test(expected = DirNotEmptyChimeraFsException.class)
@@ -1740,6 +1741,23 @@ public class JdbcFsTest extends ChimeraTestCaseHelper {
         _fs.removeXattr(inode, key);
         assertThat("inode generation must be update on xattr remote",
               _fs.stat(inode).getGeneration(), greaterThan(s0.getGeneration()));
+    }
+
+    @Test(expected = InvalidArgumentChimeraException.class)
+    public void testMvDirectoryIntoItself() throws Exception {
+
+        FsInode dir = _fs.mkdir("/dir");
+        _fs.rename(dir, _rootInode, "dir", dir, "subdir");
+    }
+
+    @Test(expected = InvalidArgumentChimeraException.class)
+    public void testMvDirectoryOwnSubtree() throws Exception {
+
+        FsInode dir = _fs.mkdir("/dir");
+        _fs.mkdir("/dir/subdir1");
+        FsInode dir2 = _fs.mkdir("/dir/subdir1/subdir2");
+
+        _fs.rename(dir, _rootInode, "dir", dir2, "subdir3");
     }
 
     private long getDirEntryCount(FsInode dir) throws IOException {


### PR DESCRIPTION
Motivation:
On directory move we must check that destination is not a subdirectory on the source directory.

Modification:
Update JdbcFs#rename to check for a potential loop creation before move. Added unit test to cover the use case.

Result:
no more loops on directory move.

Fixes: #7559
Ticket: #10608
Acked-by: Dmitry Litvintsev
Acked-by: Paul Millar
Target: master, 10.0, 9.2, 9.1, 9.0, 8.2
Require-book: no
Require-notes: yes
(cherry picked from commit 72da8e95921603b67384abbbfbb4edd539140514)