### PR TITLE
gplazma2-oidc-te: fix invalid initialization of plugin

### DIFF
--- a/modules/gplazma2-oidc-te/src/main/resources/META-INF/gplazma-plugins.xml
+++ b/modules/gplazma2-oidc-te/src/main/resources/META-INF/gplazma-plugins.xml
@@ -1,6 +1,6 @@
 <plugins>
     <plugin>
         <name>oidc-te</name>
-        <class>org.dcache.gplazma.plugins.tokenx.TokenExchange</class>
+        <class>org.dcache.gplazma.tokenx.TokenExchange</class>
     </plugin>
 </plugins>


### PR DESCRIPTION
Motivation:
The META-INF/gplazma-plugins.xml must point to the correct class name, otherwise we get:

Unable register new plugin: Class org.dcache.gplazma.plugins.tokenx.TokenExchange could not be found.

Modification:
Fix the class name in gplazma-plugins.xml

Result:
no error on start (and working plugin :) )

Acked-by: Paul Millar
Target: master, 10.1
Require-book: no
Require-notes: yes
(cherry picked from commit bb836bef2da2ae4ba50d3ea41f87a33f4b58854e)