### PR TITLE
frontend: Add an option to set SRR path mappings

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/srr/SrrResource.java
@@ -39,6 +39,7 @@ public class SrrResource {
     private HttpServletRequest request;
 
     private Map<String, List<String>> pgroup2vo = new HashMap<>();
+    private Map<String, List<String>> pgroup2path = new HashMap<>();
     // info provider properties
     private String name;
     private String id;
@@ -119,6 +120,28 @@ public class SrrResource {
 
     }
 
+    public void setPathMapping(String mapping) {
+
+        // paths=cms:/pnfs/cms,atlas:/pnfs/atlas,longvo.fqdn.name:/pnfs/longvo
+
+        Splitter.on(',')
+              .trimResults()
+              .omitEmptyStrings()
+              .splitToList(mapping)
+              .forEach(
+                    s -> {
+                        String[] pathMap = s.split(":");
+                        if (pathMap.length != 2) {
+                            throw new IllegalArgumentException(
+                                  "Invalid format of poolgroup -> path mapping");
+                        }
+                        pgroup2path.computeIfAbsent(pathMap[0], k -> new ArrayList<>()).add(pathMap[1]);
+                    }
+
+              );
+
+    }
+
     @Produces(MediaType.APPLICATION_JSON)
     @GET
     public Response getSrr() throws InterruptedException, CacheException, NoRouteToCellException {
@@ -141,6 +164,7 @@ public class SrrResource {
               .withQuality(quality)
               .withArchitecture(architecture)
               .withGroupVoMapping(pgroup2vo)
+              .withGroupPathMapping(pgroup2path)
               .withDoorTag(doorTag)
               .generate();
 

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/srr/SrrBuilder.java
@@ -34,6 +34,7 @@ public class SrrBuilder {
     private final static Logger LOGGER = LoggerFactory.getLogger(SrrBuilder.class);
 
     private Map<String, List<String>> pgroup2vo;
+    private Map<String, List<String>> pgroup2path;
     // info provider properties
     private String name;
     private String id;
@@ -109,6 +110,11 @@ public class SrrBuilder {
         return this;
     }
 
+    public SrrBuilder withGroupPathMapping(Map<String, List<String>> pgroup2path) {
+        this.pgroup2path = pgroup2path;
+        return this;
+    }
+
     public SrrBuilder withDoorTag(String doorTag) {
         this.doorTag = doorTag;
         return this;
@@ -176,6 +182,7 @@ public class SrrBuilder {
                         .withUsedsize(space.getUsedSizeInBytes())
                         .withTimestamp(now)
                         .withVos(Collections.singletonList(space.getVoGroup()))
+                        .withPath(pgroup2path.get(space.getDescription()))
                         .withAssignedendpoints(Collections.singletonList("all"))
                         .withAccesslatency(
                               Storageshare.Accesslatency.fromValue(space.getAccessLatency()))
@@ -232,6 +239,7 @@ public class SrrBuilder {
                   .withUsedsize(usedSpace)
                   .withTimestamp(now)
                   .withVos(pgroup.getValue())
+                  .withPath(pgroup2path.get(shareName))
                   .withAssignedendpoints(Collections.singletonList("all"));
             storageshares.put(shareName, share);
         }

--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -640,6 +640,7 @@
     <bean class="org.dcache.restful.resources.srr.SrrResource" scope="request">
         <property name="spaceReservationEnabled" value="${frontend.enable.space-reservation}"/>
         <property name="groupMapping" value="${frontend.srr.shares}" />
+        <property name="pathMapping" value="${frontend.srr.paths}" />
         <property name="id" value="${info-provider.se-unique-id}" />
         <property name="name" value="${info-provider.se-name}" />
         <property name="architecture" value="${info-provider.dcache-architecture}" />

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -646,6 +646,20 @@ frontend.version.swagger-ui = @version.swagger-ui@
 frontend.srr.shares =
 
 #
+# SRR path mappings
+# This setting allows the optional path field to be set in the SRR
+# storageshares entries (for either poolgroups or space reservations).
+# The same key may be specified repeatedly to add multiple paths.
+#
+# Format:
+#  poolgroup1:/path1,poolgroup2:/path2,spaceres1:/path/other,...
+#
+# Example:
+#  cms-user:/cms/store/user,default:/cms,default:/atlas
+#
+frontend.srr.paths =
+
+#
 # Should SRR information be restricted to localhost only
 #
 (one-of?true|false)frontend.srr.public=false


### PR DESCRIPTION
Hi,

This patch adds an option to populate the SRR path field, as recently discussed on the user-forum list.

I've targeted it against the master branch but I'd quite like to backport it to v9 if at all possible (it's a tiny optional feature, so I hope that isn't a problem), although I don't know how you handle backports?

Please let me know if I need to do anything further...

Regards,
Simon
