### PR TITLE
libs: update CaNL to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
             <dependency>
                 <groupId>eu.eu-emi.security</groupId>
                 <artifactId>canl</artifactId>
-                <version>2.8.3</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.italiangrid</groupId>


### PR DESCRIPTION
Motivation:
update to latest release with various bugfixes:

- fix failing tests
-  ignore idea dir
-  add CI action
-  Bump org.assertj:assertj-core from 3.23.1 to 3.27.7
-  use recent BC and commons-io
-  Fix EC key matching and ServerKeyPairValidator for non-IGTF certs
-  remove references to unicore-dev host - it no longer exists
-  add workaround key algorithm matching in checkKeysMatching method for ECDSA and EC
-  proxy: use sha2 to generate proxy request

Modification:
update CaNL to 2.9.0

Result:
up-to-date version with dCache relevant fixes

Acked-by: Dmitry Litvintsev
Target: master, 12.0, 11.2
Require-book: no
Require-notes: yes
(cherry picked from commit 6410753db17637c2d4b72a65fc1fed9f84099df3)