### PR TITLE
dependencies: update modernizer plugin to be compatible with maven 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1234,7 +1234,7 @@
                 <plugin>
                     <groupId>org.gaul</groupId>
                     <artifactId>modernizer-maven-plugin</artifactId>
-                    <version>2.4.0</version>
+                    <version>2.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
Motivation:
The currently used modernizer-maven-plugin of version 2.4 depends on plexus-utils (org.codehaus.plexus.util.StringUtils) but does not declare it as a dependency. Thus, the verify step currently fails when using maven 3.9.

Modification:
Increase the modernizer-maven-plugin version to 2.6, which adds the required dependency.

Result:
The verify step now also works with maven 3.9.

Target: master, 9.2
Requires-notes: no
Requires-book: no
Patch: https://rb.dcache.org/r/14183/
Acked-by: Tigran Mkrtchyan
Cherry-picked from 88b73c