### PR TITLE
bulk: avoid spamming log file when requests have already

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
@@ -171,6 +171,11 @@ public final class BulkRequestHandler implements BulkSubmissionHandler,
                     }
                 });
             }
+        } catch (BulkRequestNotFoundException e) {
+            /*
+             * Request has been cleared already.
+             */
+            LOGGER.debug("checkTerminated, request {} was auto-cleared on termination.", id);
         } catch (BulkStorageException e) {
             LOGGER.warn("checkTerminated, check for cancel on failure {}: {}.", id,
                   e.toString());


### PR DESCRIPTION
been cleared due to auto-clear flag

Motivation:
----------

checkTerminated method generates excessive log due to exception caught when request is not found. This happens all the time if auto-clear is set to true.

Modification:
-------------

Catch and ignore BulkRequestNotFoundException when retrieving request by ID

Result:
-------

Less verbose output in the log file

Ticket: https://github.com/dCache/dcache/issues/7931 Acked-by:
Target: trunk
Request: 11.1 11.0 10.2 10.1 10.0 9.2
Require-book: no
Require-notes: yes

Patch: https://rb.dcache.org/r/14577/
Acked-by: Tigran