### PR TITLE
gplazma: fix banfile plugin

### DIFF
--- a/modules/gplazma2-banfile/src/test/java/org/dcache/gplazma/plugins/BanFilePluginTest.java
+++ b/modules/gplazma2-banfile/src/test/java/org/dcache/gplazma/plugins/BanFilePluginTest.java
@@ -98,8 +98,20 @@ public class BanFilePluginTest {
 
     @Test(expected = AuthenticationException.class)
     public void shouldFailForBannedUserByAlias() throws IOException, AuthenticationException {
-        givenConfig("alias foo=org.dcache.auth.UserNamePrincipal\nban foo:bert");
+        givenConfig("alias foo=org.dcache.auth.UserNamePrincipal\nban foo:bert\n");
         plugin.account(Set.of(new UserNamePrincipal("bert")));
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void shouldFailForBannedUserByAliasFirstInList() throws IOException, AuthenticationException {
+        givenConfig("alias foo=org.dcache.auth.UserNamePrincipal\nban foo:bert\nban foo:bart\n");
+        plugin.account(Set.of(new UserNamePrincipal("bert")));
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void shouldFailForBannedUserByAliasLastInList() throws IOException, AuthenticationException {
+        givenConfig("alias foo=org.dcache.auth.UserNamePrincipal\nban foo:bert\nban foo:bart\n");
+        plugin.account(Set.of(new UserNamePrincipal("bart")));
     }
 
     @Test(expected = AuthenticationException.class)


### PR DESCRIPTION
Motivation:
-----------

Issue https://github.com/dCache/dcache/issues/7947 reports that banfile only bans user if there is only one 'ban foo:bar' line is present (one line per alias). Further investigation showed that actually only last line is taken.

Modification:
-------------

Modified BanFilePlugin to use List<String> containing elements already suitable for Pincipal coversion instead of Map<String, String> that naturally only kept the last instance of ban statement.

Result:
-------

Banfile plugin works as expected.

Ticket:  https://github.com/dCache/dcache/issues/7947
Acked-by: Paul Millar

Target: trunk
Request: 11.1, 11.0, 10.2
Require-book: no
Require-notes: yes