### PR TITLE
docs: fix references to old 'cleaner' service

### DIFF
--- a/docs/TheBook/src/main/markdown/config-admin.md
+++ b/docs/TheBook/src/main/markdown/config-admin.md
@@ -295,7 +295,7 @@ each domain:
       srmDomain : [RemoteTransferManager, CopyManager, SrmSpaceManager, SRM-example.dcache.org]
        httpdDomain : [billing, srm-LoginBroker, TransferObserver]
       poolDomain : [pool_2, pool_1]
-       namespaceDomain : [PnfsManager, dirLookupPool, cleaner]
+       namespaceDomain : [PnfsManager, dirLookupPool, cleaner-disk]
 
 All cells implement the `info` command to display  general information about the cell and `show pinboard` command
 for listing the last lines of the [pinboard](rf-glossary.md#pinboard) of the cell. The output of these commands contains useful information

--- a/docs/TheBook/src/main/markdown/config-billing.md
+++ b/docs/TheBook/src/main/markdown/config-billing.md
@@ -126,10 +126,10 @@ over the database configuration.
 
     ```console-root
     dcache database ls
-    |DOMAIN          CELL        DATABASE HOST      USER    MANAGEABLE AUTO
-    |namespaceDomain PnfsManager chimera  localhost dcache  Yes        Yes
-    |namespaceDomain cleaner     chimera  localhost dcache  No         No
-    |billingDomain   billing     billing  localhost dcache  Yes        Yes
+    |DOMAIN          CELL         DATABASE HOST      USER    MANAGEABLE AUTO
+    |namespaceDomain PnfsManager  chimera  localhost dcache  Yes        Yes
+    |namespaceDomain cleaner-disk chimera  localhost dcache  No         No
+    |billingDomain   billing      billing  localhost dcache  Yes        Yes
     ```
 
 -   Database inserts are batched for performance. Since 2.8, improvements

--- a/docs/TheBook/src/main/markdown/intouch.md
+++ b/docs/TheBook/src/main/markdown/intouch.md
@@ -429,7 +429,7 @@ each domain:
       srmDomain : [RemoteTransferManager, CopyManager, SrmSpaceManager, SRM-example.dcache.org]
        httpdDomain : [billing, srm-LoginBroker, TransferObserver]
       poolDomain : [pool_2, pool_1]
-       namespaceDomain : [PnfsManager, dirLookupPool, cleaner]
+       namespaceDomain : [PnfsManager, dirLookupPool, cleaner-disk]
 
 All cells implement the `info` command to display  general information about the cell and `show pinboard` command
 for listing the last lines of the [pinboard](rf-glossary.md#pinboard) of the cell. The output of these commands contains useful information

--- a/docs/TheBook/src/main/markdown/intro.md
+++ b/docs/TheBook/src/main/markdown/intro.md
@@ -74,7 +74,7 @@ support.
 | [poolmanager](config-PoolManager.md)            | When   a file  reading or writing a transfer request is sent to the dCache system, the poolmanager then decides how to handle this request.     |
 | [resilience](config-resilience.md)                      |Controls the number of replicas of a file on the pools. |
 | [hoppingmanager](config-hopping.md)               | Service that orchestrates file replica distribution across the pools triggered by a variety of conditions.     |
-| [cleaner](config-cleaner.md)                     | Service that periodically cleans (removes) deleted files' replicas from the pools. |
+| [cleaner-disk](config-cleaner.md)                | Service that periodically cleans (removes) deleted files' replicas from the pools. |
 | [info](config-info-provider.md)         | Provides information about the dCache instance in a standard format called GLUE. |
 | [missing-files](config-missing-files.md)                | A component designed to react to requests to retrieve missing files.      |
  |[pool](cookbook-pool.md)                      | Data storage (cookbook)    |


### PR DESCRIPTION
Motivation:

The docs contains some obsolete references to the `cleaner` cell.

Motification:

Update these to `cleaner-disk`, the new name for this cell.

Result:

Document updated to reflect rename of 'cleaner' to 'cleaner-disk'.

Target: master
Request: 10.2
Request: 10.1
Request: 10.0
Request: 9.2
Patch: https://rb.dcache.org/r/14397/
Acked-by: Tigran Mkrtchyan