### PR TITLE
REST API: restrict access to id resource to admin user

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/IdResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/namespace/IdResources.java
@@ -146,6 +146,13 @@ public class IdResources {
     @Produces(MediaType.APPLICATION_JSON)
     public JsonFileAttributes getAttributes(@ApiParam("The PNFS-ID of a file or directory.")
     @PathParam("pnfsid") String value) {
+
+        if (RequestUser.isAnonymous()) {
+            throw new NotAuthorizedException("Anonymous user is not authorized.");
+        } else if (!RequestUser.isAdmin()) {
+            throw new ForbiddenException("Requires admin privileges.");
+        }
+
         Set<FileAttribute> attributeSet
               = NamespaceUtils.getRequestedAttributes(true,
               true,


### PR DESCRIPTION
Motivation:
-----------

Access to id namespace resource is unrestricted
(the thinking was that pnfsid is not something is readily known). Some sites expressed concerns that knowing pnfsid one can query file metadata w/o restriction.

Modifcation:
------------

Restrict id resource to admin user

Result:
------

Access to id resource is limited to admin user/role

Target: trunk
Request: 11.x
Request: 10.x
Request: 9.x
Patch: https://rb.dcache.org/r/14438
Require-book: no
Require-notes: yes
Acked-by: Tigran