### PR TITLE
GPlazma2-Pyscript: Add mapping functionality

### DIFF
--- a/docs/TheBook/src/main/markdown/config-gplazma.md
+++ b/docs/TheBook/src/main/markdown/config-gplazma.md
@@ -558,10 +558,11 @@ In the OP definition:
 
 ##### pyscript
 
-A gplazma2 auth module which uses the Jython package to run Python files
-from within the Java runtime used for dCache. It is intended for site
-admins who want to quickly script authentication plugins without needing
-to understand or write the native dCache Java code.
+A gplazma2 module which uses the Jython package to run Python files
+from within the Java runtime used for dCache. The gplazma2 *auth* and *map*
+steps are implemented. It is intended for site admins who want to quickly
+script authentication plugins without needing to understand or write the
+native dCache Java code.
 
 *Implementation Details*
 
@@ -578,9 +579,10 @@ principals)` which returns a boolean whether the authentication was successful. 
   colon. Consider `org.dcache.auth.Subjects#principalsFromArgs` to see how the principal type string maps to the
   principals classes.
 
-The conversion from a set of principals to a set of strings is done entirely within the `authenticate` method of the
-`PyscriptPlugin`-class. The Python file only ever sees a set of strings, while someone using the plugin will only ever
-need to pass a set of principals from within Java. The conversion is done using existing functions.
+The conversion from a set of principals to a set of strings is done entirely outside of Python.
+The Python file only ever sees a set of strings, while someone using the plugin will only ever
+need to pass a set of principals from within Java. The conversion is done using existing
+functions.
 
 You will need to write Python code to handle the credentials properly. Note that the credentials will *not* come as
 primitives but as objects. Read the [Jython](https://javadoc.io/doc/org.python/jython/latest/index.html) documentation

--- a/modules/common/src/main/java/org/dcache/auth/Subjects.java
+++ b/modules/common/src/main/java/org/dcache/auth/Subjects.java
@@ -551,6 +551,87 @@ public class Subjects {
         return principals;
     }
 
+    private static String toString(Principal principal) {
+        StringBuilder sb = new StringBuilder();
+
+        if (principal instanceof GlobusPrincipal) {
+            sb.append("dn:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof KerberosPrincipal) {
+            sb.append("kerberos:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof FQANPrincipal) {
+            sb.append("fqan:");
+            String label = ((FQANPrincipal) principal).isPrimaryGroup()
+                    ? "!" + principal.getName()
+                    : principal.getName();
+            appendOptionallyInQuotes(sb, label);
+        } else if (principal instanceof LoginNamePrincipal) {
+            sb.append("desired-username:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof Origin) {
+            sb.append("origin:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof OidcSubjectPrincipal) {
+            sb.append("oidc:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof EmailAddressPrincipal) {
+            sb.append("email:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof UserNamePrincipal) {
+            sb.append("user:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof GroupNamePrincipal) {
+            sb.append("group:");
+            String label = ((GroupNamePrincipal) principal).isPrimaryGroup()
+                    ? "!" + principal.getName()
+                    : principal.getName();
+            appendOptionallyInQuotes(sb, label);
+        } else if (principal instanceof UidPrincipal) {
+            sb.append("uid:").append(((UidPrincipal) principal).getUid());
+        } else if (principal instanceof GidPrincipal) {
+            sb.append("gid:");
+            if (((GidPrincipal) principal).isPrimaryGroup()) {
+                sb.append('!');
+            }
+            sb.append(principal.getName());
+        } else if (principal instanceof DesiredRole) {
+            sb.append("desired-role:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof EntityDefinitionPrincipal) {
+            sb.append("entity-defn:").append(principal.getName());
+        } else if (principal instanceof FullNamePrincipal) {
+            sb.append("full-name:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof IGTFPolicyPrincipal) {
+            sb.append("IGTF-policy:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof IGTFStatusPrincipal) {
+            sb.append("IGTF-status:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof LoAPrincipal) {
+            sb.append("LoA:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof LoginGidPrincipal) {
+            sb.append("desired-gid:").append(((LoginGidPrincipal) principal).getGid());
+        } else if (principal instanceof LoginUidPrincipal) {
+            sb.append("desired-uid:").append(((LoginUidPrincipal) principal).getUid());
+        } else if (principal instanceof MacaroonPrincipal) {
+            sb.append("macaroon:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof OpenIdGroupPrincipal) {
+            sb.append("oidc-group:");
+            appendOptionallyInQuotes(sb, principal.getName());
+        } else if (principal instanceof Origin) {
+            sb.append("origin:").append(principal.getName());
+        } else {
+            sb.append(principal.getClass().getSimpleName()).append(':');
+            appendOptionallyInQuotes(sb, principal.getName());
+        }
+
+        return sb.toString();
+    }
+
     /**
      * Provide a one-line description of argument.  This is ostensibly the same job as
      * Subject#toString.  In contrast, this method never includes any line-break characters,
@@ -594,82 +675,22 @@ public class Subjects {
 
         for (Principal principal : subject.getPrincipals()) {
             appendComma(sb);
-            if (principal instanceof GlobusPrincipal) {
-                sb.append("dn:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof KerberosPrincipal) {
-                sb.append("kerberos:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof FQANPrincipal) {
-                sb.append("fqan:");
-                String label = ((FQANPrincipal) principal).isPrimaryGroup()
-                      ? "!" + principal.getName()
-                      : principal.getName();
-                appendOptionallyInQuotes(sb, label);
-            } else if (principal instanceof LoginNamePrincipal) {
-                sb.append("desired-username:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof Origin) {
-                sb.append("origin:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof OidcSubjectPrincipal) {
-                sb.append("oidc:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof EmailAddressPrincipal) {
-                sb.append("email:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof UserNamePrincipal) {
-                sb.append("user:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof GroupNamePrincipal) {
-                sb.append("group:");
-                String label = ((GroupNamePrincipal) principal).isPrimaryGroup()
-                      ? "!" + principal.getName()
-                      : principal.getName();
-                appendOptionallyInQuotes(sb, label);
-            } else if (principal instanceof UidPrincipal) {
-                sb.append("uid:").append(((UidPrincipal) principal).getUid());
-            } else if (principal instanceof GidPrincipal) {
-                sb.append("gid:");
-                if (((GidPrincipal) principal).isPrimaryGroup()) {
-                    sb.append('!');
-                }
-                sb.append(principal.getName());
-            } else if (principal instanceof DesiredRole) {
-                sb.append("desired-role:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof EntityDefinitionPrincipal) {
-                sb.append("entity-defn:").append(principal.getName());
-            } else if (principal instanceof FullNamePrincipal) {
-                sb.append("full-name:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof IGTFPolicyPrincipal) {
-                sb.append("IGTF-policy:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof IGTFStatusPrincipal) {
-                sb.append("IGTF-status:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof LoAPrincipal) {
-                sb.append("LoA:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof LoginGidPrincipal) {
-                sb.append("desired-gid:").append(((LoginGidPrincipal) principal).getGid());
-            } else if (principal instanceof LoginUidPrincipal) {
-                sb.append("desired-uid:").append(((LoginUidPrincipal) principal).getUid());
-            } else if (principal instanceof MacaroonPrincipal) {
-                sb.append("macaroon:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof OpenIdGroupPrincipal) {
-                sb.append("oidc-group:");
-                appendOptionallyInQuotes(sb, principal.getName());
-            } else if (principal instanceof Origin) {
-                sb.append("origin:").append(principal.getName());
-            } else {
-                sb.append(principal.getClass().getSimpleName()).append(':');
-                appendOptionallyInQuotes(sb, principal.getName());
-            }
+            sb.append(toString(principal));
         }
         return "{" + sb + "}";
+    }
+
+    /**
+     * Provide a list principals of one subject converted into strings.
+     * @param subject the identity to print
+     * @return a list of strings, where each string identifies one principal of the subject.
+     */
+    public static List<String> toStringList(Subject subject) {
+        List<String> stringList = new ArrayList<String>();
+        for (Principal principal : subject.getPrincipals()) {
+            stringList.add(toString(principal));
+        }
+        return stringList;
     }
 
     private static StringBuilder appendX509Array(StringBuilder sb, X509Certificate[] chain) {

--- a/modules/common/src/test/java/org/dcache/auth/SubjectsTest.java
+++ b/modules/common/src/test/java/org/dcache/auth/SubjectsTest.java
@@ -17,6 +17,7 @@ import com.sun.security.auth.UnixNumericGroupPrincipal;
 import com.sun.security.auth.UnixNumericUserPrincipal;
 import java.security.Principal;
 import java.util.HashSet;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import javax.security.auth.Subject;
@@ -345,5 +346,29 @@ public class SubjectsTest {
 
         assertThat(principals.size(), is(equalTo(1)));
         assertThat(principals, contains(new GroupNamePrincipal("my-group", false)));
+    }
+
+    @Test
+    public void principalFullString() {
+        String s1 = Subjects.toString(_subject1);
+        assertTrue("Full string must contain UID substring",
+                s1.contains("uid:" + UID1));
+        assertTrue("Full string must contain Username Substring",
+                s1.contains("user:" + USERNAME1));
+        assertTrue("Full string must have correct amount of commas",
+                s1.chars().filter(c -> c == ',').count() == _subject1.getPrincipals().size() - 1);
+        assertTrue("Full string must begin and end with curly braces",
+                (s1.charAt(0) == '{') && (s1.charAt(s1.length() - 1) == '}'));
+    }
+
+    @Test
+    public void principalStringList() {
+        List<String> stringList1 = Subjects.toStringList(_subject1);
+        assertTrue("Subject must have string-formatted UidPrincipal",
+                stringList1.contains("uid:" + UID1));
+        assertTrue("Subject must have string-formatted UserNamePrincipal",
+                stringList1.contains("user:" + USERNAME1));
+        assertEquals("Length of list is as expected",
+                stringList1.size(), _subject1.getPrincipals().size());
     }
 }

--- a/modules/gplazma2-pyscript/src/test/java/org/dcache/gplazma/pyscript/PyscriptPluginTest.java
+++ b/modules/gplazma2-pyscript/src/test/java/org/dcache/gplazma/pyscript/PyscriptPluginTest.java
@@ -40,15 +40,19 @@ public class PyscriptPluginTest {
      These JUnit tests are written accordingly.
      */
 
-    private static PyscriptPlugin plugin;
+    private PyscriptPlugin plugin;
 
     @Before
     public void setUp() {
         // Properties
         Properties properties = new Properties();
-        properties.setProperty("gplazma.pyscript.workdir", "gplazma2-pyscript");
+        properties.setProperty("gplazma.pyscript.workdir", "src/test/resources/gplazma2-pyscript");
         plugin = new PyscriptPlugin(properties);
     }
+
+    /*
+        Auth tests
+     */
 
     @Test
     public void passesWithPasswordCredential() throws Exception {
@@ -97,5 +101,62 @@ public class PyscriptPluginTest {
                 Collections.emptySet(),
                 Collections.emptySet()
         );
+    }
+
+    /*
+        Map tests
+     */
+    @Test
+    public void testAddsPrincipal() throws Exception {
+        UserNamePrincipal name = new UserNamePrincipal("Rosasharn");
+        Set<Principal> principals = new HashSet<>();
+        principals.add(name);
+        plugin.map(
+                principals
+        );
+        assertThat(principals, hasItems(
+                new UserNamePrincipal("Rosasharn"),
+                new UserNamePrincipal("Tom")
+        ));
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void testExpectedMappingFailure() throws Exception {
+        UserNamePrincipal name = new UserNamePrincipal("Connie");
+        Set<Principal> principals = new HashSet<>();
+        principals.add(name);
+        plugin.map(
+                principals
+        );
+    }
+
+    @Test
+    public void testAuthAndMapping() throws Exception {
+        /*
+         * This test combines tests for map and auth performed sequentially!
+         * ===
+         * Log in with PasswordCredential Rosasharn:Joad
+         * This will set a UserNamePrincipal "Rosasharn"
+         * The map test will add the UserNamePrincipal "Tom"
+         */
+        PasswordCredential pwcred = new PasswordCredential("Rosasharn", "Joad");
+        Set<Object> publicCredentials = new HashSet<>();
+        publicCredentials.add(pwcred);
+        Set<Principal> principals = new HashSet<>();
+        plugin.authenticate(
+                publicCredentials,
+                Collections.emptySet(),
+                principals
+        );
+        assertThat(principals, hasItems(
+                new UserNamePrincipal("Rosasharn")
+        ));
+        plugin.map(
+                principals
+        );
+        assertThat(principals, hasItems(
+                new UserNamePrincipal("Rosasharn"),
+                new UserNamePrincipal("Tom")
+        ));
     }
 }

--- a/modules/gplazma2-pyscript/src/test/resources/gplazma2-pyscript/sample_plugin.py
+++ b/modules/gplazma2-pyscript/src/test/resources/gplazma2-pyscript/sample_plugin.py
@@ -1,0 +1,53 @@
+def py_auth(public_credentials, private_credentials, principals):
+    """
+    Function py_auth, sample implementation for a gplazma2-pyscript plugin
+    :param public_credentials: set of public auth credentials
+    :param private_credentials: set of private auth credentials
+    :param principals: set of principals (string values)
+    :return: boolean whether authentication is permitted. The principals are
+             changed as a side effect.
+
+    Note that the set of principals may only be added to, existing principals
+    may never be removed!
+
+    Note that the principals are handled as strings in Python! Consider
+    org.dcache.auth.Subjects#principalsFromArgs how these are converted back
+    into principals in Java.
+
+    In case authentication is denied, we return False.
+    """
+    list_accepted = [
+        ("admin", "dickerelch"),
+        ("Dust", "Bowl"),
+        ("Rosasharn", "Joad")
+    ]
+    for pubcred in public_credentials:
+        # public credentials iterated in random order
+        # first username:password combination in list of accepted credentials leads to acceptance
+        if (pubcred.getUsername(), pubcred.getPassword()) in list_accepted:
+            principals.add("user:%s" % (pubcred.getUsername()))  # Python 2-style String formatting
+            return True
+    for privcred in private_credentials:
+        # public credentials iterated in random order
+        # first username:password combination in list of accepted credentials leads to acceptance
+        if (privcred.getUsername(), privcred.getPassword()) in list_accepted:
+            principals.add("user:%s" % (privcred.getUsername()))  # Python 2-style String formatting
+            return True
+    return False
+
+def py_map(principals):
+    """
+    :param principals: set of principals (converted to strings)
+    :return: boolean whether mapping has passed (throw AuthenticationException if False)
+
+    In this example implementation, we just check whether some specific full-name principals
+    are present.
+    """
+    if "user:Connie" in principals:
+        # immediately fail
+        return False
+    elif "user:Rosasharn" in principals:
+        principals.add("user:Tom")
+        return True
+    else:
+        return True

--- a/skel/doc/examples/pyscript/sample_plugin.py
+++ b/skel/doc/examples/pyscript/sample_plugin.py
@@ -18,18 +18,36 @@ def py_auth(public_credentials, private_credentials, principals):
     """
     list_accepted = [
         ("admin", "dickerelch"),
-        ("Dust", "Bowl")
+        ("Dust", "Bowl"),
+        ("Rosasharn", "Joad")
     ]
     for pubcred in public_credentials:
         # public credentials iterated in random order
         # first username:password combination in list of accepted credentials leads to acceptance
         if (pubcred.getUsername(), pubcred.getPassword()) in list_accepted:
-            principals.add("username:%s" % (pubcred.getUsername()))  # Python 2-style String formatting
+            principals.add("user:%s" % (pubcred.getUsername()))  # Python 2-style String formatting
             return True
     for privcred in private_credentials:
         # public credentials iterated in random order
         # first username:password combination in list of accepted credentials leads to acceptance
         if (privcred.getUsername(), privcred.getPassword()) in list_accepted:
-            principals.add("username:%s" % (privcred.getUsername()))  # Python 2-style String formatting
+            principals.add("user:%s" % (privcred.getUsername()))  # Python 2-style String formatting
             return True
     return False
+
+def py_map(principals):
+    """
+    :param principals: set of principals (converted to strings)
+    :return: boolean whether mapping has passed (throw AuthenticationException if False)
+
+    In this example implementation, we just check whether some specific full-name principals
+    are present.
+    """
+    if "user:Connie" in principals:
+        # immediately fail
+        return False
+    elif "user:Rosasharn" in principals:
+        principals.add("user:Tom")
+        return True
+    else:
+        return True


### PR DESCRIPTION
The Gplazma2-pyscript module now also implements the GPlazmaMappingPlugin interface.

Python plugins written for pyscript are stored within the folder specified by `gplazma.pyscript.workdir`. They are read in no particular order. Each plugin file MUST contain a `py_auth` function and a `py_map` function, which implement auth and mapping functionality. Their function signatures follow those of their Java counterparts. The Python functions are read and executed at the appropriate step in the Gplazma process (i.e. either map or auth).

This PR comes with a very short example plugin for `py_map`.

Signed off by: Anton Schwarz (anton.schwarz@desy.de)