### PR TITLE
pool: add workaround space mismanagementd by XFS (and others?)

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReplicaRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReplicaRepository.java
@@ -838,8 +838,16 @@ public class ReplicaRepository
             SpaceRecord space = _account.getSpaceRecord();
             long lru = (System.currentTimeMillis() - _sweeper.getLru()) / 1000L;
             long gap = _gap.orElse(Math.min(space.getTotalSpace() / 4, DEFAULT_GAP));
+
+            // REVISIT: This workaround addresses a filesystem behavior where the effective free space
+            // may be smaller than the total - used.
+            // To ensure correctness, we take the minimum of the disk reported and
+            // the dCache accounting expected free spaces.
+            long storeFreeSpace = _store.getFreeSpace();
+            long effectiveFreeSpace = Math.min(storeFreeSpace, space.getFreeSpace());
+
             return new SpaceRecord(space.getTotalSpace(),
-                  space.getFreeSpace(),
+                  effectiveFreeSpace,
                   space.getPreciousSpace(),
                   space.getRemovableSpace(),
                   lru,


### PR DESCRIPTION
Motivation:
Some filesystems miscalculate/report free space in respect tu used space:

```
$ df /dcache/pool-a
Filesystem        1K-blocks         Used Available Use% Mounted on
/dev/sda1      558602657792 558397210232 205447560 100% /dcache/pool-a

$ du -s /dcache/pool-a
554502450484	/dcache/pool-a

$ bc
558602657792 - 554502450484
4100207308
```

File system reports 200GB of the free space, however, total - real used gives ~4TB.

Thus dCache assumes 4TB and write the file system full... ==> IO error

Modification:

use an `effective` free space, which is the minimum between disk reported and internal accounting free spaces.

Result:
Pool uses the effective free space instead of mathematically correct value.

Acked-by: Dmitry Litvintsev
Target: master, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit 208bfbe64aed53dba865a497903e83c0573dad89)