### PR TITLE
webdav: fix X-OC-MTIME support when uploading a file

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -148,6 +148,7 @@ import org.dcache.util.list.DirectoryEntry;
 import org.dcache.util.list.DirectoryListPrinter;
 import org.dcache.util.list.ListDirectoryHandler;
 import org.dcache.vehicles.FileAttributes;
+import org.dcache.vehicles.PnfsSetFileAttributes;
 import org.dcache.webdav.owncloud.OwncloudClients;
 import org.dcache.webdav.transfer.RemoteTransferHandler;
 import org.eclipse.jetty.io.EofException;
@@ -1826,16 +1827,12 @@ public class DcacheResourceFactory
      */
     private class WriteTransfer extends HttpTransfer {
 
-        private final Optional<Instant> _mtime;
         private final Optional<Checksum> _contentMd5;
 
         public WriteTransfer(PnfsHandler pnfs, Subject subject,
               Restriction restriction, FsPath path) throws URISyntaxException {
             super(pnfs, subject, restriction, path);
 
-            HttpServletRequest request = ServletRequest.getRequest();
-
-            _mtime = OwncloudClients.parseMTime(request);
 
             wantDigest()
                   .flatMap(Checksums::parseWantDigest)
@@ -1854,7 +1851,6 @@ public class DcacheResourceFactory
         @Override
         protected FileAttributes fileAttributesForNameSpace() {
             FileAttributes attributes = super.fileAttributesForNameSpace();
-            _mtime.map(Instant::toEpochMilli).ifPresent(attributes::setModificationTime);
 
             /**
              * Add user provided extended attributes, which will be sent to the pool.
@@ -1889,9 +1885,15 @@ public class DcacheResourceFactory
         public void createNameSpaceEntry() throws CacheException {
             super.createNameSpaceEntry();
 
-            if (_mtime.isPresent()) {
-                OwncloudClients.addMTimeAccepted(ServletResponse.getResponse());
-            }
+            // Update mtime (sent to pool) to match any client-supplied value.
+            HttpServletRequest request = ServletRequest.getRequest();
+            OwncloudClients.parseMTime(request)
+                    .map(Instant::toEpochMilli)
+                    .ifPresent(m -> {
+                        getFileAttributes().setModificationTime(m);
+                        var response = ServletResponse.getResponse();
+                        OwncloudClients.addMTimeAccepted(response);
+                    });
 
             if (_contentMd5.isPresent()) {
                 setChecksum(_contentMd5.get());

--- a/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/HttpPoolRequestHandler.java
@@ -593,8 +593,11 @@ public class HttpPoolRequestHandler extends HttpRequestHandler {
                                 Optional<String> digest = _wantedDigest
                                       .flatMap(t -> Checksums.digestHeader(t,
                                             writeChannel.getFileAttributes()));
-                                context.writeAndFlush(new HttpPutResponse(size, location, digest),
-                                      promise);
+                                var response = new HttpPutResponse(size, location, digest);
+                                if (writeChannel.getFileAttributes().isDefined(FileAttribute.MODIFICATION_TIME)) {
+                                    response.headers().set("X-OC-MTime", "accepted");
+                                }
+                                context.writeAndFlush(response, promise);
                             } catch (IOException e) {
                                 context.writeAndFlush(
                                       createErrorResponse(INTERNAL_SERVER_ERROR, e.getMessage()),

--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/WriteHandleImpl.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import static org.dcache.namespace.FileAttribute.ACCESS_LATENCY;
 import static org.dcache.namespace.FileAttribute.CHECKSUM;
 import static org.dcache.namespace.FileAttribute.LABELS;
+import static org.dcache.namespace.FileAttribute.MODIFICATION_TIME;
 import static org.dcache.namespace.FileAttribute.QOS_POLICY;
 import static org.dcache.namespace.FileAttribute.QOS_STATE;
 import static org.dcache.namespace.FileAttribute.RETENTION_POLICY;
@@ -205,6 +206,10 @@ class WriteHandleImpl implements ModifiableReplicaDescriptor {
 
             if (_fileAttributes.isDefined(LABELS)) {
                 attributesToUpdate.setLabels(_fileAttributes.getLabels());
+            }
+
+            if (_fileAttributes.isDefined(MODIFICATION_TIME)) {
+                attributesToUpdate.setModificationTime(_fileAttributes.getModificationTime());
             }
         }
 


### PR DESCRIPTION
Motivation:

dCache claims to support the `X-OC-MTIME` HTTP request header when uploading data.  This may be used to specify the desired modification time (mtime) when uploading a file.

Currently, the mtime is set when creating the namespace entry.  This doesn't work because the mtime is updated (to the current time) when the pool updates the namespace entry by specifying the file's size.

Modification:

Update the WebDAV door to send the desired mtime to the pool.  This takes advantage of the existing support for updating the namespace entry (via the pool) on a successful upload.

Update pool to include the door-supplied FileAttributes' MODIFICATION_TIME in the list of attributes that is uses to update the namespace entry on successful completion of the upload.

Result:

A bug is fixed that prevented dCache's support for the 'X-OC-MTIME' HTTP request header on PUT requests from working.  Note that, for this patch to be effective, both the WebDAV doors and all pools that accept such upload requests need to be updated.

Target: master
Request: 11.0
Request: 10.2
Request: 10.1
Request: 10.0
Request: 9.2
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/14446/
Acked-by: Tigran Mkrtchyan