### PR TITLE
Fix issue with infinite replicas when replicas > 1 (9.2 backport)

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/Task.java
@@ -195,7 +195,7 @@ public class Task {
     public synchronized void
     messageArrived(PoolMigrationCopyFinishedMessage message) {
         if (_uuid.equals(message.getUUID())) {
-            _replicas.add(message.getPool());
+            _replicas.add(getTarget());
             _fsm.messageArrived(message);
         }
     }


### PR DESCRIPTION
Resolve issue with infinite replicas being created whenever more than
one requested.

Motivation:

If a `migration copy` command specifies `-replicas=n` where `n>1`, then
replicas are continuously created across all eligible pools.

Modules:

dcache

Modification:

The record of completed replica destinations (a `set`) was actually
being populated with the source pool rather than the target pool: this
has been corrected.

Result:

The `migration copy` command with `-replicas=n` (`n>1`) has the desired
behavior of creating only `n` replicas.

Release notes:

Pool migration : fixed behavior of `migration copy` with
`-replicas=n` (where `n>1`) to behave as expected.

Target: master
Request: 9.2, 10.0
Patch: https://rb.dcache.org/r/14275/
Requires-notes: yes
Requires-book: no
Acked-by: Dmitry Litvinsev
Committed:
