### PR TITLE
tape REST api: additional fix tohandling of prefixed paths

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
@@ -159,6 +159,9 @@ public final class ReleaseResources {
         JSONArray paths;
         List<String> targetPaths;
 
+	FsPath userRoot = LoginAttributes.getUserRoot(getLoginAttributes(request));
+        FsPath rootPath = pathMapper.effectiveRoot(userRoot, ForbiddenException::new);
+
         try {
             JSONObject reqPayload = new JSONObject(requestPayload);
             paths = reqPayload.getJSONArray("paths");
@@ -170,7 +173,9 @@ public final class ReleaseResources {
             int len = paths.length();
             targetPaths = new ArrayList<>();
             for (int i = 0; i < len; ++i) {
-                targetPaths.add(paths.getString(i));
+		String requestPath = paths.getString(i);
+		String path = rootPath.chroot(requestPath).toString();
+		targetPaths.add(path);
             }
         } catch (JSONException e) {
             throw newBadRequestException(requestPayload, e);
@@ -178,8 +183,6 @@ public final class ReleaseResources {
 
         Subject subject = getSubject();
         Restriction restriction = getRestriction();
-        FsPath userRoot = LoginAttributes.getUserRoot(getLoginAttributes(request));
-        FsPath rootPath = pathMapper.effectiveRoot(userRoot, ForbiddenException::new);
 
         /*
          *  For WLCG, this is a fire-and-forget request, so it does not need to


### PR DESCRIPTION
Motivation:
-----------
Users reported 2 day pin lifetime on staged files (which is a default) despite specifying different values. This is due to failure to match target key on truncated vs prefixed path in target argument map keyed on un-prefixed paths.

Modification:
-------------
Use full target paths throughout the system. Make sure to strip prefix when exposing paths to users.

Result:
-------
Observe correct user specified pin lifetime.

Ticket: https://github.com/dCache/dcache/issues/7687
Patch: https://rb.dcache.org/r/14339/
Target: trunk
Request: 10.2, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes