### PR TITLE
poolmanager: fix wrandom partition

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/WRandomPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/WRandomPartition.java
@@ -91,8 +91,7 @@ public class WRandomPartition extends Partition
         return new SelectedPool(weightedPools[index].getCostInfo());
     }
 
-    private WeightedPool[] toWeightedWritePoolsArray(List<PoolInfo> costInfos, long fileSize)
-            throws CacheException {
+    private WeightedPool[] toWeightedWritePoolsArray(List<PoolInfo> costInfos, long fileSize) {
 
         long totalFree = 0;
         int validCount = 0;
@@ -108,11 +107,10 @@ public class WRandomPartition extends Partition
             validCount++;
         }
 
-        // the validCount should macht the number of pools that have enough space, thus elegible for selection
+        // the validCount should mach the number of pools that have enough space, thus eligible for selection
         WeightedPool[] weightedPools = new WeightedPool[validCount];
-        for (int i = 0; i < weightedPools.length; /* incremented in the loop */) {
-
-            var costInfo = costInfos.get(i);
+        int i = 0;
+        for (PoolInfo costInfo : costInfos) {
 
             long gap = costInfo.getCostInfo().getSpaceInfo().getGap();
 


### PR DESCRIPTION
Motivation:
the merge of commit a778f9763cbce8ba3876d4eaf3a440e02c4c4040 added silent conflict which introduced infinite loop due to loop index freez, that ended in infinite loop.

Modification:
fix the loop using iterator and index (as original code aimed to to). Added extra unit test that check loop in action.

Result:
fixed infinite loop in wrandom partition

Acked-by: Dmitry Litvintsev
Target: master, 11.1, 11.0, 10.2, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit cd23f595bdb4d5d5d6c88ca179cac392ed9ab7fc)