### PR TITLE
REST API: add domains resource.

### DIFF
--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/ApiConfig.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/ApiConfig.java
@@ -62,6 +62,7 @@ import javax.ws.rs.ext.Provider;
             @Tag(name = "billing", description = "The log of (significant) client activity"),
             @Tag(name = "bulk-requests", description = "Processing of multiple file/path requests in bulk"),
             @Tag(name = "cells", description = "The running components within dCache"),
+            @Tag(name = "domains", description = "The running dCache domains"),
             @Tag(name = "doors", description = "Information about doors"),
             @Tag(name = "events", description = "Support for SSE clients receiving dCache events"),
             @Tag(name = "identity", description = "Information about users"),

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/DcacheRestApplication.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/DcacheRestApplication.java
@@ -11,6 +11,7 @@ import org.dcache.restful.resources.alarms.AlarmsResources;
 import org.dcache.restful.resources.billing.BillingResources;
 import org.dcache.restful.resources.bulk.BulkResources;
 import org.dcache.restful.resources.cells.CellInfoResources;
+import org.dcache.restful.resources.domains.DomainInfoResources;
 import org.dcache.restful.resources.doors.DoorsResources;
 import org.dcache.restful.resources.identity.UserResource;
 import org.dcache.restful.resources.labels.LabelsResources;
@@ -48,6 +49,7 @@ public class DcacheRestApplication extends ResourceConfig {
         register(BillingResources.class);
         register(BulkResources.class);
         register(CellInfoResources.class);
+        register(DomainInfoResources.class);
         register(DoorsResources.class);
         register(UserResource.class);
         register(RequestUser.class);

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/domains/DomainInfoResources.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/resources/domains/DomainInfoResources.java
@@ -1,0 +1,124 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure anyce necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.resources.domains;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.dcache.cells.json.DomainData;
+import org.dcache.restful.services.cells.DomainInfoService;
+import org.springframework.stereotype.Component;
+
+/**
+ * RESTful API to the {@link DomainInfoService} service.
+ */
+@Component
+@Api(value = "domains", authorizations = {@Authorization("basicAuth")})
+@Path("/domains")
+public final class DomainInfoResources {
+
+    @Inject
+    private DomainInfoService service;
+
+    @GET
+    @ApiOperation("Provide information about all domains. "
+          + "Results sorted lexicographically by domain name.")
+    @ApiResponses({
+          @ApiResponse(code = 403, message = "Domain info service only accessible to admin users."),
+    })
+    @Produces(MediaType.APPLICATION_JSON)
+    public DomainData[] getDomains() {
+        return Arrays.stream(service.getAddresses())
+              .map(service::getDomainData)
+              .sorted(Comparator.comparing(DomainData::getDomainName))
+              .toArray(DomainData[]::new);
+    }
+
+    @GET
+    @ApiOperation("Provide information about a specific domain.")
+    @ApiResponses({
+          @ApiResponse(code = 403, message = "Domain info service only accessible to admin users."),
+          @ApiResponse(code = 404, message = "Domain not found."),
+    })
+    @Path("/{domain}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public DomainData getDomain(
+          @ApiParam(value = "The domain name to query", example = "dCacheDomain")
+          @PathParam("domain") String domain) {
+        Set<String> known = Set.of(service.getAddresses());
+        if (!known.contains(domain)) {
+            throw new NotFoundException("Domain not found: " + domain);
+        }
+        return service.getDomainData(domain);
+    }
+}

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/cells/DomainInfoService.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/cells/DomainInfoService.java
@@ -1,0 +1,81 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.services.cells;
+
+import org.dcache.cells.json.DomainData;
+
+/**
+ * <p>Defines the internal API for the service providing collected/extracted
+ * domain data (name and hostname).</p>
+ */
+public interface DomainInfoService {
+
+    /**
+     * @return array of all currently known domain names.
+     */
+    String[] getAddresses();
+
+    /**
+     * @param domainName of the known domain.
+     * @return JSON object containing domain data.
+     */
+    DomainData getDomainData(String domainName);
+}
+

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/services/cells/DomainInfoServiceImpl.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/services/cells/DomainInfoServiceImpl.java
@@ -1,0 +1,133 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.services.cells;
+
+import dmg.util.command.Command;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import org.dcache.cells.json.DomainData;
+import org.dcache.restful.util.domains.DomainInfoCollector;
+import org.dcache.services.collector.CellDataCollectingService;
+
+/**
+ * <p>Responsible for collecting domain info via {@link DomainInfoCollector}
+ * and serving it from a local cache.</p>
+ */
+public class DomainInfoServiceImpl extends
+      CellDataCollectingService<Map<String, DomainData>, DomainInfoCollector>
+      implements DomainInfoService {
+
+    @Command(name = "domains set timeout",
+          hint = "Set the timeout interval between refreshes",
+          description = "Changes the interval between "
+                + "queries for domain information.")
+    class DomainsSetTimeoutCommand extends SetTimeoutCommand {
+
+    }
+
+    @Command(name = "domains refresh",
+          hint = "Query for current domain info",
+          description = "Interrupts current wait to run query immediately.")
+    class DomainsRefreshCommand extends RefreshCommand {
+
+    }
+
+    @Command(name = "domains ls",
+          hint = "List domain info",
+          description = "Displays a list of all currently known domains "
+                + "and their hostnames.")
+    class DomainsLsCommand implements Callable<String> {
+
+        @Override
+        public String call() {
+            return Arrays.stream(getAddresses())
+                  .map(DomainInfoServiceImpl.this::getDomainData)
+                  .sorted(Comparator.comparing(DomainData::getDomainName))
+                  .map(DomainData::toString)
+                  .collect(Collectors.joining("\n"));
+        }
+    }
+
+    private volatile Map<String, DomainData> cache = Map.of();
+
+    @Override
+    public synchronized String[] getAddresses() {
+        return cache.keySet().toArray(String[]::new);
+    }
+
+    @Override
+    public DomainData getDomainData(String domainName) {
+        DomainData cached = cache.get(domainName);
+        if (cached == null) {
+            cached = new DomainData();
+            cached.setDomainName(domainName);
+        }
+        return cached;
+    }
+
+    @Override
+    protected synchronized void update(Map<String, DomainData> data) {
+        cache = Map.copyOf(data);
+    }
+}
+

--- a/modules/dcache-frontend/src/main/java/org/dcache/restful/util/domains/DomainInfoCollector.java
+++ b/modules/dcache-frontend/src/main/java/org/dcache/restful/util/domains/DomainInfoCollector.java
@@ -1,0 +1,136 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.restful.util.domains;
+
+import diskCacheV111.util.SpreadAndWait;
+import dmg.cells.nucleus.CellPath;
+import dmg.cells.services.GetAllDomainsReply;
+import dmg.cells.services.GetAllDomainsRequest;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import org.dcache.cells.json.DomainData;
+import org.dcache.util.collector.CellMessagingCollector;
+
+/**
+ * <p>Collects domain names from the Routing Manager and their hostnames
+ * from each domain's System cell, returning a map of domain name to
+ * {@link DomainData}.</p>
+ */
+public final class DomainInfoCollector extends CellMessagingCollector<Map<String, DomainData>> {
+
+    @Override
+    public Map<String, DomainData> collectData() throws InterruptedException {
+        GetAllDomainsReply reply;
+
+        try {
+            reply = stub.send(new CellPath("RoutingMgr"),
+                    new GetAllDomainsRequest(),
+                    GetAllDomainsReply.class).get();
+        } catch (ExecutionException e) {
+            LOGGER.error("Could not contact Routing Manager: {}, {}.",
+                    e.getMessage(), String.valueOf(e.getCause()));
+            return Collections.emptyMap();
+        }
+
+        Map<String, Collection<String>> domains = reply.getDomains();
+
+        /*
+         * Fan out "get hostname" to the System cell of every domain.
+         * SpreadAndWait silently drops domains that don't respond, so
+         * those simply won't appear in getReplies().
+         */
+        SpreadAndWait<String> spreader = new SpreadAndWait<>(stub);
+        for (String domainName : domains.keySet()) {
+            spreader.send(new CellPath("System", domainName), String.class, "get hostname");
+        }
+        spreader.waitForReplies();
+
+        Map<String, DomainData> result = new TreeMap<>();
+
+        /*
+         * Build DomainData for each domain that replied.
+         * toAddressString() for new CellPath("System", "dCacheDomain") returns "System@dCacheDomain".
+         */
+        for (Map.Entry<CellPath, String> entry : spreader.getReplies().entrySet()) {
+            String domainName = entry.getKey().getCellDomainName();
+            DomainData data = new DomainData();
+            data.setDomainName(domainName);
+            data.setHostname(entry.getValue());
+            result.put(domainName, data);
+        }
+
+        /*
+         * Include domains that did not reply (hostname will be null).
+         */
+        for (String domainName : domains.keySet()) {
+            result.computeIfAbsent(domainName, name -> {
+                DomainData data = new DomainData();
+                data.setDomainName(name);
+                return data;
+            });
+        }
+
+        return result;
+    }
+}
+

--- a/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
+++ b/modules/dcache-frontend/src/main/resources/org/dcache/frontend/frontend.xml
@@ -305,6 +305,18 @@
     <property name="processor" ref="cell-info-processor"/>
   </bean>
 
+  <bean id="domain-info-collector" class="org.dcache.restful.util.domains.DomainInfoCollector">
+    <description>Collects domain names and hostnames from the Routing Manager.</description>
+  </bean>
+
+  <bean id="domain-info-service" class="org.dcache.restful.services.cells.DomainInfoServiceImpl">
+    <description>Caches and serves domain name and hostname information.</description>
+    <property name="timeout" value="${frontend.service.domain-info.timeout}"/>
+    <property name="timeoutUnit" value="${frontend.service.domain-info.timeout.unit}"/>
+    <property name="collector" ref="domain-info-collector"/>
+    <property name="executorService" ref="scheduling-service"/>
+  </bean>
+
   <bean id="restores-collector" class="org.dcache.restful.util.restores.RestoreCollector">
     <description>Collects staging request info from from pool manager.</description>
     <property name="pnfsStub" ref="pnfs-stub"/>
@@ -632,6 +644,7 @@
     </bean>
     <bean class="org.dcache.restful.resources.bulk.BulkResources" scope="request"/>
     <bean class="org.dcache.restful.resources.cells.CellInfoResources" scope="request"/>
+    <bean class="org.dcache.restful.resources.domains.DomainInfoResources" scope="request"/>
     <bean class="org.dcache.restful.resources.doors.DoorsResources" scope="request"/>
     <bean class="org.dcache.restful.resources.identity.UserResource" scope="request"/>
     <bean class="org.dcache.restful.resources.namespace.FileResources" scope="request">

--- a/modules/dcache/src/main/java/org/dcache/cells/json/DomainData.java
+++ b/modules/dcache/src/main/java/org/dcache/cells/json/DomainData.java
@@ -1,0 +1,96 @@
+/*
+COPYRIGHT STATUS:
+Dec 1st 2001, Fermi National Accelerator Laboratory (FNAL) documents and
+software are sponsored by the U.S. Department of Energy under Contract No.
+DE-AC02-76CH03000. Therefore, the U.S. Government retains a  world-wide
+non-exclusive, royalty-free license to publish or reproduce these documents
+and software for U.S. Government purposes.  All documents and software
+available from this server are protected under the U.S. and Foreign
+Copyright Laws, and FNAL reserves all rights.
+
+Distribution of the software available from this server is free of
+charge subject to the user following the terms of the Fermitools
+Software Legal Information.
+
+Redistribution and/or modification of the software shall be accompanied
+by the Fermitools Software Legal Information  (including the copyright
+notice).
+
+The user is asked to feed back problems, benefits, and/or suggestions
+about the software to the Fermilab Software Providers.
+
+Neither the name of Fermilab, the  URA, nor the names of the contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+DISCLAIMER OF LIABILITY (BSD):
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED  WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FERMILAB,
+OR THE URA, OR THE U.S. DEPARTMENT of ENERGY, OR CONTRIBUTORS BE LIABLE
+FOR  ANY  DIRECT, INDIRECT,  INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY  OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT  OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.
+
+Liabilities of the Government:
+
+This software is provided by URA, independent from its Prime Contract
+with the U.S. Department of Energy. URA is acting independently from
+the Government and in its own private capacity and is not acting on
+behalf of the U.S. Government, nor as its contractor nor its agent.
+Correspondingly, it is understood and agreed that the U.S. Government
+has no connection to this software and in no manner whatsoever shall
+be liable for nor assume any responsibility or obligation for any claim,
+cost, or damages arising out of or resulting from the use of the software
+available from this server.
+
+Export Control:
+
+All documents and software available from this server are subject to U.S.
+export control laws.  Anyone downloading information from this server is
+obligated to secure any necessary Government licenses before exporting
+documents or software obtained from this server.
+ */
+package org.dcache.cells.json;
+
+import java.io.Serializable;
+
+/**
+ * <p>Corresponds to the information for a dCache domain: its name and
+ * the hostname of the machine it runs on.</p>
+ */
+public class DomainData implements Serializable {
+
+    private static final long serialVersionUID = 6218546553089190832L;
+
+    private String domainName;
+    private String hostname;
+
+    public String getDomainName() {
+        return domainName;
+    }
+
+    public void setDomainName(String domainName) {
+        this.domainName = domainName;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + domainName + ")(" + hostname + ")";
+    }
+}
+

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -118,6 +118,11 @@ frontend.service.cell-info.timeout=1
 # Used for processing updates on messages returned from cells
 frontend.service.cell-info.update-threads=10
 
+# Timeout for domain info collection
+# These properties can also be set interactively through the admin door
+frontend.service.domain-info.timeout=1
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.domain-info.timeout.unit=MINUTES
+
 # Timeout for restore info collection
 # These properties can also be set interactively through the admin door
 frontend.service.restores.timeout=1


### PR DESCRIPTION
Motivation:
----------

Issue https://github.com/dCache/dcache/issues/8127 requests a REST API for domains that would map domain names and their host addresses in one API call.

Modification:
-------------

Modelled after /cells API the /domains/ API sends
GetAllDomainsRequest to RoutingMgr to obtain list of domain names and then uses SpreadAndWait to send `get hostname` message to each domain. Results are cached.

Result:
-------

Rest API /domain allows to get <name, hostname> for all running domains in dCache. The API will be extendd to return other useful domain data.

Ticket: https://github.com/dCache/dcache/issues/8127
Acked-by: tigran.mkrthcyan@desy,de

Target: trunk
Requets: 11.2
Require-book: no
Require-notes: yes