### PR TITLE
pool: Add PNFSID to st ls and rh ls commands

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -878,12 +878,14 @@ public class NearlineStorageHandler
         }
 
         public String printJobQueue(PnfsId pnfsId){
-            var requestWithPNFSID = requests.get(pnfsId);
-            if( requestWithPNFSID == null) {
-                throw new NullPointerException("PNFSID not in store queue");
-             }
+            R requestWithPNFSID;
+            try {
+                requestWithPNFSID = requests.get(pnfsId);
+            }catch (Exception e){
+                System.out.println(pnfsId + " not in store queue");
+                return pnfsId + " not in store queue";
+            }
             return requestWithPNFSID.toString();
-
         }
 
         public String printJobQueue(Comparator<R> ordering) {

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -877,6 +877,16 @@ public class NearlineStorageHandler
                   .collect(Collectors.joining("\n"));
         }
 
+        public String printJobQueue(PnfsId pnfsId){
+            return requests
+                    .values()
+                    .stream()
+                    .map(Object::toString)
+                    .filter(id -> id.equals(pnfsId.toString()))
+                    .collect(Collectors.joining("\n"));
+
+        }
+
         public String printJobQueue(Comparator<R> ordering) {
             return requests.values().stream()
                   .sorted(ordering)
@@ -1566,10 +1576,18 @@ public class NearlineStorageHandler
                 "The columns in the output show: job id, job status, pnfs id, request counter, " +
                 "and request submission time.")
     class RestoreListCommand implements Callable<String> {
+        @Argument(metaVar = "pnfsid", required = false)
+        String arg;
 
         @Override
-        public String call() {
-            return stageRequests.printJobQueue(Comparator.naturalOrder());
+        public String call() throws NoSuchElementException, IllegalStateException {
+            if (arg == null){
+                stageRequests.printJobQueue(Comparator.naturalOrder());
+            } else {
+                var pnfsId = new PnfsId(arg);
+                stageRequests.printJobQueue(pnfsId);
+            }
+            return "Restore queue list initialized";
         }
     }
 
@@ -1634,10 +1652,18 @@ public class NearlineStorageHandler
                 "The columns in the output show: job id, job status, pnfs id, request counter, " +
                 "and request submission time.")
     class StoreListCommand implements Callable<String> {
+        @Argument(metaVar = "pnfsid", required = false)
+        String arg;
 
         @Override
-        public String call() {
-            return flushRequests.printJobQueue(Comparator.naturalOrder());
+        public String call() throws NoSuchElementException, IllegalStateException {
+            if(arg == null){
+                flushRequests.printJobQueue(Comparator.naturalOrder());
+            } else {
+                var pnfsId = new PnfsId(arg);
+                flushRequests.printJobQueue(pnfsId);
+            }
+            return "Store queue list initialized";
         }
     }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -877,15 +877,13 @@ public class NearlineStorageHandler
                   .collect(Collectors.joining("\n"));
         }
 
-        public String printJobQueue(PnfsId pnfsId){
-            R requestWithPNFSID;
-            try {
-                requestWithPNFSID = requests.get(pnfsId);
-            }catch (Exception e){
-                System.out.println(pnfsId + " not in store queue");
-                return pnfsId + " not in store queue";
+        public String printJobQueue(PnfsId pnfsId) {
+            R requestWithPNFSID = requests.get(pnfsId);
+            if (requestWithPNFSID == null) {
+                return pnfsId + " not in the queue";
+            } else {
+                return requestWithPNFSID.toString();
             }
-            return requestWithPNFSID.toString();
         }
 
         public String printJobQueue(Comparator<R> ordering) {

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -879,7 +879,7 @@ public class NearlineStorageHandler
 
         public String printJobQueue(PnfsId pnfsId){
             var requestWithPNFSID = requests.get(pnfsId);
-            if( requests.get(pnfsId) == null) {
+            if( requestWithPNFSID == null) {
                 throw new NullPointerException("PNFSID not in store queue");
              }
             return requestWithPNFSID.toString();

--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -878,12 +878,11 @@ public class NearlineStorageHandler
         }
 
         public String printJobQueue(PnfsId pnfsId){
-            return requests
-                    .values()
-                    .stream()
-                    .map(Object::toString)
-                    .filter(id -> id.equals(pnfsId.toString()))
-                    .collect(Collectors.joining("\n"));
+            var requestWithPNFSID = requests.get(pnfsId);
+            if( requests.get(pnfsId) == null) {
+                throw new NullPointerException("PNFSID not in store queue");
+             }
+            return requestWithPNFSID.toString();
 
         }
 
@@ -1304,7 +1303,7 @@ public class NearlineStorageHandler
                         ReplicaState.FROM_STORE,
                         ReplicaState.CACHED,
                         Collections.emptyList(),
-                        EnumSet.noneOf(Repository.OpenFlags.class),
+                        EnumSet.noneOf(OpenFlags.class),
                         OptionalLong.empty());
             LOGGER.debug("Stage request created for {}.", pnfsId);
         }
@@ -1582,12 +1581,11 @@ public class NearlineStorageHandler
         @Override
         public String call() throws NoSuchElementException, IllegalStateException {
             if (arg == null){
-                stageRequests.printJobQueue(Comparator.naturalOrder());
+                return stageRequests.printJobQueue(Comparator.naturalOrder());
             } else {
                 var pnfsId = new PnfsId(arg);
-                stageRequests.printJobQueue(pnfsId);
+                return stageRequests.printJobQueue(pnfsId);
             }
-            return "Restore queue list initialized";
         }
     }
 
@@ -1658,12 +1656,11 @@ public class NearlineStorageHandler
         @Override
         public String call() throws NoSuchElementException, IllegalStateException {
             if(arg == null){
-                flushRequests.printJobQueue(Comparator.naturalOrder());
+                return flushRequests.printJobQueue(Comparator.naturalOrder());
             } else {
                 var pnfsId = new PnfsId(arg);
-                flushRequests.printJobQueue(pnfsId);
+                return flushRequests.printJobQueue(pnfsId);
             }
-            return "Store queue list initialized";
         }
     }
 


### PR DESCRIPTION
Motivation: Users want the capability to run the commands mentioned above for a single/specified id

Modification: Added a optional argument to the commands

Result: List hsm queues by PNFSID

Fixes: #7561
Target: master
Require-book: no
Require-notes: yes