### PR TITLE
Update hsmcp.rb: don't escape string that is returned to the pool

### DIFF
--- a/skel/share/lib/hsmcp.rb
+++ b/skel/share/lib/hsmcp.rb
@@ -133,7 +133,7 @@ when "put"
 
   sleep waitTime
   
-  puts URI.escape("hsm://#{instance}/?store=#{store}&group=#{group}&bfid=#{pnfsid}")
+  puts "hsm://#{instance}/?store=#{store}&group=#{group}&bfid=#{pnfsid}"
 
 when "remove"
   if !options.has_key? "uri"


### PR DESCRIPTION
I found this script very useful for testing tape operations with a "fake" tape backend, just a directory.

I had to make one slight change to make the script work with modern versions of dCache, and that's removing the URI.escape method. Apparently the pool does not understand the string when it is escaped.

Nowadays, URI.escape is deprecated anyway:
```
25 Mar 2025 15:22:12 (tapepool1) [] Flush of 0000EF7E42E8AFDF4F8E939307CEEC323359 failed with: CacheException(rc=1;msg=HSM script failed (script reported: 1: /usr/share/dcache/lib/hsmcp.rb:136:in `<main>': undefined method `escape' for URI:Module (NoMethodError);)).
```
When I tried with its replacement `URI.encode_www_form_component`, the pool refused it:
```
25 Mar 2025 15:33:12 (tapepool1) [] Flush of 0000EF7E42E8AFDF4F8E939307CEEC323359 failed with: CacheException(rc=2;msg=hsm type not defined in hsm%3A%2F%2Flocalhost%2F%3Fstore%3Dgeneric%26group%3Dtape%26bfid%3D0000EF7E42E8AFDF4F8E939307CEEC323359).
```
And in the end, not escaping seems to work fine. Not sure about filenames with special characters though, I haven't tested those.