### PR TITLE
srm,spacemanager: fix liquibase migration checksum mismatch

### DIFF
--- a/modules/dcache-spacemanager/src/main/resources/diskCacheV111/services/space/db/00-liquibase-fixes.xml
+++ b/modules/dcache-spacemanager/src/main/resources/diskCacheV111/services/space/db/00-liquibase-fixes.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd">
+
+    <!--
+    IMPORTANT:
+        This file contains changes that should be applied prior any other schema changes,
+        typically to fix liquibase or schema issues that prevent other changes from being applied.
+    -->
+
+    <changeSet id="0.2" author="tigran" runOrder="first">
+
+        <comment>
+            Fix liquibase issue with duplicate id and mismatching md5sums in databasechangelog table.
+            This change set should be applied before any other changes.
+        </comment>
+
+        <sql>
+            UPDATE databasechangelog SET id='1.1' WHERE md5sum = '7:06282b8a1dd8aaf973cffe417726e36e';
+            UPDATE databasechangelog SET id='2.1' WHERE md5sum = '7:cacb95e06876aa5ac4bba2288a0ff4a2';
+
+            UPDATE databasechangelog SET md5sum = '7:001b41c08a1151cb6c80f613eca8404d' WHERE md5sum = '7:2680461d52281f893a9d9a0fb09e0c3a';
+            UPDATE databasechangelog SET md5sum = '7:5e691a2d81bcea624c3cee36c8a713a1' WHERE md5sum = '7:74c38b7901e8f9c20ab109c2dce6e1a8';
+            UPDATE databasechangelog SET md5sum = '7:b39033e0e9d9a9cba9463b3ff51ea506' WHERE md5sum = '7:77c33a2aaa9cf04663eed16b67bec984';
+            UPDATE databasechangelog SET md5sum = '7:fbe6e97e29f3001817daf4be5daa1079' WHERE md5sum = '7:b93ee356b569a0a28796b3f85dae4f1c';
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/modules/dcache-spacemanager/src/main/resources/diskCacheV111/services/space/db/spacemanager.changelog-2.9.xml
+++ b/modules/dcache-spacemanager/src/main/resources/diskCacheV111/services/space/db/spacemanager.changelog-2.9.xml
@@ -105,7 +105,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="1" author="behrmann">
+    <changeSet id="1.1" author="behrmann">
         <comment>Replace free space column with available space column</comment>
         <renameColumn tableName="srmlinkgroup" oldColumnName="freespaceinbytes" newColumnName="availablespaceinbytes" columnDataType="bigint"/>
         <sql>UPDATE srmlinkgroup SET availablespaceinbytes = availablespaceinbytes - reservedspaceinbytes</sql>
@@ -387,7 +387,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="2" author="behrmann">
+    <changeSet id="2.1" author="behrmann">
         <comment>Drop pnfspath column</comment>
         <dropUniqueConstraint tableName="srmspacefile" constraintName="srmspacefile_pnfspath_unique"/>
         <dropColumn tableName="srmspacefile" columnName="pnfspath"/>
@@ -400,6 +400,9 @@
     </changeSet>
 
     <changeSet id="4.1" author="behrmann">
+        <preConditions onFail="MARK_RAN" onFailMessage="Site local srmspacefile_expirationtime_idx index not found (this is not an error)">
+            <indexExists tableName="srmspacefile" indexName="srmspacefile_expirationtime_idx"/>
+        </preConditions>
         <comment>Drop expirtationtime column</comment>
         <dropIndex tableName="srmspacefile" indexName="srmspacefile_expirationtime_idx"/>
         <dropColumn tableName="srmspacefile" columnName="expirationtime"/>

--- a/modules/dcache-spacemanager/src/main/resources/diskCacheV111/services/space/spacemanager.xml
+++ b/modules/dcache-spacemanager/src/main/resources/diskCacheV111/services/space/spacemanager.xml
@@ -83,14 +83,21 @@
         </constructor-arg>
     </bean>
 
-    <bean id="liquibase" class="org.dcache.util.SpringLiquibase">
+    <bean id="liquibase-pre" class="org.dcache.util.SpringLiquibase">
+        <description>Database schema manager</description>
+        <property name="dataSource" ref="data-source"/>
+        <property name="changeLog" value="classpath:${spacemanager.db.schema.changelog-pre}"/>
+        <property name="shouldUpdate" value="${spacemanager.db.schema.auto}"/>
+    </bean>
+
+    <bean id="liquibase" class="org.dcache.util.SpringLiquibase" depends-on="liquibase-pre">
         <description>Database schema manager</description>
         <property name="dataSource" ref="data-source"/>
         <property name="changeLog" value="classpath:${spacemanager.db.schema.changelog}"/>
         <property name="shouldUpdate" value="${spacemanager.db.schema.auto}"/>
     </bean>
 
-  <bean id="tx-manager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <bean id="tx-manager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <description>Database transaction manager</description>
         <property name="dataSource" ref="data-source"/>
   </bean>

--- a/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srmmanager.xml
+++ b/modules/dcache-srm/src/main/resources/diskCacheV111/srm/srmmanager.xml
@@ -662,7 +662,14 @@
         </constructor-arg>
     </bean>
 
-    <bean id="liquibase" class="org.dcache.util.SpringLiquibase">
+    <bean id="liquibase-pre" class="org.dcache.util.SpringLiquibase">
+        <description>Database schema manager</description>
+        <property name="dataSource" ref="data-source"/>
+        <property name="changeLog" value="${srmmanager.db.schema.changelog-pre}"/>
+        <property name="shouldUpdate" value="${srmmanager.db.schema.auto}"/>
+    </bean>
+
+    <bean id="liquibase" class="org.dcache.util.SpringLiquibase" depends-on="liquibase-pre">
         <description>Database schema manager</description>
         <property name="dataSource" ref="data-source"/>
         <property name="changeLog" value="classpath:${srmmanager.db.schema.changelog}"/>

--- a/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-master.xml
+++ b/modules/srm-server/src/main/resources/org/dcache/srm/request/sql/srm.changelog-master.xml
@@ -7,8 +7,6 @@
     <property  name="blob.type"  value="bytea"  dbms="postgresql"/>
     <property  name="blob.type"  value="BLOB"  dbms="oracle,h2,hsqldb"/>
 
-    <include file="org/dcache/srm/request/sql/00-liquibase-fixes.xml"/>
-
     <include file="org/dcache/srm/request/sql/srm.changelog-2.14.xml"/>
     <include file="org/dcache/srm/request/sql/srm.changelog-4.0.xml"/>
 </databaseChangeLog>

--- a/skel/share/defaults/spacemanager.properties
+++ b/skel/share/defaults/spacemanager.properties
@@ -160,5 +160,6 @@ spacemanager.db.schema.auto=${dcache.db.schema.auto}
 # Liquibase schema definition
 spacemanager.db.schema.changelog=diskCacheV111/services/space/db/spacemanager.changelog-master.xml
 
+spacemanager.db.schema.changelog-pre=diskCacheV111/services/space/db/00-liquibase-fixes.xml
 
 (obsolete)spacemanager.cell.export = See spacemanager.cell.consume

--- a/skel/share/defaults/srmmanager.properties
+++ b/skel/share/defaults/srmmanager.properties
@@ -167,6 +167,7 @@ srmmanager.db.connections.idle = 1
 # Liquibase schema definition
 srmmanager.db.schema.changelog=org/dcache/srm/request/sql/srm.changelog-master.xml
 
+srmmanager.db.schema.changelog-pre=org/dcache/srm/request/sql/00-liquibase-fixes.xml
 
 # ---- TCP streams to use for GridFTP transfer
 #


### PR DESCRIPTION
Motivation:
The since dCache have migrated to liquibase4, some incomatibilies have been observed in srm and spacemanager db schema migrations.

- new way of calculating checksums (with vs without spaces)

- liqubase uses id+author to identify changesets. In case of collisions the behaviour is unpredictable, in particular, with liquibase 4.xx the wrong changeset is selected for validation.

Modification:
Add DB specific conditional statement to explicitly handle incompatibility.

To ensure unique author+id combination.  Add a concept of changeset-pre that will update checksums in databasechangelog to match new calculation rules (whitespace included vs excluded) and match checksums to new ids.

`dcache database update` command as well as auto-migrate are updates to apply `pre` changes before the main change set.

Result:
srm and space manager databases can be migrated without issues

Fixes: #7930
Acked-by: Dmitry Litvintsev
Target: master, 11.1, 11.0
Require-book: no
Require-notes: yes
(cherry picked from commit 14a743ef4f565408785675d8bd481077b9d26faf)