### PR TITLE
dcache: reject access to files with nearline QoS

### DIFF
--- a/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/PolicyBasedQoSProvider.java
+++ b/modules/dcache-qos/src/main/java/org/dcache/qos/services/engine/provider/PolicyBasedQoSProvider.java
@@ -203,25 +203,14 @@ public class PolicyBasedQoSProvider extends ALRPStorageUnitQoSProvider {
 
         FileAttributes modifiedAttributes = new FileAttributes();
 
-        if (currentAttributes.isDefined(FileAttribute.QOS_POLICY)
-            && !newRequirements.hasRequiredQoSPolicy()) {
-            modifiedAttributes.setQosPolicy(null);  // remove the policy from the stored state
-            modifyRequirements(pnfsId, currentAttributes, modifiedAttributes, newRequirements,
-                  subject);
-            return;
-        }
-
         if (newRequirements.hasRequiredQoSPolicy()) {
             modifiedAttributes.setQosPolicy(newRequirements.getRequiredQoSPolicy());
             modifiedAttributes.setQosState(newRequirements.getRequiredQoSStateIndex());
+        } else {
+            modifiedAttributes.setQosPolicy(null);  // remove the policy from the stored state
         }
 
-        if (canModifyQos(subject, isEnableRoles(), currentAttributes)) {
-            pnfsHandler().setFileAttributes(pnfsId, modifiedAttributes);
-        } else {
-            throw new PermissionDeniedCacheException("User does not have permissions to set "
-                  + "attributes for " + newRequirements.getPnfsId());
-        }
+        modifyRequirements(pnfsId, currentAttributes, modifiedAttributes, newRequirements, subject);
     }
 
     @Required


### PR DESCRIPTION
Motivation:
If file has QoS policy "HSM-only" then dCache should reject the access to the file, even if file is still available on disk (as transition might take some time).

Modification:
- Update QoS policy engine to reflect policy in the namespace attributes
- Update Transfer to request policy state (as an indicate of applied policy) and reject read transfers if access latency is nearline.

Result:
dCache behavior compliant with selected QoS policy.

Acked-by: Lea Morschel
Acked-by: Dmitry Litvintsev
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit 1a3c12e8b6609b4c0350ca5e6a90c1e25dfa7d4d)