### PR TITLE
Update gplazma.properties: explain gplazma.oidc.provider options

### DIFF
--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -392,6 +392,47 @@ gplazma.htpasswd.file.cache-period.unit = SECONDS
 #                additional information is needed (e.g., group
 #                membership).
 #
+#  Besides -suppress, gplazma.oidc.provider has a few more options.
+#
+#  -profile
+#
+#      The option -profile describes with which profile the OIDC provider's
+#      tokens are processed. Valid values are oidc, scitokens and wlcg.
+#      If no -profile is specified, then oidc is used.
+#      The parameter must not be repeated.
+#
+#  -prefix
+#
+#      If the specified profile is "wlcg", then the -prefix argument is required.
+#      It is an absolute path within dCache’s namespace under which authorisation
+#      paths are resolved.
+#      For example, if an OP is configured with -prefix=/wlcg/ATLAS and the token
+#      allows reading under the /users/paul path (storage.read:/users/paul),
+#      then the token is allowed to read content under the /wlcg/ATLAS/users/paul
+#      path.
+#
+#  -authz-id
+#  -non-authz-id
+#
+#      The options -authz-id and -non-authz-id can be specified for "wlcg" profile.
+#      The -authz-id argument contains a space-separated list of principals to add
+#      if the token is an authorisation token. Authorisation tokens have
+#      one or more "storage.*" declarations in their scope. For such tokens,
+#      the option -authz-id allows for custom behaviour.
+#      The -non-authz-id argument contains a space-separated list of principals
+#      to add if the token is a non-authorised token. Non-authorised tokens
+#      don't have any "storage.*" declaration in their scope.
+#      The option -non-authz-id allows for custom behaviour for such tokens.
+#
+#
+#  An example for Atlas:
+#
+#     gplazma.oidc.provider!ATLAS = https://atlas-auth.cern.ch/ -profile=wlcg \
+#        -prefix=/pnfs/example.org/data/atlas -authz-id="uid:12345 gid:12346 username:atlas"
+#
+#  More information can be found in the dCache Book, in chapter
+#  "gPlazma: Authorization in dCache".
+#
 (prefix)gplazma.oidc.provider = ${dcache.oidc.provider}
 
 #


### PR DESCRIPTION
In the Book version 10.2, I found these options:

`-profile`
`-prefix`
`-authz-id`
`-non-authz-id`

I though it best to copy some of that info to the gplazma.properties, also since the 9.2 version of the Book does not have this info yet.

Signed-off-by: Onno Zweers (for what it's worth: I did not do much more than copying from the Book to the properties file 😸)