### PR TITLE
webdav: fix range header formatting in relay request

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -1799,8 +1799,19 @@ public class DcacheResourceFactory
                 try {
                     connection.setRequestProperty("Connection", "Close");
                     if (range != null) {
-                        connection.addRequestProperty("Range",
-                              String.format("bytes=%d-%d", range.getStart(), range.getFinish()));
+                        String rangeHeader;
+                        Long start = range.getStart();
+                        Long finish = range.getFinish();
+
+                        if (start == null && finish != null) {
+                            rangeHeader = String.format("bytes=-%d", finish);
+                        } else if (start != null && finish == null) {
+                            rangeHeader = String.format("bytes=%d-", start);
+                        } else {
+                            rangeHeader = String.format("bytes=%d-%d", start, finish);
+                        }
+
+                        connection.addRequestProperty("Range", rangeHeader);
                     }
 
                     connection.connect();


### PR DESCRIPTION
An open-ended range like `bytes=0-` produced an invalid header `bytes=0-null`, resulting in no data being transferred. This patch implements support for open-ended ranges (`bytes=0-`) and suffix ranges (`bytes=-500`).

I confirmed the fix manually using the local `system-test`. I also wanted to add a test case for this but it seemed like this requires a full integration test which could be a little over the top? Could you give me a hint how best to add a test?

While testing a suffix range like `bytes=-10` (which should return the last 10 bytes) I may have found another bug. The response returns the correct data but has the headers `Content-Range: bytes 0-10/761` and `Content-Length: 11` which seem incorrect.

References https://github.com/dCache/dcache/issues/7971