### PR TITLE
scripts: fix double rw definition in FIO benchmark script

### DIFF
--- a/skel/share/lib/pool-benchmark.fio
+++ b/skel/share/lib/pool-benchmark.fio
@@ -68,7 +68,6 @@ group_reporting=1
 [concurrent_randread]
 description=Concurrent Random READ
 rw=randread
-rw=read
 ; check checksum during read
 do_verify=1
 ; block until job is done before jumping to the next section


### PR DESCRIPTION
(cherry picked from commit 1ec7074c7e94c81c909e1265c8bd7a4817c73117)