### PR TITLE
pool: add firefly onStart marker for MoverProtocol-based transfers

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/AbstractMoverProtocolTransferService.java
@@ -73,6 +73,10 @@ public abstract class AbstractMoverProtocolTransferService
         _transferLifeCycle = transferLifeCycle;
     }
 
+    protected TransferLifeCycle getTransferLifeCycle() {
+        return _transferLifeCycle;
+    }
+
     @Override
     public Mover<?> createMover(ReplicaDescriptor handle, PoolIoFileMessage message,
           CellPath pathToDoor)

--- a/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteHttpTransferService.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/RemoteHttpTransferService.java
@@ -19,6 +19,7 @@ package org.dcache.pool.classic;
 
 import com.google.common.base.Splitter;
 import diskCacheV111.util.CacheException;
+import diskCacheV111.vehicles.PoolIoFileMessage;
 import diskCacheV111.vehicles.ProtocolInfo;
 import diskCacheV111.vehicles.RemoteHttpDataTransferProtocolInfo;
 import diskCacheV111.vehicles.RemoteHttpsDataTransferProtocolInfo;
@@ -58,8 +59,11 @@ import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpRequestExecutor;
+import org.dcache.pool.movers.Mover;
 import org.dcache.pool.movers.MoverProtocol;
+import org.dcache.pool.movers.MoverProtocolMover;
 import org.dcache.pool.movers.RemoteHttpDataTransferProtocol;
+import org.dcache.pool.repository.ReplicaDescriptor;
 import org.dcache.security.trust.AggregateX509TrustManager;
 import org.dcache.util.Version;
 import org.slf4j.Logger;
@@ -68,6 +72,8 @@ import org.springframework.beans.factory.annotation.Value;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static dmg.util.Exceptions.meaningfulMessage;
+
+import dmg.cells.nucleus.CellPath;
 
 public class RemoteHttpTransferService extends SecureRemoteTransferService {
 
@@ -129,6 +135,15 @@ public class RemoteHttpTransferService extends SecureRemoteTransferService {
     private CloseableHttpClient sharedClient;
 
     @Override
+    public Mover<?> createMover(ReplicaDescriptor handle, PoolIoFileMessage message,
+          CellPath pathToDoor) throws CacheException {
+        Mover<?> mover = super.createMover(handle, message, pathToDoor);
+        MoverProtocolMover mpm = (MoverProtocolMover) mover;
+        ((RemoteHttpDataTransferProtocol) mpm.getMover()).setSubject(message.getSubject());
+        return mover;
+    }
+
+    @Override
     protected MoverProtocol createMoverProtocol(ProtocolInfo info) throws Exception {
         if (!(info instanceof RemoteHttpDataTransferProtocolInfo)) {
             throw new CacheException(CacheException.CANNOT_CREATE_MOVER,
@@ -145,7 +160,7 @@ public class RemoteHttpTransferService extends SecureRemoteTransferService {
                 SSLContext context = buildSSLContext(credential.getKeyManager());
                 CloseableHttpClient client = createClient(context);
 
-                return new RemoteHttpDataTransferProtocol(client) {
+                return new RemoteHttpDataTransferProtocol(client, getTransferLifeCycle()) {
                     @Override
                     protected void afterTransfer() {
                         super.afterTransfer();
@@ -159,7 +174,7 @@ public class RemoteHttpTransferService extends SecureRemoteTransferService {
             }
         }
 
-        return new RemoteHttpDataTransferProtocol(sharedClient);
+        return new RemoteHttpDataTransferProtocol(sharedClient, getTransferLifeCycle());
     }
 
     @PostConstruct

--- a/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/movers/RemoteHttpDataTransferProtocol.java
@@ -16,6 +16,7 @@ import static org.dcache.util.TimeUtils.describeDuration;
 
 import diskCacheV111.util.CacheException;
 import diskCacheV111.util.ThirdPartyTransferFailedCacheException;
+import diskCacheV111.vehicles.IpProtocolInfo;
 import diskCacheV111.vehicles.ProtocolInfo;
 import diskCacheV111.vehicles.RemoteHttpDataTransferProtocolInfo;
 import java.io.IOException;
@@ -39,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
+import javax.security.auth.Subject;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpInetConnection;
@@ -213,9 +215,18 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     private Long _expectedTransferSize;
 
     private InetSocketAddress _localEndpoint;
+    private final TransferLifeCycle _transferLifeCycle;
+    private Subject _subject;
+    private boolean _startMarkerSent;
 
-    public RemoteHttpDataTransferProtocol(CloseableHttpClient client) {
+    public RemoteHttpDataTransferProtocol(CloseableHttpClient client,
+          TransferLifeCycle transferLifeCycle) {
         _client = requireNonNull(client);
+        _transferLifeCycle = requireNonNull(transferLifeCycle);
+    }
+
+    public void setSubject(Subject subject) {
+        _subject = subject;
     }
 
     private static void checkThat(boolean isOk, String message) throws CacheException {
@@ -540,6 +551,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
         CloseableHttpResponse response = _client.execute(get, context);
 
         _localEndpoint = localAddress().orElse(null);
+        startFlowMarker();
 
         boolean isSuccessful = false;
         try {
@@ -605,6 +617,7 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
 
                 try (CloseableHttpResponse response = _client.execute(put, context)) {
                     _localEndpoint = localAddress().orElse(null);
+                    startFlowMarker();
                     StatusLine status = response.getStatusLine();
                     switch (status.getStatusCode()) {
                         case 200: /* OK (not actually a valid response from PUT) */
@@ -979,6 +992,26 @@ public class RemoteHttpDataTransferProtocol implements MoverProtocol,
     @Override
     public Long getBytesExpected() {
         return _expectedTransferSize;
+    }
+
+    private void startFlowMarker() {
+        if (_startMarkerSent || _localEndpoint == null || _subject == null) {
+            return;
+        }
+
+        ProtocolInfo protocolInfo = _channel.getProtocolInfo();
+        if (!(protocolInfo instanceof IpProtocolInfo ipInfo)) {
+            return;
+        }
+
+        InetSocketAddress remoteEndpoint = ipInfo.getSocketAddress();
+        if (remoteEndpoint == null) {
+            return;
+        }
+
+        _transferLifeCycle.onStart(remoteEndpoint, _localEndpoint,
+              protocolInfo, _subject);
+        _startMarkerSent = true;
     }
 
     @Override


### PR DESCRIPTION
## Problem

`AbstractMoverProtocolTransferService`, the base class for `MoverProtocol`-based transfer services (used by `RemoteHttpTransferService` for FTS third-party copy movers), never calls `transferLifeCycle.onStart()`. This means **firefly flow-start UDP markers are never emitted for TPC movers**, even though:

- `DefaultPostTransferService` correctly sends `onEnd()` markers (using the `deriveLocalEndpoint()` fallback added in 11.2.3)
- `NettyTransferService` (direct client connections via xrootd/HTTP) correctly calls `onStart()` in its `executeMover()` method

## Impact

ESnet Stardust dashboards show **incomplete flow information for TPC transfers**. Specifically:
- TPC `onEnd` markers are present with correct experiment/activity IDs from transfer tags (e.g., activityId=11, 15, 16 for ATLAS categories)
- **Zero TPC `onStart` markers** are emitted from pool nodes for TPC transfers
- Direct-read `onStart` markers (from `NettyTransferService`) are present but use FQAN fallback (`activityId=1`) since worker nodes don't send SciTag headers

Evidence from ATLAS AGLT2 pool logs:
```
# 194 TPC end markers with correct transfer-tag classifier
scitags event=marker state=end protocol=remotehttpsdatatransfer ... transferTag=143 experimentId=2 activityId=15 classifier=transfer-tag

# 0 TPC start markers
grep -c 'protocol=remote.*state=start' → 0

# 141 direct-read start markers, all FQAN/activityId=1
scitags event=marker state=start protocol=https ... experimentId=2 activityId=1 classifier=fqan
```

## Fix

Add a `startTransferLifeCycle()` call in `MoverTask.run()` (before I/O begins) that:

1. Checks `_transferLifeCycle` is configured and protocol is IP-based
2. Derives the local endpoint from the remote address using `NetworkUtils.getLocalAddress()` — the same approach used by `DefaultPostTransferService.deriveLocalEndpoint()` for `onEnd`
3. Calls `transferLifeCycle.onStart()` with the remote endpoint, derived local endpoint, protocol info, and subject
4. Handles `SocketException` gracefully with debug logging

This mirrors the pattern already established in `NettyTransferService.executeMover()` for direct connections, extending it to all `MoverProtocol`-based transfers.

## Testing

- Compilation verified (`mvn -pl modules/dcache -am compile -DskipTests`)
- Consistent with existing patterns in `NettyTransferService` and `DefaultPostTransferService`

Signed-off-by: Shawn McKee <smckee@umich.edu>