### PR TITLE
pool manager: retry request on pool up

### DIFF
--- a/modules/dcache-vehicles/src/main/java/org/dcache/util/FileAttributesBuilder.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/util/FileAttributesBuilder.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2021-2022 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2021-2024 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -20,6 +20,8 @@ package org.dcache.util;
 
 import diskCacheV111.util.PnfsId;
 import diskCacheV111.vehicles.StorageInfo;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -82,6 +84,11 @@ public class FileAttributesBuilder {
 
     public FileAttributesBuilder withChecksum(Checksum checksum) {
         _checksums.add(checksum);
+        return this;
+    }
+
+    public FileAttributesBuilder withLocations(String...locations) {
+        _attributes.setLocations(Arrays.asList(locations));
         return this;
     }
 


### PR DESCRIPTION
Motivation:
If a pool with the file is online and a tape copy available, then dCache will trigger stage and wait until file is restored on disk. However, if pool becomes available again, the stage request is not interrupted and client will wait for tape.

Modification:
Update request container 'onPoolUp' logic to retry the request if the file expected to be on that pool. Added unit test to validate the behavior.

Result:
pool selection succeeds then a pool with the file becomes online despite the on-going stage request.

NOTE (1): the stage request is not interrupted
NOTE (2): if newly enabled pool doesn't contains the expected file, then double stage is very likely.

Target: master
Acked-by: Lea Morschel
Require-book: no
Require-notes: yes
(cherry picked from commit f945c3db9875fb5e322aa3f3ede97a229591be81)