### PR TITLE
pool: New `hotfile show` command, and show enablement status with `info -a`

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/classic/PoolV4.java
@@ -662,6 +662,7 @@ public class PoolV4
         info.setPingHeartbeatInSecs(_pingThread.getHeartbeat());
         info.setP2pFileMode(_p2pFileMode == P2P_PRECIOUS ?
               P2PMode.PRECIOUS : P2PMode.CACHED);
+        info.setHotFileReplicationEnabled(_hotFileReplicationEnabled);
         info.setPoolMode(_poolMode.toString());
         if (_poolMode.isDisabled()) {
             info.setPoolStatusCode(_poolStatusCode);

--- a/modules/dcache/src/main/java/org/dcache/pool/json/PoolDataDetails.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/json/PoolDataDetails.java
@@ -112,6 +112,7 @@ public class PoolDataDetails implements Serializable {
     private Lsf largeFileStore;
 
     private P2PMode p2pFileMode;
+    private boolean isHotFileReplicationEnabled;
     private Integer hybridInventory;
 
     private int errorCode;
@@ -159,6 +160,10 @@ public class PoolDataDetails implements Serializable {
         return p2pFileMode;
     }
 
+    public boolean isHotFileReplicationEnabled() {
+        return isHotFileReplicationEnabled;
+    }
+
     public Integer getPingHeartbeatInSecs() {
         return pingHeartbeatInSecs;
     }
@@ -196,22 +201,23 @@ public class PoolDataDetails implements Serializable {
     }
 
     public void print(PrintWriter pw) {
-        pw.println("Base directory    : " + baseDir);
-        pw.println("Version           : " + poolVersion);
-        pw.println("Report remove     : " + asOnOff(isRemovalReported));
-        pw.println("Pool Mode         : " + poolMode);
+        pw.println("Base directory       : " + baseDir);
+        pw.println("Version              : " + poolVersion);
+        pw.println("Report remove        : " + asOnOff(isRemovalReported));
+        pw.println("Pool Mode            : " + poolMode);
         if (poolStatusCode != null) {
-            pw.println("Detail            : [" + poolStatusCode + "] "
+            pw.println("Detail               : [" + poolStatusCode + "] "
                   + poolStatusMessage);
         }
-        pw.println("Hsm Load Suppr.   : " + asOnOff(isHsmLoadSuppressed));
-        pw.println("Ping Heartbeat    : " + pingHeartbeatInSecs + " seconds");
-        pw.println("Breakeven         : " + breakEven);
-        pw.println("LargeFileStore    : " + largeFileStore);
-        pw.println("P2P File Mode     : " + p2pFileMode);
+        pw.println("Hsm Load Suppression : " + asOnOff(isHsmLoadSuppressed));
+        pw.println("Ping Heartbeat       : " + pingHeartbeatInSecs + " seconds");
+        pw.println("Breakeven            : " + breakEven);
+        pw.println("LargeFileStore       : " + largeFileStore);
+        pw.println("P2P File Mode        : " + p2pFileMode);
+        pw.println("Hot File Replication : " + asOnOff(isHotFileReplicationEnabled));
 
         if (hybridInventory != null) {
-            pw.println("Inventory         : " + hybridInventory);
+            pw.println("Inventory            : " + hybridInventory);
         }
 
         if (costData != null) {
@@ -267,6 +273,10 @@ public class PoolDataDetails implements Serializable {
     public void setP2pFileMode(
           P2PMode p2pFileMode) {
         this.p2pFileMode = p2pFileMode;
+    }
+
+    public void setHotFileReplicationEnabled(boolean isEnabled) {
+        this.isHotFileReplicationEnabled = isEnabled;
     }
 
     public void setPingHeartbeatInSecs(Integer pingHeartbeatInSecs) {

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -1634,4 +1634,17 @@ public class MigrationModule
             return "Current threshold: " + getThreshold();
         }
     }
+
+    @Command(name = "hotfile show",
+          description = "Show the current status of the hot-file replication facility, "
+                + "including whether it is enabled and the values of the 'replicas' "
+                + "and 'threshold' parameters.",
+          hint = "Show hot-file replication status.")
+    public class HotfileShowCommand implements Callable<String> {
+
+        @Override
+        public String call() {
+            return "replicas=" + hotFileReplicaCount + "  threshold=" + hotFileThreshold;
+        }
+    }
 }

--- a/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
+++ b/modules/dcache/src/main/java/org/dcache/pool/migration/MigrationModule.java
@@ -1636,9 +1636,7 @@ public class MigrationModule
     }
 
     @Command(name = "hotfile show",
-          description = "Show the current status of the hot-file replication facility, "
-                + "including whether it is enabled and the values of the 'replicas' "
-                + "and 'threshold' parameters.",
+          description = "Show the values of the 'replicas' and 'threshold' parameters.",
           hint = "Show hot-file replication status.")
     public class HotfileShowCommand implements Callable<String> {
 

--- a/modules/dcache/src/test/java/org/dcache/pool/json/PoolDataDetailsTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/json/PoolDataDetailsTest.java
@@ -1,0 +1,29 @@
+package org.dcache.pool.json;
+
+import org.junit.Test;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import static org.junit.Assert.assertTrue;
+
+public class PoolDataDetailsTest {
+
+    @Test
+    public void shouldPrintHotfileReplicationStatus() {
+        PoolDataDetails details = new PoolDataDetails();
+        details.setHotFileReplicationEnabled(true);
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        details.print(pw);
+
+        String output = sw.toString();
+        assertTrue("Output should contain Hot File Replication  status", output.contains("Hot File Replication : ON"));
+
+        details.setHotFileReplicationEnabled(false);
+        sw = new StringWriter();
+        pw = new PrintWriter(sw);
+        details.print(pw);
+        output = sw.toString();
+        assertTrue("Output should contain HotFile Replication  status", output.contains("Hot File Replication : OFF"));
+    }
+}

--- a/modules/dcache/src/test/java/org/dcache/pool/json/PoolDataDetailsTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/json/PoolDataDetailsTest.java
@@ -18,7 +18,7 @@ public class PoolDataDetailsTest {
         }
 
         String output = sw.toString();
-        assertTrue("Output should contain Hot File Replication  status", output.contains("Hot File Replication : ON"));
+        assertTrue("Output should contain Hot File Replication status", output.contains("Hot File Replication : ON"));
 
         details.setHotFileReplicationEnabled(false);
         sw = new StringWriter();
@@ -26,6 +26,6 @@ public class PoolDataDetailsTest {
             details.print(pw);
         }
         output = sw.toString();
-        assertTrue("Output should contain HotFile Replication  status", output.contains("Hot File Replication : OFF"));
+        assertTrue("Output should contain Hot File Replication status", output.contains("Hot File Replication : OFF"));
     }
 }

--- a/modules/dcache/src/test/java/org/dcache/pool/json/PoolDataDetailsTest.java
+++ b/modules/dcache/src/test/java/org/dcache/pool/json/PoolDataDetailsTest.java
@@ -13,16 +13,18 @@ public class PoolDataDetailsTest {
         details.setHotFileReplicationEnabled(true);
 
         StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        details.print(pw);
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            details.print(pw);
+        }
 
         String output = sw.toString();
         assertTrue("Output should contain Hot File Replication  status", output.contains("Hot File Replication : ON"));
 
         details.setHotFileReplicationEnabled(false);
         sw = new StringWriter();
-        pw = new PrintWriter(sw);
-        details.print(pw);
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            details.print(pw);
+        }
         output = sw.toString();
         assertTrue("Output should contain HotFile Replication  status", output.contains("Hot File Replication : OFF"));
     }


### PR DESCRIPTION
Motivation:

It is desirable to have a single admin command to display the values of both hot-file migration parameters (`replicas` and `threshold`).

It is also desirable to see quickly whether the hot file migration facility is enabled on a given pool.

Modification:

- The addition of a pool command `hotfile show` to `MigrationModule`
- The hot file replication enablement status has been added to the `pool` section of `info -a`

Result:

- `hotfile show`

    ```
    replicas=3  threshold=5
    ```

- `info -a`

    ```
    …
    --- pool (Main pool component) ---
    Base directory       : /diska/rw-pool-1
    Version              : 12.0.0-SNAPSHOT(bddeaa4) (Sub=4)
    Report remove        : ON
    Pool Mode            : enabled
    Hsm Load Suppression : OFF
    Ping Heartbeat       : 30 seconds
    Breakeven            : 0.7
    LargeFileStore       : NONE
    P2P File Mode        : CACHED
    Hot File Replication : ON
    Mover Queue (DCap) 0(100)/0
    Mover Queue (FTP) 0(30)/0
    Mover Queue (TPC) 0(1000)/0
    Mover Queue (XRootD) 0(1000)/0
    Mover Queue (HTTP) 0(1000)/0
    Mover Queue (NFS) 0(1000)/0
    Mover Queue (regular) 0(1000)/0
    Mover Queue (CVMFS) 0(10000)/0
    …
    ```

Acked-by: Dmitry Litvintsev
Patch: https://rb.dcache.org/r/14640/diff/raw
Commit:
Target: master
Request: 11.2
Require-book: no
Require-notes: yes
