### PR TITLE
pool: define replocas' lastAccessTime and creationTime on start up wh…

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/meta/db/CacheRepositoryEntryImpl.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.net.URI;
 import java.nio.file.OpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -97,7 +98,10 @@ public class CacheRepositoryEntryImpl implements ReplicaRecord {
         if (storageInfo == null) {
 
             try {
-                _size = _fileStore.getFileAttributeView(pnfsId).readAttributes().size();
+                BasicFileAttributes basicFileAttributes = _fileStore.getFileAttributeView(pnfsId).readAttributes();
+                _size = basicFileAttributes.size();
+                _creationTime =  basicFileAttributes.creationTime().toMillis();
+                _lastAccess = basicFileAttributes.lastAccessTime().toMillis();
             } catch (IOException e) {
                 LOGGER.error("Failed to read file size: {}", e.toString());
             }


### PR DESCRIPTION
…en repository

is not present

Motivation:
-----------

Replicas on pools that have been restarted after their meta ditrectories were wiped out show nonsensical lifetimes (55 years)

Modification:
-------------

Define lastAccessTime and creationTime when loading repository from directory on startup from scrach

Result:
-------

Correct lastAccess and creationTime displayed by sweeper ls and thus replica lifetimes reported by dCache REST Api

Patch: https://rb.dcache.org/r/14502/
Acked-by: Karen
Target: trunk
Request: 11.0
Request: 10.2
Request: 10.1
Request: 9.2

Require-book: no
Require-notes: yes