### PR TITLE
qos: Uncaught NullPointerException due to QoS being set to null

### DIFF
--- a/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/FileAttributes.java
+++ b/modules/dcache-vehicles/src/main/java/org/dcache/vehicles/FileAttributes.java
@@ -831,7 +831,7 @@ public class FileAttributes implements Serializable, Cloneable {
 
     @Nonnull
     private <T> Optional<T> toOptional(FileAttribute attribute, T value) {
-        return isDefined(attribute) ? Optional.of(value) : Optional.empty();
+        return isDefined(attribute) ? Optional.ofNullable(value) : Optional.empty();
     }
 
     private void readObject(ObjectInputStream stream)


### PR DESCRIPTION
Motivation: null is a valid value for FileAttribute.QOS_POLICY, however, it is not a valid value to be encapsulated within an Optional.

Modification: Update Optional.of for Optional.ofNullable since the later will take into account null as a value and return Optional.empty() where Optional.of will not and hence throw the NPE.

Result: QosPolicy can still be set to null and we will no longer show a NPE.

Acked-by: Dmitry Litvintsev
Target: master, 10.2, 10.1, 10.0 and 9.2
Require-book: no
Require-notes: no
(cherry picked from commit 466c97e39033d718e97c73a38a0b902f4007d537)