### PR TITLE
WLCG tape API: do not report empty fields in json responses

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/tape/ArchiveInfo.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/tape/ArchiveInfo.java
@@ -59,12 +59,16 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.providers.tape;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import diskCacheV111.util.FileLocality;
 import java.io.Serializable;
 
 /**
  *  Specialized for WLCG archiveinfo, encapsulates path, file locality and error message.
+ *  The JsonInclude(JsonInclude.Include.NON_NULL) is added to skip null fields that WLCG
+ *  REST API expects
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ArchiveInfo implements Serializable {
 
     private static final long serialVersionUID = 3273661715952056706L;

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/tape/StageRequestInfo.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/tape/StageRequestInfo.java
@@ -59,6 +59,7 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.providers.tape;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -90,7 +91,12 @@ import org.dcache.services.bulk.BulkRequestInfo;
  *         <td>The files that got submitted and their state/disk residency.</td>
  *     </tr>
  * </table>
+ *
+ *  The JsonInclude(JsonInclude.Include.NON_NULL) is added to skip null fields that WLCG
+ *  REST API expects
  */
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StageRequestInfo implements Serializable {
 
     private static final long serialVersionUID = 1269517713600606880L;

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/tape/StagedFileInfo.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/tape/StagedFileInfo.java
@@ -59,6 +59,7 @@ documents or software obtained from this server.
  */
 package org.dcache.restful.providers.tape;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.io.Serializable;
 import org.dcache.services.bulk.BulkRequestTargetInfo;
 
@@ -96,7 +97,12 @@ import org.dcache.services.bulk.BulkRequestTargetInfo;
  *
  * <p> From the above, it will be dCache policy always to return state and not onDisk unless
  *     the former is not set.
+ *
+ *  The JsonInclude(JsonInclude.Include.NON_NULL) is added to skip null fields that WLCG
+ *  REST API expects
  */
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StagedFileInfo implements Serializable {
 
     private static final long serialVersionUID = 7530936044659226339L;


### PR DESCRIPTION
Motivation
----------

Commit 36d6a5ef8a1a886eb06118386d9e8963253e77c1 added reporting null and default value fields. Turns out FTS (CERN File Transfer Service), when it processes REST API Reponse checks the "error" field
and considers request failed if the field is present (ignoring that it has null value)

Modification
------------

Annotate classes used by WCLG tape API w/
@JsonInclude(JsonInclude.Include.NON_NULL)
to skip null fields only for WCLC tape rest api

Result
------

No null error is reported

Acked-by: Chris Green
Patch: https://rb.dcache.org/r/14512/
Target: trunk
Request: 11.x, 10.x, 9.x
Require-book: no
Require-notes: yes