### PR TITLE
bulk: fix broken command `activities`

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -183,7 +183,7 @@ public final class BulkServiceCommands implements CellCommandListener {
     /**
      * name | class | type | permits
      */
-    private static final String FORMAT_ACTIVITY = "%-20s | %100s | %7s | %10s";
+    private static final String FORMAT_ACTIVITY = "%-20s | %100s | %7s";
 
     /**
      * name | required | description
@@ -552,7 +552,7 @@ public final class BulkServiceCommands implements CellCommandListener {
                 return "There are no mapped activities!";
             }
 
-            return String.format(FORMAT_ACTIVITY, "NAME", "CLASS", "TYPE", "RATE")
+            return String.format(FORMAT_ACTIVITY, "NAME", "CLASS", "TYPE")
                   + "\n" + activities;
         }
     }


### PR DESCRIPTION
Motivation:
Commit 00ba8c attempted to fix the bulk admin command `activities`, but broke it in a different way. The actual data contains three columns, but four placeholders were specified.

Modification:
Remove the fourth placeholder and fourth column name.

Result:
The admin command `activities` in the bulk service works again.

Target: master
Request: 9.2, 10.0, 10.1
Fixes: #7661
Requires-notes: yes
Requires-book: no
Acked-by: Tigran Mkrtchyan