### PR TITLE
script: add `dcache pool benchmark` command

### DIFF
--- a/skel/bin/dcache
+++ b/skel/bin/dcache
@@ -56,6 +56,7 @@ usage()
     echo "   pool ls"
     echo "   pool reconstruct <directory> <target dir>"
     echo "   pool yaml <name>"
+    echo "   pool benchmark [fio options] [ -- [<directory>]]"
     echo "   property <property-name> [<domain-name> [<cell-name>]]"
     echo "   restart [<domain>]..."
     echo "   services"
@@ -609,6 +610,51 @@ case "$1" in
                         done
                     done
                 ) | column
+                ;;
+
+            benchmark)
+                fio --version >/dev/null 2>&1 || fail 1 "fio is not installed. Please install fio to run the benchmark command."
+
+                fio_options=""
+                while  [ $# -gt 0 ]
+                do
+                  case "$1" in
+                    --)
+                      shift
+                      break
+                      ;;
+                    *)
+                      fio_options="$fio_options $1"
+                      shift
+                      ;;
+                  esac
+                done
+
+                [ $# -gt 1 ] && usage
+
+                if [ $# -eq 1 ]
+                then
+                    path="$1"
+                    echo ""
+                    echo "  Running fio benchmark for directory ${path}"
+                    echo ""
+                    fio --directory=${path} ${fio_options} ${lib}/pool-benchmark.fio
+                else
+                  for domain in $(getProperty dcache.domains); do
+                      for cell in $(getProperty dcache.domain.cells "$domain"); do
+                          service=$(getProperty dcache.domain.service "$domain" "$cell")
+                          if [ "$service" = "pool" ]; then
+                              name=$(getProperty pool.name "$domain" "$cell")
+                              path=$(getProperty pool.path "$domain" "$cell")
+
+                              echo ""
+                              echo "  Running fio benchmark for pool $name@$domain."
+                              echo ""
+                              fio --directory=${path}/data ${fio_options} ${lib}/pool-benchmark.fio
+                          fi
+                      done
+                  done
+                fi
                 ;;
 
             *)

--- a/skel/man/man8/dcache.8
+++ b/skel/man/man8/dcache.8
@@ -178,6 +178,14 @@ to manually replace the content of the meta directory of the pool with
 the reconstructed database. It is recommended to keep a copy of the
 old database.
 
+.TP
+.B pool benchmark [fio options ] [ -- directory]
+Run filesystem benchmarks on the file system containing the pool's \fBdata directory.
+The benchmark uses the fio tool. The options passed to the command are passed directly to fio.
+If a path is specified, the benchmark is run on specified directory only. Otherwise,
+the benchmark is run on all file systems for all configured pools.
+By default, the output of the benchmark is written to standard out.
+
 .SH DATABASE MANAGEMENT COMMANDS
 
 Several services in dCache rely on relational databases. The commands

--- a/skel/share/lib/pool-benchmark.fio
+++ b/skel/share/lib/pool-benchmark.fio
@@ -1,0 +1,83 @@
+;
+; FIO workload to benchmark disk performance
+;
+; block verification information is forced on write, which is
+; used during read workloads.
+;
+;
+; Run sequential write, sequential read and random read
+;
+;
+; NOTE: ALL READ JOBS DELETE TEST FILE AFTER BENCHMARK
+;
+
+[global]
+filename_format=fio-test-$jobnum-$filenum
+; file size
+size=10g
+ioengine=libaio
+; do not pre-create files
+create_on_open=1
+; checksum type
+verify=sha1
+; fail on first checksum error
+verify_fatal=1
+; invalidate page cache before running jobs
+invalidate=1
+
+[seqwrite]
+description=Streaming WRITE
+rw=write
+; do not check sum during write
+do_verify=0
+; block until job is done before jumping to the next section
+stonewall
+
+[seqread]
+description=Streaming READ
+rw=read
+; check checksum during read
+do_verify=1
+; block until job is done before jumping to the next section
+stonewall
+
+[randread]
+description=Random READ
+rw=randread
+; inremental random offest
+rw_sequencer=sequential
+; check checksum during read
+do_verify=1
+; block until job is done before jumping to the next section
+stonewall
+; remove file at the end of the test
+unlink=1
+
+[concurrent_write]
+description=Concurrent Streaming WRITE
+rw=write
+; do not check sum during write
+do_verify=0
+; block until job is done before jumping to the next section
+stonewall
+; write with multiple threads
+numjobs=24
+thread=1
+group_reporting=1
+
+[concurrent_randread]
+description=Concurrent Random READ
+rw=randread
+rw=read
+; check checksum during read
+do_verify=1
+; block until job is done before jumping to the next section
+stonewall
+; read with multiple threads
+numjobs=24
+thread=1
+group_reporting=1
+; remove file at the end of the test
+unlink=1
+
+; -- end job file --


### PR DESCRIPTION
Motivation:
Often admins want to know the expected I/O rates that a pool can provide. The desired benchmarks can be hart to configure. This, it makes sense to provide a 'good starting point' with dcache.

Modification:
update `dcache` command to provide `pool benchmark` command that will benchmark all configure pools in the layout file that that host. Optionally, a specific directory can be used.

Result:
simple test to benchmark pools filesystem

```
$ dcache pool benchmark

  Running fio benchmark for pool pool_write@dCacheDomain.

seqwrite: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=1
seqread: (g=1): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=1
randread: (g=2): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=1
concurrent_write: (g=3): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=1
...
concurrent_randread: (g=4): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=1
...
fio-3.40
Starting 48 threads and 3 processes
Jobs: 1 (f=1): [_(36),V(1),_(14)][100.0%][r=556MiB/s][r=142k IOPS][eta 00m:00s]
seqwrite: (groupid=0, jobs=1): err= 0: pid=156310: Fri Mar  6 11:57:47 2026

....

Run status group 0 (all jobs):
  WRITE: bw=636MiB/s (667MB/s), 636MiB/s-636MiB/s (667MB/s-667MB/s), io=10.0GiB (10.7GB), run=16110-16110msec

Run status group 1 (all jobs):
   READ: bw=628MiB/s (659MB/s), 628MiB/s-628MiB/s (659MB/s-659MB/s), io=10.0GiB (10.7GB), run=16298-16298msec

Run status group 2 (all jobs):
   READ: bw=41.0MiB/s (43.0MB/s), 41.0MiB/s-41.0MiB/s (43.0MB/s-43.0MB/s), io=10.0GiB (10.7GB), run=249909-249909msec

Run status group 3 (all jobs):
  WRITE: bw=1738MiB/s (1822MB/s), 1738MiB/s-1738MiB/s (1822MB/s-1822MB/s), io=240GiB (258GB), run=141418-141418msec

Run status group 4 (all jobs):
   READ: bw=1845MiB/s (1935MB/s), 1845MiB/s-1845MiB/s (1935MB/s-1935MB/s), io=240GiB (258GB), run=133205-133205msec

```

Acked-by: Marina Sahakyan
Target: master
Require-book: no
Require-notes: yes
(cherry picked from commit 2e61583af75cc89a244023cd016648dd9ad8133a)