### PR TITLE
 rest api: add support for Java8 Optional data type

### DIFF
--- a/modules/dcache-frontend/pom.xml
+++ b/modules/dcache-frontend/pom.xml
@@ -92,6 +92,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
+	<!-- Java 8 Datatypes -->
+	<dependency>
+	    <groupId>com.fasterxml.jackson.datatype</groupId>
+	    <artifactId>jackson-datatype-jdk8</artifactId>
+	</dependency>
         <dependency>
             <groupId>org.springframework.plugin</groupId>
             <artifactId>spring-plugin-core</artifactId>

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/ObjectMapperProvider.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/providers/ObjectMapperProvider.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 
@@ -30,6 +31,7 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
     private static ObjectMapper createDefaultMapper() {
         return new ObjectMapper()
               .registerModule(PNFSID_SERIALIZER)
+              .registerModule(new Jdk8Module())
               .enable(SerializationFeature.INDENT_OUTPUT)
               .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -940,6 +940,12 @@
                 <version>${version.jackson}</version>
             </dependency>
 
+	    <dependency>
+	        <groupId>com.fasterxml.jackson.datatype</groupId>
+		<artifactId>jackson-datatype-jdk8</artifactId>
+		<version>${version.jackson}</version>
+	    </dependency>
+
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>


### PR DESCRIPTION
Motivation:
-----------

With upgrade of jackson dependencies for 11.x handling of Optional datatype started to fail like so:

"Unable to interpret JSON: Java 8 optional type `java.util.Optional<java.lang.Double>`..."

when calling rest api to query pool information

Modification:
-------------

Following this recipe:

https://github.com/FasterXML/jackson-modules-java8

registered Jdk8Module to json ObjectMapper

Result:
-------

No more error

Ticket: https://github.com/dCache/dcache/issues/8007
Patch: https://rb.dcache.org/r/14616/
Acked-by: Marina
Target: trunk
Request: 11.x
Require-book: no
Require-notes: yes