### PR TITLE
tpc: Remove remote transfer manager's database

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -397,8 +397,7 @@ public abstract class TransferManager extends AbstractCellComponent
     }
 
     @Autowired(required = false)
-    @Qualifier("")
-    public void setTransferTemplate( KafkaTemplate kafkaTemplate) {
+    public void setTransferTemplate(KafkaTemplate kafkaTemplate) {
         _kafkaSender = kafkaTemplate::sendDefault;
     }
 

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManager.java
@@ -34,9 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.jdo.PersistenceManager;
-import javax.jdo.PersistenceManagerFactory;
-import javax.jdo.Transaction;
 import org.dcache.cells.CellStub;
 import org.dcache.poolmanager.PoolManagerStub;
 import org.dcache.util.Args;
@@ -44,6 +41,7 @@ import org.dcache.util.CDCExecutorServiceDecorator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.kafka.core.KafkaTemplate;
 
 
@@ -81,15 +79,12 @@ public abstract class TransferManager extends AbstractCellComponent
     public final Set<PnfsId> justRequestedIDs = new HashSet<>();
     private final ExecutorService executor =
           new CDCExecutorServiceDecorator<>(Executors.newCachedThreadPool());
-    private PersistenceManagerFactory _pmf;
-
     public void cleanUp() {
         executor.shutdown();
     }
 
     @Override
     public void getInfo(PrintWriter pw) {
-        pw.printf("DB logging            : %b\n", doDbLogging());
         pw.printf("Transfer ID generated : %s\n", idGenerator == null ? "locally" : "from DB");
         pw.printf("Next Transfer ID      : %d\n", nextMessageID);
         pw.printf("Active transfers      : %d\n", _numTransfers);
@@ -343,52 +338,12 @@ public abstract class TransferManager extends AbstractCellComponent
 
     public void addActiveTransfer(long id, TransferManagerHandler handler) {
         _activeTransfers.put(id, handler);
-        if (doDbLogging()) {
-            PersistenceManager pm = _pmf.getPersistenceManager();
-            try {
-                Transaction tx = pm.currentTransaction();
-                try {
-                    tx.begin();
-                    pm.makePersistent(handler);
-                    tx.commit();
-                    LOGGER.debug("Recording new handler into database.");
-                } catch (Exception e) {
-                    LOGGER.error(e.toString());
-                } finally {
-                    rollbackIfActive(tx);
-                }
-            } finally {
-                pm.close();
-            }
-        }
     }
 
     public void removeActiveTransfer(long id) {
         TransferManagerHandler handler = _activeTransfers.remove(id);
         if (handler == null) {
             return;
-        }
-        if (doDbLogging()) {
-            PersistenceManager pm = _pmf.getPersistenceManager();
-            try {
-                Transaction tx = pm.currentTransaction();
-                TransferManagerHandlerBackup handlerBackup
-                      = new TransferManagerHandlerBackup(handler);
-                try {
-                    tx.begin();
-                    pm.makePersistent(handler);
-                    pm.deletePersistent(handler);
-                    pm.makePersistent(handlerBackup);
-                    tx.commit();
-                    LOGGER.debug("handler removed from db");
-                } catch (Exception e) {
-                    LOGGER.error(e.toString());
-                } finally {
-                    rollbackIfActive(tx);
-                }
-            } finally {
-                pm.close();
-            }
         }
     }
 
@@ -424,41 +379,8 @@ public abstract class TransferManager extends AbstractCellComponent
         return _ioQueueName;
     }
 
-    public static void rollbackIfActive(Transaction tx) {
-        if (tx != null && tx.isActive()) {
-            tx.rollback();
-        }
-    }
-
-    public boolean doDbLogging() {
-        return _pmf != null;
-    }
-
     public int getMaxNumberOfDeleteRetries() {
         return _maxNumberOfDeleteRetries;
-    }
-
-    public void persist(Object o) {
-        if (doDbLogging()) {
-            PersistenceManager pm = _pmf.getPersistenceManager();
-            try {
-                Transaction tx = pm.currentTransaction();
-                try {
-                    tx.begin();
-                    pm.makePersistent(o);
-                    tx.commit();
-                    LOGGER.debug("[{}]: Recording new state of handler into database.",
-                          o);
-                } catch (Exception e) {
-                    LOGGER.error("[{}]: failed to persist object: {}.",
-                          o, e.getMessage());
-                } finally {
-                    rollbackIfActive(tx);
-                }
-            } finally {
-                pm.close();
-            }
-        }
     }
 
     @Override
@@ -475,7 +397,8 @@ public abstract class TransferManager extends AbstractCellComponent
     }
 
     @Autowired(required = false)
-    public void setTransferTemplate(KafkaTemplate kafkaTemplate) {
+    @Qualifier("")
+    public void setTransferTemplate( KafkaTemplate kafkaTemplate) {
         _kafkaSender = kafkaTemplate::sendDefault;
     }
 
@@ -509,10 +432,6 @@ public abstract class TransferManager extends AbstractCellComponent
 
     public void setOverwrite(boolean overwrite) {
         _overwrite = overwrite;
-    }
-
-    public void setPersistenceManagerFactory(PersistenceManagerFactory pmf) {
-        _pmf = pmf;
     }
 
     public void setTLogRoot(String tLogRoot) {

--- a/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
+++ b/modules/dcache/src/main/java/diskCacheV111/services/TransferManagerHandler.java
@@ -65,7 +65,6 @@ import org.dcache.vehicles.PnfsGetFileAttributes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.KafkaException;
-import org.springframework.kafka.core.KafkaTemplate;
 
 public class TransferManagerHandler extends AbstractMessageCallback<Message> {
 
@@ -269,7 +268,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
     }
 
     private void sentToPnfsManager(PnfsMessage message) {
-        manager.persist(this);
+
         CellStub.addCallback(manager.getPnfsManagerStub().send(message), this, executor);
     }
 
@@ -339,7 +338,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
                     sendErrorReply();
                 }
             }
-            manager.persist(this);
+
         } catch (RuntimeException e) {
             LOGGER.error(
                   "Bug detected in transfermanager, please report this to <support@dCache.org>", e);
@@ -454,7 +453,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
 
     public void createEntryResponseArrived(PnfsCreateEntryMessage create) {
         created = true;
-        manager.persist(this);
+
 
         fileAttributes = create.getFileAttributes();
         pnfsId = create.getPnfsId();
@@ -470,7 +469,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
     }
 
     private void getFileAttributesArrived(FileAttributes attributes) {
-        manager.persist(this);
+
 
         fileAttributes = attributes;
         info.setStorageInfo(attributes.getStorageInfo());
@@ -490,7 +489,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
         info.setPnfsId(pnfsId);
         info.setStorageInfo(attributes.getStorageInfo());
         pnfsIdString = pnfsId.toString();
-        manager.persist(this);
+
         if (store) {
             synchronized (manager.justRequestedIDs) {
                 if (manager.justRequestedIDs.contains(id)) {
@@ -526,7 +525,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
         request.setSubject(transferRequest.getSubject());
         LOGGER.debug("PoolMgrSelectPoolMsg: {}", request);
         setState(WAITING_FOR_POOL_INFO_STATE);
-        manager.persist(this);
+
         CellStub.addCallback(manager.getPoolManagerStub().sendAsync(request), this, executor);
     }
 
@@ -540,7 +539,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
 
         setPool(pool_info.getPool());
         fileAttributes = pool_info.getFileAttributes();
-        manager.persist(this);
+
         LOGGER.debug("Positive reply from pool {}", pool);
         startMoverOnThePool();
     }
@@ -567,7 +566,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
         poolMessage.setInitiator(info.getTransaction());
         poolMessage.setId(id);
         setState(WAITING_FIRST_POOL_REPLY_STATE);
-        manager.persist(this);
+
         CellStub.addCallback(
               manager.getPoolManagerStub().startAsync(pool.getAddress(), poolMessage), this,
               executor);
@@ -581,7 +580,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
         LOGGER.debug("Starting moverTimeout timer");
         manager.startTimer(id);
         setMoverId(poolMessage.getMoverId());
-        manager.persist(this);
+
 
     }
 
@@ -589,7 +588,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
         if (state == RECEIVED_PNFS_CHECK_BEFORE_DELETE_STATE) {
             PnfsDeleteEntryMessage pnfsMsg = new PnfsDeleteEntryMessage(pnfsPath);
             setState(WAITING_FOR_PNFS_ENTRY_DELETE);
-            manager.persist(this);
+
             pnfsMsg.setReplyRequired(true);
             CellStub.addCallback(manager.getPnfsManagerStub().send(pnfsMsg), this, executor);
         } else {
@@ -641,7 +640,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
         sendDoorRequestInfo(replyCode, errorObject.toString());
 
         setState(SENT_ERROR_REPLY_STATE, errorObject);
-        manager.persist(this);
+
         manager.stopTimer(id);
 
         if (store) {
@@ -684,7 +683,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
         sendDoorRequestInfo(replyCode, errorObject.toString());
 
         setState(SENT_ERROR_REPLY_STATE, errorObject);
-        manager.persist(this);
+
         manager.stopTimer(id);
 
         if (store) {
@@ -719,7 +718,7 @@ public class TransferManagerHandler extends AbstractMessageCallback<Message> {
         }
         sendDoorRequestInfo(0, "");
         setState(SENT_SUCCESS_REPLY_STATE);
-        manager.persist(this);
+
         manager.stopTimer(id);
         if (store) {
             synchronized (manager.justRequestedIDs) {

--- a/modules/dcache/src/main/resources/diskCacheV111/services/transfer-manager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/services/transfer-manager.xml
@@ -85,7 +85,6 @@
   </beans>
 
   <beans profile="db.enabled-true">
-
     <bean id="dataSource" class="org.dcache.db.AlarmEnabledDataSource" destroy-method="close">
         <description>Database connection pool</description>
         <constructor-arg value="${transfermanagers.db.url}"/>
@@ -120,20 +119,6 @@
             </map>
         </constructor-arg>
         <property name="connectionFactory" ref="dataSource"/>
-    </bean>
-
-    <bean id="transferManager" class="diskCacheV111.services.RemoteTransferManager"
-            destroy-method="cleanUp">
-        <property name="poolManager" ref="poolmanager"/>
-        <property name="pnfsManager" ref="pnfsmanager"/>
-        <property name="pool" ref="pool"/>
-        <property name="billing" ref="billing"/>
-        <property name="moverTimeout" value="${transfermanagers.limits.transfer-time}"/>
-        <property name="moverTimeoutUnit" value="${transfermanagers.limits.transfer-time.unit}"/>
-        <property name="maxTransfers" value="${transfermanagers.limits.external-transfers}"/>
-        <property name="ioQueueName" value="${transfermanagers.mover.queue}"/>
-        <property name="maxNumberOfDeleteRetries" value="1"/>
-        <property name="overwrite" value="false"/>
     </bean>
  </beans>
 

--- a/modules/dcache/src/main/resources/diskCacheV111/services/transfer-manager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/services/transfer-manager.xml
@@ -68,7 +68,6 @@
       <property name="maxTransfers" value="${transfermanagers.limits.internal-transfers}"/>
   </bean>
 
-  <beans profile="db.enabled-false">
     <bean id="transferManager" class="diskCacheV111.services.RemoteTransferManager"
             destroy-method="cleanUp">
         <property name="poolManager" ref="poolmanager"/>
@@ -82,45 +81,6 @@
         <property name="maxNumberOfDeleteRetries" value="1"/>
         <property name="overwrite" value="false"/>
     </bean>
-  </beans>
-
-  <beans profile="db.enabled-true">
-    <bean id="dataSource" class="org.dcache.db.AlarmEnabledDataSource" destroy-method="close">
-        <description>Database connection pool</description>
-        <constructor-arg value="${transfermanagers.db.url}"/>
-        <constructor-arg value="TransferManager"/>
-        <constructor-arg>
-            <bean id="hikariDataSource" class="com.zaxxer.hikari.HikariDataSource">
-                <constructor-arg>
-                    <bean class="com.zaxxer.hikari.HikariConfig">
-                        <constructor-arg>
-                            <bean class="org.dcache.util.configuration.ConfigurationPropertiesFactoryBean">
-                                <property name="prefix" value="transfer-manager.db.hikari-properties"/>
-                                <property name="staticEnvironment">
-                                    <map>
-                                        <entry key="jdbcUrl" value="${transfermanagers.db.url}"/>
-                                        <entry key="username" value="${transfermanagers.db.user}"/>
-                                        <entry key="password" value="#{ T(diskCacheV111.util.Pgpass).getPassword('${transfermanagers.db.password.file}', '${transfermanagers.db.url}', '${transfermanagers.db.user}', '${transfermanagers.db.password}') }"/>
-                                    </map>
-				</property>
-                            </bean>
-                        </constructor-arg>
-                    </bean>
-                </constructor-arg>
-            </bean>
-        </constructor-arg>
-    </bean>
-
-    <bean id="pmf" class="org.datanucleus.api.jdo.JDOPersistenceManagerFactory"
-            destroy-method="close">
-        <constructor-arg>
-            <map>
-                <entry key="datanucleus.persistenceunitname" value="TransferManager"/>
-            </map>
-        </constructor-arg>
-        <property name="connectionFactory" ref="dataSource"/>
-    </bean>
- </beans>
 
   <beans profile="kafka-true">
 

--- a/modules/dcache/src/main/resources/diskCacheV111/services/transfer-manager.xml
+++ b/modules/dcache/src/main/resources/diskCacheV111/services/transfer-manager.xml
@@ -132,7 +132,6 @@
         <property name="moverTimeoutUnit" value="${transfermanagers.limits.transfer-time.unit}"/>
         <property name="maxTransfers" value="${transfermanagers.limits.external-transfers}"/>
         <property name="ioQueueName" value="${transfermanagers.mover.queue}"/>
-        <property name="persistenceManagerFactory" ref="pmf"/>
         <property name="maxNumberOfDeleteRetries" value="1"/>
         <property name="overwrite" value="false"/>
     </bean>

--- a/skel/share/defaults/transfermanagers.properties
+++ b/skel/share/defaults/transfermanagers.properties
@@ -85,18 +85,19 @@ transfermanagers.limits.transfer-time = 7200
 (one-of?true|false|${dcache.enable.space-reservation})transfermanagers.enable.space-reservation=${dcache.enable.space-reservation}
 
 # Database settings
+# Obsolete
 (one-of?true|false)transfermanagers.enable.db=false
-transfermanagers.db.host = ${dcache.db.host}
-transfermanagers.db.name = transfermanagers
-transfermanagers.db.user = ${dcache.db.user}
-transfermanagers.db.password = ${dcache.db.password}
-transfermanagers.db.password.file = ${dcache.db.password.file}
-transfermanagers.db.url=jdbc:postgresql://${transfermanagers.db.host}/${transfermanagers.db.name}?targetServerType=master
-(prefix)transfer-manager.db.hikari-properties = Hikari-specific properties
+(obsolete)transfermanagers.db.host = ${dcache.db.host}
+(obsolete)transfermanagers.db.name = transfermanagers
+(obsolete)transfermanagers.db.user = ${dcache.db.user}
+(obsolete)transfermanagers.db.password = ${dcache.db.password}
+(obsolete)transfermanagers.db.password.file = ${dcache.db.password.file}
+(obsolete)transfermanagers.db.url=jdbc:postgresql://${transfermanagers.db.host}/${transfermanagers.db.name}?targetServerType=master
+(obsolete)(prefix)transfer-manager.db.hikari-properties = Hikari-specific properties
 
 
 # The transfermanagers service automatically manages its database schema
-(immutable)transfermanagers.db.schema.auto=true
+(obsolete)(immutable)transfermanagers.db.schema.auto=true
 
 # Kafka
 (one-of?true|false|${dcache.enable.kafka})transfermanagers.enable.kafka = ${dcache.enable.kafka}

--- a/skel/share/defaults/transfermanagers.properties
+++ b/skel/share/defaults/transfermanagers.properties
@@ -87,17 +87,17 @@ transfermanagers.limits.transfer-time = 7200
 # Database settings
 # Obsolete
 (one-of?true|false)transfermanagers.enable.db=false
-(obsolete)transfermanagers.db.host = ${dcache.db.host}
-(obsolete)transfermanagers.db.name = transfermanagers
-(obsolete)transfermanagers.db.user = ${dcache.db.user}
-(obsolete)transfermanagers.db.password = ${dcache.db.password}
-(obsolete)transfermanagers.db.password.file = ${dcache.db.password.file}
-(obsolete)transfermanagers.db.url=jdbc:postgresql://${transfermanagers.db.host}/${transfermanagers.db.name}?targetServerType=master
-(obsolete)(prefix)transfer-manager.db.hikari-properties = Hikari-specific properties
+(obsolete)transfermanagers.db.host = DB functionality is removed
+(obsolete)transfermanagers.db.name = DB functionality is removed
+(obsolete)transfermanagers.db.user = DB functionality is removed
+(obsolete)transfermanagers.db.password = DB functionality is removed
+(obsolete)transfermanagers.db.password.file = DB functionality is removed
+(obsolete)transfermanagers.db.url= DB functionality is removed
+(obsolete)(prefix)transfer-manager.db.hikari-properties = DB functionality is removed
 
 
 # The transfermanagers service automatically manages its database schema
-(obsolete)(immutable)transfermanagers.db.schema.auto=true
+(obsolete)(immutable)transfermanagers.db.schema.auto=DB functionality is removed
 
 # Kafka
 (one-of?true|false|${dcache.enable.kafka})transfermanagers.enable.kafka = ${dcache.enable.kafka}

--- a/skel/share/services/transfermanagers.batch
+++ b/skel/share/services/transfermanagers.batch
@@ -24,17 +24,9 @@ check -strong transfermanagers.limits.transfer-time.unit
 check -strong transfermanagers.limits.internal-transfers
 check -strong transfermanagers.limits.external-transfers
 
-check -strong transfermanagers.enable.db
-
-check -strong transfermanagers.db.url
-check -strong transfermanagers.db.user
-
-check transfermanagers.db.password
-check transfermanagers.db.password.file
-
 check transfermanagers.mover.queue
 
 create org.dcache.cells.UniversalSpringCell ${transfermanagers.cell.name} \
         "classpath:diskCacheV111/services/transfer-manager.xml \
         -consume=${transfermanagers.cell.consume} \
-        -profiles=db.enabled-${transfermanagers.enable.db},kafka-${transfermanagers.enable.kafka}"
+        -profiles=kafka-${transfermanagers.enable.kafka}"


### PR DESCRIPTION
Motivation: Information can/is monitored by different means other than remote transfer manager.

Modification: Remove classes that defined and use remote transfer services.

Result: One less connection to worry about.

Fixes: #7591
Target: master
Require-book: yes
Require-notes: yes