### PR TITLE
dcache-billing-indexer: add explicit dependency on commons-io

### DIFF
--- a/skel/share/lib/billing.sh
+++ b/skel/share/lib/billing.sh
@@ -2,7 +2,7 @@
 billing_indexer() # $* = arguments
 {
     CLASSPATH="$(printLimitedClassPath slf4j-api logback-classic logback-core logback-console-config \
-        jul-to-slf4j commons-compress gson spring-core guava dcache-common common-cli cells dcache-core \
+        jul-to-slf4j commons-compress commons-io gson spring-core guava dcache-common common-cli cells dcache-core \
         curator-client)" \
         quickJava \
           "-Ddcache.home=${DCACHE_HOME}" \


### PR DESCRIPTION
Motivation:
the dcache-billing-indexer uses commons-compress to handle bz2 files, and has non-optional dependency on commons-io, which is missing. So we get:

```
/usr/sbin/dcache-billing-indexer -index /var/lib/dcache/billing/2025/01/billing-2025.01.27.bz2
ERROR - Uncaught exception
java.lang.NoClassDefFoundError: org/apache/commons/io/input/CloseShieldInputStream
at org.dcache.services.billing.text.Indexer$7.openStream(Indexer.java:526)
at com.google.common.io.ByteSource$AsCharSource.openStream(ByteSource.java:474)
at com.google.common.io.CharSource.readLines(CharSource.java:371)
at org.dcache.services.billing.text.Indexer.produceIndex(Indexer.java:510)
at org.dcache.services.billing.text.Indexer.index(Indexer.java:396)
at org.dcache.services.billing.text.Indexer.(Indexer.java:211)
at org.dcache.services.billing.text.Indexer.main(Indexer.java:686)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.io.input.CloseShieldInputStream
at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
... 7 common frames omitted
```

Modification:
explicitly add commons-io into dcache-billing-indexer classpath.

Result:
dcache-billing-indexer can process compressed files.

Fixes: #7738
Acked-by: Lea Morschel
Tested-by: Ville Salmela
Target: master, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit 153a018b0687e501c1b104e5fb36a2cddb166373)