### PR TITLE
Scitags: Firefly usage and stats

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/MoverInfoMessage.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/MoverInfoMessage.java
@@ -22,6 +22,8 @@ public class MoverInfoMessage extends PnfsFileInfoMessage {
     private Duration _readIdle;
     private Duration _writeActive;
     private Duration _writeIdle;
+    private double bytesRead = Double.NaN;
+    private double bytesWritten = Double.NaN;
 
     private static final long serialVersionUID = -7013160118909496211L;
     private String _transferPath;
@@ -140,6 +142,23 @@ public class MoverInfoMessage extends PnfsFileInfoMessage {
     public Optional<InetSocketAddress> getLocalEndpoint() {
         return Optional.ofNullable(_localEndpoint);
     }
+
+    public double getBytesRead() {
+        return bytesRead;
+    }
+
+    public void setBytesRead(double bytesRead) {
+        this.bytesRead = bytesRead;
+    }
+
+    public double getBytesWritten() {
+        return bytesWritten;
+    }
+
+    public void setBytesWritten(double bytesWritten) {
+        this.bytesWritten = bytesWritten;
+    }
+
     @Override
     public String toString() {
         return "MoverInfoMessage{" +

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -208,12 +208,14 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
         SnapshotStatistics writeStats = writes.statistics();
 
         if (readStats.requestedBytes().getN() > 0) {
+            info.setBytesRead(readStats.transferredBytes().getMax());
             info.setMeanReadBandwidth(readStats.instantaneousBandwidth().getMean());
             info.setReadActive(reads.active());
             info.setReadIdle(reads.idle());
         }
 
         if (writeStats.requestedBytes().getN() > 0) {
+            info.setBytesWritten(writeStats.transferredBytes().getMax());
             info.setMeanWriteBandwidth(writeStats.instantaneousBandwidth().getMean());
             info.setWriteActive(writes.active());
             info.setWriteIdle(writes.idle());
@@ -240,8 +242,7 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
         mover.getLocalEndpoint().ifPresent(e ->
                 transferLifeCycle.onEnd(((IpProtocolInfo) mover.getProtocolInfo()).getSocketAddress(),
                         e,
-                        mover.getProtocolInfo(),
-                        mover.getSubject()));
+                        moverInfoMessage));
 
         _door.notify(mover.getPathToDoor(), finished);
     }

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/DefaultPostTransferService.java
@@ -208,14 +208,14 @@ public class DefaultPostTransferService extends AbstractCellComponent implements
         SnapshotStatistics writeStats = writes.statistics();
 
         if (readStats.requestedBytes().getN() > 0) {
-            info.setBytesRead(readStats.transferredBytes().getMax());
+            info.setBytesRead(readStats.transferredBytes().getSum());
             info.setMeanReadBandwidth(readStats.instantaneousBandwidth().getMean());
             info.setReadActive(reads.active());
             info.setReadIdle(reads.idle());
         }
 
         if (writeStats.requestedBytes().getN() > 0) {
-            info.setBytesWritten(writeStats.transferredBytes().getMax());
+            info.setBytesWritten(writeStats.transferredBytes().getSum());
             info.setMeanWriteBandwidth(writeStats.instantaneousBandwidth().getMean());
             info.setWriteActive(writes.active());
             info.setWriteIdle(writes.idle());

--- a/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
+++ b/modules/dcache/src/main/resources/org/dcache/pool/classic/pool.xml
@@ -351,6 +351,7 @@
     <property name="fireflyDestination" value="${pool.firefly.destination}" />
     <property name="excludes" value="${pool.firefly.excludes}" />
     <property name="voMapping" value="${pool.firefly.vo-mapping}" />
+    <property name="storageStatisticsEnabled" value="${pool.firefly.storage-statistics}" />
   </bean>
 
   <bean id="default-transfer-service" class="org.dcache.pool.classic.MoverMapTransferService"

--- a/skel/share/defaults/pool.properties
+++ b/skel/share/defaults/pool.properties
@@ -949,3 +949,8 @@ pool.firefly.excludes=
 # example: atlas:2, cms:3,etc.
 #
 pool.firefly.vo-mapping=atlas:2, cms:3, lhcb:4, alice:5, belleii:6, ska:7, dune:8, lsst:9, ilc:10, auger:11, juno:12, nova:13, xenon:14
+
+#
+# Enable sending storage statistics as part of the firefly packets
+#
+pool.firefly.storage-statistics=false


### PR DESCRIPTION
This introduces usage in the fireflies, which we need to estimate direction of the transfer. It is devised from the storage statistics in the MoverInfoMessage. Optionally, based on configuration, it also adds storage statistics to the fireflies.