### PR TITLE
transfermanagers: complete removal of DB support

### DIFF
--- a/packages/system-test/src/main/skel/etc/layouts/system-test.conf
+++ b/packages/system-test/src/main/skel/etc/layouts/system-test.conf
@@ -139,7 +139,6 @@ ftp.authn.protocol=gsi
 ftp.net.internal=127.0.0.1
 
 [dCacheDomain/transfermanagers]
-transfermanagers.enable.db=true
 
 [dCacheDomain/xrootd]
 xrootd.cell.name=Xrootd-${host.name}

--- a/plugins/hsqldb/src/main/skel/hsqldb.properties
+++ b/plugins/hsqldb/src/main/skel/hsqldb.properties
@@ -25,8 +25,6 @@ spacemanager.db.hikari-properties!maxLifetime = 0
 srmmanager.db.url = jdbc:hsqldb:file:${hsqldb.path}/${srmmanager.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
 srmmanager.db.hikari-properties!maxLifetime = 0
 
-transfermanagers.db.url = jdbc:hsqldb:file:${hsqldb.path}/${transfermanagers.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3
-
 alarms.url-when-type-is-off =
 alarms.url-when-type-is-xml = xml:file:${alarms.db.xml.path}
 alarms.url-when-type-is-rdbms = jdbc:hsqldb:file:${hsqldb.path}/${alarms.db.name};shutdown=true;hsqldb.tx=mvcc;hsqldb.sqllog=3

--- a/skel/share/defaults/transfermanagers.properties
+++ b/skel/share/defaults/transfermanagers.properties
@@ -84,21 +84,6 @@ transfermanagers.limits.transfer-time = 7200
 # Whether space reservations should be supported for third party SRM copy transfers.
 (one-of?true|false|${dcache.enable.space-reservation})transfermanagers.enable.space-reservation=${dcache.enable.space-reservation}
 
-# Database settings
-# Obsolete
-(one-of?true|false)transfermanagers.enable.db=false
-(obsolete)transfermanagers.db.host = DB functionality is removed
-(obsolete)transfermanagers.db.name = DB functionality is removed
-(obsolete)transfermanagers.db.user = DB functionality is removed
-(obsolete)transfermanagers.db.password = DB functionality is removed
-(obsolete)transfermanagers.db.password.file = DB functionality is removed
-(obsolete)transfermanagers.db.url= DB functionality is removed
-(obsolete)(prefix)transfer-manager.db.hikari-properties = DB functionality is removed
-
-
-# The transfermanagers service automatically manages its database schema
-(obsolete)(immutable)transfermanagers.db.schema.auto=DB functionality is removed
-
 # Kafka
 (one-of?true|false|${dcache.enable.kafka})transfermanagers.enable.kafka = ${dcache.enable.kafka}
 transfermanagers.kafka.topic = ${dcache.kafka.topic}
@@ -107,3 +92,12 @@ transfermanagers.kafka.producer.bootstrap.servers = ${dcache.kafka.bootstrap-ser
 
 # Obsolete
 (obsolete)transfermanagers.cell.export = See transfermanagers.cell.consume
+(obsolete)transfermanagers.enable.db=DB functionality is removed
+(obsolete)transfermanagers.db.host = DB functionality is removed
+(obsolete)transfermanagers.db.name = DB functionality is removed
+(obsolete)transfermanagers.db.user = DB functionality is removed
+(obsolete)transfermanagers.db.password = DB functionality is removed
+(obsolete)transfermanagers.db.password.file = DB functionality is removed
+(obsolete)transfermanagers.db.url= DB functionality is removed
+(obsolete,prefix)transfer-manager.db.hikari-properties = DB functionality is removed
+(obsolete)transfermanagers.db.schema.auto=DB functionality is removed


### PR DESCRIPTION
Motivation:

Commit 5a0a09e152b removed support for serialising the transfermanager state in a database.  Unfortunately, the commit failed to update system-test (which configures transfermanagers to use a database) and the hsqldb configuration. The commit also had a few (minor) stylistic and syntactic issues.

Modification:

Disable the use of a database in system-test for the transfermanagers service.

Remove hsqldb-specific configuration for transfermanagers db.

Mark the `transfermanagers.enable.db` property obsolete.

Fix the multi-annotated property to use the correct syntax: `(obsolete)(prefix)` to `(obsolete,prefix)`.

Move obsolete properties to the end of the defaults file.

Result:

System-test now builds.

Target: master
Requires-notes: yes
Requires-book: no
Request: 11.1
Request: 11.0
Request: 10.2
Request: 10.1
Patch: https://rb.dcache.org/r/14565/
Acked-by: Tigran Mkrtchyan