### PR TITLE
pool: separate cases for disk error and no space available

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/util/DiskErrorCacheException.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/util/DiskErrorCacheException.java
@@ -14,7 +14,12 @@ package diskCacheV111.util;
  */
 public class DiskErrorCacheException extends CacheException {
 
+
     private static final long serialVersionUID = -5386946146340646052L;
+
+    public enum FileStoreState {
+        READ_ONLY, FAILED
+    }
 
     public DiskErrorCacheException(String msg) {
         super(CacheException.ERROR_IO_DISK, msg);
@@ -23,4 +28,13 @@ public class DiskErrorCacheException extends CacheException {
     public DiskErrorCacheException(String message, Throwable cause) {
         super(CacheException.ERROR_IO_DISK, message, cause);
     }
+
+    public FileStoreState checkStatus(String message) {
+        if (message.contains("No space available.")) {
+            return FileStoreState.READ_ONLY;
+        } else {
+            return FileStoreState.FAILED;
+        }
+    }
+
 }


### PR DESCRIPTION
Motivation

when there are no avvailable space on a pool, the pool will go to DISABLED mode and no data could be read anymore.

This is wrong we still want to be able to read data from the file.

Modification

this is a temp change, trying to get the info from the eroor message, sice therer is no a specific error code,

and then based on that info separate two cases DISABLED AND READONLY

Acked-by: Tigran Mkrtchyan
Target: master. 10.2, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
Commited:master@862963e