### PR TITLE
poolmanager: fix wrandom partition

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/poolmanager/WRandomPartition.java
+++ b/modules/dcache/src/main/java/org/dcache/poolmanager/WRandomPartition.java
@@ -91,8 +91,7 @@ public class WRandomPartition extends Partition
         return new SelectedPool(weightedPools[index].getCostInfo());
     }
 
-    private WeightedPool[] toWeightedWritePoolsArray(List<PoolInfo> costInfos, long fileSize)
-            throws CacheException {
+    private WeightedPool[] toWeightedWritePoolsArray(List<PoolInfo> costInfos, long fileSize) {
 
         long totalFree = 0;
         int validCount = 0;
@@ -108,24 +107,21 @@ public class WRandomPartition extends Partition
             validCount++;
         }
 
-        // the validCount should macht the number of pools that have enough space, thus elegible for selection
+        // the validCount should mach the number of pools that have enough space, thus eligible for selection
         WeightedPool[] weghtedPools = new WeightedPool[validCount];
-
-        for (int i = 0; i < weghtedPools.length; /* incremented in the loop */) {
-            var costInfo = costInfos.get(i);
+        int i = 0;
+        for (PoolInfo costInfo : costInfos) {
 
             long gap = costInfo.getCostInfo().getSpaceInfo().getGap();
 
             long spaceToUse = costInfo.getCostInfo().getSpaceInfo().getFreeSpace()
                     + costInfo.getCostInfo().getSpaceInfo().getRemovableSpace();
 
-            weghtedPools[i] = new WeightedPool(costInfo, (double) spaceToUse / totalFree);
             if (fileSize > spaceToUse - gap) {
                 continue; // skip pools that do not have enough space
             }
 
             weghtedPools[i] = new WeightedPool(costInfo, (double) spaceToUse / totalFree);
-
             i++;
         }
 

--- a/modules/dcache/src/test/java/org/dcache/poolmanager/WRandomPartitionTest.java
+++ b/modules/dcache/src/test/java/org/dcache/poolmanager/WRandomPartitionTest.java
@@ -32,7 +32,7 @@ public class WRandomPartitionTest {
         ).collect(Collectors.toList());
 
         long fileSize = 1000L;
-        var selectedPool = wrandom.selectWritePool(null, pools, null, fileSize);
+        wrandom.selectWritePool(null, pools, null, fileSize);
     }
 
     @Test
@@ -52,7 +52,29 @@ public class WRandomPartitionTest {
         var selectedPool = wrandom.selectWritePool(null, pools, null, fileSize);
 
         var spaceInfo = selectedPool.info().getCostInfo().getSpaceInfo();
-        assertTrue("selected pool has no sufficient space", spaceInfo.getFreeSpace() + spaceInfo.getRemovableSpace() - fileSize > spaceInfo.getGap());
+        assertTrue("selected pool has no sufficient space", spaceInfo.getFreeSpace() + spaceInfo.getRemovableSpace() - fileSize >= spaceInfo.getGap());
     }
 
+
+    @Test
+    public void shouldSkipFullPool() throws CacheException {
+
+        var wrandom = new WRandomPartition(Map.of());
+
+        // starting the 5th pools have enough space
+        var pools = IntStream.range(0, 10).mapToObj(i -> {
+                    var cost = new PoolCostInfo("pool" + i, "default-queue");
+                    cost.setSpaceUsage(10_000L, 3_000L + 100L*i, 0L, 0L);
+                    cost.getSpaceInfo().setParameter(0.0d, 2500L);
+
+                    return new PoolInfo(new CellAddressCore("pool" + i), cost, ImmutableMap.of());
+                }
+        ).collect(Collectors.toList());
+
+        long fileSize = 1000L;
+        var selectedPool = wrandom.selectWritePool(null, pools, null, fileSize);
+
+        var spaceInfo = selectedPool.info().getCostInfo().getSpaceInfo();
+        assertTrue("selected pool has no sufficient space", spaceInfo.getFreeSpace() + spaceInfo.getRemovableSpace() - fileSize >= spaceInfo.getGap());
+    }
 }


### PR DESCRIPTION
Motivation:
the merge of commit a778f9763cbce8ba3876d4eaf3a440e02c4c4040 added silent conflict which introduced infinite loop due to loop index freez, that ended in infinite loop.

Modification:
fix the loop using iterator and index (as original code aimed to to). Added extra unit test that check loop in action.

Result:
fixed infinite loop in wrandom partition

Acked-by: Dmitry Litvintsev
Target: master, 11.1, 11.0, 10.2, 10.1, 10.0, 9.2
Require-book: no
Require-notes: yes
(cherry picked from commit cd23f595bdb4d5d5d6c88ca179cac392ed9ab7fc)