### PR TITLE
pool: log at warn when files state in pool change

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReplicaRepository.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/repository/v5/ReplicaRepository.java
@@ -891,6 +891,7 @@ public class ReplicaRepository
                                 case CACHED:
                                 case PRECIOUS:
                                 case BROKEN:
+                                    LOGGER.warn("Changing state of {} from {} to {}: {}", id, source, state, why);
                                     return r.setState(state);
                                 default:
                                     break;


### PR DESCRIPTION
Motivation:
to trace why files change tier states from PRECIOUS to CACHED all log entry.

Modification:
Log and warn when file changes it state in a pool

Result:
better observability

Acked-by: Karen Hoyos
Target: master, 11.1, 11.0, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit f3aab0de2b2aa37a6ad43c626a565a0e8717ef77)