### PR TITLE
xroot: handle haproxy and checksum command

### DIFF
--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/NettyXrootdServer.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/NettyXrootdServer.java
@@ -1,3 +1,4 @@
+
 package org.dcache.xrootd.door;
 
 import static org.dcache.xrootd.plugins.tls.SSLHandlerFactory.SERVER_TLS;
@@ -286,7 +287,8 @@ public class NettyXrootdServer implements CellIdentityAware {
                       }
 
                       XrootdRedirectHandler handler = new XrootdRedirectHandler(_door, _rootPath,
-                            _requestExecutor, _queryConfig, _appIoQueues);
+										_requestExecutor, _queryConfig,
+										_appIoQueues, _expectProxyProtocol);
                       handler.setSigningPolicy(_signingPolicy);
                       handler.setTlsSessionInfo(tlsSessionInfo);
                       pipeline.addLast("redirector", handler);

--- a/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
+++ b/modules/dcache-xrootd/src/main/java/org/dcache/xrootd/door/XrootdRedirectHandler.java
@@ -234,6 +234,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
     private final Deque<LoginSessionInfo> _logins;
     private final FsPath _rootPath;
     private final AtomicInteger openRetry = new AtomicInteger(0);
+    private boolean _expectProxy;
 
     /**
      * Custom entries for kXR_Qconfig requests.
@@ -247,9 +248,13 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
      */
     private volatile Thread onOpenThread;
 
-    public XrootdRedirectHandler(XrootdDoor door, FsPath rootPath, ExecutorService executor,
-          Map<String, String> queryConfig,
-          Map<String, String> appIoQueues) {
+    public XrootdRedirectHandler(XrootdDoor door,
+				 FsPath rootPath,
+				 ExecutorService executor,
+				 Map<String, String> queryConfig,
+				 Map<String, String> appIoQueues,
+				 boolean expectProxy
+				 ) {
         super(executor);
         _door = door;
         _rootPath = rootPath;
@@ -257,6 +262,7 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
         _appIoQueues = appIoQueues;
         _defaultLoginSessionInfo = new LoginSessionInfo(Restrictions.denyAll());
         _logins = new ArrayDeque<>(2);
+	_expectProxy = expectProxy;
     }
 
     @Override
@@ -516,7 +522,8 @@ public class XrootdRedirectHandler extends ConcurrentXrootdRequestHandler {
          * Use the advertised endpoint, if possble, otherwise fall back to the
          * address to which the client connected.
          */
-        return _door.publicEndpoint().orElse(getDestinationAddress());
+        return _expectProxy ? getDestinationAddress() :
+	    _door.publicEndpoint().orElse(getDestinationAddress());
     }
 
     /**


### PR DESCRIPTION
Motivation:
----------
When using xrootd doors behind an HAProxy w/
`xrootd.enable.proxy-protocol=true` it has been discovered that
```
xrdcp --cksum adler32:<value> <source> <destiation>
```
hangs after upload has completed and then eventually fails after a timeout. This is due to xrootd door repoting actual door address to the client.

Modification:
-------------
Return destination address (that is haproxy address) if `xrootd.enable.proxy-protocol=true` is set.

Result:
-------
```
xrdcp --cksum adler32:<value> <source> <destiation>
```
works as expected (and likely many other similar commands)

Target: trunk
Request: 10.*
Request: 9.2
Patch: https://rb.dcache.org/r/14338/
Acked-by: Tigran
Require-book: no
Require-notes: yes
Signed-off-by: Dmitry Litvintsev <litvinse@fnal.gov>
(cherry picked from commit e98ab942648f5b9e1eda4e1c08c3b7fe4588b08c)