### PR TITLE
utils: fix buildGenericWantDigest for RFC9530 (issue8191)

### DIFF
--- a/modules/dcache/src/main/java/org/dcache/util/Checksums.java
+++ b/modules/dcache/src/main/java/org/dcache/util/Checksums.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps.EntryTransformer;
 import com.google.common.collect.Ordering;
 
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
@@ -108,13 +107,22 @@ public class Checksums {
         }
     };
 
-    private static final Ordering<ChecksumType> PREFERRED_CHECKSUM_TYPE_ORDERING =
-          Ordering.explicit(SHA512, SHA256, SHA1, MD5_TYPE, ADLER32, MD4_TYPE);
-    private static final Ordering<Checksum> PREFERRED_CHECKSUM_ORDERING =
-          PREFERRED_CHECKSUM_TYPE_ORDERING.onResultOf(Checksum::getType);
 
-    private static final Ordering<ChecksumType> PREFERRED_CHECKSUM_RFC9530_TYPE_ORDERING =
-            Ordering.explicit(SHA512, SHA256);
+    /**
+     * Order list of checksum types used by rfc3230.
+     */
+    private static final List<ChecksumType> PREFERRED_CHECKSUM_TYPE_ORDER = List.of(SHA512, SHA256, SHA1, MD5_TYPE, ADLER32, MD4_TYPE);
+
+    /**
+     * Order list of checksum types used by rfc9530.
+     */
+    private static final List<ChecksumType> PREFERRED_CHECKSUM_RFC9530_TYPE_ORDER = List.of(SHA512, SHA256);
+
+    private static final Ordering<Checksum> PREFERRED_CHECKSUM_ORDERING =
+          Ordering.explicit(PREFERRED_CHECKSUM_TYPE_ORDER).onResultOf(Checksum::getType);
+
+    private static final Ordering<ChecksumType> PREFERRED_CHECKSUM_TYPE_ORDERING =
+          Ordering.explicit(PREFERRED_CHECKSUM_TYPE_ORDER);
 
     /**
      * This Function maps an instance of Checksum to the corresponding fragment of an RFC 3230
@@ -183,11 +191,12 @@ public class Checksums {
      * supports, in the preferred order.
      */
     public static String buildGenericWantDigest(RfcType rfc) {
-        List<String> names = Arrays.stream(ChecksumType.values())
-              .sorted((rfc.equals(RfcType.RFC9530)) ? PREFERRED_CHECKSUM_RFC9530_TYPE_ORDERING : PREFERRED_CHECKSUM_TYPE_ORDERING)
+
+        var allowedTypes = rfc.equals(RfcType.RFC9530) ? PREFERRED_CHECKSUM_RFC9530_TYPE_ORDER : PREFERRED_CHECKSUM_TYPE_ORDER;
+        List<String> names = allowedTypes.stream()
               .map(CHECKSUMTYPE_TO_RFC_NAME::get)
               .filter(Objects::nonNull)
-              .collect(Collectors.toList());
+              .toList();
 
         return wantDigest(names);
     }

--- a/modules/dcache/src/test/java/org/dcache/util/ChecksumsTests.java
+++ b/modules/dcache/src/test/java/org/dcache/util/ChecksumsTests.java
@@ -682,6 +682,14 @@ public class ChecksumsTests {
               is(equalTo("sha-512,sha-256;q=0.8,sha;q=0.6,md5;q=0.4,adler32;q=0.2")));
     }
 
+    @Test
+    public void shouldBuildExpectedGenericWantRFC9530Digest() {
+        String wantDigest = Checksums.buildGenericWantDigest(Checksums.RfcType.RFC9530);
+
+        assertThat(wantDigest,
+              is(equalTo("sha-512,sha-256;q=0.5")));
+    }
+
     private Checksum newMd4Checksum(String value) {
         return new Checksum(ChecksumType.MD4_TYPE, value);
     }


### PR DESCRIPTION
Motivation:
The Checksums class uses guava's Ordering.explicit in buildGenericWantDigest. However, explicit ordering throws IncomparableValueException if element is not in the explicit list:

Caused by: com.google.common.collect.Ordering$IncomparableValueException: Cannot compare value: MD5
	at com.google.common.collect.ExplicitOrdering.rank(ExplicitOrdering.java:46)
	at com.google.common.collect.ExplicitOrdering.compare(ExplicitOrdering.java:40)
	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
	at java.base/java.util.TimSort.sort(TimSort.java:220)
	at java.base/java.util.Arrays.sort(Arrays.java:1304)
	at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:353)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:571)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:723)
	at org.dcache.util.Checksums.buildGenericWantDigest(Checksums.java:190)

Modification:
As instead of using Ordering.explicit, use List.of, which has the same effect. Derive Want-Digest header and explicit ordering from that lists if needed.

Result:
fixed runtime exception and failing HTTP-TPC  transfers

Fixes: #8191
Acked-by: Dmitry Litvintsev
Target: master, 12.0
Require-book: no
Require-notes: yes
(cherry picked from commit 5d13b535d65747481e8a94b0d28ec0b639209812)