### PR TITLE
bulk: handle absolute/relative paths in uniform fashion

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/BulkActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/BulkActivity.java
@@ -114,7 +114,7 @@ public abstract class BulkActivity<R> {
         retryPolicy = DEFAULT_RETRY_POLICY;
     }
 
-    public void cancel(BulkRequestTarget target) {
+    public void cancel(String prefix, BulkRequestTarget target) {
         target.cancel();
     }
 
@@ -173,11 +173,12 @@ public abstract class BulkActivity<R> {
      *
      * @param rid  of the request.
      * @param tid  of the target.
+     * @param prefix target prefix
      * @param path of the target on which to perform the activity.
      * @return future result of the activity.
      * @throws BulkServiceException
      */
-    public abstract ListenableFuture<R> perform(String rid, long tid, FsPath path, FileAttributes attributes)
+    public abstract ListenableFuture<R> perform(String rid, long tid, String prefix, FsPath path, FileAttributes attributes)
             throws BulkServiceException;
 
     /**

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/delete/DeleteActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/delete/DeleteActivity.java
@@ -89,9 +89,10 @@ public final class DeleteActivity extends BulkActivity<PnfsDeleteEntryMessage> i
     }
 
     @Override
-    public ListenableFuture<PnfsDeleteEntryMessage> perform(String rid, long tid, FsPath path,
+    public ListenableFuture<PnfsDeleteEntryMessage> perform(String rid, long tid, String prefix, FsPath path,
           FileAttributes attributes) {
-        PnfsDeleteEntryMessage msg = new PnfsDeleteEntryMessage(path.toString());
+        FsPath absolutePath = BulkRequestTarget.computeFsPath(prefix, path.toString());
+        PnfsDeleteEntryMessage msg = new PnfsDeleteEntryMessage(absolutePath.toString());
         msg.setSubject(subject);
         if (attributes != null && attributes.getFileType() == FileType.DIR && skipDirs) {
             msg.setSucceeded();

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/log/LogTargetActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/log/LogTargetActivity.java
@@ -89,7 +89,7 @@ public final class LogTargetActivity extends BulkActivity<BulkRequestTarget> {
     }
 
     @Override
-    public ListenableFuture<BulkRequestTarget> perform(String ruid, long tid, FsPath path,
+    public ListenableFuture<BulkRequestTarget> perform(String ruid, long tid, String prefix, FsPath path,
           FileAttributes attributes) {
         long now = System.currentTimeMillis();
         BulkRequestTarget t = BulkRequestTargetBuilder.builder(null).activity(this.getName()).id(tid)

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinActivity.java
@@ -91,18 +91,18 @@ public final class PinActivity extends PinManagerActivity {
         super(name, targetType);
     }
 
-    public void cancel(BulkRequestTarget target) {
-        super.cancel(target);
+    public void cancel(String prefix, BulkRequestTarget target) {
+        super.cancel(prefix, target);
         try {
-            pinManager.send(unpinMessage(id, target));
+            pinManager.send(unpinMessage(id, prefix, target));
         } catch (CacheException e) {
-            target.setErrorObject(new BulkServiceException("unable to fetch pnfsid of target in "
+                        target.setErrorObject(new BulkServiceException("unable to fetch pnfsid of target in "
                   + "order to cancel pinning.", e));
         }
     }
 
     @Override
-    public ListenableFuture<Message> perform(String rid, long tid, FsPath target,
+    public ListenableFuture<Message> perform(String rid, long tid, String prefix, FsPath path,
           FileAttributes attributes) {
         if (id == null) {
             id = rid;
@@ -110,7 +110,8 @@ public final class PinActivity extends PinManagerActivity {
 
         try {
             if (attributes == null) {
-                attributes = getAttributes(target);
+                FsPath absolutePath = BulkRequestTarget.computeFsPath(prefix, path.toString());
+                attributes = getAttributes(absolutePath);
             }
 
             checkPinnable(attributes);

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinManagerActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinManagerActivity.java
@@ -61,6 +61,7 @@ package org.dcache.services.bulk.activity.plugin.pin;
 
 import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
 import static diskCacheV111.util.CacheException.INVALID_ARGS;
+import static org.dcache.services.bulk.util.BulkRequestTarget.computeFsPath;
 import static org.dcache.services.bulk.util.BulkRequestTarget.State.SKIPPED;
 
 import com.google.common.util.concurrent.Futures;
@@ -130,11 +131,12 @@ abstract class PinManagerActivity extends BulkActivity<Message> implements PinMa
         return pnfsHandler.getFileAttributes(path, MINIMALLY_REQUIRED_ATTRIBUTES);
     }
 
-    protected PinManagerUnpinMessage unpinMessage(String id, BulkRequestTarget target)
+    protected PinManagerUnpinMessage unpinMessage(String id, String prefix, BulkRequestTarget target)
           throws CacheException {
         PnfsId pnfsId = target.getPnfsId();
         if (pnfsId == null) {
-            pnfsId = getAttributes(target.getPath()).getPnfsId();
+            FsPath absolutePath = computeFsPath(prefix, target.getPath().toString());
+            pnfsId = getAttributes(absolutePath).getPnfsId();
         }
         return unpinMessage(id, pnfsId);
     }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/ReleaseActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/ReleaseActivity.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.services.bulk.activity.plugin.pin;
 
 import static org.dcache.services.bulk.activity.plugin.pin.ReleaseActivityProvider.REQUEST_ID;
+import static org.dcache.services.bulk.util.BulkRequestTarget.computeFsPath;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -77,11 +78,12 @@ public final class ReleaseActivity extends PinManagerActivity {
     }
 
     @Override
-    public ListenableFuture<Message> perform(String rid, long tid, FsPath target,
+    public ListenableFuture<Message> perform(String rid, long tid, String prefix, FsPath path,
           FileAttributes attributes) {
         try {
             if (attributes == null) {
-                attributes = getAttributes(target);
+                FsPath absolutePath = computeFsPath(prefix, path.toString());
+                attributes = getAttributes(absolutePath);
             }
             return pinManager.send(unpinMessage(id, attributes.getPnfsId()));
         } catch (CacheException e) {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/UnpinActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/UnpinActivity.java
@@ -60,6 +60,7 @@ documents or software obtained from this server.
 package org.dcache.services.bulk.activity.plugin.pin;
 
 import static org.dcache.services.bulk.activity.plugin.pin.UnpinActivityProvider.UNPIN_REQUEST_ID;
+import static org.dcache.services.bulk.util.BulkRequestTarget.computeFsPath;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -78,11 +79,12 @@ public final class UnpinActivity extends PinManagerActivity {
     }
 
     @Override
-    public ListenableFuture<Message> perform(String rid, long tid, FsPath target,
+    public ListenableFuture<Message> perform(String rid, long tid, String prefix, FsPath path,
           FileAttributes attributes) {
         try {
             if (attributes == null) {
-                attributes = getAttributes(target);
+                FsPath absolutePath = computeFsPath(prefix, path.toString());
+                attributes = getAttributes(absolutePath);
             }
             return pinManager.send(unpinMessage(id, attributes.getPnfsId()));
         } catch (CacheException e) {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkRequestContainerJob.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/job/BulkRequestContainerJob.java
@@ -120,7 +120,6 @@ import org.dcache.util.list.DirectoryStream;
 import org.dcache.util.list.ListDirectoryHandler;
 import org.dcache.vehicles.FileAttributes;
 import org.dcache.vehicles.PnfsGetFileAttributes;
-import org.dcache.vehicles.PnfsResolveSymlinksMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -140,18 +139,7 @@ public final class BulkRequestContainerJob
     static final AtomicLong taskCounter = new AtomicLong(0L);
 
     public static FsPath findAbsolutePath(String prefix, String path) {
-        FsPath absPath = computeFsPath(null, path);
-        if (prefix == null) {
-            return absPath;
-        }
-
-        FsPath pref = FsPath.create(prefix);
-
-        if (!absPath.hasPrefix(pref)) {
-            absPath = computeFsPath(prefix, path);
-        }
-
-        return absPath;
+        return computeFsPath(prefix, path);
     }
 
     /**
@@ -235,7 +223,7 @@ public final class BulkRequestContainerJob
      * proper paths and attributes from listing.
      */
     enum TaskState {
-        RESOLVE_PATH, FETCH_ATTRIBUTES, HANDLE_TARGET, HANDLE_DIR_TARGET
+        FETCH_ATTRIBUTES, HANDLE_TARGET, HANDLE_DIR_TARGET
     }
 
     /**
@@ -452,7 +440,7 @@ public final class BulkRequestContainerJob
             }
 
             if (target != null) {
-                activity.cancel(target);
+                activity.cancel(targetPrefix, target);
                 LOGGER.debug("{} - target cancelled for task {}.", ruid, seqNo);
             }
 
@@ -464,9 +452,6 @@ public final class BulkRequestContainerJob
             try {
                 checkForRequestCancellation();
                 switch (state) {
-                    case RESOLVE_PATH:
-                        resolvePath();
-                        break;
                     case FETCH_ATTRIBUTES:
                         fetchAttributes();
                         break;
@@ -512,43 +497,15 @@ public final class BulkRequestContainerJob
         }
 
         /**
-         * (1) symlink resolution on initial targets; bypassed for discovered targets.
-         */
-        private void resolvePath() {
-            LOGGER.debug("{} - resolvePath, resolving {}", ruid, target.getPath());
-            PnfsResolveSymlinksMessage message = new PnfsResolveSymlinksMessage(
-                  target.getPath().toString(), null);
-            ListenableFuture<PnfsResolveSymlinksMessage> requestFuture = pnfsHandler.requestAsync(
-                  message);
-            CellStub.addCallback(requestFuture, new AbstractMessageCallback<>() {
-                @Override
-                public void success(PnfsResolveSymlinksMessage message) {
-                    LOGGER.debug("{} - resolvePath {}, callback success.", ruid, target.getPath());
-                    FsPath path = FsPath.create(message.getResolvedPath());
-                    if (targetPrefix != null && !path.contains(targetPrefix)) {
-                        path = computeFsPath(targetPrefix, path.toString());
-                    }
-                    LOGGER.debug("{} - resolvePath, resolved path {}", ruid, path);
-                    target.setPath(path);
-                    state = TaskState.FETCH_ATTRIBUTES;
-                    taskFuture = executor.submit(TargetTask.this);
-                }
-
-                @Override
-                public void failure(int rc, Object error) {
-                    LOGGER.error("{} - resolvePath, callback failure for {}.", ruid, target);
-                    storeOrUpdate(CacheExceptionFactory.exceptionOf(
-                          rc, Objects.toString(error, null)));
-                }
-            }, callbackExecutor);
-        }
-
-        /**
-         * (2) retrieval of required file attributes.
+         * (1) retrieval of required file attributes.
          */
         private void fetchAttributes() {
-            LOGGER.debug("{} - fetchAttributes for path {}", ruid, target.getPath());
-            PnfsGetFileAttributes message = new PnfsGetFileAttributes(target.getPath().toString(),
+            FsPath absolutePath = findAbsolutePath(targetPrefix,
+                                                   target.getPath().toString());
+            LOGGER.debug("{} - fetchAttributes for path {}, prefix {}, absolute path {} ", ruid, target.getPath(), targetPrefix, absolutePath);
+
+
+            PnfsGetFileAttributes message = new PnfsGetFileAttributes(absolutePath.toString(),
                   MINIMALLY_REQUIRED_ATTRIBUTES);
             ListenableFuture<PnfsGetFileAttributes> requestFuture = pnfsHandler.requestAsync(
                   message);
@@ -573,7 +530,7 @@ public final class BulkRequestContainerJob
         }
 
         /**
-         * (3b) either recurs on directory or performs activity on file.
+         * (2b) either recurs on directory or performs activity on file.
          */
         private void handleTarget() throws InterruptedException {
             LOGGER.debug("{} - handleTarget for {}, path {}.", ruid, target.getActivity(),
@@ -611,17 +568,20 @@ public final class BulkRequestContainerJob
             FsPath path = target.getPath();
             FileAttributes attributes = target.getAttributes();
             LOGGER.debug("{} - performActivity {} on {}.", ruid, activity, path);
-
             storeOrUpdate(null);
 
             if (hasBeenSpecificallyCancelled(this)) {
                 LOGGER.debug("{} - performActivity hasBeenSpecificallyCancelled for {}.", ruid,
-                      path);
+                             path);
                 remove();
             }
 
             try {
-                activityFuture = activity.perform(ruid, id == null ? seqNo : id, path, attributes);
+                activityFuture = activity.perform(ruid,
+                                                  id == null ? seqNo : id,
+                                                  targetPrefix,
+                                                  path,
+                                                  attributes);
                 if (async) {
                     activityFuture.addListener(() -> handleCompletion(), callbackExecutor);
                     permitHolder.throttledRelease();
@@ -1077,7 +1037,7 @@ public final class BulkRequestContainerJob
         for (BulkRequestTarget target : requestTargets) {
             try {
                 checkForRequestCancellation();
-                new TargetTask(target, TaskState.RESOLVE_PATH).submitAsync();
+                new TargetTask(target, TaskState.FETCH_ATTRIBUTES).submitAsync();
             } catch (InterruptedException e) {
                 /*
                  * Cancel most likely called; stop processing.

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTarget.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestTarget.java
@@ -87,12 +87,15 @@ public final class BulkRequestTarget {
           RUNNING};
 
     public static FsPath computeFsPath(String prefix, String target) {
-        if (prefix == null) {
-            return FsPath.create(FsPath.ROOT + target);
-        } else {
-            return FsPath.create(
-                  FsPath.ROOT + (prefix.endsWith("/") ? prefix : prefix + "/") + target);
+        FsPath absolutePath = FsPath.create(FsPath.ROOT + target);
+        if (prefix != null) {
+            FsPath pref = FsPath.create(prefix);
+            if (!absolutePath.hasPrefix(pref)) {
+                absolutePath = FsPath.create(
+                                             FsPath.ROOT + (prefix.endsWith("/") ? prefix : prefix + "/") + target);
+            }
         }
+        return absolutePath;
     }
 
     public static final FsPath ROOT_REQUEST_PATH = computeFsPath(null, "=request_target=");

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ArchiveInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ArchiveInfoResources.java
@@ -160,19 +160,17 @@ public final class ArchiveInfoResources {
             paths = new ArrayList<>();
             for (int i = 0; i < len; ++i) {
                 String requestedPath = jsonArray.getString(i);
-                String dcachePath = rootPath.chroot(requestedPath).toString();
-                paths.add(dcachePath);
+                paths.add(requestedPath);
             }
         } catch (JSONException e) {
             throw newBadRequestException(requestPayload, e);
         }
 
         var archiveInfos = archiveInfoCollector.getInfo(HandlerBuilders.roleAwarePnfsHandler(pnfsManager),
-              paths);
-
-        archiveInfos.forEach(ai ->
-            ai.setPath(FsPath.create(ai.getPath()).stripPrefix(rootPath)));
-
+                                                        rootPath.toString(),
+                                                        paths);
         return archiveInfos;
     }
+
+
 }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/ReleaseResources.java
@@ -173,8 +173,7 @@ public final class ReleaseResources {
             int len = paths.length();
             targetPaths = new ArrayList<>();
             for (int i = 0; i < len; ++i) {
-		String requestPath = paths.getString(i);
-		String path = rootPath.chroot(requestPath).toString();
+		String path = paths.getString(i);
 		targetPaths.add(path);
             }
         } catch (JSONException e) {

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/tape/StageResources.java
@@ -127,6 +127,7 @@ import org.springframework.stereotype.Component;
 @Api(value = "tape", authorizations = {@Authorization("basicAuth")})
 @Path("tape/stage")
 public final class StageResources {
+
     private static final String STAGE = "STAGE";
 
     @Context
@@ -189,7 +190,6 @@ public final class StageResources {
             offset = lastInfo.getNextId();
         }
 
-	targetInfos.forEach(ti -> ti.setTarget(FsPath.create(ti.getTarget()).stripPrefix(rootPath)));
         lastInfo.setTargets(targetInfos);
 
         return new StageRequestInfo(lastInfo);
@@ -238,8 +238,7 @@ public final class StageResources {
         List<String> targetPaths = new ArrayList<>();
         int len = paths.length();
         for (int i = 0; i < len; ++i) {
-	    String requestPath = paths.getString(i);
-	    String path = rootPath.chroot(requestPath).toString();
+	    String path = paths.getString(i);
             targetPaths.add(path);
         }
 
@@ -397,8 +396,7 @@ public final class StageResources {
                 if (!file.has("path")) {
                     throw new BadRequestException("file object " + i + " has no path.");
                 }
-                String requestPath = file.getString("path");
-		String path = rootPath.chroot(requestPath).toString();
+                String path = file.getString("path");
                 paths.add(path);
                 if (file.has("diskLifetime")) {
                     jsonLifetimes.put(path,

--- a/modules/dcache-frontend/src/test/java/org/dcache/restful/resources/bulk/BulkRequestJsonParseTest.java
+++ b/modules/dcache-frontend/src/test/java/org/dcache/restful/resources/bulk/BulkRequestJsonParseTest.java
@@ -59,6 +59,7 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.resources.bulk;
 
+import static diskCacheV111.util.FsPath.create;
 import static org.dcache.restful.resources.bulk.BulkResources.toBulkRequest;
 import static org.junit.Assert.assertEquals;
 
@@ -182,6 +183,6 @@ public class BulkRequestJsonParseTest {
     }
 
     private void whenParsed() {
-        bulkRequest = toBulkRequest(requestJson, null, handler);
+        bulkRequest = toBulkRequest(requestJson, null, handler, create("/"));
     }
 }


### PR DESCRIPTION
Motivation:
-----------
Recent change(s) that massaged user input target paths and stored absolute paths on bulk backend lead to ambiguity between user provided and dcache resolved paths and also resulted in inability to use full paths (i.e. only relative paths are supported). At Fermilab we need to use both - relative and absolute paths

Modification:
-------------
Revert all recent changes that appended prefix to user supplied paths, stored the result and then stripped the prefix so that only "original" paths are exposed to the user. Instead, like before, store user supplied paths but carry over request prefix which is computed from user root and door root. When calling PnfsManager using paths the full paths of the targets are reassembled using the prefix

Result:
------
Restored ability to use absolute paths when using REST API.

Issue: https://github.com/dCache/dcache/issues/7693
Patch: https://rb.dcache.org/r/14355/
Target: trunk
Request: 10.2, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
Acked-by: Lea Morschel, Tigran Mkrtchyan