### PR TITLE
libs: update apache-curator to 5.9.0

### DIFF
--- a/modules/cells/src/main/java/dmg/cells/zookeeper/CellCuratorFramework.java
+++ b/modules/cells/src/main/java/dmg/cells/zookeeper/CellCuratorFramework.java
@@ -1,6 +1,6 @@
 /* dCache - http://www.dcache.org/
  *
- * Copyright (C) 2016 - 2024 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2016 - 2026 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -395,6 +395,11 @@ public class CellCuratorFramework implements CuratorFramework {
     }
 
     @Override
+    public boolean compressionEnabled() {
+        return inner.compressionEnabled();
+    }
+
+    @Override
     public CompletableFuture<Void> postSafeNotify(Object monitorHolder) {
         return inner.postSafeNotify(monitorHolder);
     }
@@ -548,6 +553,11 @@ public class CellCuratorFramework implements CuratorFramework {
         @Override
         public CreateBackgroundModeStatACLable compressed() {
             return new CreateBackgroundModeStatACLableDecorator(inner.compressed());
+        }
+
+        @Override
+        public CreateBackgroundModeStatACLable uncompressed() {
+            return new CreateBackgroundModeStatACLableDecorator(inner.uncompressed());
         }
 
         @Override
@@ -767,6 +777,11 @@ public class CellCuratorFramework implements CuratorFramework {
         }
 
         @Override
+        public GetDataWatchBackgroundStatable undecompressed() {
+            return new GetDataWatchBackgroundStatableDecorator(inner.undecompressed());
+        }
+
+        @Override
         public byte[] forPath(String path) throws Exception {
             return inner.forPath(path);
         }
@@ -840,6 +855,11 @@ public class CellCuratorFramework implements CuratorFramework {
         @Override
         public SetDataBackgroundVersionable compressed() {
             return new SetDataBackgroundVersionableDecorator(inner.compressed());
+        }
+
+        @Override
+        public SetDataBackgroundVersionable uncompressed() {
+            return new SetDataBackgroundVersionableDecorator(inner.uncompressed());
         }
 
         @Override
@@ -1059,6 +1079,11 @@ public class CellCuratorFramework implements CuratorFramework {
         }
 
         @Override
+        public ACLCreateModePathAndBytesable<CuratorTransactionBridge> uncompressed() {
+            return new ACLCreateModePathAndBytesableDecorator<>(inner.uncompressed());
+        }
+
+        @Override
         public ACLPathAndBytesable<CuratorTransactionBridge> withMode(CreateMode mode) {
             return new ACLPathAndBytesableDecorator<>(inner.withMode(mode));
         }
@@ -1116,6 +1141,11 @@ public class CellCuratorFramework implements CuratorFramework {
         @Override
         public VersionPathAndBytesable<CuratorTransactionBridge> compressed() {
             return new VersionPathAndBytesableCuratorTransactionBridgeDecorator(inner.compressed());
+        }
+
+        @Override
+        public VersionPathAndBytesable<CuratorTransactionBridge> uncompressed() {
+            return new VersionPathAndBytesableCuratorTransactionBridgeDecorator(inner.uncompressed());
         }
 
         @Override

--- a/modules/dcache/src/main/java/org/dcache/cells/HAServiceLeadershipManager.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/HAServiceLeadershipManager.java
@@ -1,7 +1,7 @@
 /*
  * dCache - http://www.dcache.org/
  *
- * Copyright (C) 2020 - 2024 Deutsches Elektronen-Synchrotron
+ * Copyright (C) 2020 - 2026 Deutsches Elektronen-Synchrotron
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.curator.framework.recipes.leader.LeaderLatch.CloseMode;
 import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
 import org.apache.curator.framework.recipes.leader.Participant;
 import org.apache.curator.utils.CloseableUtils;
@@ -102,7 +103,7 @@ public class HAServiceLeadershipManager implements CellIdentityAware, CellComman
      * Creates a ZooKeeper leader latch, attaches and starts a listener.
      */
     private void initZkLeaderListener() {
-        zkLeaderLatch = new LeaderLatch(zkClient, zkLeaderPath, cellAddress.toString());
+        zkLeaderLatch = new LeaderLatch(zkClient, zkLeaderPath, cellAddress.toString(), CloseMode.NOTIFY_LEADER);
         zkLeaderLatch.addListener(new CDCLeaderLatchListener(leadershipListener));
         try {
             zkLeaderLatch.start();
@@ -118,7 +119,7 @@ public class HAServiceLeadershipManager implements CellIdentityAware, CellComman
 
     private synchronized void releaseLeadership() {
         try {
-            zkLeaderLatch.close(LeaderLatch.CloseMode.NOTIFY_LEADER);
+            zkLeaderLatch.close();
         } catch (Exception e) {
             Throwables.throwIfUnchecked(e);
             throw new RuntimeException(e);

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
             <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
-                <version>5.7.0</version>
+                <version>5.9.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Motivation:
The in-use curator version might fail to recover leader in some cases:

https://github.com/apache/curator/issues//1239

Modification:
Update apacke-curator iversion to 5.9.0
Update HAServiceLeadershipManager to specify the 'behaviour of listener on explicit close' when LeaderLatch is created.

Result:
up-to-date curator version with a potential issue fix.

Issue: #8057
Acked-by: Dmitry Litvintsev
Target: master, 11.2
Require-book: no
Require-notes: yes
(cherry picked from commit b656f9a53d087b1f854024b982fd420ed5fb08ec)