### PR TITLE
pool: send firefly for https transfers

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/movers/TransferLifeCycle.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/TransferLifeCycle.java
@@ -230,6 +230,7 @@ public class TransferLifeCycle {
         switch (protocolInfo.getProtocol().toLowerCase()) {
             case "xrootd":
             case "http":
+            case "https":
                 return true;
             default:
                 return false;


### PR DESCRIPTION
The TransferLifeCycle should accept https as protocol that needs fireflys.

Fixes: #8015
Acked-by: Dmitry Litvintsev
Target: master, 11.2
Require-book: no
Require-notes: yes
(cherry picked from commit b82ea31b1cca63ee4d1ed0ba05390f1c3373a13c)