### PR TITLE
doc improvements

### DIFF
--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -111,6 +111,8 @@ frontend.service.transfers.timeout=1
 frontend.service.transfers.maxCacheSize=1000
 
 # Timeout for cell info collection
+#
+# Amongst others, this affects the `/cells`-resource of the REST interface.
 # These properties can also be set interactively through the admin door
 frontend.service.cell-info.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.cell-info.timeout.unit=MINUTES
@@ -119,6 +121,8 @@ frontend.service.cell-info.timeout=1
 frontend.service.cell-info.update-threads=10
 
 # Timeout for domain info collection
+#
+# Amongst others, this affects the `/domains`-resource of the REST interface.
 # These properties can also be set interactively through the admin door
 frontend.service.domain-info.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.domain-info.timeout.unit=MINUTES
@@ -135,11 +139,16 @@ frontend.service.alarms.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.alarms.timeout.unit=MINUTES
 
 # Timeout for pool info collection
+#
+# Amongst others, this affects the `/pools`-resource of the REST interface.
 # These properties can also be set interactively through the admin door
 frontend.service.pool-info.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pool-info.timeout.unit=MINUTES
 
 # Timeout for pool history info collection
+#
+# Amongst others, this affects the `/poolgroups/{group}/histograms`- and
+# `/pools/{pool}/histograms`-resources of the REST interface.
 # These properties can also be set interactively through the admin door
 frontend.service.pool-history.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pool-history.timeout.unit=MINUTES

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -149,7 +149,6 @@ frontend.service.pool-info.timeout=1
 #
 # Amongst others, this affects the `/poolgroups/{group}/histograms`- and
 # `/pools/{pool}/histograms`-resources of the REST interface.
-# These properties can also be set interactively through the admin door
 frontend.service.pool-history.timeout=1
 (one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)frontend.service.pool-history.timeout.unit=MINUTES
 

--- a/skel/share/defaults/frontend.properties
+++ b/skel/share/defaults/frontend.properties
@@ -467,6 +467,8 @@ frontend.service.billing.collection.timeout = 1
 # Whether to submit namespace qos requests to the QoSEngine or to use
 # the embedded legacy mechanism.  Defaults to the new QoSEngine.
 (one-of?true|false)frontend.service.namespace.use-qos-service= true
+(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
+frontend.service.billing.collection.timeout.unit = MINUTES
 
 # Geographic placement
 #
@@ -475,8 +477,6 @@ frontend.service.billing.collection.timeout = 1
 #
 frontend.geographic-placement =
 
-(one-of?MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)\
-frontend.service.billing.collection.timeout.unit = MINUTES
 
 #  ---- Directory with default static content
 #


### PR DESCRIPTION
Hey.

As for 34827be79b95b488cea8a96a133b23d07ec182c4, please check someone whether there’s really no such command - I couldn't find it, but maybe `pools refresh` is simply shared by pool-info and pool-history.

As for 1e51e8b0a4dab61565a8b75cba53b8a7d0807d21, this is based on @DmitryLitvintsev’s comments and my own look at the code (though I had a hard time to actually understand which paths are affected by which timeout properties).
The problem with it is that it's incomplete:
- I haven't added the path infos to options at all, where I don't use the path in my prometheus exporter.
- Even for those that I've added, I'm not 100% sure whether the info is complete.
   in particular:
   - Are any others paths (which I don't list) affected by each of the options, e.g. `/pools/{name}/usage` somewhere contains a copy of the `/cells` data for that pool, but that for example does **not** seem to be affected by `frontend.service.cell-info.timeout` but rather by `frontend.service.pool-info.timeout`. Or `frontend.service.pool-info.timeout` might also affect `/poolgroups/`
   - Do I list any paths, where subpaths are however **not** affected by the respective option? E.g. `/pools/` contains a lot, but I've only really checked that `frontend.service.pool-info.timeout` affects `/pools/{name}/usage`.
   - Also I'm not sure whether the list for `frontend.service.pool-history.timeout` is complete/exact.

So maybe this should rather be only a draft, but in general I think these options are less useful if it's not really clear what **exactly** they do.