### PR TITLE
gmplazma: excessive caching of failed login attempts leads to system …

### DIFF
--- a/modules/dcache-gplazma/src/main/resources/org/dcache/services/login/gplazma.xml
+++ b/modules/dcache-gplazma/src/main/resources/org/dcache/services/login/gplazma.xml
@@ -66,7 +66,12 @@
     </constructor-arg>
     <property name="observers">
       <util:list>
-	<bean class="org.dcache.gplazma.RecordFailedLogins"/>
+	<bean class="org.dcache.gplazma.RecordFailedLogins" init-method="initialize">
+      <property name="loginFailureCacheSize" value="${gplazma.authz.loginFailure.cache.size}"/>
+      <property name="loginFailureCacheSizeExpiry" value="${gplazma.authz.loginFailure.cache-size-expiry}"/>
+      <property name="loginFailureCacheSizeExpiryUnit" value="${gplazma.authz.loginFailure.cache-size-expiry.unit}"/>
+    </bean>
+
       </util:list>
     </property>
   </bean>

--- a/modules/gplazma2/src/test/java/org/dcache/gplazma/RecordFailedLoginsTest.java
+++ b/modules/gplazma2/src/test/java/org/dcache/gplazma/RecordFailedLoginsTest.java
@@ -1,0 +1,75 @@
+package org.dcache.gplazma;
+
+import junit.framework.TestCase;
+import org.dcache.auth.GidPrincipal;
+import org.dcache.auth.UidPrincipal;
+import org.dcache.auth.UserNamePrincipal;
+import org.dcache.gplazma.monitor.LoginMonitor;
+import org.dcache.gplazma.monitor.LoginResult;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+
+public class RecordFailedLoginsTest extends TestCase {
+
+    LoginResult _resuttFirstEntry;
+
+    // it will be evicted only if no entries are ever read (.get(), .getIfPresent()),
+    // that is why the test on eviction is done on the second entry
+    LoginResult _resuttSecondtEntry;
+
+    LoginResult _result;
+
+    @Test
+    public void testCacheDelete() {
+
+        // fill with random principals
+        RecordFailedLogins observer = new RecordFailedLogins();
+        observer.setLoginFailureCacheSize(20);
+        observer.setLoginFailureCacheSizeExpiry(60);
+        observer.setLoginFailureCacheSizeExpiryUnit(SECONDS);
+        observer.initialize();
+
+        _resuttFirstEntry = new LoginResult();
+        _resuttFirstEntry.setValidationResult(LoginMonitor.Result.FAIL);
+        _resuttFirstEntry.setInitialPrincipals(Set.of(
+                new UserNamePrincipal("testuser" + 0),
+                new UidPrincipal("1000" + 0),
+                new GidPrincipal("1000", true)));
+
+        _resuttSecondtEntry = new LoginResult();
+        _resuttSecondtEntry.setValidationResult(LoginMonitor.Result.FAIL);
+        _resuttSecondtEntry.setInitialPrincipals(Set.of(
+                new UserNamePrincipal("testuser" + 1),
+                new UidPrincipal("1000" + 1),
+                new GidPrincipal("1000", true)));
+
+        observer.accept(_resuttFirstEntry);
+
+        for (int i = 2; i < 55; i++) {
+
+            _result = new LoginResult();
+            _result.setValidationResult(LoginMonitor.Result.FAIL);
+            _result.setInitialPrincipals(Set.of(
+                    new UserNamePrincipal("testuser" + i),
+                    new UidPrincipal("1000" + i),
+                    new GidPrincipal("1000", true)));
+
+            observer.accept(_result);
+
+            if (i == 10) {
+                boolean hasFirstEntry = (observer.has(_resuttFirstEntry));
+                assertTrue("First inserted subject still exists", hasFirstEntry);
+            }
+        }
+        // check if second entry is still there
+        boolean hasSecondEntryAfter = (observer.has(_resuttSecondtEntry));
+        assertFalse("First inserted subject should have been evicted", hasSecondEntryAfter);
+    }
+
+}
+
+

--- a/skel/share/defaults/gplazma.properties
+++ b/skel/share/defaults/gplazma.properties
@@ -111,6 +111,27 @@ gplazma.service.pnfsmanager=${dcache.service.pnfsmanager}
 #
 gplazma.authz.upload-directory=${dcache.upload-directory}
 
+# -- this property is the maximal size of cached entries per failed login attempts to be cache.
+# this cache stores  UserNamePrincipal, UIDPrincipal, and GIDPrincipal for the feiled login attampts
+#
+# Excessive caching of failed login attempts in dCache may lead to system overload.
+# Large cache sizes can cause the Java garbage collector to run at 100% CPU and consume significant memory,
+# which may degrade system performance.
+#
+# When the cache reaches this size, older entries are evicted.
+# Remove the least-recently-used (LRU) entries when that limit is exceeded.
+# important: the cache size is an approximate size not exact.
+#
+gplazma.authz.loginFailure.cache.size=10000
+#  ----- timeout cache entry life time. By default  expire entries 1 hour after they are written.
+# If a key is expired due to time, it is gone even if the cache is not full.
+# If the cache is full, LRU entries are evicted even if they are not expired.
+gplazma.authz.loginFailure.cache-size-expiry=1
+#  ----- timeout cache entry life time unit.
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)gplazma.authz.loginFailure.cache-size-expiry.unit=HOURS
+
+
+
 
 #  -----------------------------------------------------------------------
 #         Properties for gPlazma plugins


### PR DESCRIPTION
…overload.

In the  ticket 10723 was discovered that  dCache caching a response for
    a rejected authentication attempt, based on the identity.
   (in case of chained certificates) might create 100k "cached" failed login entries in dCache.

This can  lead to overeading to an overload and triggering java garbage collectors
    running at 100 % CPU and large memory consumption.

Motivation
dCache Overload from Failed Logins via Chained Proxies.

Modification

Replace CopyOnWriteArraySet with Guava cache.

Result

FailedLogins will now be  keeping only the last specfied number of logs by  `gplazma.authz.max-cache-size= 10000` property.

Acked-by: Tigra Mkrtchyan
Target: master. 11.0, 10.2, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
Patch: https://rb.dcache.org/r/14444/