### PR TITLE
webdav: return 403 on unauthorized attempt to rename resource

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResource.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResource.java
@@ -12,6 +12,7 @@ import io.milton.http.LockTimeout;
 import io.milton.http.LockToken;
 import io.milton.http.Request;
 import io.milton.http.Response;
+import io.milton.http.exceptions.BadRequestException;
 import io.milton.http.exceptions.ConflictException;
 import io.milton.http.exceptions.NotAuthorizedException;
 import io.milton.property.PropertySource;
@@ -115,7 +116,7 @@ public class DcacheResource
 
     @Override
     public void moveTo(CollectionResource newParent, String name)
-          throws ConflictException {
+        throws ConflictException, NotAuthorizedException, BadRequestException {
         if (!(newParent instanceof DcacheDirectoryResource)) {
             throw new RuntimeException(
                   "Destination is an unknown type. Must be a DcacheDirectoryResource, is a: "
@@ -128,8 +129,10 @@ public class DcacheResource
             FsPath newPath = directory._path.child(name);
             _factory.move(_path, _attributes.getPnfsId(), newPath);
             _path = newPath;
+        } catch (PermissionDeniedCacheException e) {
+            throw WebDavExceptions.permissionDenied(this);
         } catch (CacheException e) {
-            throw new RuntimeException(e);
+             throw new WebDavException(e.getMessage(), e, this);
         }
     }
 


### PR DESCRIPTION
Motivation:
-----------

WebDAV returns 500 on unauthorized attempt to rename resource, like so:

Internal problem: CacheException(rc=10018;msg=Restriction Restrict[MANAGE,UPLOAD,DELETE,UPDATE_METADATA,STAGE] denied activity MANAGE on ...)

Modification:
------------

Handle CacheException in dCacheResource.moveTo method

Result:
-------

Return 403 on unauthorized attempt to rename resource, like so:

Ticket: https://github.com/dCache/dcache/issues/7879
Target: trunk
Request: 11.1, 11.0, 10.2

Acked-by: Tigran
Require-book: no
Require-notes: yes