### PR TITLE
jetty: disable sending version number

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/jetty/ConnectorFactoryBean.java
+++ b/modules/dcache/src/main/java/org/dcache/util/jetty/ConnectorFactoryBean.java
@@ -308,6 +308,10 @@ public class ConnectorFactoryBean implements FactoryBean<ServerConnector> {
         checkState(protocol == PLAIN || certificateAuthorityPath != null);
 
         HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory();
+        /*
+         * disable reporting of Jetty version
+         */
+        httpConnectionFactory.getHttpConfiguration().setSendServerVersion(false);
 
         switch (protocol) {
             case PLAIN:


### PR DESCRIPTION
Motivation
----------

Security scans flag dCache application as non-compliant because it reports Jetty version number

Modification
------------

Disable reporting Jetty version

Result
------

Baseline security compliant

Target: trunk
Request: 10.2, 10.1, 10.0, 9.2
Acked-by: Tigran

Patch: https://rb.dcache.org/r/14383/