### PR TITLE
bulk/qos: shutdown executor services when stopped

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/ConcurrentRequestManager.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/manager/ConcurrentRequestManager.java
@@ -405,6 +405,7 @@ public final class ConcurrentRequestManager implements BulkRequestManager {
         if (processorFuture != null) {
             processorFuture.cancel(true);
         }
+        processorExecutorService.shutdown();
         requestJobs = null;
         cancelledTargets = null;
         requestStore.clearCache();

--- a/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
+++ b/modules/dcache-bulk/src/main/resources/org/dcache/services/bulk/bulk.xml
@@ -262,7 +262,7 @@
     <property name="requestStore" ref="request-store"/>
   </bean>
 
-  <bean id="request-manager" class="org.dcache.services.bulk.manager.ConcurrentRequestManager">
+  <bean id="request-manager" class="org.dcache.services.bulk.manager.ConcurrentRequestManager" destroy-method="shutdown">
     <description>Core of the service which manages the request and target job lifecycle.</description>
     <property name="statistics" ref="statistics"/>
     <property name="targetStore" ref="target-store"/>

--- a/modules/dcache-qos/src/main/resources/org/dcache/qos/qos-adjuster.xml
+++ b/modules/dcache-qos/src/main/resources/org/dcache/qos/qos-adjuster.xml
@@ -67,7 +67,7 @@
   <bean id="adjuster-executor" class="org.dcache.util.CDCExecutorServiceDecorator">
     <description>Preserves the QOS session id generated for the task.</description>
     <constructor-arg>
-      <bean class="org.dcache.util.BoundedCachedExecutor">
+      <bean class="org.dcache.util.BoundedCachedExecutor" destroy-method="shutdown">
         <constructor-arg value="${qos.limits.adjuster.submit-threads}"/>
       </bean>
     </constructor-arg>


### PR DESCRIPTION
Motivation:
As scheduled executors are not shutdown cleanly, when dcache stops running threads logged.

Modification:
shutdown ConcurrentRequestManager and adjuster-executor when dcache stopped.

Result:

less stack traces in logs.

Acked-by: Lea Morschel
Target: master, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit 5f67bddf57ddc6c21e28081509e08305396fd70b)