### PR TITLE
dcache rest api: do not filter out fields with default and null values

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/ObjectMapperProvider.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/ObjectMapperProvider.java
@@ -24,9 +24,7 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
         return new ObjectMapper()
               .registerModule(PNFSID_SERIALIZER)
               .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
-              .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-              .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-              .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+              .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     private static ObjectMapper createDefaultMapper() {

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/quota/QuotaResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/quota/QuotaResources.java
@@ -398,17 +398,8 @@ public final class QuotaResources {
     private List<QuotaInfo> getQuotas(PnfsManagerGetQuotaMessage message) {
         try {
             message = pnfsmanager.sendAndWait(message);
-
-            /*
-             *  REVISIT.  Output is currently not used.  This will be revisted with
-             *            further redesign of the QoS definitions. For now, we null
-             *            out those settings (just in case).
-             */
-            return message.getQuotaInfos().stream().map(quotaInfo -> {
-                quotaInfo.setOutput(null);
-                quotaInfo.setOutputLimit(null);
-                return quotaInfo;
-            }).collect(Collectors.toList());
+            return message.getQuotaInfos().stream()
+                .collect(Collectors.toList());
         } catch (CacheException e) {
             switch (e.getRc()) {
                 case SERVICE_UNAVAILABLE:
@@ -469,13 +460,9 @@ public final class QuotaResources {
             request.setReplicaLimit(jsonObject.getString("replicaLimit"));
         }
 
-        /*
-         *  REVISIT.  Output is currently not used.  This will be revisted with
-         *            further redesign of the QoS definitions.
-         */
-//        if (jsonObject.has("outputLimit")) {
-//            request.setOutputLimit(jsonObject.getString("outputLimit"));
-//        }
+        if (jsonObject.has("outputLimit")) {
+            request.setOutputLimit(jsonObject.getString("outputLimit"));
+        }
 
         return request;
     }


### PR DESCRIPTION
when building json reply object. Enable get/set of OUTPUT quota

Motivation:
-----------

dCache rest api response filters out fields that have null or default (for that type) values. As the result, for instance, integer filed with 0 value is skipped (so is any filed with null value). This is not desirable

Modification:
-------------

Change custom Json ObjectMapper to retain fields with null and default values

Result:
-------

Request results returned by dCache rest api contain fields having null or default values

Ticket: https://github.com/dCache/dcache/issues/7836
Patch: https://rb.dcache.org/r/14479/
Target: trunk
Request: 11.0, 10.2, 10.1, 10.0, 9.2

Acked-by: Tigran

Require-book: no
Require-notes: yes