### PR TITLE
Support WAN SciTag markers for remote HTTP(S) TPC transfers

### DIFF
--- a/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/RemoteHttpDataTransferProtocolInfo.java
+++ b/modules/dcache-vehicles/src/main/java/diskCacheV111/vehicles/RemoteHttpDataTransferProtocolInfo.java
@@ -29,6 +29,7 @@ public class RemoteHttpDataTransferProtocolInfo implements IpProtocolInfo {
     private final boolean isVerificationRequired;
     private final ImmutableMap<String, String> headers;
     private final OpenIdCredential openIdCredential;
+    private String transferTag = "";
     @Nullable
     private final ChecksumType desiredChecksum;
     @Nonnull
@@ -104,6 +105,15 @@ public class RemoteHttpDataTransferProtocolInfo implements IpProtocolInfo {
         return headers;
     }
 
+    public void setTransferTag(String transferTag) {
+        this.transferTag = transferTag == null ? "" : transferTag;
+    }
+
+    @Override
+    public String getTransferTag() {
+        return transferTag;
+    }
+
     @Override
     public String toString() {
         return getVersionString() + ':' + sourceHttpUrl;
@@ -135,6 +145,11 @@ public class RemoteHttpDataTransferProtocolInfo implements IpProtocolInfo {
             desiredChecksums = desiredChecksum == null
                     ? Collections.emptySet()
                     : Set.of(desiredChecksum);
+        }
+
+        // Handle objects sent from old doors.
+        if (transferTag == null) {
+            transferTag = "";
         }
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/LoggingHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/LoggingHandler.java
@@ -59,5 +59,7 @@ public class LoggingHandler extends AbstractLoggingHandler {
         log.add("tpc.require-checksum", CopyFilter.getTpcRequireChecksumVerification(request));
         log.add("tpc.source", CopyFilter.getTpcSource(request));
         log.add("tpc.destination", CopyFilter.getTpcDestination(request));
+        log.add("tpc.scitag", CopyFilter.getTpcSciTag(request));
+        log.add("tpc.transferheaderscitag", CopyFilter.getTpcTransferHeaderSciTag(request));
     }
 }

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/CopyFilter.java
@@ -103,6 +103,8 @@ public class CopyFilter implements Filter {
 
     private static final String QUERY_KEY_ASKED_TO_DELEGATE = "asked-to-delegate";
     private static final String REQUEST_HEADER_CREDENTIAL = "Credential";
+    private static final String REQUEST_HEADER_SCITAG = "SciTag";
+    private static final String REQUEST_HEADER_TRANSFER_HEADER_SCITAG = "TransferHeaderSciTag";
     private static final String REQUEST_HEADER_TRANSFER_HEADER_PREFIX = "transferheader";
     private static final String REQUEST_HEADER_VERIFICATION = "RequireChecksumVerification";
     private static final String TPC_ERROR_ATTRIBUTE = "org.dcache.tpc-error";
@@ -110,6 +112,11 @@ public class CopyFilter implements Filter {
     private static final String TPC_REQUIRE_CHECKSUM_VERIFICATION_ATTRIBUTE = "org.dcache.tpc-require-checksum-verify";
     private static final String TPC_SOURCE_ATTRIBUTE = "org.dcache.tpc-source";
     private static final String TPC_DESTINATION_ATTRIBUTE = "org.dcache.tpc-destination";
+    private static final String TPC_SCITAG_ATTRIBUTE = "org.dcache.tpc-scitag";
+    private static final String TPC_TRANSFER_HEADER_SCITAG_ATTRIBUTE =
+          "org.dcache.tpc-transferheaderscitag";
+    // Sentinel for a missing or blank SciTag-related header value.
+    private static final String MISSING_HEADER_VALUE = "-";
 
 
     private ImmutableMap<String, String> _clientIds;
@@ -184,12 +191,32 @@ public class CopyFilter implements Filter {
         return (String) request.getAttribute(TPC_REQUIRE_CHECKSUM_VERIFICATION_ATTRIBUTE);
     }
 
+    /**
+     * Provide the remote source URI for pull-type third-party copies.
+     */
     public static URI getTpcSource(HttpServletRequest request) {
         return (URI) request.getAttribute(TPC_SOURCE_ATTRIBUTE);
     }
 
+    /**
+     * Provide the remote destination URI for push-type third-party copies.
+     */
     public static URI getTpcDestination(HttpServletRequest request) {
         return (URI) request.getAttribute(TPC_DESTINATION_ATTRIBUTE);
+    }
+
+    /**
+     * Provide the SciTag header value supplied directly by the client.
+     */
+    public static String getTpcSciTag(HttpServletRequest request) {
+        return (String) request.getAttribute(TPC_SCITAG_ATTRIBUTE);
+    }
+
+    /**
+     * Provide the transfer-header-carried SciTag value supplied by the client.
+     */
+    public static String getTpcTransferHeaderSciTag(HttpServletRequest request) {
+        return (String) request.getAttribute(TPC_TRANSFER_HEADER_SCITAG_ATTRIBUTE);
     }
 
     @Required
@@ -404,6 +431,9 @@ public class CopyFilter implements Filter {
           throws BadRequestException, InterruptedException, ErrorResponseException {
         Direction direction = getDirection();
         URI remote = getRemoteLocation();
+        HttpServletRequest servletRequest = ServletRequest.getRequest();
+
+        captureSciTagHeaders(servletRequest);
 
         setRemoteUrlAttribute(direction, remote);
 
@@ -434,12 +464,12 @@ public class CopyFilter implements Filter {
 
         var transferHeaders = buildTransferHeaders(request);
         var transferFlags = buildTransferFlags();
+          String transferTag = transferTagForPool(servletRequest);
 
         var transferResult = _remoteTransfers.acceptRequest(transferHeaders,
               getSubject(), getRestriction(), path, remote, credential,
-              direction, transferFlags, overwriteAllowed, wantDigest);
+              transferTag, direction, transferFlags, overwriteAllowed, wantDigest);
 
-        HttpServletRequest servletRequest = ServletRequest.getRequest();
         transferResult.addListener(() -> {
             try {
                 var error = transferResult.get();
@@ -449,6 +479,36 @@ public class CopyFilter implements Filter {
                       "problem getting result: " + e);
             }
         }, MoreExecutors.directExecutor());
+    }
+
+    private void captureSciTagHeaders(HttpServletRequest request) {
+        request.setAttribute(TPC_SCITAG_ATTRIBUTE,
+              sanitiseHeaderValue(request.getHeader(REQUEST_HEADER_SCITAG)));
+        request.setAttribute(TPC_TRANSFER_HEADER_SCITAG_ATTRIBUTE,
+              sanitiseHeaderValue(request.getHeader(REQUEST_HEADER_TRANSFER_HEADER_SCITAG)));
+    }
+
+    private String sanitiseHeaderValue(String value) {
+        if (value == null) {
+            return MISSING_HEADER_VALUE;
+        }
+
+        String trimmedValue = value.trim();
+        return trimmedValue.isEmpty() ? MISSING_HEADER_VALUE : trimmedValue;
+    }
+
+    private String transferTagForPool(HttpServletRequest request) {
+        String sciTag = getTpcSciTag(request);
+        if (sciTag != null && !MISSING_HEADER_VALUE.equals(sciTag)) {
+            return sciTag;
+        }
+
+        String transferHeaderSciTag = getTpcTransferHeaderSciTag(request);
+        if (transferHeaderSciTag != null && !MISSING_HEADER_VALUE.equals(transferHeaderSciTag)) {
+            return transferHeaderSciTag;
+        }
+
+        return "";
     }
 
     private void setRemoteUrlAttribute(Direction direction, URI remote) {

--- a/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
+++ b/modules/dcache-webdav/src/main/java/org/dcache/webdav/transfer/RemoteTransferHandler.java
@@ -677,11 +677,12 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
     public ListenableFuture<Optional<String>> acceptRequest(
           ImmutableMap<String, String> transferHeaders,
           Subject subject, Restriction restriction, FsPath path, URI remote,
-          Object credential, Direction direction, EnumSet<TransferFlag> flags,
+            Object credential, String transferTag, Direction direction,
+            EnumSet<TransferFlag> flags,
           boolean overwriteAllowed, Optional<String> wantDigest)
           throws ErrorResponseException, InterruptedException {
         RemoteTransfer transfer = new RemoteTransfer(subject, restriction,
-              path, remote, credential, flags, transferHeaders, direction,
+              path, remote, credential, transferTag, flags, transferHeaders, direction,
               overwriteAllowed, wantDigest);
 
         return transfer.start();
@@ -763,6 +764,7 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
         private final CredentialSource _source;
         private final EnumSet<TransferFlag> _flags;
         private final ImmutableMap<String, String> _transferHeaders;
+        private final String _transferTag;
         private final Direction _direction;
         private final boolean _overwriteAllowed;
         private final Optional<String> _wantDigest;
@@ -787,6 +789,7 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
 
         public RemoteTransfer(Subject subject, Restriction restriction,
               FsPath path, URI destination, @Nullable Object credential,
+              String transferTag,
               EnumSet<TransferFlag> flags, ImmutableMap<String, String> transferHeaders,
               Direction direction, boolean overwriteAllowed, Optional<String> wantDigest)
               throws ErrorResponseException {
@@ -818,6 +821,7 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
 
             _flags = flags;
             _transferHeaders = transferHeaders;
+            _transferTag = transferTag == null ? "" : transferTag.trim();
             _direction = direction;
             _overwriteAllowed = overwriteAllowed;
             _wantDigest = wantDigest;
@@ -1057,24 +1061,33 @@ public class RemoteTransferHandler implements CellMessageReceiver, CellCommandLi
                           null, desiredChecksum);
 
                 case HTTP:
-                    return new RemoteHttpDataTransferProtocolInfo("RemoteHttpDataTransfer",
+                      RemoteHttpDataTransferProtocolInfo httpInfo =
+                          new RemoteHttpDataTransferProtocolInfo("RemoteHttpDataTransfer",
                           1, 1, address, _destination.toASCIIString(),
                           _flags.contains(TransferFlag.REQUIRE_VERIFICATION),
                           _transferHeaders, desiredChecksums);
+                      httpInfo.setTransferTag(_transferTag);
+                      return httpInfo;
 
                 case HTTPS:
                     if (_source == CredentialSource.OIDC) {
-                        return new RemoteHttpsDataTransferProtocolInfo("RemoteHttpsDataTransfer",
+                        RemoteHttpsDataTransferProtocolInfo httpsInfo =
+                            new RemoteHttpsDataTransferProtocolInfo("RemoteHttpsDataTransfer",
                               1, 1, address, _destination.toASCIIString(),
                               _flags.contains(TransferFlag.REQUIRE_VERIFICATION),
                               _transferHeaders, desiredChecksums,
                               _oidCredential);
+                        httpsInfo.setTransferTag(_transferTag);
+                        return httpsInfo;
                     } else {
-                        return new RemoteHttpsDataTransferProtocolInfo("RemoteHttpsDataTransfer",
+                        RemoteHttpsDataTransferProtocolInfo httpsInfo =
+                            new RemoteHttpsDataTransferProtocolInfo("RemoteHttpsDataTransfer",
                               1, 1, address, _destination.toASCIIString(),
                               _flags.contains(TransferFlag.REQUIRE_VERIFICATION),
                               _transferHeaders, _privateKey, _certificateChain,
                               desiredChecksums);
+                        httpsInfo.setTransferTag(_transferTag);
+                        return httpsInfo;
                     }
             }
 

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/TransferLifeCycle.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/TransferLifeCycle.java
@@ -272,6 +272,8 @@ public class TransferLifeCycle {
             case "xrootd":
             case "http":
             case "https":
+            case "remotehttpdatatransfer":
+            case "remotehttpsdatatransfer":
                 return true;
             default:
                 return false;


### PR DESCRIPTION
## Summary
This PR implements the agreed Patch 1-3 scope for WAN SciTag marker support.

### Patch 1: Pool marker protocol allowlist
- Add remotehttpdatatransfer and remotehttpsdatatransfer to TransferLifeCycle.needMarker(...).
- Keep WAN protocol scope as: xrootd, http, https, remotehttpdatatransfer, remotehttpsdatatransfer.

### Patch 2: WebDAV TPC transfer-tag plumbing for remote HTTP(S)
- Capture SciTag carriers from COPY request in CopyFilter (SciTag, TransferHeaderSciTag).
- Pass selected transfer tag into RemoteTransferHandler.acceptRequest(...) and RemoteTransfer.
- Set transfer tag on both remote HTTP and remote HTTPS protocol-info objects.
- Add serialized transfer-tag storage and getter support to RemoteHttpDataTransferProtocolInfo (used by HTTPS subclass as well).

### Patch 3: Access-log observability
- Add tpc.scitag and tpc.transferheaderscitag fields in WebDAV LoggingHandler access logs.

## Validation Evidence
Validated on umfs19 with dcdum02 TPC traffic:
- pool protocol observed: remotehttpsdatatransfer
- exact tag matches confirmed (pool transferTag equals door tpc.scitag) for multiple pnfsids, including:
  - 00004C3CC39D92B94DF2B02B4A870AF09DA8 (144)
  - 00004677DBAD412943CAB37A32E479D3C103 (143)
  - 0000E1813ED9C11149D19137F03ABE1CC628 (144)
  - 00000FDBDB1E8DEA4FC7B2FD25FDC4C2361D (144)

## Out of Scope
- No gftp, dcap, or nfs4 protocol expansion in this PR.
- No optional GSIFTP extension in this PR.
