### PR TITLE
dcache cli: fix issue with printing pool size when max diskspace is s…

### DIFF
--- a/skel/share/lib/pool.sh
+++ b/skel/share/lib/pool.sh
@@ -25,6 +25,7 @@ getSizeOfPool() # in $1 = pool path
     local size
 
     size=$(getPoolSetting "$path" "set max diskspace" max)
+
     if [ -z "$size" ]; then
         size=$(getProperty pool.size "$domain" "$cell")
     fi
@@ -38,6 +39,13 @@ getSizeOfPool() # in $1 = pool path
         "")
             echo "-"
             ;;
+	*%)
+	    total=$(getTotalSpace  "$path")
+	    percent=$(echo "${size}" | tr -d "%")
+	    size=$((${total}*${percent}/100))
+	    stringToGiB "${size}G" size
+	    echo "${size}G"
+	    ;;
         *)
             stringToGiB "$size" size
             echo "${size}G"

--- a/skel/share/lib/utils.sh
+++ b/skel/share/lib/utils.sh
@@ -305,6 +305,12 @@ getFreeSpace() # in $1 = path
     [ -d "$1" ] && ( df -k "${1}" | awk 'NR == 2 { if (NF < 4) { getline; x = $3 } else { x = $4 }; printf "%d", x / (1024 * 1024)}' )
 }
 
+# Extracts the amount of free space in GiB.
+getTotalSpace() # in $1 = path
+{
+    [ -d "$1" ] && ( df -k "${1}" | awk 'NR == 2 { if (NF < 4) { getline; x = $1 } else { x = $2 }; printf "%d", x / (1024 * 1024)}' )
+}
+
 # Reads configuration file into shell variables. The shell variable
 # names can optionally be prefixed. Returns 1 if file does not exist.
 readconf() # in $1 = file in $2 = prefix


### PR DESCRIPTION
…et in percentage

Motivation:
-----------

patch 8c71927 introduced ability to specify max disk space in percentage of partition space like so:

set max diskspace 98%

unfortunately it breaks dcache pool ls command like so:

   98% is not an integer.

Modification:
------------

Calculate pool size based on partition size and percentage

Result:
------

No error when running "dcache pool ls" and pool size properly reported

Ticket: https://github.com/dCache/dcache/issues/8014
Patch: https://rb.dcache.org/r/14618/

Acked-by: Marina
Request: trunk
Target: 11.x
Require-book: no
Require-notes: yes