### PR TITLE
gplazma: check BEARER TOKEN empty case

### DIFF
--- a/modules/common/src/main/java/org/dcache/auth/BearerTokenCredential.java
+++ b/modules/common/src/main/java/org/dcache/auth/BearerTokenCredential.java
@@ -23,6 +23,7 @@ public class BearerTokenCredential implements Serializable {
     private final String _token;
 
     public BearerTokenCredential(String token) {
+        checkArgument(!token.isEmpty(), "Bearer Token must not be empty");
         checkArgument(CharMatcher.ascii().matchesAllOf(token), "Bearer Token not ASCII");
         _token = token;
     }

--- a/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
+++ b/modules/dcache/src/main/java/org/dcache/http/AuthenticationHandler.java
@@ -439,16 +439,22 @@ public class AuthenticationHandler extends HandlerWrapper {
             LOG.debug("No credentials found in Authorization header");
             return Optional.empty();
         }
+        String authScheme;
+        String authData;
 
         if (header.length() == 0) {
             LOG.debug("Credentials in Authorization header are not-null, but are empty");
             return Optional.empty();
         }
-
         int space = header.indexOf(" ");
-        String authScheme =
-              space >= 0 ? header.substring(0, space).toUpperCase() : HttpServletRequest.BASIC_AUTH;
-        String authData = space >= 0 ? header.substring(space + 1) : header;
+
+        if (space < 0) {
+            authScheme = header.toUpperCase();
+            authData = "";
+        } else {
+            authScheme = header.substring(0, space).toUpperCase();
+            authData = header.substring(space + 1);
+        }
         return Optional.of(new AuthInfo(authScheme, authData));
     }
 


### PR DESCRIPTION
  Motivation

As reported by KIT, a LoginNamePrincipal  has started to appear in their logs (  (ticket #10723)). This was due the  Bearer (with an empty token). In this case, getHeader("Authorization") returns a trimmed string, so the authorizationScheme ends up being set to HttpServletRequest.BASIC_AUTH.
  Indecipherable login credential for CMS at GridKa)

Modification
   It should be checked not only whether the Authorization header is non-null, but also whether it is empty (i.e., an empty BEARER_TOKEN is being used).
And the empty token should be rejected

Acked-by: Tigran Mkrtchyan
Target: master, 11.0, 10.2, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
Patch: https://rb.dcache.org/r/14462/