### PR TITLE
pool: use SSLTrustManagerWithHostnameChecking to initialize CAnL

### DIFF
--- a/modules/common-security/src/test/java/org/dcache/security/trust/AggregateX509TrustManagerTest.java
+++ b/modules/common-security/src/test/java/org/dcache/security/trust/AggregateX509TrustManagerTest.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2021 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2021 - 2025 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -31,6 +31,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +40,7 @@ import org.mockito.BDDMockito;
 public class AggregateX509TrustManagerTest {
 
     private X509TrustManager manager;
-    private List<X509TrustManager> inner;
+    private List<X509ExtendedTrustManager> inner;
 
     @Before
     public void setup() {
@@ -251,7 +252,7 @@ public class AggregateX509TrustManagerTest {
      */
     private static class MockX509TrustManagerBuilder {
 
-        private final X509TrustManager manager = mock(X509TrustManager.class);
+        private final X509ExtendedTrustManager manager = mock(X509ExtendedTrustManager.class);
 
         public MockX509TrustManagerBuilder thatFailsClientsWith(CertificateException e) {
             try {
@@ -276,7 +277,7 @@ public class AggregateX509TrustManagerTest {
             return this;
         }
 
-        public X509TrustManager build() {
+        public X509ExtendedTrustManager build() {
             return manager;
         }
     }


### PR DESCRIPTION
Motivation:
JVM uses X509ExtendedTrustManager class to validate the host certificate. The CANL provides two implementations of TrustManagers: SSLTrustManagerWithHostnameChecking, which extends X509ExtendedTrustManager, and SSLTrustManager, which extends X509TrustManager. In case of the latter one, JDK will wrap with a AbstractTrustManagerWrapper implementation, which enforces additional checks, which are not desired.

Modification:
Update RemoteHttpTransferService to use SSLTrustManagerWithHostnameChecking to initialize CAnL for remote endpoint certificate validation.

Result:
TPC-HTTP remote endpoint validation performed based on local trusted store and host name.

Fixes: #7927
Acked-by: Karen Hoyos
Target: master, 11.1, 11.0, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit c483a3ce65bddb5d48eeb3376467ef16e0a3f297)