### PR TITLE
gplazma2-voms: enforce openssl SHA1 mode for certificate hash calculation

### DIFF
--- a/modules/gplazma2-voms/src/main/java/org/dcache/gplazma/plugins/VomsPlugin.java
+++ b/modules/gplazma2-voms/src/main/java/org/dcache/gplazma/plugins/VomsPlugin.java
@@ -30,6 +30,7 @@ import org.italiangrid.voms.error.VOMSValidationErrorMessage;
 import org.italiangrid.voms.store.VOMSTrustStore;
 import org.italiangrid.voms.store.VOMSTrustStores;
 import org.italiangrid.voms.util.CertificateValidatorBuilder;
+import org.italiangrid.voms.util.CertificateValidatorBuilder.OpensslHashFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,6 +71,7 @@ public class VomsPlugin implements GPlazmaAuthenticationPlugin {
               .lazyAnchorsLoading(false)
               .trustAnchorsUpdateInterval(trustAnchorsUpdateInterval)
               .trustAnchorsDir(caDir)
+              .opensslHashFunction(OpensslHashFunction.SHA1)
               .build();
         validator = VOMSValidators.newValidator(vomsTrustStore, certChainValidator);
     }


### PR DESCRIPTION


Motivation:
The latest update IGTF drops MD5 version for certificate hashes. As a result, gplazma voms plugin stop working

Modification:
Enforce SHA1 hash in voms plugin.

Result:
the voms validation works again.

Acked-by: Dmitry Litvintsev
Target: master, 12.0, 11.2, 11.1, 11.0, 10.2
Require-book: no
Require-notes: yes
(cherry picked from commit fbaec62d743541e94fa4b93c36250f22ac46c6f1)