### PR TITLE
poolmanager: update wrandom partition to respect gap

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/WRandomPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/WRandomPartition.java
@@ -5,7 +5,6 @@ import com.google.common.collect.Lists;
 
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -84,27 +83,49 @@ public class WRandomPartition extends Partition
 
     @Override
     public SelectedPool selectWritePool(CostModule cm, List<PoolInfo> pools, FileAttributes attributes, long preallocated) throws CacheException {
-        WeightedPool weightedPools[] = toWeightedWritePoolsArray(pools);
+        WeightedPool weightedPools[] = toWeightedWritePoolsArray(pools, preallocated);
+        if (weightedPools.length == 0) {
+            throw new CostException("All pools are full", null, false, false);
+        }
         int index = selectWrandomIndex(weightedPools);
         return new SelectedPool(weightedPools[index].getCostInfo());
     }
 
-    private WeightedPool[] toWeightedWritePoolsArray(Collection<PoolInfo> costInfos) {
+    private WeightedPool[] toWeightedWritePoolsArray(List<PoolInfo> costInfos, long fileSize)
+            throws CacheException {
 
         long totalFree = 0;
+        int validCount = 0;
         for (PoolInfo costInfo : costInfos) {
+            long gap = costInfo.getCostInfo().getSpaceInfo().getGap();
+
             long spaceToUse = costInfo.getCostInfo().getSpaceInfo().getFreeSpace()
                     + costInfo.getCostInfo().getSpaceInfo().getRemovableSpace();
+            if (fileSize > spaceToUse - gap) {
+                continue; // skip pools that do not have enough space
+            }
             totalFree += spaceToUse;
+            validCount++;
         }
 
-        WeightedPool[] weghtedPools = new WeightedPool[costInfos.size()];
-        int i = 0;
-        for (PoolInfo costInfo : costInfos) {
+        // the validCount should macht the number of pools that have enough space, thus elegible for selection
+        WeightedPool[] weghtedPools = new WeightedPool[validCount];
+
+        for (int i = 0; i < weghtedPools.length; /* incremented in the loop */) {
+            var costInfo = costInfos.get(i);
+
+            long gap = costInfo.getCostInfo().getSpaceInfo().getGap();
+
             long spaceToUse = costInfo.getCostInfo().getSpaceInfo().getFreeSpace()
                     + costInfo.getCostInfo().getSpaceInfo().getRemovableSpace();
 
             weghtedPools[i] = new WeightedPool(costInfo, (double) spaceToUse / totalFree);
+            if (fileSize > spaceToUse - gap) {
+                continue; // skip pools that do not have enough space
+            }
+
+            weghtedPools[i] = new WeightedPool(costInfo, (double) spaceToUse / totalFree);
+
             i++;
         }
 

--- a/modules/dcache/src/test/java/org/dcache/poolmanager/WRandomPartitionTest.java
+++ b/modules/dcache/src/test/java/org/dcache/poolmanager/WRandomPartitionTest.java
@@ -1,0 +1,58 @@
+package org.dcache.poolmanager;
+
+import com.google.common.collect.ImmutableMap;
+import diskCacheV111.pools.PoolCostInfo;
+import diskCacheV111.util.CacheException;
+import dmg.cells.nucleus.CellAddressCore;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.AdditionalMatchers;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+public class WRandomPartitionTest {
+
+
+    @Test(expected = CostException.class)
+    public void shouldFailIfAllocatesIntoGap() throws CacheException {
+
+        var wrandom = new WRandomPartition(Map.of());
+        var pools = IntStream.range(0, 10).mapToObj(i -> {
+                    var cost = new PoolCostInfo("pool" + i, "default-queue");
+                    cost.setSpaceUsage(10_000L, 3000L, 0L, 0L);
+                    cost.getSpaceInfo().setParameter(0.0d, 2500L);
+
+                    return new PoolInfo(new CellAddressCore("pool" + i), cost, ImmutableMap.of());
+                }
+        ).collect(Collectors.toList());
+
+        long fileSize = 1000L;
+        var selectedPool = wrandom.selectWritePool(null, pools, null, fileSize);
+    }
+
+    @Test
+    public void shouldSelectValidPool() throws CacheException {
+
+        var wrandom = new WRandomPartition(Map.of());
+        var pools = IntStream.range(0, 10).mapToObj(i -> {
+                    var cost = new PoolCostInfo("pool" + i, "default-queue");
+                    cost.setSpaceUsage(10_000L, 5000L, 0L, 0L);
+                    cost.getSpaceInfo().setParameter(0.0d, 2500L);
+
+                    return new PoolInfo(new CellAddressCore("pool" + i), cost, ImmutableMap.of());
+                }
+        ).collect(Collectors.toList());
+
+        long fileSize = 1000L;
+        var selectedPool = wrandom.selectWritePool(null, pools, null, fileSize);
+
+        var spaceInfo = selectedPool.info().getCostInfo().getSpaceInfo();
+        assertTrue("selected pool has no sufficient space", spaceInfo.getFreeSpace() + spaceInfo.getRemovableSpace() - fileSize > spaceInfo.getGap());
+    }
+
+}


### PR DESCRIPTION
Motivation:
The wrandom partition ignores pool gap, thus can select a full pull. Issue: #7863

Modification:
Update WRandomPartition to skip pools that will run into gap if accept the file. Added unit test to ensure the behavior.

Result:
full pulls are skipped by wrandom partition.

Acked-by: Dmitry Litvintsev
Target: master, 11.0, 10.2, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit a778f9763cbce8ba3876d4eaf3a440e02c4c4040)