### PR TITLE
pool: don't treat InterruptedIOException as a disk IO error

### DIFF
--- a/modules/dcache-dcap/src/main/java/org/dcache/pool/movers/DCapProtocol_3_nio.java
+++ b/modules/dcache-dcap/src/main/java/org/dcache/pool/movers/DCapProtocol_3_nio.java
@@ -17,6 +17,7 @@ import dmg.cells.nucleus.CellMessage;
 import dmg.cells.nucleus.CellPath;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -730,7 +731,7 @@ public class DCapProtocol_3_nio implements MoverProtocol, ChecksumMover, CellArg
                     if (rc <= 0) {
                         break;
                     }
-                } catch (ClosedByInterruptException ee) {
+                } catch (ClosedByInterruptException | InterruptedIOException ee) {
                     // clear interrupted state
                     Thread.interrupted();
                     throw new InterruptedException(ee.getMessage());
@@ -924,7 +925,7 @@ public class DCapProtocol_3_nio implements MoverProtocol, ChecksumMover, CellArg
 
                         _bigBuffer.flip();
                         bytesAdded += fileChannel.write(_bigBuffer);
-                    } catch (ClosedByInterruptException ee) {
+                    } catch (ClosedByInterruptException | InterruptedIOException ee) {
                         // clear interrupted state
                         Thread.interrupted();
                         throw new InterruptedException(ee.getMessage());


### PR DESCRIPTION
Motivation:
When a thread performing I/O get interrupted, then InterruptedIOException might be thrown. DCAP mover will treat such exception as a disk I/O error and propagate as such, thus, disabling the pool.

Modification:
treat InterruptedIOException as interrupt and cancel only the mover.

Result:
reduce false positive disk IO errors.

Acked-by: Lea Morschel
Target: master, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit fb734fb6c6f480b02676f86d4b29bb6d819c69ee)