### PR TITLE
rpm: make package require java17 or java21

### DIFF
--- a/packages/fhs/src/main/rpm/dcache-server.spec
+++ b/packages/fhs/src/main/rpm/dcache-server.spec
@@ -13,7 +13,7 @@ Requires(pre): shadow-utils
 Requires: which
 Requires: hostname
 Requires: procps-ng
-Requires: java-17-headless
+Requires: (java-17-headless or jre-21-headless)
 
 %{?systemd_requires}
 BuildRequires: systemd


### PR DESCRIPTION
Motivation:
dCache can run with java 17 as well as java 21. However, if a side decided to run dcache with java21, the RPM will pull java17 as dependency anyway.

Modification:
Make RPM require java 17 or 21.

Result:
If java is not installed, rpm will pull java17. If java21 is already installed, then no extra java packages will be pulled.

Acked-by: Karen Hoyos
Target: master, 11.2
Require-book: no
Require-notes: yes
(cherry picked from commit 5fe6ec98bd902b71b09d9172e84620148d44dd2d)