### PR TITLE
nfs: lower nfs-client workaround message

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/door/NFSv41Door.java
@@ -1524,7 +1524,7 @@ public class NFSv41Door extends AbstractCellComponent implements
                          *
                          * see: https://bugzilla.redhat.com/show_bug.cgi?id=1901524
                          */
-                        _log.warn(
+                        _log.info(
                               "Deploying work-around for buggy client {} issuing CLOSE before LAYOUT_RETURN for transfer {}@{} of {}",
                               t.getMoverId(), t.getPool(), t.getPnfsId(),
                               t.getClient().getRemoteAddress());


### PR DESCRIPTION
Motivation:
NFS door logs a message when a client-side bug workaround is applied. This was useful during debugging, but in production generates far too many log entries. Moreover, admins can 't do noting about it.

Modification:A
lower nfs-client workaround message

Result:
Less useless messages in logs under normal operation.

Acked-by: Karen Hoyos
Target: master, 11.1, 11.0, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit fe4d1896ed0428db0abee69ace3bd42545a9aac1)