### PR TITLE
bulk: catch another place generating verbose logging

### DIFF
--- a/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
+++ b/modules/dcache-bulk/src/main/java/org/dcache/services/bulk/handler/BulkRequestHandler.java
@@ -318,6 +318,12 @@ public final class BulkRequestHandler implements BulkSubmissionHandler,
                 statistics.incrementRequestsCompleted();
                 return true;
             }
+        } catch (BulkRequestNotFoundException e) {
+            /*
+             * Request has been cleared already.
+             */
+            LOGGER.debug("setStateIfTerminated, request {} was auto-cleared on termination.", id);
+            return true;
         } catch (BulkServiceException e) {
             LOGGER.error("Failed to post-process request {}: {}.", id,
                   e.toString());


### PR DESCRIPTION
Motivation:
-----------

Patch 466b32883f1614baf57771575f6f70ba1338d2d2 addressd the issue https://github.com/dCache/dcache/issues/7931 only partially

Modification:
------------

Fix another place where the auto clear of requests leads to unnecessary logging

Result:
-------

Smaller log files.

Ticket: https://github.com/dCache/dcache/issues/7931
Acked-by: Chris Green
Target: trunk
Request: 11.1
Request: 11.0
Request: 10.2
Request: 10.1
Request: 10.0
Request: 9.2
Require-book: no
Require-notes: yes