### PR TITLE
jvm: drop UseCompressedOops JVM option

### DIFF
--- a/skel/share/defaults/dcache.properties
+++ b/skel/share/defaults/dcache.properties
@@ -198,7 +198,6 @@ dcache.log.qos.max-history=30
     -XX:HeapDumpPath=${dcache.java.oom.file} \
     -XX:+ExitOnOutOfMemoryError \
     -XX:+StartAttachListener \
-    -XX:+UseCompressedOops \
     -javaagent:${dcache.paths.classes}/aspectjweaver-1.9.21.2.jar \
     -Djava.net.preferIPv6Addresses=system \
     --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.sql/java.sql=ALL-UNNAMED  --add-opens=java.base/java.math=ALL-UNNAMED --add-opens java.base/sun.nio.fs=ALL-UNNAMED \


### PR DESCRIPTION
Motivation:
Starting java7, the UseCompressedOops is dynamically controed by heap size.

```
$ java -Xmx32g -XX:+PrintFlagsFinal 2>/dev/null | grep UseCompressedOops
     bool UseCompressedOops                        = false                          {product lp64_product} {default}

$ java -Xmx28g -XX:+PrintFlagsFinal 2>/dev/null | grep UseCompressedOops
     bool UseCompressedOops                        = true                           {product lp64_product} {ergonomic}
```

The mismatch between UseCompressedOops endup with error:

```
OpenJDK 64-Bit Server VM warning: Max heap size too large for Compressed Oops
***** WARNING! INCORRECT SYSTEM CONFIGURATION DETECTED! *****
The system limit on number of memory mappings per process might be too low for the given
[gc] max Java heap size (40960M). Please adjust /proc/sys/vm/max_map_count to allow for at
[gc] least 73728 mappings (current limit is 65530). Continuing execution with the current
```

Modification:
drop UseCompressedOops JVM option from defaults.

Result:
correct behavior on JVMs with large heap

Acked-by: Lea Morschel
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit 59ea69ff019987bdb30f365b12520b7bc88ef168)