### PR TITLE
pool: fix mover's local endpoint reported by a mover

### DIFF
--- a/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
+++ b/modules/dcache-nfs/src/main/java/org/dcache/chimera/nfsv41/mover/NfsTransferService.java
@@ -509,7 +509,7 @@ public class NfsTransferService
         NfsMover mover = _activeIO.get(stateid);
         if (mover != null) {
             if (mover.attachSession(context.getSession())) {
-                mover.setLocalEndpoint(context.getRemoteSocketAddress());
+                mover.setLocalEndpoint(context.getLocalSocketAddress());
             }
             mover.attachSession(context.getSession());
         }


### PR DESCRIPTION
fix typo local vs. remote

Result:
correct endpoint reported in the billing.

Acked-by: Karen Hoyos
Target: master, 11.1, 11.0, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit 831145ae2c0a9c23dfe936ecd933de8c1ba54429)