### PR TITLE
Support EC Signed OIDC Jwt tokens

### DIFF
--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
@@ -129,6 +129,12 @@ public class JsonWebToken {
         switch (alg) {
             case "RS256":
                 return Signature.getInstance("SHA256withRSA");
+            case "ES256":
+                return Signature.getInstance("SHA256withECDSA");
+            case "ES384":
+                return Signature.getInstance("SHA384withECDSA");
+            case "ES512":
+                return Signature.getInstance("SHA512withECDSA");
             default:
                 throw new NoSuchAlgorithmException("Unknown JWT alg " + alg);
         }

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
@@ -162,7 +162,10 @@ public class JsonWebToken {
                 sig = transcodeJWTECDSASignatureToDER(sig);
             }
             return signature.verify(sig);
-        } catch (GeneralSecurityException | SignatureException e) {
+        } catch (SignatureException e) {
+            LOGGER.warn("Problem verifying signature: {}", e.toString());
+            return false;
+        } catch (GeneralSecurityException e) {
             LOGGER.warn("Problem verifying signature: {}", e.toString());
             return false;
         }

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.time.Instant;

--- a/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
+++ b/modules/gplazma2/src/main/java/org/dcache/gplazma/util/JsonWebToken.java
@@ -161,7 +161,7 @@ public class JsonWebToken {
                 sig = transcodeJWTECDSASignatureToDER(sig);
             }
             return signature.verify(sig);
-        } catch (GeneralSecurityException e) {
+        } catch (GeneralSecurityException | SignatureException e) {
             LOGGER.warn("Problem verifying signature: {}", e.toString());
             return false;
         }


### PR DESCRIPTION
dCache gplazma2 OIDC was only supporting RSA signed JWT tokens. I had a OIDC OP that issues EC signed tokens.
I added the support for EC Signed Tokens and now my tokens are accepted.