### PR TITLE
docs: change openjdk 11 to 17

### DIFF
--- a/docs/TheBook/src/main/markdown/cookbook-debugging.md
+++ b/docs/TheBook/src/main/markdown/cookbook-debugging.md
@@ -4,7 +4,7 @@ This chapter provides an information on how to exam running dCache system, ident
 
 ## Java Flight recorder
 
-When debugging an issue on a running system often we need to collect jvm performance stats with `Java flight recorder`. Starting from release 7.2 the Java flight recorder attach listener is enabled by default. Site admins can collect and provide developers with additional information when high CPU load, memory consumption or file descriptor leaks are observed. To enable the `flight recorder` _jcmd_ command is used, which is typically provided as a part of `java-11-openjdk-devel` (on RHEL and clones).
+When debugging an issue on a running system often we need to collect jvm performance stats with `Java flight recorder`. Starting from release 7.2 the Java flight recorder attach listener is enabled by default. Site admins can collect and provide developers with additional information when high CPU load, memory consumption or file descriptor leaks are observed. To enable the `flight recorder` _jcmd_ command is used, which is typically provided as a part of `java-17-openjdk-headless` (on RHEL and clones).
 
 To control recoding the following subcommands of _jcmd_ available:
 

--- a/docs/TheBook/src/main/markdown/dcache-minimal-installation.md
+++ b/docs/TheBook/src/main/markdown/dcache-minimal-installation.md
@@ -13,21 +13,21 @@ and how dCache's users will interact with the system.  There is no one size fits
   - At least 500 MiB free disk space
 
 - Software:
-  - OpenJDK 11
+  - OpenJDK 17
   - Postgres SQL Server 13.0 or later
   - ZooKeeper version 3.5 (embedded)
 
 ## Minimal Installation
 
 ### Java 
-For this installation, we use OpenJDK 11 (java 17 for dCache version 10.2 and later)
+For this installation, we use OpenJDK 17.
 
 ```bash
 sudo -s
 
-yum install java-11-openjdk
+dnf install java-17-openjdk
 
-dnf install java-11-openjdk-devel
+dnf install java-17-openjdk-devel
 ```
 For a production installation, you will need standalone ZooKeeper version 3.8 or later.  
 

--- a/docs/TheBook/src/main/markdown/install.md
+++ b/docs/TheBook/src/main/markdown/install.md
@@ -74,14 +74,14 @@ rpm -ivh https://www.dcache.org/old/downloads/1.9/repo/##SERIES##/dcache-##VERSI
 |   1:dcache-##VERSION##-1                   ################################# [100%]
 ```
 
-For example, `##SERIES##` could be `9.1` and `##VERSION##` could be `9.1.1`.
+For example, `##SERIES##` could be `10.1` and `##VERSION##` could be `10.1.1`.
 
 ### Installing prerequisite packages
 
 First, install OpenJDK and httpd-tools packages.
 
 ```console-root
-yum install java-11-openjdk-headless httpd-tools
+yum install java-17-openjdk-headless httpd-tools
 ```
 
 ### Installing PostgreSQL


### PR DESCRIPTION
And jcmd is not in java-11-openjdk-devel but in java-11-openjdk-headless
And use a more recent dCache version in the version example