### PR TITLE
tape rest API: remove AccessMask.READ_DATA requirement when querying

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/wlcg/ArchiveInfoCollector.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/wlcg/ArchiveInfoCollector.java
@@ -81,7 +81,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import org.dcache.acl.enums.AccessMask;
 import org.dcache.namespace.FileAttribute;
 import org.dcache.poolmanager.PoolMonitor;
 import org.dcache.restful.providers.tape.ArchiveInfo;
@@ -95,7 +94,6 @@ public class ArchiveInfoCollector implements CellCommandListener {
     private static final Set<FileAttribute> REQUIRED_ATTRIBUTES
           = EnumSet.of(FileAttribute.TYPE, FileAttribute.SIZE, FileAttribute.STORAGEINFO,
           FileAttribute.LOCATIONS);
-    private static final Set<AccessMask> ACCESS_MASK = EnumSet.of(AccessMask.READ_DATA);
     private static final int MAX_PATHS_DEFAULT = 10_000;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveInfoCollector.class);
@@ -166,8 +164,7 @@ public class ArchiveInfoCollector implements CellCommandListener {
 
     private FileLocality getInfo(String path, String prefix, PnfsHandler pnfsHandler) throws CacheException {
         String absolutePath = computeFsPath(prefix, path).toString();
-        FileAttributes attributes = pnfsHandler.getFileAttributes(absolutePath, REQUIRED_ATTRIBUTES,
-              ACCESS_MASK, false);
+        FileAttributes attributes = pnfsHandler.getFileAttributes(absolutePath, REQUIRED_ATTRIBUTES);
         FileLocality locality = poolMonitor.getFileLocality(attributes, "localhost");
         /**
          * This is done to placate CERN FTS that refuses


### PR DESCRIPTION
for file attributes for file locality

Motivation:
-----------
While testing storage.poll scope it was observed that querying file locality imposes requirement of DOWNLOAD activity to be available in the list of allowed activities in OIDC scope claim. This is unnecessary and complicates handling of storage.poll

Modification:
-------------
Remove AccessMask.READ_DATA requirement when querying file attributes via PnfsHandler.getFileAttributes before querying file locality via PoolMonitorV5.getFileLocality.

Result:
-------
DOWNLOAD activity is no longer required to query file locality. This allows implementation of storage.poll as READ_METADATA activity

Acked-by: Paul Millar, Chris Green
Target: trunk
Request: 11.2
Require-book: no
Require-notes: yes