### PR TITLE
namespace: ensure that access latency and retention policy are always…

### DIFF
--- a/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
+++ b/modules/dcache-chimera/src/main/java/org/dcache/chimera/namespace/ChimeraHsmStorageInfoExtractor.java
@@ -83,10 +83,6 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
                 }
             }
 
-            Optional<String> spaceToken = getFirstLine(dirInode.getTag("WriteToken"));
-            if (spaceToken.isPresent()) {
-                return null;
-            }
             return getDefaultAccessLatency();
         } catch (FileNotFoundChimeraFsException e) {
             throw new FileNotFoundCacheException(e.getMessage(), e);
@@ -123,11 +119,6 @@ public abstract class ChimeraHsmStorageInfoExtractor implements
                     LOGGER.error("Badly formatted RetentionPolicy tag in {}: {}", dirInode,
                           e.getMessage());
                 }
-            }
-
-            Optional<String> spaceToken = getFirstLine(dirInode.getTag("WriteToken"));
-            if (spaceToken.isPresent()) {
-                return null;
             }
 
             return getDefaultRetentionPolicy();

--- a/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
+++ b/modules/dcache-spacemanager/src/main/java/diskCacheV111/services/space/SpaceManagerService.java
@@ -1155,18 +1155,18 @@ public final class SpaceManagerService
             StorageInfo storageInfo = selectWritePool.getStorageInfo();
             storageInfo.setKey("SpaceToken", Long.toString(space.getId()));
             storageInfo.setKey("LinkGroupId", Long.toString(linkGroup.getId()));
-            if (!fileAttributes.isDefined(FileAttribute.ACCESS_LATENCY)) {
-                fileAttributes.setAccessLatency(space.getAccessLatency());
-            } else if (fileAttributes.getAccessLatency() != space.getAccessLatency()) {
-                throw new SpaceException(
-                      "Access latency conflicts with access latency defined by default space reservation.");
+
+            if (fileAttributes.isDefined(FileAttribute.ACCESS_LATENCY) && (fileAttributes.getAccessLatency() != space.getAccessLatency())) {
+                LOGGER.warn("The access latency {} in file attributes will be overridden by value {} defined for space reservation {}.",
+                      fileAttributes.getAccessLatency(), space.getAccessLatency(), defaultSpaceToken);
             }
-            if (!fileAttributes.isDefined(FileAttribute.RETENTION_POLICY)) {
-                fileAttributes.setRetentionPolicy(space.getRetentionPolicy());
-            } else if (fileAttributes.getRetentionPolicy() != space.getRetentionPolicy()) {
-                throw new SpaceException(
-                      "Retention policy conflicts with retention policy defined by default space reservation.");
+            fileAttributes.setAccessLatency(space.getAccessLatency());
+
+            if (fileAttributes.isDefined(FileAttribute.RETENTION_POLICY) && (fileAttributes.getRetentionPolicy() != space.getRetentionPolicy())) {
+                LOGGER.warn("The retention policy {} in file attributes will be overridden by value {} defined for space reservation {}.",
+                      fileAttributes.getRetentionPolicy(), space.getRetentionPolicy(), defaultSpaceToken);
             }
+            fileAttributes.setRetentionPolicy(space.getRetentionPolicy());
 
             if (space.getDescription() != null) {
                 storageInfo.setKey("SpaceTokenDescription", space.getDescription());


### PR DESCRIPTION
… defined

Motivation:
Many parts in dcache expected that files access latency and retention policy are always defined. The namespace fallbacks to default values, if there are no explicit tags are defined. However, there is shortcat tha skips default values if WriteToken tag is specified. The lately introduces Archivemetadata is a functionality that directry affected by this behaviour:

```
java.lang.IllegalStateException: Attribute is not defined: RETENTION_POLICY
	at org.dcache.vehicles.FileAttributes.guard(FileAttributes.java:335)
	at org.dcache.vehicles.FileAttributes.getRetentionPolicy(FileAttributes.java:504)
	at org.dcache.webdav.DcacheResourceFactory$WriteTransfer.createNameSpaceEntry(DcacheResourceFactory.java:1940)
	at org.dcache.webdav.DcacheResourceFactory.createFile(DcacheResourceFactory.java:752)
	at org.dcache.webdav.DcacheDirectoryResource.createNew(DcacheDirectoryResource.java:148)
	at io.milton.http.http11.PutHandler.processCreate(PutHandler.java:229)
	at io.milton.http.http11.PutHandler.process(PutHandler.java:207)
	at org.dcache.webdav.DcacheStandardFilter.process(DcacheStandardFilter.java:50)
	at io.milton.http.FilterChain.process(FilterChain.java:46)
	at org.dcache.webdav.transfer.CopyFilter.process(CopyFilter.java:278)
	at io.milton.http.FilterChain.process(FilterChain.java:46)
	at io.milton.http.HttpManager.process(HttpManager.java:158)
	at org.dcache.webdav.MiltonHandler.handle(MiltonHandler.java:77)
	at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:59)
```

Modification:
Remove dependency on WriteToken. Update Spacemanager (which expected no access latency and retention policy) to override the value, if space token has a different value. The mismatch is logged.

Result:
The access latency and retention policies are always defined.

Fixes: #8033
Acked-by: Dmitry Litvintsev
Target: master, 11.2
Require-book: no
Require-notes: yes
(cherry picked from commit 5acd486b27588b380a10e804afdc608a08eb70cf)