### PR TITLE
cells: fix race condition between thread start and flag check

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/network/LocationManagerConnector.java
+++ b/modules/cells/src/main/java/dmg/cells/network/LocationManagerConnector.java
@@ -54,8 +54,8 @@ public class LocationManagerConnector
     @Override
     protected void started() {
         _thread = getNucleus().newThread(this, "TunnelConnector-" + _domain);
-        _thread.start();
         _isRunning = true;
+        _thread.start();
     }
 
     private StreamEngine connect()


### PR DESCRIPTION
Motivation:

If newly started thread runs before `running` flag is set, then tunnel with shutdown instantly.

Thread-1: Create T2 -->  | T2.start()         | --> set running flag
Thread-2:                | check flag; exit   |

Modification:

set `running` before thread starts.

Result:
race is fixed

Issue: #5326
Acked-by: Paul Millar
Target: master, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit 2440b2227727c929132919f569a643083efc9138)