### PR TITLE
chimera: fix reading of empty tags

### DIFF
--- a/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
+++ b/modules/chimera/src/main/java/org/dcache/chimera/FsSqlDriver.java
@@ -1507,7 +1507,8 @@ public class FsSqlDriver implements AutoCloseable {
                           /* some databases (hsqldb in particular) fill a full record for
                            * BLOBs and on read reads a full record, which is not what we expect.
                            */
-                          return in.readNBytes(data, offset,
+                          // If tag is not set or NULL, then getBinaryStream will return null.
+                          return in == null ? 0 : in.readNBytes(data, offset,
                                 Math.min(len, (int) rs.getLong("isize")));
                       } catch (IOException e) {
                           throw new LobRetrievalFailureException(e.getMessage(), e);

--- a/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
+++ b/modules/chimera/src/test/java/org/dcache/chimera/JdbcFsTest.java
@@ -1649,6 +1649,16 @@ public class JdbcFsTest extends ChimeraTestCaseHelper {
     }
 
     @Test
+    public void testReadNullTag() throws Exception {
+
+        FsInode top = _rootInode.mkdir("top");
+        _fs.createTag(top, "aTag");
+
+        int n = _fs.getTag(top, "aTag", new byte[10], 0, 10);
+        assertThat("Tag without content should return zero bytes", n, is(0));
+    }
+
+    @Test
     public void testTashTimestampOnRemove() throws Exception {
         final String name = "testTashTimestampOnRemove";
         FsInode inode = _rootInode.create(name, 0, 0, 0644);


### PR DESCRIPTION
Motivation:
if tag is only created without any content then ResultSet#getBinaryStream return `null` as a stream which will trigger NPE.

Modification:
Update org.dcache.chimera.FsSqlDriver#getTag to check for null before accessing the stream.

Result:
NPE is fixed.

Fixes: #8071
Acked-by: Dmitry Litvintsev
Target: master, 11.2
Require-book: no
Require-notes: yes
(cherry picked from commit 6682edadd9cca7dc6acec5d23281ab9f133b6ff4)