### PR TITLE
frontend: respect admin role when requested

### DIFF
--- a/.ci/migrationEndpoint.http
+++ b/.ci/migrationEndpoint.http
@@ -9,7 +9,7 @@ Content-Type: application/octet-stream
 ### Migrate frontend file from pool_write to pool_res1
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -47,7 +47,7 @@ Content-Type: application/json
 GET {{frontend-door}}{{endpoint}}/id/{{pnfsId}}
 accept: application/json
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Retrieval of pnfsid successful", function() {
@@ -86,7 +86,7 @@ Content-Type: application/json
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 accept: application/json
 Content-Type: text/html
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
 "sourcePool": "pool_write",
@@ -106,7 +106,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Source pool not provided
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "targetPools": [{{targetPools}}]
@@ -117,20 +117,6 @@ Authorization: Basic {{user_name}} {{passwd}}
         client.assert(response.status === 400, "Response status is not 400");
     });
 %}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 ### copy endpoint without authentication
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
@@ -155,7 +141,7 @@ Content-Type: application/json
 ### copy endpoint with authentication
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -172,7 +158,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### test if response body is null
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -188,7 +174,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - bad request when sourcePool is not provided
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "targetPools": [{{targetPools}}]
@@ -204,7 +190,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - bad request when targetPool is not provided
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}}
@@ -220,7 +206,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - bad request when sourcePool is incorrect
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{wrong_src_pool_name}},
@@ -237,7 +223,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - bad request when targetPool is incorrect
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -253,7 +239,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - bad request when targetPools array has no length
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -269,7 +255,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - bad request when provided array of targetPools
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -286,7 +272,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 //TODO: concurrency should be a whole number
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -303,7 +289,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when sourcePool is not provided
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -320,7 +306,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when pins attribute set to move
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -337,7 +323,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when smode attribute set to same
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -354,7 +340,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when smode attribute set to cached
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -370,7 +356,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when smode attribute set to precious
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -387,7 +373,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when smode attribute set to removable
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -404,7 +390,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when smode attribute set to delete
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -421,7 +407,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when smode attribute set to delete+u2
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -438,7 +424,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when tmode attribute set to same
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -455,7 +441,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when tmode attribute set to cached
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -472,7 +458,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when tmode attribute set to precious
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -489,7 +475,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when verify attribute set to true
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -506,7 +492,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when verify attribute set to false
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -523,7 +509,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when eager attribute set to true
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -540,7 +526,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when eager attribute set to false
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -557,7 +543,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when exclude attribute set
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -574,7 +560,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when include attribute set
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -592,7 +578,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when refresh attribute set
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -610,7 +596,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when refresh select set
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -628,7 +614,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when target attribute set to hsm
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -646,7 +632,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when select attribute set
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -664,7 +650,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when target attribute set to pool
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -718,7 +704,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request when target attribute set
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -736,7 +722,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -758,7 +744,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Test for additional attributes for POST
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -797,7 +783,7 @@ GET {{frontend-door}}{{endpoint}}{{migrations}}/pool_write/1
 ### GET request to test if response type is json
 GET {{frontend-door}}{{endpoint}}{{migrations}}/{{pool_name}}/1
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Response content-type is json", function() {
@@ -809,7 +795,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -829,7 +815,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -849,7 +835,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -869,7 +855,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -889,7 +875,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -909,7 +895,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -929,7 +915,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -949,7 +935,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -969,7 +955,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -989,7 +975,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -1010,7 +996,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### copy endpoint - create request with fileAttributes
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -1043,7 +1029,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Unsuccessful request
 GET {{frontend-door}}{{endpoint}}{{migrations}}/{{pool_name}}/{{job_id}}
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Response content-type is json", function() {
@@ -1095,7 +1081,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Unsuccessful request
 GET {{frontend-door}}{{endpoint}}{{migrations}}/{{pool_name}}/{{job_id}}
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
 
@@ -1108,7 +1094,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Unsuccessful request
 GET {{frontend-door}}{{endpoint}}{{migrations}}/{{pool_name}}/{{job_id}}
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
 
@@ -1134,7 +1120,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Unsuccessful request
 GET {{frontend-door}}{{endpoint}}{{migrations}}/{{pool_name}}/{{job_id}}
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
 

--- a/.ci/poolEndpoint.http
+++ b/.ci/poolEndpoint.http
@@ -1,6 +1,6 @@
 ### Upload ReadMeFile
 PUT {{webdav-door}}/data/pool-a/ReadMeFile
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 Content-Type: application/octet-stream
 
 < /README.md
@@ -26,7 +26,7 @@ GET {{frontend-door}}{{endpoint}}{{namespace}}/%2Fdata%2Fpool-a%2FReadMeFile?chi
 ### Migrate ReadMeFile from source pool (pool-a) to target pool (pool-b)
 POST {{frontend-door}}{{endpoint}}{{migrations}}/copy
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "sourcePool": {{sourcePool}},
@@ -43,7 +43,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Get information about migration job ( Verify the job started)
 GET {{frontend-door}}{{endpoint}}{{migrations}}/{{sourcePool}}/{{migration-job-id}}
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Getting migration information", function() {
@@ -57,7 +57,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Check contents of target pool after migration
 GET {{frontend-door}}{{endpoint}}{{pools}}/{{targetPools}}/{{pnfsId}}
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Getting migration information for pool-b", function() {
@@ -69,7 +69,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Check contents of pool-c after migration
 GET {{frontend-door}}{{endpoint}}{{pools}}/pool-c/{{pnfsId}}
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Getting migration information for pool-c", function() {
@@ -81,7 +81,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Check contents of pool-c after entering an incorrect id -- should give a bad request
 GET {{frontend-door}}{{endpoint}}{{pools}}/pool-c/0000A9995C9903D846CFB1CBCED3CC7F323F526325147896325
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Getting information for incorrect id in pool-c", function() {

--- a/.ci/poolEndpoint.http
+++ b/.ci/poolEndpoint.http
@@ -88,3 +88,4 @@ Authorization: Basic {{username}} {{password}}
         client.assert(response.status === 404, "Incorrect pnfsId");
     });
 %}
+~

--- a/.ci/qos-policyEndpoint.http
+++ b/.ci/qos-policyEndpoint.http
@@ -1,7 +1,7 @@
 ### Create qos-policy "test102"
 POST {{frontend-door}}{{endpoint}}{{qos-policy}}
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "name": "test102",
@@ -38,7 +38,7 @@ Content-Type: application/json
 ### Successful DELETE request for policy "test102"
 DELETE {{frontend-door}}{{endpoint}}{{qos-policy}}/test102
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response when deleting a policy by name", function() {
@@ -60,7 +60,7 @@ Content-Type: application/json
 ### Successful request for policy "test103" with 1 state and 2 medias
 POST {{frontend-door}}{{endpoint}}{{qos-policy}}
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 {
   "name": "test103",
@@ -101,7 +101,7 @@ Content-Type: application/json
 ### Successful DELETE request for policy name "test103"
 DELETE {{frontend-door}}{{endpoint}}{{qos-policy}}/test103
 Content-Type: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response when deleting a policy by name", function() {

--- a/.ci/qosEndpoint.http
+++ b/.ci/qosEndpoint.http
@@ -2,7 +2,7 @@
 ### successful qos type:file
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/file
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for list of quality of services", function() {
@@ -13,7 +13,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### successful qos type:directory
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/directory
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for list of quality of services", function() {
@@ -24,7 +24,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### successful qos file:tape
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/file/tape
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for tape service", function() {
@@ -35,7 +35,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### successful qos file:disk
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/file/disk
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for disk service", function() {
@@ -47,7 +47,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### successful qos file:disk+tape
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/file/disk+tape
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for disk+tape service", function() {
@@ -58,7 +58,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### successful qos file:volatile
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/file/volatile
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for volatile service", function() {
@@ -70,7 +70,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Not defined QoS
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/file/test
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("qos requested does not exist", function() {
@@ -81,7 +81,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### Incorrect basic authentication credentials
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/file/test
 accept: application/json
-Authorization: Basic {{user_name}} {{incorrect_passwd}}
+Authorization: Basic {{username}} {{incorrect_password}}
 
 > {%
     client.test("Incorrect basic authentication credentials ", function() {
@@ -93,7 +93,7 @@ Authorization: Basic {{user_name}} {{incorrect_passwd}}
 ### successful qos directoy:tape
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/directory/tape
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for tape service", function() {
@@ -104,7 +104,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### successful qos directoy:disk
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/directory/disk
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for disk service", function() {
@@ -116,7 +116,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### successful qos directoy:disk+tape
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/directory/disk+tape
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for disk+tape service", function() {
@@ -127,7 +127,7 @@ Authorization: Basic {{user_name}} {{passwd}}
 ### successful qos directoy:volatile
 GET {{frontend-door}}{{endpoint}}{{qos-management}}/directory/volatile
 accept: application/json
-Authorization: Basic {{user_name}} {{passwd}}
+Authorization: Basic {{username}} {{password}}
 
 > {%
     client.test("Successful response for volatile service", function() {

--- a/.ci/userEndpoint.http
+++ b/.ci/userEndpoint.http
@@ -1,0 +1,45 @@
+### Anonymouns user
+GET {{frontend-door}}{{endpoint}}/user
+Accept: application/json
+
+> {%
+
+  client.assert(response.status === 200, "Mapping failed");
+  client.assert(response.body['status'] == "ANONYMOUS",
+      "Expected 'status' to have value 'ANONYMOUS' but received '" + response.body['status']
+      + "'");
+
+%}
+
+### Accessing without role
+GET {{frontend-door}}{{endpoint}}/user
+Accept: application/json
+Authorization: Basic {{username}} {{password}}
+
+> {%
+
+  client.assert(response.status === 200, "Mapping failed");
+  client.assert(response.body['roles'] == null,
+      "Unexpected Roles: '" + response.body['roles']
+      + "'");
+
+%}
+
+### Requesting Admin role
+GET {{frontend-door}}{{endpoint}}/user
+Accept: application/json
+Authorization: Basic admin#admin {{password}}
+
+> {%
+  client.assert(response.status === 200, "Mapping failed");
+  client.assert(response.body['roles'][0] == 'admin', "Admin Role not granted");
+%}
+
+### Requesting invalid role
+GET {{frontend-door}}{{endpoint}}/user
+Accept: application/json
+Authorization: Basic admin#foo {{password}}
+
+> {%
+  client.assert(response.status === 401, "Invalid role accepted");
+%}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -564,10 +564,11 @@ Frontend test suite:
     - kubectl -n $K8S_NAMESPACE cp .ci/poolEndpoint.http http-tester:/poolEndpoint.http
     - kubectl -n $K8S_NAMESPACE cp .ci/qosEndpoint.http http-tester:/qosEndpoint.http
     - kubectl -n $K8S_NAMESPACE cp .ci/qos-policyEndpoint.http http-tester:/qos-policyEndpoint.http
+    - kubectl -n $K8S_NAMESPACE cp .ci/userEndpoint.http http-tester:/userEndpoint.http
     - kubectl -n $K8S_NAMESPACE cp README.md http-tester:/README.md
     - kubectl -n $K8S_NAMESPACE cp .ci/migrationEndpoint.http http-tester:/migrationEndpoint.http
     - kubectl -n $K8S_NAMESPACE cp http-client.private.env.json http-tester:/http-client.private.env.json
-    - kubectl -n $K8S_NAMESPACE exec http-tester -- java --add-opens=java.base/java.util=ALL-UNNAMED $IJHTTP_JAVA_OPTS -cp /intellij-http-client/\* com.intellij.httpClient.cli.HttpClientMain -e Test -D /poolEndpoint.http -p /http-client.private.env.json --insecure --report=/httpTests
+    - kubectl -n $K8S_NAMESPACE exec http-tester -- java --add-opens=java.base/java.util=ALL-UNNAMED $IJHTTP_JAVA_OPTS -cp /intellij-http-client/\* com.intellij.httpClient.cli.HttpClientMain -e Test -D /poolEndpoint.http /userEndpoint.http -p /http-client.private.env.json --insecure --report=/httpTests
     - kubectl -n $K8S_NAMESPACE cp http-tester:/httpTests/report.xml pool-report.xml
   artifacts:
     reports:

--- a/http-client.private.env.json
+++ b/http-client.private.env.json
@@ -1,8 +1,8 @@
 {
   "Test": {
-    "user_name": "admin",
-    "passwd" : "dickerelch",
-    "incorrect_passwd" : "password",
+    "username": "admin",
+    "password": "dickerelch",
+    "incorrect_password": "password",
     "webdav-door" : "https://store-door-svc:8083",
     "frontend-door" : "https://store-door-svc:3881",
     "endpoint": "/api/v1",
@@ -13,9 +13,10 @@
     "namespace": "/namespace",
     "labels": "/labels",
     "sourcePool" : "pool-a",
-    "target": "hsm",
     "targetPools": "pool-b",
+    "target": "hsm",
     "osm_targetPools": "\"osm\"",
+    "pool_name" : "pool_write",
     "wrong_src_pool_name" :  "wrong_src_pool_name",
     "wrong_target_pool_name" : "wrong_target_pool_name",
     "excludePools" : "pool_res1",
@@ -26,10 +27,6 @@
     "pnfsid" : "\"000044CE270AED9A46B4836AD79FF3335224\",\"0000A054084D4BC248A18911AFFE18338FAA\"",
     "owners" : "\"sandro\",\"tigran\"",
     "storage" : "\"test:default\"" ,
-
-
-
-    "pool_name" : "pool_write",
     "job_id": "1"
   }
 }

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/identity/UserResource.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/identity/UserResource.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2016 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2016 - 2025 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -24,6 +24,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -78,12 +79,19 @@ public class UserResource {
             List<String> emails = Subjects.getEmailAddresses(subject);
             user.setEmail(emails.isEmpty() ? null : emails);
 
+            List<String> roles = new ArrayList<>();
             for (LoginAttribute attribute : getLoginAttributes(request)) {
                 if (attribute instanceof HomeDirectory) {
                     user.setHomeDirectory(((HomeDirectory) attribute).getHome());
                 } else if (attribute instanceof RootDirectory) {
                     user.setRootDirectory(((RootDirectory) attribute).getRoot());
+                } else if (attribute instanceof org.dcache.auth.attributes.Role) {
+                    roles.add(((org.dcache.auth.attributes.Role) attribute).getRole());
                 }
+            }
+
+            if (!roles.isEmpty()) {
+                user.setRoles(roles);
             }
 
             Optional<Principal> principal

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/HttpServletRequests.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/HttpServletRequests.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2017 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2017 - 2025 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
 import org.dcache.auth.Subjects;
 import org.dcache.auth.attributes.LoginAttribute;
+import org.dcache.auth.attributes.LoginAttributes;
 import org.dcache.auth.attributes.Restriction;
 import org.dcache.auth.attributes.Restrictions;
 import org.dcache.auth.attributes.RootDirectory;
@@ -54,7 +55,8 @@ public class HttpServletRequests {
     }
 
     public static boolean isAdmin(HttpServletRequest request) {
-        return Subjects.hasAdminRole(RequestUser.getSubject());
+        return Subjects.hasAdminRole(RequestUser.getSubject()) ||
+              LoginAttributes.hasAdminRole(AuthenticationHandler.getLoginAttributes(request));
     }
 
     public static Subject roleAwareSubject(HttpServletRequest request) {


### PR DESCRIPTION
Motivation:
dCache has two identify admin role: login attribute and RolePrincipal. As HttpServletRequests#isAdmin checks only the RolePrincipal, attribute based roles are ignored.

Modification:
Update HttpServletRequests#isAdmin to check both principal and login attribute. Added frontend test.

Result:
Restore expected behaviour.

Fixes: #7808
Acked-by: Karen Hoyos
Target: master, 11.0, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit 7dc561d58f9f4ad7a1254b09d6dec2d512275f9f)