### PR TITLE
build(deps): bump org.apache.zookeeper:zookeeper from 3.8.4 to 3.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.8.4</version>
+                <version>3.8.6</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.jmx</groupId>


### PR DESCRIPTION
Bumps org.apache.zookeeper:zookeeper from 3.8.4 to 3.8.6.

---
updated-dependencies:
- dependency-name: org.apache.zookeeper:zookeeper dependency-version: 3.8.6 dependency-type: direct:production ...


(cherry picked from commit 6537358ef613c5540981990760068d1a9ebfdcbc)