### PR TITLE
libs: use jetty 9.4.57.v20241219

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.aspectj>1.9.21.2</version.aspectj>
         <version.smc>6.6.0</version.smc>
         <version.xerces>2.12.0</version.xerces>
-        <version.jetty>9.4.55.v20240627</version.jetty>
+        <version.jetty>9.4.57.v20241219</version.jetty>
         <version.xrootd4j>4.6.0</version.xrootd4j>
         <version.jersey>2.41</version.jersey>
         <version.dcache-view>3.0.0</version.dcache-view>


### PR DESCRIPTION
Motivation:
latest version in 9.4 series

Acked-by: Dmitry Litvintsev
Target: master, 10.2, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit f6d6e31dc69c90472b891186809174803e777465)