### PR TITLE
bulk: remove residual code having to do with delay_clear

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/BulkServiceCommands.java
@@ -444,10 +444,6 @@ public final class BulkServiceCommands implements CellCommandListener {
               usage = "Whether the request has this set to true or false.")
         Boolean clearOnFailure;
 
-        @Option(name = "delayClear",
-              usage = "True means the request has a non-zero value of this.")
-        Boolean delayClear;
-
         @Option(name = "expandDirectories",
               valueSpec = "NONE|TARGETS|ALL",
               usage = "The recursion depth of the request.")
@@ -489,8 +485,8 @@ public final class BulkServiceCommands implements CellCommandListener {
             }
 
             rFilter = new BulkRequestFilter(beforeStart, afterStart, owners, urlPrefixes, ids,
-                  activities, statuses, cancelOnFailure, clearOnSuccess, clearOnFailure, delayClear,
-                  depth);
+                                            activities, statuses, cancelOnFailure, clearOnSuccess, clearOnFailure,
+                                            depth);
             rFilter.setId(id);
         }
 
@@ -524,7 +520,6 @@ public final class BulkServiceCommands implements CellCommandListener {
                   && activity == null
                   && clearOnFailure == null
                   && clearOnSuccess == null
-                  && delayClear == null
                   && expandDirectories == null
                   && status == null;
         }

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestCriterion.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestCriterion.java
@@ -200,13 +200,6 @@ public final class JdbcBulkRequestCriterion extends JdbcCriterion {
         return this;
     }
 
-    public JdbcBulkRequestCriterion delayClear(Boolean delayClear) {
-        if (delayClear != null) {
-            addClause("delay_clear = ?", delayClear);
-        }
-        return this;
-    }
-
     public JdbcBulkRequestCriterion expandDirectories(Depth depth) {
         if (depth != null) {
             addClause("expand_directories = ?", depth.name());
@@ -249,7 +242,6 @@ public final class JdbcBulkRequestCriterion extends JdbcCriterion {
             cancelOnFailure(filter.getCancelOnFailure());
             clearOnFailure(filter.getClearOnFailure());
             clearOnSuccess(filter.getClearOnSuccess());
-            delayClear(filter.getDelayClear());
             expandDirectories(filter.getExpandDirectories());
             activity(filter.getActivity());
             status(filter.getStatuses());

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestStore.java
@@ -269,7 +269,7 @@ public final class JdbcBulkRequestStore implements BulkRequestStore {
         String key = checkRequestPermissions(subject, uid);
         LOGGER.trace("clearWhenTerminated {}, {}.", key, uid);
         requestDao.update(requestDao.where().uids(uid),
-              requestDao.set().clearOnFailure(true).clearOnSuccess(true).delayClear(0));
+                          requestDao.set().clearOnFailure(true).clearOnSuccess(true));
         requestCache.invalidate(uid);
     }
 

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestUpdate.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/store/jdbc/request/JdbcBulkRequestUpdate.java
@@ -172,11 +172,6 @@ public final class JdbcBulkRequestUpdate extends JdbcUpdate {
         return this;
     }
 
-    public JdbcBulkRequestUpdate delayClear(int delayClear) {
-        set("delay_clear", delayClear);
-        return this;
-    }
-
     public JdbcBulkRequestUpdate depth(Depth depth) {
         if (depth != null) {
             set("expand_directories", depth.name());

--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestFilter.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/util/BulkRequestFilter.java
@@ -78,7 +78,6 @@ public final class BulkRequestFilter {
     private final Boolean cancelOnFailure;
     private final Boolean clearOnSuccess;
     private final Boolean clearOnFailure;
-    private final Boolean delayClear;
     private final Depth expandDirectories;
 
     private Long id;
@@ -86,13 +85,13 @@ public final class BulkRequestFilter {
     public BulkRequestFilter(Set<BulkRequestStatus> statuses) {
         this(null, null, null, null, null, null,
               statuses, null, null,
-              null, null, null);
+              null, null);
     }
 
     public BulkRequestFilter(Long before, Long after, Set<String> owner, Set<String> urlPrefix,
           Set<String> uuid, Set<String> activity, Set<BulkRequestStatus> statuses,
           Boolean cancelOnFailure, Boolean clearOnSuccess, Boolean clearOnFailure,
-          Boolean delayClear, Depth expandDirectories) {
+          Depth expandDirectories) {
         this.before = before;
         this.after = after;
         this.activity = activity;
@@ -100,7 +99,6 @@ public final class BulkRequestFilter {
         this.cancelOnFailure = cancelOnFailure;
         this.clearOnSuccess = clearOnSuccess;
         this.clearOnFailure = clearOnFailure;
-        this.delayClear = delayClear;
         this.expandDirectories = expandDirectories;
         this.owner = owner;
         this.urlPrefix = urlPrefix;
@@ -129,10 +127,6 @@ public final class BulkRequestFilter {
 
     public Boolean getClearOnFailure() {
         return clearOnFailure;
-    }
-
-    public Boolean getDelayClear() {
-        return delayClear;
     }
 
     public Depth getExpandDirectories() {


### PR DESCRIPTION
Motivation:
----------

The delay option has been deprecated
(e83f39ab5d974454fbaaaf6a454e3e8c01fa0776,
https://rb.dcache.org/r/13767/)
But apparently some code using this option has not been completely excised. There is issue #7858 opened

Modification:
------------

Remove all code related to this feature

Results:
-------

No stack trace

Ticket: https://github.com/dCache/dcache/issues/7858A
Patch: https://rb.dcache.org/r/14509/
Acked-by: Tigran
Target: trunk
Request: 11.x
Request: 10.x
Request: 9.2

Require-book: no
Require-notes: yes