### PR TITLE
chimera: add CTA HSM StorageInfo extractor

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCtaStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraCtaStorageInfoExtractor.java
@@ -1,0 +1,115 @@
+package org.dcache.chimera.namespace;
+
+import com.google.common.collect.ImmutableList;
+import diskCacheV111.util.AccessLatency;
+import diskCacheV111.util.CacheException;
+import diskCacheV111.util.FileNotFoundCacheException;
+import diskCacheV111.util.RetentionPolicy;
+import diskCacheV111.vehicles.CtaStorageInfo;
+import diskCacheV111.vehicles.StorageInfo;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+import org.dcache.chimera.ChimeraFsException;
+import org.dcache.chimera.FileState;
+import org.dcache.chimera.StorageGenericLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ChimeraCtaStorageInfoExtractor extends ChimeraHsmStorageInfoExtractor {
+
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+          ChimeraHsmStorageInfoExtractor.class);
+
+
+    public ChimeraCtaStorageInfoExtractor(AccessLatency defaultAL,
+                                          RetentionPolicy defaultRP) {
+        super(defaultAL, defaultRP);
+    }
+
+
+    @Override
+    public StorageInfo getFileStorageInfo(ExtendedInode inode) throws CacheException {
+        try {
+
+            CtaStorageInfo parentStorageInfo = (CtaStorageInfo) getDirStorageInfo(inode);
+
+            List<String> locations = inode.
+                getLocations(StorageGenericLocation.TAPE);
+
+            if (locations.isEmpty()) {
+                if (inode.statCache().getState() != FileState.CREATED) {
+                    parentStorageInfo.setIsNew(false);
+                }
+                return parentStorageInfo;
+            } else {
+                StorageInfo info = new CtaStorageInfo(parentStorageInfo.getStorageGroup(),
+                                                      parentStorageInfo.getFileFamily());
+                info.setIsNew(false);
+                for (String location : locations) {
+                    try {
+                        info.addLocation(new URI(location));
+                    } catch (URISyntaxException e) {
+                        LOGGER.debug("Ignoring bad tape location {}: {}",
+                                     location, e.toString());
+                    }
+                }
+                return info;
+            }
+        } catch (ChimeraFsException e) {
+            throw new CacheException(e.getMessage());
+        }
+    }
+
+    @Override
+    public StorageInfo getDirStorageInfo(ExtendedInode inode) throws CacheException {
+        ExtendedInode directory = inode.isDirectory() ?
+            inode : inode.getParent();
+
+        if (directory == null) {
+            throw new FileNotFoundCacheException("file unlinked");
+        }
+
+        ImmutableList<String> group = directory.getTag("storage_group");
+        ImmutableList<String> family = directory.getTag("file_family");
+
+        CtaStorageInfo info;
+
+        if (!group.isEmpty()) {
+            /**
+             * Enstore
+             */
+            String sg = getFirstLine(group).map(String::intern).orElse("none");
+            String ff = getFirstLine(family).map(String::intern).orElse("none");
+            info = new CtaStorageInfo(sg, ff);
+        } else {
+            /**
+             * OSM
+             */
+            List<String> osmTemplateTag = directory.getTag("OSMTemplate");
+
+            Map<String, String> hash = new HashMap<>();
+            osmTemplateTag.stream()
+                .map(StringTokenizer::new)
+                .filter(t -> t.countTokens() >= 2)
+                .forEach(t -> hash.put(t.nextToken().intern(), t.nextToken()));
+
+            String storeName = hash.get("StoreName");
+
+            if (storeName == null && !osmTemplateTag.isEmpty()) {
+                throw new CacheException(37, "StoreName not found in template");
+            }
+
+            List<String> sGroupTag = directory.getTag("sGroup");
+            String sGroup = getFirstLine(sGroupTag).map(String::intern).orElse(null);
+            info = new CtaStorageInfo(storeName, sGroup);
+        }
+
+        return info;
+    }
+}

--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/CtaStorageInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/CtaStorageInfo.java
@@ -1,0 +1,70 @@
+package diskCacheV111.vehicles;
+
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+/**
+ * Implementation of the StorageInfo for CTA.
+ */
+public class CtaStorageInfo extends GenericStorageInfo {
+
+    private String _family;
+    private String _group;
+
+    private static final long serialVersionUID = 1L;
+
+    public CtaStorageInfo(String storageGroup, String fileFamily) {
+        setHsm("cta");
+        _family = fileFamily;
+        _group = storageGroup;
+        setIsNew(true);
+    }
+
+
+    @Override
+    public String getStorageClass() {
+        return (_group == null ? "None" : _group) + '.' +
+              (_family == null ? "None" : _family);
+    }
+
+    public String toString() {
+        return
+              super.toString() +
+            ";group=" + (_group == null ? "<Unknown>" : _group) +
+            ";family=" + (_family == null ? "<Unknown>" : _family) + ";";
+    }
+
+    public String getStorageGroup() {
+        return _group;
+    }
+
+    public String getFileFamily() {
+        return _family;
+    }
+
+    @Override
+    public String getKey(String key) {
+        switch (key) {
+            case "store":
+                return _group;
+            case "group":
+                return _family;
+            default:
+                return super.getKey(key);
+        }
+    }
+
+    private void readObject(java.io.ObjectInputStream stream)
+          throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        if (_group != null) {
+            _group = _group.intern();
+        }
+
+        if (_family != null) {
+            _family = _family.intern();
+        }
+    }
+}

--- a/modules/dcache/src/main/java/diskCacheV111/util/CtaLocationExtractor.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/CtaLocationExtractor.java
@@ -1,0 +1,27 @@
+package diskCacheV111.util;
+
+import java.net.URI;
+import java.util.Map;
+
+
+public class CtaLocationExtractor implements HsmLocation {
+
+    private final URI _uri;
+
+    public CtaLocationExtractor(URI location) {
+        _uri = location;
+    }
+
+
+    @Override
+    public URI location() {
+        return _uri;
+    }
+
+
+    @Override
+    public Map<Integer, String> toLevels() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
Motivation:
===========
When transitioning from Enstore to CTA we must define hsm type. And we can drop a lot of miscellaneous information typically collected by Enstore extractor

Modification:
=============
Add CtaStorageIndo and CtaStorageInfo Extractor

Result:
======
Can read/write CTA and migrated Enstore files without having to set hsmInstance tag in the full directory tree.

Patch: https://rb.dcache.org/r/14262
Target: trunk
Request: 10.x
Request: 9.x