### PR TITLE
nfs41: remove transfers with no movers on layout state disposal

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1536,6 +1536,9 @@ public class NFSv41Door extends AbstractCellComponent implements
                               t.getClient().getRemoteAddress());
                         t.shutdownMover();
                     }
+                } else {
+                    // no associated mover, thus, we need to remove the transfer manually as cleanup will be never be called
+                    _transfers.remove(_stateid.stateid());
                 }
             });
             _openStateid = openStateId;


### PR DESCRIPTION
Motivation:
NFS door associates transfers with layout- or open- state ids. On state disposal, for example, when client closes a file, transfers shutdown is called, that will remove the transfer when mover is finished. However, if no mover associated with a transfer, then such transfers will stay in the door.

Modification:
explicitly remove transfers that have no mover associated.

Result:
Less orphan transfers in the nfs door.

Acked-by: Dmitry Litvintsev
Target: master, 11.0, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit fd4b8991101c349c2381886c5c3f0864097dcc6d)