### PR TITLE
libs: update mina-sshd  to version 2.13.1

### DIFF
--- a/modules/dcache/pom.xml
+++ b/modules/dcache/pom.xml
@@ -205,6 +205,11 @@
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd-core</artifactId>
     </dependency>
+    <!-- For ed25519 support -->
+    <dependency>
+        <groupId>net.i2p.crypto</groupId>
+        <artifactId>eddsa</artifactId>
+    </dependency>
     <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -557,8 +557,14 @@
 	    <dependency>
 	      <groupId>org.apache.sshd</groupId>
 	      <artifactId>sshd-core</artifactId>
-	      <version>2.7.0</version>
+	      <version>2.13.1</version>
 	    </dependency>
+        <!-- For ed25519 support -->
+        <dependency>
+            <groupId>net.i2p.crypto</groupId>
+            <artifactId>eddsa</artifactId>
+            <version>0.3.0</version>
+        </dependency>
             <dependency>
                 <!-- Newer versions have two problems. A performance regression causes it to block on non-responding network
                      interfaces (https://liquibase.jira.com/browse/CORE-2549). There is also an as of yet unreported regression


### PR DESCRIPTION
Motivation:
major version update with support of newer and stronger cyphers and key exchange algorithms

Modification:
Update mina-sshd to 2.13.1, added net.i2p.crypto:eddsa:0.3.0 dependency for ssh-ed25519 key pairs.

Result:
state of the art ssh support

Fixes: #7273
Ticket: #10637, #10638
Acked-by: Lea Morschel
Target: master, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit 4043dd3a351e9b9751d63e3959c840065b79af11)