### PR TITLE
Bulk: remove skipIfOnline method from PinManagerActivity

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinActivity.java
@@ -74,7 +74,6 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.dcache.pinmanager.PinManagerPinMessage;
 import org.dcache.services.bulk.BulkServiceException;
@@ -122,11 +121,6 @@ public final class PinActivity extends PinManagerActivity {
                   id,
                   lifetimeInMillis);
             message.setSubject(subject);
-
-            Optional<ListenableFuture<Message>> skipOption = skipIfOnline(attributes, message);
-            if (skipOption.isPresent()) {
-                return skipOption.get();
-            }
 
             return pinManager.send(message, Long.MAX_VALUE);
         } catch (URISyntaxException | CacheException e) {

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinManagerActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/PinManagerActivity.java
@@ -64,9 +64,6 @@ import static diskCacheV111.util.CacheException.INVALID_ARGS;
 import static org.dcache.services.bulk.util.BulkRequestTarget.computeFsPath;
 import static org.dcache.services.bulk.util.BulkRequestTarget.State.SKIPPED;
 
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import diskCacheV111.util.AccessLatency;
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.FsPath;
 import diskCacheV111.util.NamespaceHandlerAware;
@@ -145,23 +142,16 @@ abstract class PinManagerActivity extends BulkActivity<Message> implements PinMa
         return message;
     }
 
+    /**
+     * Only regular files get pinned
+     * @param attributes
+     * @throws CacheException
+     */
     protected void checkPinnable(FileAttributes attributes) throws CacheException {
         switch(attributes.getFileType()) {
             case SPECIAL:
             case DIR:
                 throw new CacheException(INVALID_ARGS, "Not a regular file.");
         }
-    }
-
-    protected Optional<ListenableFuture<Message>> skipIfOnline(FileAttributes attributes,
-          PinManagerPinMessage message) {
-        ListenableFuture<Message> future = null;
-        if (attributes.getAccessLatency() == AccessLatency.ONLINE) {
-            message.setReply();
-            message.setLifetime(-1L);
-            future = Futures.immediateFuture(message);
-        }
-
-        return Optional.ofNullable(future);
     }
 }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/activity/plugin/pin/StageActivity.java
@@ -119,12 +119,13 @@ public final class StageActivity extends PinManagerActivity {
 
         try {
             /*
-             *  refetch the attributes because RP is not stored in the bulk database.
+             *  refetch the attributes because Retention Policy is not stored in the bulk database.
              */
 
             FsPath absolutePath = BulkRequestTarget.computeFsPath(prefix, path.toString());
             attributes = getAttributes(absolutePath);
 
+            //Checks for files' RetentionPolicy to be CUSTODIAL
             checkStageable(attributes);
 
             PinManagerPinMessage message
@@ -133,11 +134,6 @@ public final class StageActivity extends PinManagerActivity {
                   id,
                   getLifetimeInMillis(path));
             message.setSubject(subject);
-
-            Optional<ListenableFuture<Message>> skipOption = skipIfOnline(attributes, message);
-            if (skipOption.isPresent()) {
-                return skipOption.get();
-            }
 
             return pinManager.send(message, Long.MAX_VALUE);
         } catch (URISyntaxException | CacheException e) {
@@ -177,6 +173,7 @@ public final class StageActivity extends PinManagerActivity {
     }
 
     private void checkStageable(FileAttributes attributes) throws CacheException {
+        //check if it's a regular file
         checkPinnable(attributes);
 
         if (attributes.getRetentionPolicy() != RetentionPolicy.CUSTODIAL) {


### PR DESCRIPTION
Motivation: as per ticket #10647 some files are showing skipped when trying to stage them

Modification: removal of skipIfOnline method. To create a permanent pin use lifetime=-1 AND lifetimeUnit=MILLISECONDS.

Result: files are stageable

Acked-by:Tigran Mkrtchyan
Target: master, 10.2, 11.0
Require-book: no
Require-notes: no