### PR TITLE
bulk: check targets for empty strings

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/bulk/BulkResources.java
@@ -595,13 +595,23 @@ public final class BulkResources {
                 int close = stringTarget.indexOf("]");
                 stringTarget = stringTarget.substring(open+1, close);
             }
-            return Arrays.stream(stringTarget.split("[,]")).collect(Collectors.toList());
+            return Arrays.stream(stringTarget.split("[,]"))
+		.filter(i-> !i.isEmpty())
+		.collect(Collectors.toList());
         } else if (target instanceof String[]) {
-            return Arrays.stream(((String) target).split("[,]")).collect(Collectors.toList());
+            return Arrays.stream(((String) target).split("[,]"))
+		.map(String::strip)
+		.filter(i-> !i.isEmpty())
+		.collect(Collectors.toList());
         } else {
-            return (List<String>) target;
+            return ((List<String>) target)
+		.stream()
+		.map(String::strip)
+		.filter(i -> !i.isEmpty())
+		.collect(Collectors.toList());
         }
     }
+
 
     private static <T> T removeEntry(Map map, Class<T> clzz, String... names) {
         T value = null;


### PR DESCRIPTION
Motivation:

When specifying empty target the bulk proceeds to process the request instead of failing fast.

Modification:

Fix parsing of target string arguments.

Result:

Fail fast with invalid request

Patch: https://rb.dcache.org/r/14312/
Acked-by: Tigran
Target: trunk
Request: 10.x, 9.x