### PR TITLE
webdav: fix range header formatting in relay request

### DIFF
--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/DcacheResourceFactory.java
@@ -1793,8 +1793,19 @@ public class DcacheResourceFactory
                 try {
                     connection.setRequestProperty("Connection", "Close");
                     if (range != null) {
-                        connection.addRequestProperty("Range",
-                              String.format("bytes=%d-%d", range.getStart(), range.getFinish()));
+                        String rangeHeader;
+                        Long start = range.getStart();
+                        Long finish = range.getFinish();
+
+                        if (start == null && finish != null) {
+                            rangeHeader = String.format("bytes=-%d", finish);
+                        } else if (start != null && finish == null) {
+                            rangeHeader = String.format("bytes=%d-", start);
+                        } else {
+                            rangeHeader = String.format("bytes=%d-%d", start, finish);
+                        }
+
+                        connection.addRequestProperty("Range", rangeHeader);
                     }
 
                     connection.connect();


### PR DESCRIPTION
An open-ended range like `bytes=0-` produced an invalid header like "bytes=0-null", resulting in no data being transferred. This patch implements support for open-ended ranges (`bytes=0-`) and suffix ranges (`bytes=-500`).

References https://github.com/dCache/dcache/issues/7971

(cherry picked from commit https://github.com/dCache/dcache/commit/c7cbf8eede79d27788d13d6cc920c89a79869e0b)