### PR TITLE
pool: fix double decrement of hsm requests

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/nearline/NearlineStorageHandler.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2014 - 2023 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2014 - 2024 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -519,7 +519,7 @@ public class NearlineStorageHandler
      */
     private abstract static class AbstractRequest<K> implements Comparable<AbstractRequest<K>> {
 
-        protected enum State {QUEUED, ACTIVE, CANCELED}
+        protected enum State {QUEUED, ACTIVE, CANCELED, REMOVED}
 
         private final List<CompletionHandler<Void, K>> callbacks = new ArrayList<>();
         protected final long createdAt = System.currentTimeMillis();
@@ -644,7 +644,7 @@ public class NearlineStorageHandler
         }
 
         public void removeFromQueue() {
-            State currentState = state.get();
+            State currentState = state.getAndSet(State.REMOVED);
             switch (currentState) {
                 case QUEUED:
                     decQueued();
@@ -654,6 +654,9 @@ public class NearlineStorageHandler
                     break;
                 case CANCELED:
                     decCanceled();
+                    break;
+                case REMOVED:
+                    LOGGER.warn("Request {} was already removed from the queue.", this);
                     break;
                 default:
                     throw new RuntimeException();


### PR DESCRIPTION
Motivation:
If hsm requests completed twice due to a bug or a race condition, then `AbstractRequest#removeFromQueue` can be called twice. As removeFromQueue uses `state#get` then two competing requests might get the same value and introduce double decrement.

Modification:
Add new state 'REMOVED' that with get-and-set semantic avoids double decrement situation.

Result:
Fix double decrement on active hsm requests

Fixes: #7511
Acked-by: Dmitry Litvintsev
Target: master, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit daad2ab76fad534a63cc1c4be1033636a9ec3c96)