### PR TITLE
Removed comparison to max value of long in isLargerThan

### DIFF
--- a/modules/dcache/src/main/java/diskCacheV111/util/DiskSpace.java
+++ b/modules/dcache/src/main/java/diskCacheV111/util/DiskSpace.java
@@ -94,7 +94,7 @@ public class DiskSpace {
     }
 
     public boolean isLargerThan(long value) {
-        return value < _value && _value < Long.MAX_VALUE;
+        return value < _value;
     }
 
     public boolean isLessThan(long value) {


### PR DESCRIPTION
Comparison of the value held by a Instace of DiskSpace to max value of Long is not a piece of information that is assumed or requested by a user when calling isLargerThan.

Fixes #7703 