### PR TITLE
pom: compile code in the same jvm as maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1047,9 +1047,6 @@
                     <configuration>
                         <showDeprecation>true</showDeprecation>
                         <release>${java.version}</release>
-                        <!-- without forking compilation happens in the
-                        same process, so no arguments are applied -->
-                        <fork>true</fork>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Motivation:
Java11 migration required than code is compiled in a different JVM than maven, as extra arguments were not respected. This change had slowed down the compilation. The workaround is not needed anymore, thus can be removed.

Modification:
Remove JVM forking for compilation.

Result:
Compile time 3x faster.

before:
Total time:  06:23 min

after:
Total time:  02:02 min

Acked-by: Karen Hoyos
Target: master, 10.0, 9.2
(cherry picked from commit d321e7e24fede393880389e4362158c10df60623)