### PR TITLE
pool:fix outofspace error sending pool into diasbled mode

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/MoverRequestScheduler.java
@@ -41,6 +41,7 @@ import org.dcache.pool.FaultListener;
 import org.dcache.pool.movers.Mover;
 import org.dcache.pool.movers.json.MoverData;
 import org.dcache.pool.repository.FileStore;
+import org.dcache.pool.repository.OutOfDiskException;
 import org.dcache.util.AdjustableSemaphore;
 import org.dcache.util.IoPrioritizable;
 import org.dcache.util.IoPriority;
@@ -527,6 +528,13 @@ public class MoverRequestScheduler {
                               FaultEvent faultEvent = new FaultEvent("transfer",
                                       faultAction, exc.getMessage(), exc);
                               _faultListeners.forEach(l -> l.faultOccurred(faultEvent));
+                          } else if (exc instanceof OutOfDiskException) {
+                              FaultEvent faultEvent = new FaultEvent(
+                                    "post-processing",
+                                    FaultAction.READONLY,
+                                    exc.getMessage(), exc);
+                              _faultListeners.forEach(
+                                    l -> l.faultOccurred(faultEvent));
                           }
                           postprocess();
                       }
@@ -555,6 +563,13 @@ public class MoverRequestScheduler {
                                                 FaultEvent faultEvent = new FaultEvent(
                                                       "post-processing",
                                                         faultAction,
+                                                      exc.getMessage(), exc);
+                                                _faultListeners.forEach(
+                                                      l -> l.faultOccurred(faultEvent));
+                                            } else if (exc instanceof OutOfDiskException) {
+                                                FaultEvent faultEvent = new FaultEvent(
+                                                      "post-processing",
+                                                      FaultAction.READONLY,
                                                       exc.getMessage(), exc);
                                                 _faultListeners.forEach(
                                                       l -> l.faultOccurred(faultEvent));


### PR DESCRIPTION
Motivation

we are seeing the this error wen there is no space on the pool left, and pool goes into disabled mode,

AB56598C55] WRITE failed : IOError
AB56598C55] Transfer failed due to a disk error: CacheException(rc=204;msg=Disk I/O Error )
AB56598C55] Pool mode changed to disabled(fetch,store,stage,p2p-client,p2p-server): Pool disabled: Disk I/O Error
AB56598C55] Pool: dcache-xfel487-01, fault occurred in transfer: Disk I/O Error . Pool disabled: , cause: CacheException(rc=204;msg=Disk I/O Error )

however we want it to go into READ-ONLY mode and files could stay accesable.

the privous patch (https://rb.dcache.org/r/14357/diff/3/#index_header) did not fix the issue.

so the new changes are still a try to fix the issue.

Acked-by: Dmitry Litvintsev
Target: master, 10.2
Require-book: no
Require-notes: yes
Patch: https://rb.dcache.org/r/14368/