### PR TITLE
Bulk: PinManagerActivity do not set state of files that are pinned in…

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinManagerActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinManagerActivity.java
@@ -112,9 +112,6 @@ abstract class PinManagerActivity extends BulkActivity<Message> implements PinMa
             reply = getUninterruptibly(future);
             if (reply.getReturnCode() != 0) {
                 target.setErrorObject(reply.getErrorObject());
-            } else if (reply instanceof PinManagerPinMessage
-                  && ((PinManagerPinMessage) reply).getLifetime() == -1L) {
-                target.setState(SKIPPED);
             } else {
                 target.setState(State.COMPLETED);
             }


### PR DESCRIPTION
…definitely to SKIPPED

Motivaton:
----------

Setting files having infinite pin to state SKIPPED seems to prevents them from being staged if pool goes down.

Modification:
-------------

Set state to COMPLETED if pin lifetime is infinite.

Result:
------

As tested and reported by DESY, the staging of files that happen to be on offline pools works properly

Target: trunk
Request: 10.2
Request: 9.2
Patch: https://rb.dcache.org/r/14365/

Require-notes: yes
Require-book: no