### PR TITLE
common: increase robustness of access log file

### DIFF
--- a/modules/cells/src/main/java/org/dcache/util/NetLoggerBuilder.java
+++ b/modules/cells/src/main/java/org/dcache/util/NetLoggerBuilder.java
@@ -8,6 +8,7 @@ import com.google.common.escape.Escaper;
 import com.google.common.net.InetAddresses;
 import java.net.InetSocketAddress;
 import java.security.Principal;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.function.Function;
@@ -240,6 +241,10 @@ public class NetLoggerBuilder {
 
     public NetLoggerBuilder add(String name, long value) {
         return add(name, String.valueOf(value));
+    }
+
+    public NetLoggerBuilder add(String name, Duration d) {
+        return add(name, TimeUtils.describe(d).orElse("0"));
     }
 
     public NetLoggerBuilder add(String name, Exception e) {


### PR DESCRIPTION
Motivaition:

The information about HTTP-based requests (WebDAV and REST) are only logged in the access log file when the request has been processed.

Currently, this logging only happens if the request is handled normally; i.e., no exception was thrown and (for async requests) the processing didn't take too long.

This means that a request that triggers certain failure modes would not have an entry in the access log file.

Modification:

Update existing `requestCompleted` method to accept a `NetLoggerBuilder` consumer.  This consumer should add any mode-specific additional logging information.

Create methods that handle the three modes in which the processing of a request might finish: `requestCompletedNormally`,
`requestCompletedExceptionally`, `requestTimedOut`.  All three modes add mode-specific information to the access log entry.

The access log entry key-value pairs derived from the response are moved to the `requestCompletedNormally` method.  The other modes will use default responses, rendering this information unreliable in those cases.

The async listener `LogOnComplete` is updated so that `onTimeout` and `onError` event notification trigger `requestTimedOut` and `requestCompletedExceptionally` logging, respectively.

The `NetLoggerBuilder` class is updated to accept key-value pairs where the value has type Duration.

Result:

Fix bug where webdav and frontend door access log files would fail to log requests that trigger certain failures in dCache.

Target: master
Requires-notes: yes
Requires-book: no
Request: 11.1
Request: 11.0
Request: 10.2
Request: 10.1
Request: 10.0
Request: 9.2
Closes: #7939
Patch: https://rb.dcache.org/r/14581/
Acked-by: Tigran Mkrtchyan