### PR TITLE
qos: make db name configurable

### DIFF
--- a/skel/share/defaults/qos-engine.properties
+++ b/skel/share/defaults/qos-engine.properties
@@ -37,7 +37,7 @@ qos-engine.db.connections.idle=1
 
 # ---- Database related settings reserved for internal use.
 #
-(immutable)qos-engine.db.name=qos
+qos-engine.db.name=qos
 qos-engine.db.host=${dcache.db.host}
 qos-engine.db.user=${dcache.db.user}
 qos-engine.db.password=${dcache.db.password}

--- a/skel/share/defaults/qos-verifier.properties
+++ b/skel/share/defaults/qos-verifier.properties
@@ -43,7 +43,7 @@ qos-verifier.db.connections.idle=1
 
 # ---- Database related settings reserved for internal use.
 #
-(immutable)qos-verifier.db.name=qos
+qos-verifier.db.name=qos
 qos-verifier.db.host=${dcache.db.host}
 qos-verifier.db.user=${dcache.db.user}
 qos-verifier.db.password=${dcache.db.password}


### PR DESCRIPTION
Admins might want to fave a different name

Acked-by: Karen Hoyos
Target: master, 11.0, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit cab11e7486ab74cac8596267eaf0fda6136c7ac1)